### PR TITLE
fix: Revert py2.7 incompatible formatting

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.revert-spacecmd-dir
+++ b/spacecmd/spacecmd.changes.mczernek.revert-spacecmd-dir
@@ -1,0 +1,1 @@
+- Revert py2.7-incompatible formatting 

--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -34,7 +33,6 @@
 import re
 import shlex
 import gettext
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -42,36 +40,32 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_activationkey_addpackages(self):
-    print(_("activationkey_addpackages: Add packages to an activation key"))
-    print(_("usage: activationkey_addpackages KEY <PACKAGE ...>"))
+    print(_('activationkey_addpackages: Add packages to an activation key'))
+    print(_('usage: activationkey_addpackages KEY <PACKAGE ...>'))
 
 
 def complete_activationkey_addpackages(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True),
+                             text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.get_package_names(), text)
 
     return None
 
 
 def do_activationkey_addpackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -79,43 +73,39 @@ def do_activationkey_addpackages(self, args):
         return 1
 
     key = args.pop(0)
-    packages = [{"name": a} for a in args]
+    packages = [{'name': a} for a in args]
 
     self.client.activationkey.addPackages(self.session, key, packages)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_removepackages(self):
-    print(
-        _("activationkey_removepackages: Remove packages from an " + "activation key")
-    )
-    print(_("usage: activationkey_removepackages KEY <PACKAGE ...>"))
+    print(_('activationkey_removepackages: Remove packages from an ' +
+            'activation key'))
+    print(_('usage: activationkey_removepackages KEY <PACKAGE ...>'))
 
 
 def complete_activationkey_removepackages(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True),
+                             text)
     elif len(parts) > 2:
-        details = self.client.activationkey.getDetails(self.session, parts[1])
-        packages = [p["name"] for p in details.get("packages")]
-        # pylint: disable-next=undefined-variable
+        details = self.client.activationkey.getDetails(self.session,
+                                                       parts[1])
+        packages = [p['name'] for p in details.get('packages')]
         return tab_completer(packages, text)
 
     return None
 
 
 def do_activationkey_removepackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -123,41 +113,36 @@ def do_activationkey_removepackages(self, args):
         return 1
 
     key = args.pop(0)
-    packages = [{"name": a} for a in args]
+    packages = [{'name': a} for a in args]
 
     self.client.activationkey.removePackages(self.session, key, packages)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_addgroups(self):
-    print(_("activationkey_addgroups: Add groups to an activation key"))
-    print(_("usage: activationkey_addgroups KEY <GROUP ...>"))
+    print(_('activationkey_addgroups: Add groups to an activation key'))
+    print(_('usage: activationkey_addgroups KEY <GROUP ...>'))
 
 
 def complete_activationkey_addgroups(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_group_list("", True), parts[-1])
+        return tab_completer(self.do_group_list('', True), parts[-1])
 
     return None
 
 
 def do_activationkey_addgroups(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -169,47 +154,44 @@ def do_activationkey_addgroups(self, args):
     groups = []
     for a in args:
         details = self.client.systemgroup.getDetails(self.session, a)
-        groups.append(details.get("id"))
+        groups.append(details.get('id'))
 
     self.client.activationkey.addServerGroups(self.session, key, groups)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_removegroups(self):
-    print(_("activationkey_removegroups: Remove groups from an activation key"))
-    print(_("usage: activationkey_removegroups KEY <GROUP ...>"))
+    print(_('activationkey_removegroups: Remove groups from an activation key'))
+    print(_('usage: activationkey_removegroups KEY <GROUP ...>'))
 
 
 def complete_activationkey_removegroups(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
-        key_details = self.client.activationkey.getDetails(self.session, parts[-1])
+        key_details = self.client.activationkey.getDetails(self.session,
+                                                           parts[-1])
 
         groups = []
-        for group in key_details.get("server_group_ids"):
-            details = self.client.systemgroup.getDetails(self.session, group)
-            groups.append(details.get("name"))
-        # pylint: disable-next=undefined-variable
+        for group in key_details.get('server_group_ids'):
+            details = self.client.systemgroup.getDetails(self.session,
+                                                         group)
+            groups.append(details.get('name'))
         return tab_completer(groups, text)
 
     return None
 
 
 def do_activationkey_removegroups(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -221,41 +203,36 @@ def do_activationkey_removegroups(self, args):
     groups = []
     for a in args:
         details = self.client.systemgroup.getDetails(self.session, a)
-        groups.append(details.get("id"))
+        groups.append(details.get('id'))
 
     self.client.activationkey.removeServerGroups(self.session, key, groups)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_addentitlements(self):
-    print(
-        _("activationkey_addentitlements: Add entitlements to an " + "activation key")
-    )
-    print(_("usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"))
+    print(_('activationkey_addentitlements: Add entitlements to an ' +
+            'activation key'))
+    print(_('usage: activationkey_addentitlements KEY <ENTITLEMENT ...>'))
 
 
 def complete_activationkey_addentitlements(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True),
+                             text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.ENTITLEMENTS, text)
 
     return None
 
 
 def do_activationkey_addentitlements(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -265,44 +242,38 @@ def do_activationkey_addentitlements(self, args):
     key = args.pop(0)
     entitlements = args
 
-    self.client.activationkey.addEntitlements(self.session, key, entitlements)
+    self.client.activationkey.addEntitlements(self.session,
+                                              key,
+                                              entitlements)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_removeentitlements(self):
-    print(
-        _(
-            "activationkey_removeentitlements: Remove entitlements from an "
-            + "activation key"
-        )
-    )
-    print(_("usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"))
+    print(_('activationkey_removeentitlements: Remove entitlements from an ' +
+            'activation key'))
+    print(_('usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>'))
 
 
 def complete_activationkey_removeentitlements(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
-        details = self.client.activationkey.getDetails(self.session, parts[1])
-        entitlements = details.get("entitlements")
-        # pylint: disable-next=undefined-variable
+        details = \
+            self.client.activationkey.getDetails(self.session, parts[1])
+        entitlements = details.get('entitlements')
         return tab_completer(entitlements, text)
 
     return None
 
 
 def do_activationkey_removeentitlements(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -312,57 +283,53 @@ def do_activationkey_removeentitlements(self, args):
     key = args.pop(0)
     entitlements = args
 
-    self.client.activationkey.removeEntitlements(self.session, key, entitlements)
+    self.client.activationkey.removeEntitlements(self.session,
+                                                 key,
+                                                 entitlements)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_addchildchannels(self):
-    print(
-        _(
-            "activationkey_addchildchannels: Add child channels to an "
-            + "activation key"
-        )
-    )
-    print(_("usage: activationkey_addchildchannels KEY <CHANNEL ...>"))
+    print(_('activationkey_addchildchannels: Add child channels to an ' +
+            'activation key'))
+    print(_('usage: activationkey_addchildchannels KEY <CHANNEL ...>'))
 
 
 def complete_activationkey_addchildchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True),
+                             text)
     elif len(parts) > 2:
-        key_details = self.client.activationkey.getDetails(self.session, parts[1])
-        base_channel = key_details.get("base_channel_label")
+        key_details = \
+            self.client.activationkey.getDetails(self.session, parts[1])
+        base_channel = key_details.get('base_channel_label')
 
-        all_channels = self.client.channel.listSoftwareChannels(self.session)
+        all_channels = \
+            self.client.channel.listSoftwareChannels(self.session)
 
         child_channels = []
         for c in all_channels:
-            if base_channel == "none":
+            if base_channel == 'none':
                 # this gets all child channels
-                if c.get("parent_label"):
-                    child_channels.append(c.get("label"))
+                if c.get('parent_label'):
+                    child_channels.append(c.get('label'))
             else:
-                if c.get("parent_label") == base_channel:
-                    child_channels.append(c.get("label"))
+                if c.get('parent_label') == base_channel:
+                    child_channels.append(c.get('label'))
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(child_channels, text)
 
     return None
 
 
 def do_activationkey_addchildchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -376,39 +343,31 @@ def do_activationkey_addchildchannels(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_removechildchannels(self):
-    print(
-        _(
-            "activationkey_removechildchannels: Remove child channels from "
-            + "an activation key"
-        )
-    )
-    print(_("usage: activationkey_removechildchannels KEY <CHANNEL ...>"))
+    print(_('activationkey_removechildchannels: Remove child channels from ' +
+            'an activation key'))
+    print(_('usage: activationkey_removechildchannels KEY <CHANNEL ...>'))
 
 
 def complete_activationkey_removechildchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
-        key_details = self.client.activationkey.getDetails(self.session, parts[1])
-        # pylint: disable-next=undefined-variable
-        return tab_completer(key_details.get("child_channel_labels"), text)
+        key_details = \
+            self.client.activationkey.getDetails(self.session, parts[1])
+        return tab_completer(key_details.get('child_channel_labels'), text)
 
     return None
 
 
 def do_activationkey_removechildchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -418,34 +377,28 @@ def do_activationkey_removechildchannels(self, args):
     key = args.pop(0)
     channels = args
 
-    self.client.activationkey.removeChildChannels(self.session, key, channels)
+    self.client.activationkey.removeChildChannels(self.session,
+                                                  key,
+                                                  channels)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_listchildchannels(self):
-    print(
-        _(
-            "activationkey_listchildchannels: List the child channels "
-            + "for an activation key"
-        )
-    )
-    print(_("usage: activationkey_listchildchannels KEY"))
+    print(_('activationkey_listchildchannels: List the child channels ' +
+            'for an activation key'))
+    print(_('usage: activationkey_listchildchannels KEY'))
 
 
 def complete_activationkey_listchildchannels(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_listchildchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -456,35 +409,27 @@ def do_activationkey_listchildchannels(self, args):
 
     details = self.client.activationkey.getDetails(self.session, key)
 
-    if details.get("child_channel_labels"):
-        print("\n".join(sorted(details.get("child_channel_labels"))))
+    if details.get('child_channel_labels'):
+        print('\n'.join(sorted(details.get('child_channel_labels'))))
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_listbasechannel(self):
-    print(
-        _(
-            "activationkey_listbasechannel: List the base channels "
-            + "for an activation key"
-        )
-    )
-    print(_("usage: activationkey_listbasechannel KEY"))
+    print(_('activationkey_listbasechannel: List the base channels ' +
+            'for an activation key'))
+    print(_('usage: activationkey_listbasechannel KEY'))
 
 
 def complete_activationkey_listbasechannel(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_listbasechannel(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -495,29 +440,26 @@ def do_activationkey_listbasechannel(self, args):
 
     details = self.client.activationkey.getDetails(self.session, key)
 
-    print(details.get("base_channel_label"))
+    print(details.get('base_channel_label'))
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_listgroups(self):
-    print(_("activationkey_listgroups: List the groups for an " + "activation key"))
-    print(_("usage: activationkey_listgroups KEY"))
+    print(_('activationkey_listgroups: List the groups for an ' +
+            'activation key'))
+    print(_('usage: activationkey_listgroups KEY'))
 
 
 def complete_activationkey_listgroups(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_listgroups(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -528,36 +470,29 @@ def do_activationkey_listgroups(self, args):
 
     details = self.client.activationkey.getDetails(self.session, key)
 
-    for group in details.get("server_group_ids"):
-        group_details = self.client.systemgroup.getDetails(self.session, group)
-        print(group_details.get("name"))
+    for group in details.get('server_group_ids'):
+        group_details = self.client.systemgroup.getDetails(self.session,
+                                                           group)
+        print(group_details.get('name'))
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_listentitlements(self):
-    print(
-        _(
-            "activationkey_listentitlements: List the entitlements "
-            + "for an activation key"
-        )
-    )
-    print(_("usage: activationkey_listentitlements KEY"))
+    print(_('activationkey_listentitlements: List the entitlements ' +
+            'for an activation key'))
+    print(_('usage: activationkey_listentitlements KEY'))
 
 
 def complete_activationkey_listentitlements(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_listentitlements(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -568,30 +503,27 @@ def do_activationkey_listentitlements(self, args):
 
     details = self.client.activationkey.getDetails(self.session, key)
 
-    if details.get("entitlements"):
-        print("\n".join(details.get("entitlements")))
+    if details.get('entitlements'):
+        print('\n'.join(details.get('entitlements')))
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_listpackages(self):
-    print(_("activationkey_listpackages: List the packages for an " + "activation key"))
-    print(_("usage: activationkey_listpackages KEY"))
+    print(_('activationkey_listpackages: List the packages for an ' +
+            'activation key'))
+    print(_('usage: activationkey_listpackages KEY'))
 
 
 def complete_activationkey_listpackages(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_listpackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -602,41 +534,30 @@ def do_activationkey_listpackages(self, args):
 
     details = self.client.activationkey.getDetails(self.session, key)
 
-    for package in sorted(
-        details.get("packages"), key=lambda x: (x["name"]), reverse=True
-    ):
-        if "arch" in package:
-            # pylint: disable-next=consider-using-f-string
-            print("%s.%s" % (package["name"], package["arch"]))
+    for package in sorted(details.get('packages'), key=lambda x: (x['name']), reverse=True):
+        if 'arch' in package:
+            print('%s.%s' % (package['name'], package['arch']))
         else:
-            print(package["name"])
+            print(package['name'])
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_listconfigchannels(self):
-    print(
-        _(
-            "activationkey_listconfigchannels: List the configuration "
-            + "channels for an activation key"
-        )
-    )
-    print(_("usage: activationkey_listconfigchannels KEY"))
+    print(_('activationkey_listconfigchannels: List the configuration ' +
+            'channels for an activation key'))
+    print(_('usage: activationkey_listconfigchannels KEY'))
 
 
 def complete_activationkey_listconfigchannels(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_listconfigchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -645,57 +566,46 @@ def do_activationkey_listconfigchannels(self, args):
 
     key = args[0]
 
-    channels = self.client.activationkey.listConfigChannels(self.session, key)
+    channels = \
+        self.client.activationkey.listConfigChannels(self.session,
+                                                     key)
 
-    channels = sorted([c.get("label") for c in channels])
+    channels = sorted([c.get('label') for c in channels])
 
     if channels:
-        print("\n".join(channels))
+        print('\n'.join(channels))
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_addconfigchannels(self):
-    print(
-        _(
-            "activationkey_addconfigchannels: Add config channels "
-            + "to an activation key"
-        )
-    )
-    print(
-        _(
-            """usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])
+    print(_('activationkey_addconfigchannels: Add config channels ' +
+            'to an activation key'))
+    print(_('''usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])
 
 options:
   -t add channels to the top of the list
-  -b add channels to the bottom of the list"""
-        )
-    )
+  -b add channels to the bottom of the list'''))
 
 
 def complete_activationkey_addconfigchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True), text)
 
     return None
 
 
 def do_activationkey_addconfigchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-t", "--top", action="store_true")
-    arg_parser.add_argument("-b", "--bottom", action="store_true")
+    arg_parser.add_argument('-t', '--top', action='store_true')
+    arg_parser.add_argument('-b', '--bottom', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -705,11 +615,9 @@ def do_activationkey_addconfigchannels(self, args):
     key = [args.pop(0)]
     channels = args
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        answer = prompt_user("Add to top or bottom? [T/b]:")
-        if re.match("b", answer, re.I):
+        answer = prompt_user('Add to top or bottom? [T/b]:')
+        if re.match('b', answer, re.I):
             options.top = False
         else:
             options.top = True
@@ -719,49 +627,41 @@ def do_activationkey_addconfigchannels(self, args):
         else:
             options.top = True
 
-    self.client.activationkey.addConfigChannels(
-        self.session, key, channels, options.top
-    )
+    self.client.activationkey.addConfigChannels(self.session,
+                                                key,
+                                                channels,
+                                                options.top)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_removeconfigchannels(self):
-    print(
-        _(
-            "activationkey_removeconfigchannels: Remove config channels "
-            + "from an activation key"
-        )
-    )
-    print(_("usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"))
+    print(_('activationkey_removeconfigchannels: Remove config channels ' +
+            'from an activation key'))
+    print(_('usage: activationkey_removeconfigchannels KEY <CHANNEL ...>'))
 
 
 def complete_activationkey_removeconfigchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
-        key_channels = self.client.activationkey.listConfigChannels(
-            self.session, parts[1]
-        )
+        key_channels = \
+            self.client.activationkey.listConfigChannels(self.session,
+                                                         parts[1])
 
-        config_channels = [c.get("label") for c in key_channels]
-        # pylint: disable-next=undefined-variable
+        config_channels = [c.get('label') for c in key_channels]
         return tab_completer(config_channels, text)
 
     return None
 
 
 def do_activationkey_removeconfigchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -771,34 +671,29 @@ def do_activationkey_removeconfigchannels(self, args):
     key = [args.pop(0)]
     channels = args
 
-    self.client.activationkey.removeConfigChannels(self.session, key, channels)
+    self.client.activationkey.removeConfigChannels(self.session,
+                                                   key,
+                                                   channels)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_setconfigchannelorder(self):
-    print(
-        _(
-            "activationkey_setconfigchannelorder: Set the ranked order of "
-            + "configuration channels"
-        )
-    )
-    print(_("usage: activationkey_setconfigchannelorder KEY"))
+    print(_('activationkey_setconfigchannelorder: Set the ranked order of ' +
+            'configuration channels'))
+    print(_('usage: activationkey_setconfigchannelorder KEY'))
 
 
-def complete_activationkey_setconfigchannelorder(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+def complete_activationkey_setconfigchannelorder(self, text, line, beg,
+                                                 end):
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_setconfigchannelorder(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -809,135 +704,118 @@ def do_activationkey_setconfigchannelorder(self, args):
 
     # get the current configuration channels from the first activationkey
     # in the list
-    new_channels = self.client.activationkey.listConfigChannels(self.session, key)
-    new_channels = [c.get("label") for c in new_channels]
+    new_channels = \
+        self.client.activationkey.listConfigChannels(self.session, key)
+    new_channels = [c.get('label') for c in new_channels]
 
     # call an interface for the user to make selections
-    all_channels = self.do_configchannel_list("", True)
-    # pylint: disable-next=undefined-variable
+    all_channels = self.do_configchannel_list('', True)
     new_channels = config_channel_order(all_channels, new_channels)
 
-    print("")
-    print(_("New Configuration Channels:"))
+    print('')
+    print(_('New Configuration Channels:'))
     for i, new_channel in enumerate(new_channels, 1):
-        # pylint: disable-next=consider-using-f-string
-        print("[%i] %s" % (i, new_channel))
+        print('[%i] %s' % (i, new_channel))
 
-    self.client.activationkey.setConfigChannels(self.session, [key], new_channels)
+    self.client.activationkey.setConfigChannels(self.session,
+                                                [key],
+                                                new_channels)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_create(self):
-    print(_("activationkey_create: Create an activation key"))
-    print(
-        _(
-            """usage: activationkey_create [options])
+    print(_('activationkey_create: Create an activation key'))
+    print(_('''usage: activationkey_create [options])
 
 options:
   -n NAME
   -d DESCRIPTION
   -b BASE_CHANNEL
   -u set key as universal default
-  -e [enterprise_entitled,virtualization_host]"""
-        )
-    )
+  -e [enterprise_entitled,virtualization_host]'''))
 
 
 def do_activationkey_create(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-d", "--description")
-    arg_parser.add_argument("-b", "--base-channel")
-    arg_parser.add_argument("-e", "--entitlements")
-    arg_parser.add_argument("-u", "--universal", action="store_true")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-d', '--description')
+    arg_parser.add_argument('-b', '--base-channel')
+    arg_parser.add_argument('-e', '--entitlements')
+    arg_parser.add_argument('-u', '--universal', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Name (blank to autogenerate):"))
-        # pylint: disable-next=undefined-variable
-        options.description = prompt_user(_("Description [None]:"))
+        options.name = prompt_user(_('Name (blank to autogenerate):'))
+        options.description = prompt_user(_('Description [None]:'))
 
-        print("")
-        print(_("Base Channels"))
-        print("-------------")
-        print("\n".join(sorted(self.list_base_channels())))
-        print("")
+        print('')
+        print(_('Base Channels'))
+        print('-------------')
+        print('\n'.join(sorted(self.list_base_channels())))
+        print('')
 
-        # pylint: disable-next=undefined-variable
-        options.base_channel = prompt_user(_("Base Channel (blank for default):"))
+        options.base_channel = prompt_user(_('Base Channel (blank for default):'))
 
         options.entitlements = []
 
         for e in self.ENTITLEMENTS:
-            if e == "enterprise_entitled":
+            if e == 'enterprise_entitled':
                 continue
 
-            if self.user_confirm(_("%s Entitlement [y/N]:") % e, ignore_yes=True):
+            if self.user_confirm(_('%s Entitlement [y/N]:') % e,
+                                 ignore_yes=True):
                 options.entitlements.append(e)
 
-        options.universal = self.user_confirm(
-            _("Universal Default [y/N]:"), ignore_yes=True
-        )
+        options.universal = self.user_confirm(_('Universal Default [y/N]:'),
+                                              ignore_yes=True)
     else:
         if not options.name:
-            options.name = ""
+            options.name = ''
         if not options.description:
-            options.description = ""
+            options.description = ''
         if not options.base_channel:
-            options.base_channel = ""
+            options.base_channel = ''
         if not options.universal:
             options.universal = False
         if options.entitlements:
-            options.entitlements = options.entitlements.split(",")
+            options.entitlements = options.entitlements.split(',')
 
             # remove empty strings from the list
-            if "" in options.entitlements:
-                options.entitlements.remove("")
+            if '' in options.entitlements:
+                options.entitlements.remove('')
         else:
             options.entitlements = []
 
-    new_key = self.client.activationkey.create(
-        self.session,
-        options.name,
-        options.description,
-        options.base_channel,
-        options.entitlements,
-        options.universal,
-    )
+    new_key = self.client.activationkey.create(self.session,
+                                               options.name,
+                                               options.description,
+                                               options.base_channel,
+                                               options.entitlements,
+                                               options.universal)
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Created activation key %s") % new_key)
+    logging.info(_N('Created activation key %s') % new_key)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_delete(self):
-    print(_("activationkey_delete: Delete an activation key"))
-    print(_("usage: activationkey_delete KEY"))
+    print(_('activationkey_delete: Delete an activation key'))
+    print(_('usage: activationkey_delete KEY'))
 
 
 def complete_activationkey_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -945,36 +823,32 @@ def do_activationkey_delete(self, args):
         return 1
 
     # allow globbing of activationkey names
-    # pylint: disable-next=undefined-variable
-    keys = filter_results(self.do_activationkey_list("", True), args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("activationkey_delete called with args %s, keys=%s" % (args, keys))
+    keys = filter_results(self.do_activationkey_list('', True), args)
+    logging.debug("activationkey_delete called with args %s, keys=%s" %
+                  (args, keys))
 
     if not keys:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confimation
-    print("\n".join(sorted(keys)))
+    print('\n'.join(sorted(keys)))
 
-    if not self.user_confirm(_("Delete activation key(s) [y/N]:")):
+    if not self.user_confirm(_('Delete activation key(s) [y/N]:')):
         return 1
 
     for key in keys:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Deleting key %s" % key)
         self.client.activationkey.delete(self.session, key)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_list(self):
-    print(_("activationkey_list: List all activation keys"))
-    print(_("usage: activationkey_list"))
+    print(_('activationkey_list: List all activation keys'))
+    print(_('usage: activationkey_list'))
 
 
 def do_activationkey_list(self, args, doreturn=False):
@@ -983,36 +857,32 @@ def do_activationkey_list(self, args, doreturn=False):
     keys = []
     for k in all_keys:
         # don't list auto-generated re-activation keys
-        if not re.match("Kickstart re-activation", k.get("description")):
-            keys.append(k.get("key"))
+        if not re.match('Kickstart re-activation', k.get('description')):
+            keys.append(k.get('key'))
 
     if doreturn:
         return keys
     else:
         if keys:
-            print("\n".join(sorted(keys)))
+            print('\n'.join(sorted(keys)))
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_listsystems(self):
-    print(_("activationkey_listsystems: List systems registered with a key"))
-    print(_("usage: activationkey_listsystems KEY"))
+    print(_('activationkey_listsystems: List systems registered with a key'))
+    print(_('usage: activationkey_listsystems KEY'))
 
 
 def complete_activationkey_listsystems(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_listsystems(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1022,38 +892,35 @@ def do_activationkey_listsystems(self, args):
     key = args[0]
 
     try:
-        systems = self.client.activationkey.listActivatedSystems(self.session, key)
+        systems = \
+            self.client.activationkey.listActivatedSystems(self.session,
+                                                           key)
     except xmlrpclib.Fault:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("%s is not a valid activation key") % key)
+        logging.warning(_N('%s is not a valid activation key') % key)
         return 1
 
-    systems = sorted([s.get("hostname") for s in systems])
+    systems = sorted([s.get('hostname') for s in systems])
 
     if systems:
-        print("\n".join(systems))
+        print('\n'.join(systems))
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_details(self):
-    print(_("activationkey_details: Show the details of an activation key"))
-    print(_("usage: activationkey_details KEY ..."))
+    print(_('activationkey_details: Show the details of an activation key'))
+    print(_('usage: activationkey_details KEY ...'))
 
 
 def complete_activationkey_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1065,79 +932,72 @@ def do_activationkey_details(self, args):
     result = []
     for key in args:
         try:
-            details = self.client.activationkey.getDetails(self.session, key)
-            config_channels = self.client.activationkey.listConfigChannels(
-                self.session, key
-            )
+            details = self.client.activationkey.getDetails(self.session,
+                                                           key)
+            config_channels = \
+                self.client.activationkey.listConfigChannels(
+                    self.session, key)
 
-            config_channel_deploy = self.client.activationkey.checkConfigDeployment(
-                self.session, key
-            )
+            config_channel_deploy = \
+                self.client.activationkey.checkConfigDeployment(
+                    self.session, key)
 
             # API returns 0/1 instead of boolean
             config_channel_deploy = config_channel_deploy == 1
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s is not a valid activation key") % key)
+            logging.warning(_N('%s is not a valid activation key') % key)
             return None
 
         groups = []
-        for group in details.get("server_group_ids"):
-            group_details = self.client.systemgroup.getDetails(self.session, group)
-            groups.append(group_details.get("name"))
+        for group in details.get('server_group_ids'):
+            group_details = self.client.systemgroup.getDetails(self.session,
+                                                               group)
+            groups.append(group_details.get('name'))
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        result.append(_("Key:                    %s") % details.get("key"))
-        result.append(_("Description:            %s") % details.get("description"))
-        result.append(
-            _("Universal Default:      %s") % details.get("universal_default")
-        )
-        result.append(_("Usage Limit:            %s") % details.get("usage_limit"))
-        result.append(_("Deploy Config Channels: %s") % config_channel_deploy)
-        if "contact_method" in details:
-            result.append(
-                _("Contact Method:         %s") % details.get("contact_method")
-            )
+        result.append(_('Key:                    %s') % details.get('key'))
+        result.append(_('Description:            %s') % details.get('description'))
+        result.append(_('Universal Default:      %s') % details.get('universal_default'))
+        result.append(_('Usage Limit:            %s') % details.get('usage_limit'))
+        result.append(_('Deploy Config Channels: %s') % config_channel_deploy)
+        if 'contact_method' in details:
+            result.append(_('Contact Method:         %s') % details.get('contact_method'))
 
-        result.append("")
-        result.append(_("Software Channels"))
-        result.append("-----------------")
-        result.append(details.get("base_channel_label"))
+        result.append('')
+        result.append(_('Software Channels'))
+        result.append('-----------------')
+        result.append(details.get('base_channel_label'))
 
-        for channel in sorted(details.get("child_channel_labels")):
-            # pylint: disable-next=consider-using-f-string
-            result.append(" |-- %s" % channel)
+        for channel in sorted(details.get('child_channel_labels')):
+            result.append(' |-- %s' % channel)
 
-        result.append("")
-        result.append(_("Configuration Channels"))
-        result.append("----------------------")
+        result.append('')
+        result.append(_('Configuration Channels'))
+        result.append('----------------------')
         for channel in config_channels:
-            result.append(channel.get("label"))
+            result.append(channel.get('label'))
 
-        result.append("")
-        result.append(_("Entitlements"))
-        result.append("------------")
-        result.append("\n".join(sorted(details.get("entitlements"))))
+        result.append('')
+        result.append(_('Entitlements'))
+        result.append('------------')
+        result.append('\n'.join(sorted(details.get('entitlements'))))
 
-        result.append("")
-        result.append(_("System Groups"))
-        result.append("-------------")
-        result.append("\n".join(sorted(groups)))
+        result.append('')
+        result.append(_('System Groups'))
+        result.append('-------------')
+        result.append('\n'.join(sorted(groups)))
 
-        result.append("")
-        result.append(_("Packages"))
-        result.append("--------")
-        for package in sorted(
-            details.get("packages"), key=lambda x: (x["name"]), reverse=True
-        ):
-            name = package.get("name")
+        result.append('')
+        result.append(_('Packages'))
+        result.append('--------')
+        for package in sorted(details.get('packages'), key=lambda x: (x['name']), reverse=True):
+            name = package.get('name')
 
-            if package.get("arch"):
-                # pylint: disable-next=consider-using-f-string
-                name += ".%s" % package.get("arch")
+            if package.get('arch'):
+                name += '.%s' % package.get('arch')
 
             result.append(name)
     for entry in result:
@@ -1145,27 +1005,23 @@ def do_activationkey_details(self, args):
 
     return result
 
-
 ####################
 
 
 def help_activationkey_enableconfigdeployment(self):
-    print(
-        _("activationkey_enableconfigdeployment: Enable config " + "channel deployment")
-    )
-    print(_("usage: activationkey_enableconfigdeployment KEY"))
+    print(_('activationkey_enableconfigdeployment: Enable config ' +
+            'channel deployment'))
+    print(_('usage: activationkey_enableconfigdeployment KEY'))
 
 
-def complete_activationkey_enableconfigdeployment(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+def complete_activationkey_enableconfigdeployment(self, text, line, beg,
+                                                  end):
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_enableconfigdeployment(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1173,36 +1029,28 @@ def do_activationkey_enableconfigdeployment(self, args):
         return 1
 
     for key in args:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Enabling config file deployment for %s" % key)
+        logging.debug('Enabling config file deployment for %s' % key)
         self.client.activationkey.enableConfigDeployment(self.session, key)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_disableconfigdeployment(self):
-    print(
-        _(
-            "activationkey_disableconfigdeployment: Disable config "
-            + "channel deployment"
-        )
-    )
-    print(_("usage: activationkey_disableconfigdeployment KEY"))
+    print(_('activationkey_disableconfigdeployment: Disable config ' +
+            'channel deployment'))
+    print(_('usage: activationkey_disableconfigdeployment KEY'))
 
 
-def complete_activationkey_disableconfigdeployment(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+def complete_activationkey_disableconfigdeployment(self, text, line, beg,
+                                                   end):
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_disableconfigdeployment(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1210,44 +1058,34 @@ def do_activationkey_disableconfigdeployment(self, args):
         return 1
 
     for key in args:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Disabling config file deployment for %s" % key)
+        logging.debug('Disabling config file deployment for %s' % key)
         self.client.activationkey.disableConfigDeployment(self.session, key)
 
     return 0
-
 
 ####################
 
 
 def help_activationkey_setbasechannel(self):
-    print(
-        _(
-            "activationkey_setbasechannel: Set the base channel of an "
-            + "activation key"
-        )
-    )
-    print(_("usage: activationkey_setbasechannel KEY CHANNEL"))
+    print(_('activationkey_setbasechannel: Set the base channel of an ' +
+            'activation key'))
+    print(_('usage: activationkey_setbasechannel KEY CHANNEL'))
 
 
 def complete_activationkey_setbasechannel(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.list_base_channels(), text)
 
     return None
 
 
 def do_activationkey_setbasechannel(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -1257,46 +1095,40 @@ def do_activationkey_setbasechannel(self, args):
     key = args.pop(0)
     channel = args[0]
 
-    current_details = self.client.activationkey.getDetails(self.session, key)
+    current_details = self.client.activationkey.getDetails(self.session,
+                                                           key)
 
-    details = {
-        "description": current_details.get("description"),
-        "base_channel_label": channel,
-        "usage_limit": current_details.get("usage_limit"),
-        "universal_default": current_details.get("universal_default"),
-    }
+    details = {'description': current_details.get('description'),
+               'base_channel_label': channel,
+               'usage_limit': current_details.get('usage_limit'),
+               'universal_default':
+               current_details.get('universal_default')}
 
     # getDetails returns a usage_limit of 0 unlimited, which is then
     # interpreted literally as zero when passed into setDetails, doh!
     # Setting it to -1 seems to keep the usage limit unlimited
-    if details["usage_limit"] == 0:
-        details["usage_limit"] = -1
+    if details['usage_limit'] == 0:
+        details['usage_limit'] = -1
 
     self.client.activationkey.setDetails(self.session, key, details)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_setusagelimit(self):
-    print(
-        _(
-            "activationkey_setusagelimit: Set the usage limit of an "
-            + 'activation key, can be a number or "unlimited"'
-        )
-    )
-    print(_("usage: activationkey_setusagelimit KEY <usage limit>"))
-    print(_("usage: activationkey_setusagelimit KEY unlimited "))
+    print(_('activationkey_setusagelimit: Set the usage limit of an ' +
+            'activation key, can be a number or \"unlimited\"'))
+    print(_('usage: activationkey_setusagelimit KEY <usage limit>'))
+    print(_('usage: activationkey_setusagelimit KEY unlimited '))
 
 
 def complete_activationkey_setusagelimit(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     elif len(parts) > 2:
         return "unlimited"
 
@@ -1304,10 +1136,8 @@ def complete_activationkey_setusagelimit(self, text, line, beg, end):
 
 
 def do_activationkey_setusagelimit(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -1316,56 +1146,47 @@ def do_activationkey_setusagelimit(self, args):
 
     key = args.pop(0)
     usage_limit = -1
-    if args[0] == "unlimited":
-        # pylint: disable-next=undefined-variable,consider-using-f-string
+    if args[0] == 'unlimited':
         logging.debug("Setting usage for key %s unlimited" % key)
     else:
         try:
             usage_limit = int(args[0])
-            # pylint: disable-next=undefined-variable,consider-using-f-string
             logging.debug("Setting usage for key %s to %d" % (key, usage_limit))
         except ValueError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Couldn't convert argument %s to an integer") % args[0])
+            logging.error(_N("Couldn't convert argument %s to an integer") %
+                          args[0])
             self.help_activationkey_setusagelimit()
             return 1
 
-    current_details = self.client.activationkey.getDetails(self.session, key)
-    details = {
-        "description": current_details.get("description"),
-        "base_channel_label": current_details.get("base_channel_label"),
-        "usage_limit": usage_limit,
-        "universal_default": current_details.get("universal_default"),
-    }
+    current_details = self.client.activationkey.getDetails(self.session,
+                                                           key)
+    details = {'description': current_details.get('description'),
+               'base_channel_label':
+               current_details.get('base_channel_label'),
+               'usage_limit': usage_limit,
+               'universal_default':
+               current_details.get('universal_default')}
 
     self.client.activationkey.setDetails(self.session, key, details)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_setuniversaldefault(self):
-    print(
-        _(
-            "activationkey_setuniversaldefault: Set this key as the "
-            + "universal default"
-        )
-    )
-    print(_("usage: activationkey_setuniversaldefault KEY"))
+    print(_('activationkey_setuniversaldefault: Set this key as the ' +
+            'universal default'))
+    print(_('usage: activationkey_setuniversaldefault KEY'))
 
 
 def complete_activationkey_setuniversaldefault(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_setuniversaldefault(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1374,108 +1195,93 @@ def do_activationkey_setuniversaldefault(self, args):
 
     key = args.pop(0)
 
-    current_details = self.client.activationkey.getDetails(self.session, key)
+    current_details = self.client.activationkey.getDetails(self.session,
+                                                           key)
 
-    details = {
-        "description": current_details.get("description"),
-        "base_channel_label": current_details.get("base_channel_label"),
-        "usage_limit": current_details.get("usage_limit"),
-        "universal_default": True,
-    }
+    details = {'description': current_details.get('description'),
+               'base_channel_label':
+               current_details.get('base_channel_label'),
+               'usage_limit': current_details.get('usage_limit'),
+               'universal_default': True}
 
     # getDetails returns a usage_limit of 0 unlimited, which is then
     # interpreted literally as zero when passed into setDetails, doh!
     # Setting it to -1 seems to keep the usage limit unlimited
-    if details["usage_limit"] == 0:
-        details["usage_limit"] = -1
+    if details['usage_limit'] == 0:
+        details['usage_limit'] = -1
 
     self.client.activationkey.setDetails(self.session, key, details)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_export(self):
-    print(_("activationkey_export: Export activation key(s) to JSON format file"))
-    print(
-        _(
-            """usage: activationkey_export [options] [<KEY> ...])
+    print(_('activationkey_export: Export activation key(s) to JSON format file'))
+    print(_('''usage: activationkey_export [options] [<KEY> ...])
 
 options:
     -f outfile.json : specify an output filename, defaults to <KEY>.json
                       if exporting a single key, akeys.json for multiple keys,
                       or akey_all.json if no KEY specified (export ALL)
 
-Note : KEY list is optional, default is to export ALL keys """
-        )
-    )
+Note : KEY list is optional, default is to export ALL keys '''))
 
 
 def complete_activationkey_export(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def export_activationkey_getdetails(self, key):
     # Get the key details
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.info(_N("Getting activation key details for %s" % key))
     details = self.client.activationkey.getDetails(self.session, key)
 
     # Get the key config-channel data, add it to the existing details
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("activationkey.listConfigChannels %s" % key)
     ccdlist = []
     try:
-        ccdlist = self.client.activationkey.listConfigChannels(self.session, key)
+        ccdlist = self.client.activationkey.listConfigChannels(self.session,
+                                                               key)
     except xmlrpclib.Fault:
-        # pylint: disable-next=undefined-variable
-        logging.debug(
-            "activationkey.listConfigChannel threw an exeception, setting config_channels=False"
-        )
+        logging.debug("activationkey.listConfigChannel threw an exeception, setting config_channels=False")
 
-    cclist = [c["label"] for c in ccdlist]
-    # pylint: disable-next=undefined-variable,consider-using-f-string
+    cclist = [c['label'] for c in ccdlist]
     logging.debug("Got config channel label list of %s" % cclist)
-    details["config_channels"] = cclist
+    details['config_channels'] = cclist
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("activationkey.checkConfigDeployment %s" % key)
-    details["config_deploy"] = self.client.activationkey.checkConfigDeployment(
-        self.session, key
-    )
+    details['config_deploy'] = \
+        self.client.activationkey.checkConfigDeployment(self.session, key)
 
     # Get group details, as the server group IDs are not necessarily the same
     # across servers, so we need the group name on import
-    details["server_groups"] = []
-    if details["server_group_ids"]:
+    details['server_groups'] = []
+    if details['server_group_ids']:
         grp_detail_list = []
-        for grp in details["server_group_ids"]:
+        for grp in details['server_group_ids']:
             grp_details = self.client.systemgroup.getDetails(self.session, grp)
 
             if grp_details:
                 grp_detail_list.append(grp_details)
 
-        details["server_groups"] = [g["name"] for g in grp_detail_list]
+        details['server_groups'] = [g['name'] for g in grp_detail_list]
 
     # Now append the details dict describing the key to the specified file
     return details
 
 
 def do_activationkey_export(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     filename = ""
     if options.file is not None:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Passed filename do_activationkey_export %s" % options.file)
+        logging.debug("Passed filename do_activationkey_export %s" %
+                      options.file)
         filename = options.file
 
     # Get the list of keys to export and sort out the filename if required
@@ -1483,22 +1289,15 @@ def do_activationkey_export(self, args):
     if not args:
         if not filename:
             filename = "akey_all.json"
-        # pylint: disable-next=undefined-variable
         logging.info(_N("Exporting ALL activation keys to %s") % filename)
-        keys = self.do_activationkey_list("", True)
+        keys = self.do_activationkey_list('', True)
     else:
         # allow globbing of activationkey names
-        # pylint: disable-next=undefined-variable
-        keys = filter_results(self.do_activationkey_list("", True), args)
-        # pylint: disable-next=undefined-variable
-        logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "activationkey_export called with args %s, keys=%s"
-            % (args, keys)
-        )
+        keys = filter_results(self.do_activationkey_list('', True), args)
+        logging.debug("activationkey_export called with args %s, keys=%s" %
+                      (args, keys))
 
         if not keys:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("Invalid activation key passed"))
             return 1
 
@@ -1507,7 +1306,6 @@ def do_activationkey_export(self, args):
             # If we are exporting exactly one key, we default to keyname.json
             # otherwise, generic akeys.json name
             if len(keys) == 1:
-                # pylint: disable-next=consider-using-f-string
                 filename = "%s.json" % keys[0]
             else:
                 filename = "akeys.json"
@@ -1515,167 +1313,145 @@ def do_activationkey_export(self, args):
     # Dump as a list of dict
     keydetails_list = []
     for k in keys:
-        # pylint: disable-next=undefined-variable
         logging.info(_N("Exporting key %s to %s") % (k, filename))
         keydetails_list.append(self.export_activationkey_getdetails(k))
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("About to dump %d keys to %s" % (len(keydetails_list), filename))
+    logging.debug("About to dump %d keys to %s" %
+                  (len(keydetails_list), filename))
 
     # Check if filepath exists, if it is an existing file
     # we prompt the user for confirmation
-    # pylint: disable-next=undefined-variable
     if os.path.isfile(filename):
-        if not self.user_confirm(
-            _("File %s exists, confirm overwrite file? (y/n)") % filename
-        ):
+        if not self.user_confirm(_("File %s exists, confirm overwrite file? (y/n)") %
+                                 filename):
             return 1
 
-    # pylint: disable-next=undefined-variable
     if json_dump_to_file(keydetails_list, filename) is not True:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Failed to save exported keys to file: {}").format(filename))
         return 1
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_import(self):
-    print(_("activationkey_import: import activation key(s) from JSON file(s)"))
-    print(_("""usage: activationkey_import <JSONFILE ...>"""))
+    print(_('activationkey_import: import activation key(s) from JSON file(s)'))
+    print(_('''usage: activationkey_import <JSONFILE ...>'''))
 
 
 def do_activationkey_import(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No filename passed"))
         self.help_activationkey_import()
         return 1
 
     for filename in args:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Passed filename do_activationkey_import %s" % filename)
-        # pylint: disable-next=undefined-variable
         keydetails_list = json_read_from_file(filename)
 
         if not keydetails_list:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("Could not read json data from %s") % filename)
             return 1
 
         for keydetails in keydetails_list:
             if self.import_activationkey_fromdetails(keydetails) is not True:
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("Failed to import key %s") % keydetails["key"])
+                logging.error(_N("Failed to import key %s") %
+                              keydetails['key'])
                 return 1
 
     return 0
-
 
 # create a new key based on the dict from export_activationkey_getdetails
 
 
 def import_activationkey_fromdetails(self, keydetails):
     # First we check that an existing key with the same name does not exist
-    existing_keys = self.do_activationkey_list("", True)
+    existing_keys = self.do_activationkey_list('', True)
 
-    if keydetails["key"] in existing_keys:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("%s already exists! Skipping!") % keydetails["key"])
+    if keydetails['key'] in existing_keys:
+        logging.warning(_N("%s already exists! Skipping!") % keydetails['key'])
         return False
     else:
         # create the key, we need to drop the org prefix from the key name
-        keyname = re.sub("^[0-9]-", "", keydetails["key"])
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Found key %s, importing as %s" % (keydetails["key"], keyname))
+        keyname = re.sub('^[0-9]-', '', keydetails['key'])
+        logging.debug("Found key %s, importing as %s" %
+                      (keydetails['key'], keyname))
 
         # Channel label must be an empty-string for "Red Hat Satellite Default"
         # The export to json maps this to a unicode string "none"
         # To avoid changing the json format now, just fix it up here...
-        if keydetails["base_channel_label"] == "none":
-            keydetails["base_channel_label"] = ""
+        if keydetails['base_channel_label'] == "none":
+            keydetails['base_channel_label'] = ''
 
-        if keydetails["usage_limit"] != 0:
-            newkey = self.client.activationkey.create(
-                self.session,
-                keyname,
-                keydetails["description"],
-                keydetails["base_channel_label"],
-                keydetails["usage_limit"],
-                keydetails["entitlements"],
-                keydetails["universal_default"],
-            )
+        if keydetails['usage_limit'] != 0:
+            newkey = self.client.activationkey.create(self.session,
+                                                      keyname,
+                                                      keydetails['description'],
+                                                      keydetails['base_channel_label'],
+                                                      keydetails['usage_limit'],
+                                                      keydetails['entitlements'],
+                                                      keydetails['universal_default'])
         else:
-            newkey = self.client.activationkey.create(
-                self.session,
-                keyname,
-                keydetails["description"],
-                keydetails["base_channel_label"],
-                keydetails["entitlements"],
-                keydetails["universal_default"],
-            )
+            newkey = self.client.activationkey.create(self.session,
+                                                      keyname,
+                                                      keydetails['description'],
+                                                      keydetails['base_channel_label'],
+                                                      keydetails['entitlements'],
+                                                      keydetails['universal_default'])
         if not newkey:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to import key %s") % keyname)
+            logging.error(_N("Failed to import key %s") %
+                          keyname)
             return False
 
         # add child channels
-        self.client.activationkey.addChildChannels(
-            self.session, newkey, keydetails["child_channel_labels"]
-        )
+        self.client.activationkey.addChildChannels(self.session, newkey,
+                                                   keydetails['child_channel_labels'])
 
         # set config channel options and channels (missing are skipped)
-        if keydetails["config_deploy"] != 0:
-            self.client.activationkey.enableConfigDeployment(self.session, newkey)
+        if keydetails['config_deploy'] != 0:
+            self.client.activationkey.enableConfigDeployment(self.session,
+                                                             newkey)
         else:
-            self.client.activationkey.disableConfigDeployment(self.session, newkey)
+            self.client.activationkey.disableConfigDeployment(self.session,
+                                                              newkey)
 
-        if keydetails["config_channels"]:
-            self.client.activationkey.addConfigChannels(
-                self.session, [newkey], keydetails["config_channels"], False
-            )
+        if keydetails['config_channels']:
+            self.client.activationkey.addConfigChannels(self.session, [newkey],
+                                                        keydetails['config_channels'], False)
 
         # set groups (missing groups are created)
         gids = []
-        for grp in keydetails["server_groups"]:
+        for grp in keydetails['server_groups']:
             grpdetails = self.client.systemgroup.getDetails(self.session, grp)
             if grpdetails is None:
-                # pylint: disable-next=undefined-variable
                 logging.info(_N("System group %s doesn't exist, creating") % grp)
-                grpdetails = self.client.systemgroup.create(self.session, grp, grp)
-            gids.append(grpdetails.get("id"))
+                grpdetails = self.client.systemgroup.create(self.session, grp,
+                                                            grp)
+            gids.append(grpdetails.get('id'))
 
         if gids:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
             logging.debug("Adding groups %s to key %s" % (gids, newkey))
-            self.client.activationkey.addServerGroups(self.session, newkey, gids)
+            self.client.activationkey.addServerGroups(self.session, newkey,
+                                                      gids)
 
         # Finally add the package list
-        if keydetails["packages"]:
-            self.client.activationkey.addPackages(
-                self.session, newkey, keydetails["packages"]
-            )
+        if keydetails['packages']:
+            self.client.activationkey.addPackages(self.session, newkey,
+                                                  keydetails['packages'])
 
         return True
-
 
 ####################
 
 
 def help_activationkey_clone(self):
-    print(_("activationkey_clone: Clone an activation key"))
-    print(
-        _(
-            """usage examples:
+    print(_('activationkey_clone: Clone an activation key'))
+    print(_('''usage examples:
                  activationkey_clone foo_key -c bar_key
                  activationkey_clone foo_key1 foo_key2 -c prefix
                  activationkey_clone foo_key -x "s/foo/bar"
@@ -1686,73 +1462,57 @@ options:
                    keys
   -x "s/foo/bar" : Optional regex replacement, replaces foo with bar in the
                    clone description, base-channel label, child-channel
-                   labels, config-channel names """
-        )
-    )
+                   labels, config-channel names '''))
 
 
 def complete_activationkey_clone(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_activationkey_list("", True), text)
+    return tab_completer(self.do_activationkey_list('', True), text)
 
 
 def do_activationkey_clone(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-c", "--clonename")
-    arg_parser.add_argument("-x", "--regex")
+    arg_parser.add_argument('-c', '--clonename')
+    arg_parser.add_argument('-x', '--regex')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
-    allkeys = self.do_activationkey_list("", True)
+    allkeys = self.do_activationkey_list('', True)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        print("")
-        print(_("Activation Keys"))
-        print("------------------")
-        print("\n".join(sorted(allkeys)))
-        print("")
+        print('')
+        print(_('Activation Keys'))
+        print('------------------')
+        print('\n'.join(sorted(allkeys)))
+        print('')
 
         if len(args) == 1:
             print(_("Key to clone: %s") % args[0])
         else:
             # Clear out any args as interactive doesn't handle multiple keys
             args = []
-            # pylint: disable-next=undefined-variable
-            args.append(prompt_user(_("Original Key:"), noblank=True))
+            args.append(prompt_user(_('Original Key:'), noblank=True))
 
-        # pylint: disable-next=undefined-variable
-        options.clonename = prompt_user(_("Cloned Key:"), noblank=True)
+        options.clonename = prompt_user(_('Cloned Key:'), noblank=True)
     else:
         if not options.clonename and not options.regex:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("Error - must specify either -c or -x options!"))
             self.help_activationkey_clone()
             return 1
 
     if options.clonename in allkeys:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Key %s already exists") % options.clonename)
         return 1
 
     if not args:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Error no activationkey to clone passed!"))
         self.help_activationkey_clone()
         return 1
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got args=%s %d" % (args, len(args)))
     # allow globbing of configchannel channel names
-    # pylint: disable-next=undefined-variable
     akeys = filter_results(allkeys, args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Filtered akeys %s" % akeys)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("all akeys %s" % allkeys)
     for ak in akeys:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Cloning %s" % ak)
         # Replace the key-name with the clonename specified by the user
         keydetails = self.export_activationkey_getdetails(ak)
@@ -1764,129 +1524,93 @@ def do_activationkey_clone(self, args):
             # formatted like a sed-replacement, s/foo/bar
             findstr = options.regex.split("/")[1]
             replacestr = options.regex.split("/")[2]
-            # pylint: disable-next=undefined-variable
-            logging.debug(
-                # pylint: disable-next=consider-using-f-string
-                "Regex option with %s, replacing %s with %s"
-                % (options.regex, findstr, replacestr)
-            )
+            logging.debug("Regex option with %s, replacing %s with %s" %
+                          (options.regex, findstr, replacestr))
 
             # First we do the key name
-            newkey = re.sub(findstr, replacestr, keydetails["key"])
-            keydetails["key"] = newkey
+            newkey = re.sub(findstr, replacestr, keydetails['key'])
+            keydetails['key'] = newkey
 
             # Then the description
-            newdesc = re.sub(findstr, replacestr, keydetails["description"])
-            keydetails["description"] = newdesc
+            newdesc = re.sub(findstr, replacestr, keydetails['description'])
+            keydetails['description'] = newdesc
 
             # Then the base-channel label
-            newbasech = re.sub(findstr, replacestr, keydetails["base_channel_label"])
+            newbasech = re.sub(findstr, replacestr,
+                               keydetails['base_channel_label'])
             if newbasech in self.list_base_channels():
-                keydetails["base_channel_label"] = newbasech
+                keydetails['base_channel_label'] = newbasech
                 # Now iterate over any child-channel labels
                 # we have the new base-channel, we can check if the new child
                 # label exists under the new base-channel:
                 # If it doesn't we can only skip it and print(a warning)
-                all_childch = self.list_child_channels(
-                    system=None, parent=newbasech, subscribed=False
-                )
+                all_childch = self.list_child_channels(system=None,
+                                                       parent=newbasech, subscribed=False)
 
                 new_child_channel_labels = []
-                for c in keydetails["child_channel_labels"]:
+                for c in keydetails['child_channel_labels']:
                     newc = re.sub(findstr, replacestr, c)
                     if newc in all_childch:
-                        # pylint: disable-next=undefined-variable
-                        logging.debug(
-                            # pylint: disable-next=consider-using-f-string
-                            "Found child channel %s for key %s, "
-                            % (c, keydetails["key"])
-                            # pylint: disable-next=consider-using-f-string
-                            + "replacing with %s" % newc
-                        )
+                        logging.debug("Found child channel %s for key %s, " %
+                                      (c, keydetails['key']) +
+                                      "replacing with %s" % newc)
 
                         new_child_channel_labels.append(newc)
                     else:
-                        # pylint: disable-next=undefined-variable
-                        logging.warning(
-                            _N("Found child channel %s key %s, %s")
-                            % (c, keydetails["key"], newc)
-                            + _N(" does not exist, skipping!")
-                        )
+                        logging.warning(_N("Found child channel %s key %s, %s") %
+                                        (c, keydetails['key'], newc) +
+                                        _N(" does not exist, skipping!"))
 
-                # pylint: disable-next=undefined-variable
-                logging.debug(
-                    "Processed all child channels, "
-                    # pylint: disable-next=consider-using-f-string
-                    + "new_child_channel_labels=%s" % new_child_channel_labels
-                )
+                logging.debug("Processed all child channels, " +
+                              "new_child_channel_labels=%s" % new_child_channel_labels)
 
-                keydetails["child_channel_labels"] = new_child_channel_labels
+                keydetails['child_channel_labels'] = new_child_channel_labels
             else:
-                # pylint: disable-next=undefined-variable
-                logging.error(
-                    _N(
-                        "Regex-replacement results in new "
-                        + "base-channel %s which does not exist!"
-                    )
-                    % newbasech
-                )
+                logging.error(_N("Regex-replacement results in new " +
+                                 "base-channel %s which does not exist!") % newbasech)
 
             # Finally, any config-channels
             new_config_channels = []
-            allccs = self.do_configchannel_list("", True)
-            for cc in keydetails["config_channels"]:
+            allccs = self.do_configchannel_list('', True)
+            for cc in keydetails['config_channels']:
                 newcc = re.sub(findstr, replacestr, cc)
 
                 if newcc in allccs:
-                    # pylint: disable-next=undefined-variable
-                    logging.debug(
-                        # pylint: disable-next=consider-using-f-string
-                        "Found config channel %s for key %s, " % (cc, keydetails["key"])
-                        # pylint: disable-next=consider-using-f-string
-                        + "replacing with %s" % newcc
-                    )
+                    logging.debug("Found config channel %s for key %s, " %
+                                  (cc, keydetails['key']) +
+                                  "replacing with %s" % newcc)
 
                     new_config_channels.append(newcc)
                 else:
-                    # pylint: disable-next=undefined-variable
-                    logging.warning(
-                        _N("Found config channel %s for key %s, %s ")
-                        % (cc, keydetails["key"], newcc)
-                        + _N("does not exist, skipping!")
-                    )
+                    logging.warning(_N("Found config channel %s for key %s, %s ")
+                                    % (cc, keydetails['key'], newcc) +
+                                    _N("does not exist, skipping!"))
 
-            # pylint: disable-next=undefined-variable
-            logging.debug(
-                "Processed all config channels, "
-                # pylint: disable-next=consider-using-f-string
-                + "new_config_channels = %s" % new_config_channels
-            )
+            logging.debug("Processed all config channels, " +
+                          "new_config_channels = %s" % new_config_channels)
 
-            keydetails["config_channels"] = new_config_channels
+            keydetails['config_channels'] = new_config_channels
 
         # Not regex mode
         elif options.clonename:
             if len(akeys) > 1:
                 # We treat the clonename as a prefix for multiple keys
                 # However we need to insert the prefix after the org-
-                newkey = re.sub(
-                    r"^([0-9]-)", r"\1" + options.clonename, keydetails["key"]
-                )
-                keydetails["key"] = newkey
+                newkey = re.sub(r'^([0-9]-)', r'\1' + options.clonename,
+                                keydetails['key'])
+                keydetails['key'] = newkey
             else:
-                keydetails["key"] = options.clonename
+                keydetails['key'] = options.clonename
 
-        # pylint: disable-next=undefined-variable
-        logging.info(_N("Cloning key %s as %s") % (ak, keydetails["key"]))
+        logging.info(_N("Cloning key %s as %s") % (ak, keydetails['key']))
 
         # Finally : import the key from the modified keydetails dict
         if self.import_activationkey_fromdetails(keydetails) is not True:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to clone %s to %s") % (ak, keydetails["key"]))
+            logging.error(_N("Failed to clone %s to %s") %
+                          (ak, keydetails['key']))
             return 1
 
     return 0
-
 
 ####################
 # activationkey helper
@@ -1900,11 +1624,9 @@ def is_activationkey(self, name):
 
 def check_activationkey(self, name):
     if not name:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("no activationkey label given"))
         return False
     if not self.is_activationkey(name):
-        # pylint: disable-next=undefined-variable
         logging.error(_N("invalid activationkey label ") + name)
         return False
     return True
@@ -1914,41 +1636,35 @@ def dump_activationkey(self, name, replacedict=None, excludes=None):
     content = self.do_activationkey_details(name)
     if not excludes:
         excludes = ["Universal Default:"]
-    # pylint: disable-next=undefined-variable
     content = get_normalized_text(content, replacedict=replacedict, excludes=excludes)
 
     return content
-
 
 ####################
 
 
 def help_activationkey_diff(self):
-    print(_("activationkey_diff: Diff activation keys"))
-    print("")
-    print(_("usage: activationkey_diff SOURCE_KEY TARGET_KEY"))
+    print(_('activationkey_diff: Diff activation keys'))
+    print('')
+    print(_('usage: activationkey_diff SOURCE_KEY TARGET_KEY'))
 
 
 def complete_activationkey_diff(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     return []
 
 
 def do_activationkey_diff(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) not in [1, 2]:
@@ -1968,125 +1684,107 @@ def do_activationkey_diff(self, args):
     if not self.check_activationkey(target_channel):
         return None
 
-    # pylint: disable-next=undefined-variable
-    source_replacedict, target_replacedict = get_string_diff_dicts(
-        source_channel, target_channel
-    )
+    source_replacedict, target_replacedict = get_string_diff_dicts(source_channel, target_channel)
 
     source_data = self.dump_activationkey(source_channel, source_replacedict)
     target_data = self.dump_activationkey(target_channel, target_replacedict)
 
-    # pylint: disable-next=undefined-variable
     for line in diff(source_data, target_data, source_channel, target_channel):
         print(line)
-
 
 ####################
 
 
 def help_activationkey_disable(self):
-    print(_("activationkey_disable: Disable an activation key"))
-    print("")
-    print(_("usage: activationkey_disable KEY [KEY ...]"))
+    print(_('activationkey_disable: Disable an activation key'))
+    print('')
+    print(_('usage: activationkey_disable KEY [KEY ...]'))
 
 
 def complete_activationkey_disable(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) >= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
 
     return None
 
 
 def do_activationkey_disable(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 1:
         self.help_activationkey_disable()
         return 1
 
-    # pylint: disable-next=undefined-variable
-    keys = filter_results(self.do_activationkey_list("", True), args)
+    keys = filter_results(self.do_activationkey_list('', True), args)
 
-    details = {"disabled": True}
+    details = {'disabled': True}
 
     for akey in keys:
         self.client.activationkey.setDetails(self.session, akey, details)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_enable(self):
-    print(_("activationkey_enable: Enable an activation key"))
-    print("")
-    print(_("usage: activationkey_enable KEY [KEY ...]"))
+    print(_('activationkey_enable: Enable an activation key'))
+    print('')
+    print(_('usage: activationkey_enable KEY [KEY ...]'))
 
 
 def complete_activationkey_enable(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) >= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
 
     return None
 
 
 def do_activationkey_enable(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 1:
         self.help_activationkey_enable()
         return 1
 
-    # pylint: disable-next=undefined-variable
-    keys = filter_results(self.do_activationkey_list("", True), args)
+    keys = filter_results(self.do_activationkey_list('', True), args)
 
-    details = {"disabled": False}
+    details = {'disabled': False}
 
     for akey in keys:
         self.client.activationkey.setDetails(self.session, akey, details)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_setdescription(self):
-    print(_("activationkey_setdescription: Set the activation key description"))
-    print("")
-    print(_("usage: activationkey_setdescription KEY DESCRIPTION"))
+    print(_('activationkey_setdescription: Set the activation key description'))
+    print('')
+    print(_('usage: activationkey_setdescription KEY DESCRIPTION'))
 
 
 def complete_activationkey_setdescription(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
 
     return None
 
 
 def do_activationkey_setdescription(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -2094,52 +1792,43 @@ def do_activationkey_setdescription(self, args):
         return 1
 
     akey = args.pop(0)
-    description = " ".join(args)
+    description = ' '.join(args)
 
-    details = {"description": description}
+    details = {'description': description}
 
     self.client.activationkey.setDetails(self.session, akey, details)
 
     return 0
 
-
 ####################
 
 
 def help_activationkey_setcontactmethod(self):
-    print(
-        _(
-            "activationkey_setcontactmethod: Set the contact method to use for "
-            "systems registered with this key."
-        )
-    )
-    print(_("Available contact methods: ") + str(self.CONTACT_METHODS))
-    print(_("usage: activationkey_setcontactmethod KEY CONTACT_METHOD"))
+    print(_('activationkey_setcontactmethod: Set the contact method to use for ' \
+          'systems registered with this key.'))
+    print(_('Available contact methods: ') + str(self.CONTACT_METHODS))
+    print(_('usage: activationkey_setcontactmethod KEY CONTACT_METHOD'))
 
 
 def complete_activationkey_setcontactmethod(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True), text)
     else:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.CONTACT_METHODS, text)
 
 
 def do_activationkey_setcontactmethod(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) == 2:
         self.help_activationkey_setcontactmethod()
         return 1
 
-    details = {"contact_method": args.pop()}
+    details = {'contact_method': args.pop()}
     akey = args.pop()
 
     self.client.activationkey.setDetails(self.session, akey, details)

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -28,7 +27,6 @@
 import logging
 import sys
 import gettext
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -36,18 +34,15 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_api(self):
-    print(_("api: call server API with arguments directly"))
-    print(
-        _(
-            """usage: api [options] API_STRING)
+    print(_('api: call server API with arguments directly'))
+    print(_('''usage: api [options] API_STRING)
 
 options:
   -A, --args  Arguments for the API other than session id in comma separated
@@ -60,20 +55,16 @@ examples:
   api --args "sysgroup_A" systemgroup.listSystems
   api -A "rhel-i386-server-5,2011-04-01,2011-05-01" -F "%(name)s" \\
       channel.software.listAllPackages
-"""
-        )
-    )
+'''))
 
 
 def do_api(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-A", "--args", default="")
-    arg_parser.add_argument("-F", "--format", default="")
-    arg_parser.add_argument("-o", "--output", default="")
+    arg_parser.add_argument('-A', '--args', default='')
+    arg_parser.add_argument('-F', '--format', default='')
+    arg_parser.add_argument('-o', '--output', default='')
 
     # set glob = False otherwise repo filters cannot set wildcard characters
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser, glob=False)
 
     if not args:
@@ -81,12 +72,10 @@ def do_api(self, args):
         return
 
     api_name = args[0]
-    # pylint: disable-next=undefined-variable
     api_args = parse_api_args(options.args)
 
     if options.output:
         try:
-            # pylint: disable-next=unspecified-encoding
             output = open(options.output, "w")
         except IOError:
             logging.warning(_N("Could not open to write: %s"), options.output)
@@ -103,7 +92,7 @@ def do_api(self, args):
         return
 
     try:
-        if api_name in ["api.getVersion", "api.systemVersion"]:
+        if api_name in ['api.getVersion', 'api.systemVersion']:
             res = api(*api_args)
         else:
             res = api(self.session, *api_args)
@@ -115,13 +104,12 @@ def do_api(self, args):
             for r in res:
                 output.write(options.format % r + "\n")
         else:
-            # pylint: disable-next=undefined-variable
             json_dump(res, output, indent=2, cls=CustomJsonEncoder)
 
-        if output != sys.stdout:
+        if (output != sys.stdout):
             output.close()
 
     except xmlrpclib.Fault as e:
         logging.error(e)
-        if output != sys.stdout:
+        if (output != sys.stdout):
             output.close()

--- a/spacecmd/src/spacecmd/argumentparser.py
+++ b/spacecmd/src/spacecmd/argumentparser.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -37,6 +36,6 @@ from argparse import ArgumentParser
 
 
 class SpacecmdArgumentParser(ArgumentParser):
+
     def error(self, message):
-        # pylint: disable-next=broad-exception-raised
         raise Exception(message)

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -35,7 +34,6 @@ from datetime import datetime
 import base64
 import codecs
 import gettext
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -43,54 +41,48 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_configchannel_list(self):
-    print(_("configchannel_list: List all configuration channels"))
-    print(_("usage: configchannel_list"))
+    print(_('configchannel_list: List all configuration channels'))
+    print(_('usage: configchannel_list'))
 
 
 def do_configchannel_list(self, args, doreturn=False):
     channels = self.client.configchannel.listGlobals(self.session)
-    channels = sorted([c.get("label") for c in channels])
+    channels = sorted([c.get('label') for c in channels])
 
     if doreturn:
         return channels
     else:
         if channels:
-            print("\n".join(channels))
+            print('\n'.join(channels))
 
     return None
-
 
 ####################
 
 
 def help_configchannel_listsystems(self):
-    print(_("configchannel_listsystems: List the systems subscribed to a"))
-    print(_("                           configuration channel"))
-    print(_("usage: configchannel_listsystems CHANNEL"))
+    print(_('configchannel_listsystems: List the systems subscribed to a'))
+    print(_('                           configuration channel'))
+    print(_('usage: configchannel_listsystems CHANNEL'))
 
 
 def complete_configchannel_listsystems(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def do_configchannel_listsystems(self, args):
-    if not self.check_api_version("10.11"):
-        # pylint: disable-next=undefined-variable
+    if not self.check_api_version('10.11'):
         logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -99,38 +91,33 @@ def do_configchannel_listsystems(self, args):
 
     channel = args[0]
     systems = self.client.configchannel.listSubscribedSystems(self.session, channel)
-    systems = sorted([s.get("name") for s in systems])
+    systems = sorted([s.get('name') for s in systems])
 
     if systems:
-        print("\n".join(systems))
+        print('\n'.join(systems))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_configchannel_listgroups(self):
-    print(_("configchannel_listgroups: List the groups subscribed to a"))
-    print(_("                           configuration channel"))
-    print(_("usage: configchannel_listgroups CHANNEL"))
+    print(_('configchannel_listgroups: List the groups subscribed to a'))
+    print(_('                           configuration channel'))
+    print(_('usage: configchannel_listgroups CHANNEL'))
 
 
 def complete_configchannel_listgroups(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def do_configchannel_listgroups(self, args):
-    if not self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
+    if not self.check_api_version('25.0'):
         logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -139,33 +126,29 @@ def do_configchannel_listgroups(self, args):
 
     channel = args[0]
     groups = self.client.configchannel.listAssignedSystemGroups(self.session, channel)
-    groups = sorted([g.get("name") for g in groups])
+    groups = sorted([g.get('name') for g in groups])
 
     if groups:
-        print("\n".join(groups))
+        print('\n'.join(groups))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_configchannel_listfiles(self):
-    print(_("configchannel_listfiles: List the files in a config channel"))
-    print(_("usage: configchannel_listfiles CHANNEL ..."))
+    print(_('configchannel_listfiles: List the files in a config channel'))
+    print(_('usage: configchannel_listfiles CHANNEL ...'))
 
 
 def complete_configchannel_listfiles(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def do_configchannel_listfiles(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -173,42 +156,33 @@ def do_configchannel_listfiles(self, args, doreturn=False):
         return []
 
     for channel in args:
-        files = sorted(
-            [
-                f.get("path")
-                for f in self.client.configchannel.listFiles(self.session, channel)
-            ]
-        )
+        files = sorted([f.get('path') for f in self.client.configchannel.listFiles(self.session, channel)])
 
         if doreturn:
             return files
         else:
             if files:
-                print("\n".join(files))
+                print('\n'.join(files))
 
     return None
-
 
 ####################
 
 
 def help_configchannel_forcedeploy(self):
-    print(_("configchannel_forcedeploy: Forces a redeployment"))
-    print(_("                           of files within this channel"))
-    print(_("                           on all subscribed systems"))
-    print(_("usage: configchannel_forcedeploy CHANNEL"))
+    print(_('configchannel_forcedeploy: Forces a redeployment'))
+    print(_('                           of files within this channel'))
+    print(_('                           on all subscribed systems'))
+    print(_('usage: configchannel_forcedeploy CHANNEL'))
 
 
 def complete_configchannel_forcedeploy(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def do_configchannel_forcedeploy(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args or len(args) > 1:
@@ -218,57 +192,54 @@ def do_configchannel_forcedeploy(self, args):
     channel = args[0]
 
     files = self.client.configchannel.listFiles(self.session, channel)
-    files = [f["path"] for f in files if f.get("path")]
+    files = [f['path'] for f in files if f.get("path")]
 
     if not files:
-        print(_("No files within selected configchannel."))
+        print(_('No files within selected configchannel.'))
         return 1
     else:
         systems = self.client.configchannel.listSubscribedSystems(self.session, channel)
-        systems = sorted([s.get("name") for s in systems])
+        systems = sorted([s.get('name') for s in systems])
         if not systems:
-            print(_("Channel has no subscribed Systems"))
+            print(_('Channel has no subscribed Systems'))
             return 1
         else:
-            print(_("Force deployment of the following configfiles:"))
-            print("==============================================")
-            print("\n".join(files))
-            print(_("\nOn these systems:"))
-            print("=================")
-            print("\n".join(systems))
-    if self.user_confirm(_("Really force deployment [y/N]:")):
+            print(_('Force deployment of the following configfiles:'))
+            print('==============================================')
+            print('\n'.join(files))
+            print(_('\nOn these systems:'))
+            print('=================')
+            print('\n'.join(systems))
+    if self.user_confirm(_('Really force deployment [y/N]:')):
         self.client.configchannel.deployAllSystems(self.session, channel)
 
     return 0
-
 
 ####################
 
 
 def help_configchannel_filedetails(self):
-    print(_("configchannel_filedetails: Show the details of a file"))
-    print(_("in a configuration channel"))
-    print(_("usage: configchannel_filedetails CHANNEL FILE [REVISION]"))
+    print(_('configchannel_filedetails: Show the details of a file'))
+    print(_('in a configuration channel'))
+    print(_('usage: configchannel_filedetails CHANNEL FILE [REVISION]'))
 
 
 def complete_configchannel_filedetails(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
     if len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_listfiles(parts[1], True), text)
+        return tab_completer(
+            self.do_configchannel_listfiles(parts[1], True), text)
 
     return []
 
 
 def do_configchannel_filedetails(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not 4 > len(args) > 1:
@@ -282,93 +253,82 @@ def do_configchannel_filedetails(self, args):
         try:
             revision = int(args[2])
         except (ValueError, IndexError):
-            # pylint: disable-next=undefined-variable
             logging.error(_N("Invalid revision: %s"), args[2])
             return 1
 
     # the server return a null exception if an invalid file is passed
     valid_files = self.do_configchannel_listfiles(channel, True)
     if filename not in valid_files:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("%s is not in this configuration channel") % filename)
+        logging.warning(_N('%s is not in this configuration channel') % filename)
         return 1
 
     if revision:
-        details = self.client.configchannel.lookupFileInfo(
-            self.session, channel, filename, revision
-        )
+        details = self.client.configchannel.lookupFileInfo(self.session,
+                                                           channel,
+                                                           filename,
+                                                           revision)
     else:
-        results = self.client.configchannel.lookupFileInfo(
-            self.session, channel, [filename]
-        )
+        results = self.client.configchannel.lookupFileInfo(self.session,
+                                                           channel,
+                                                           [filename])
 
         # grab the first item since we only do one file
         details = results[0]
 
-    # pylint: disable-next=undefined-variable
     details = DictToDefault(details, default="N/A")
     result = []
-    result.append(_("Path:     %s") % details.get("path"))
-    result.append(_("Type:     %s") % details.get("type"))
-    result.append(_("Revision: %s") % details.get("revision"))
-    result.append(_("Created:  %s") % details.get("creation"))
-    result.append(_("Modified: %s") % details.get("modified"))
+    result.append(_('Path:     %s') % details.get('path'))
+    result.append(_('Type:     %s') % details.get('type'))
+    result.append(_('Revision: %s') % details.get('revision'))
+    result.append(_('Created:  %s') % details.get('creation'))
+    result.append(_('Modified: %s') % details.get('modified'))
 
-    if details.get("type") == "symlink":
-        result.append("")
-        result.append(_("Target Path:     %s") % details.get("target_path"))
+    if details.get('type') == 'symlink':
+        result.append('')
+        result.append(_('Target Path:     %s') % details.get('target_path'))
     else:
-        result.append("")
-        result.append(_("Owner:           %s") % details.get("owner"))
-        result.append(_("Group:           %s") % details.get("group"))
-        result.append(_("Mode:            %s") % details.get("permissions_mode"))
+        result.append('')
+        result.append(_('Owner:           %s') % details.get('owner'))
+        result.append(_('Group:           %s') % details.get('group'))
+        result.append(_('Mode:            %s') % details.get('permissions_mode'))
 
-    result.append(_("SELinux Context: %s") % details.get("selinux_ctx"))
+    result.append(_('SELinux Context: %s') % details.get('selinux_ctx'))
 
-    if details.get("type") == "file":
-        result.append(_("SHA256:          %s") % details.get("sha256"))
-        result.append(_("Binary:          %s") % details.get("binary"))
+    if details.get('type') == 'file':
+        result.append(_('SHA256:          %s') % details.get('sha256'))
+        result.append(_('Binary:          %s') % details.get('binary'))
 
-        if not details.get("binary"):
-            result.append("")
-            result.append(_("Contents"))
-            result.append("--------")
-            result.append(details.get("contents"))
+        if not details.get('binary'):
+            result.append('')
+            result.append(_('Contents'))
+            result.append('--------')
+            result.append(details.get('contents'))
 
     for line in result:
         print(line)
-
 
 ####################
 
 
 def help_configchannel_backup(self):
-    print(_("configchannel_backup: backup a config channel"))
-    print(
-        _(
-            """usage: configchannel_backup CHANNEL [OUTDIR])
+    print(_('configchannel_backup: backup a config channel'))
+    print(_('''usage: configchannel_backup CHANNEL [OUTDIR])
 
 OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL
-"""
-        )
-    )
+'''))
 
 
 def complete_configchannel_backup(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True), text)
 
     return None
 
-
 def do_configchannel_backup(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 1:
@@ -379,117 +339,88 @@ def do_configchannel_backup(self, args):
 
     # use an output base from the user if it was passed
     if len(args) == 2:
-        # pylint: disable-next=undefined-variable
         outputpath_base = datetime.now().strftime(os.path.expanduser(args[1]))
     else:
-        # pylint: disable-next=undefined-variable
-        outputpath_base = os.path.expanduser("~/spacecmd-backup/configchannel")
+        outputpath_base = os.path.expanduser('~/spacecmd-backup/configchannel')
 
         # make the final output path be <base>/date/channel
-        # pylint: disable-next=undefined-variable
-        outputpath_base = os.path.join(
-            outputpath_base, datetime.now().strftime("%Y-%m-%d"), channel
-        )
+        outputpath_base = os.path.join(outputpath_base,
+                                       datetime.now().strftime("%Y-%m-%d"),
+                                       channel)
 
     try:
-        # pylint: disable-next=undefined-variable
         if not os.path.isdir(outputpath_base):
-            # pylint: disable-next=undefined-variable
             os.makedirs(outputpath_base)
     except OSError as exc:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Could not create output directory: %s"), str(exc))
+        logging.error(_N('Could not create output directory: %s'), str(exc))
         return 1
 
     # the server return a null exception if an invalid file is passed
     valid_files = self.do_configchannel_listfiles(channel, True)
-    results = self.client.configchannel.lookupFileInfo(
-        self.session, channel, valid_files
-    )
+    results = self.client.configchannel.lookupFileInfo(self.session,
+                                                       channel,
+                                                       valid_files)
 
-    # pylint: disable-next=undefined-variable
     fh_path = os.path.join(outputpath_base, ".metainfo")
     try:
-        # pylint: disable-next=unspecified-encoding
-        fh = open(fh_path, "w")
+        fh = open(fh_path, 'w')
     except IOError as exc:
-        # pylint: disable-next=undefined-variable
         logging.error(_N('Could not create "%s" file: %s'), fh_path, str(exc))
         return 1
 
     for details in results:
-        dumpfile = outputpath_base + details.get("path")
+        dumpfile = outputpath_base + details.get('path')
         dumpdir = dumpfile
-        print(_("Output Path:   %s") % dumpfile)
-        # pylint: disable-next=consider-using-f-string
-        fh.write("[%s]\n" % details.get("path"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("type = %s\n" % details.get("type"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("revision = %s\n" % details.get("revision"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("creation = %s\n" % details.get("creation"))
-        # pylint: disable-next=consider-using-f-string
-        fh.write("modified = %s\n" % details.get("modified"))
+        print(_('Output Path:   %s') % dumpfile)
+        fh.write('[%s]\n' % details.get('path'))
+        fh.write('type = %s\n' % details.get('type'))
+        fh.write('revision = %s\n' % details.get('revision'))
+        fh.write('creation = %s\n' % details.get('creation'))
+        fh.write('modified = %s\n' % details.get('modified'))
 
-        if details.get("type") == "symlink":
-            # pylint: disable-next=consider-using-f-string
-            fh.write("target_path = %s\n" % details.get("target_path"))
+        if details.get('type') == 'symlink':
+            fh.write('target_path = %s\n' % details.get('target_path'))
         else:
-            # pylint: disable-next=consider-using-f-string
-            fh.write("owner = %s\n" % details.get("owner"))
-            # pylint: disable-next=consider-using-f-string
-            fh.write("group = %s\n" % details.get("group"))
-            # pylint: disable-next=consider-using-f-string
-            fh.write("permissions_mode = %s\n" % details.get("permissions_mode"))
+            fh.write('owner = %s\n' % details.get('owner'))
+            fh.write('group = %s\n' % details.get('group'))
+            fh.write('permissions_mode = %s\n' % details.get('permissions_mode'))
 
-        # pylint: disable-next=consider-using-f-string
-        fh.write("selinux_ctx = %s\n" % details.get("selinux_ctx"))
+        fh.write('selinux_ctx = %s\n' % details.get('selinux_ctx'))
 
-        if details.get("type") == "file":
-            # pylint: disable-next=undefined-variable
+        if details.get('type') == 'file':
             dumpdir = os.path.dirname(dumpfile)
 
-        # pylint: disable-next=undefined-variable
         if not os.path.isdir(dumpdir):
-            # pylint: disable-next=undefined-variable
             os.makedirs(dumpdir)
 
-        if details.get("type") == "file":
-            # pylint: disable-next=consider-using-f-string
-            fh.write("sha256 = %s\n" % details.get("sha256"))
-            # pylint: disable-next=consider-using-f-string
-            fh.write("binary = %s\n" % details.get("binary"))
-            # pylint: disable-next=unspecified-encoding
-            of = open(dumpfile, "w")
-            of.write(details.get("contents") or "")
+        if details.get('type') == 'file':
+            fh.write('sha256 = %s\n' % details.get('sha256'))
+            fh.write('binary = %s\n' % details.get('binary'))
+            of = open(dumpfile, 'w')
+            of.write(details.get('contents') or '')
             of.close()
 
-        fh.write("\n")
+        fh.write('\n')
 
     fh.close()
 
     return 0
 
-
 ####################
 
 
 def help_configchannel_details(self):
-    print(_("configchannel_details: Show the details of a config channel"))
-    print(_("usage: configchannel_details CHANNEL ..."))
+    print(_('configchannel_details: Show the details of a config channel'))
+    print(_('usage: configchannel_details CHANNEL ...'))
 
 
 def complete_configchannel_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def do_configchannel_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -500,120 +431,101 @@ def do_configchannel_details(self, args):
 
     result = []
     for channel in args:
-        details = self.client.configchannel.getDetails(self.session, channel)
+        details = self.client.configchannel.getDetails(self.session,
+                                                       channel)
 
-        files = self.client.configchannel.listFiles(self.session, channel)
+        files = self.client.configchannel.listFiles(self.session,
+                                                    channel)
 
         if add_separator:
             result.append(self.SEPARATOR)
         add_separator = True
 
-        result.append(_("Label:       %s") % details.get("label"))
-        result.append(_("Name:        %s") % details.get("name"))
-        result.append(_("Description: %s") % details.get("description"))
-        result.append(
-            _("Type:        %s") % details.get("configChannelType", {}).get("label")
-        )
+        result.append(_('Label:       %s') % details.get('label'))
+        result.append(_('Name:        %s') % details.get('name'))
+        result.append(_('Description: %s') % details.get('description'))
+        result.append(_('Type:        %s') % details.get('configChannelType', {}).get('label'))
 
-        result.append("")
-        result.append(_("Files"))
-        result.append("-----")
+        result.append('')
+        result.append(_('Files'))
+        result.append('-----')
         for f in files:
-            result.append(f.get("path"))
+            result.append(f.get('path'))
     return result
-
 
 ####################
 
 
 def help_configchannel_create(self):
-    print(_("configchannel_create: Create a configuration channel of specific type"))
-    print(
-        _(
-            """usage: configchannel_create [options])
+    print(_('configchannel_create: Create a configuration channel of specific type'))
+    print(_('''usage: configchannel_create [options])
 
 options:
   -n NAME
   -l LABEL
   -d DESCRIPTION
-  -t TYPE('normal,'state')"""
-        )
-    )
+  -t TYPE('normal,'state')'''))
 
 
 def do_configchannel_create(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-l", "--label")
-    arg_parser.add_argument("-d", "--description")
-    arg_parser.add_argument("-t", "--type")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-l', '--label')
+    arg_parser.add_argument('-d', '--description')
+    arg_parser.add_argument('-t', '--type')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.label = prompt_user(_("Label:"))
-        # pylint: disable-next=undefined-variable
-        options.description = prompt_user(_("Description:"))
-        # pylint: disable-next=undefined-variable
-        options.type = prompt_user(_("Type [normal, state]:"))
+        options.name = prompt_user(_('Name:'), noblank=True)
+        options.label = prompt_user(_('Label:'))
+        options.description = prompt_user(_('Description:'))
+        options.type = prompt_user(_('Type [normal, state]:'))
 
-        if options.label == "":
+        if options.label == '':
             options.label = options.name
-        if options.description == "":
+        if options.description == '':
             options.description = options.name
-        if options.type not in ("normal", "state"):
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Only [normal/state] values are acceptable for type"))
+        if options.type not in ('normal', 'state'):
+            logging.error(_N('Only [normal/state] values are acceptable for type'))
             return 1
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A name is required"))
+            logging.error(_N('A name is required'))
             return 1
         if not options.label:
             options.label = options.name
         if not options.description:
             options.description = options.name
         if not options.type:
-            options.type = "normal"
-        if options.type not in ("normal", "state"):
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N("Only [normal/state] values are acceptable for --type parameter")
-            )
+            options.type = 'normal'
+        if options.type not in ('normal', 'state'):
+            logging.error(_N('Only [normal/state] values are acceptable for --type parameter'))
             return 1
 
-    self.client.configchannel.create(
-        self.session, options.label, options.name, options.description, options.type
-    )
+    self.client.configchannel.create(self.session,
+                                     options.label,
+                                     options.name,
+                                     options.description,
+                                     options.type)
 
     return 0
-
 
 ####################
 
 
 def help_configchannel_delete(self):
-    print(_("configchannel_delete: Delete a configuration channel"))
-    print(_("usage: configchannel_delete CHANNEL ..."))
+    print(_('configchannel_delete: Delete a configuration channel'))
+    print(_('usage: configchannel_delete CHANNEL ...'))
 
 
 def complete_configchannel_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def do_configchannel_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -621,28 +533,20 @@ def do_configchannel_delete(self, args):
         return 1
 
     # allow globbing of configchannel names
-    # pylint: disable-next=undefined-variable
-    channels = filter_results(self.do_configchannel_list("", True), args)
-    # pylint: disable-next=undefined-variable
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "configchannel_delete called with args %s, channels=%s"
-        % (args, channels)
-    )
+    channels = filter_results(self.do_configchannel_list('', True), args)
+    logging.debug("configchannel_delete called with args %s, channels=%s" % (args, channels))
 
     if not channels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No channels matched argument(s): %s") % ", ".join(args))
         return 1
 
     # Print the channels prior to the confirmation
-    print("\n".join(sorted(channels)))
+    print('\n'.join(sorted(channels)))
 
-    if self.user_confirm(_("Delete these channels [y/N]:")):
+    if self.user_confirm(_('Delete these channels [y/N]:')):
         self.client.configchannel.deleteChannels(self.session, channels)
 
     return 0
-
 
 ####################
 
@@ -657,43 +561,38 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
     # no file for this path exists already
 
     # initialize here instead of multiple times below
-    contents = ""
+    contents = ''
 
     if interactive:
         # use existing values if available
         if file_info:
             for info in file_info:
-                if info.get("path") == options.path:
-                    # pylint: disable-next=undefined-variable
-                    logging.debug("Found existing file in channel")
+                if info.get('path') == options.path:
+                    logging.debug('Found existing file in channel')
 
-                    options.owner = info.get("owner")
-                    options.group = info.get("group")
-                    options.mode = info.get("permissions_mode")
-                    options.target_path = info.get("target_path")
-                    options.selinux_ctx = info.get("selinux_ctx")
-                    contents = info.get("contents")
+                    options.owner = info.get('owner')
+                    options.group = info.get('group')
+                    options.mode = info.get('permissions_mode')
+                    options.target_path = info.get('target_path')
+                    options.selinux_ctx = info.get('selinux_ctx')
+                    contents = info.get('contents')
 
-                    if info.get("type") == "symlink":
+                    if info.get('type') == 'symlink':
                         options.symlink = True
 
         if not options.owner:
-            options.owner = "root"
+            options.owner = 'root'
         if not options.group:
-            options.group = "root"
+            options.group = 'root'
 
         # if this is a new file, ask if it's a symlink
         if not options.symlink:
-            # pylint: disable-next=undefined-variable
-            userinput = prompt_user(_("Symlink [y/N]:"))
-            # pylint: disable-next=undefined-variable
-            options.symlink = re.match("y", userinput, re.I)
+            userinput = prompt_user(_('Symlink [y/N]:'))
+            options.symlink = re.match('y', userinput, re.I)
 
         if options.symlink:
-            # pylint: disable-next=undefined-variable
-            target_input = prompt_user(_("Target Path:"), noblank=True)
-            # pylint: disable-next=undefined-variable
-            selinux_input = prompt_user(_("SELinux Context [none]:"))
+            target_input = prompt_user(_('Target Path:'), noblank=True)
+            selinux_input = prompt_user(_('SELinux Context [none]:'))
 
             if target_input:
                 options.target_path = target_input
@@ -701,29 +600,21 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
             if selinux_input:
                 options.selinux_ctx = selinux_input
         else:
-            # pylint: disable-next=undefined-variable
-            userinput = prompt_user(_("Directory [y/N]:"))
-            # pylint: disable-next=undefined-variable
-            options.directory = re.match("y", userinput, re.I)
+            userinput = prompt_user(_('Directory [y/N]:'))
+            options.directory = re.match('y', userinput, re.I)
 
             if not options.mode:
                 if options.directory:
-                    options.mode = "0755"
+                    options.mode = '0755'
                 else:
-                    options.mode = "0644"
+                    options.mode = '0644'
 
-            # pylint: disable-next=undefined-variable
-            owner_input = prompt_user(_("Owner [%s]:") % options.owner)
-            # pylint: disable-next=undefined-variable
-            group_input = prompt_user(_("Group [%s]:") % options.group)
-            # pylint: disable-next=undefined-variable
-            mode_input = prompt_user(_("Mode [%s]:") % options.mode)
-            # pylint: disable-next=undefined-variable
-            selinux_input = prompt_user(
-                _("SELinux Context [%s]:") % options.selinux_ctx
-            )
-            # pylint: disable-next=undefined-variable
-            revision_input = prompt_user(_("Revision [next]:"))
+            owner_input = prompt_user(_('Owner [%s]:') % options.owner)
+            group_input = prompt_user(_('Group [%s]:') % options.group)
+            mode_input = prompt_user(_('Mode [%s]:') % options.mode)
+            selinux_input = \
+                prompt_user(_('SELinux Context [%s]:') % options.selinux_ctx)
+            revision_input = prompt_user(_('Revision [next]:'))
 
             if owner_input:
                 options.owner = owner_input
@@ -741,144 +632,122 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                 try:
                     options.revision = int(revision_input)
                 except ValueError:
-                    # pylint: disable-next=undefined-variable
-                    logging.warning(_N("The revision must be an integer"))
+                    logging.warning(_N('The revision must be an integer'))
 
             if not options.directory:
-                if self.user_confirm(
-                    _("Read an existing file [y/N]:"), nospacer=True, ignore_yes=True
-                ):
-                    # pylint: disable-next=undefined-variable
-                    options.file = prompt_user(_("File:"))
+                if self.user_confirm(_('Read an existing file [y/N]:'),
+                                     nospacer=True, ignore_yes=True):
+                    options.file = prompt_user(_('File:'))
 
-                    # pylint: disable-next=undefined-variable
                     contents = read_file(options.file)
 
                     if options.binary is None and self.file_is_binary(options.file):
                         options.binary = True
-                        # pylint: disable-next=undefined-variable
                         logging.debug("Binary detected")
                     elif options.binary:
-                        # pylint: disable-next=undefined-variable
                         logging.debug("Binary selected")
                 else:
                     if contents:
                         template = contents
                     else:
-                        template = ""
+                        template = ''
 
-                    # pylint: disable-next=undefined-variable,unused-variable
                     (contents, _ignore) = editor(template=template, delete=True)
     else:
         if not options.path:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The path is required"))
+            logging.error(_N('The path is required'))
             return None
 
         if not options.symlink and not options.directory:
             if options.file:
-                # pylint: disable-next=undefined-variable
                 contents = read_file(options.file)
 
                 if options.binary is None:
                     options.binary = self.file_is_binary(options.file)
                     if options.binary:
-                        # pylint: disable-next=undefined-variable
                         logging.debug("Binary detected")
                 elif options.binary:
-                    # pylint: disable-next=undefined-variable
                     logging.debug("Binary selected")
             else:
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("You must provide the file contents"))
+                logging.error(_N('You must provide the file contents'))
                 return None
 
         if options.symlink and not options.target_path:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("You must provide the target path for a symlink"))
+            logging.error(_N('You must provide the target path for a symlink'))
             return None
 
     # selinux_ctx can't be None
     if not options.selinux_ctx:
-        options.selinux_ctx = ""
+        options.selinux_ctx = ''
 
     # directory can't be None
     if not options.directory:
         options.directory = False
 
     if options.symlink:
-        file_info = {
-            "target_path": options.target_path,
-            "selinux_ctx": options.selinux_ctx,
-        }
+        file_info = {'target_path': options.target_path,
+                     'selinux_ctx': options.selinux_ctx}
 
-        print(_("Path:            %s") % options.path)
-        print(_("Target Path:     %s") % file_info["target_path"])
-        print(_("SELinux Context: %s") % file_info["selinux_ctx"])
+        print(_('Path:            %s') % options.path)
+        print(_('Target Path:     %s') % file_info['target_path'])
+        print(_('SELinux Context: %s') % file_info['selinux_ctx'])
     else:
         if not options.owner:
-            options.owner = "root"
+            options.owner = 'root'
         if not options.group:
-            options.group = "root"
+            options.group = 'root'
         if not options.mode:
             if options.directory:
-                options.mode = "0755"
+                options.mode = '0755'
             else:
-                options.mode = "0644"
+                options.mode = '0644'
 
-        # pylint: disable-next=undefined-variable
         logging.debug("base64 encoding contents")
-        contents = base64.b64encode(contents.encode("utf8")).decode()
+        contents = base64.b64encode(contents.encode('utf8')).decode()
 
-        file_info = {
-            "contents": "".join(contents),
-            "owner": options.owner,
-            "group": options.group,
-            "selinux_ctx": options.selinux_ctx,
-            "permissions": options.mode,
-            "contents_enc64": True,
-            "binary": options.binary,
-        }
+        file_info = {'contents': ''.join(contents),
+                     'owner': options.owner,
+                     'group': options.group,
+                     'selinux_ctx': options.selinux_ctx,
+                     'permissions': options.mode,
+                     'contents_enc64': True,
+                     'binary': options.binary}
 
         # Binary set or detected
         if options.binary:
-            file_info["binary"] = True
+            file_info['binary'] = True
 
-        print(_("Path:            %s") % options.path)
-        print(_("Directory:       %s") % options.directory)
-        print(_("Owner:           %s") % file_info["owner"])
-        print(_("Group:           %s") % file_info["group"])
-        print(_("Mode:            %s") % file_info["permissions"])
-        print(_("Binary:          %s") % file_info["binary"])
-        print(_("SELinux Context: %s") % file_info["selinux_ctx"])
+        print(_('Path:            %s') % options.path)
+        print(_('Directory:       %s') % options.directory)
+        print(_('Owner:           %s') % file_info['owner'])
+        print(_('Group:           %s') % file_info['group'])
+        print(_('Mode:            %s') % file_info['permissions'])
+        print(_('Binary:          %s') % file_info['binary'])
+        print(_('SELinux Context: %s') % file_info['selinux_ctx'])
 
         # only add the revision field if the user supplied it
         if options.revision:
-            file_info["revision"] = int(options.revision)
-            print(_("Revision:        %i") % file_info["revision"])
+            file_info['revision'] = int(options.revision)
+            print(_('Revision:        %i') % file_info['revision'])
 
         if not options.directory:
-            print("")
+            print('')
             if options.binary:
-                print(_("Contents not displayed (base64 encoded)"))
+                print(_('Contents not displayed (base64 encoded)'))
             else:
-                print(_("Contents"))
-                print("--------")
-                if file_info["contents_enc64"]:
-                    print(base64.b64decode(file_info["contents"]))
+                print(_('Contents'))
+                print('--------')
+                if file_info['contents_enc64']:
+                    print(base64.b64decode(file_info['contents']))
                 else:
-                    print(file_info["contents"])
+                    print(file_info['contents'])
 
     return file_info
 
 
 def help_configchannel_addfile(self):
-    print(
-        _("configchannel_addfile/configchannel_updatefile: Create a configuration file")
-    )
-    print(
-        _(
-            """usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f LOCAL_FILE_PATH [OPTIONS])
+    print(_('configchannel_addfile/configchannel_updatefile: Create a configuration file'))
+    print(_('''usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f LOCAL_FILE_PATH [OPTIONS])
 
 options:
   -c CHANNEL
@@ -899,39 +768,33 @@ options:
   newlines, those containing ASCII escape characters (or other charaters not
   allowed in XML) need to be sent as binary (-b).  Some effort is made to auto-
   detect files which require this, but you may need to explicitly specify.
-"""
-        )
-    )
+'''))
 
 
 def complete_configchannel_addfile(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
-def do_configchannel_addfile(self, args, update_path=""):
-    # pylint: disable-next=undefined-variable
+def do_configchannel_addfile(self, args, update_path=''):
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-c", "--channel")
-    arg_parser.add_argument("-p", "--path")
-    arg_parser.add_argument("-o", "--owner")
-    arg_parser.add_argument("-g", "--group")
-    arg_parser.add_argument("-m", "--mode")
-    arg_parser.add_argument("-x", "--selinux-ctx")
-    arg_parser.add_argument("-t", "--target-path")
-    arg_parser.add_argument("-f", "--file")
-    arg_parser.add_argument("-r", "--revision")
-    arg_parser.add_argument("-s", "--symlink", action="store_true")
-    arg_parser.add_argument("-b", "--binary", action="store_true")
-    arg_parser.add_argument("-d", "--directory", action="store_true")
-    arg_parser.add_argument("-y", "--yes", action="store_true")
+    arg_parser.add_argument('-c', '--channel')
+    arg_parser.add_argument('-p', '--path')
+    arg_parser.add_argument('-o', '--owner')
+    arg_parser.add_argument('-g', '--group')
+    arg_parser.add_argument('-m', '--mode')
+    arg_parser.add_argument('-x', '--selinux-ctx')
+    arg_parser.add_argument('-t', '--target-path')
+    arg_parser.add_argument('-f', '--file')
+    arg_parser.add_argument('-r', '--revision')
+    arg_parser.add_argument('-s', '--symlink', action='store_true')
+    arg_parser.add_argument('-b', '--binary', action='store_true')
+    arg_parser.add_argument('-d', '--directory', action='store_true')
+    arg_parser.add_argument('-y', '--yes', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     file_info = None
 
-    # pylint: disable-next=undefined-variable
     interactive = is_interactive(options)
     if interactive:
         # the channel name can be passed in
@@ -939,131 +802,115 @@ def do_configchannel_addfile(self, args, update_path=""):
             options.channel = args[0]
         else:
             failures = 0
-            config_channels = sorted(self.do_configchannel_list("", True))
+            config_channels = sorted(self.do_configchannel_list('', True))
             while failures < 3:
-                print(_("Configuration Channels"))
-                print("----------------------")
-                print("\n".join(config_channels))
-                print("")
+                print(_('Configuration Channels'))
+                print('----------------------')
+                print('\n'.join(config_channels))
+                print('')
 
-                # pylint: disable-next=undefined-variable
-                options.channel = prompt_user(_("Select:"), noblank=True)
+                options.channel = prompt_user(_('Select:'), noblank=True)
 
                 # ensure the user enters a valid configuration channel
                 if options.channel in config_channels:
                     failures = 0
                     break
-                print("")
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("%s is not a valid channel"), options.channel)
-                print("")
+                print('')
+                logging.warning(_N('%s is not a valid channel'),
+                                options.channel)
+                print('')
                 failures += 1
             if failures > 0:
-                # pylint: disable-next=undefined-variable
                 logging.error(_N("Unable to obtain a valid channel. Aborting."))
                 return 1
 
         if update_path:
             options.path = update_path
         else:
-            # pylint: disable-next=undefined-variable
-            options.path = prompt_user(_("Path:"), noblank=True)
+            options.path = prompt_user(_('Path:'), noblank=True)
 
         # check if this file already exists
         try:
-            file_info = self.client.configchannel.lookupFileInfo(
-                self.session, options.channel, [options.path]
-            )
+            file_info = \
+                self.client.configchannel.lookupFileInfo(self.session,
+                                                         options.channel,
+                                                         [options.path])
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("No existing file information found for %s" % options.path)
+            logging.debug("No existing file information found for %s" %
+                          options.path)
             file_info = None
 
     file_info = self.configfile_getinfo(args, options, file_info, interactive)
 
     if not options.channel:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No config channel specified!"))
         self.help_configchannel_addfile()
         return 1
 
     if not file_info:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Error obtaining file info"))
         self.help_configchannel_addfile()
         return 1
 
     if options.yes or self.user_confirm():
         if options.symlink:
-            self.client.configchannel.createOrUpdateSymlink(
-                self.session, options.channel, options.path, file_info
-            )
+            self.client.configchannel.createOrUpdateSymlink(self.session,
+                                                            options.channel,
+                                                            options.path,
+                                                            file_info)
         else:
             # TODO: This should be removed
             # compatibility for Satellite 5.3
-            if not self.check_api_version("10.11"):
+            if not self.check_api_version('10.11'):
                 if "selinux_ctx" in file_info:
-                    del file_info["selinux_ctx"]
+                    del file_info['selinux_ctx']
 
-                if "revision" in file_info:
-                    del file_info["revision"]
+                if 'revision' in file_info:
+                    del file_info['revision']
 
             if options.directory:
-                if "contents" in file_info:
-                    del file_info["contents"]
-                if "contents_enc64" in file_info:
-                    del file_info["contents_enc64"]
-                if "binary" in file_info:
-                    del file_info["binary"]
+                if 'contents' in file_info:
+                    del file_info['contents']
+                if 'contents_enc64' in file_info:
+                    del file_info['contents_enc64']
+                if 'binary' in file_info:
+                    del file_info['binary']
 
             try:
-                self.client.configchannel.createOrUpdatePath(
-                    self.session,
-                    options.channel,
-                    options.path,
-                    options.directory,
-                    file_info,
-                )
+                self.client.configchannel.createOrUpdatePath(self.session,
+                                                             options.channel,
+                                                             options.path,
+                                                             options.directory,
+                                                             file_info)
             except xmlrpclib.Fault as exc:
-                # pylint: disable-next=undefined-variable
                 logging.error(exc)
                 return 1
 
     return 0
 
-
 ####################
 
-
 def help_configchannel_updateinitsls(self):
-    print(_("configchannel_updateinitsls: Update init.sls file"))
-    print(
-        _(
-            """usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])
+    print(_('configchannel_updateinitsls: Update init.sls file'))
+    print(_('''usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])
 
 options:
   -c CHANNEL
   -r REVISION
   -f local path to file contents
   -y automatically proceed with file contents
-"""
-        )
-    )
+'''))
 
-
-def do_configchannel_updateinitsls(self, args, update_path=""):
-    # pylint: disable-next=undefined-variable
+def do_configchannel_updateinitsls(self, args, update_path=''):
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-c", "--channel")
-    arg_parser.add_argument("-f", "--file")
-    arg_parser.add_argument("-r", "--revision")
-    arg_parser.add_argument("-y", "--yes", action="store_true")
-    # pylint: disable-next=undefined-variable
+    arg_parser.add_argument('-c', '--channel')
+    arg_parser.add_argument('-f', '--file')
+    arg_parser.add_argument('-r', '--revision')
+    arg_parser.add_argument('-y', '--yes', action='store_true')
     (args, options) = parse_command_arguments(args, arg_parser)
 
     file_info = None
     path = "/init.sls"
-    # pylint: disable-next=undefined-variable
     interactive = is_interactive(options)
     if interactive:
         # the channel name can be passed in
@@ -1071,99 +918,86 @@ def do_configchannel_updateinitsls(self, args, update_path=""):
             options.channel = args[0]
         else:
             while True:
-                print(_("Configuration Channels"))
-                print("----------------------")
-                print("\n".join(sorted(self.do_configchannel_list("", True))))
-                print("")
+                print(_('Configuration Channels'))
+                print('----------------------')
+                print('\n'.join(sorted(self.do_configchannel_list('', True))))
+                print('')
 
-                # pylint: disable-next=undefined-variable
-                options.channel = prompt_user("Select:", noblank=True)
+                options.channel = prompt_user('Select:', noblank=True)
 
                 # ensure the user enters a valid configuration channel
-                if options.channel in self.do_configchannel_list("", True):
+                if options.channel in self.do_configchannel_list('', True):
                     break
-                print("")
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("%s is not a valid channel"), options.channel)
-                print("")
+                print('')
+                logging.warning(_N('%s is not a valid channel'),
+                                options.channel)
+                print('')
         # check if this file already exists
         try:
-            file_info = self.client.configchannel.lookupFileInfo(
-                self.session, options.channel, [path]
-            )
+            file_info = \
+               self.client.configchannel.lookupFileInfo(self.session,
+                                                        options.channel,
+                                                        [path])
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N("No existing file information found for %s") % options.path
-            )
+            logging.error(_N("No existing file information found for %s") %
+                          options.path)
             return 1
-        contents = file_info[0].get("contents")
-        if self.user_confirm(
-            _("Read an existing file [y/N]:"), nospacer=True, ignore_yes=True
-        ):
-            # pylint: disable-next=undefined-variable
-            options.file = prompt_user("File:")
-            # pylint: disable-next=undefined-variable
+        contents = file_info[0].get('contents')
+        if self.user_confirm(_('Read an existing file [y/N]:'),
+                             nospacer=True, ignore_yes=True):
+            options.file = prompt_user('File:')
             contents = read_file(options.file)
             if self.file_is_binary(options.file):
-                # pylint: disable-next=undefined-variable
                 logging.debug("Binary selected")
         else:
             if contents:
                 template = contents
             else:
-                template = ""
-            # pylint: disable-next=undefined-variable,unused-variable
+                template = ''
             (contents, _ignore) = editor(template=template, delete=True)
 
-        # pylint: disable-next=undefined-variable
-        revision_input = prompt_user(_("Revision [next]:"))
+        revision_input = prompt_user(_('Revision [next]:'))
         if revision_input:
             try:
                 options.revision = int(revision_input)
             except ValueError:
-                # pylint: disable-next=undefined-variable
-                logging.warning(_("The revision must be an integer"))
+                logging.warning(_('The revision must be an integer'))
 
     else:
         if options.file:
-            # pylint: disable-next=undefined-variable
             contents = read_file(options.file)
         else:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("You must provide the file contents"))
+            logging.error(_N('You must provide the file contents'))
             return 1
 
-    contents = base64.b64encode(contents.encode("utf8")).decode()
+    contents = base64.b64encode(contents.encode('utf8')).decode()
 
-    file_info = {"contents": "".join(contents), "contents_enc64": True}
+    file_info = {'contents': ''.join(contents),
+                 'contents_enc64': True
+                }
     if options.revision:
-        file_info["revision"] = options.revision
+        file_info['revision'] = options.revision
+
 
     if not options.channel:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No config channel specified!"))
         self.help_configchannel_updateinitsls()
         return 1
 
     if not file_info:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Error obtaining file info"))
         self.help_configchannel_updateinitsls()
         return 1
-    if "revision" in file_info:
-        print(_("revision:                 %s") % file_info["revision"])
-    print(_("contents_enc64:           %s") % file_info["contents_enc64"])
-    print(_("Contents"))
-    print("--------")
-    print(base64.b64decode(file_info["contents"]))
+    if 'revision' in file_info:
+        print(_('revision:                 %s') % file_info['revision'])
+    print(_('contents_enc64:           %s') % file_info['contents_enc64'])
+    print(_('Contents'))
+    print('--------')
+    print(base64.b64decode(file_info['contents']))
     if options.yes or self.user_confirm():
-        self.client.configchannel.updateInitSls(
-            self.session, options.channel, file_info
-        )
+        self.client.configchannel.updateInitSls(self.session, options.channel, file_info)
 
     return 0
-
 
 ####################
 
@@ -1179,34 +1013,32 @@ def complete_configchannel_updatefile(self, text, line, beg, end):
 def do_configchannel_updatefile(self, args):
     return self.do_configchannel_addfile(args)
 
-
 ####################
 
 
 def help_configchannel_removefiles(self):
-    print(_("configchannel_removefiles: Remove configuration files"))
-    print(_("usage: configchannel_removefiles CHANNEL <FILE ...>"))
+    print(_('configchannel_removefiles: Remove configuration files'))
+    print(_('usage: configchannel_removefiles CHANNEL <FILE ...>'))
 
 
 def complete_configchannel_removefiles(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
     elif len(parts) > 2:
         channel = parts[1]
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_listfiles(channel, True), text)
+        return tab_completer(self.do_configchannel_listfiles(channel,
+                                                             True),
+                             text)
 
     return None
 
 
 def do_configchannel_removefiles(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1216,43 +1048,38 @@ def do_configchannel_removefiles(self, args):
     channel = args.pop(0)
     files = args
 
-    if self.options.yes or self.user_confirm("Remove these files [y/N]:"):
+    if self.options.yes or self.user_confirm('Remove these files [y/N]:'):
         self.client.configchannel.deleteFiles(self.session, channel, files)
 
     return 0
-
 
 ####################
 
 
 def help_configchannel_verifyfile(self):
-    print(_("configchannel_verifyfile: Verify a configuration file"))
-    print(_("usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"))
-    print("")
+    print(_('configchannel_verifyfile: Verify a configuration file'))
+    print(_('usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_configchannel_verifyfile(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True), text)
     elif len(parts) == 3:
         channel = parts[1]
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_listfiles(channel, True), text)
+        return tab_completer(self.do_configchannel_listfiles(channel, True),
+                             text)
     elif len(parts) > 3:
         return self.tab_complete_systems(text)
 
     return None
 
-
 def do_configchannel_verifyfile(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
@@ -1263,8 +1090,7 @@ def do_configchannel_verifyfile(self, args):
     path = args[1]
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[2], re.I):
+    if re.match('ssm', args[2], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args[2:])
@@ -1272,51 +1098,44 @@ def do_configchannel_verifyfile(self, args):
     system_ids = list(filter(None, (self.get_system_id(s) for s in systems)))
 
     if not system_ids:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("No valid system selected"))
+        logging.error(_N('No valid system selected'))
         return 1
-    action_id = self.client.configchannel.scheduleFileComparisons(
-        self.session, channel, path, system_ids
-    )
+    action_id = \
+        self.client.configchannel.scheduleFileComparisons(self.session,
+                                                          channel,
+                                                          path,
+                                                          system_ids)
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Action ID: %i") % action_id)
+    logging.info(_N('Action ID: %i') % action_id)
 
     return 0
-
 
 ####################
 
 
 def help_configchannel_export(self):
-    print(_("configchannel_export: export config channel(s) to json format file"))
-    print(
-        _(
-            """usage: configchannel_export <CHANNEL>... [options])
+    print(_('configchannel_export: export config channel(s) to json format file'))
+    print(_('''usage: configchannel_export <CHANNEL>... [options])
 options:
     -f outfile.json : specify an output filename, defaults to <CHANNEL>.json
                       if exporting a single channel, ccs.json for multiple
                       channels, or cc_all.json if no CHANNEL specified
                       e.g (export ALL)
 
-Note : CHANNEL list is optional, default is to export ALL"""
-        )
-    )
+Note : CHANNEL list is optional, default is to export ALL'''))
 
 
 def complete_configchannel_export(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def export_configchannel_getdetails(self, channel):
     # Get the cc details
-    # pylint: disable-next=undefined-variable
     logging.info(_N("Getting config channel details for %s") % channel)
     details = self.client.configchannel.getDetails(self.session, channel)
     files = self.client.configchannel.listFiles(self.session, channel)
-    details["files"] = []
-    paths = [f["path"] for f in files]
+    details['files'] = []
+    paths = [f['path'] for f in files]
     fileinfo = []
     # Some versions of the API blow up when lookupFileInfo is asked to
     # return details of files containing non-XML-valid characters.
@@ -1325,17 +1144,15 @@ def export_configchannel_getdetails(self, channel):
     # we can iterate over each file, then we just error on individual files
     # instead of failing to export anything at all...
     for p in paths:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Found file %s for %s" % (p, channel))
         try:
-            pinfo = self.client.configchannel.lookupFileInfo(self.session, channel, [p])
+            pinfo = self.client.configchannel.lookupFileInfo(self.session,
+                                                             channel, [p])
             if pinfo:
                 fileinfo.append(pinfo[0])
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N("Failed to get details for file %s from %s") % (p, channel)
-            )
+            logging.error(_N("Failed to get details for file %s from %s")
+                          % (p, channel))
     # Now we strip the datetime fields from the Info structs, as they
     # are not JSON serializable with the default encoder, and we don't
     # need them on import anyway
@@ -1363,74 +1180,51 @@ def export_configchannel_getdetails(self, channel):
     # string "macro-start-delimiter"  Y               N
     # string "macro-end-delimiter"    Y               N
     for f in fileinfo:
-        if f["type"] == "symlink":
-            for k in [
-                "contents",
-                "owner",
-                "group",
-                "permissions",
-                "macro-start-delimiter",
-                "macro-end-delimiter",
-            ]:
+
+        if f['type'] == 'symlink':
+            for k in ['contents', 'owner', 'group', 'permissions',
+                      'macro-start-delimiter', 'macro-end-delimiter']:
                 if k in f:
                     del f[k]
         else:
-            if "target_path" in f:
-                del f["target_path"]
-            f["permissions"] = str(f["permissions"])
+            if 'target_path' in f:
+                del f['target_path']
+            f['permissions'] = str(f['permissions'])
 
             # If we're using a recent API version files exported with no contents
             # i.e binary or non-xml encodable ascii files can be exported as
             # base64 encoded
-            if not "contents" in f:
-                if f["type"] != "directory":
-                    if not self.check_api_version("11.1"):
-                        # pylint: disable-next=undefined-variable
-                        logging.warning(
-                            _N("File %s could not be exported ") % f["path"]
-                            + _N("with this API version(needs base64 encoding)")
-                        )
+            if not 'contents' in f:
+                if f['type'] != 'directory':
+                    if not self.check_api_version('11.1'):
+                        logging.warning(_N("File %s could not be exported ") % f['path'] +
+                                        _N("with this API version(needs base64 encoding)"))
                     else:
-                        # pylint: disable-next=undefined-variable
-                        logging.info(
-                            _N("File %s could not be exported as") % f["path"]
-                            + _N(" text...getting base64 encoded version")
-                        )
+                        logging.info(_N("File %s could not be exported as") % f['path'] +
+                                     _N(" text...getting base64 encoded version"))
                         b64f = self.client.configchannel.getEncodedFileRevision(
-                            self.session, channel, f["path"], f["revision"]
-                        )
-                        f["contents"] = b64f["contents"]
-                        f["contents_enc64"] = b64f["contents_enc64"]
+                            self.session, channel, f['path'], f['revision'])
+                        f['contents'] = b64f['contents']
+                        f['contents_enc64'] = b64f['contents_enc64']
 
-        for k in [
-            "channel",
-            "revision",
-            "creation",
-            "modified",
-            "permissions_mode",
-            "sha256",
-        ]:
+        for k in ['channel', 'revision', 'creation', 'modified',
+                  'permissions_mode', 'sha256']:
             if k in f:
                 del f[k]
 
-    details["files"] = fileinfo
+    details['files'] = fileinfo
     return details
 
 
 def do_configchannel_export(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
 
     filename = ""
     if options.file is not None:
-        # pylint: disable-next=undefined-variable
-        logging.debug(
-            "Passed filename '%s' to do_configchannel_export command.", options.file
-        )
+        logging.debug("Passed filename '%s' to do_configchannel_export command.", options.file)
         filename = options.file
 
     # Get the list of ccs to export and sort out the filename if required
@@ -1438,30 +1232,21 @@ def do_configchannel_export(self, args):
     if not args:
         if not filename:
             filename = "cc_all.json"
-        # pylint: disable-next=undefined-variable
         logging.info(_N("Exporting ALL config channels to %s"), filename)
-        ccs = self.do_configchannel_list("", True)
+        ccs = self.do_configchannel_list('', True)
     else:
         # allow globbing of configchannel names
-        # pylint: disable-next=undefined-variable
-        ccs = filter_results(self.do_configchannel_list("", True), args)
-        # pylint: disable-next=undefined-variable
+        ccs = filter_results(self.do_configchannel_list('', True), args)
         logging.debug("configchannel_export called with args %s, ccs=%s", args, ccs)
         if not ccs:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N(
-                    "Error, no valid config channel passed, "
-                    "check name is  correct with spacecmd configchannel_list"
-                )
-            )
+            logging.error(_N("Error, no valid config channel passed, "
+                             "check name is  correct with spacecmd configchannel_list"))
             return 1
         if not filename:
             # No filename arg, so we try to do something sensible:
             # If we are exporting exactly one cc, we default to ccname.json
             # otherwise, generic ccs.json name
             if len(ccs) == 1:
-                # pylint: disable-next=consider-using-f-string
                 filename = "%s.json" % ccs[0]
             else:
                 filename = "ccs.json"
@@ -1469,128 +1254,98 @@ def do_configchannel_export(self, args):
     # Dump as a list of dict
     ccdetails_list = []
     for c in ccs:
-        # pylint: disable-next=undefined-variable
         logging.info(_N("Exporting cc %s to %s"), c, filename)
         ccdetails_list.append(self.export_configchannel_getdetails(c))
 
-    # pylint: disable-next=undefined-variable
     logging.debug("About to dump %d ccs to %s", len(ccdetails_list), filename)
     # Check if filepath exists, if it is an existing file
     # we prompt the user for confirmation
-    # pylint: disable-next=undefined-variable
     if os.path.isfile(filename):
-        if not self.options.yes and not self.user_confirm(
-            _("File '{}' exists, confirm overwrite file? (y/n)").format(filename)
-        ):
+        if not self.options.yes and not self.user_confirm(_("File '{}' exists, confirm overwrite file? (y/n)"
+                                                           ).format(filename)):
             return 1
-    # pylint: disable-next=undefined-variable
     if not json_dump_to_file(ccdetails_list, filename):
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Error saving exported config channels to file: %s"), filename)
         return 1
 
     return 0
 
-
 ####################
 
 
 def help_configchannel_import(self):
-    print(_("configchannel_import: import config channel(s) from json file"))
-    print(_("""usage: configchannel_import <JSONFILES...>"""))
+    print(_('configchannel_import: import config channel(s) from json file'))
+    print(_('''usage: configchannel_import <JSONFILES...>'''))
 
 
 def do_configchannel_import(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Error, no filename passed"))
         self.help_configchannel_import()
         return 1
 
     for filename in args:
-        # pylint: disable-next=undefined-variable
         logging.debug("Passed filename do_configchannel_import %s", filename)
-        # pylint: disable-next=undefined-variable
         ccdetails_list = json_read_from_file(filename)
         if not ccdetails_list:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("Error, could not read json data from %s"), filename)
             return 1
         for ccdetails in ccdetails_list:
             if not self.import_configchannel_fromdetails(ccdetails):
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("Error importing configchannel %s"), ccdetails["name"])
+                logging.error(_N("Error importing configchannel %s"), ccdetails['name'])
 
     return 0
-
 
 # create a new cc based on the dict from export_configchannel_getdetails
 
 
 def import_configchannel_fromdetails(self, ccdetails):
+
     # First we check that an existing channel with the same name does not exist
-    existing_ccs = self.do_configchannel_list("", True)
-    if ccdetails["name"] in existing_ccs:
-        # pylint: disable-next=undefined-variable
-        logging.warning(
-            _N("Config channel %s already exists! Skipping!") % ccdetails["name"]
-        )
+    existing_ccs = self.do_configchannel_list('', True)
+    if ccdetails['name'] in existing_ccs:
+        logging.warning(_N("Config channel %s already exists! Skipping!") %
+                        ccdetails['name'])
         return False
     else:
         # create the cc, we need to drop the org prefix from the cc name
-        # pylint: disable-next=undefined-variable
-        logging.info(_N("Importing config channel  %s") % ccdetails["name"])
+        logging.info(_N("Importing config channel  %s") % ccdetails['name'])
 
-        channeltype = "normal"
-        if "configChannelType" in ccdetails:
-            channeltype = ccdetails["configChannelType"]["label"]
+        channeltype = 'normal'
+        if 'configChannelType' in ccdetails:
+            channeltype = ccdetails['configChannelType']['label']
 
         # Create the channel
-        self.client.configchannel.create(
-            self.session,
-            ccdetails["label"],
-            ccdetails["name"],
-            ccdetails["description"],
-            channeltype,
-        )
-        for filedetails in ccdetails["files"]:
-            path = filedetails["path"]
-            del filedetails["path"]
-            # pylint: disable-next=undefined-variable
-            logging.info(
-                _N("Found %s %s for cc %s")
-                % (filedetails["type"], path, ccdetails["name"])
-            )
+        self.client.configchannel.create(self.session,
+                                         ccdetails['label'],
+                                         ccdetails['name'],
+                                         ccdetails['description'],
+                                         channeltype)
+        for filedetails in ccdetails['files']:
+            path = filedetails['path']
+            del filedetails['path']
+            logging.info(_N("Found %s %s for cc %s") %
+                         (filedetails['type'], path, ccdetails['name']))
             ret = None
-            if filedetails["type"] == "symlink":
-                del filedetails["type"]
-                # pylint: disable-next=undefined-variable,consider-using-f-string
+            if filedetails['type'] == 'symlink':
+                del filedetails['type']
                 logging.debug("Adding symlink %s" % filedetails)
                 ret = self.client.configchannel.createOrUpdateSymlink(
-                    self.session, ccdetails["label"], path, filedetails
-                )
-            elif filedetails["type"] == "sls":
+                    self.session, ccdetails['label'], path, filedetails)
+            elif filedetails['type'] == 'sls':
                 # Filter out everything except the file contents:
-                init_sls_details = dict(
-                    filter(
-                        lambda e: e[0] in ["contents", "contents_enc64"],
-                        filedetails.items(),
-                    )
-                )
+                init_sls_details = dict(filter(lambda e: e[0] in ['contents', 'contents_enc64'], filedetails.items()))
                 ret = self.client.configchannel.updateInitSls(
-                    self.session, ccdetails["label"], init_sls_details
-                )
+                    self.session, ccdetails['label'], init_sls_details)
             else:
-                if filedetails["type"] == "directory":
+                if filedetails['type'] == 'directory':
                     isdir = True
-                    if "contents" in filedetails:
-                        del filedetails["contents"]
+                    if 'contents' in filedetails:
+                        del filedetails['contents']
                 else:
                     isdir = False
                     # If binary files (or those containing characters which are
@@ -1599,56 +1354,45 @@ def import_configchannel_fromdetails(self, ccdetails):
                     # with no "contents" key (
                     # I guess the best thing to do here flag an error and
                     # import everything else
-                    if not "contents" in filedetails:
-                        # pylint: disable-next=undefined-variable
+                    if not 'contents' in filedetails:
                         logging.error(
-                            _("Failed trying to import file %s (empty content)") % path
-                        )
-                        # pylint: disable-next=undefined-variable
+                            _("Failed trying to import file %s (empty content)")
+                            % path)
                         logging.error(_N("Older APIs can't export encoded files"))
                         continue
 
-                    if not filedetails["contents_enc64"]:
-                        # pylint: disable-next=undefined-variable
+                    if not filedetails['contents_enc64']:
                         logging.debug("base64 encoding file")
-                        filedetails["contents"] = base64.b64encode(
-                            filedetails["contents"].encode("utf8")
-                        )
+                        filedetails['contents'] = \
+                            base64.b64encode(filedetails['contents'].encode('utf8'))
 
-                        # change bytes to string before sending
-                        filedetails["contents"] = filedetails["contents"].decode("utf8")
-                        filedetails["contents_enc64"] = True
+                        #change bytes to string before sending
+                        filedetails['contents'] =  filedetails['contents'].decode('utf8')
+                        filedetails['contents_enc64'] = True
 
-                # pylint: disable-next=undefined-variable,consider-using-f-string
-                logging.debug("Creating %s %s" % (filedetails["type"], filedetails))
-                if "type" in filedetails:
-                    del filedetails["type"]
+                logging.debug("Creating %s %s" %
+                              (filedetails['type'], filedetails))
+                if 'type' in filedetails:
+                    del filedetails['type']
 
                 ret = self.client.configchannel.createOrUpdatePath(
-                    self.session, ccdetails["label"], path, isdir, filedetails
-                )
+                    self.session, ccdetails['label'], path, isdir, filedetails)
             if ret is not None:
-                # pylint: disable-next=undefined-variable,consider-using-f-string
-                logging.debug("Added file %s to %s" % (ret["path"], ccdetails["name"]))
+                logging.debug("Added file %s to %s" %
+                              (ret['path'], ccdetails['name']))
             else:
-                # pylint: disable-next=undefined-variable
-                logging.error(
-                    _N("Error adding file %s to %s")
-                    % (filedetails["path"], ccdetails["label"])
-                )
+                logging.error(_N("Error adding file %s to %s") %
+                              (filedetails['path'], ccdetails['label']))
                 continue
 
     return True
-
 
 ####################
 
 
 def help_configchannel_clone(self):
-    print(_("configchannel_clone: Clone config channel(s)"))
-    print(
-        _(
-            """usage examples:
+    print(_('configchannel_clone: Clone config channel(s)'))
+    print(_('''usage examples:
                  configchannel_clone foo_label -c bar_label
                  configchannel_clone foo_label1 foo_label2 -c prefix
                  configchannel_clone foo_label -x "s/foo/bar"
@@ -1660,75 +1404,58 @@ options:
                    multiple keys are passed
   -x "s/foo/bar" : Optional regex replacement, replaces foo with bar in the
                    clone name, label and description
-  Note : If no -c or -x option is specified, interactive is assumed"""
-        )
-    )
+  Note : If no -c or -x option is specified, interactive is assumed'''))
 
 
 def complete_configchannel_clone(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_configchannel_list("", True), text)
+    return tab_completer(self.do_configchannel_list('', True), text)
 
 
 def do_configchannel_clone(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-c", "--clonelabel")
-    arg_parser.add_argument("-x", "--regex")
+    arg_parser.add_argument('-c', '--clonelabel')
+    arg_parser.add_argument('-x', '--regex')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
-    allccs = sorted(filter(None, self.do_configchannel_list("", True)))
+    allccs = sorted(filter(None, self.do_configchannel_list('', True)))
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
         if not allccs:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("No config channels found"))
             return 1
-        print("")
-        print(_("Config Channels"))
-        print("------------------")
-        print("\n".join(allccs))
-        print("")
+        print('')
+        print(_('Config Channels'))
+        print('------------------')
+        print('\n'.join(allccs))
+        print('')
 
         if len(args) == 1:
             print(_("Channel to clone: %s") % args[0])
         else:
             # Clear out any args as interactive doesn't handle multiple ccs
             args = []
-            # pylint: disable-next=undefined-variable
-            args.append(prompt_user(_("Channel to clone:"), noblank=True))
-        # pylint: disable-next=undefined-variable
-        options.clonelabel = prompt_user(_("Clone label:"), noblank=True)
+            args.append(prompt_user(_('Channel to clone:'), noblank=True))
+        options.clonelabel = prompt_user(_('Clone label:'), noblank=True)
     else:
         if not options.clonelabel and not options.regex:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("Error - must specify either -c or -x options!"))
             self.help_configchannel_clone()
         else:
-            # pylint: disable-next=undefined-variable
             logging.debug("%s : %s", options.clonelabel, options.regex)
 
     if not args:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Error no channel label passed!"))
         self.help_configchannel_clone()
         return 1
-    # pylint: disable-next=undefined-variable
     logging.debug("Got args=%s %d", args, len(args))
     # allow globbing of configchannel names
-    # pylint: disable-next=undefined-variable
-    ccs = filter_results(self.do_configchannel_list("", True), args)
-    # pylint: disable-next=undefined-variable
+    ccs = filter_results(self.do_configchannel_list('', True), args)
     logging.debug("Filtered ccs %s", ccs)
 
     if not ccs:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No suitable channels to clone has been found."))
 
     for cc in ccs:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Cloning %s" % cc)
         ccdetails = self.export_configchannel_getdetails(cc)
 
@@ -1739,54 +1466,33 @@ def do_configchannel_clone(self, args):
             # Expect option to be formatted like a sed-replacement, s/foo/bar
             findstr = options.regex.split("/")[1]
             replacestr = options.regex.split("/")[2]
-            # pylint: disable-next=undefined-variable
-            logging.debug(
-                "--regex selected with %s, replacing %s with %s",
-                options.regex,
-                findstr,
-                replacestr,
-            )
-            # pylint: disable-next=undefined-variable
-            newname = re.sub(findstr, replacestr, ccdetails["name"])
-            ccdetails["name"] = newname
-            # pylint: disable-next=undefined-variable
-            newlabel = re.sub(findstr, replacestr, ccdetails["label"])
-            ccdetails["label"] = newlabel
-            # pylint: disable-next=undefined-variable
-            newdesc = re.sub(findstr, replacestr, ccdetails["description"])
-            ccdetails["description"] = newdesc
-            # pylint: disable-next=undefined-variable
-            logging.debug(
-                "regex mode : %s %s %s",
-                ccdetails["name"],
-                ccdetails["label"],
-                ccdetails["description"],
-            )
+            logging.debug("--regex selected with %s, replacing %s with %s", options.regex, findstr, replacestr)
+            newname = re.sub(findstr, replacestr, ccdetails['name'])
+            ccdetails['name'] = newname
+            newlabel = re.sub(findstr, replacestr, ccdetails['label'])
+            ccdetails['label'] = newlabel
+            newdesc = re.sub(findstr, replacestr, ccdetails['description'])
+            ccdetails['description'] = newdesc
+            logging.debug("regex mode : %s %s %s", ccdetails['name'], ccdetails['label'], ccdetails['description'])
         elif options.clonelabel:
             if len(ccs) > 1:
-                newlabel = options.clonelabel + ccdetails["label"]
-                ccdetails["label"] = newlabel
-                newname = options.clonelabel + ccdetails["name"]
-                ccdetails["name"] = newname
-                # pylint: disable-next=undefined-variable
-                logging.debug(
-                    "clonelabel mode with >1 channel : %s", ccdetails["label"]
-                )
+                newlabel = options.clonelabel + ccdetails['label']
+                ccdetails['label'] = newlabel
+                newname = options.clonelabel + ccdetails['name']
+                ccdetails['name'] = newname
+                logging.debug("clonelabel mode with >1 channel : %s", ccdetails['label'])
             else:
                 newlabel = options.clonelabel
-                ccdetails["label"] = newlabel
+                ccdetails['label'] = newlabel
                 newname = options.clonelabel
-                ccdetails["name"] = newname
-                # pylint: disable-next=undefined-variable
-                logging.debug("clonelabel mode with 1 channel : %s", ccdetails["label"])
+                ccdetails['name'] = newname
+                logging.debug("clonelabel mode with 1 channel : %s", ccdetails['label'])
 
         # Finally : import the cc from the modified ccdetails
         if not self.import_configchannel_fromdetails(ccdetails):
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to clone %s to %s"), cc, ccdetails["label"])
+            logging.error(_N("Failed to clone %s to %s"), cc, ccdetails['label'])
 
     return 0
-
 
 ####################
 # configchannel helper
@@ -1800,11 +1506,9 @@ def is_configchannel(self, name):
 
 def check_configchannel(self, name):
     if not name:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("no configchannel given"))
         return False
     if not self.is_configchannel(name):
-        # pylint: disable-next=undefined-variable
         logging.error(_N("invalid configchannel label ") + name)
         return False
     return True
@@ -1823,42 +1527,35 @@ def dump_configchannel(self, name, replacedict=None, excludes=None):
     for filename in self.do_configchannel_listfiles(name, True):
         content.extend(self.dump_configchannel_filedetails(name, filename))
 
-    # pylint: disable-next=undefined-variable
     content = get_normalized_text(content, replacedict=replacedict, excludes=excludes)
 
     return content
-
 
 ####################
 
 
 def help_configchannel_diff(self):
-    print(_("configchannel_diff: diff between config channels"))
-    print("")
-    print(_("usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"))
+    print(_('configchannel_diff: diff between config channels'))
+    print('')
+    print(_('usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_configchannel_diff(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True), text)
     return []
 
 
 def do_configchannel_diff(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not 1 <= len(args) < 3:
@@ -1878,50 +1575,40 @@ def do_configchannel_diff(self, args):
     if not self.check_configchannel(target_channel):
         return 1
 
-    # pylint: disable-next=undefined-variable
-    source_replacedict, target_replacedict = get_string_diff_dicts(
-        source_channel, target_channel
-    )
+    source_replacedict, target_replacedict = get_string_diff_dicts(source_channel, target_channel)
 
     source_data = self.dump_configchannel(source_channel, source_replacedict)
     target_data = self.dump_configchannel(target_channel, target_replacedict)
 
-    # pylint: disable-next=undefined-variable
     for line in diff(source_data, target_data, source_channel, target_channel):
         print(line)
-
 
 ####################
 
 
 def help_configchannel_sync(self):
-    print(_("configchannel_sync:"))
-    print(_("sync config files between two config channels"))
-    print("")
-    print(_("usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"))
+    print(_('configchannel_sync:'))
+    print(_('sync config files between two config channels'))
+    print('')
+    print(_('usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_configchannel_sync(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True), text)
     return []
 
 
 def do_configchannel_sync(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not 1 <= len(args) < 3:
@@ -1941,13 +1628,7 @@ def do_configchannel_sync(self, args, doreturn=False):
     if not self.check_configchannel(target_channel):
         return 1
 
-    # pylint: disable-next=undefined-variable
-    logging.info(
-        _N("syncing files from configchannel ")
-        + source_channel
-        + " to "
-        + target_channel
-    )
+    logging.info(_N("syncing files from configchannel ") + source_channel + " to " + target_channel)
 
     source_files = set(self.do_configchannel_listfiles(source_channel, doreturn=True))
     target_files = set(self.do_configchannel_listfiles(target_channel, doreturn=True))
@@ -1956,60 +1637,55 @@ def do_configchannel_sync(self, args, doreturn=False):
     if both:
         print(_("files common in both channels:"))
         print("\n".join(both))
-        print("")
+        print('')
 
     source_only = source_files.difference(target_files)
     if source_only:
         print(_("files only in source ") + source_channel)
         print("\n".join(source_only))
-        print("")
+        print('')
 
     target_only = target_files.difference(source_files)
     if target_only:
         print(_("files only in target ") + target_channel)
         print("\n".join(target_only))
-        print("")
+        print('')
 
     if both:
-        print(
-            _(
-                "files that are in both channels will be overwritten in the target channel"
-            )
-        )
+        print(_("files that are in both channels will be overwritten in the target channel"))
     if source_only:
         print(_("files only in the source channel will be added to the target channel"))
     if target_only:
         print(_("files only in the target channel will be deleted"))
 
     if not (both or source_only or target_only):
-        # pylint: disable-next=undefined-variable
         logging.info(_N("nothing to do"))
         return 1
 
     if not self.options.yes:
-        if not self.user_confirm(_("perform synchronisation [y/N]:")):
+        if not self.user_confirm(_('perform synchronisation [y/N]:')):
             return 1
 
     source_data_list = self.client.configchannel.lookupFileInfo(
-        self.session, source_channel, list(both) + list(source_only)
-    )
+        self.session, source_channel,
+        list(both) + list(source_only))
 
     for source_data in source_data_list:
-        if source_data.get("type") == "file" or source_data.get("type") == "directory":
-            if source_data.get("contents") and not source_data.get("binary"):
-                contents = codecs.encode(source_data.get("contents"), "base64")
+        if source_data.get('type') == 'file' or source_data.get('type') == 'directory':
+            if source_data.get('contents') and not source_data.get('binary'):
+                contents = codecs.encode(source_data.get('contents'), "base64")
             else:
-                contents = source_data.get("contents")
+                contents = source_data.get('contents')
             target_data = {
-                "contents": contents,
-                "contents_enc64": True,
-                "owner": source_data.get("owner"),
-                "group": source_data.get("group"),
+                'contents':                 contents,
+                'contents_enc64':           True,
+                'owner':                    source_data.get('owner'),
+                'group':                    source_data.get('group'),
                 # get permissions from permissions_mode instead of permissions
-                "permissions": source_data.get("permissions_mode"),
-                "selinux_ctx": source_data.get("selinux_ctx"),
-                "macro-start-delimiter": source_data.get("macro-start-delimiter"),
-                "macro-end-delimiter": source_data.get("macro-end-delimiter"),
+                'permissions':              source_data.get('permissions_mode'),
+                'selinux_ctx':              source_data.get('selinux_ctx'),
+                'macro-start-delimiter':    source_data.get('macro-start-delimiter'),
+                'macro-end-delimiter':      source_data.get('macro-end-delimiter'),
             }
             _target_data = {}
             for k, v in target_data.items():
@@ -2018,36 +1694,32 @@ def do_configchannel_sync(self, args, doreturn=False):
             target_data = _target_data
             del _target_data
 
-            if source_data.get("type") == "directory":
-                del target_data["contents_enc64"]
-            # pylint: disable-next=undefined-variable
-            logging.debug(source_data.get("path") + ": " + str(target_data))
-            self.client.configchannel.createOrUpdatePath(
-                self.session,
-                target_channel,
-                source_data.get("path"),
-                source_data.get("type") == "directory",
-                target_data,
-            )
+            if source_data.get('type') == 'directory':
+                del target_data['contents_enc64']
+            logging.debug(source_data.get('path') + ": " + str(target_data))
+            self.client.configchannel.createOrUpdatePath(self.session,
+                                                         target_channel,
+                                                         source_data.get('path'),
+                                                         source_data.get('type') == 'directory',
+                                                         target_data)
 
-        elif source_data.get("type") == "symlink":
+        elif source_data.get('type') == 'symlink':
             target_data = {
-                "target_path": source_data.get("target_path"),
-                "selinux_ctx": source_data.get("selinux_ctx"),
+                'target_path':  source_data.get('target_path'),
+                'selinux_ctx':  source_data.get('selinux_ctx'),
             }
-            # pylint: disable-next=undefined-variable
-            logging.debug(source_data.get("path") + ": " + str(target_data))
-            self.client.configchannel.createOrUpdateSymlink(
-                self.session, target_channel, source_data.get("path"), target_data
-            )
+            logging.debug(source_data.get('path') + ": " + str(target_data))
+            self.client.configchannel.createOrUpdateSymlink(self.session,
+                                                            target_channel,
+                                                            source_data.get('path'),
+                                                            target_data)
 
         else:
-            # pylint: disable-next=undefined-variable
             logging.warning(_N("unknown file type ") + source_data.type)
 
     # removing all files from target channel that did not exist on source channel
     if target_only:
-        # self.do_configchannel_removefiles( target_channel + " " + "/.metainfo" + " ".join(target_only) )
+        #self.do_configchannel_removefiles( target_channel + " " + "/.metainfo" + " ".join(target_only) )
         self.do_configchannel_removefiles(target_channel + " " + " ".join(target_only))
 
     return 0

--- a/spacecmd/src/spacecmd/cryptokey.py
+++ b/spacecmd/src/spacecmd/cryptokey.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -28,7 +27,6 @@
 # pylint: disable=W0613
 
 import gettext
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -36,25 +34,20 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_cryptokey_create(self):
-    print(_("cryptokey_create: Create a cryptographic key"))
-    print(
-        _(
-            """usage: cryptokey_create [options])
+    print(_('cryptokey_create: Create a cryptographic key'))
+    print(_('''usage: cryptokey_create [options])
 
 options:
   -t GPG or SSL
   -d DESCRIPTION
-  -f KEY_FILE"""
-        )
-    )
+  -f KEY_FILE'''))
 
 
 def do_cryptokey_create(self, args):
@@ -62,28 +55,24 @@ def do_cryptokey_create(self, args):
     if options is None:
         return 1
 
-    self.client.kickstart.keys.create(
-        self.session, options.description, options.type, options.contents
-    )
+    self.client.kickstart.keys.create(self.session,
+                                      options.description,
+                                      options.type,
+                                      options.contents)
 
     return 0
-
 
 ####################
 
 
 def help_cryptokey_update(self):
-    print(_("cryptokey_update: Update a cryptographic key"))
-    print(
-        _(
-            """usage: cryptokey_update [options])
+    print(_('cryptokey_update: Update a cryptographic key'))
+    print(_('''usage: cryptokey_update [options])
 
 options:
   -t GPG or SSL
   -d DESCRIPTION
-  -f KEY_FILE"""
-        )
-    )
+  -f KEY_FILE'''))
 
 
 def do_cryptokey_update(self, args):
@@ -91,107 +80,87 @@ def do_cryptokey_update(self, args):
     if options is None:
         return 1
 
-    self.client.kickstart.keys.update(
-        self.session, options.description, options.type, options.contents
-    )
+    self.client.kickstart.keys.update(self.session,
+                                      options.description,
+                                      options.type,
+                                      options.contents)
 
     return 0
-
 
 ####################
 
 
 def _cryptokey_process_options(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-t", "--type")
-    arg_parser.add_argument("-d", "--description")
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-t', '--type')
+    arg_parser.add_argument('-d', '--description')
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
     options.contents = None
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.type = prompt_user(_("GPG or SSL [G/S]:"))
+        options.type = prompt_user(_('GPG or SSL [G/S]:'))
 
-        options.description = ""
-        while options.description == "":
-            # pylint: disable-next=undefined-variable
-            options.description = prompt_user(_("Description:"))
+        options.description = ''
+        while options.description == '':
+            options.description = prompt_user(_('Description:'))
 
-        if self.user_confirm(
-            _("Read an existing file [y/N]:"), nospacer=True, ignore_yes=True
-        ):
-            # pylint: disable-next=undefined-variable
-            options.file = prompt_user("File:")
+        if self.user_confirm(_('Read an existing file [y/N]:'),
+                             nospacer=True, ignore_yes=True):
+            options.file = prompt_user('File:')
         else:
-            # pylint: disable-next=undefined-variable
             options.contents = editor(delete=True)
     else:
         if not options.type:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The key type is required"))
+            logging.error(_N('The key type is required'))
             return None
 
         if not options.description:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A description is required"))
+            logging.error(_N('A description is required'))
             return None
 
         if not options.file:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A file containing the key is required"))
+            logging.error(_N('A file containing the key is required'))
             return None
 
     # read the file the user specified
     if options.file:
-        # pylint: disable-next=undefined-variable
         options.contents = read_file(options.file)
 
     if not options.contents:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("No contents of the file"))
+        logging.error(_N('No contents of the file'))
         return None
 
     # translate the key type to what the server expects
-    # pylint: disable-next=undefined-variable
-    if re.match("G", options.type, re.I):
-        options.type = "GPG"
-    # pylint: disable-next=undefined-variable
-    elif re.match("S", options.type, re.I):
-        options.type = "SSL"
+    if re.match('G', options.type, re.I):
+        options.type = 'GPG'
+    elif re.match('S', options.type, re.I):
+        options.type = 'SSL'
     else:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Invalid key type"))
+        logging.error(_N('Invalid key type'))
         return None
 
     return options
-
 
 ####################
 
 
 def help_cryptokey_delete(self):
-    print(_("cryptokey_delete: Delete a cryptographic key"))
-    print(_("usage: cryptokey_delete NAME"))
+    print(_('cryptokey_delete: Delete a cryptographic key'))
+    print(_('usage: cryptokey_delete NAME'))
 
 
 def complete_cryptokey_delete(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_cryptokey_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_cryptokey_list('', True),
+                             text)
 
     return None
 
-
 def do_cryptokey_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=invalid-name,undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -199,65 +168,58 @@ def do_cryptokey_delete(self, args):
         return 1
 
     # allow globbing of cryptokey names
-    # pylint: disable-next=undefined-variable
-    keys = filter_results(self.do_cryptokey_list("", True), args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("cryptokey_delete called with args %s, keys=%s" % (args, keys))
+    keys = filter_results(self.do_cryptokey_list('', True), args)
+    logging.debug("cryptokey_delete called with args %s, keys=%s" %
+                  (args, keys))
 
     if not keys:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confirmation
-    print("\n".join(sorted(keys)))
+    print('\n'.join(sorted(keys)))
 
-    if self.user_confirm(_("Delete key(s) [y/N]:")):
+    if self.user_confirm(_('Delete key(s) [y/N]:')):
         for key in keys:
             self.client.kickstart.keys.delete(self.session, key)
         return 0
     else:
         return 1
 
-
 ####################
 
 
 def help_cryptokey_list(self):
-    print(_("cryptokey_list: List all cryptographic keys (SSL, GPG)"))
-    print(_("usage: cryptokey_list"))
+    print(_('cryptokey_list: List all cryptographic keys (SSL, GPG)'))
+    print(_('usage: cryptokey_list'))
 
 
 def do_cryptokey_list(self, args, doreturn=False):
     keys = self.client.kickstart.keys.listAllKeys(self.session)
-    keys = [k.get("description") for k in keys]
+    keys = [k.get('description') for k in keys]
 
     if doreturn:
         return keys
     if keys:
-        print("\n".join(sorted(keys)))
+        print('\n'.join(sorted(keys)))
 
     return None
-
 
 ####################
 
 
 def help_cryptokey_details(self):
-    print(_("cryptokey_details: Show the contents of a cryptographic key"))
-    print(_("usage: cryptokey_details KEY ..."))
+    print(_('cryptokey_details: Show the contents of a cryptographic key'))
+    print(_('usage: cryptokey_details KEY ...'))
 
 
 def complete_cryptokey_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_cryptokey_list("", True), text)
+    return tab_completer(self.do_cryptokey_list('', True), text)
 
 
 def do_cryptokey_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=invalid-name,undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -265,13 +227,11 @@ def do_cryptokey_details(self, args):
         return 1
 
     # allow globbing of cryptokey names
-    # pylint: disable-next=undefined-variable
-    keys = filter_results(self.do_cryptokey_list("", True), args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("cryptokey_details called with args %s, keys=%s" % (args, keys))
+    keys = filter_results(self.do_cryptokey_list('', True), args)
+    logging.debug("cryptokey_details called with args %s, keys=%s" %
+                  (args, keys))
 
     if not keys:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No keys matched argument %s") % args)
         return 1
 
@@ -279,20 +239,20 @@ def do_cryptokey_details(self, args):
 
     for key in keys:
         try:
-            details = self.client.kickstart.keys.getDetails(self.session, key)
+            details = self.client.kickstart.keys.getDetails(self.session,
+                                                            key)
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s is not a valid crypto key") % key)
+            logging.warning(_N('%s is not a valid crypto key') % key)
             return 1
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("Description: %s") % details.get("description"))
-        print(_("Type:        %s") % details.get("type"))
+        print(_('Description: %s') % details.get('description'))
+        print(_('Type:        %s') % details.get('type'))
 
-        print("")
-        print(details.get("content"))
+        print('')
+        print(details.get('content'))
 
     return 0

--- a/spacecmd/src/spacecmd/custominfo.py
+++ b/spacecmd/src/spacecmd/custominfo.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -31,65 +30,58 @@ import gettext
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_custominfo_createkey(self):
-    print(_("custominfo_createkey: Create a custom key"))
-    print(_("usage: custominfo_createkey [NAME] [DESCRIPTION]"))
+    print(_('custominfo_createkey: Create a custom key'))
+    print(_('usage: custominfo_createkey [NAME] [DESCRIPTION]'))
 
 
 def do_custominfo_createkey(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=invalid-name,undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
         key = args[0]
     else:
-        key = ""
+        key = ''
 
-    while key == "":
-        # pylint: disable-next=undefined-variable
-        key = prompt_user(_("Name:"))
+    while key == '':
+        key = prompt_user(_('Name:'))
 
     if len(args) > 1:
-        description = " ".join(args[1:])
+        description = ' '.join(args[1:])
     else:
-        # pylint: disable-next=undefined-variable
-        description = prompt_user(_("Description:"))
-        if description == "":
+        description = prompt_user(_('Description:'))
+        if description == '':
             description = key
 
-    self.client.system.custominfo.createKey(self.session, key, description)
+    self.client.system.custominfo.createKey(self.session,
+                                            key,
+                                            description)
 
     return 0
-
 
 ####################
 
 
 def help_custominfo_deletekey(self):
-    print(_("custominfo_deletekey: Delete a custom key"))
-    print(_("usage: custominfo_deletekey KEY ..."))
+    print(_('custominfo_deletekey: Delete a custom key'))
+    print(_('usage: custominfo_deletekey KEY ...'))
 
 
 def complete_custominfo_deletekey(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_custominfo_listkeys("", True), text)
+    return tab_completer(self.do_custominfo_listkeys('', True), text)
 
 
 def do_custominfo_deletekey(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=invalid-name,undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -97,20 +89,18 @@ def do_custominfo_deletekey(self, args):
         return 1
 
     # allow globbing of custominfo key names
-    # pylint: disable-next=undefined-variable
-    keys = filter_results(self.do_custominfo_listkeys("", True), args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("customkey_deletekey called with args %s, keys=%s" % (args, keys))
+    keys = filter_results(self.do_custominfo_listkeys('', True), args)
+    logging.debug("customkey_deletekey called with args %s, keys=%s" %
+                  (args, keys))
 
     if not keys:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confirmation
-    print("\n".join(sorted(keys)))
+    print('\n'.join(sorted(keys)))
 
-    if not self.user_confirm("Delete these keys [y/N]:"):
+    if not self.user_confirm('Delete these keys [y/N]:'):
         return 1
 
     for key in keys:
@@ -118,45 +108,40 @@ def do_custominfo_deletekey(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_custominfo_listkeys(self):
-    print(_("custominfo_listkeys: List all custom keys"))
-    print(_("usage: custominfo_listkeys"))
+    print(_('custominfo_listkeys: List all custom keys'))
+    print(_('usage: custominfo_listkeys'))
 
 
 def do_custominfo_listkeys(self, args, doreturn=False):
     keys = self.client.system.custominfo.listAllKeys(self.session)
-    keys = [k.get("label") for k in keys]
+    keys = [k.get('label') for k in keys]
 
     if doreturn:
         return keys
     if keys:
-        print("\n".join(sorted(keys)))
+        print('\n'.join(sorted(keys)))
 
     return None
-
 
 ####################
 
 
 def help_custominfo_details(self):
-    print(_("custominfo_details: Show the details of a custom key"))
-    print(_("usage: custominfo_details KEY ..."))
+    print(_('custominfo_details: Show the details of a custom key'))
+    print(_('usage: custominfo_details KEY ...'))
 
 
 def complete_custominfo_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_custominfo_listkeys("", True), text)
+    return tab_completer(self.do_custominfo_listkeys('', True), text)
 
 
 def do_custominfo_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=invalid-name,undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -164,18 +149,11 @@ def do_custominfo_details(self, args):
         return 1
 
     # allow globbing of custominfo key names
-    # pylint: disable-next=undefined-variable
-    keys = filter_results(self.do_custominfo_listkeys("", True), args)
-    # pylint: disable-next=undefined-variable
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "customkey_details called with args: '{}', keys: '{}'.".format(
-            ", ".join(args), ", ".join(keys)
-        )
-    )
+    keys = filter_results(self.do_custominfo_listkeys('', True), args)
+    logging.debug("customkey_details called with args: '{}', keys: '{}'.".format(
+        ", ".join(args), ", ".join(keys)))
 
     if not keys:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No keys matched argument '{}'.").format(", ".join(args)))
         return 1
 
@@ -186,53 +164,50 @@ def do_custominfo_details(self, args):
     for key in keys:
         details = {}
         for key_details in all_keys:
-            if key_details.get("label") == key:
+            if key_details.get('label') == key:
                 details = key_details
 
         if details:
             if add_separator:
                 print(self.SEPARATOR)
             add_separator = True
-            print(_("Label:        %s") % (details.get("label") or "N/A"))
-            print(_("Description:  %s") % (details.get("description") or "N/A"))
-            print(_("Modified:     %s") % (details.get("last_modified") or "N/A"))
-            print(_("System Count: %i") % (details.get("system_count") or 0))
+            print(_('Label:        %s') % (details.get('label') or "N/A"))
+            print(_('Description:  %s') % (details.get('description') or "N/A"))
+            print(_('Modified:     %s') % (details.get('last_modified') or "N/A"))
+            print(_('System Count: %i') % (details.get('system_count') or 0))
 
     return 0
-
 
 ####################
 
 
 def help_custominfo_updatekey(self):
-    print(_("custominfo_updatekey: Update a custom key"))
-    print(_("usage: custominfo_updatekey [NAME] [DESCRIPTION]"))
+    print(_('custominfo_updatekey: Update a custom key'))
+    print(_('usage: custominfo_updatekey [NAME] [DESCRIPTION]'))
 
 
 def do_custominfo_updatekey(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=invalid-name,undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
         key = args[0]
     else:
-        key = ""
+        key = ''
 
-    while key == "":
-        # pylint: disable-next=undefined-variable
-        key = prompt_user(_("Name:"))
+    while key == '':
+        key = prompt_user(_('Name:'))
 
     if len(args) > 1:
-        description = " ".join(args[1:])
+        description = ' '.join(args[1:])
     else:
-        # pylint: disable-next=undefined-variable
-        description = prompt_user(_("Description:"))
-        if description == "":
+        description = prompt_user(_('Description:'))
+        if description == '':
             description = key
 
-    self.client.system.custominfo.updateKey(self.session, key, description)
+    self.client.system.custominfo.updateKey(self.session,
+                                            key,
+                                            description)
 
     return 0

--- a/spacecmd/src/spacecmd/distribution.py
+++ b/spacecmd/src/spacecmd/distribution.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -34,37 +33,30 @@ import gettext
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_distribution_create(self):
-    print(_("distribution_create: Create a Kickstart tree"))
-    print(
-        _(
-            """usage: distribution_create [options]
+    print(_('distribution_create: Create a Kickstart tree'))
+    print(_('''usage: distribution_create [options]
 
 options:
   -n NAME
   -p path to tree
   -b base channel to associate with
-  -t install type [fedora18|rhel_6/7/8|sles12generic|sles15generic|suse|generic_rpm|...]"""
-        )
-    )
+  -t install type [fedora18|rhel_6/7/8|sles12generic|sles15generic|suse|generic_rpm|...]'''))
 
 
 def do_distribution_create(self, args, update=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-p", "--path")
-    arg_parser.add_argument("-b", "--base-channel")
-    arg_parser.add_argument("-t", "--install-type")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-p', '--path')
+    arg_parser.add_argument('-b', '--base-channel')
+    arg_parser.add_argument('-t', '--install-type')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     # fill in the name of the distribution when updating
@@ -72,159 +64,141 @@ def do_distribution_create(self, args, update=False):
         if args:
             options.name = args[0]
         elif not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The name of the distribution is required"))
+            logging.error(_N('The name of the distribution is required'))
             self.help_distribution_update()
             return 1
         details = self.client.kickstart.tree.getDetails(self.session, options.name)
-        channel = self.client.channel.software.getDetails(
-            self.session, details.get("channel_id")
-        )
+        channel = \
+            self.client.channel.software.getDetails(self.session,
+                                                    details.get('channel_id'))
 
         if not options.path:
-            options.path = details.get("abs_path")
+            options.path = details.get('abs_path')
 
         if not options.base_channel:
-            options.base_channel = channel.get("label")
+            options.base_channel = channel.get('label')
 
         if not options.install_type:
-            inst_type = details.get("install_type")
+            inst_type = details.get('install_type')
             if inst_type:
-                options.install_type = inst_type.get("label")
+                options.install_type = inst_type.get('label')
 
-    # pylint: disable-next=undefined-variable
+
     if is_interactive(options):
         if not update:
-            # pylint: disable-next=undefined-variable
-            options.name = prompt_user(_("Name:"), noblank=True)
+            options.name = prompt_user(_('Name:'), noblank=True)
 
-        # pylint: disable-next=undefined-variable
-        options.path = prompt_user(_("Path to Kickstart Tree:"), noblank=True)
+        options.path = prompt_user(_('Path to Kickstart Tree:'), noblank=True)
 
-        options.base_channel = ""
-        while options.base_channel == "":
-            print("")
-            print(_("Base Channels"))
-            print("-------------")
-            print("\n".join(sorted(self.list_base_channels())))
-            print("")
+        options.base_channel = ''
+        while options.base_channel == '':
+            print('')
+            print(_('Base Channels'))
+            print('-------------')
+            print('\n'.join(sorted(self.list_base_channels())))
+            print('')
 
-            # pylint: disable-next=undefined-variable
-            options.base_channel = prompt_user(_("Base Channel:"))
+            options.base_channel = prompt_user(_('Base Channel:'))
 
         if options.base_channel not in self.list_base_channels():
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("Invalid channel label"))
-            options.base_channel = ""
+            logging.warning(_N('Invalid channel label'))
+            options.base_channel = ''
 
-        install_types = self.client.kickstart.tree.listInstallTypes(self.session)
+        install_types = \
+            self.client.kickstart.tree.listInstallTypes(self.session)
 
-        install_types = [t.get("label") for t in install_types]
+        install_types = [t.get('label') for t in install_types]
 
-        options.install_type = ""
-        while options.install_type == "":
-            print("")
-            print(_("Install Types"))
-            print("-------------")
-            print("\n".join(sorted(install_types)))
-            print("")
+        options.install_type = ''
+        while options.install_type == '':
+            print('')
+            print(_('Install Types'))
+            print('-------------')
+            print('\n'.join(sorted(install_types)))
+            print('')
 
-            # pylint: disable-next=undefined-variable
-            options.install_type = prompt_user(_("Install Type:"))
+            options.install_type = prompt_user(_('Install Type:'))
 
             if options.install_type not in install_types:
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("Invalid install type"))
-                options.install_type = ""
+                logging.warning(_N('Invalid install type'))
+                options.install_type = ''
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A name is required"))
+            logging.error(_N('A name is required'))
             return 1
 
         if not options.path:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A path is required"))
+            logging.error(_N('A path is required'))
             return 1
 
         if not options.base_channel:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A base channel is required"))
+            logging.error(_N('A base channel is required'))
             return 1
 
         if not options.install_type:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("An install type is required"))
+            logging.error(_N('An install type is required'))
             return 1
 
     if update:
-        self.client.kickstart.tree.update(
-            self.session,
-            options.name,
-            options.path,
-            options.base_channel,
-            options.install_type,
-        )
+        self.client.kickstart.tree.update(self.session,
+                                          options.name,
+                                          options.path,
+                                          options.base_channel,
+                                          options.install_type)
     else:
-        self.client.kickstart.tree.create(
-            self.session,
-            options.name,
-            options.path,
-            options.base_channel,
-            options.install_type,
-        )
+        self.client.kickstart.tree.create(self.session,
+                                          options.name,
+                                          options.path,
+                                          options.base_channel,
+                                          options.install_type)
 
     return 0
-
 
 ####################
 
 
 def help_distribution_list(self):
-    print(_("distribution_list: List the available autoinstall trees"))
-    print(_("usage: distribution_list"))
-
+    print(_('distribution_list: List the available autoinstall trees'))
+    print(_('usage: distribution_list'))
 
 def do_distribution_list(self, args, doreturn=False):
     channels = self.client.kickstart.listAutoinstallableChannels(self.session)
 
     avail_trees = []
     for c in channels:
-        trees = self.client.kickstart.tree.list(self.session, c.get("label"))
+        trees = self.client.kickstart.tree.list(self.session,
+                                                c.get('label'))
         for t in trees:
-            label = t.get("label")
+            label = t.get('label')
             if label not in avail_trees:
                 avail_trees.append(label)
 
     if doreturn:
         return avail_trees
     if avail_trees:
-        print("\n".join(sorted(avail_trees)))
+        print('\n'.join(sorted(avail_trees)))
 
     return None
-
 
 ####################
 
 
 def help_distribution_delete(self):
-    print(_("distribution_delete: Delete a Kickstart tree"))
-    print(_("usage: distribution_delete LABEL"))
+    print(_('distribution_delete: Delete a Kickstart tree'))
+    print(_('usage: distribution_delete LABEL'))
 
 
 def complete_distribution_delete(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_distribution_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_distribution_list('', True),
+                             text)
 
     return None
 
 
 def do_distribution_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -232,44 +206,38 @@ def do_distribution_delete(self, args):
         return 1
 
     # allow globbing of distribution names
-    # pylint: disable-next=undefined-variable
-    dists = filter_results(self.do_distribution_list("", True), args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("distribution_delete called with args %s, dists=%s" % (args, dists))
+    dists = filter_results(self.do_distribution_list('', True), args)
+    logging.debug("distribution_delete called with args %s, dists=%s" %
+                  (args, dists))
 
     if not dists:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No distributions matched argument %s") % args)
         return 1
 
     # Print the distributions prior to the confirmation
-    print("\n".join(sorted(dists)))
+    print('\n'.join(sorted(dists)))
 
-    if self.user_confirm(_("Delete distribution tree(s) [y/N]:")):
+    if self.user_confirm(_('Delete distribution tree(s) [y/N]:')):
         for d in dists:
             self.client.kickstart.tree.delete(self.session, d)
 
     return 0
 
-
 ####################
 
 
 def help_distribution_details(self):
-    print(_("distribution_details: Show the details of a Kickstart tree"))
-    print(_("usage: distribution_details LABEL"))
+    print(_('distribution_details: Show the details of a Kickstart tree'))
+    print(_('usage: distribution_details LABEL'))
 
 
 def complete_distribution_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_distribution_list("", True), text)
+    return tab_completer(self.do_distribution_list('', True), text)
 
 
 def do_distribution_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -277,13 +245,11 @@ def do_distribution_details(self, args):
         return 1
 
     # allow globbing of distribution names
-    # pylint: disable-next=undefined-variable
-    dists = filter_results(self.do_distribution_list("", True), args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("distribution_details called with args %s, dists=%s" % (args, dists))
+    dists = filter_results(self.do_distribution_list('', True), args)
+    logging.debug("distribution_details called with args %s, dists=%s" %
+                  (args, dists))
 
     if not dists:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No distributions matched argument %s") % args)
         return 1
 
@@ -292,42 +258,39 @@ def do_distribution_details(self, args):
     for label in dists:
         details = self.client.kickstart.tree.getDetails(self.session, label)
 
-        channel = self.client.channel.software.getDetails(
-            self.session, details.get("channel_id")
-        )
+        channel = \
+            self.client.channel.software.getDetails(self.session,
+                                                    details.get('channel_id'))
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("Name:    %s") % details.get("label"))
-        print(_("Path:    %s") % details.get("abs_path"))
-        print(_("Channel: %s") % channel.get("label"))
+        print(_('Name:    %s') % details.get('label'))
+        print(_('Path:    %s') % details.get('abs_path'))
+        print(_('Channel: %s') % channel.get('label'))
 
     return 0
-
 
 ####################
 
 
 def help_distribution_rename(self):
-    print(_("distribution_rename: Rename a Kickstart tree"))
-    print(_("usage: distribution_rename OLDNAME NEWNAME"))
+    print(_('distribution_rename: Rename a Kickstart tree'))
+    print(_('usage: distribution_rename OLDNAME NEWNAME'))
 
 
 def complete_distribution_rename(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_distribution_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_distribution_list('', True),
+                             text)
 
     return None
 
 
 def do_distribution_rename(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -341,28 +304,23 @@ def do_distribution_rename(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_distribution_update(self):
-    print(_("distribution_update: Update the path of a Kickstart tree"))
-    print(
-        _(
-            """usage: distribution_update NAME [options]
+    print(_('distribution_update: Update the path of a Kickstart tree'))
+    print(_('''usage: distribution_update NAME [options]
 
 options:
   -p path to tree
   -b base channel to associate with
-  -t install type [fedora18|rhel_6/7/8|sles12generic|sles15generic|suse|generic_rpm|...]"""
-        )
-    )
+  -t install type [fedora18|rhel_6/7/8|sles12generic|sles15generic|suse|generic_rpm|...]'''))
 
 
 def complete_distribution_update(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_distribution_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_distribution_list('', True),
+                             text)
 
     return None
 

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -32,7 +31,6 @@
 # pylint: disable=C0103
 
 import gettext
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -41,16 +39,15 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_errata_list(self):
-    print(_("errata_list: List all patches"))
-    print(_("usage: errata_list"))
+    print(_('errata_list: List all patches'))
+    print(_('usage: errata_list'))
 
 
 def do_errata_list(self, args, doreturn=False):
@@ -59,44 +56,35 @@ def do_errata_list(self, args, doreturn=False):
     if doreturn:
         return self.all_errata.keys()
     if self.all_errata.keys():
-        print("\n".join(sorted(self.all_errata.keys())))
+        print('\n'.join(sorted(self.all_errata.keys())))
 
     return None
-
 
 ####################
 
 
 def help_errata_summary(self):
-    print(_("errata_summary: Print a summary of all errata"))
-    print(_("usage: errata_summary"))
+    print(_('errata_summary: Print a summary of all errata'))
+    print(_('usage: errata_summary'))
 
 
 def do_errata_summary(self, args):
     self.generate_errata_cache()
-    for erratum in sorted(
-        self.all_errata.values(), key=lambda x: (x["advisory_name"]), reverse=True
-    ):
-        # pylint: disable-next=undefined-variable
+    for erratum in sorted(self.all_errata.values(), key=lambda x: (x['advisory_name']), reverse=True):
         print_errata_summary(erratum=erratum)
 
     return 0
-
 
 ####################
 
 
 def help_errata_apply(self):
-    print(_("errata_apply: Apply an erratum to all affected systems"))
-    print(
-        _(
-            """usage: errata_apply [options] ERRATA|search:XXX ...)
+    print(_('errata_apply: Apply an erratum to all affected systems'))
+    print(_('''usage: errata_apply [options] ERRATA|search:XXX ...)
 
 options:
-  -s START_TIME"""
-        )
-    )
-    print("")
+  -s START_TIME'''))
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
@@ -105,12 +93,10 @@ def complete_errata_apply(self, text, line, beg, end):
 
 
 def do_errata_apply(self, args, errata_list=None, only_systems=None):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("errata", nargs="*")
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('errata', nargs="*")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
     only_systems = only_systems or []
 
@@ -127,18 +113,13 @@ def do_errata_apply(self, args, errata_list=None, only_systems=None):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and not self.options.yes:
-        # pylint: disable-next=undefined-variable
-        start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        start_time = prompt_user(_('Start Time [now]:'))
         start_time = parse_time_input(start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            start_time = parse_time_input("now")
+            start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             start_time = parse_time_input(options.start_time)
             # Do not assume non-interactive mode
             del options.start_time
@@ -149,9 +130,7 @@ def do_errata_apply(self, args, errata_list=None, only_systems=None):
     for erratum in errata_list:
         try:
             # get the systems affected by each errata
-            affected_systems = self.client.errata.listAffectedSystems(
-                self.session, erratum
-            )
+            affected_systems = self.client.errata.listAffectedSystems(self.session, erratum)
 
             # build a list of systems that we will schedule errata for,
             # indexed by errata name
@@ -160,26 +139,21 @@ def do_errata_apply(self, args, errata_list=None, only_systems=None):
                 # this erratum if we were not passed a list of systems
                 # (and therefore all systems are to be touched) or we were
                 # passed a list of systems and this one is part of that list
-                if not only_systems or system.get("name") in only_systems:
+                if not only_systems or system.get('name') in only_systems:
                     if erratum not in to_apply_by_name:
                         to_apply_by_name[erratum] = []
-                    if system.get("name") not in to_apply_by_name[erratum]:
-                        to_apply_by_name[erratum].append(system.get("name"))
+                    if system.get('name') not in to_apply_by_name[erratum]:
+                        to_apply_by_name[erratum].append(system.get('name'))
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("%s does not affect any systems" % erratum)
+            logging.debug('%s does not affect any systems' % erratum)
             continue
 
         # make a summary list to show the user
         if erratum in to_apply_by_name:
-            summary.append(
-                # pylint: disable-next=consider-using-f-string
-                "%s        %s"
-                % (erratum.ljust(15), str(len(to_apply_by_name[erratum])).rjust(3))
-            )
+            summary.append('%s        %s' % (erratum.ljust(15),
+                                             str(len(to_apply_by_name[erratum])).rjust(3)))
         else:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("%s does not affect any systems" % erratum)
+            logging.debug('%s does not affect any systems' % erratum)
 
     # get a unique list of all systems we need to touch
     for systemlist in to_apply_by_name.values():
@@ -187,100 +161,89 @@ def do_errata_apply(self, args, errata_list=None, only_systems=None):
     systems = sorted(list(set(systems)))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No patches to apply"))
+        logging.warning(_N('No patches to apply'))
         return 1
 
     # a summary of which errata we're going to apply
-    print(_("Errata             Systems"))
-    print("--------------     -------")
-    print("\n".join(sorted(summary)))
-    print("")
-    print(_("Start Time: %s") % start_time)
+    print(_('Errata             Systems'))
+    print('--------------     -------')
+    print('\n'.join(sorted(summary)))
+    print('')
+    print(_('Start Time: %s') % start_time)
 
-    # pylint: disable-next=undefined-variable
     if not is_interactive(options) and not self.options.yes:
         return 1
 
-    # pylint: disable-next=undefined-variable
-    if is_interactive(options) and not self.user_confirm(
-        _("Apply these patches [y/N]:")
-    ):
+    if is_interactive(options) and not self.user_confirm(_('Apply these patches [y/N]:')):
         return 1
 
     # if the API supports it, try to schedule multiple systems for one erratum
     # in order to reduce the number of actions scheduled
-    if self.check_api_version("10.11"):
+    if self.check_api_version('10.11'):
         to_apply = {}
 
         for system in systems:
             system_id = self.get_system_id(system)
 
             # only attempt to schedule unscheduled errata
-            system_errata = self.client.system.getUnscheduledErrata(
-                self.session, system_id
-            )
+            system_errata = self.client.system.getUnscheduledErrata(self.session,
+                                                                    system_id)
 
             # make a list of systems for each erratum
             for erratum in system_errata:
-                erratum_id = erratum.get("id")
+                erratum_id = erratum.get('id')
 
-                if erratum.get("advisory_name") in errata_list:
+                if erratum.get('advisory_name') in errata_list:
                     to_apply.setdefault(erratum_id, []).append(system_id)
 
         # apply the errata
         for erratum in sorted(to_apply):
-            self.client.system.scheduleApplyErrata(
-                self.session, to_apply[erratum], [erratum], start_time
-            )
+            self.client.system.scheduleApplyErrata(self.session,
+                                                   to_apply[erratum],
+                                                   [erratum],
+                                                   start_time)
 
-            # pylint: disable-next=undefined-variable
-            logging.info(
-                _N("Scheduled %i system(s) for %s")
-                % (len(to_apply[erratum]), self.get_erratum_name(erratum))
-            )
+            logging.info(_N('Scheduled %i system(s) for %s') %
+                         (len(to_apply[erratum]),
+                          self.get_erratum_name(erratum)))
     else:
         for system in systems:
             system_id = self.get_system_id(system)
 
             # only schedule unscheduled errata
-            system_errata = self.client.system.getUnscheduledErrata(
-                self.session, system_id
-            )
+            system_errata = self.client.system.getUnscheduledErrata(self.session,
+                                                                    system_id)
 
             # if an errata specified for installation is unscheduled for
             # this system, add it to the list to schedule
             errata_to_apply = []
             for erratum in errata_list:
                 for e in system_errata:
-                    if erratum == e.get("advisory_name"):
-                        errata_to_apply.append(e.get("id"))
+                    if erratum == e.get('advisory_name'):
+                        errata_to_apply.append(e.get('id'))
                         break
 
             if not errata_to_apply:
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("No patches to schedule for %s") % system)
+                logging.warning(_N('No patches to schedule for %s') % system)
                 continue
 
             # this results in one action per erratum for each server
-            self.client.system.scheduleApplyErrata(
-                self.session, system_id, errata_to_apply, start_time
-            )
+            self.client.system.scheduleApplyErrata(self.session,
+                                                   system_id,
+                                                   errata_to_apply,
+                                                   start_time)
 
-            # pylint: disable-next=undefined-variable
-            logging.info(
-                _N("Scheduled %i patches for %s") % (len(errata_to_apply), system)
-            )
+            logging.info(_N('Scheduled %i patches for %s') %
+                         (len(errata_to_apply), system))
 
     return 0
-
 
 ####################
 
 
 def help_errata_listaffectedsystems(self):
-    print(_("errata_listaffectedsystems: List of systems affected by an patch"))
-    print(_("usage: errata_listaffectedsystems ERRATA|search:XXX ..."))
+    print(_('errata_listaffectedsystems: List of systems affected by an patch'))
+    print(_('usage: errata_listaffectedsystems ERRATA|search:XXX ...'))
 
 
 def complete_errata_listaffectedsystems(self, text, line, beg, end):
@@ -288,10 +251,8 @@ def complete_errata_listaffectedsystems(self, text, line, beg, end):
 
 
 def do_errata_listaffectedsystems(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -311,19 +272,17 @@ def do_errata_listaffectedsystems(self, args):
                 print(self.SEPARATOR)
             add_separator = True
 
-            # pylint: disable-next=consider-using-f-string
-            print("%s:" % erratum)
-            print("\n".join(sorted([s.get("name") for s in systems])))
+            print('%s:' % erratum)
+            print('\n'.join(sorted([s.get('name') for s in systems])))
 
     return 0
-
 
 ####################
 
 
 def help_errata_listcves(self):
-    print(_("errata_listcves: List of CVEs addressed by an patch"))
-    print(_("usage: errata_listcves ERRATA|search:XXX ..."))
+    print(_('errata_listcves: List of CVEs addressed by an patch'))
+    print(_('usage: errata_listcves ERRATA|search:XXX ...'))
 
 
 def complete_errata_listcves(self, text, line, beg, end):
@@ -331,10 +290,8 @@ def complete_errata_listcves(self, text, line, beg, end):
 
 
 def do_errata_listcves(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -356,22 +313,20 @@ def do_errata_listcves(self, args):
                         print(self.SEPARATOR)
                     add_separator = True
 
-                    # pylint: disable-next=consider-using-f-string
-                    print("%s:" % erratum)
+                    print('%s:' % erratum)
 
-                print("\n".join(sorted(cves)))
+                print('\n'.join(sorted(cves)))
         return 0
     else:
         print(_("No errata has been found"))
         return 1
 
-
 ####################
 
 
 def help_errata_findbycve(self):
-    print(_("errata_findbycve: List errata addressing a CVE"))
-    print(_("usage: errata_findbycve CVE-YYYY-NNNN ..."))
+    print(_('errata_findbycve: List errata addressing a CVE'))
+    print(_('usage: errata_findbycve CVE-YYYY-NNNN ...'))
 
 
 def complete_errata_findbycve(self, text, line, beg, end):
@@ -379,13 +334,11 @@ def complete_errata_findbycve(self, text, line, beg, end):
 
 
 def do_errata_findbycve(self, args):
-    # pylint: disable-next=undefined-variable,unused-variable
     cve_list, _options = parse_command_arguments(args, get_argument_parser())
     if not cve_list:
         self.help_errata_findbycve()
         return 1
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got CVE list %s" % cve_list)
     add_separator = False
 
@@ -395,23 +348,20 @@ def do_errata_findbycve(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        # pylint: disable-next=consider-using-f-string
         print("%s:" % c)
         errata = self.client.errata.findByCve(self.session, c)
         if errata:
             for e in errata:
-                # pylint: disable-next=consider-using-f-string
-                print("%s" % e.get("advisory_name"))
+                print("%s" % e.get('advisory_name'))
 
     return 0
-
 
 ####################
 
 
 def help_errata_details(self):
-    print(_("errata_details: Show the details of an patch"))
-    print(_("usage: errata_details ERRATA|search:XXX ..."))
+    print(_('errata_details: Show the details of an patch'))
+    print(_('usage: errata_details ERRATA|search:XXX ...'))
 
 
 def complete_errata_details(self, text, line, beg, end):
@@ -419,10 +369,8 @@ def complete_errata_details(self, text, line, beg, end):
 
 
 def do_errata_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -440,84 +388,78 @@ def do_errata_details(self, args):
 
             packages = self.client.errata.listPackages(self.session, erratum)
 
-            systems = self.client.errata.listAffectedSystems(self.session, erratum)
+            systems = self.client.errata.listAffectedSystems(self.session,
+                                                             erratum)
 
             cves = self.client.errata.listCves(self.session, erratum)
 
-            channels = self.client.errata.applicableToChannels(self.session, erratum)
+            channels = \
+                self.client.errata.applicableToChannels(self.session, erratum)
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s is not a valid erratum") % erratum)
+            logging.warning(_N('%s is not a valid erratum') % erratum)
             continue
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("Name:       %s") % erratum)
-        print(_("Product:    %s") % (details.get("product") or "N/A"))
-        print(_("Type:       %s") % (details.get("type") or "N/A"))
-        print(_("Status:     %s") % (details.get("advisory_status") or "N/A"))
-        print(_("Issue Date: %s") % (details.get("issue_date") or "N/A"))
-        print("")
-        print(_("Topic"))
-        print("-----")
-        # pylint: disable-next=undefined-variable
-        print("\n".join(wrap(details.get("topic") or "N/A")))
-        print("")
-        print(_("Description"))
-        print("-----------")
-        # pylint: disable-next=undefined-variable
-        print("\n".join(wrap(details.get("description") or "N/A")))
+        print(_('Name:       %s') % erratum)
+        print(_('Product:    %s') % (details.get('product') or "N/A"))
+        print(_('Type:       %s') % (details.get('type') or "N/A"))
+        print(_('Status:     %s') % (details.get('advisory_status') or "N/A"))
+        print(_('Issue Date: %s') % (details.get('issue_date') or "N/A"))
+        print('')
+        print(_('Topic'))
+        print('-----')
+        print('\n'.join(wrap(details.get('topic') or "N/A")))
+        print('')
+        print(_('Description'))
+        print('-----------')
+        print('\n'.join(wrap(details.get('description') or "N/A")))
 
-        if details.get("notes"):
-            print("")
-            print(_("Notes"))
-            print("-----")
-            # pylint: disable-next=undefined-variable
-            print("\n".join(wrap(details.get("notes") or "N/A")))
+        if details.get('notes'):
+            print('')
+            print(_('Notes'))
+            print('-----')
+            print('\n'.join(wrap(details.get('notes') or "N/A")))
 
-        print("")
-        print(_("CVEs"))
-        print("----")
-        print("\n".join(sorted(cves)))
-        print("")
-        print(_("Vendor Advisory"))
-        print("---------------")
-        print(details.get("vendor_advisory") or "N/A")
-        print("")
-        print(_("Solution"))
-        print("--------")
-        # pylint: disable-next=undefined-variable
-        print("\n".join(wrap(details.get("solution") or "N/A")))
-        print("")
-        print(_("References"))
-        print("----------")
-        # pylint: disable-next=undefined-variable
-        print("\n".join(wrap(details.get("references") or "N/A")))
-        print("")
-        print(_("Affected Channels"))
-        print("-----------------")
-        print("\n".join(sorted(filter(None, [c.get("label") or "" for c in channels]))))
-        print("")
-        print(_("Affected Systems"))
-        print("----------------")
+        print('')
+        print(_('CVEs'))
+        print('----')
+        print('\n'.join(sorted(cves)))
+        print('')
+        print(_('Vendor Advisory'))
+        print('---------------')
+        print(details.get('vendor_advisory') or "N/A")
+        print('')
+        print(_('Solution'))
+        print('--------')
+        print('\n'.join(wrap(details.get('solution') or "N/A")))
+        print('')
+        print(_('References'))
+        print('----------')
+        print('\n'.join(wrap(details.get('references') or "N/A")))
+        print('')
+        print(_('Affected Channels'))
+        print('-----------------')
+        print('\n'.join(sorted(filter(None, [c.get('label') or "" for c in channels]))))
+        print('')
+        print(_('Affected Systems'))
+        print('----------------')
         print(str(len(systems)))
-        print("")
-        print(_("Affected Packages"))
-        print("-----------------")
-        # pylint: disable-next=undefined-variable
-        print("\n".join(sorted(build_package_names(packages))))
+        print('')
+        print(_('Affected Packages'))
+        print('-----------------')
+        print('\n'.join(sorted(build_package_names(packages))))
 
     return 0
-
 
 ####################
 
 
 def help_errata_delete(self):
-    print(_("errata_delete: Delete an patch"))
-    print(_("usage: errata_delete ERRATA|search:XXX ..."))
+    print(_('errata_delete: Delete an patch'))
+    print(_('usage: errata_delete ERRATA|search:XXX ...'))
 
 
 def complete_errata_delete(self, text, line, beg, end):
@@ -525,10 +467,8 @@ def complete_errata_delete(self, text, line, beg, end):
 
 
 def do_errata_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -539,58 +479,51 @@ def do_errata_delete(self, args):
     errata = self.expand_errata(args)
 
     if not errata:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No patches to delete"))
+        logging.warning(_N('No patches to delete'))
         return 1
 
-    print(_("Erratum            Channels"))
-    print("-------            --------")
+    print(_('Erratum            Channels'))
+    print('-------            --------')
 
     # tell the user how many channels each erratum affects
     for erratum in sorted(errata):
         channels = self.client.errata.applicableToChannels(self.session, erratum)
-        # pylint: disable-next=consider-using-f-string
-        print("%s    %s" % (erratum.ljust(20), str(len(channels)).rjust(3)))
+        print('%s    %s' % (erratum.ljust(20), str(len(channels)).rjust(3)))
 
-    if not self.options.yes and not self.user_confirm(_("Delete these patches [y/N]:")):
+    if not self.options.yes and not self.user_confirm(_('Delete these patches [y/N]:')):
         return 1
 
     for erratum in errata:
         self.client.errata.delete(self.session, erratum)
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Deleted %i patches") % len(errata))
+    logging.info(_N('Deleted %i patches') % len(errata))
 
     self.generate_errata_cache(True)
 
     return 0
 
-
 ####################
 
 
 def help_errata_publish(self):
-    print(_("errata_publish: Publish an patch to a channel"))
-    print(_("usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"))
+    print(_('errata_publish: Publish an patch to a channel'))
+    print(_('usage: errata_publish ERRATA|search:XXX <CHANNEL ...>'))
 
 
 def complete_errata_publish(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_errata(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
 
     return None
 
 
 def do_errata_publish(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -603,15 +536,12 @@ def do_errata_publish(self, args):
     channels = args[1:]
 
     if not errata:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No patches to publish"))
+        logging.warning(_N('No patches to publish'))
         return 1
 
-    print("\n".join(sorted(errata)))
+    print('\n'.join(sorted(errata)))
 
-    if not self.options.yes and not self.user_confirm(
-        _("Publish these patches [y/N]:")
-    ):
+    if not self.options.yes and not self.user_confirm(_('Publish these patches [y/N]:')):
         return 1
 
     for erratum in errata:
@@ -619,29 +549,25 @@ def do_errata_publish(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_errata_search(self):
-    print(_("errata_search: List patches that meet the given criteria"))
-    print(_("usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."))
-    print("")
-    print(_("Example:"))
-    print("> errata_search CVE-2009:1674")
-    print("> errata_search RHSA-2009:1674")
+    print(_('errata_search: List patches that meet the given criteria'))
+    print(_('usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ...'))
+    print('')
+    print(_('Example:'))
+    print('> errata_search CVE-2009:1674')
+    print('> errata_search RHSA-2009:1674')
 
 
 def complete_errata_search(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_errata_list("", True), text)
+    return tab_completer(self.do_errata_list('', True), text)
 
 
 def do_errata_search(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -654,32 +580,25 @@ def do_errata_search(self, args, doreturn=False):
     for query in args:
         errata = []
 
-        # pylint: disable-next=undefined-variable
-        if re.match("CVE", query, re.I):
-            errata = self.client.errata.findByCve(self.session, query.upper())
+        if re.match('CVE', query, re.I):
+            errata = self.client.errata.findByCve(self.session,
+                                                  query.upper())
         else:
             self.generate_errata_cache()
 
             for name in self.all_errata.keys():
-                # pylint: disable-next=undefined-variable
-                if re.search(query, name, re.I) or re.search(
-                    query,
-                    self.all_errata[name]["advisory_synopsis"],
-                    # pylint: disable-next=undefined-variable
-                    re.I,
-                ):
+                if re.search(query, name, re.I) or \
+                   re.search(query, self.all_errata[name]['advisory_synopsis'],
+                             re.I):
+
                     match = self.all_errata[name]
 
                     # build a structure to pass to print_errata_summary()
-                    errata.append(
-                        {
-                            "advisory_name": name,
-                            "advisory_type": match["advisory_type"],
-                            "advisory_status": match["advisory_status"],
-                            "advisory_synopsis": match["advisory_synopsis"],
-                            "date": match["date"],
-                        }
-                    )
+                    errata.append({'advisory_name': name,
+                                   'advisory_type': match['advisory_type'],
+                                   'advisory_status': match['advisory_status'],
+                                   'advisory_synopsis': match['advisory_synopsis'],
+                                   'date': match['date']})
 
         if add_separator:
             print(self.SEPARATOR)
@@ -687,12 +606,9 @@ def do_errata_search(self, args, doreturn=False):
             add_separator = True
 
         if doreturn:
-            out += [erratum["advisory_name"] for erratum in errata]
+            out += [erratum['advisory_name'] for erratum in errata]
         else:
-            for erratum in sorted(
-                errata, key=lambda x: (x["advisory_name"]), reverse=True
-            ):
-                # pylint: disable-next=undefined-variable
+            for erratum in sorted(errata, key=lambda x: (x['advisory_name']), reverse=True):
                 print_errata_summary(erratum=erratum)
 
     return out if doreturn else None

--- a/spacecmd/src/spacecmd/filepreservation.py
+++ b/spacecmd/src/spacecmd/filepreservation.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -33,53 +32,43 @@
 import gettext
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_filepreservation_list(self):
-    print(_("filepreservation_list: List all file preservations"))
-    print(_("usage: filepreservation_list"))
+    print(_('filepreservation_list: List all file preservations'))
+    print(_('usage: filepreservation_list'))
 
 
 def do_filepreservation_list(self, args, doreturn=False):
-    lists = [
-        l.get("name")
-        for l in self.client.kickstart.filepreservation.listAllFilePreservations(
-            self.session
-        )
-    ]
+    lists = [l.get('name') for l in self.client.kickstart.filepreservation.listAllFilePreservations(self.session)]
 
     if not doreturn:
-        print("\n".join(sorted(lists)))
+        print('\n'.join(sorted(lists)))
         return None
 
     return lists
-
 
 ####################
 
 
 def help_filepreservation_create(self):
-    print(_("filepreservation_create: Create a file preservation list"))
-    print(_("usage: filepreservation_create [NAME] [FILE ...]"))
+    print(_('filepreservation_create: Create a file preservation list'))
+    print(_('usage: filepreservation_create [NAME] [FILE ...]'))
 
 
 def do_filepreservation_create(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
         name = args[0]
     else:
-        # pylint: disable-next=undefined-variable
-        name = prompt_user(_("Name:"), noblank=True)
+        name = prompt_user(_('Name:'), noblank=True)
 
     if len(args) > 1:
         files = args[1:]
@@ -87,50 +76,47 @@ def do_filepreservation_create(self, args):
         files = []
 
         while True:
-            print(_("File List"))
-            print("---------")
-            print("\n".join(sorted(files)))
-            print("")
+            print(_('File List'))
+            print('---------')
+            print('\n'.join(sorted(files)))
+            print('')
 
-            # pylint: disable-next=undefined-variable
-            userinput = prompt_user(_("File [blank to finish]:"))
+            userinput = prompt_user(_('File [blank to finish]:'))
 
-            if userinput == "":
+            if userinput == '':
                 break
             if userinput not in files:
                 files.append(userinput)
 
-    print("")
-    print(_("File List"))
-    print("---------")
-    print("\n".join(sorted(files)))
+    print('')
+    print(_('File List'))
+    print('---------')
+    print('\n'.join(sorted(files)))
 
     if not self.user_confirm():
         return 1
 
-    self.client.kickstart.filepreservation.create(self.session, name, files)
+    self.client.kickstart.filepreservation.create(self.session,
+                                                  name,
+                                                  files)
 
     return 0
-
 
 ####################
 
 
 def help_filepreservation_delete(self):
-    print(_("filepreservation_delete: Delete a file preservation list"))
-    print(_("usage: filepreservation_delete NAME"))
+    print(_('filepreservation_delete: Delete a file preservation list'))
+    print(_('usage: filepreservation_delete NAME'))
 
 
 def complete_filepreservation_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_filepreservation_list("", True), text)
+    return tab_completer(self.do_filepreservation_list('', True), text)
 
 
 def do_filepreservation_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -139,37 +125,29 @@ def do_filepreservation_delete(self, args):
 
     name = args[0]
 
-    if not self.user_confirm(_("Delete this list [y/N]:")):
+    if not self.user_confirm(_('Delete this list [y/N]:')):
         return 1
 
     self.client.kickstart.filepreservation.delete(self.session, name)
 
     return 0
 
-
 ####################
 
 
 def help_filepreservation_details(self):
-    print(
-        _(
-            """filepreservation_details: Show the details of a file
-'preservation list"""
-        )
-    )
-    print(_("usage: filepreservation_details NAME"))
+    print(_('''filepreservation_details: Show the details of a file
+'preservation list'''))
+    print(_('usage: filepreservation_details NAME'))
 
 
 def complete_filepreservation_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_filepreservation_list("", True), text)
+    return tab_completer(self.do_filepreservation_list('', True), text)
 
 
 def do_filepreservation_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -178,8 +156,10 @@ def do_filepreservation_details(self, args):
 
     name = args[0]
 
-    details = self.client.kickstart.filepreservation.getDetails(self.session, name)
+    details = \
+        self.client.kickstart.filepreservation.getDetails(self.session,
+                                                          name)
 
-    print("\n".join(sorted(details.get("file_names"))))
+    print('\n'.join(sorted(details.get('file_names'))))
 
     return 0

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -34,7 +33,6 @@ import gettext
 import os
 import re
 import shlex
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -43,7 +41,7 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
@@ -51,21 +49,20 @@ except AttributeError:
 
 
 def help_group_addsystems(self):
-    print(_("group_addsystems: Add systems to a group"))
-    print(_("usage: group_addsystems GROUP <SYSTEMS>"))
-    print(_("       group_addsystems GROUP <ssm>"))
-    print("")
+    print(_('group_addsystems: Add systems to a group'))
+    print(_('usage: group_addsystems GROUP <SYSTEMS>'))
+    print(_('       group_addsystems GROUP <ssm>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_group_addsystems(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_group_list("", True), text)
+        return tab_completer(self.do_group_list('', True), text)
     elif len(parts) > 2:
         return self.tab_complete_systems(parts[-1])
 
@@ -73,10 +70,8 @@ def complete_group_addsystems(self, text, line, beg, end):
 
 
 def do_group_addsystems(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -86,7 +81,7 @@ def do_group_addsystems(self, args):
     group_name = args.pop(0)
 
     # use the systems listed in the SSM
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
@@ -99,32 +94,29 @@ def do_group_addsystems(self, args):
         system_ids.append(system_id)
 
     if system_ids:
-        self.client.systemgroup.addOrRemoveSystems(
-            self.session, group_name, system_ids, True
-        )
+        self.client.systemgroup.addOrRemoveSystems(self.session, group_name,
+                                                   system_ids, True)
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_group_removesystems(self):
-    print(_("group_removesystems: Remove systems from a group"))
-    print(_("usage: group_removesystems GROUP <SYSTEMS>"))
-    print("")
+    print(_('group_removesystems: Remove systems from a group'))
+    print(_('usage: group_removesystems GROUP <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_group_removesystems(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_group_list("", True), text)
+        return tab_completer(self.do_group_list('', True), text)
     elif len(parts) > 2:
         return self.tab_complete_systems(parts[-1])
 
@@ -132,10 +124,8 @@ def complete_group_removesystems(self, text, line, beg, end):
 
 
 def do_group_removesystems(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -145,7 +135,7 @@ def do_group_removesystems(self, args):
     group_name = args.pop(0)
 
     # use the systems listed in the SSM
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
@@ -158,16 +148,17 @@ def do_group_removesystems(self, args):
         system_ids.append(system_id)
 
     if system_ids:
-        print(_("Systems"))
-        print("-------")
-        print("\n".join(sorted(systems)))
+        print(_('Systems'))
+        print('-------')
+        print('\n'.join(sorted(systems)))
 
-        if not self.user_confirm(_("Remove these systems [y/N]:")):
+        if not self.user_confirm(_('Remove these systems [y/N]:')):
             return None
 
-        self.client.systemgroup.addOrRemoveSystems(
-            self.session, group_name, system_ids, False
-        )
+        self.client.systemgroup.addOrRemoveSystems(self.session,
+                                                   group_name,
+                                                   system_ids,
+                                                   False)
         return 0
     else:
         print(_("No systems found"))
@@ -175,57 +166,48 @@ def do_group_removesystems(self, args):
 
     return None
 
-
 ####################
 
 
 def help_group_create(self):
-    print(_("group_create: Create a system group"))
-    print(_("usage: group_create [NAME] [DESCRIPTION]"))
+    print(_('group_create: Create a system group'))
+    print(_('usage: group_create [NAME] [DESCRIPTION]'))
 
 
 def do_group_create(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
         name = args[0]
     else:
-        # pylint: disable-next=undefined-variable
-        name = prompt_user(_("Name:"))
+        name = prompt_user(_('Name:'))
 
     if len(args) > 1:
-        description = " ".join(args[1:])
+        description = ' '.join(args[1:])
     else:
-        # pylint: disable-next=undefined-variable
-        description = prompt_user(_("Description:"))
+        description = prompt_user(_('Description:'))
 
     self.client.systemgroup.create(self.session, name, description)
 
     return 0
 
-
 ####################
 
 
 def help_group_delete(self):
-    print(_("group_delete: Delete a system group"))
-    print(_("usage: group_delete NAME ..."))
+    print(_('group_delete: Delete a system group'))
+    print(_('usage: group_delete NAME ...'))
 
 
 def complete_group_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_group_list("", True), text)
+    return tab_completer(self.do_group_list('', True), text)
 
 
 def do_group_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -234,8 +216,8 @@ def do_group_delete(self, args):
 
     groups = args
 
-    self.do_group_details("", True)
-    if not self.user_confirm(_("Delete these groups [y/N]:")):
+    self.do_group_details('', True)
+    if not self.user_confirm(_('Delete these groups [y/N]:')):
         return 1
 
     for group in groups:
@@ -243,36 +225,28 @@ def do_group_delete(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_group_backup(self):
-    print(_("group_backup: backup a system group"))
-    print(
-        _(
-            """usage: group_backup <NAME> [OUTDIR])
+    print(_('group_backup: backup a system group'))
+    print(_('''usage: group_backup <NAME> [OUTDIR])
                     group_backup ALL
 
 "OUTDIR" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME
 "ALL" is a keyword and collects all groups
-"""
-        )
-    )
+'''))
 
 
 def complete_group_backup(self, text, line, beg, end):
-    List = self.do_group_list("", True)
-    List.append("ALL")
-    # pylint: disable-next=undefined-variable
+    List = self.do_group_list('', True)
+    List.append('ALL')
     return tab_completer(List, text)
 
 
 def do_group_backup(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -280,59 +254,53 @@ def do_group_backup(self, args):
         return 1
 
     groups = args
-    if len(args) > 0 and args[0] == "ALL":  # pylint: disable=len-as-condition
-        groups = self.do_group_list("", True)
+    if len(args) > 0 and args[0] == 'ALL':      # pylint: disable=len-as-condition
+        groups = self.do_group_list('', True)
 
     # use an output base from the user if it was passed
     if len(args) > 1:
-        # pylint: disable-next=undefined-variable
         outputpath_base = datetime.now().strftime(os.path.expanduser(args[1]))
     else:
-        outputpath_base = os.path.expanduser("~/spacecmd-backup/group")
+        outputpath_base = os.path.expanduser('~/spacecmd-backup/group')
 
         # make the final output path be <base>/date
-        outputpath_base = os.path.join(
-            outputpath_base,
-            # pylint: disable-next=undefined-variable
-            datetime.now().strftime("%Y-%m-%d"),
-        )
+        outputpath_base = os.path.join(outputpath_base,
+                                       datetime.now().strftime("%Y-%m-%d"))
 
     try:
         if not os.path.isdir(outputpath_base):
             os.makedirs(outputpath_base)
     except OSError:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Could not create output directory: %s"), outputpath_base)
+        logging.error(_N('Could not create output directory: %s'), outputpath_base)
         return 1
 
     for group in groups:
         print(_("Backup Group: %s") % group)
         details = self.client.systemgroup.getDetails(self.session, group)
-        formulas = self.client.formula.getFormulasByGroupId(self.session, details["id"])
+        formulas = self.client.formula.getFormulasByGroupId(self.session, details['id'])
         formula_data = {
-            f: self.client.formula.getGroupFormulaData(self.session, details["id"], f)
+            f: self.client.formula.getGroupFormulaData(self.session, details['id'], f)
             for f in formulas
         }
 
         outputpath = outputpath_base + "/" + group
         print(_("Output File: %s") % outputpath)
 
-        backup = {"description": details["description"], "formulas": formula_data}
+        backup = {
+            'description': details['description'],
+            'formulas': formula_data
+        }
 
-        # pylint: disable-next=undefined-variable
         json_dump_to_file(backup, outputpath)
 
     return 0
-
 
 ####################
 
 
 def help_group_restore(self):
-    print(_("group_restore: restore a system group"))
-    print(
-        _(
-            """
+    print(_('group_restore: restore a system group'))
+    print(_('''
 usage: group_restore INPUTDIR [NAME] ...
        group_restore INPUTDIR ALL
        group_restore INPUTDIR
@@ -340,25 +308,21 @@ usage: group_restore INPUTDIR [NAME] ...
 
 Specifying only INPUTDIR will default to ALL groups.
 Setting dot (.) instead of full INPUTDIR will imply current directory.
-    """
-        )
-    )
+    '''))
 
 
 def complete_group_restore(self, text, line, beg, end):
     parts = shlex.split(line)
 
     if len(parts) > 1:
-        groups = self.do_group_list("", True)
-        groups.append("ALL")
-        # pylint: disable-next=undefined-variable
+        groups = self.do_group_list('', True)
+        groups.append('ALL')
         return tab_completer(groups, text)
 
     return None
 
 
 def do_group_restore(self, args):
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, get_argument_parser())
 
     files = {}
@@ -372,7 +336,6 @@ def do_group_restore(self, args):
         return 1
 
     inputdir = os.path.abspath(inputdir)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Input Directory: %s" % (inputdir))
 
     # make a list of file items in the input dir
@@ -380,175 +343,126 @@ def do_group_restore(self, args):
         d_content = os.listdir(inputdir)
         for d_item in d_content:
             if os.path.isfile(inputdir + "/" + d_item):
-                # pylint: disable-next=undefined-variable,consider-using-f-string
                 logging.debug("Found file %s" % inputdir + "/" + d_item)
                 files[d_item] = inputdir + "/" + d_item
     else:
-        # pylint: disable-next=undefined-variable
-        logging.error(
-            _N("Restore dir %s does not exits or is not a directory") % inputdir
-        )
+        logging.error(_N("Restore dir %s does not exits or is not a directory") % inputdir)
         return 1
 
     if not files:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Restore dir %s has no restore items") % inputdir)
         return 1
 
     missing_groups = 0
-    if groups and next(iter(groups)) != "ALL":
+    if groups and next(iter(groups)) != 'ALL':
         for group in groups:
             if group not in files:
-                # pylint: disable-next=undefined-variable
                 logging.error(_N("Group %s was not found in backup") % (group))
                 missing_groups += 1
     if missing_groups:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Found %s missing groups, terminating"), missing_groups)
         return 1
 
-    for groupname in self.do_group_list("", True):
+    for groupname in self.do_group_list('', True):
         details = self.client.systemgroup.getDetails(self.session, groupname)
-        formulas = self.client.formula.getFormulasByGroupId(self.session, details["id"])
+        formulas = self.client.formula.getFormulasByGroupId(self.session, details['id'])
         formula_data = {}
         for f in formulas:
-            formula_data[f] = self.client.formula.getGroupFormulaData(
-                self.session, details["id"], f
-            )
+            formula_data[f] = self.client.formula.getGroupFormulaData(self.session, details['id'], f)
 
         current[groupname] = {
-            "description": details["description"],
-            "id": details["id"],
-            "formulas": formula_data,
+            'description': details['description'],
+            'id': details['id'],
+            'formulas': formula_data
         }
 
-    # pylint: disable-next=consider-using-dict-items
     for groupname in files:
-        # pylint: disable-next=undefined-variable
         backup = json_read_from_file(files[groupname])
         if backup is None:
             # assume old backup, not in json format. Read complete file as string
-            # pylint: disable-next=undefined-variable
             logging.info(_("Assuming group to be in old plain text format"))
-            # pylint: disable-next=unspecified-encoding
-            with open(files[groupname], "r") as fh:
+            with open(files[groupname], 'r') as fh:
                 details = fh.read()
-            backup = {"description": details.rstrip("\n"), "formulas": {}}
+            backup = {
+                'description': details.rstrip('\n'),
+                'formulas': {}
+            }
 
         if groupname in current:
             # pass id to the backup structure, so that comparison works
-            backup["id"] = current[groupname]["id"]
+            backup['id'] = current[groupname]['id']
             if current[groupname] == backup:
-                # pylint: disable-next=undefined-variable
                 logging.error(_N("Group %s already restored") % groupname)
             else:
-                # pylint: disable-next=undefined-variable,consider-using-f-string
                 logging.debug("Already have %s but the data have changed" % groupname)
 
-                # pylint: disable-next=undefined-variable
                 if is_interactive(options):
-                    if current[groupname]["description"] != backup["description"]:
+                    if current[groupname]['description'] != backup['description']:
                         print(_("Changing description from:"))
-                        print(
-                            # pylint: disable-next=consider-using-f-string
-                            '\n"%s"\nto\n"%s"\n'
-                            % (current[groupname]["description"], backup["description"])
-                        )
-                        # pylint: disable-next=undefined-variable
-                        userinput = prompt_user(_("Continue [y/N]:"))
+                        print('\n"%s"\nto\n"%s"\n' % (current[groupname]['description'], backup['description']))
+                        userinput = prompt_user(_('Continue [y/N]:'))
 
-                        if userinput.lower() == "y":
-                            # pylint: disable-next=undefined-variable
-                            logging.info(
-                                _N("Updating description for group: %s") % groupname
-                            )
-                            self.client.systemgroup.update(
-                                self.session, groupname, backup["description"]
-                            )
-                    if current[groupname]["formulas"] != backup["formulas"]:
-                        # pylint: disable-next=undefined-variable
-                        userinput = prompt_user(
-                            _("Update formula data from backup? [y/N]:")
-                        )
-                        if userinput.lower() == "y":
-                            formulas = list(backup["formulas"].keys())
-                            self.client.formula.setFormulasOfGroup(
-                                self.session, current[groupname]["id"], formulas
-                            )
-                            for f, v in backup["formulas"].items():
-                                self.client.formula.setGroupFormulaData(
-                                    self.session, current[groupname]["id"], f, v
-                                )
+                        if userinput.lower() == 'y':
+                            logging.info(_N("Updating description for group: %s") % groupname)
+                            self.client.systemgroup.update(self.session, groupname, backup['description'])
+                    if current[groupname]['formulas'] != backup['formulas']:
+                        userinput = prompt_user(_('Update formula data from backup? [y/N]:'))
+                        if userinput.lower() == 'y':
+                            formulas = list(backup['formulas'].keys())
+                            self.client.formula.setFormulasOfGroup(self.session, current[groupname]['id'], formulas)
+                            for f, v in backup['formulas'].items():
+                                self.client.formula.setGroupFormulaData(self.session, current[groupname]['id'], f, v)
                 else:
-                    # pylint: disable-next=undefined-variable
                     logging.info(_N("Updating data for group: %s") % groupname)
-                    self.client.systemgroup.update(
-                        self.session, groupname, backup["description"]
-                    )
-                    formulas = list(backup["formulas"].keys())
-                    self.client.formula.setFormulasOfGroup(
-                        self.session, current[groupname]["id"], formulas
-                    )
-                    for f, v in backup["formulas"].items():
-                        self.client.formula.setGroupFormulaData(
-                            self.session, current[groupname]["id"], f, v
-                        )
+                    self.client.systemgroup.update(self.session, groupname, backup['description'])
+                    formulas = list(backup['formulas'].keys())
+                    self.client.formula.setFormulasOfGroup(self.session, current[groupname]['id'], formulas)
+                    for f, v in backup['formulas'].items():
+                        self.client.formula.setGroupFormulaData(self.session, current[groupname]['id'], f, v)
 
         else:
-            # pylint: disable-next=undefined-variable
             logging.info(_N("Creating new group %s") % groupname)
-            details = self.client.systemgroup.create(
-                self.session, groupname, backup["description"]
-            )
-            formulas = list(backup["formulas"].keys())
-            self.client.formula.setFormulasOfGroup(
-                self.session, details["id"], formulas
-            )
-            for f, v in backup["formulas"].items():
-                self.client.formula.setGroupFormulaData(
-                    self.session, details["id"], f, v
-                )
+            details = self.client.systemgroup.create(self.session, groupname, backup['description'])
+            formulas = list(backup['formulas'].keys())
+            self.client.formula.setFormulasOfGroup(self.session, details['id'], formulas)
+            for f, v in backup['formulas'].items():
+                self.client.formula.setGroupFormulaData(self.session, details['id'], f, v)
 
     return 0
-
 
 ####################
 
 
 def help_group_list(self):
-    print(_("group_list: List available system groups"))
-    print(_("usage: group_list"))
+    print(_('group_list: List available system groups'))
+    print(_('usage: group_list'))
 
 
 def do_group_list(self, args, doreturn=False):
     groups = self.client.systemgroup.listAllGroups(self.session)
-    groups = [g.get("name") for g in groups]
+    groups = [g.get('name') for g in groups]
 
     if doreturn:
         return groups
     if groups:
-        print("\n".join(sorted(groups)))
+        print('\n'.join(sorted(groups)))
     return None
-
 
 ####################
 
 
 def help_group_listsystems(self):
-    print(_("group_listsystems: List the members of a group"))
-    print(_("usage: group_listsystems GROUP"))
+    print(_('group_listsystems: List the members of a group'))
+    print(_('usage: group_listsystems GROUP'))
 
 
 def complete_group_listsystems(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_group_list("", True), text)
+    return tab_completer(self.do_group_list('', True), text)
 
 
 def do_group_listsystems(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -559,38 +473,33 @@ def do_group_listsystems(self, args, doreturn=False):
 
     try:
         systems = self.client.systemgroup.listSystems(self.session, group)
-        systems = [s.get("profile_name") for s in systems]
+        systems = [s.get('profile_name') for s in systems]
     except xmlrpclib.Fault:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("%s is not a valid group") % group)
+        logging.warning(_N('%s is not a valid group') % group)
         return []
 
     if doreturn:
         return systems
     if systems:
-        print("\n".join(sorted(systems)))
+        print('\n'.join(sorted(systems)))
 
     return None
-
 
 ####################
 
 
 def help_group_details(self):
-    print(_("group_details: Show the details of a system group"))
-    print(_("usage: group_details GROUP ..."))
+    print(_('group_details: Show the details of a system group'))
+    print(_('usage: group_details GROUP ...'))
 
 
 def complete_group_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_group_list("", True), text)
+    return tab_completer(self.do_group_list('', True), text)
 
 
 def do_group_details(self, args, short=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -602,12 +511,8 @@ def do_group_details(self, args, short=False):
     for group in args:
         try:
             details = self.client.systemgroup.getDetails(self.session, group)
-            systems = [
-                stm.get("profile_name")
-                for stm in self.client.systemgroup.listSystems(self.session, group)
-            ]
+            systems = [stm.get('profile_name') for stm in self.client.systemgroup.listSystems(self.session, group)]
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
             logging.warning(_N('The group "%s" is invalid') % group)
             return 1
 
@@ -615,47 +520,35 @@ def do_group_details(self, args, short=False):
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("ID:                %i") % details.get("id"))
-        print(_("Name:              %s") % details.get("name"))
-        print(_("Description:       %s") % details.get("description"))
-        print(_("Number of Systems: %i") % details.get("system_count"))
+        print(_('ID:                %i') % details.get('id'))
+        print(_('Name:              %s') % details.get('name'))
+        print(_('Description:       %s') % details.get('description'))
+        print(_('Number of Systems: %i') % details.get('system_count'))
 
         if not short:
-            print("")
-            print(_("Members"))
-            print("-------")
-            print("\n".join(sorted(systems)))
+            print('')
+            print(_('Members'))
+            print('-------')
+            print('\n'.join(sorted(systems)))
 
     return 0
 
-
 ####################
 
-
 def help_group_listconfigchannels(self):
-    print(
-        _(
-            "group_listconfigchannels: List configuration channels assigned to a system group"
-        )
-    )
-    print(_("usage: group_listconfigchannels GROUP"))
-
+    print(_('group_listconfigchannels: List configuration channels assigned to a system group'))
+    print(_('usage: group_listconfigchannels GROUP'))
 
 def complete_group_listconfigchannels(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_group_list("", True), text)
-
+    return tab_completer(self.do_group_list('', True), text)
 
 def do_group_listconfigchannels(self, args):
-    if not self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
+    if not self.check_api_version('25.0'):
         logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -666,11 +559,8 @@ def do_group_listconfigchannels(self, args):
 
     for group in args:
         try:
-            channels = self.client.systemgroup.listAssignedConfigChannels(
-                self.session, group
-            )
+            channels = self.client.systemgroup.listAssignedConfigChannels(self.session, group)
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
             logging.warning(_N('The group "%s" is invalid') % group)
             return 1
         for details in channels:
@@ -678,47 +568,41 @@ def do_group_listconfigchannels(self, args):
                 print(self.SEPARATOR)
             add_separator = True
 
-            print(_("Label:       %s") % details.get("label"))
-            print(_("Name:        %s") % details.get("name"))
-            print(_("Description: %s") % details.get("description"))
-            print(
-                _("Type:        %s") % details.get("configChannelType", {}).get("label")
-            )
+            print(_('Label:       %s') % details.get('label'))
+            print(_('Name:        %s') % details.get('name'))
+            print(_('Description: %s') % details.get('description'))
+            print(_('Type:        %s') % details.get('configChannelType', {}).get('label'))
 
     return 0
-
 
 ####################
 
 
 def help_group_addconfigchannels(self):
-    print(_("group_addconfigchannels: Add config channels to a group"))
-    print(_("""usage: group_addconfigchannels <GROUP> <CHANNEL ...>"""))
-    print("")
+    print(_('group_addconfigchannels: Add config channels to a group'))
+    print(_('''usage: group_addconfigchannels <GROUP> <CHANNEL ...>'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_group_addconfigchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        return self.tab_completer(self.do_group_list("", True), text)
+        return self.tab_completer(self.do_group_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
     return None
 
 
 def do_group_addconfigchannels(self, args):
-    if not self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
+    if not self.check_api_version('25.0'):
         logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    # pylint: disable-next=undefined-variable
-    (args, _) = parse_command_arguments(args, arg_parser)
+    (args,_) = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_group_addconfigchannels()
@@ -729,38 +613,34 @@ def do_group_addconfigchannels(self, args):
     self.client.systemgroup.subscribeConfigChannel(self.session, group, channels)
     return 0
 
-
 ####################
 
 
 def help_group_removeconfigchannels(self):
-    print(_("group_removeconfigchannels: Remove config channels from a group"))
-    print(_("""usage: group_removeconfigchannels <GROUP> <CHANNEL ...>"""))
-    print("")
+    print(_('group_removeconfigchannels: Remove config channels from a group'))
+    print(_('''usage: group_removeconfigchannels <GROUP> <CHANNEL ...>'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_group_removeconfigchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        return self.tab_completer(self.do_group_list("", True), text)
+        return self.tab_completer(self.do_group_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
     return None
 
 
 def do_group_removeconfigchannels(self, args):
-    if not self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
+    if not self.check_api_version('25.0'):
         logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    # pylint: disable-next=undefined-variable
-    (args, _) = parse_command_arguments(args, arg_parser)
+    (args,_) = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_group_removeconfigchannels()

--- a/spacecmd/src/spacecmd/i18n.py
+++ b/spacecmd/src/spacecmd/i18n.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -17,7 +16,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 # Copyright (c) 2020 SUSE LLC
-
 
 def _N(message):
     return message

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -35,14 +34,12 @@ import gettext
 import os
 from getpass import getpass
 from operator import itemgetter
-
 try:
     from urllib2 import urlopen, HTTPError
 except ImportError:
     from urllib.request import urlopen
     from urllib.error import HTTPError
 import re
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -51,212 +48,151 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-KICKSTART_OPTIONS = [
-    "autostep",
-    "interactive",
-    "install",
-    "upgrade",
-    "text",
-    "network",
-    "cdrom",
-    "harddrive",
-    "nfs",
-    "url",
-    "lang",
-    "langsupport keyboard",
-    "mouse",
-    "device",
-    "deviceprobe",
-    "zerombr",
-    "clearpart",
-    "bootloader",
-    "timezone",
-    "auth",
-    "rootpw",
-    "selinux",
-    "reboot",
-    "firewall",
-    "xconfig",
-    "skipx",
-    "key",
-    "ignoredisk",
-    "autopart",
-    "cmdline",
-    "firstboot",
-    "graphical",
-    "iscsi",
-    "iscsiname",
-    "logging",
-    "monitor",
-    "multipath",
-    "poweroff",
-    "halt",
-    "service",
-    "shutdown",
-    "user",
-    "vnc",
-    "zfcp",
-]
+KICKSTART_OPTIONS = ['autostep', 'interactive', 'install', 'upgrade',
+                     'text', 'network', 'cdrom', 'harddrive', 'nfs',
+                     'url', 'lang', 'langsupport keyboard', 'mouse',
+                     'device', 'deviceprobe', 'zerombr', 'clearpart',
+                     'bootloader', 'timezone', 'auth', 'rootpw', 'selinux',
+                     'reboot', 'firewall', 'xconfig', 'skipx', 'key',
+                     'ignoredisk', 'autopart', 'cmdline', 'firstboot',
+                     'graphical', 'iscsi', 'iscsiname', 'logging',
+                     'monitor', 'multipath', 'poweroff', 'halt', 'service',
+                     'shutdown', 'user', 'vnc', 'zfcp']
 
-VIRT_TYPES = ["none", "para_host", "qemu", "xenfv", "xenpv"]
+VIRT_TYPES = ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']
 
-UPDATE_TYPES = ["red_hat", "all", "none"]
+UPDATE_TYPES = ['red_hat', 'all', 'none']
 
 
 def help_kickstart_list(self):
-    print(_("kickstart_list: List the available Kickstart profiles"))
-    print(_("usage: kickstart_list"))
+    print(_('kickstart_list: List the available Kickstart profiles'))
+    print(_('usage: kickstart_list'))
 
 
 def do_kickstart_list(self, args, doreturn=False):
-    kickstarts = sorted(
-        [kst.get("name") for kst in self.client.kickstart.listKickstarts(self.session)]
-    )
+    kickstarts = sorted([kst.get('name') for kst in self.client.kickstart.listKickstarts(self.session)])
 
     if doreturn:
         return kickstarts
     if kickstarts:
         print(os.linesep.join(kickstarts))
     else:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No kickstart profiles available"))
 
     return None
-
 
 ####################
 
 
 def help_kickstart_create(self):
-    print(_("kickstart_create: Create a Kickstart profile"))
-    print(
-        _(
-            """usage: kickstart_create [options])
+    print(_('kickstart_create: Create a Kickstart profile'))
+    print(_('''usage: kickstart_create [options])
 
 options:
   -n NAME
   -d DISTRIBUTION
   -p ROOT_PASSWORD
-  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"""
-        )
-    )
+  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']'''))
 
 
 def do_kickstart_create(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-d", "--distribution")
-    arg_parser.add_argument("-v", "--virt-type")
-    arg_parser.add_argument("-p", "--root-password")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-d', '--distribution')
+    arg_parser.add_argument('-v', '--virt-type')
+    arg_parser.add_argument('-p', '--root-password')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user("Name:", noblank=True)
+        options.name = prompt_user('Name:', noblank=True)
 
-        print(_("Virtualization Types"))
-        print("--------------------")
-        print("\n".join(sorted(self.VIRT_TYPES)))
-        print("")
+        print(_('Virtualization Types'))
+        print('--------------------')
+        print('\n'.join(sorted(self.VIRT_TYPES)))
+        print('')
 
-        # pylint: disable-next=undefined-variable
-        options.virt_type = prompt_user(_("Virtualization Type [none]:"))
-        if options.virt_type == "" or options.virt_type not in self.VIRT_TYPES:
-            options.virt_type = "none"
+        options.virt_type = prompt_user(_('Virtualization Type [none]:'))
+        if options.virt_type == '' or options.virt_type not in self.VIRT_TYPES:
+            options.virt_type = 'none'
 
-        options.distribution = ""
-        while options.distribution == "":
-            trees = self.do_distribution_list("", True)
-            print("")
-            print(_("Distributions"))
-            print("-------------")
-            print("\n".join(sorted(trees)))
-            print("")
+        options.distribution = ''
+        while options.distribution == '':
+            trees = self.do_distribution_list('', True)
+            print('')
+            print(_('Distributions'))
+            print('-------------')
+            print('\n'.join(sorted(trees)))
+            print('')
 
-            # pylint: disable-next=undefined-variable
-            options.distribution = prompt_user("Select:")
+            options.distribution = prompt_user('Select:')
 
-        options.root_password = ""
-        while options.root_password == "":
-            print("")
-            password1 = getpass(_("Root Password: "))
-            password2 = getpass(_("Repeat Password: "))
+        options.root_password = ''
+        while options.root_password == '':
+            print('')
+            password1 = getpass(_('Root Password: '))
+            password2 = getpass(_('Repeat Password: '))
 
             if password1 == password2:
                 options.root_password = password1
-            elif password1 == "":
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("Password must be at least 5 characters"))
+            elif password1 == '':
+                logging.warning(_N('Password must be at least 5 characters'))
             else:
-                # pylint: disable-next=undefined-variable
                 logging.warning(_N("Passwords don't match"))
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The Kickstart name is required"))
+            logging.error(_N('The Kickstart name is required'))
             return 1
 
         if not options.distribution:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The distribution is required"))
+            logging.error(_N('The distribution is required'))
             return 1
 
         if not options.virt_type:
-            options.virt_type = "none"
+            options.virt_type = 'none'
 
         if not options.root_password:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A root password is required"))
+            logging.error(_N('A root password is required'))
             return 1
 
     # leave this blank to use the default server
-    host = ""
+    host = ''
 
-    self.client.kickstart.createProfile(
-        self.session,
-        options.name,
-        options.virt_type,
-        options.distribution,
-        host,
-        options.root_password,
-    )
+    self.client.kickstart.createProfile(self.session,
+                                        options.name,
+                                        options.virt_type,
+                                        options.distribution,
+                                        host,
+                                        options.root_password)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_delete(self):
-    print(_("kickstart_delete: Delete kickstart profile(s)"))
-    print(_("usage: kickstart_delete PROFILE"))
-    print(_("usage: kickstart_delete PROFILE1 PROFILE2"))
-    print(_('usage: kickstart_delete "PROF*"'))
+    print(_('kickstart_delete: Delete kickstart profile(s)'))
+    print(_('usage: kickstart_delete PROFILE'))
+    print(_('usage: kickstart_delete PROFILE1 PROFILE2'))
+    print(_('usage: kickstart_delete \"PROF*\"'))
 
 
 def complete_kickstart_delete(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, arg_parser)
 
     if len(args) < 1:
@@ -264,50 +200,38 @@ def do_kickstart_delete(self, args):
         return 1
 
     # allow globbing of kickstart labels
-    all_labels = self.do_kickstart_list("", True)
-    # pylint: disable-next=undefined-variable
+    all_labels = self.do_kickstart_list('', True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got labels to delete of %s" % labels)
 
     if not labels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_delete()
         return 1
 
     mismatched = sorted(set(args).difference(set(all_labels)))
     if mismatched:
-        # pylint: disable-next=undefined-variable
-        logging.error(
-            _N("The following kickstart labels are invalid:"), ", ".join(mismatched)
-        )
+        logging.error(_N("The following kickstart labels are invalid:"),
+                      ", ".join(mismatched))
         return 1
     else:
         for label in labels:
-            if self.options.yes or self.user_confirm(
-                _("Delete profile %s [y/N]:") % label
-            ):
+            if self.options.yes or self.user_confirm(_("Delete profile %s [y/N]:") % label):
                 self.client.kickstart.deleteProfile(self.session, label)
         return 0
-
 
 ####################
 
 
 def help_kickstart_import(self):
-    print(_("kickstart_import: Import a Kickstart profile from a file"))
-    print(
-        _(
-            """usage: kickstart_import [options])
+    print(_('kickstart_import: Import a Kickstart profile from a file'))
+    print(_('''usage: kickstart_import [options])
 
 options:
   -f FILE
   -n NAME
   -d DISTRIBUTION
-  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"""
-        )
-    )
+  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']'''))
 
 
 def do_kickstart_import(self, args):
@@ -315,136 +239,108 @@ def do_kickstart_import(self, args):
 
 
 def kickstart_import_file(self, raw, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-d", "--distribution")
-    arg_parser.add_argument("-v", "--virt-type")
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-d', '--distribution')
+    arg_parser.add_argument('-v', '--virt-type')
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user("Name:", noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.file = prompt_user("File:", noblank=True)
+        options.name = prompt_user('Name:', noblank=True)
+        options.file = prompt_user('File:', noblank=True)
 
-        print(_("Virtualization Types"))
-        print("--------------------")
-        print("\n".join(sorted(self.VIRT_TYPES)))
-        print("")
+        print(_('Virtualization Types'))
+        print('--------------------')
+        print('\n'.join(sorted(self.VIRT_TYPES)))
+        print('')
 
-        # pylint: disable-next=undefined-variable
-        options.virt_type = prompt_user(_("Virtualization Type [none]:"))
-        if options.virt_type == "" or options.virt_type not in self.VIRT_TYPES:
-            options.virt_type = "none"
+        options.virt_type = prompt_user(_('Virtualization Type [none]:'))
+        if options.virt_type == '' or options.virt_type not in self.VIRT_TYPES:
+            options.virt_type = 'none'
 
-        options.distribution = ""
-        while options.distribution == "":
-            trees = self.do_distribution_list("", True)
-            print("")
-            print(_("Distributions"))
-            print("-------------")
-            print("\n".join(sorted(trees)))
-            print("")
+        options.distribution = ''
+        while options.distribution == '':
+            trees = self.do_distribution_list('', True)
+            print('')
+            print(_('Distributions'))
+            print('-------------')
+            print('\n'.join(sorted(trees)))
+            print('')
 
-            # pylint: disable-next=undefined-variable
-            options.distribution = prompt_user("Select:")
+            options.distribution = prompt_user('Select:')
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The Kickstart name is required"))
+            logging.error(_N('The Kickstart name is required'))
             return
 
         if not options.distribution:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The distribution is required"))
+            logging.error(_N('The distribution is required'))
             return
 
         if not options.file:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A filename is required"))
+            logging.error(_N('A filename is required'))
             return
 
         if not options.virt_type:
-            options.virt_type = "none"
+            options.virt_type = 'none'
 
     # read the contents of the Kickstart file
-    # pylint: disable-next=undefined-variable
     options.contents = read_file(options.file)
 
     if raw:
-        self.client.kickstart.importRawFile(
-            self.session,
-            options.name,
-            options.virt_type,
-            options.distribution,
-            options.contents,
-        )
+        self.client.kickstart.importRawFile(self.session,
+                                            options.name,
+                                            options.virt_type,
+                                            options.distribution,
+                                            options.contents)
     else:
         # use the default server
-        host = ""
+        host = ''
 
-        self.client.kickstart.importFile(
-            self.session,
-            options.name,
-            options.virt_type,
-            options.distribution,
-            host,
-            options.contents,
-        )
-
+        self.client.kickstart.importFile(self.session,
+                                         options.name,
+                                         options.virt_type,
+                                         options.distribution,
+                                         host,
+                                         options.contents)
 
 ####################
 
 
 def help_kickstart_import_raw(self):
-    print(
-        _(
-            "kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
-        )
-    )
-    print(
-        _(
-            """usage: kickstart_import_raw [options])
+    print(_('kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file'))
+    print(_('''usage: kickstart_import_raw [options])
 
 options:
   -f FILE
   -n NAME
   -d DISTRIBUTION
-  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"""
-        )
-    )
+  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']'''))
 
 
 def do_kickstart_import_raw(self, args):
     self.kickstart_import_file(raw=True, args=args)
 
-
 ####################
 
 
 def help_kickstart_details(self):
-    print(_("kickstart_details: Show the details of a Kickstart profile"))
-    print(_("usage: kickstart_details PROFILE"))
+    print(_('kickstart_details: Show the details of a Kickstart profile'))
+    print(_('usage: kickstart_details PROFILE'))
 
 
 def complete_kickstart_details(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -456,146 +352,150 @@ def do_kickstart_details(self, args):
 
     profiles = self.client.kickstart.listKickstarts(self.session)
     for p in profiles:
-        if p.get("label") == label:
+        if p.get('label') == label:
             kickstart = p
             break
 
     if not kickstart:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("Invalid Kickstart profile"))
+        logging.warning(_N('Invalid Kickstart profile'))
         return None
 
-    act_keys = self.client.kickstart.profile.keys.getActivationKeys(self.session, label)
+    act_keys = \
+        self.client.kickstart.profile.keys.getActivationKeys(self.session,
+                                                             label)
 
     try:
-        variables = self.client.kickstart.profile.getVariables(self.session, label)
+        variables = self.client.kickstart.profile.getVariables(self.session,
+                                                               label)
     except xmlrpclib.Fault:
         variables = {}
 
-    tree = self.client.kickstart.tree.getDetails(
-        self.session, kickstart.get("tree_label")
-    )
+    tree = \
+        self.client.kickstart.tree.getDetails(self.session,
+                                              kickstart.get('tree_label'))
 
-    base_channel = self.client.channel.software.getDetails(
-        self.session, tree.get("channel_id")
-    )
+    base_channel = \
+        self.client.channel.software.getDetails(self.session,
+                                                tree.get('channel_id'))
 
-    child_channels = self.client.kickstart.profile.getChildChannels(self.session, label)
+    child_channels = \
+        self.client.kickstart.profile.getChildChannels(self.session,
+                                                       label)
 
-    custom_options = self.client.kickstart.profile.getCustomOptions(self.session, label)
+    custom_options = \
+        self.client.kickstart.profile.getCustomOptions(self.session,
+                                                       label)
 
-    advanced_options = self.client.kickstart.profile.getAdvancedOptions(
-        self.session, label
-    )
+    advanced_options = \
+        self.client.kickstart.profile.getAdvancedOptions(self.session,
+                                                         label)
 
-    config_manage = self.client.kickstart.profile.system.checkConfigManagement(
-        self.session, label
-    )
+    config_manage = \
+        self.client.kickstart.profile.system.checkConfigManagement(
+            self.session, label)
 
-    remote_commands = self.client.kickstart.profile.system.checkRemoteCommands(
-        self.session, label
-    )
+    remote_commands = \
+        self.client.kickstart.profile.system.checkRemoteCommands(
+            self.session, label)
 
-    partitions = self.client.kickstart.profile.system.getPartitioningScheme(
-        self.session, label
-    )
+    partitions = \
+        self.client.kickstart.profile.system.getPartitioningScheme(
+            self.session, label)
 
-    crypto_keys = self.client.kickstart.profile.system.listKeys(self.session, label)
+    crypto_keys = \
+        self.client.kickstart.profile.system.listKeys(self.session,
+                                                      label)
 
-    file_preservations = self.client.kickstart.profile.system.listFilePreservations(
-        self.session, label
-    )
+    file_preservations = \
+        self.client.kickstart.profile.system.listFilePreservations(
+            self.session, label)
 
     software = self.client.kickstart.profile.software.getSoftwareList(
-        self.session, label
-    )
+        self.session, label)
 
-    scripts = self.client.kickstart.profile.listScripts(self.session, label)
+    scripts = self.client.kickstart.profile.listScripts(self.session,
+                                                        label)
 
     result = []
-    result.append(_("Name:        %s") % kickstart.get("name"))
-    result.append(_("Label:       %s") % kickstart.get("label"))
-    result.append(_("Tree:        %s") % kickstart.get("tree_label"))
-    result.append(_("Active:      %s") % kickstart.get("active"))
-    result.append(_("Advanced:    %s") % kickstart.get("advanced_mode"))
-    result.append(_("Org Default: %s") % kickstart.get("org_default"))
+    result.append(_('Name:        %s') % kickstart.get('name'))
+    result.append(_('Label:       %s') % kickstart.get('label'))
+    result.append(_('Tree:        %s') % kickstart.get('tree_label'))
+    result.append(_('Active:      %s') % kickstart.get('active'))
+    result.append(_('Advanced:    %s') % kickstart.get('advanced_mode'))
+    result.append(_('Org Default: %s') % kickstart.get('org_default'))
 
-    result.append("")
-    result.append(_("Configuration Management: %s") % config_manage)
-    result.append(_("Remote Commands:          %s") % remote_commands)
+    result.append('')
+    result.append(_('Configuration Management: %s') % config_manage)
+    result.append(_('Remote Commands:          %s') % remote_commands)
 
-    result.append("")
-    result.append(_("Software Channels"))
-    result.append("-----------------")
-    result.append(base_channel.get("label"))
+    result.append('')
+    result.append(_('Software Channels'))
+    result.append('-----------------')
+    result.append(base_channel.get('label'))
 
     for channel in sorted(child_channels):
-        # pylint: disable-next=consider-using-f-string
-        result.append("  |-- %s" % channel)
+        result.append('  |-- %s' % channel)
 
     if advanced_options:
-        result.append("")
-        result.append(_("Advanced Options"))
-        result.append("----------------")
-        for o in sorted(advanced_options, key=itemgetter("name")):
-            if o.get("arguments"):
-                # pylint: disable-next=consider-using-f-string
-                result.append("%s %s" % (o.get("name"), o.get("arguments")))
+        result.append('')
+        result.append(_('Advanced Options'))
+        result.append('----------------')
+        for o in sorted(advanced_options, key=itemgetter('name')):
+            if o.get('arguments'):
+                result.append('%s %s' % (o.get('name'), o.get('arguments')))
 
     if custom_options:
-        result.append("")
-        result.append(_("Custom Options"))
-        result.append("--------------")
-        for o in sorted(custom_options, key=itemgetter("arguments")):
-            result.append(re.sub("\n", "", o.get("arguments")))
+        result.append('')
+        result.append(_('Custom Options'))
+        result.append('--------------')
+        for o in sorted(custom_options, key=itemgetter('arguments')):
+            result.append(re.sub('\n', '', o.get('arguments')))
 
     if partitions:
-        result.append("")
-        result.append(_("Partitioning"))
-        result.append("------------")
-        result.append("\n".join(partitions))
+        result.append('')
+        result.append(_('Partitioning'))
+        result.append('------------')
+        result.append('\n'.join(partitions))
 
-    result.append("")
-    result.append(_("Software"))
-    result.append("--------")
-    result.append("\n".join(software))
+    result.append('')
+    result.append(_('Software'))
+    result.append('--------')
+    result.append('\n'.join(software))
 
     if act_keys:
-        result.append("")
-        result.append(_("Activation Keys"))
-        result.append("---------------")
-        for k in sorted(act_keys, key=itemgetter("key")):
-            result.append(k.get("key"))
+        result.append('')
+        result.append(_('Activation Keys'))
+        result.append('---------------')
+        for k in sorted(act_keys, key=itemgetter('key')):
+            result.append(k.get('key'))
 
     if crypto_keys:
-        result.append("")
-        result.append(_("Crypto Keys"))
-        result.append("-----------")
-        for k in sorted(crypto_keys, key=itemgetter("description")):
-            result.append(k.get("description"))
+        result.append('')
+        result.append(_('Crypto Keys'))
+        result.append('-----------')
+        for k in sorted(crypto_keys, key=itemgetter('description')):
+            result.append(k.get('description'))
 
     if file_preservations:
-        result.append("")
-        result.append(_("File Preservations"))
-        result.append("------------------")
-        for fp in sorted(file_preservations, key=itemgetter("name")):
-            result.append(fp.get("name"))
-            for profile_name in sorted(fp.get("file_names")):
-                # pylint: disable-next=consider-using-f-string
-                result.append("    |-- %s" % profile_name)
+        result.append('')
+        result.append(_('File Preservations'))
+        result.append('------------------')
+        for fp in sorted(file_preservations, key=itemgetter('name')):
+            result.append(fp.get('name'))
+            for profile_name in sorted(fp.get('file_names')):
+                result.append('    |-- %s' % profile_name)
 
     if variables:
-        result.append("")
-        result.append(_("Variables"))
-        result.append("---------")
+        result.append('')
+        result.append(_('Variables'))
+        result.append('---------')
         for k in sorted(variables.keys()):
-            # pylint: disable-next=consider-using-f-string
-            result.append("%s = %s" % (k, str(variables[k])))
+            result.append('%s = %s' % (k, str(variables[k])))
 
     if scripts:
-        result.append("")
-        result.append(_("Scripts"))
-        result.append("-------")
+        result.append('')
+        result.append(_('Scripts'))
+        result.append('-------')
 
         add_separator = False
 
@@ -604,62 +504,55 @@ def do_kickstart_details(self, args):
                 result.append(self.SEPARATOR)
             add_separator = True
 
-            result.append(_("Type:        %s") % s.get("script_type"))
-            result.append(_("Chroot:      %s") % s.get("chroot"))
+            result.append(_('Type:        %s') % s.get('script_type'))
+            result.append(_('Chroot:      %s') % s.get('chroot'))
 
-            if s.get("interpreter"):
-                result.append(_("Interpreter: %s") % s.get("interpreter"))
+            if s.get('interpreter'):
+                result.append(_('Interpreter: %s') % s.get('interpreter'))
 
-            result.append("")
-            result.append(s.get("contents"))
+            result.append('')
+            result.append(s.get('contents'))
 
     for line in result:
         print(line)
-
 
 ####################
 
 
 def kickstart_getcontents(self, profile):
+
     kickstart = None
-    if self.check_api_version("10.11"):
+    if self.check_api_version('10.11'):
         kickstart = self.client.kickstart.profile.downloadRenderedKickstart(
-            self.session, profile
-        )
+            self.session, profile)
     else:
         # old versions of th API don't return a rendered Kickstart,
         # so grab it in a hacky way
-        # pylint: disable-next=consider-using-f-string
-        url = "http://%s/ks/cfg/label/%s" % (self.server, profile)
+        url = 'http://%s/ks/cfg/label/%s' % (self.server, profile)
 
         try:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("Retrieving %s" % url)
+            logging.debug('Retrieving %s' % url)
             response = urlopen(url)
             kickstart = response.read()
         except HTTPError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Could not retrieve the Kickstart file"))
+            logging.error(_N('Could not retrieve the Kickstart file'))
 
     return kickstart
 
 
 def help_kickstart_getcontents(self):
-    print(_("kickstart_getcontents: Show the contents of a Kickstart profile"))
-    print(_("                   as they would be presented to a client"))
-    print(_("usage: kickstart_getcontents LABEL"))
+    print(_('kickstart_getcontents: Show the contents of a Kickstart profile'))
+    print(_('                   as they would be presented to a client'))
+    print(_('usage: kickstart_getcontents LABEL'))
 
 
 def complete_kickstart_getcontents(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_kickstart_list("", True), text)
+    return tab_completer(self.do_kickstart_list('', True), text)
 
 
 def do_kickstart_getcontents(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -674,34 +567,30 @@ def do_kickstart_getcontents(self, args):
         # We try to encode the output as UTF8, which is what we expect from
         # the API.  This avoids "'ascii' codec can't encode character" errors
         try:
-            print(kickstart.encode("UTF8"))
+            print(kickstart.encode('UTF8'))
         except UnicodeDecodeError:
             print(kickstart)
 
     return 0
 
-
 ####################
 
 
 def help_kickstart_rename(self):
-    print(_("kickstart_rename: Rename a Kickstart profile"))
-    print(_("usage: kickstart_rename OLDNAME NEWNAME"))
+    print(_('kickstart_rename: Rename a Kickstart profile'))
+    print(_('usage: kickstart_rename OLDNAME NEWNAME'))
 
 
 def complete_kickstart_rename(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_rename(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -715,35 +604,27 @@ def do_kickstart_rename(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_kickstart_listcryptokeys(self):
-    print(
-        _(
-            "kickstart_listcryptokeys: List the crypto keys associated "
-            + "with a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_listcryptokeys PROFILE"))
+    print(_('kickstart_listcryptokeys: List the crypto keys associated ' +
+            'with a Kickstart profile'))
+    print(_('usage: kickstart_listcryptokeys PROFILE'))
 
 
 def complete_kickstart_listcryptokeys(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_listcryptokeys(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -752,42 +633,37 @@ def do_kickstart_listcryptokeys(self, args, doreturn=False):
 
     profile = args[0]
     keys = self.client.kickstart.profile.system.listKeys(self.session, profile)
-    keys = sorted([k.get("description") for k in keys])
+    keys = sorted([k.get('description') for k in keys])
 
     if doreturn:
         return keys
     if keys:
-        print("\n".join(keys))
+        print('\n'.join(keys))
     else:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No crypto keys has been found"))
 
     return None
-
 
 ####################
 
 
 def help_kickstart_addcryptokeys(self):
-    print(_("kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"))
-    print(_("usage: kickstart_addcryptokeys PROFILE <KEY ...>"))
+    print(_('kickstart_addcryptokeys: Add crypto keys to a Kickstart profile'))
+    print(_('usage: kickstart_addcryptokeys PROFILE <KEY ...>'))
 
 
 def complete_kickstart_addcryptokeys(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_cryptokey_list("", True), text)
+        return tab_completer(self.do_cryptokey_list('', True), text)
 
     return None
 
 
 def do_kickstart_addcryptokeys(self, args):
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, get_argument_parser())
     if len(args) > 1:
         profile, keys = args[0], args[1:]
@@ -797,26 +673,20 @@ def do_kickstart_addcryptokeys(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_kickstart_removecryptokeys(self):
-    print(
-        _(
-            "kickstart_removecryptokeys: Remove crypto keys from a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_removecryptokeys PROFILE <KEY ...>"))
+    print(_('kickstart_removecryptokeys: Remove crypto keys from a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_removecryptokeys PROFILE <KEY ...>'))
 
 
 def complete_kickstart_removecryptokeys(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
         # only tab complete keys currently assigned to the profile
         try:
@@ -824,17 +694,14 @@ def complete_kickstart_removecryptokeys(self, text, line, beg, end):
         except xmlrpclib.Fault:
             keys = []
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(keys, text)
 
     return None
 
 
 def do_kickstart_removecryptokeys(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -844,36 +711,31 @@ def do_kickstart_removecryptokeys(self, args):
     profile = args[0]
     keys = args[1:]
 
-    self.client.kickstart.profile.system.removeKeys(self.session, profile, keys)
+    self.client.kickstart.profile.system.removeKeys(self.session,
+                                                    profile,
+                                                    keys)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_listactivationkeys(self):
-    print(
-        _(
-            "kickstart_listactivationkeys: List the activation keys "
-            + "associated with a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_listactivationkeys PROFILE"))
+    print(_('kickstart_listactivationkeys: List the activation keys ' +
+            'associated with a Kickstart profile'))
+    print(_('usage: kickstart_listactivationkeys PROFILE'))
 
 
 def complete_kickstart_listactivationkeys(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_listactivationkeys(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, get_argument_parser())
 
     if not args:
@@ -881,87 +743,64 @@ def do_kickstart_listactivationkeys(self, args, doreturn=False):
         return None
 
     profile = args[0]
-    keys = sorted(
-        filter(
-            None,
-            [
-                k.get("key")
-                for k in self.client.kickstart.profile.keys.getActivationKeys(
-                    self.session, profile
-                )
-            ],
-        )
-    )
+    keys = sorted(filter(None, [k.get('key') for k in
+                                self.client.kickstart.profile.keys.getActivationKeys(self.session, profile)]))
 
     if doreturn:
         return keys
     if keys:
-        print("\n".join(keys))
+        print('\n'.join(keys))
 
     return None
-
 
 ####################
 
 
 def help_kickstart_addactivationkeys(self):
-    print(
-        _(
-            "kickstart_addactivationkeys: Add activation keys to a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_addactivationkeys PROFILE <KEY ...>"))
+    print(_('kickstart_addactivationkeys: Add activation keys to a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_addactivationkeys PROFILE <KEY ...>'))
 
 
 def complete_kickstart_addactivationkeys(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_activationkey_list("", True), text)
+        return tab_completer(self.do_activationkey_list('', True),
+                             text)
 
     return None
 
 
 def do_kickstart_addactivationkeys(self, args):
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, get_argument_parser())
 
     if len(args) > 1:
         profile = args[0]
         for key in args[1:]:
-            self.client.kickstart.profile.keys.addActivationKey(
-                self.session, profile, key
-            )
+            self.client.kickstart.profile.keys.addActivationKey(self.session, profile, key)
     else:
         self.help_kickstart_addactivationkeys()
 
     return 0
 
-
 ####################
 
 
 def help_kickstart_removeactivationkeys(self):
-    print(
-        _(
-            "kickstart_removeactivationkeys: Remove activation keys from "
-            + "a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_removeactivationkeys PROFILE <KEY ...>"))
+    print(_('kickstart_removeactivationkeys: Remove activation keys from ' +
+            'a Kickstart profile'))
+    print(_('usage: kickstart_removeactivationkeys PROFILE <KEY ...>'))
 
 
-def complete_kickstart_removeactivationkeys(self, text, line, beg, end):
-    parts = line.split(" ")
+def complete_kickstart_removeactivationkeys(self, text, line, beg,
+                                            end):
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
         # only tab complete keys currently assigned to the profile
         try:
@@ -969,60 +808,49 @@ def complete_kickstart_removeactivationkeys(self, text, line, beg, end):
         except xmlrpclib.Fault:
             keys = []
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(keys, text)
 
     return None
 
 
 def do_kickstart_removeactivationkeys(self, args):
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, get_argument_parser())
 
     if len(args) > 1:
         if not self.options.yes:
-            if not self.user_confirm(_("Remove these keys [y/N]:")):
+            if not self.user_confirm(_('Remove these keys [y/N]:')):
                 return 1
 
         profile = args[0]
         for key in args[1:]:
-            self.client.kickstart.profile.keys.removeActivationKey(
-                self.session, profile, key
-            )
+            self.client.kickstart.profile.keys.removeActivationKey(self.session, profile, key)
     else:
         self.help_kickstart_removeactivationkeys()
 
     return 0
 
-
 ####################
 
 
 def help_kickstart_enableconfigmanagement(self):
-    print(
-        _(
-            "kickstart_enableconfigmanagement: Enable configuration "
-            + "management on a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_enableconfigmanagement PROFILE"))
+    print(_('kickstart_enableconfigmanagement: Enable configuration ' +
+            'management on a Kickstart profile'))
+    print(_('usage: kickstart_enableconfigmanagement PROFILE'))
 
 
-def complete_kickstart_enableconfigmanagement(self, text, line, beg, end):
-    parts = line.split(" ")
+def complete_kickstart_enableconfigmanagement(self, text, line, beg,
+                                              end):
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_enableconfigmanagement(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1031,39 +859,33 @@ def do_kickstart_enableconfigmanagement(self, args):
 
     profile = args[0]
 
-    self.client.kickstart.profile.system.enableConfigManagement(self.session, profile)
+    self.client.kickstart.profile.system.enableConfigManagement(
+        self.session, profile)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_disableconfigmanagement(self):
-    print(
-        _(
-            "kickstart_disableconfigmanagement: Disable configuration "
-            + "management on a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_disableconfigmanagement PROFILE"))
+    print(_('kickstart_disableconfigmanagement: Disable configuration ' +
+            'management on a Kickstart profile'))
+    print(_('usage: kickstart_disableconfigmanagement PROFILE'))
 
 
-def complete_kickstart_disableconfigmanagement(self, text, line, beg, end):
-    parts = line.split(" ")
+def complete_kickstart_disableconfigmanagement(self, text, line, beg,
+                                               end):
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_disableconfigmanagement(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1072,39 +894,33 @@ def do_kickstart_disableconfigmanagement(self, args):
 
     profile = args[0]
 
-    self.client.kickstart.profile.system.disableConfigManagement(self.session, profile)
+    self.client.kickstart.profile.system.disableConfigManagement(
+        self.session, profile)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_enableremotecommands(self):
-    print(
-        _(
-            "kickstart_enableremotecommands: Enable remote commands "
-            + "on a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_enableremotecommands PROFILE"))
+    print(_('kickstart_enableremotecommands: Enable remote commands ' +
+            'on a Kickstart profile'))
+    print(_('usage: kickstart_enableremotecommands PROFILE'))
 
 
-def complete_kickstart_enableremotecommands(self, text, line, beg, end):
-    parts = line.split(" ")
+def complete_kickstart_enableremotecommands(self, text, line, beg,
+                                            end):
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_enableremotecommands(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1113,39 +929,32 @@ def do_kickstart_enableremotecommands(self, args):
 
     profile = args[0]
 
-    self.client.kickstart.profile.system.enableRemoteCommands(self.session, profile)
+    self.client.kickstart.profile.system.enableRemoteCommands(self.session,
+                                                              profile)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_disableremotecommands(self):
-    print(
-        _(
-            "kickstart_disableremotecommands: Disable remote commands "
-            + "on a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_disableremotecommands PROFILE"))
+    print(_('kickstart_disableremotecommands: Disable remote commands ' +
+            'on a Kickstart profile'))
+    print(_('usage: kickstart_disableremotecommands PROFILE'))
 
 
 def complete_kickstart_disableremotecommands(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_disableremotecommands(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1154,37 +963,33 @@ def do_kickstart_disableremotecommands(self, args):
 
     profile = args[0]
 
-    self.client.kickstart.profile.system.disableRemoteCommands(self.session, profile)
+    self.client.kickstart.profile.system.disableRemoteCommands(self.session,
+                                                               profile)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_setlocale(self):
-    print(_("kickstart_setlocale: Set the locale for a Kickstart profile"))
-    print(_("usage: kickstart_setlocale PROFILE LOCALE"))
+    print(_('kickstart_setlocale: Set the locale for a Kickstart profile'))
+    print(_('usage: kickstart_setlocale PROFILE LOCALE'))
 
 
 def complete_kickstart_setlocale(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) == 3:
-        # pylint: disable-next=undefined-variable
         return tab_completer(list_locales(), text)
 
     return None
 
 
 def do_kickstart_setlocale(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -1197,38 +1002,37 @@ def do_kickstart_setlocale(self, args):
     # always use UTC
     utc = True
 
-    self.client.kickstart.profile.system.setLocale(self.session, profile, locale, utc)
+    self.client.kickstart.profile.system.setLocale(self.session,
+                                                   profile,
+                                                   locale,
+                                                   utc)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_setselinux(self):
-    print(_("kickstart_setselinux: Set the SELinux mode for a Kickstart " + "profile"))
-    print(_("usage: kickstart_setselinux PROFILE MODE"))
+    print(_('kickstart_setselinux: Set the SELinux mode for a Kickstart ' +
+            'profile'))
+    print(_('usage: kickstart_setselinux PROFILE MODE'))
 
 
 def complete_kickstart_setselinux(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) == 3:
-        modes = ["enforcing", "permissive", "disabled"]
-        # pylint: disable-next=undefined-variable
+        modes = ['enforcing', 'permissive', 'disabled']
         return tab_completer(modes, text)
 
     return None
 
 
 def do_kickstart_setselinux(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -1238,39 +1042,33 @@ def do_kickstart_setselinux(self, args):
     profile = args[0]
     mode = args[1]
 
-    self.client.kickstart.profile.system.setSELinux(self.session, profile, mode)
+    self.client.kickstart.profile.system.setSELinux(self.session,
+                                                    profile,
+                                                    mode)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_setpartitions(self):
-    print(
-        _(
-            "kickstart_setpartitions: Set the partitioning scheme for a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_setpartitions PROFILE"))
+    print(_('kickstart_setpartitions: Set the partitioning scheme for a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_setpartitions PROFILE'))
 
 
 def complete_kickstart_setpartitions(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_setpartitions(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1281,61 +1079,51 @@ def do_kickstart_setpartitions(self, args):
 
     try:
         # get the current scheme so the user can edit it
-        current = self.client.kickstart.profile.system.getPartitioningScheme(
-            self.session, profile
-        )
+        current = \
+            self.client.kickstart.profile.system.getPartitioningScheme(
+                self.session, profile)
 
-        template = "\n".join(current)
+        template = '\n'.join(current)
     except xmlrpclib.Fault:
-        template = ""
+        template = ''
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (partitions, _ignore) = editor(template=template, delete=True)
 
     print(partitions)
     if not self.user_confirm():
         return 1
 
-    lines = partitions.split("\n")
+    lines = partitions.split('\n')
 
-    self.client.kickstart.profile.system.setPartitioningScheme(
-        self.session, profile, lines
-    )
+    self.client.kickstart.profile.system.setPartitioningScheme(self.session,
+                                                               profile,
+                                                               lines)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_setdistribution(self):
-    print(
-        _(
-            "kickstart_setdistribution: Set the distribution for a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_setdistribution PROFILE DISTRIBUTION"))
+    print(_('kickstart_setdistribution: Set the distribution for a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_setdistribution PROFILE DISTRIBUTION'))
 
 
 def complete_kickstart_setdistribution(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_distribution_list("", True), text)
+        return tab_completer(self.do_distribution_list('', True), text)
 
     return None
 
 
 def do_kickstart_setdistribution(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -1345,34 +1133,32 @@ def do_kickstart_setdistribution(self, args):
     profile = args[0]
     distribution = args[1]
 
-    self.client.kickstart.profile.setKickstartTree(self.session, profile, distribution)
+    self.client.kickstart.profile.setKickstartTree(self.session,
+                                                   profile,
+                                                   distribution)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_enablelogging(self):
-    print(_("kickstart_enablelogging: Enable logging for a Kickstart profile"))
-    print(_("usage: kickstart_enablelogging PROFILE"))
+    print(_('kickstart_enablelogging: Enable logging for a Kickstart profile'))
+    print(_('usage: kickstart_enablelogging PROFILE'))
 
 
 def complete_kickstart_enablelogging(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_enablelogging(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1381,34 +1167,33 @@ def do_kickstart_enablelogging(self, args):
 
     profile = args[0]
 
-    self.client.kickstart.profile.setLogging(self.session, profile, True, True)
+    self.client.kickstart.profile.setLogging(self.session,
+                                             profile,
+                                             True,
+                                             True)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_addvariable(self):
-    print(_("kickstart_addvariable: Add a variable to a Kickstart profile"))
-    print(_("usage: kickstart_addvariable PROFILE KEY VALUE"))
+    print(_('kickstart_addvariable: Add a variable to a Kickstart profile'))
+    print(_('usage: kickstart_addvariable PROFILE KEY VALUE'))
 
 
 def complete_kickstart_addvariable(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_addvariable(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
@@ -1417,96 +1202,89 @@ def do_kickstart_addvariable(self, args):
 
     profile = args[0]
     key = args[1]
-    value = " ".join(args[2:])
+    value = ' '.join(args[2:])
 
-    variables = self.client.kickstart.profile.getVariables(self.session, profile)
+    variables = self.client.kickstart.profile.getVariables(self.session,
+                                                           profile)
 
     variables[key] = value
 
-    self.client.kickstart.profile.setVariables(self.session, profile, variables)
+    self.client.kickstart.profile.setVariables(self.session,
+                                               profile,
+                                               variables)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_updatevariable(self):
-    print(_("kickstart_updatevariable: Update a variable in a Kickstart " + "profile"))
-    print(_("usage: kickstart_updatevariable PROFILE KEY VALUE"))
+    print(_('kickstart_updatevariable: Update a variable in a Kickstart ' +
+            'profile'))
+    print(_('usage: kickstart_updatevariable PROFILE KEY VALUE'))
 
 
 def complete_kickstart_updatevariable(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
         variables = {}
         try:
-            variables = self.client.kickstart.profile.getVariables(
-                self.session, parts[1]
-            )
+            variables = \
+                self.client.kickstart.profile.getVariables(self.session,
+                                                           parts[1])
         except xmlrpclib.Fault:
             pass
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(variables.keys(), text)
 
     return None
 
 
 def do_kickstart_updatevariable(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
         self.help_kickstart_updatevariable()
         return 1
 
-    return self.do_kickstart_addvariable(" ".join(args))
-
+    return self.do_kickstart_addvariable(' '.join(args))
 
 ####################
 
 
 def help_kickstart_removevariables(self):
-    print(
-        _("kickstart_removevariables: Remove variables from a " + "Kickstart profile")
-    )
-    print(_("usage: kickstart_removevariables PROFILE <KEY ...>"))
+    print(_('kickstart_removevariables: Remove variables from a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_removevariables PROFILE <KEY ...>'))
 
 
 def complete_kickstart_removevariables(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
         variables = {}
         try:
-            variables = self.client.kickstart.profile.getVariables(
-                self.session, parts[1]
-            )
+            variables = \
+                self.client.kickstart.profile.getVariables(self.session,
+                                                           parts[1])
         except xmlrpclib.Fault:
             pass
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(variables.keys(), text)
 
     return None
 
 
 def do_kickstart_removevariables(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1516,40 +1294,40 @@ def do_kickstart_removevariables(self, args):
     profile = args[0]
     keys = args[1:]
 
-    variables = self.client.kickstart.profile.getVariables(self.session, profile)
+    variables = self.client.kickstart.profile.getVariables(self.session,
+                                                           profile)
 
     for key in keys:
         if key in variables:
             del variables[key]
 
-    self.client.kickstart.profile.setVariables(self.session, profile, variables)
+    self.client.kickstart.profile.setVariables(self.session,
+                                               profile,
+                                               variables)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_listvariables(self):
-    print(_("kickstart_listvariables: List the variables of a Kickstart " + "profile"))
-    print(_("usage: kickstart_listvariables PROFILE"))
+    print(_('kickstart_listvariables: List the variables of a Kickstart ' +
+            'profile'))
+    print(_('usage: kickstart_listvariables PROFILE'))
 
 
 def complete_kickstart_listvariables(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_listvariables(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1558,41 +1336,36 @@ def do_kickstart_listvariables(self, args):
 
     profile = args[0]
 
-    variables = self.client.kickstart.profile.getVariables(self.session, profile)
+    variables = self.client.kickstart.profile.getVariables(self.session,
+                                                           profile)
 
     for v in variables:
-        # pylint: disable-next=consider-using-f-string
-        print("%s = %s" % (v, variables[v]))
+        print('%s = %s' % (v, variables[v]))
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_addoption(self):
-    print(_("kickstart_addoption: Set an option for a Kickstart profile"))
-    print(_("usage: kickstart_addoption PROFILE KEY [VALUE]"))
+    print(_('kickstart_addoption: Set an option for a Kickstart profile'))
+    print(_('usage: kickstart_addoption PROFILE KEY [VALUE]'))
 
 
 def complete_kickstart_addoption(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) == 3:
-        # pylint: disable-next=undefined-variable
         return tab_completer(sorted(self.KICKSTART_OPTIONS), text)
 
     return None
 
 
 def do_kickstart_addoption(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1603,69 +1376,62 @@ def do_kickstart_addoption(self, args):
     key = args[1]
 
     if len(args) > 2:
-        value = " ".join(args[2:])
+        value = ' '.join(args[2:])
     else:
-        value = ""
+        value = ''
 
     # only pre-defined options can be set as 'advanced options'
     if key in self.KICKSTART_OPTIONS:
-        advanced = self.client.kickstart.profile.getAdvancedOptions(
-            self.session, profile
-        )
+        advanced = \
+            self.client.kickstart.profile.getAdvancedOptions(self.session,
+                                                             profile)
 
         # remove any instances of this key from the current list
         for item in advanced:
-            if item.get("name") == key:
+            if item.get('name') == key:
                 advanced.remove(item)
                 break
 
-        advanced.append({"name": key, "arguments": value})
+        advanced.append({'name': key, 'arguments': value})
 
-        self.client.kickstart.profile.setAdvancedOptions(
-            self.session, profile, advanced
-        )
+        self.client.kickstart.profile.setAdvancedOptions(self.session,
+                                                         profile,
+                                                         advanced)
     else:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("%s needs to be set as a custom option") % key)
+        logging.warning(_N('%s needs to be set as a custom option') % key)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_removeoptions(self):
-    print(_("kickstart_removeoptions: Remove options from a Kickstart profile"))
-    print(_("usage: kickstart_removeoptions PROFILE <OPTION ...>"))
+    print(_('kickstart_removeoptions: Remove options from a Kickstart profile'))
+    print(_('usage: kickstart_removeoptions PROFILE <OPTION ...>'))
 
 
 def complete_kickstart_removeoptions(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
         try:
             options = self.client.kickstart.profile.getAdvancedOptions(
-                self.session, parts[1]
-            )
+                self.session, parts[1])
 
-            options = [o.get("name") for o in options]
+            options = [o.get('name') for o in options]
         except xmlrpclib.Fault:
             options = self.KICKSTART_OPTIONS
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(sorted(options), text)
 
     return None
 
 
 def do_kickstart_removeoptions(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1675,42 +1441,43 @@ def do_kickstart_removeoptions(self, args):
     profile = args[0]
     keys = args[1:]
 
-    advanced = self.client.kickstart.profile.getAdvancedOptions(self.session, profile)
+    advanced = \
+        self.client.kickstart.profile.getAdvancedOptions(self.session,
+                                                         profile)
 
     # remove any instances of this key from the current list
     for key in keys:
         for item in advanced:
-            if item.get("name") == key:
+            if item.get('name') == key:
                 advanced.remove(item)
 
-    self.client.kickstart.profile.setAdvancedOptions(self.session, profile, advanced)
+    self.client.kickstart.profile.setAdvancedOptions(self.session,
+                                                     profile,
+                                                     advanced)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_listoptions(self):
-    print(_("kickstart_listoptions: List the options of a Kickstart " + "profile"))
-    print(_("usage: kickstart_listoptions PROFILE"))
+    print(_('kickstart_listoptions: List the options of a Kickstart ' +
+            'profile'))
+    print(_('usage: kickstart_listoptions PROFILE'))
 
 
 def complete_kickstart_listoptions(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_listoptions(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1719,44 +1486,36 @@ def do_kickstart_listoptions(self, args):
 
     profile = args[0]
 
-    options = self.client.kickstart.profile.getAdvancedOptions(self.session, profile)
+    options = self.client.kickstart.profile.getAdvancedOptions(self.session,
+                                                               profile)
 
-    for o in sorted(options, key=itemgetter("name")):
-        if o.get("arguments"):
-            # pylint: disable-next=consider-using-f-string
-            print("%s %s" % (o.get("name"), o.get("arguments")))
+    for o in sorted(options, key=itemgetter('name')):
+        if o.get('arguments'):
+            print('%s %s' % (o.get('name'), o.get('arguments')))
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_listcustomoptions(self):
-    print(
-        _(
-            "kickstart_listcustomoptions: List the custom options of a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_listcustomoptions PROFILE"))
+    print(_('kickstart_listcustomoptions: List the custom options of a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_listcustomoptions PROFILE'))
 
 
 def complete_kickstart_listcustomoptions(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_listcustomoptions(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1765,40 +1524,36 @@ def do_kickstart_listcustomoptions(self, args):
 
     profile = args[0]
 
-    options = self.client.kickstart.profile.getCustomOptions(self.session, profile)
+    options = self.client.kickstart.profile.getCustomOptions(self.session,
+                                                             profile)
 
     for o in options:
-        if "arguments" in o:
-            print(o.get("arguments"))
+        if 'arguments' in o:
+            print(o.get('arguments'))
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_setcustomoptions(self):
-    print(
-        _("kickstart_setcustomoptions: Set custom options for a " + "Kickstart profile")
-    )
-    print(_("usage: kickstart_setcustomoptions PROFILE"))
+    print(_('kickstart_setcustomoptions: Set custom options for a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_setcustomoptions PROFILE'))
 
 
 def complete_kickstart_setcustomoptions(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_setcustomoptions(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1807,73 +1562,71 @@ def do_kickstart_setcustomoptions(self, args):
 
     profile = args[0]
 
-    options = self.client.kickstart.profile.getCustomOptions(self.session, profile)
+    options = self.client.kickstart.profile.getCustomOptions(self.session,
+                                                             profile)
 
     # the first item in the list is missing the 'arguments' key
     old_options = []
     for o in options:
-        if "arguments" in o:
-            old_options.append(o.get("arguments"))
+        if 'arguments' in o:
+            old_options.append(o.get('arguments'))
 
-    old_options = "\n".join(old_options)
+    old_options = '\n'.join(old_options)
 
     # let the user edit the custom options
-    # pylint: disable-next=undefined-variable,unused-variable
-    (new_options, _ignore) = editor(template=old_options, delete=True)
+    (new_options, _ignore) = editor(template=old_options,
+                                    delete=True)
 
-    new_options = new_options.split("\n")
+    new_options = new_options.split('\n')
 
-    self.client.kickstart.profile.setCustomOptions(self.session, profile, new_options)
+    self.client.kickstart.profile.setCustomOptions(self.session,
+                                                   profile,
+                                                   new_options)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_addchildchannels(self):
-    print(
-        _(
-            "kickstart_addchildchannels: Add a child channels to a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"))
+    print(_('kickstart_addchildchannels: Add a child channels to a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_addchildchannels PROFILE <CHANNEL ...>'))
 
 
 def complete_kickstart_addchildchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
         profile = parts[1]
 
         try:
-            tree = self.client.kickstart.profile.getKickstartTree(self.session, profile)
+            tree = \
+                self.client.kickstart.profile.getKickstartTree(self.session,
+                                                               profile)
 
-            tree_details = self.client.kickstart.tree.getDetails(self.session, tree)
+            tree_details = self.client.kickstart.tree.getDetails(
+                self.session, tree)
 
-            base_channel = self.client.channel.software.getDetails(
-                self.session, tree_details.get("channel_id")
-            )
+            base_channel = \
+                self.client.channel.software.getDetails(self.session,
+                                                        tree_details.get('channel_id'))
 
-            parent_channel = base_channel.get("label")
+            parent_channel = base_channel.get('label')
         except xmlrpclib.Fault:
             return []
 
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.list_child_channels(parent=parent_channel), text)
+        return tab_completer(self.list_child_channels(
+            parent=parent_channel), text)
 
     return None
 
 
 def do_kickstart_addchildchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1883,46 +1636,42 @@ def do_kickstart_addchildchannels(self, args):
     profile = args[0]
     new_channels = args[1:]
 
-    channels = self.client.kickstart.profile.getChildChannels(self.session, profile)
+    channels = self.client.kickstart.profile.getChildChannels(self.session,
+                                                              profile)
 
     channels.extend(new_channels)
 
-    self.client.kickstart.profile.setChildChannels(self.session, profile, channels)
+    self.client.kickstart.profile.setChildChannels(self.session,
+                                                   profile,
+                                                   channels)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_removechildchannels(self):
-    print(
-        _(
-            "kickstart_removechildchannels: Remove child channels from "
-            + "a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"))
+    print(_('kickstart_removechildchannels: Remove child channels from ' +
+            'a Kickstart profile'))
+    print(_('usage: kickstart_removechildchannels PROFILE <CHANNEL ...>'))
 
 
-def complete_kickstart_removechildchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+def complete_kickstart_removechildchannels(self, text, line, beg,
+                                           end):
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_listchildchannels(parts[1], True), text)
+        return tab_completer(self.do_kickstart_listchildchannels(
+            parts[1], True), text)
 
     return None
 
 
 def do_kickstart_removechildchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1932,45 +1681,40 @@ def do_kickstart_removechildchannels(self, args):
     profile = args[0]
     to_remove = args[1:]
 
-    channels = self.client.kickstart.profile.getChildChannels(self.session, profile)
+    channels = self.client.kickstart.profile.getChildChannels(self.session,
+                                                              profile)
 
     for channel in to_remove:
         if channel in channels:
             channels.remove(channel)
 
-    self.client.kickstart.profile.setChildChannels(self.session, profile, channels)
+    self.client.kickstart.profile.setChildChannels(self.session,
+                                                   profile,
+                                                   channels)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_listchildchannels(self):
-    print(
-        _(
-            "kickstart_listchildchannels: List the child channels of a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_listchildchannels PROFILE"))
+    print(_('kickstart_listchildchannels: List the child channels of a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_listchildchannels PROFILE'))
 
 
 def complete_kickstart_listchildchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_listchildchannels(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1979,47 +1723,40 @@ def do_kickstart_listchildchannels(self, args, doreturn=False):
 
     profile = args[0]
 
-    channels = self.client.kickstart.profile.getChildChannels(self.session, profile)
+    channels = self.client.kickstart.profile.getChildChannels(self.session,
+                                                              profile)
 
     if doreturn:
         return channels
     if channels:
-        print("\n".join(sorted(channels)))
+        print('\n'.join(sorted(channels)))
 
     return None
-
 
 ####################
 
 
 def help_kickstart_addfilepreservations(self):
-    print(
-        _(
-            "kickstart_addfilepreservations: Add file preservations to a "
-            + "Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"))
+    print(_('kickstart_addfilepreservations: Add file preservations to a ' +
+            'Kickstart profile'))
+    print(_('usage: kickstart_addfilepreservations PROFILE <FILELIST ...>'))
 
 
 def complete_kickstart_addfilepreservations(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_filepreservation_list("", True), text)
+        return tab_completer(self.do_filepreservation_list('', True),
+                             text)
 
     return None
 
 
 def do_kickstart_addfilepreservations(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2029,55 +1766,47 @@ def do_kickstart_addfilepreservations(self, args):
     profile = args[0]
     files = args[1:]
 
-    self.client.kickstart.profile.system.addFilePreservations(
-        self.session, profile, files
-    )
+    self.client.kickstart.profile.system.addFilePreservations(self.session,
+                                                              profile,
+                                                              files)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_removefilepreservations(self):
-    print(
-        _(
-            "kickstart_removefilepreservations: Remove file "
-            + "preservations from a Kickstart profile"
-        )
-    )
-    print(_("usage: kickstart_removefilepreservations PROFILE <FILE ...>"))
+    print(_('kickstart_removefilepreservations: Remove file ' +
+            'preservations from a Kickstart profile'))
+    print(_('usage: kickstart_removefilepreservations PROFILE <FILE ...>'))
 
 
-def complete_kickstart_removefilepreservations(self, text, line, beg, end):
-    parts = line.split(" ")
+def complete_kickstart_removefilepreservations(self, text, line, beg,
+                                               end):
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
         files = []
 
         try:
             # only tab complete files currently assigned to the profile
-            files = self.client.kickstart.profile.system.listFilePreservations(
-                self.session, parts[1]
-            )
-            files = [f.get("name") for f in files]
+            files = \
+                self.client.kickstart.profile.system.listFilePreservations(
+                    self.session, parts[1])
+            files = [f.get('name') for f in files]
         except xmlrpclib.Fault:
             return []
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(files, text)
 
     return None
 
 
 def do_kickstart_removefilepreservations(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -2088,30 +1817,26 @@ def do_kickstart_removefilepreservations(self, args):
     files = args[1:]
 
     self.client.kickstart.profile.system.removeFilePreservations(
-        self.session, profile, files
-    )
+        self.session, profile, files)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_listpackages(self):
-    print(_("kickstart_listpackages: List the packages for a Kickstart " + "profile"))
-    print(_("usage: kickstart_listpackages PROFILE"))
+    print(_('kickstart_listpackages: List the packages for a Kickstart ' +
+            'profile'))
+    print(_('usage: kickstart_listpackages PROFILE'))
 
 
 def complete_kickstart_listpackages(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_kickstart_list("", True), text)
+    return tab_completer(self.do_kickstart_list('', True), text)
 
 
 def do_kickstart_listpackages(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2120,44 +1845,39 @@ def do_kickstart_listpackages(self, args, doreturn=False):
 
     profile = args[0]
 
-    packages = self.client.kickstart.profile.software.getSoftwareList(
-        self.session, profile
-    )
+    packages = \
+        self.client.kickstart.profile.software.getSoftwareList(self.session,
+                                                               profile)
 
     if doreturn:
         return packages
     if packages:
-        print("\n".join(packages))
+        print('\n'.join(packages))
 
     return None
-
 
 ####################
 
 
 def help_kickstart_addpackages(self):
-    print(_("kickstart_addpackages: Add packages to a Kickstart profile"))
-    print(_("usage: kickstart_addpackages PROFILE <PACKAGE ...>"))
+    print(_('kickstart_addpackages: Add packages to a Kickstart profile'))
+    print(_('usage: kickstart_addpackages PROFILE <PACKAGE ...>'))
 
 
 def complete_kickstart_addpackages(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.get_package_names(), text)
 
     return None
 
 
 def do_kickstart_addpackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) >= 2:
@@ -2168,38 +1888,35 @@ def do_kickstart_addpackages(self, args):
     packages = args[1:]
 
     self.client.kickstart.profile.software.appendToSoftwareList(
-        self.session, profile, packages
-    )
+        self.session, profile, packages)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_removepackages(self):
-    print(_("kickstart_removepackages: Remove packages from a Kickstart " + "profile"))
-    print(_("usage: kickstart_removepackages PROFILE <PACKAGE ...>"))
+    print(_('kickstart_removepackages: Remove packages from a Kickstart ' +
+            'profile'))
+    print(_('usage: kickstart_removepackages PROFILE <PACKAGE ...>'))
 
 
 def complete_kickstart_removepackages(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True),
+                             text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_listpackages(parts[1], True), text)
+        return tab_completer(self.do_kickstart_listpackages(
+            parts[1], True), text)
 
     return None
 
 
 def do_kickstart_removepackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -2216,31 +1933,28 @@ def do_kickstart_removepackages(self, args):
         if package in packages:
             packages.remove(package)
 
-    self.client.kickstart.profile.software.setSoftwareList(
-        self.session, profile, packages
-    )
+    self.client.kickstart.profile.software.setSoftwareList(self.session,
+                                                           profile,
+                                                           packages)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_listscripts(self):
-    print(_("kickstart_listscripts: List the scripts for a Kickstart " + "profile"))
-    print(_("usage: kickstart_listscripts PROFILE"))
+    print(_('kickstart_listscripts: List the scripts for a Kickstart ' +
+            'profile'))
+    print(_('usage: kickstart_listscripts PROFILE'))
 
 
 def complete_kickstart_listscripts(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_kickstart_list("", True), text)
+    return tab_completer(self.do_kickstart_list('', True), text)
 
 
 def do_kickstart_listscripts(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2250,7 +1964,6 @@ def do_kickstart_listscripts(self, args):
     profile = args[0]
     scripts = self.client.kickstart.profile.listScripts(self.session, profile)
     if not scripts:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No scripts has been found for profile '%s'"), profile)
     else:
         add_separator = False
@@ -2259,26 +1972,23 @@ def do_kickstart_listscripts(self, args):
                 print(self.SEPARATOR)
             add_separator = True
 
-            print(_("ID:          %i") % script.get("id"))
-            print(_("Type:        %s") % script.get("script_type"))
-            print(_("Chroot:      %s") % script.get("chroot"))
-            print(_("Interpreter: %s") % script.get("interpreter"))
-            print("")
-            print(_("Contents"))
-            print("--------")
-            print(script.get("contents"))
+            print(_('ID:          %i') % script.get('id'))
+            print(_('Type:        %s') % script.get('script_type'))
+            print(_('Chroot:      %s') % script.get('chroot'))
+            print(_('Interpreter: %s') % script.get('interpreter'))
+            print('')
+            print(_('Contents'))
+            print('--------')
+            print(script.get('contents'))
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_addscript(self):
-    print(_("kickstart_addscript: Add a script to a Kickstart profile"))
-    print(
-        _(
-            """usage: kickstart_addscript PROFILE [options])
+    print(_('kickstart_addscript: Add a script to a Kickstart profile'))
+    print(_('''usage: kickstart_addscript PROFILE [options])
 
 options:
   -p PROFILE
@@ -2286,154 +1996,131 @@ options:
   -i INTERPRETER
   -f FILE
   -c execute in a chroot environment
-  -t ENABLING_TEMPLATING"""
-        )
-    )
+  -t ENABLING_TEMPLATING'''))
 
 
 def complete_kickstart_addscript(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_addscript(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-p", "--profile")
-    arg_parser.add_argument("-e", "--execution-time")
-    arg_parser.add_argument("-c", "--chroot", action="store_true")
-    arg_parser.add_argument("-t", "--template", action="store_true")
-    arg_parser.add_argument("-i", "--interpreter")
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-p', '--profile')
+    arg_parser.add_argument('-e', '--execution-time')
+    arg_parser.add_argument('-c', '--chroot', action='store_true')
+    arg_parser.add_argument('-t', '--template', action='store_true')
+    arg_parser.add_argument('-i', '--interpreter')
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
         if args:
             options.profile = args[0]
         else:
-            # pylint: disable-next=undefined-variable
-            options.profile = prompt_user(_("Profile Name:"), noblank=True)
+            options.profile = prompt_user(_('Profile Name:'), noblank=True)
 
-        # pylint: disable-next=undefined-variable
-        options.execution_time = prompt_user(_("Pre/Post Script [post]:"))
-        # pylint: disable-next=undefined-variable
-        options.chroot = prompt_user(_("Chrooted [Y/n]:"))
-        # pylint: disable-next=undefined-variable
-        options.interpreter = prompt_user(_("Interpreter [/bin/bash]:"))
+        options.execution_time = prompt_user(_('Pre/Post Script [post]:'))
+        options.chroot = prompt_user(_('Chrooted [Y/n]:'))
+        options.interpreter = prompt_user(_('Interpreter [/bin/bash]:'))
 
         # get the contents of the script
-        if self.user_confirm(
-            _("Read an existing file [y/N]:"), nospacer=True, ignore_yes=True
-        ):
-            # pylint: disable-next=undefined-variable
-            options.file = prompt_user(_("File:"))
+        if self.user_confirm(_('Read an existing file [y/N]:'),
+                             nospacer=True, ignore_yes=True):
+            options.file = prompt_user(_('File:'))
         else:
-            # pylint: disable-next=undefined-variable,unused-variable
             (options.contents, _ignore) = editor(delete=True)
 
         # check user input
-        if options.interpreter == "":
-            options.interpreter = "/bin/bash"
+        if options.interpreter == '':
+            options.interpreter = '/bin/bash'
 
-        if re.match("n", options.chroot, re.I):
+        if re.match('n', options.chroot, re.I):
             options.chroot = False
         else:
             options.chroot = True
 
-        if re.match("n", options.template, re.I):
+        if re.match('n', options.template, re.I):
             options.template = False
         else:
             options.template = True
 
-        if re.match("pre", options.execution_time, re.I):
-            options.execution_time = "pre"
+        if re.match('pre', options.execution_time, re.I):
+            options.execution_time = 'pre'
         else:
-            options.execution_time = "post"
+            options.execution_time = 'post'
     else:
         if not options.profile:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The Kickstart name is required"))
+            logging.error(_N('The Kickstart name is required'))
             return 1
 
         if not options.file:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A filename is required"))
+            logging.error(_N('A filename is required'))
             return 1
 
         if not options.execution_time:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The execution time is required"))
+            logging.error(_N('The execution time is required'))
             return 1
 
         if not options.chroot:
             options.chroot = False
 
         if not options.interpreter:
-            options.interpreter = "/bin/bash"
+            options.interpreter = '/bin/bash'
 
         if not options.template:
             options.template = False
 
     if options.file:
-        # pylint: disable-next=undefined-variable
         options.contents = read_file(options.file)
 
-    print("")
-    print(_("Profile Name:   %s") % options.profile)
-    print(_("Execution Time: %s") % options.execution_time)
-    print(_("Chroot:         %s") % options.chroot)
-    print(_("Template:       %s") % options.template)
-    print(_("Interpreter:    %s") % options.interpreter)
-    print(_("Contents:"))
+    print('')
+    print(_('Profile Name:   %s') % options.profile)
+    print(_('Execution Time: %s') % options.execution_time)
+    print(_('Chroot:         %s') % options.chroot)
+    print(_('Template:       %s') % options.template)
+    print(_('Interpreter:    %s') % options.interpreter)
+    print(_('Contents:'))
     print(options.contents)
 
     if not self.user_confirm():
         return 1
 
-    self.client.kickstart.profile.addScript(
-        self.session,
-        options.profile,
-        options.contents,
-        options.interpreter,
-        options.execution_time,
-        options.chroot,
-        options.template,
-    )
+    self.client.kickstart.profile.addScript(self.session,
+                                            options.profile,
+                                            options.contents,
+                                            options.interpreter,
+                                            options.execution_time,
+                                            options.chroot,
+                                            options.template)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_removescript(self):
-    print(_("kickstart_removescript: Remove a script from a Kickstart profile"))
-    print(_("usage: kickstart_removescript PROFILE [ID]"))
+    print(_('kickstart_removescript: Remove a script from a Kickstart profile'))
+    print(_('usage: kickstart_removescript PROFILE [ID]'))
 
 
 def complete_kickstart_removescript(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_removescript(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2449,238 +2136,193 @@ def do_kickstart_removescript(self, args):
         try:
             script_id = int(args[1])
         except ValueError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Invalid script ID"))
+            logging.error(_N('Invalid script ID'))
 
     # print(the scripts for the user to review)
     self.do_kickstart_listscripts(profile)
 
     if not script_id:
         while script_id == 0:
-            print("")
-            # pylint: disable-next=undefined-variable
-            userinput = prompt_user(_("Script ID:"), noblank=True)
+            print('')
+            userinput = prompt_user(_('Script ID:'), noblank=True)
 
             try:
                 script_id = int(userinput)
             except ValueError:
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("Invalid script ID"))
+                logging.error(_N('Invalid script ID'))
 
-    if not self.user_confirm(_("Remove this script [y/N]:")):
+    if not self.user_confirm(_('Remove this script [y/N]:')):
         return 1
 
-    self.client.kickstart.profile.removeScript(self.session, profile, script_id)
+    self.client.kickstart.profile.removeScript(self.session,
+                                               profile,
+                                               script_id)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_clone(self):
-    print(_("kickstart_clone: Clone a Kickstart profile"))
-    print(
-        _(
-            """usage: kickstart_clone [options])
+    print(_('kickstart_clone: Clone a Kickstart profile'))
+    print(_('''usage: kickstart_clone [options])
 
 options:
   -n NAME
-  -c CLONE_NAME"""
-        )
-    )
+  -c CLONE_NAME'''))
 
 
 def complete_kickstart_clone(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_kickstart_list("", True), text)
+    return tab_completer(self.do_kickstart_list('', True), text)
 
 
 def do_kickstart_clone(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-c", "--clonename")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-c', '--clonename')
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
-    profiles = sorted(filter(None, self.do_kickstart_list("", True)))
+    profiles = sorted(filter(None, self.do_kickstart_list('', True)))
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
         if not profiles:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("No kickstart profiles available"))
             return 1
 
-        print("")
-        print(_("Kickstart Profiles"))
-        print("------------------")
-        print("\n".join(profiles))
-        print("")
+        print('')
+        print(_('Kickstart Profiles'))
+        print('------------------')
+        print('\n'.join(profiles))
+        print('')
 
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Original Profile:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.clonename = prompt_user(_("Cloned Profile:"), noblank=True)
+        options.name = prompt_user(_('Original Profile:'), noblank=True)
+        options.clonename = prompt_user(_('Cloned Profile:'), noblank=True)
     else:
+
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The Kickstart name is required"))
+            logging.error(_N('The Kickstart name is required'))
             return 1
 
         if not options.clonename:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("The Kickstart clone name is required"))
+            logging.error(_N('The Kickstart clone name is required'))
             return 1
 
     args.append(options.name)
-    # pylint: disable-next=undefined-variable
     if not filter_results(profiles, args):
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Kickstart profile you've entered was not found"))
         return 1
 
-    self.client.kickstart.cloneProfile(self.session, options.name, options.clonename)
+    self.client.kickstart.cloneProfile(self.session,
+                                       options.name,
+                                       options.clonename)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_export(self):
-    print(_("kickstart_export: export kickstart profile(s) to json format file"))
-    print(
-        _(
-            """usage: kickstart_export <KSPROFILE>... [options])
+    print(_('kickstart_export: export kickstart profile(s) to json format file'))
+    print(_('''usage: kickstart_export <KSPROFILE>... [options])
 options:
     -f outfile.json : specify an output filename, defaults to <KSPROFILE>.json
                       if exporting a single kickstart, profiles.json for multiple
                       kickstarts, or ks_all.json if no KSPROFILE specified
                       e.g (export ALL)
 
-Note : KSPROFILE list is optional, default is to export ALL"""
-        )
-    )
+Note : KSPROFILE list is optional, default is to export ALL'''))
 
 
 def complete_kickstart_export(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_kickstart_list("", True), text)
+    return tab_completer(self.do_kickstart_list('', True), text)
 
 
 def export_kickstart_getdetails(self, profile, kickstarts):
+
     # Get the initial ks details struct from the kickstarts list-of-struct,
     # which is returned from kickstart.listKickstarts()
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Getting kickstart profile details for %s" % profile)
     details = None
     for k in kickstarts:
-        if k.get("label") == profile:
+        if k.get('label') == profile:
             details = k
             break
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got basic details for %s : %s" % (profile, details))
 
     # Now use the various other API functions to build up a more complete
     # details struct for export.  Note there are a some ommisions from the API
     # e.g the "template" option which enables cobbler templating on scripts
-    details["child_channels"] = self.client.kickstart.profile.getChildChannels(
-        self.session, profile
-    )
-    details["advanced_opts"] = self.client.kickstart.profile.getAdvancedOptions(
-        self.session, profile
-    )
-    details["software_list"] = self.client.kickstart.profile.software.getSoftwareList(
-        self.session, profile
-    )
-    details["custom_opts"] = self.client.kickstart.profile.getCustomOptions(
-        self.session, profile
-    )
-    details["script_list"] = self.client.kickstart.profile.listScripts(
-        self.session, profile
-    )
-    details["ip_ranges"] = self.client.kickstart.profile.listIpRanges(
-        self.session, profile
-    )
-    # pylint: disable-next=undefined-variable,consider-using-f-string
+    details['child_channels'] = \
+        self.client.kickstart.profile.getChildChannels(self.session, profile)
+    details['advanced_opts'] = \
+        self.client.kickstart.profile.getAdvancedOptions(self.session, profile)
+    details['software_list'] = \
+        self.client.kickstart.profile.software.getSoftwareList(self.session,
+                                                               profile)
+    details['custom_opts'] = \
+        self.client.kickstart.profile.getCustomOptions(self.session, profile)
+    details['script_list'] = \
+        self.client.kickstart.profile.listScripts(self.session, profile)
+    details['ip_ranges'] = \
+        self.client.kickstart.profile.listIpRanges(self.session, profile)
     logging.debug("About to get variable_list for %s" % profile)
-    details["variable_list"] = self.client.kickstart.profile.getVariables(
-        self.session, profile
-    )
-    # pylint: disable-next=undefined-variable
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "done variable_list for %s = %s"
-        % (profile, details["variable_list"])
-    )
+    details['variable_list'] = \
+        self.client.kickstart.profile.getVariables(self.session, profile)
+    logging.debug("done variable_list for %s = %s" % (profile,
+                                                      details['variable_list']))
     # just export the key names, then look for one with the same name on import
-    details["activation_keys"] = [
-        k["key"]
-        for k in self.client.kickstart.profile.keys.getActivationKeys(
-            self.session, profile
-        )
-    ]
-    details[
-        "partitioning_scheme"
-    ] = self.client.kickstart.profile.system.getPartitioningScheme(
-        self.session, profile
-    )
-    if self.check_api_version("10.11"):
-        details["reg_type"] = self.client.kickstart.profile.system.getRegistrationType(
-            self.session, profile
-        )
+    details['activation_keys'] = [k['key'] for k in
+                                  self.client.kickstart.profile.keys.getActivationKeys(self.session,
+                                                                                       profile)]
+    details['partitioning_scheme'] = \
+        self.client.kickstart.profile.system.getPartitioningScheme(
+            self.session, profile)
+    if self.check_api_version('10.11'):
+        details['reg_type'] = \
+            self.client.kickstart.profile.system.getRegistrationType(self.session,
+                                                                     profile)
     else:
-        details["reg_type"] = "none"
-    details["config_mgmt"] = self.client.kickstart.profile.system.checkConfigManagement(
-        self.session, profile
-    )
-    details["remote_cmds"] = self.client.kickstart.profile.system.checkRemoteCommands(
-        self.session, profile
-    )
+        details['reg_type'] = "none"
+    details['config_mgmt'] = \
+        self.client.kickstart.profile.system.checkConfigManagement(
+            self.session, profile)
+    details['remote_cmds'] = \
+        self.client.kickstart.profile.system.checkRemoteCommands(
+            self.session, profile)
     # Just export the file preservation list names, then look for one with the
     # same name on import
-    details["file_preservations"] = [
-        f["name"]
-        for f in self.client.kickstart.profile.system.listFilePreservations(
-            self.session, profile
-        )
-    ]
+    details['file_preservations'] = [
+        f['name'] for f in self.client.kickstart.profile.system.listFilePreservations(
+            self.session, profile)]
     # just export the key description/names , then look for one with the same
     # name on import
-    details["gpg_ssl_keys"] = [
-        k["description"]
-        for k in self.client.kickstart.profile.system.listKeys(self.session, profile)
-    ]
+    details['gpg_ssl_keys'] = [k['description'] for k in
+                               self.client.kickstart.profile.system.listKeys(self.session, profile)]
 
     # There's a setLogging() but no getLogging(), so we look in the rendered
     # kickstart to figure out if pre/post logging is enabled
     kscontents = self.kickstart_getcontents(profile)
     if re.search("pre --logfile", kscontents):
-        # pylint: disable-next=undefined-variable
         logging.debug("Detected pre script logging")
-        details["pre_logging"] = True
+        details['pre_logging'] = True
     else:
-        details["pre_logging"] = False
+        details['pre_logging'] = False
     if re.search("post --logfile", kscontents):
-        # pylint: disable-next=undefined-variable
         logging.debug("Detected post script logging")
-        details["post_logging"] = True
+        details['post_logging'] = True
     else:
-        details["post_logging"] = False
+        details['post_logging'] = False
 
     # There's also no way to get the "Kernel Options" and "Post Kernel Options"
     # The Post options can be derived from the grubby --default-kernel` --args
     # line in the kickstart, ugly but at least we can then show some of what's
     # missing in the warnings that get printed on import
     if re.search("`/sbin/grubby --default-kernel` --args=", kscontents):
-        post_kopts = kscontents.split("`/sbin/grubby --default-kernel` --args=")[
-            1
-        ].split('"')[1]
-        # pylint: disable-next=undefined-variable,consider-using-f-string
+        post_kopts = \
+            kscontents.split("`/sbin/grubby --default-kernel` --args=")[1].\
+            split("\"")[1]
         logging.debug("Post kernel options %s detected" % post_kopts)
-        details["post_kopts"] = post_kopts
+        details['post_kopts'] = post_kopts
 
     # and now sort all the lists
     for i in details.keys():
@@ -2697,17 +2339,15 @@ def export_kickstart_getdetails(self, profile, kickstarts):
 
 
 def do_kickstart_export(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     filename = ""
     if options.file is not None:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Passed filename do_kickstart_export %s" % options.file)
+        logging.debug("Passed filename do_kickstart_export %s" %
+                      options.file)
         filename = options.file
 
     # Get the list of profiles to export and sort out the filename if required
@@ -2715,34 +2355,22 @@ def do_kickstart_export(self, args):
     if not args:
         if not filename:
             filename = "ks_all.json"
-        # pylint: disable-next=undefined-variable
         logging.info(_N("Exporting ALL kickstart profiles to %s") % filename)
-        profiles = self.do_kickstart_list("", True)
+        profiles = self.do_kickstart_list('', True)
     else:
         # allow globbing of kickstart kickstart names
-        # pylint: disable-next=undefined-variable
-        profiles = filter_results(self.do_kickstart_list("", True), args)
-        # pylint: disable-next=undefined-variable
-        logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "kickstart_export called with args %s, profiles=%s"
-            % (args, profiles)
-        )
+        profiles = filter_results(self.do_kickstart_list('', True), args)
+        logging.debug("kickstart_export called with args %s, profiles=%s" %
+                      (args, profiles))
         if not profiles:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N(
-                    "Error, no valid kickstart profile passed, "
-                    + "check name is  correct with spacecmd kickstart_list"
-                )
-            )
+            logging.error(_N("Error, no valid kickstart profile passed, " +
+                             "check name is  correct with spacecmd kickstart_list"))
             return 1
         if not filename:
             # No filename arg, so we try to do something sensible:
             # If we are exporting exactly one ks, we default to ksname.json
             # otherwise, generic ks_profiles.json name
             if len(profiles) == 1:
-                # pylint: disable-next=consider-using-f-string
                 filename = "%s.json" % profiles[0]
             else:
                 filename = "ks_profiles.json"
@@ -2755,134 +2383,99 @@ def do_kickstart_export(self, args):
     # Dump as a list of dict
     ksdetails_list = []
     for p in profiles:
-        # pylint: disable-next=undefined-variable
         logging.info(_N("Exporting ks %s to %s") % (p, filename))
         ksdetails_list.append(self.export_kickstart_getdetails(p, kickstarts))
 
-    # pylint: disable-next=undefined-variable
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "About to dump %d ks profiles to %s"
-        % (len(ksdetails_list), filename)
-    )
+    logging.debug("About to dump %d ks profiles to %s" %
+                  (len(ksdetails_list), filename))
     # Check if filepath exists, if an existing file we prompt for confirmation
     if os.path.isfile(filename):
-        if not self.user_confirm(
-            _("File %s exists, ") % filename + _("confirm overwrite file? (y/n)")
-        ):
+        if not self.user_confirm(_("File %s exists, ") % filename +
+                                 _("confirm overwrite file? (y/n)")):
             return 1
-    # pylint: disable-next=undefined-variable
     if json_dump_to_file(ksdetails_list, filename) is not True:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Error saving exported kickstart profiles to file") % filename)
+        logging.error(_N("Error saving exported kickstart profiles to file") %
+                      filename)
         return 1
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_importjson(self):
-    print(_("kickstart_import: import kickstart profile(s) from json file"))
-    print(_("""usage: kickstart_import <JSONFILES...>"""))
+    print(_('kickstart_import: import kickstart profile(s) from json file'))
+    print(_('''usage: kickstart_import <JSONFILES...>'''))
 
 
 def do_kickstart_importjson(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Error, no filename passed"))
         self.help_kickstart_importjson()
         return 1
 
     for filename in args:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Passed filename do_kickstart_import %s" % filename)
-        # pylint: disable-next=undefined-variable
         ksdetails_list = json_read_from_file(filename)
         if not ksdetails_list:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("Error, could not read json data from %s") % filename)
             return 1
         for ksdetails in ksdetails_list:
             if self.import_kickstart_fromdetails(ksdetails) is not True:
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("Error importing kickstart %s") % ksdetails["name"])
+                logging.error(_N("Error importing kickstart %s") %
+                              ksdetails['name'])
 
     return 0
-
 
 # create a new ks based on the dict from export_kickstart_getdetails
 
 
 def import_kickstart_fromdetails(self, ksdetails):
+
     # First we check that an existing kickstart with the same name does not exist
-    existing_profiles = self.do_kickstart_list("", True)
-    if ksdetails["name"] in existing_profiles:
-        # pylint: disable-next=undefined-variable
-        logging.error(
-            _N("ERROR : kickstart profile %s already exists! Skipping!")
-            % ksdetails["name"]
-        )
+    existing_profiles = self.do_kickstart_list('', True)
+    if ksdetails['name'] in existing_profiles:
+        logging.error(_N("ERROR : kickstart profile %s already exists! Skipping!")
+                      % ksdetails['name'])
         return False
     # create the ks, we need to drop the org prefix from the ks name
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Found ks %s") % ksdetails["name"])
+    logging.info(_N("Found ks %s") % ksdetails['name'])
 
     # Create the kickstart
     # for adding new profiles, we require a root password.
     # This is overridden when we set the 'advanced options'
-    tmppw = "foobar"
-    virt_type = "none"  # assume none as there's no API call to read this info
-    ks_host = ""
-    self.client.kickstart.createProfile(
-        self.session,
-        ksdetails["label"],
-        virt_type,
-        ksdetails["tree_label"],
-        ks_host,
-        tmppw,
-    )
+    tmppw = 'foobar'
+    virt_type = 'none'  # assume none as there's no API call to read this info
+    ks_host = ''
+    self.client.kickstart.createProfile(self.session, ksdetails['label'],
+                                        virt_type, ksdetails['tree_label'], ks_host, tmppw)
     # Now set other options
     self.client.kickstart.profile.setChildChannels(
-        self.session, ksdetails["label"], ksdetails["child_channels"]
-    )
+        self.session, ksdetails['label'], ksdetails['child_channels'])
     self.client.kickstart.profile.setAdvancedOptions(
-        self.session, ksdetails["label"], ksdetails["advanced_opts"]
-    )
+        self.session, ksdetails['label'], ksdetails['advanced_opts'])
     self.client.kickstart.profile.system.setPartitioningScheme(
-        self.session, ksdetails["label"], ksdetails["partitioning_scheme"]
-    )
+        self.session, ksdetails['label'], ksdetails['partitioning_scheme'])
     self.client.kickstart.profile.software.setSoftwareList(
-        self.session, ksdetails["label"], ksdetails["software_list"]
-    )
+        self.session, ksdetails['label'], ksdetails['software_list'])
     self.client.kickstart.profile.setCustomOptions(
-        self.session,
-        ksdetails["label"],
-        [o and o.get("arguments") or "\n" for o in ksdetails["custom_opts"]],
-    )
+        self.session, ksdetails['label'], [o and o.get('arguments') or "\n" for o in ksdetails['custom_opts']])
     self.client.kickstart.profile.setVariables(
-        self.session, ksdetails["label"], ksdetails["variable_list"]
-    )
+        self.session, ksdetails['label'], ksdetails['variable_list'])
     self.client.kickstart.profile.system.setRegistrationType(
-        self.session, ksdetails["label"], ksdetails["reg_type"]
-    )
-    if ksdetails["config_mgmt"]:
+        self.session, ksdetails['label'], ksdetails['reg_type'])
+    if ksdetails['config_mgmt']:
         self.client.kickstart.profile.system.enableConfigManagement(
-            self.session, ksdetails["label"]
-        )
-    if ksdetails["remote_cmds"]:
+            self.session, ksdetails['label'])
+    if ksdetails['remote_cmds']:
         self.client.kickstart.profile.system.enableRemoteCommands(
-            self.session, ksdetails["label"]
-        )
+            self.session, ksdetails['label'])
     # Add the scripts
-    for script in ksdetails["script_list"]:
+    for script in ksdetails['script_list']:
         # Somewhere between spacewalk-java-1.2.39-85 and 1.2.39-108,
         # two new versions of listScripts and addScripts were added, which
         # allows us to correctly set the "template" checkbox on import
@@ -2893,148 +2486,90 @@ def import_kickstart_fromdetails(self, ksdetails):
         # kickstarts from a server with the new API call to one without it,
         # so ensure the target satellite is at least as up-to-date as the
         # satellite where the export was performed.
-        if "template" in script:
-            ret = self.client.kickstart.profile.addScript(
-                self.session,
-                ksdetails["label"],
-                script["name"],
-                script["contents"],
-                script["interpreter"],
-                script["script_type"],
-                script["chroot"],
-                script["template"],
-            )
+        if 'template' in script:
+            ret = self.client.kickstart.profile.addScript(self.session,
+                                                          ksdetails['label'], script['name'], script['contents'],
+                                                          script['interpreter'], script[
+                                                              'script_type'], script['chroot'],
+                                                          script['template'])
         else:
             ret = self.client.kickstart.profile.addScript(
-                self.session,
-                ksdetails["label"],
-                script["name"],
-                script["contents"],
-                script["interpreter"],
-                script["script_type"],
-                script["chroot"],
-            )
+                self.session, ksdetails['label'], script['name'], script['contents'],
+                script['interpreter'], script['script_type'], script['chroot'])
         if ret:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("Added %s script to profile" % script["script_type"])
+            logging.debug("Added %s script to profile" % script['script_type'])
         else:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Error adding %s script") % script["script_type"])
+            logging.error(_N("Error adding %s script") % script['script_type'])
     # Specify ip ranges
-    for iprange in ksdetails["ip_ranges"]:
-        if self.client.kickstart.profile.addIpRange(
-            self.session, ksdetails["label"], iprange["min"], iprange["max"]
-        ):
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("added ip range %s-%s" % iprange["min"], iprange["max"])
+    for iprange in ksdetails['ip_ranges']:
+        if self.client.kickstart.profile.addIpRange(self.session,
+                                                    ksdetails['label'], iprange['min'], iprange['max']):
+            logging.debug("added ip range %s-%s" %
+                          iprange['min'], iprange['max'])
         else:
-            # pylint: disable-next=undefined-variable
-            logging.warning(
-                _N("failed to add ip range %s-%s, continuing") % iprange["min"],
-                iprange["max"],
-            )
+            logging.warning(_N("failed to add ip range %s-%s, continuing") %
+                            iprange['min'], iprange['max'])
             continue
     # File preservations, only if the list exists
     existing_file_preservations = [
-        x["name"]
-        for x in self.client.kickstart.filepreservation.listAllFilePreservations(
-            self.session
-        )
-    ]
-    if ksdetails["file_preservations"]:
-        for fp in ksdetails["file_preservations"]:
+        x['name'] for x in self.client.kickstart.filepreservation.listAllFilePreservations(
+            self.session)]
+    if ksdetails['file_preservations']:
+        for fp in ksdetails['file_preservations']:
             if fp in existing_file_preservations:
                 if self.client.kickstart.profile.system.addFilePreservations(
-                    self.session, ksdetails["label"], [fp]
-                ):
-                    # pylint: disable-next=undefined-variable,consider-using-f-string
+                        self.session, ksdetails['label'], [fp]):
                     logging.debug("added file preservation '%s'" % fp)
                 else:
-                    # pylint: disable-next=undefined-variable
-                    logging.warning(
-                        _N("failed to add file preservation %s, skipping") % fp
-                    )
+                    logging.warning(_N("failed to add file preservation %s, skipping") % fp)
             else:
-                # pylint: disable-next=undefined-variable
-                logging.warning(
-                    _N("file preservation list %s doesn't exist, skipping") % fp
-                )
+                logging.warning(_N("file preservation list %s doesn't exist, skipping") % fp)
 
     # Now add activationkeys, only if they exist
-    existing_act_keys = [
-        k["key"] for k in self.client.activationkey.listActivationKeys(self.session)
-    ]
-    for akey in ksdetails["activation_keys"]:
+    existing_act_keys = [k['key'] for k in
+                         self.client.activationkey.listActivationKeys(self.session)]
+    for akey in ksdetails['activation_keys']:
         if akey in existing_act_keys:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
             logging.debug("Adding activation key %s to profile" % akey)
-            self.client.kickstart.profile.keys.addActivationKey(
-                self.session, ksdetails["label"], akey
-            )
+            self.client.kickstart.profile.keys.addActivationKey(self.session,
+                                                                ksdetails['label'], akey)
         else:
-            # pylint: disable-next=undefined-variable
-            logging.warning(
-                _N("Actvationkey %s does not exist on the ") % akey
-                + ("satellite, skipping")
-            )
+            logging.warning(_N("Actvationkey %s does not exist on the ") % akey +
+                            ("satellite, skipping"))
 
     # The GPG/SSL keys, only if they exist
-    existing_gpg_ssl_keys = [
-        x["description"] for x in self.client.kickstart.keys.listAllKeys(self.session)
-    ]
-    for key in ksdetails["gpg_ssl_keys"]:
+    existing_gpg_ssl_keys = [x['description'] for x in self.client.kickstart.keys.listAllKeys(self.session)]
+    for key in ksdetails['gpg_ssl_keys']:
         if key in existing_gpg_ssl_keys:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
             logging.debug("Adding GPG/SSL key %s to profile" % key)
-            self.client.kickstart.profile.system.addKeys(
-                self.session, ksdetails["label"], [key]
-            )
+            self.client.kickstart.profile.system.addKeys(self.session,
+                                                         ksdetails['label'], [key])
         else:
-            # pylint: disable-next=undefined-variable
-            logging.warning(
-                _N("GPG/SSL key %s does not exist on the Spacewalk server, skipping")
-                % key
-            )
+            logging.warning(_N("GPG/SSL key %s does not exist on the Spacewalk server, skipping") % key)
 
     # The pre/post logging settings
-    self.client.kickstart.profile.setLogging(
-        self.session,
-        ksdetails["label"],
-        ksdetails["pre_logging"],
-        ksdetails["post_logging"],
-    )
+    self.client.kickstart.profile.setLogging(self.session, ksdetails['label'],
+                                             ksdetails['pre_logging'], ksdetails['post_logging'])
 
     # There are some frustrating ommisions from the API which means we can't
     # export/import some settings, so we post a warning that some manual
     # fixup may be required
-    # pylint: disable-next=undefined-variable
-    logging.warning(
-        _N(
-            "Due to API ommissions, there are some settings which"
-            + " cannot be imported, please check and fixup manually if necessary"
-        )
-    )
-    # pylint: disable-next=undefined-variable
+    logging.warning(_N("Due to API ommissions, there are some settings which" +
+                       " cannot be imported, please check and fixup manually if necessary"))
     logging.warning(_N(" * Details->Preserve ks.cfg"))
-    # pylint: disable-next=undefined-variable
     logging.warning(_N(" * Details->Comment"))
     # Org default gets exported but no way to set it, so we can just show this
     # warning if they are trying to import an org_default profile
-    if ksdetails["org_default"]:
-        # pylint: disable-next=undefined-variable
+    if ksdetails['org_default']:
         logging.warning(_N(" * Details->Organization Default Profile"))
     # No way to set the kernel options
-    # pylint: disable-next=undefined-variable
     logging.warning(_N(" * Details->Kernel Options"))
     # We can export Post kernel options (sort of, see above)
     # if they exist on import, flag a warning
-    if "post_kopts" in ksdetails:
-        # pylint: disable-next=undefined-variable
-        logging.warning(
-            _N(" * Details->Post Kernel Options : %s") % ksdetails["post_kopts"]
-        )
+    if 'post_kopts' in ksdetails:
+        logging.warning(_N(" * Details->Post Kernel Options : %s") %
+                        ksdetails['post_kopts'])
     return True
-
 
 ####################
 # kickstart helper
@@ -3048,11 +2583,9 @@ def is_kickstart(self, name):
 
 def check_kickstart(self, name):
     if not name:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("no kickstart label given"))
         return False
     if not self.is_kickstart(name):
-        # pylint: disable-next=undefined-variable
         logging.error(_N("invalid kickstart label ") + name)
         return False
     return True
@@ -3062,42 +2595,35 @@ def dump_kickstart(self, name, replacedict=None, excludes=None):
     excludes = excludes or ["Org Default:"]
     content = self.do_kickstart_details(name)
 
-    # pylint: disable-next=undefined-variable
     content = get_normalized_text(content, replacedict=replacedict, excludes=excludes)
 
     return content
-
 
 ####################
 
 
 def help_kickstart_diff(self):
-    print(_("kickstart_diff: diff kickstart files"))
-    print("")
-    print(_("usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"))
+    print(_('kickstart_diff: diff kickstart files'))
+    print('')
+    print(_('usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_kickstart_diff(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     return []
 
 
 def do_kickstart_diff(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1 and len(args) != 2:
@@ -3117,42 +2643,34 @@ def do_kickstart_diff(self, args):
     if not self.check_kickstart(target_channel):
         return None
 
-    # pylint: disable-next=undefined-variable
-    source_replacedict, target_replacedict = get_string_diff_dicts(
-        source_channel, target_channel
-    )
+    source_replacedict, target_replacedict = get_string_diff_dicts(source_channel, target_channel)
 
     source_data = self.dump_kickstart(source_channel, source_replacedict)
     target_data = self.dump_kickstart(target_channel, target_replacedict)
 
-    # pylint: disable-next=undefined-variable
     for line in diff(source_data, target_data, source_channel, target_channel):
         print(line)
-
 
 ####################
 
 
 def help_kickstart_getupdatetype(self):
-    print(_("kickstart_getupdatetype: Get the update type for a kickstart profile(s)"))
-    print(_("usage: kickstart_getupdatetype PROFILE"))
-    print(_("usage: kickstart_getupdatetype PROFILE1 PROFILE2"))
-    print(_('usage: kickstart_getupdatetype "PROF*"'))
+    print(_('kickstart_getupdatetype: Get the update type for a kickstart profile(s)'))
+    print(_('usage: kickstart_getupdatetype PROFILE'))
+    print(_('usage: kickstart_getupdatetype PROFILE1 PROFILE2'))
+    print(_('usage: kickstart_getupdatetype \"PROF*\"'))
 
 
 def complete_kickstart_getupdatetype(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_getupdatetype(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 1:
@@ -3160,21 +2678,17 @@ def do_kickstart_getupdatetype(self, args):
         return 1
 
     # allow globbing of kickstart labels
-    all_labels = self.do_kickstart_list("", True)
-    # pylint: disable-next=undefined-variable
+    all_labels = self.do_kickstart_list('', True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got labels to list the update type %s" % labels)
 
     if not labels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_getupdatetype()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("kickstart label %s doesn't exist!") % label)
             continue
 
@@ -3187,94 +2701,76 @@ def do_kickstart_getupdatetype(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_kickstart_setupdatetype(self):
-    print(_("kickstart_setupdatetype: Set the update type for a kickstart profile(s)"))
-    print(
-        _(
-            """usage: kickstart_setupdatetype [options] KS_LABEL)
+    print(_('kickstart_setupdatetype: Set the update type for a kickstart profile(s)'))
+    print(_('''usage: kickstart_setupdatetype [options] KS_LABEL)
 
 options:
-    -u UPDATE_TYPE ['red_hat', 'all', 'none']"""
-        )
-    )
+    -u UPDATE_TYPE ['red_hat', 'all', 'none']'''))
 
 
 def do_kickstart_setupdatetype(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-u", "--update-type")
+    arg_parser.add_argument('-u', '--update-type')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        print(_("Update Types"))
-        print("--------------------")
-        print("\n".join(sorted(self.UPDATE_TYPES)))
-        print("")
 
-        # pylint: disable-next=undefined-variable
-        options.update_type = prompt_user(_("Update Type [none]:"))
-        if options.update_type == "" or options.update_type not in self.UPDATE_TYPES:
-            options.update_type = "none"
+        print(_('Update Types'))
+        print('--------------------')
+        print('\n'.join(sorted(self.UPDATE_TYPES)))
+        print('')
+
+        options.update_type = prompt_user(_('Update Type [none]:'))
+        if options.update_type == '' or options.update_type not in self.UPDATE_TYPES:
+            options.update_type = 'none'
 
     else:
         if not options.update_type:
-            options.update_type = "none"
+            options.update_type = 'none'
 
     # allow globbing of kickstart labels
-    all_labels = self.do_kickstart_list("", True)
-    # pylint: disable-next=undefined-variable
+    all_labels = self.do_kickstart_list('', True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got labels to set the update type %s" % labels)
 
     if not labels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_setupdatetype()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("kickstart label %s doesn't exist!") % label)
             continue
 
-        self.client.kickstart.profile.setUpdateType(
-            self.session, label, options.update_type
-        )
+        self.client.kickstart.profile.setUpdateType(self.session, label, options.update_type)
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_getsoftwaredetails(self):
-    print(_("kickstart_getsoftwaredetails: Gets kickstart profile software details"))
-    print(_("usage: kickstart_getsoftwaredetails KS_LABEL"))
-    print(_("usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."))
+    print(_('kickstart_getsoftwaredetails: Gets kickstart profile software details'))
+    print(_('usage: kickstart_getsoftwaredetails KS_LABEL'))
+    print(_('usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ...'))
 
 
 def complete_kickstart_getsoftwaredetails(self, text, line, beg, end):
-    if len(line.split(" ")) >= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+    if len(line.split(' ')) >= 2:
+        return tab_completer(self.do_kickstart_list('', True), text)
 
     return None
 
 
 def do_kickstart_getsoftwaredetails(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 1:
@@ -3282,27 +2778,21 @@ def do_kickstart_getsoftwaredetails(self, args):
         return 1
 
     # allow globbing of kickstart labels
-    all_labels = self.do_kickstart_list("", True)
-    # pylint: disable-next=undefined-variable
+    all_labels = self.do_kickstart_list('', True)
     labels = filter_results(all_labels, args)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got labels to set the update type %s" % labels)
 
     if not labels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_getsoftwaredetails()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("kickstart label %s doesn't exist!") % label)
             continue
 
-        software_details = self.client.kickstart.profile.software.getSoftwareDetails(
-            self.session, label
-        )
+        software_details = self.client.kickstart.profile.software.getSoftwareDetails(self.session, label)
 
         if len(labels) == 1:
             print(_("noBase:        %s") % software_details.get("noBase"))
@@ -3311,111 +2801,84 @@ def do_kickstart_getsoftwaredetails(self, args):
             print(_("Kickstart Label: %s") % label)
             print(_("noBase:          %s") % software_details.get("noBase"))
             print(_("ignoreMissing:   %s") % software_details.get("ignoreMissing"))
-            print("")
+            print('')
 
     return 0
-
 
 ####################
 
 
 def help_kickstart_setsoftwaredetails(self):
-    print(_("kickstart_setsoftwaredetails: Sets kickstart profile software details."))
-    print(
-        _("usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE")
-    )
-    print(
-        _(
-            "usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE KICKSTART_PACKAGES_INFO VALUE"
-        )
-    )
-
+    print(_('kickstart_setsoftwaredetails: Sets kickstart profile software details.'))
+    print(_('usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE'))
+    print(_('usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE KICKSTART_PACKAGES_INFO VALUE'))
 
 def complete_kickstart_setsoftwaredetails(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
     length = len(parts)
 
     if length == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_kickstart_list("", True), text)
+        return tab_completer(self.do_kickstart_list('', True), text)
     if length in [3, 5]:
-        if "noBase" in parts:
-            # pylint: disable-next=undefined-variable
-            return tab_completer(["ignoreMissing"], text)
-        if "ignoreMissing" in parts:
-            # pylint: disable-next=undefined-variable
-            return tab_completer(["noBase"], text)
+        if 'noBase' in parts:
+            return tab_completer(['ignoreMissing'], text)
+        if 'ignoreMissing' in parts:
+            return tab_completer(['noBase'], text)
 
-        kspkginfo = ["noBase", "ignoreMissing"]
-        # pylint: disable-next=undefined-variable
+        kspkginfo = ['noBase', 'ignoreMissing']
         return tab_completer(kspkginfo, text)
     if length in [4, 6]:
-        mode = ["True", "False"]
-        # pylint: disable-next=undefined-variable
+        mode= ['True', 'False']
         return tab_completer(mode, text)
 
     return None
 
 
 def do_kickstart_setsoftwaredetails(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
     length = len(args)
-    kspkginfo = ["noBase", "ignoreMissing"]
-    mode = ["True", "False"]
+    kspkginfo = ['noBase', 'ignoreMissing']
+    mode = ['True', 'False']
 
     if length < 1 or length not in [3, 5]:
         self.help_kickstart_setsoftwaredetails()
         return 1
 
-    if args[0] not in self.do_kickstart_list("", True):
+    if args[0] not in self.do_kickstart_list('', True):
         print(_("Selected profile does not exist"))
         return 1
     if args[1] not in kspkginfo or args[2] not in mode:
         print(_("Enter valid input"))
         self.help_kickstart_setsoftwaredetails()
         return 1
-    if length == 5:
+    if length==5:
         if (args[3] not in kspkginfo or args[4] not in mode) or args[1] == args[3]:
             print(_("Enter valid input"))
             self.help_kickstart_setsoftwaredetails()
             return 1
 
-    # pylint: disable-next=undefined-variable
     args[2] = string_to_bool(args[2])
     if length == 5:
-        # pylint: disable-next=undefined-variable
         args[4] = string_to_bool(args[4])
 
     profile = args[0]
     if length == 3:
-        software_details = self.client.kickstart.profile.software.getSoftwareDetails(
-            self.session, profile
-        )
+        software_details = self.client.kickstart.profile.software.getSoftwareDetails(self.session, profile)
 
-        if args[1] == "noBase":
-            kspkginfo = {
-                "noBase": args[2],
-                # pylint: disable-next=undefined-variable
-                "ignoreMissing": string_to_bool(software_details.get("ignoreMissing")),
-            }
-        elif args[1] == "ignoreMissing":
-            kspkginfo = {
-                # pylint: disable-next=undefined-variable
-                "noBase": string_to_bool(software_details.get("noBase")),
-                "ignoreMissing": args[2],
-            }
+        if args[1] == 'noBase':
+            kspkginfo= {'noBase': args[2], 'ignoreMissing': string_to_bool(software_details.get("ignoreMissing"))}
+        elif args[1] == 'ignoreMissing':
+            kspkginfo= {'noBase': string_to_bool(software_details.get("noBase")), 'ignoreMissing':args[2]}
     else:
-        if args[3] == "noBase":
-            kspkginfo = {"noBase": args[4], "ignoreMissing": args[2]}
-        elif args[3] == "ignoreMissing":
-            kspkginfo = {"noBase": args[2], "ignoreMissing": args[4]}
+        if args[3] == 'noBase':
+            kspkginfo= {'noBase': args[4], 'ignoreMissing': args[2]}
+        elif args[3] == 'ignoreMissing':
+            kspkginfo= {'noBase': args[2], 'ignoreMissing':args[4]}
 
-    self.client.kickstart.profile.software.setSoftwareDetails(
-        self.session, profile, kspkginfo
-    )
+    self.client.kickstart.profile.software.setSoftwareDetails(self.session,
+                                                              profile,
+                                                              kspkginfo)
 
     return 0

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -36,40 +35,35 @@ import logging
 import readline
 import shlex
 from getpass import getpass
-
-try:  # python 3
+try: # python 3
     from configparser import NoOptionError
-except ImportError:  # python 2
+except ImportError: # python 2
     from ConfigParser import NoOptionError
 
 from time import sleep
-
-try:  # python 3
+try: # python 3
     from xmlrpc import client as xmlrpclib
-except ImportError:  # python2
+except ImportError: # python2
     import xmlrpclib
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
 # list of system selection options for the help output
-HELP_SYSTEM_OPTS = _(
-    """<SYSTEMS> can be any of the following:
+HELP_SYSTEM_OPTS = _('''<SYSTEMS> can be any of the following:
 name
 ssm (see 'help ssm')
 search:QUERY (see 'help system_search')
 group:GROUP
 channel:CHANNEL
-"""
-)
+''')
 
-HELP_TIME_OPTS = _(
-    """Dates can be any of the following:
+HELP_TIME_OPTS = _('''Dates can be any of the following:
 Explicit Dates:
 Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]
 format.  The year, month and day are required, while the hours and
@@ -86,8 +80,7 @@ s -> seconds
 m -> minutes
 h -> hours
 d -> days
-"""
-)
+''')
 
 ####################
 
@@ -98,24 +91,18 @@ ERRATA_CACHE_TTL = 86400
 
 MINIMUM_API_VERSION = 10.8
 
-SEPARATOR = "\n" + "#" * 30 + "\n"
+SEPARATOR = '\n' + '#' * 30 + '\n'
 
 ####################
 
-ENTITLEMENTS = ["enterprise_entitled", "virtualization_host"]
+ENTITLEMENTS = ['enterprise_entitled',
+                'virtualization_host'
+               ]
 
-SYSTEM_SEARCH_FIELDS = [
-    "id",
-    "name",
-    "ip",
-    "hostname",
-    "device",
-    "vendor",
-    "driver",
-    "uuid",
-]
+SYSTEM_SEARCH_FIELDS = ['id', 'name', 'ip', 'hostname',
+                        'device', 'vendor', 'driver', 'uuid']
 
-CONTACT_METHODS = ["default", "ssh-push", "ssh-push-tunnel"]
+CONTACT_METHODS = ['default', 'ssh-push', 'ssh-push-tunnel']
 
 ####################
 
@@ -127,26 +114,24 @@ def help_systems(self):
 def help_time(self):
     print(HELP_TIME_OPTS)
 
-
 ####################
 
 
 def help_clear(self):
-    print(_("clear: clear the screen"))
-    print(_("usage: clear"))
+    print(_('clear: clear the screen'))
+    print(_('usage: clear'))
 
 
 def do_clear(self, args):
     print("\x1b[H\x1b[J")
     return 0
 
-
 ####################
 
 
 def help_clear_caches(self):
-    print(_("clear_caches: Clear the internal caches kept for systems and packages"))
-    print(_("usage: clear_caches"))
+    print(_('clear_caches: Clear the internal caches kept for systems and packages'))
+    print(_('usage: clear_caches'))
 
 
 def do_clear_caches(self, args):
@@ -155,26 +140,24 @@ def do_clear_caches(self, args):
     self.clear_errata_cache()
     return 0
 
-
 ####################
 
 
 def help_get_apiversion(self):
-    print(_("get_apiversion: Display the API version of the server"))
-    print(_("usage: get_apiversion"))
+    print(_('get_apiversion: Display the API version of the server'))
+    print(_('usage: get_apiversion'))
 
 
 def do_get_apiversion(self, args):
     print(self.client.api.getVersion())
     return 0
 
-
 ####################
 
 
 def help_get_serverversion(self):
-    print(_("get_serverversion: Display the version of the server"))
-    print(_("usage: get_serverversion"))
+    print(_('get_serverversion: Display the version of the server'))
+    print(_('usage: get_serverversion'))
 
 
 def do_get_serverversion(self, args):
@@ -186,8 +169,8 @@ def do_get_serverversion(self, args):
 
 
 def help_list_proxies(self):
-    print(_("list_proxies: List the proxies within the user's organization "))
-    print(_("usage: list_proxies"))
+    print(_('list_proxies: List the proxies within the user\'s organization '))
+    print(_('usage: list_proxies'))
 
 
 def do_list_proxies(self, args):
@@ -195,13 +178,12 @@ def do_list_proxies(self, args):
     print(proxies)
     return 0
 
-
 ####################
 
 
 def help_get_session(self):
-    print(_("get_session: Show the current session string"))
-    print(_("usage: get_session"))
+    print(_('get_session: Show the current session string'))
+    print(_('usage: get_session'))
 
 
 def do_get_session(self, args):
@@ -209,67 +191,58 @@ def do_get_session(self, args):
         print(self.session)
         return 0
     else:
-        logging.error(_N("No session found"))
+        logging.error(_N('No session found'))
         return 1
-
 
 ####################
 
 
 def help_help(self):
-    print(_("help: Show help for the given command"))
-    print(_("usage: help COMMAND"))
-
+    print(_('help: Show help for the given command'))
+    print(_('usage: help COMMAND'))
 
 ####################
 
 
 def help_history(self):
-    print(_("history: List your command history"))
-    print(_("usage: history"))
+    print(_('history: List your command history'))
+    print(_('usage: history'))
 
 
 def do_history(self, args):
     for i in range(1, readline.get_current_history_length()):
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s" % (str(i).rjust(4), readline.get_history_item(i)))
+        print('%s  %s' % (str(i).rjust(4), readline.get_history_item(i)))
     return 0
-
 
 ####################
 
 
 def help_toggle_confirmations(self):
-    print(_("toggle_confirmations: Toggle confirmation messages on/off"))
-    print(_("usage: toggle_confirmations"))
+    print(_('toggle_confirmations: Toggle confirmation messages on/off'))
+    print(_('usage: toggle_confirmations'))
 
 
 def do_toggle_confirmations(self, args):
     self.options.yes = not self.options.yes
-    print(
-        _("Confirmation messages are"), "disabled" if self.options.yes else _("enabled")
-    )
+    print(_('Confirmation messages are'), "disabled" if self.options.yes else _("enabled"))
     return 0
-
 
 ####################
 
 
 def help_login(self):
-    print(_("login: Connect to a Spacewalk server"))
-    print(_("usage: login [USERNAME] [SERVER]"))
+    print(_('login: Connect to a Spacewalk server'))
+    print(_('usage: login [USERNAME] [SERVER]'))
 
 
 def do_login(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     # logout before logging in again
     if self.session:
-        logging.warning(_N("You are already logged in"))
+        logging.warning(_N('You are already logged in'))
         return True
 
     # an argument passed to the function get precedence
@@ -281,7 +254,7 @@ def do_login(self, args):
 
     # bail out if not server was given
     if not server:
-        logging.warning(_N("No server specified"))
+        logging.warning(_N('No server specified'))
         return False
 
     # load the server-specific configuration
@@ -290,23 +263,22 @@ def do_login(self, args):
     # an argument passed to the function get precedence
     if args:
         username = args[0]
-    elif "username" in self.config:
+    elif 'username' in self.config:
         # use the username from before
-        username = self.config["username"]
+        username = self.config['username']
     elif self.options.username:
         # use the username from before
         username = self.options.username
     else:
-        username = ""
+        username = ''
 
     # set the protocol
     if self.config.get("nossl"):
-        proto = "http"
+        proto = 'http'
     else:
-        proto = "https"
+        proto = 'https'
 
-    # pylint: disable-next=consider-using-f-string
-    server_url = "%s://%s/rpc/api" % (proto, server)
+    server_url = '%s://%s/rpc/api' % (proto, server)
 
     # this will enable spewing out all client/server traffic
     verbose_xmlrpc = False
@@ -314,57 +286,49 @@ def do_login(self, args):
         verbose_xmlrpc = True
 
     # connect to the server
-    logging.debug("Connecting to %s", server_url)
+    logging.debug('Connecting to %s', server_url)
     self.client = xmlrpclib.Server(server_url, verbose=verbose_xmlrpc)
 
     # check the API to verify connectivity
     # pylint: disable=W0702
     try:
         self.api_version = self.client.api.getVersion()
-        logging.debug("Server API Version = %s", self.api_version)
-    except Exception as exc:  # pylint: disable=broad-except
+        logging.debug('Server API Version = %s', self.api_version)
+    except Exception as exc: # pylint: disable=broad-except
         if self.options.debug > 0:
-            # pylint: disable-next=undefined-variable
             e = sys.exc_info()[0]
             logging.exception(e)
 
-        logging.error(_N("Failed to connect to %s"), server_url)
-        logging.debug(
-            "Error while connecting to the server %s: %s", server_url, str(exc)
-        )
+        logging.error(_N('Failed to connect to %s'), server_url)
+        logging.debug("Error while connecting to the server %s: %s",
+                      server_url, str(exc))
         self.client = None
         return False
 
     # ensure the server is recent enough
     if float(self.api_version) < self.MINIMUM_API_VERSION:
-        logging.error(
-            _N("API (%s) is too old (>= %s required)"),
-            self.api_version,
-            self.MINIMUM_API_VERSION,
-        )
+        logging.error(_N('API (%s) is too old (>= %s required)'),
+                      self.api_version, self.MINIMUM_API_VERSION)
 
         self.client = None
         return False
 
     # Handle initial org and user creation
     # Only 'self.client' object required, skip login and session caching
-    if "org_createfirst" in self.options.command:
+    if 'org_createfirst' in self.options.command:
         return True
 
     # store the session file in the server's own directory
-    # pylint: disable-next=undefined-variable
-    session_file = os.path.join(self.conf_dir, server, "session")
+    session_file = os.path.join(self.conf_dir, server, 'session')
 
     # retrieve a cached session
-    # pylint: disable-next=undefined-variable
     if os.path.isfile(session_file) and not self.options.password:
         try:
-            # pylint: disable-next=unspecified-encoding
-            sessionfile = open(session_file, "r")
+            sessionfile = open(session_file, 'r')
 
             # read the session (format = username:session)
             for line in sessionfile.readlines():
-                parts = line.split(":")
+                parts = line.split(':')
 
                 # if a username was passed, make sure it matches
                 if username:
@@ -378,26 +342,25 @@ def do_login(self, args):
 
             sessionfile.close()
         except IOError:
-            logging.error(_N("Could not read %s"), session_file)
+            logging.error(_N('Could not read %s'), session_file)
 
     # check the cached credentials by doing an API call
     if self.session:
         try:
-            logging.debug("Using cached credentials from %s", session_file)
+            logging.debug('Using cached credentials from %s', session_file)
 
             self.client.user.listAssignableRoles(self.session)
         except xmlrpclib.Fault:
-            logging.warning(_N("Cached credentials are invalid"))
-            self.current_user = ""
-            self.session = ""
+            logging.warning(_N('Cached credentials are invalid'))
+            self.current_user = ''
+            self.session = ''
 
     # attempt to login if we don't have a valid session yet
     if not self.session:
         if username:
-            logging.info(_N("Spacewalk Username: %s"), username)
+            logging.info(_N('Spacewalk Username: %s'), username)
         else:
-            # pylint: disable-next=undefined-variable
-            username = prompt_user(_("Spacewalk Username:"), noblank=True)
+            username = prompt_user(_('Spacewalk Username:'), noblank=True)
 
         if self.options.password:
             password = self.options.password
@@ -405,39 +368,34 @@ def do_login(self, args):
             # remove this from the options so that if 'login' is called
             # again, the user is prompted for the information
             self.options.password = None
-        elif "password" in self.config:
-            password = self.config["password"]
+        elif 'password' in self.config:
+            password = self.config['password']
         else:
-            password = getpass(_("Spacewalk Password: "))
+            password = getpass(_('Spacewalk Password: '))
 
         # login to the server
         try:
             self.session = self.client.auth.login(username, password)
         except xmlrpclib.Fault as exc:
-            logging.error(_N("Invalid credentials"))
+            logging.error(_N('Invalid credentials'))
             logging.debug("Login error: %s (%s)", exc.faultString, exc.faultCode)
             return False
         try:
             # make sure ~/.spacecmd/<server> exists
-            # pylint: disable-next=undefined-variable
             conf_dir = os.path.join(self.conf_dir, server)
 
-            # pylint: disable-next=undefined-variable
             if not os.path.isdir(conf_dir):
-                # pylint: disable-next=undefined-variable
-                os.mkdir(conf_dir, int("0700", 8))
+                os.mkdir(conf_dir, int('0700', 8))
 
             # add the new cache to the file
-            # pylint: disable-next=consider-using-f-string
-            line = "%s:%s\n" % (username, self.session)
+            line = '%s:%s\n' % (username, self.session)
 
             # write the new cache file out
-            # pylint: disable-next=unspecified-encoding
-            sessionfile = open(session_file, "w")
+            sessionfile = open(session_file, 'w')
             sessionfile.write(line)
             sessionfile.close()
         except IOError as exc:
-            logging.error(_N("Could not write session file: %s"), str(exc))
+            logging.error(_N('Could not write session file: %s'), str(exc))
 
     # load the system/package/errata caches
     self.load_caches(server, username)
@@ -446,37 +404,35 @@ def do_login(self, args):
     self.current_user = username
     self.server = server
 
-    logging.info(_N("Connected to %s as %s"), server_url, username)
+    logging.info(_N('Connected to %s as %s'), server_url, username)
     _show_traditional_stack_message(self)
 
     return True
-
 
 ####################
 
 
 def help_logout(self):
-    print(_("logout: Disconnect from the server"))
-    print(_("usage: logout"))
+    print(_('logout: Disconnect from the server'))
+    print(_('usage: logout'))
 
 
 def do_logout(self, args):
     if self.session:
         self.client.auth.logout(self.session)
 
-    self.session = ""
-    self.current_user = ""
-    self.server = ""
-    self.do_clear_caches("")
+    self.session = ''
+    self.current_user = ''
+    self.server = ''
+    self.do_clear_caches('')
     return 0
-
 
 ####################
 
 
 def help_whoami(self):
-    print(_("whoami: Print the name of the currently logged in user"))
-    print(_("usage: whoami"))
+    print(_('whoami: Print the name of the currently logged in user'))
+    print(_('usage: whoami'))
 
 
 def do_whoami(self, args):
@@ -487,13 +443,12 @@ def do_whoami(self, args):
         logging.warning(_N("You are not logged in"))
         return 1
 
-
 ####################
 
 
 def help_whoamitalkingto(self):
-    print(_("whoamitalkingto: Print the name of the server"))
-    print(_("usage: whoamitalkingto"))
+    print(_('whoamitalkingto: Print the name of the server'))
+    print(_('usage: whoamitalkingto'))
 
 
 def do_whoamitalkingto(self, args):
@@ -501,68 +456,53 @@ def do_whoamitalkingto(self, args):
         print(self.server)
         return 0
     else:
-        logging.warning(_N("Yourself"))
+        logging.warning(_N('Yourself'))
         return 1
 
-
 ####################
-
 
 def _show_traditional_stack_message(self):
     try:
         has_traditional_systems = self.client.system.hasTraditionalSystems(self.session)
 
         if has_traditional_systems:
-            logging.warning(
-                (
-                    "The traditional stack is unsupported and scheduled for removal. "
-                    "Consider migrating to salt minions."
-                )
-            )
+            logging.warning((
+                'The traditional stack is unsupported and scheduled for removal. '
+                'Consider migrating to salt minions.'
+            ))
     except xmlrpclib.Fault:
         # hasTraditionalSystems endpoint is not available prior to 4.3
         logging.debug(_N("Skipping traditional system check"))
 
-
 def tab_complete_errata(self, text):
-    options = self.do_errata_list("", True)
-    options.append("search:")
+    options = self.do_errata_list('', True)
+    options.append('search:')
 
-    # pylint: disable-next=undefined-variable
     return tab_completer(options, text)
 
 
 def tab_complete_systems(self, text):
-    # pylint: disable-next=undefined-variable
-    if re.match("group:", text):
+    if re.match('group:', text):
         # prepend 'group' to each item for tab completion
-        # pylint: disable-next=consider-using-f-string
-        groups = ["group:%s" % g for g in self.do_group_list("", True)]
+        groups = ['group:%s' % g for g in self.do_group_list('', True)]
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(groups, text)
-    # pylint: disable-next=undefined-variable
-    if re.match("channel:", text):
+    if re.match('channel:', text):
         # prepend 'channel' to each item for tab completion
-        # pylint: disable-next=consider-using-f-string
-        channels = ["channel:%s" % s for s in self.do_softwarechannel_list("", True)]
+        channels = ['channel:%s' % s
+                    for s in self.do_softwarechannel_list('', True)]
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(channels, text)
-    # pylint: disable-next=undefined-variable
-    if re.match("search:", text):
+    if re.match('search:', text):
         # prepend 'search' to each item for tab completion
-        # pylint: disable-next=consider-using-f-string
-        fields = ["search:%s:" % f for f in self.SYSTEM_SEARCH_FIELDS]
-        # pylint: disable-next=undefined-variable
+        fields = ['search:%s:' % f for f in self.SYSTEM_SEARCH_FIELDS]
         return tab_completer(fields, text)
 
     options = self.get_system_names()
 
     # add our special search options
-    options.extend(["group:", "channel:", "search:"])
+    options.extend(['group:', 'channel:', 'search:'])
 
-    # pylint: disable-next=undefined-variable
     return tab_completer(options, text)
 
 
@@ -575,61 +515,57 @@ def remove_last_history_item(self):
 
 def clear_errata_cache(self):
     self.all_errata = {}
-    # pylint: disable-next=undefined-variable
     self.errata_cache_expire = datetime.now()
     self.save_errata_cache()
 
 
 def get_errata_names(self):
-    return sorted([e.get("advisory_name") for e in self.all_errata])
+    return sorted([e.get('advisory_name') for e in self.all_errata])
 
 
 def get_erratum_id(self, name):
     if name in self.all_errata:
-        return self.all_errata[name]["id"]
+        return self.all_errata[name]['id']
 
     return None
 
 
 def get_erratum_name(self, erratum_id):
     for erratum in self.all_errata:
-        if self.all_errata[erratum]["id"] == erratum_id:
+        if self.all_errata[erratum]['id'] == erratum_id:
             return erratum
 
     return None
 
 
 def generate_errata_cache(self, force=False):
-    # pylint: disable-next=undefined-variable
     if not force and datetime.now() < self.errata_cache_expire:
         return
 
     if not self.options.quiet:
         # tell the user what's going on
-        self.replace_line_buffer(_("** Generating errata cache **"))
+        self.replace_line_buffer(_('** Generating errata cache **'))
 
     channels = self.client.channel.listSoftwareChannels(self.session)
-    channels = [c.get("label") for c in channels]
+    channels = [c.get('label') for c in channels]
 
     for c in channels:
         try:
             errata = self.client.channel.software.listErrata(self.session, c)
         except xmlrpclib.Fault as exc:
-            logging.debug("No access to %s (%s): %s", c, exc.faultCode, exc.faultString)
+            logging.debug('No access to %s (%s): %s', c, exc.faultCode, exc.faultString)
             continue
 
         for erratum in errata:
-            if erratum.get("advisory_name") not in self.all_errata:
-                self.all_errata[erratum.get("advisory_name")] = {
-                    "id": erratum.get("id"),
-                    "advisory_name": erratum.get("advisory_name"),
-                    "advisory_type": erratum.get("advisory_type"),
-                    "advisory_status": erratum.get("advisory_status"),
-                    "date": erratum.get("date"),
-                    "advisory_synopsis": erratum.get("advisory_synopsis"),
-                }
+            if erratum.get('advisory_name') not in self.all_errata:
+                self.all_errata[erratum.get('advisory_name')] = \
+                    {'id': erratum.get('id'),
+                     'advisory_name': erratum.get('advisory_name'),
+                     'advisory_type': erratum.get('advisory_type'),
+                     'advisory_status': erratum.get('advisory_status'),
+                     'date': erratum.get('date'),
+                     'advisory_synopsis': erratum.get('advisory_synopsis')}
 
-    # pylint: disable-next=undefined-variable
     self.errata_cache_expire = datetime.now() + timedelta(self.ERRATA_CACHE_TTL)
     self.save_errata_cache()
 
@@ -639,49 +575,47 @@ def generate_errata_cache(self, force=False):
 
 
 def save_errata_cache(self):
-    # pylint: disable-next=undefined-variable
-    save_cache(self.errata_cache_file, self.all_errata, self.errata_cache_expire)
+    save_cache(self.errata_cache_file,
+               self.all_errata,
+               self.errata_cache_expire)
 
 
 def clear_package_cache(self):
     self.all_packages_short = {}
     self.all_packages = {}
     self.all_packages_by_id = {}
-    # pylint: disable-next=undefined-variable
     self.package_cache_expire = datetime.now()
     self.save_package_caches()
 
 
 def generate_package_cache(self, force=False):
-    # pylint: disable-next=undefined-variable
     if not force and datetime.now() < self.package_cache_expire:
         return
 
     if not self.options.quiet:
         # tell the user what's going on
-        self.replace_line_buffer(_("** Generating package cache **"))
+        self.replace_line_buffer(_('** Generating package cache **'))
 
     channels = self.client.channel.listSoftwareChannels(self.session)
-    channels = [c.get("label") for c in channels]
+    channels = [c.get('label') for c in channels]
 
     for c in channels:
         try:
             packages = self.client.channel.software.listAllPackages(self.session, c)
         except xmlrpclib.Fault:
-            logging.debug("No access to %s", c)
+            logging.debug('No access to %s', c)
             continue
 
         for p in packages:
-            if not p.get("name") in self.all_packages_short:
-                self.all_packages_short[p.get("name")] = ""
+            if not p.get('name') in self.all_packages_short:
+                self.all_packages_short[p.get('name')] = ''
 
-            # pylint: disable-next=undefined-variable
             longname = build_package_names(p)
 
             if longname not in self.all_packages:
-                self.all_packages[longname] = [p.get("id")]
+                self.all_packages[longname] = [p.get('id')]
             else:
-                self.all_packages[longname].append(p.get("id"))
+                self.all_packages[longname].append(p.get('id'))
 
     # keep a reverse dictionary so we can lookup package names by ID
     # We assume that package IDs are unique, so one ID is only
@@ -691,18 +625,13 @@ def generate_package_cache(self, force=False):
         for i in sorted(v):
             # Alert in case of non-unique ID is detected.
             if i in self.all_packages_by_id:
-                logging.debug(  # pylint: disable=logging-not-lazy
-                    # pylint: disable-next=consider-using-f-string
+                logging.debug(                                                 # pylint: disable=logging-not-lazy
                     'Non-unique package id "%s" is detected. Taking "%s" '
-                    'instead of "%s"' % (i, k, self.all_packages_by_id[i])
-                )
+                    'instead of "%s"' % (i, k, self.all_packages_by_id[i]))
 
             self.all_packages_by_id[i] = k
 
-    # pylint: disable-next=undefined-variable
-    self.package_cache_expire = datetime.now() + timedelta(
-        seconds=self.PACKAGE_CACHE_TTL
-    )
+    self.package_cache_expire = datetime.now() + timedelta(seconds=self.PACKAGE_CACHE_TTL)
     self.save_package_caches()
 
     if not self.options.quiet:
@@ -712,24 +641,17 @@ def generate_package_cache(self, force=False):
 
 def save_package_caches(self):
     # store the cache to disk to speed things up
-    # pylint: disable-next=undefined-variable
-    save_cache(
-        self.packages_short_cache_file,
-        self.all_packages_short,
-        self.package_cache_expire,
-    )
+    save_cache(self.packages_short_cache_file,
+               self.all_packages_short,
+               self.package_cache_expire)
 
-    # pylint: disable-next=undefined-variable
-    save_cache(
-        self.packages_long_cache_file, self.all_packages, self.package_cache_expire
-    )
+    save_cache(self.packages_long_cache_file,
+               self.all_packages,
+               self.package_cache_expire)
 
-    # pylint: disable-next=undefined-variable
-    save_cache(
-        self.packages_by_id_cache_file,
-        self.all_packages_by_id,
-        self.package_cache_expire,
-    )
+    save_cache(self.packages_by_id_cache_file,
+               self.all_packages_by_id,
+               self.package_cache_expire)
 
 
 # create a global list of all available package names
@@ -771,19 +693,17 @@ def get_package_name(self, package_id):
 
 def clear_system_cache(self):
     self.all_systems = {}
-    # pylint: disable-next=undefined-variable
     self.system_cache_expire = datetime.now()
     self.save_system_cache()
 
 
 def generate_system_cache(self, force=False, delay=0):
-    # pylint: disable-next=undefined-variable
     if not force and datetime.now() < self.system_cache_expire:
         return
 
     if not self.options.quiet:
         # tell the user what's going on
-        self.replace_line_buffer(_("** Generating system cache **"))
+        self.replace_line_buffer(_('** Generating system cache **'))
 
     # we might need to wait for some systems to delete
     if delay:
@@ -793,10 +713,10 @@ def generate_system_cache(self, force=False, delay=0):
 
     self.all_systems = {}
     for s in systems:
-        self.all_systems[s.get("id")] = s.get("name")
+        self.all_systems[s.get('id')] = s.get('name')
 
-    # pylint: disable-next=undefined-variable
-    self.system_cache_expire = datetime.now() + timedelta(seconds=self.SYSTEM_CACHE_TTL)
+    self.system_cache_expire = \
+        datetime.now() + timedelta(seconds=self.SYSTEM_CACHE_TTL)
 
     self.save_system_cache()
 
@@ -806,68 +726,55 @@ def generate_system_cache(self, force=False, delay=0):
 
 
 def save_system_cache(self):
-    # pylint: disable-next=undefined-variable
-    save_cache(self.system_cache_file, self.all_systems, self.system_cache_expire)
+    save_cache(self.system_cache_file,
+               self.all_systems,
+               self.system_cache_expire)
 
 
 def load_caches(self, server, username):
-    # pylint: disable-next=undefined-variable
     conf_dir = os.path.join(self.conf_dir, server, username)
 
     try:
-        # pylint: disable-next=undefined-variable
         if not os.path.isdir(conf_dir):
-            # pylint: disable-next=undefined-variable
-            os.mkdir(conf_dir, int("0700", 8))
+            os.mkdir(conf_dir, int('0700', 8))
     except OSError:
-        logging.error(_N("Could not create directory %s"), conf_dir)
+        logging.error(_N('Could not create directory %s'), conf_dir)
         return
 
-    # pylint: disable-next=undefined-variable
-    self.ssm_cache_file = os.path.join(conf_dir, "ssm")
-    # pylint: disable-next=undefined-variable
-    self.system_cache_file = os.path.join(conf_dir, "systems")
-    # pylint: disable-next=undefined-variable
-    self.errata_cache_file = os.path.join(conf_dir, "errata")
-    # pylint: disable-next=undefined-variable
-    self.packages_long_cache_file = os.path.join(conf_dir, "packages_long")
-    # pylint: disable-next=undefined-variable
-    self.packages_by_id_cache_file = os.path.join(conf_dir, "packages_by_id")
-    # pylint: disable-next=undefined-variable
-    self.packages_short_cache_file = os.path.join(conf_dir, "packages_short")
+    self.ssm_cache_file = os.path.join(conf_dir, 'ssm')
+    self.system_cache_file = os.path.join(conf_dir, 'systems')
+    self.errata_cache_file = os.path.join(conf_dir, 'errata')
+    self.packages_long_cache_file = os.path.join(conf_dir, 'packages_long')
+    self.packages_by_id_cache_file = \
+        os.path.join(conf_dir, 'packages_by_id')
+    self.packages_short_cache_file = \
+        os.path.join(conf_dir, 'packages_short')
 
     # load self.ssm from disk
-    # pylint: disable-next=undefined-variable,unused-variable
     (self.ssm, _ignore) = load_cache(self.ssm_cache_file)
 
     # update the prompt now that we loaded the SSM
-    self.postcmd(False, "")
+    self.postcmd(False, '')
 
     # load self.all_systems from disk
-    # pylint: disable-next=undefined-variable
-    (self.all_systems, self.system_cache_expire) = load_cache(self.system_cache_file)
+    (self.all_systems, self.system_cache_expire) = \
+        load_cache(self.system_cache_file)
 
     # load self.all_errata from disk
-    # pylint: disable-next=undefined-variable
-    (self.all_errata, self.errata_cache_expire) = load_cache(self.errata_cache_file)
+    (self.all_errata, self.errata_cache_expire) = \
+        load_cache(self.errata_cache_file)
 
     # load self.all_packages_short from disk
-    # pylint: disable-next=undefined-variable
-    (self.all_packages_short, self.package_cache_expire) = load_cache(
-        self.packages_short_cache_file
-    )
+    (self.all_packages_short, self.package_cache_expire) = \
+        load_cache(self.packages_short_cache_file)
 
     # load self.all_packages from disk
-    # pylint: disable-next=undefined-variable
-    (self.all_packages, self.package_cache_expire) = load_cache(
-        self.packages_long_cache_file
-    )
+    (self.all_packages, self.package_cache_expire) = \
+        load_cache(self.packages_long_cache_file)
 
     # load self.all_packages_by_id from disk
-    # pylint: disable-next=undefined-variable
-    (self.all_packages_by_id, self.package_cache_expire) = load_cache(
-        self.packages_by_id_cache_file
-    )
+    (self.all_packages_by_id, self.package_cache_expire) = \
+        load_cache(self.packages_by_id_cache_file)
 
 
 def get_system_names(self):
@@ -882,7 +789,6 @@ def get_system_names_ids(self):
 
 # check for duplicate system names and return the system ID
 def get_system_id(self, name):
-    # pylint: disable-next=consider-using-f-string
     name = "%s" % name
     self.generate_system_cache()
     systems = []
@@ -909,18 +815,16 @@ def get_system_id(self, name):
     else:
         if len(systems) == 2 and systems[0] == systems[1]:
             return systems[0]
-        logging.warning(_N("Duplicate system profile names found!"))
+        logging.warning(_N('Duplicate system profile names found!'))
         logging.warning(_N("Please reference systems by ID or resolve the"))
         logging.warning(_N("underlying issue with 'system_delete' or 'system_rename'"))
 
-        # pylint: disable-next=consider-using-f-string
-        id_list = "%s = " % name
+        id_list = '%s = ' % name
 
         for system_id in sorted(systems):
-            # pylint: disable-next=consider-using-f-string
-            id_list = id_list + "%i, " % system_id
+            id_list = id_list + '%i, ' % system_id
 
-        logging.warning("")
+        logging.warning('')
         logging.warning(id_list[:-2])
 
         return 0
@@ -939,7 +843,7 @@ def get_system_name(self, system_id):
 
 def get_org_id(self, name):
     details = self.client.org.getDetails(self.session, name)
-    return details.get("id")
+    return details.get('id')
 
 
 def expand_errata(self, args):
@@ -953,15 +857,12 @@ def expand_errata(self, args):
 
     errata = []
     for item in args:
-        # pylint: disable-next=undefined-variable
-        if re.match("search:", item):
-            # pylint: disable-next=undefined-variable
-            item = re.sub("search:", "", item)
+        if re.match('search:', item):
+            item = re.sub('search:', '', item)
             errata.extend(self.do_errata_search(item, True))
         else:
             errata.append(item)
 
-    # pylint: disable-next=undefined-variable
     matches = filter_results(self.all_errata, errata)
 
     return matches
@@ -975,39 +876,30 @@ def expand_systems(self, args):
     system_ids = []
 
     for item in args:
-        # pylint: disable-next=undefined-variable
-        if re.match("ssm", item, re.I):
+        if re.match('ssm', item, re.I):
             systems.extend(self.ssm)
-        # pylint: disable-next=undefined-variable
-        elif re.match("group:", item):
-            # pylint: disable-next=undefined-variable
-            item = re.sub("group:", "", item)
-            # pylint: disable-next=consider-using-f-string
+        elif re.match('group:', item):
+            item = re.sub('group:', '', item)
             members = self.do_group_listsystems("'%s'" % item, True)
 
             if members:
-                # pylint: disable-next=undefined-variable
                 systems.extend([re.escape(m) for m in members])
             else:
-                logging.warning(_N("No systems in group %s"), item)
-        # pylint: disable-next=undefined-variable
-        elif re.match("search:", item):
-            query = item.split(":", 1)[1]
+                logging.warning(_N('No systems in group %s'), item)
+        elif re.match('search:', item):
+            query = item.split(':', 1)[1]
             results = self.do_system_search(query, True)
 
             if results:
                 system_ids.extend(results)
-        # pylint: disable-next=undefined-variable
-        elif re.match("channel:", item):
-            # pylint: disable-next=undefined-variable
-            item = re.sub("channel:", "", item)
+        elif re.match('channel:', item):
+            item = re.sub('channel:', '', item)
             members = self.do_softwarechannel_listsystems(item, True)
 
             if members:
-                # pylint: disable-next=undefined-variable
                 systems.extend([re.escape(m) for m in members])
             else:
-                logging.warning(_N("No systems subscribed to %s"), item)
+                logging.warning(_N('No systems subscribed to %s'), item)
         else:
             # translate system IDs that the user passes
             try:
@@ -1017,10 +909,8 @@ def expand_systems(self, args):
                 # just a system name
                 systems.append(item)
 
-    # pylint: disable-next=undefined-variable
     matches = filter_results(self.get_system_names(), systems)
 
-    # pylint: disable-next=consider-using-f-string
     return ["%s" % x for x in list(set(matches + system_ids))]
 
 
@@ -1029,8 +919,8 @@ def list_base_channels(self):
 
     base_channels = []
     for c in all_channels:
-        if not c.get("parent_label"):
-            base_channels.append(c.get("label"))
+        if not c.get('parent_label'):
+            base_channels.append(c.get('label'))
 
     return base_channels
 
@@ -1044,45 +934,43 @@ def list_child_channels(self, system=None, parent=None, subscribed=False):
             return None
 
         if subscribed:
-            channels = self.client.system.listSubscribedChildChannels(
-                self.session, system_id
-            )
+            channels = \
+                self.client.system.listSubscribedChildChannels(self.session,
+                                                               system_id)
         else:
             channels = self.client.system.listSubscribableChildChannels(
-                self.session, system_id
-            )
+                self.session, system_id)
     elif parent:
-        all_channels = self.client.channel.listSoftwareChannels(self.session)
+        all_channels = \
+            self.client.channel.listSoftwareChannels(self.session)
 
         for c in all_channels:
-            if parent == c.get("parent_label"):
+            if parent == c.get('parent_label'):
                 channels.append(c)
     else:
         # get all channels that have a parent
-        all_channels = self.client.channel.listSoftwareChannels(self.session)
+        all_channels = \
+            self.client.channel.listSoftwareChannels(self.session)
 
         for c in all_channels:
-            if c.get("parent_label"):
+            if c.get('parent_label'):
                 channels.append(c)
 
-    return [c.get("label") for c in channels]
+    return [c.get('label') for c in channels]
 
 
-def user_confirm(
-    self, prompt=_("Is this ok [y/N]:"), nospacer=False, integer=False, ignore_yes=False
-):
+def user_confirm(self, prompt=_('Is this ok [y/N]:'), nospacer=False,
+                 integer=False, ignore_yes=False):
+
     if self.options.yes and not ignore_yes:
         return True
 
     if nospacer:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        answer = prompt_user("%s" % prompt)
+        answer = prompt_user('%s' % prompt)
     else:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        answer = prompt_user("\n%s" % prompt)
+        answer = prompt_user('\n%s' % prompt)
 
-    # pylint: disable-next=undefined-variable
-    if re.match("y", answer, re.I):
+    if re.match('y', answer, re.I):
         if integer:
             return 1
 
@@ -1103,8 +991,8 @@ def check_api_version(self, want):
     :param want:
     :return:
     """
-    want_parts = [int(i) for i in want.split(".")]
-    have_parts = [int(i) for i in self.api_version.split(".")]
+    want_parts = [int(i) for i in want.split('.')]
+    have_parts = [int(i) for i in self.api_version.split('.')]
 
     if len(have_parts) == 2 and len(want_parts) == 2:
         if have_parts[0] == want_parts[0]:
@@ -1126,19 +1014,16 @@ def replace_line_buffer(self, msg=None):
 
     # don't print(a prompt if there wasn't one to begin with)
     if readline.get_line_buffer():
-        # pylint: disable-next=consider-using-f-string
-        new_line = "%s%s" % (self.prompt, msg)
+        new_line = '%s%s' % (self.prompt, msg)
     else:
-        # pylint: disable-next=consider-using-f-string
-        new_line = "%s" % msg
+        new_line = '%s' % msg
 
     # clear the current line
-    self.stdout.write("\r".ljust(len(self.current_line) + 1))
+    self.stdout.write('\r'.ljust(len(self.current_line) + 1))
     self.stdout.flush()
 
     # write the new line
-    # pylint: disable-next=consider-using-f-string
-    self.stdout.write("\r%s" % new_line)
+    self.stdout.write('\r%s' % new_line)
     self.stdout.flush()
 
     # keep track of what is displayed so we can clear it later
@@ -1146,13 +1031,13 @@ def replace_line_buffer(self, msg=None):
 
 
 def load_config_section(self, section):
-    config_opts = ["server", "username", "password", "nossl"]
+    config_opts = ['server', 'username', 'password', 'nossl']
 
     if not self.config_parser.has_section(section):
-        logging.debug("Configuration section [%s] does not exist", section)
+        logging.debug('Configuration section [%s] does not exist', section)
         return
 
-    logging.debug("Loading configuration section [%s]", section)
+    logging.debug('Loading configuration section [%s]', section)
 
     for key in config_opts:
         # don't override command-line options
@@ -1166,21 +1051,19 @@ def load_config_section(self, section):
                 pass
 
     try:
-        if "username" in self.config and self.config[
-            "username"
-        ] != self.config_parser.get(section, "username"):
-            del self.config["password"]
+        if ('username' in self.config
+                and self.config['username'] != self.config_parser.get(section, 'username')):
+            del self.config['password']
     except NoOptionError:
         pass
 
     # handle the nossl boolean
-    if "nossl" in self.config and isinstance(self.config["nossl"], str):
-        # pylint: disable-next=undefined-variable
-        self.config["nossl"] = re.match("^1|y|true$", self.config["nossl"], re.I)
+    if 'nossl' in self.config and isinstance(self.config['nossl'], str):
+        self.config['nossl'] = re.match('^1|y|true$', self.config['nossl'], re.I)
 
     # Obfuscate the password with asterisks
     config_debug = self.config.copy()
-    if "password" in config_debug:
-        config_debug["password"] = "*" * len(config_debug["password"])
+    if 'password' in config_debug:
+        config_debug['password'] = "*" * len(config_debug['password'])
 
-    logging.debug("Current Configuration: %s", config_debug)
+    logging.debug('Current Configuration: %s', config_debug)

--- a/spacecmd/src/spacecmd/org.py
+++ b/spacecmd/src/spacecmd/org.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -37,91 +36,78 @@ from operator import itemgetter
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-_PREFIXES = ["Dr.", "Mr.", "Miss", "Mrs.", "Ms."]
+_PREFIXES = ['Dr.', 'Mr.', 'Miss', 'Mrs.', 'Ms.']
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def _org_create_handler(self, args, first):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--org-name")
-    arg_parser.add_argument("-u", "--username")
+    arg_parser.add_argument('-n', '--org-name')
+    arg_parser.add_argument('-u', '--username')
     if not first:
-        arg_parser.add_argument("-P", "--prefix")
-    arg_parser.add_argument("-f", "--first-name")
-    arg_parser.add_argument("-l", "--last-name")
-    arg_parser.add_argument("-e", "--email")
-    arg_parser.add_argument("-p", "--password")
+        arg_parser.add_argument('-P', '--prefix')
+    arg_parser.add_argument('-f', '--first-name')
+    arg_parser.add_argument('-l', '--last-name')
+    arg_parser.add_argument('-e', '--email')
+    arg_parser.add_argument('-p', '--password')
     if not first:
-        arg_parser.add_argument("--pam", action="store_true")
+        arg_parser.add_argument('--pam', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.org_name = prompt_user(_("Organization Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.username = prompt_user(_("Username:"), noblank=True)
+        options.org_name = prompt_user(_('Organization Name:'), noblank=True)
+        options.username = prompt_user(_('Username:'), noblank=True)
         if not first:
-            # pylint: disable-next=undefined-variable
-            options.prefix = prompt_user(
-                _("Prefix (%s):") % ", ".join(_PREFIXES), noblank=True
-            )
-        # pylint: disable-next=undefined-variable
-        options.first_name = prompt_user(_("First Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.last_name = prompt_user(_("Last Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.email = prompt_user(_("Email:"), noblank=True)
+            options.prefix = prompt_user(_('Prefix (%s):') % ', '.join(_PREFIXES),
+                                        noblank=True)
+        options.first_name = prompt_user(_('First Name:'), noblank=True)
+        options.last_name = prompt_user(_('Last Name:'), noblank=True)
+        options.email = prompt_user(_('Email:'), noblank=True)
         if not first:
-            options.pam = self.user_confirm(
-                _("PAM Authentication [y/N]:"),
-                nospacer=True,
-                integer=False,
-                ignore_yes=True,
-            )
+            options.pam = self.user_confirm(_('PAM Authentication [y/N]:'),
+                                        nospacer=True,
+                                        integer=False,
+                                        ignore_yes=True)
 
-        options.password = ""
-        while options.password == "":
-            password1 = getpass(_("Password: "))
-            password2 = getpass(_("Repeat Password: "))
+        options.password = ''
+        while options.password == '':
+            password1 = getpass(_('Password: '))
+            password2 = getpass(_('Repeat Password: '))
 
             if password1 == password2:
                 options.password = password1
             elif len(password1) < 5:
-                logging.warning(_N("Password must be at least 5 characters"))
+                logging.warning(_N('Password must be at least 5 characters'))
             else:
                 logging.warning(_N("Passwords don't match"))
     else:
         if not options.org_name:
-            logging.error(_N("An organization name is required"))
+            logging.error(_N('An organization name is required'))
             return 1
 
         if not options.username:
-            logging.error(_N("A username is required"))
+            logging.error(_N('A username is required'))
             return 1
 
         if not options.first_name:
-            logging.error(_N("A first name is required"))
+            logging.error(_N('A first name is required'))
             return 1
 
         if not options.last_name:
-            logging.error(_N("A last name is required"))
+            logging.error(_N('A last name is required'))
             return 1
 
         if not options.email:
-            logging.error(_N("An email address is required"))
+            logging.error(_N('An email address is required'))
             return 1
 
         if not options.password:
-            logging.error(_N("A password is required"))
+            logging.error(_N('A password is required'))
             return 1
         if not first:
             if not options.pam:
@@ -129,20 +115,18 @@ def _org_create_handler(self, args, first):
 
         if not first:
             if not options.prefix:
-                options.prefix = _("Dr.")
+                options.prefix = _('Dr.')
 
     if not first:
-        if options.prefix[-1] != "." and options.prefix != _("Miss"):
-            options.prefix = options.prefix + "."
+        if options.prefix[-1] != '.' and options.prefix != _('Miss'):
+            options.prefix = options.prefix + '.'
 
     return options
 
 
 def help_org_createfirst(self):
-    print(_("org_createfirst: Create first organization and user after server setup"))
-    print(
-        _(
-            """usage: org_createfirst [options])
+    print(_('org_createfirst: Create first organization and user after server setup'))
+    print(_('''usage: org_createfirst [options])
 
 options:
   -n ORG_NAME
@@ -150,32 +134,25 @@ options:
   -f FIRST_NAME
   -l LAST_NAME
   -e EMAIL
-  -p PASSWORD"""
-        )
-    )
+  -p PASSWORD'''))
 
 
 def do_org_createfirst(self, args):
     options = _org_create_handler(self, args, True)
 
-    self.client.org.createFirst(
-        options.org_name,
-        options.username,
-        options.password,
-        options.first_name,
-        options.last_name,
-        options.email,
-    )
+    self.client.org.createFirst(options.org_name,
+                           options.username,
+                           options.password,
+                           options.first_name,
+                           options.last_name,
+                           options.email)
 
     return 0
 
 
 def help_org_create(self):
-    print(_("org_create: Create an organization"))
-    print(
-        _(
-            # pylint: disable-next=consider-using-f-string
-            """usage: org_create [options])
+    print(_('org_create: Create an organization'))
+    print(_('''usage: org_create [options])
 
 options:
   -n ORG_NAME
@@ -185,48 +162,39 @@ options:
   -l LAST_NAME
   -e EMAIL
   -p PASSWORD
-  --pam enable PAM authentication"""
-            % ", ".join(_PREFIXES)
-        )
-    )
+  --pam enable PAM authentication''' % ', '.join(_PREFIXES)))
 
 
-def do_org_create(self, args):  # pylint: disable=too-many-return-statements
+def do_org_create(self, args): # pylint: disable=too-many-return-statements
     options = _org_create_handler(self, args, False)
 
-    self.client.org.create(
-        self.session,
-        options.org_name,
-        options.username,
-        options.password,
-        options.prefix.capitalize(),
-        options.first_name,
-        options.last_name,
-        options.email,
-        options.pam,
-    )
+    self.client.org.create(self.session,
+                           options.org_name,
+                           options.username,
+                           options.password,
+                           options.prefix.capitalize(),
+                           options.first_name,
+                           options.last_name,
+                           options.email,
+                           options.pam)
 
     return 0
-
 
 ####################
 
 
 def help_org_delete(self):
-    print(_("org_delete: Delete an organization"))
-    print(_("usage: org_delete NAME"))
+    print(_('org_delete: Delete an organization'))
+    print(_('usage: org_delete NAME'))
 
 
 def complete_org_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -239,31 +207,27 @@ def do_org_delete(self, args):
         logging.warning(_N("No organisation found for the name %s"), name)
         print(_("Organisation '{}' was not found").format(name))
         return 1
-    elif self.user_confirm(_("Delete this organization [y/N]:")):
+    elif self.user_confirm(_('Delete this organization [y/N]:')):
         self.client.org.delete(self.session, org_id)
         return 0
 
     return None
 
-
 ####################
 
 
 def help_org_rename(self):
-    print(_("org_rename: Rename an organization"))
-    print(_("usage: org_rename OLDNAME NEWNAME"))
+    print(_('org_rename: Rename an organization'))
+    print(_('usage: org_rename OLDNAME NEWNAME'))
 
 
 def complete_org_rename(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_rename(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -281,25 +245,21 @@ def do_org_rename(self, args):
         self.client.org.updateName(self.session, org_id, new_name)
         return 0
 
-
 ####################
 
 
 def help_org_addtrust(self):
-    print(_("org_addtrust: Add a trust between two organizations"))
-    print(_("usage: org_addtrust YOUR_ORG ORG_TO_TRUST"))
+    print(_('org_addtrust: Add a trust between two organizations'))
+    print(_('usage: org_addtrust YOUR_ORG ORG_TO_TRUST'))
 
 
 def complete_org_addtrust(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_addtrust(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -322,25 +282,21 @@ def do_org_addtrust(self, args):
         self.client.org.trusts.addTrust(self.session, your_org_id, org_to_trust_id)
         return 0
 
-
 ####################
 
 
 def help_org_removetrust(self):
-    print(_("org_removetrust: Remove a trust between two organizations"))
-    print(_("usage: org_removetrust YOUR_ORG TRUSTED_ORG"))
+    print(_('org_removetrust: Remove a trust between two organizations'))
+    print(_('usage: org_removetrust YOUR_ORG TRUSTED_ORG'))
 
 
 def complete_org_removetrust(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_removetrust(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -359,39 +315,32 @@ def do_org_removetrust(self, args):
         print(_("Organisation '{}' to trust for, was not found").format(trust_org))
         return 1
     else:
-        systems = self.client.org.trusts.listSystemsAffected(
-            self.session, your_org_id, trusted_org_id
-        )
-        print(_("Affected Systems"))
-        print("----------------")
+        systems = self.client.org.trusts.listSystemsAffected(self.session, your_org_id, trusted_org_id)
+        print(_('Affected Systems'))
+        print('----------------')
 
         if systems:
-            print("\n".join(sorted([s.get("systemName") for s in systems])))
+            print('\n'.join(sorted([s.get('systemName') for s in systems])))
         else:
-            print(_("None"))
+            print(_('None'))
 
-        if self.user_confirm(_("Remove this trust [y/N]:")):
-            self.client.org.trusts.removeTrust(
-                self.session, your_org_id, trusted_org_id
-            )
+        if self.user_confirm(_('Remove this trust [y/N]:')):
+            self.client.org.trusts.removeTrust(self.session, your_org_id, trusted_org_id)
         return 0
 
 
 def help_org_trustdetails(self):
-    print(_("org_trustdetails: Show the details of an organizational trust"))
-    print(_("usage: org_trustdetails TRUSTED_ORG"))
+    print(_('org_trustdetails: Show the details of an organizational trust'))
+    print(_('usage: org_trustdetails TRUSTED_ORG'))
 
 
 def complete_org_trustdetails(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_trustdetails(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -401,9 +350,7 @@ def do_org_trustdetails(self, args):
     trusted_org = args[0]
     org_id = self.get_org_id(trusted_org)
     if org_id is None:
-        logging.warning(
-            _N("No trusted organisation found for the name %s"), trusted_org
-        )
+        logging.warning(_N("No trusted organisation found for the name %s"), trusted_org)
         print(_("Trusted organisation '{}' was not found").format(trusted_org))
         return 1
     else:
@@ -411,64 +358,56 @@ def do_org_trustdetails(self, args):
         consumed = self.client.org.trusts.listChannelsConsumed(self.session, org_id)
         provided = self.client.org.trusts.listChannelsProvided(self.session, org_id)
 
-        print(_("Trusted Organization:   %s") % trusted_org)
-        print(_("Trusted Since:          %s") % details.get("trusted_since"))
-        print(
-            _("Systems Transferred From:  %i") % details.get("systems_transferred_from")
-        )
-        print(
-            _("Systems Transferred To:    %i") % details.get("systems_transferred_to")
-        )
-        print("")
-        print(_("Channels Consumed"))
-        print("-----------------")
+        print(_('Trusted Organization:   %s') % trusted_org)
+        print(_('Trusted Since:          %s') % details.get('trusted_since'))
+        print(_('Systems Transferred From:  %i') % details.get('systems_transferred_from'))
+        print(_('Systems Transferred To:    %i') % details.get('systems_transferred_to'))
+        print('')
+        print(_('Channels Consumed'))
+        print('-----------------')
         if consumed:
-            print("\n".join(sorted([c.get("name") for c in consumed])))
+            print('\n'.join(sorted([c.get('name') for c in consumed])))
 
-        print("")
+        print('')
 
-        print(_("Channels Provided"))
-        print("-----------------")
+        print(_('Channels Provided'))
+        print('-----------------')
         if provided:
-            print("\n".join(sorted([c.get("name") for c in provided])))
+            print('\n'.join(sorted([c.get('name') for c in provided])))
         return 0
 
 
 def help_org_list(self):
-    print(_("org_list: List all organizations"))
-    print(_("usage: org_list"))
+    print(_('org_list: List all organizations'))
+    print(_('usage: org_list'))
 
 
 def do_org_list(self, args, doreturn=False):
     orgs = self.client.org.listOrgs(self.session)
-    orgs = [o.get("name") for o in orgs]
+    orgs = [o.get('name') for o in orgs]
 
     if doreturn:
         return orgs
     if orgs:
-        print("\n".join(sorted(orgs)))
+        print('\n'.join(sorted(orgs)))
 
     return None
-
 
 ####################
 
 
 def help_org_listtrusts(self):
     print(_("org_listtrusts: List an organization's trusts"))
-    print(_("usage: org_listtrusts NAME"))
+    print(_('usage: org_listtrusts NAME'))
 
 
 def complete_org_listtrusts(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_listtrusts(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -487,27 +426,24 @@ def do_org_listtrusts(self, args):
             logging.warning(_N("No trust organisation has been found"))
             return 1
         else:
-            for trust in sorted(trusts, key=itemgetter("orgName")):
-                if trust.get("trustEnabled"):
-                    print(trust.get("orgName"))
+            for trust in sorted(trusts, key=itemgetter('orgName')):
+                if trust.get('trustEnabled'):
+                    print(trust.get('orgName'))
             return 0
 
 
 def help_org_listusers(self):
     print(_("org_listusers: List an organization's users"))
-    print(_("usage: org_listusers NAME"))
+    print(_('usage: org_listusers NAME'))
 
 
 def complete_org_listusers(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_listusers(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -521,28 +457,24 @@ def do_org_listusers(self, args):
         return 1
     else:
         users = self.client.org.listUsers(self.session, org_id)
-        print("\n".join(sorted([u.get("login") for u in users])))
+        print('\n'.join(sorted([u.get('login') for u in users])))
         return 0
-
 
 ####################
 
 
 def help_org_details(self):
-    print(_("org_details: Show the details of an organization"))
-    print(_("usage: org_details NAME"))
+    print(_('org_details: Show the details of an organization'))
+    print(_('usage: org_details NAME'))
 
 
 def complete_org_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_org_list("", True), text)
+    return tab_completer(self.do_org_list('', True), text)
 
 
 def do_org_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -553,19 +485,19 @@ def do_org_details(self, args):
 
     details = self.client.org.getDetails(self.session, name)
 
-    print(_("Name:                   %s") % details.get("name"))
-    print(_("Active Users:           %i") % details.get("active_users"))
-    print(_("Systems:                %i") % details.get("systems"))
+    print(_('Name:                   %s') % details.get('name'))
+    print(_('Active Users:           %i') % details.get('active_users'))
+    print(_('Systems:                %i') % details.get('systems'))
 
     # trusts is optional, which is annoying...
-    if "trusts" in details:
-        print(_("Trusts:                 %i") % details.get("trusts"))
+    if 'trusts' in details:
+        print(_('Trusts:                 %i') % details.get('trusts'))
     else:
-        print(_("Trusts:                 %i") % 0)
+        print(_('Trusts:                 %i') % 0)
 
-    print(_("System Groups:          %i") % details.get("system_groups"))
-    print(_("Activation Keys:        %i") % details.get("activation_keys"))
-    print(_("Kickstart Profiles:     %i") % details.get("kickstart_profiles"))
-    print(_("Configuration Channels: %i") % details.get("configuration_channels"))
+    print(_('System Groups:          %i') % details.get('system_groups'))
+    print(_('Activation Keys:        %i') % details.get('activation_keys'))
+    print(_('Kickstart Profiles:     %i') % details.get('kickstart_profiles'))
+    print(_('Configuration Channels: %i') % details.get('configuration_channels'))
 
     return 0

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -31,7 +30,6 @@
 # pylint: disable=C0103
 
 import gettext
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -39,40 +37,34 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_package_details(self):
-    self.help_package_search(
-        "package_details", _("Show the details of a software package")
-    )
+    self.help_package_search('package_details',
+                             _('Show the details of a software package'))
 
 
 def complete_package_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.get_package_names(True), text)
 
 
 def do_package_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
-    (args, _options) = parse_command_arguments(args.replace("\\", "\\\\"), arg_parser)
+    (args, _options) = parse_command_arguments(args.replace('\\', '\\\\'), arg_parser)
 
     if not args:
         self.help_package_details()
         return None
 
-    packages = self.do_package_search(" ".join(args), True)
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No packages found"))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -85,90 +77,59 @@ def do_package_details(self, args):
         package_ids = self.get_package_id(package)
 
         if not package_ids:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s is not a valid package") % package)
+            logging.warning(_N('%s is not a valid package') % package)
             continue
 
         for package_id in package_ids:
             details = self.client.packages.getDetails(self.session, package_id)
 
-            channels = self.client.packages.listProvidingChannels(
-                self.session, package_id
-            )
+            channels = \
+                self.client.packages.listProvidingChannels(self.session, package_id)
 
-            installed_systems = self.client.system.listSystemsWithPackage(
-                self.session, package_id
-            )
+            installed_systems = \
+                self.client.system.listSystemsWithPackage(self.session, package_id)
 
-            # pylint: disable-next=consider-using-f-string
-            print(_("Name:      %s" % details.get("name")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Version:   %s" % details.get("version")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Release:   %s" % details.get("release")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Epoch:     %s" % details.get("epoch")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Arch:      %s" % details.get("arch_label")))
-            print("")
-            # pylint: disable-next=consider-using-f-string
-            print(_("File:      %s" % details.get("file")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Path:      %s" % details.get("path")))
-            # pylint: disable-next=consider-using-f-string
-            print(_("Size:      %s" % details.get("size")))
-            print(
-                _(
-                    # pylint: disable-next=consider-using-f-string
-                    "Retracted: %s"
-                    % (_("Yes") if details.get("part_of_retracted_patch") else _("No"))
-                )
-            )
-            print(
-                # pylint: disable-next=consider-using-f-string
-                "%s%s"
-                % (
-                    (details.get("checksum_type").upper() + ":").ljust(11),
-                    details.get("checksum"),
-                )
-            )
-            print("")
-            print(_("Installed Systems: %i") % len(installed_systems))
-            print("")
-            print(_("Description"))
-            print("-----------")
-            # pylint: disable-next=undefined-variable
-            print("\n".join(wrap(details.get("description"))))
-            print("")
-            print(_("Available From Channels"))
-            print("-----------------------")
-            print("\n".join(sorted([c.get("label") for c in channels])))
-            print("")
+            print(_('Name:      %s' % details.get('name')))
+            print(_('Version:   %s' % details.get('version')))
+            print(_('Release:   %s' % details.get('release')))
+            print(_('Epoch:     %s' % details.get('epoch')))
+            print(_('Arch:      %s' % details.get('arch_label')))
+            print('')
+            print(_('File:      %s' % details.get('file')))
+            print(_('Path:      %s' % details.get('path')))
+            print(_('Size:      %s' % details.get('size')))
+            print(_('Retracted: %s' % (_('Yes') if details.get('part_of_retracted_patch')
+                                       else _('No'))))
+            print('%s%s' % ((details.get('checksum_type').upper() + ":").ljust(11),
+                            details.get('checksum')))
+            print('')
+            print(_('Installed Systems: %i') % len(installed_systems))
+            print('')
+            print(_('Description'))
+            print('-----------')
+            print('\n'.join(wrap(details.get('description'))))
+            print('')
+            print(_('Available From Channels'))
+            print('-----------------------')
+            print('\n'.join(sorted([c.get('label') for c in channels])))
+            print('')
 
     return 0
-
 
 ####################
 
 
-def help_package_search(
-    self,
-    command="package_search",
-    description="Find packages that meet the given criteria",
-):
-    # pylint: disable-next=consider-using-f-string
-    print("%s: %s" % (command, description))
-    # pylint: disable-next=consider-using-f-string
-    print(_("usage: %s NAME|QUERY" % command))
-    print("")
-    # pylint: disable-next=consider-using-f-string
-    print(_("Example: %s kernel" % command))
-    print("")
-    print(_("Advanced Search:"))
-    print(
-        _("Available Fields: name, epoch, version, release, arch, description, summary")
-    )
-    print(_("Example: name:kernel AND version:2.6.18 AND -description:devel"))
+def help_package_search(self,
+                        command='package_search',
+                        description='Find packages that meet the given criteria'):
+    print('%s: %s' % (command, description))
+    print(_('usage: %s NAME|QUERY' % command))
+    print('')
+    print(_('Example: %s kernel' % command))
+    print('')
+    print(_('Advanced Search:'))
+    print(_('Available Fields: name, epoch, version, release, arch, description, summary'))
+    print(_('Example: name:kernel AND version:2.6.18 AND -description:devel'))
 
 
 def do_package_search(self, args, doreturn=False):
@@ -176,18 +137,10 @@ def do_package_search(self, args, doreturn=False):
         self.help_package_search()
         return None
 
-    # pylint: disable-next=undefined-variable,unused-variable
     _args, _options = parse_command_arguments(args, get_argument_parser())
 
-    fields = (
-        "name:",
-        "epoch:",
-        "version:",
-        "release:",
-        "arch:",
-        "description:",
-        "summary:",
-    )
+    fields = ('name:', 'epoch:', 'version:', 'release:',
+              'arch:', 'description:', 'summary:')
     # Check fields
     for arg in _args:
         if ":" in arg:
@@ -201,68 +154,60 @@ def do_package_search(self, args, doreturn=False):
 
     for f in fields:
         if args.find(f) != -1:
-            # pylint: disable-next=undefined-variable
-            logging.debug("Using advanced search")
+            logging.debug('Using advanced search')
             advanced = True
             break
 
     if advanced:
         packages = self.client.packages.search.advanced(self.session, args)
-        # pylint: disable-next=undefined-variable
         packages = build_package_names(packages)
     else:
         # for non-advanced searches, use local regex instead of
         # the APIs for searching; this is done because the fuzzy
         # search on the server gives a lot of garbage back
-        # pylint: disable-next=undefined-variable
-        packages = filter_results(self.get_package_names(True), _args, search=True)
+        packages = filter_results(self.get_package_names(True),
+                                  _args, search=True)
 
     if doreturn:
         return packages
     if packages:
-        print("\n".join(sorted(packages)))
+        print('\n'.join(sorted(packages)))
 
     return None
-
 
 ####################
 
 
 def help_package_remove(self):
-    print(_("package_remove: Remove a package from Spacewalk"))
-    print(_("usage: package_remove PACKAGE ..."))
+    print(_('package_remove: Remove a package from Spacewalk'))
+    print(_('usage: package_remove PACKAGE ...'))
 
 
 def complete_package_remove(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.get_package_names(True), text)
 
 
 def do_package_remove(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
-    (args, _options) = parse_command_arguments(args.replace("\\", "\\\\"), arg_parser)
+    (args, _options) = parse_command_arguments(args.replace('\\', '\\\\'), arg_parser)
 
     if not args:
         self.help_package_remove()
         return 1
 
-    # pylint: disable-next=undefined-variable
     to_remove = filter_results(self.get_package_names(True), args)
 
     if not to_remove:
-        # pylint: disable-next=undefined-variable
         logging.debug("Failed to find packages for criteria %s", str(args))
         print(_("No packages found to remove"))
         return 1
 
-    print(_("Packages"))
-    print("--------")
-    print("\n".join(sorted(to_remove)))
+    print(_('Packages'))
+    print('--------')
+    print('\n'.join(sorted(to_remove)))
 
-    if not self.user_confirm(_("Remove these packages [y/N]:")):
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
         print(_("No packages has been removed"))
         return 1
 
@@ -271,104 +216,93 @@ def do_package_remove(self, args):
             try:
                 self.client.packages.removePackage(self.session, package_id)
             except xmlrpclib.Fault:
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("Failed to remove package ID %i") % package_id)
+                logging.error(_N('Failed to remove package ID %i') % package_id)
 
     # regenerate the package cache after removing these packages
     self.generate_package_cache(True)
 
     return 0
 
-
 ####################
 
 
 def help_package_listorphans(self):
-    print(_("package_listorphans: List packages that are not in a channel"))
-    print(_("usage: package_listorphans"))
+    print(_('package_listorphans: List packages that are not in a channel'))
+    print(_('usage: package_listorphans'))
 
 
 def do_package_listorphans(self, args, doreturn=False):
-    packages = self.client.channel.software.listPackagesWithoutChannel(self.session)
+    packages = self.client.channel.software.listPackagesWithoutChannel(
+        self.session)
 
-    # pylint: disable-next=undefined-variable
     packages = build_package_names(packages)
 
     if doreturn:
         return packages
     if packages:
-        print("\n".join(sorted(packages)))
+        print('\n'.join(sorted(packages)))
 
     return None
-
 
 ####################
 
 
 def help_package_removeorphans(self):
-    print(_("package_removeorphans: Remove packages that are not in a channel"))
-    print(_("usage: package_removeorphans"))
+    print(_('package_removeorphans: Remove packages that are not in a channel'))
+    print(_('usage: package_removeorphans'))
 
 
 def do_package_removeorphans(self, args):
-    packages = self.client.channel.software.listPackagesWithoutChannel(self.session)
+    packages = \
+        self.client.channel.software.listPackagesWithoutChannel(self.session)
 
     if not packages:
         print(_("No orphaned packages has been found"))
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No orphaned packages"))
+        logging.warning(_N('No orphaned packages'))
         return 1
 
-    print(_("Packages"))
-    print("--------")
-    # pylint: disable-next=undefined-variable
-    print("\n".join(sorted(build_package_names(packages))))
+    print(_('Packages'))
+    print('--------')
+    print('\n'.join(sorted(build_package_names(packages))))
 
-    if not self.user_confirm(_("Remove these packages [y/N]:")):
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
         print(_("No packages were removed"))
         return 1
 
     for package in packages:
         try:
-            self.client.packages.removePackage(self.session, package.get("id"))
+            self.client.packages.removePackage(self.session, package.get('id'))
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to remove package ID %i") % package.get("id"))
+            logging.error(_N('Failed to remove package ID %i') % package.get('id'))
             return 1
 
     return 0
-
 
 ####################
 
 
 def help_package_listinstalledsystems(self):
-    self.help_package_search(
-        "package_listinstalledsystems", _("List the systems with a package installed")
-    )
+    self.help_package_search('package_listinstalledsystems',
+                             _('List the systems with a package installed'))
 
 
 def complete_package_listinstalledsystems(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.get_package_names(True), text)
 
 
 def do_package_listinstalledsystems(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
-    (args, _options) = parse_command_arguments(args.replace("\\", "\\\\"), arg_parser)
+    (args, _options) = parse_command_arguments(args.replace('\\', '\\\\'), arg_parser)
 
     if not args:
         self.help_package_listinstalledsystems()
         return 1
 
-    packages = self.do_package_search(" ".join(args), True)
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No packages found"))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -380,54 +314,42 @@ def do_package_listinstalledsystems(self, args):
 
         systems = []
         for package_id in self.get_package_id(package):
-            systems += self.client.system.listSystemsWithPackage(
-                self.session, package_id
-            )
+            systems += self.client.system.listSystemsWithPackage(self.session,
+                                                                 package_id)
 
         print(package)
-        print("-" * len(package))
+        print('-' * len(package))
 
         if systems:
-            print(
-                "\n".join(
-                    # pylint: disable-next=consider-using-f-string
-                    sorted(["%s : %s" % (s.get("name"), s.get("id")) for s in systems])
-                )
-            )
+            print('\n'.join(sorted(['%s : %s' % (s.get('name'), s.get('id')) for s in systems])))
 
     return 0
-
 
 ####################
 
 
 def help_package_listerrata(self):
-    self.help_package_search(
-        "package_listerrata", _("List the errata that provide this package")
-    )
+    self.help_package_search('package_listerrata',
+                             _('List the errata that provide this package'))
 
 
 def complete_package_listerrata(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.get_package_names(True), text)
 
 
 def do_package_listerrata(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
-    (args, _options) = parse_command_arguments(args.replace("\\", "\\\\"), arg_parser)
+    (args, _options) = parse_command_arguments(args.replace('\\', '\\\\'), arg_parser)
 
     if not args:
         self.help_package_listerrata()
         return 1
 
-    packages = self.do_package_search(" ".join(args), True)
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No packages found"))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -438,42 +360,38 @@ def do_package_listerrata(self, args):
         add_separator = True
 
         for package_id in self.get_package_id(package):
-            errata = self.client.packages.listProvidingErrata(self.session, package_id)
+            errata = self.client.packages.listProvidingErrata(self.session,
+                                                              package_id)
 
             print(package)
-            print("-" * len(package))
+            print('-' * len(package))
 
             if errata:
-                print("\n".join(sorted([e.get("advisory") for e in errata])))
+                print('\n'.join(sorted([e.get('advisory') for e in errata])))
 
     return 0
-
 
 ####################
 
 
 def help_package_listdependencies(self):
-    self.help_package_search(
-        "package_listdependencies", _("List the dependencies for a package")
-    )
+    self.help_package_search('package_listdependencies',
+                             _('List the dependencies for a package'))
 
 
 def do_package_listdependencies(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
-    (args, _options) = parse_command_arguments(args.replace("\\", "\\\\"), arg_parser)
+    (args, _options) = parse_command_arguments(args.replace('\\', '\\\\'), arg_parser)
 
     if not args:
         self.help_package_listdependencies()
         return 1
 
-    packages = self.do_package_search(" ".join(args), True)
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No packages found"))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -484,22 +402,15 @@ def do_package_listdependencies(self, args):
         add_separator = False
         for package_id in self.get_package_id(package):
             if not package_id:
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("%s is not a valid package") % package)
+                logging.warning(_N('%s is not a valid package') % package)
                 continue
 
             package_id = int(package_id)
             pkgdeps = self.client.packages.list_dependencies(self.session, package_id)
-            print(_("Package Name: %s") % package)
+            print(_('Package Name: %s') % package)
             for dep in pkgdeps:
-                print(
-                    _("Dependency: %s Type: %s Modifier: %s")
-                    % (
-                        dep["dependency"],
-                        dep["dependency_type"],
-                        dep["dependency_modifier"],
-                    )
-                )
+                print(_('Dependency: %s Type: %s Modifier: %s') % \
+                      (dep['dependency'], dep['dependency_type'], dep['dependency_modifier']))
             print(self.SEPARATOR)
             add_separator = True
 

--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -20,30 +19,18 @@
 
 import getpass
 import gettext
-
-# pylint: disable-next=unused-import
 import logging
-
-# pylint: disable-next=wildcard-import,unused-wildcard-import
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
-# pylint: disable-next=unused-argument
 def help_proxy_container_config(self):
-    print(
-        _(
-            "proxy_container_config: create a proxy system and return its configuration file"
-        )
-    )
-    print(
-        _(
-            """usage: proxy_container_config [options] PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL ROOT_CA CRT KEY
+    print(_('proxy_container_config: create a proxy system and return its configuration file'))
+    print(_('''usage: proxy_container_config [options] PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL ROOT_CA CRT KEY
 
 parameters:
   PROXY_FQDN  the unique, DNS-resolvable FQDN of this proxy. It should be different from any registered clients.
@@ -62,22 +49,18 @@ options:
 
 examples:
   proxy_container_config -o config.zip proxy.lab server.lab 1024 proxy@acme.org root_ca.crt proxy.crt proxy.key
-"""
-        )
-    )
+'''))
 
 
 def do_proxy_container_config(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-r", "--root-ca", default="")
-    arg_parser.add_argument("-i", "--intermediate-ca", action="append", default=[])
-    arg_parser.add_argument("-c", "--certificate", default="")
-    arg_parser.add_argument("-k", "--key", default="")
-    arg_parser.add_argument("-o", "--output", default="config.tar.gz")
-    arg_parser.add_argument("-p", "--ssh-port", type=int, default=8022)
+    arg_parser.add_argument('-r', '--root-ca', default='')
+    arg_parser.add_argument('-i', '--intermediate-ca', action='append', default=[])
+    arg_parser.add_argument('-c', '--certificate', default='')
+    arg_parser.add_argument('-k', '--key', default='')
+    arg_parser.add_argument('-o', '--output', default='config.tar.gz')
+    arg_parser.add_argument('-p', '--ssh-port', type=int, default=8022)
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
 
     try:
@@ -86,39 +69,25 @@ def do_proxy_container_config(self, args):
         self.help_proxy_container_config()
         return
 
+
     root_ca = read_file(root_ca)
     intermediate_cas = [read_file(path) for path in options.intermediate_ca]
     cert = read_file(certificate)
     key = read_file(key)
 
-    config = self.client.proxy.container_config(
-        self.session,
-        proxy_fqdn,
-        options.ssh_port,
-        server_fqdn,
-        int(max_cache),
-        email,
-        root_ca,
-        intermediate_cas,
-        cert,
-        key,
+    config = self.client.proxy.container_config(self.session,
+            proxy_fqdn, options.ssh_port, server_fqdn, int(max_cache), email,
+            root_ca, intermediate_cas, cert, key,
     )
 
-    with open(options.output, "wb") as fd:
+    with open(options.output, 'wb') as fd:
         fd.write(config.data)
     print(options.output)
 
 
-# pylint: disable-next=unused-argument
 def help_proxy_container_config_generate_cert(self):
-    print(
-        _(
-            "proxy_container_config_generate_cert: create a proxy system and return its configuration file"
-        )
-    )
-    print(
-        _(
-            """usage: proxy_container_config_generate_cert PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL
+    print(_('proxy_container_config_generate_cert: create a proxy system and return its configuration file'))
+    print(_('''usage: proxy_container_config_generate_cert PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL
 
 parameters:
   PROXY_FQDN  the unique, DNS-resolvable FQDN of this proxy. It should be different from any registered clients.
@@ -144,32 +113,24 @@ options:
 
 examples:
   proxy_container_config proxy.lab server.lab 1024 proxy@acme.org --ca-pass password-file
-"""
-        )
-    )
+'''))
 
 
 def do_proxy_container_config_generate_cert(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-o", "--output", default="config.tar.gz")
-    arg_parser.add_argument("-p", "--ssh-port", type=int, default=8022)
-    arg_parser.add_argument(
-        "--ca-cert", default="/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT"
-    )
-    arg_parser.add_argument(
-        "--ca-key", default="/root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY"
-    )
-    arg_parser.add_argument("--ca-pass")
-    arg_parser.add_argument("--ssl-cname", action="append", default=[])
-    arg_parser.add_argument("--ssl-country", default="")
-    arg_parser.add_argument("--ssl-state", default="")
-    arg_parser.add_argument("--ssl-city", default="")
-    arg_parser.add_argument("--ssl-org", default="")
-    arg_parser.add_argument("--ssl-org-unit", default="")
-    arg_parser.add_argument("--ssl-email", default="")
+    arg_parser.add_argument('-o', '--output', default='config.tar.gz')
+    arg_parser.add_argument('-p', '--ssh-port', type=int, default=8022)
+    arg_parser.add_argument('--ca-cert', default='/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT')
+    arg_parser.add_argument('--ca-key', default='/root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY')
+    arg_parser.add_argument('--ca-pass')
+    arg_parser.add_argument('--ssl-cname', action='append', default=[])
+    arg_parser.add_argument('--ssl-country', default='')
+    arg_parser.add_argument('--ssl-state', default='')
+    arg_parser.add_argument('--ssl-city', default='')
+    arg_parser.add_argument('--ssl-org', default='')
+    arg_parser.add_argument('--ssl-org-unit', default='')
+    arg_parser.add_argument('--ssl-email', default='')
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
 
     try:
@@ -178,6 +139,7 @@ def do_proxy_container_config_generate_cert(self, args):
         self.help_proxy_container_config_generate_cert()
         return
 
+
     ca_cert = read_file(options.ca_cert)
     ca_key = read_file(options.ca_key)
     if options.ca_pass:
@@ -185,38 +147,22 @@ def do_proxy_container_config_generate_cert(self, args):
     else:
         ca_password = getpass.getpass("SSL CA private key password: ")
 
-    config = self.client.proxy.container_config(
-        self.session,
-        proxy_fqdn,
-        options.ssh_port,
-        server_fqdn,
-        int(max_cache),
-        email,
-        ca_cert,
-        ca_key,
-        ca_password,
-        options.ssl_cname,
-        options.ssl_country,
-        options.ssl_state,
-        options.ssl_city,
-        options.ssl_org,
-        options.ssl_org_unit,
-        options.ssl_email,
-    )
+    config = self.client.proxy.container_config(self.session, proxy_fqdn, options.ssh_port,
+            server_fqdn, int(max_cache), email,
+            ca_cert, ca_key, ca_password, options.ssl_cname, options.ssl_country, options.ssl_state,
+            options.ssl_city, options.ssl_org, options.ssl_org_unit, options.ssl_email)
 
-    with open(options.output, "wb") as fd:
+    with open(options.output, 'wb') as fd:
         fd.write(config.data)
     print(options.output)
 
 
-# pylint: disable-next=function-redefined
 def read_file(path):
-    """
+    '''
     utility function reading a file and returning its content.
-    """
+    '''
     if not path:
         return None
 
-    # pylint: disable-next=unspecified-encoding
-    with open(path, "r") as fd:
+    with open(path, 'r') as fd:
         return fd.read()

--- a/spacecmd/src/spacecmd/repo.py
+++ b/spacecmd/src/spacecmd/repo.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -32,7 +31,6 @@
 
 import gettext
 import shlex
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -40,48 +38,43 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_repo_list(self):
-    print(_("repo_list: List all available user repos"))
-    print(_("usage: repo_list"))
+    print(_('repo_list: List all available user repos'))
+    print(_('usage: repo_list'))
 
 
 def do_repo_list(self, args, doreturn=False):
     repos = self.client.channel.software.listUserRepos(self.session)
-    repos = [c.get("label") for c in repos]
+    repos = [c.get('label') for c in repos]
 
     if doreturn:
         return repos
     if repos:
-        print("\n".join(sorted(repos)))
+        print('\n'.join(sorted(repos)))
 
     return None
-
 
 ####################
 
 
 def help_repo_details(self):
-    print(_("repo_details: Show the details of a user repo"))
-    print(_("usage: repo_details <repo ...>"))
+    print(_('repo_details: Show the details of a user repo'))
+    print(_('usage: repo_details <repo ...>'))
 
 
 def complete_repo_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_repo_list("", True), text)
+    return tab_completer(self.do_repo_list('', True), text)
 
 
 def do_repo_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -89,57 +82,44 @@ def do_repo_details(self, args):
         return 1
 
     # allow globbing of repo names
-    # pylint: disable-next=undefined-variable
-    repos = filter_results(self.do_repo_list("", True), args)
+    repos = filter_results(self.do_repo_list('', True), args)
     if repos:
         add_separator = False
         for repo in repos:
-            details = self.client.channel.software.getRepoDetails(self.session, repo)
+            details = self.client.channel.software.getRepoDetails(
+                self.session, repo)
 
             if add_separator:
                 print(self.SEPARATOR)
             add_separator = True
 
-            print(_("Repository Label:                  %s") % details.get("label"))
-            print(_("Repository URL:                    %s") % details.get("sourceUrl"))
-            print(_("Repository Type:                   %s") % details.get("type"))
-            print(
-                _("Repository SSL Ca Certificate:     %s")
-                % (details.get("sslCaDesc") or "None")
-            )
-            print(
-                _("Repository SSL Client Certificate: %s")
-                % (details.get("sslCertDesc") or "None")
-            )
-            print(
-                _("Repository SSL Client Key:         %s")
-                % (details.get("sslKeyDesc") or "None")
-            )
+            print(_('Repository Label:                  %s') % details.get('label'))
+            print(_('Repository URL:                    %s') % details.get('sourceUrl'))
+            print(_('Repository Type:                   %s') % details.get('type'))
+            print(_('Repository SSL Ca Certificate:     %s') % (details.get('sslCaDesc') or "None"))
+            print(_('Repository SSL Client Certificate: %s') % (details.get('sslCertDesc') or "None"))
+            print(_('Repository SSL Client Key:         %s') % (details.get('sslKeyDesc') or "None"))
     else:
-        print(_("No repositories found for '{}' query").format(" ".join(args)))
+        print(_("No repositories found for '{}' query").format(' '.join(args)))
         return 1
 
     return 0
-
 
 ####################
 
 
 def help_repo_listfilters(self):
-    print(_("repo_listfilters: Show the filters for a user repo"))
-    print(_("usage: repo_listfilters repo"))
+    print(_('repo_listfilters: Show the filters for a user repo'))
+    print(_('usage: repo_listfilters repo'))
 
 
 def complete_repo_listfilters(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_repo_list("", True), text)
+    return tab_completer(self.do_repo_list('', True), text)
 
 
 def do_repo_listfilters(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -149,27 +129,25 @@ def do_repo_listfilters(self, args):
     filters = self.client.channel.software.listRepoFilters(self.session, args[0])
     if filters:
         for flt in filters:
-            # pylint: disable-next=consider-using-f-string
-            print("%s%s" % (flt.get("flag"), flt.get("filter")))
+            print("%s%s" % (flt.get('flag'), flt.get('filter')))
     else:
         print(_("No filters found"))
         return 1
 
     return 0
 
-
 ####################
 
 
 def help_repo_addfilters(self):
-    print(_("repo_addfilters: Add filters for a user repo"))
-    print(_("usage: repo_addfilters repo <filter ...>"))
+    print(_('repo_addfilters: Add filters for a user repo'))
+    print(_('usage: repo_addfilters repo <filter ...>'))
 
 
 def complete_repo_addfilters(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_repo_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_repo_list('', True),
+                             text)
 
     return None
 
@@ -188,29 +166,27 @@ def do_repo_addfilters(self, args):
         flag = arg[0]
         repofilter = arg[1:]
 
-        if not flag in ("+", "-"):
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Each filter must start with + or -"))
+        if not flag in ('+', '-'):
+            logging.error(_N('Each filter must start with + or -'))
             return 1
 
-        self.client.channel.software.addRepoFilter(
-            self.session, repo, {"filter": repofilter, "flag": flag}
-        )
+        self.client.channel.software.addRepoFilter(self.session,
+                                                   repo,
+                                                   {'filter': repofilter,
+                                                    'flag': flag})
 
     return 0
-
 
 ####################
 
 
 def help_repo_removefilters(self):
-    print(_("repo_removefilters: Remove filters from a user repo"))
-    print(_("usage: repo_removefilters repo <filter ...>"))
+    print(_('repo_removefilters: Remove filters from a user repo'))
+    print(_('usage: repo_removefilters repo <filter ...>'))
 
 
 def complete_repo_removefilters(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_repo_remove("", True), text)
+    return tab_completer(self.do_repo_remove('', True), text)
 
 
 def do_repo_removefilters(self, args):
@@ -227,29 +203,27 @@ def do_repo_removefilters(self, args):
         flag = arg[0]
         repofilter = arg[1:]
 
-        if not flag in ("+", "-"):
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Each filter must start with + or -"))
+        if not flag in('+', '-'):
+            logging.error(_N('Each filter must start with + or -'))
             return 1
 
-        self.client.channel.software.removeRepoFilter(
-            self.session, repo, {"filter": repofilter, "flag": flag}
-        )
+        self.client.channel.software.removeRepoFilter(self.session,
+                                                      repo,
+                                                      {'filter': repofilter,
+                                                       'flag': flag})
 
     return 0
-
 
 ####################
 
 
 def help_repo_setfilters(self):
-    print(_("repo_setfilters: Set the filters for a user repo"))
-    print(_("usage: repo_setfilters repo <filter ...>"))
+    print(_('repo_setfilters: Set the filters for a user repo'))
+    print(_('usage: repo_setfilters repo <filter ...>'))
 
 
 def complete_repo_setfilters(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_repo_set("", True), text)
+    return tab_completer(self.do_repo_set('', True), text)
 
 
 def do_repo_setfilters(self, args):
@@ -268,76 +242,63 @@ def do_repo_setfilters(self, args):
         flag = arg[0]
         repofilter = arg[1:]
 
-        if not flag in ("+", "-"):
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Each filter must start with + or -"))
+        if not flag in ('+', '-'):
+            logging.error(_N('Each filter must start with + or -'))
             return 1
 
-        filters.append({"filter": repofilter, "flag": flag})
+        filters.append({'filter': repofilter, 'flag': flag})
 
     self.client.channel.software.setRepoFilters(self.session, repo, filters)
 
     return 0
 
-
 ####################
 
 
 def help_repo_clearfilters(self):
-    print(_("repo_clearfilters: Clears the filters for a user repo"))
-    print(
-        _(
-            """usage: repo_clearfilters repo <options>
+    print(_('repo_clearfilters: Clears the filters for a user repo'))
+    print(_('''usage: repo_clearfilters repo <options>
 
 options:
   -y, --yes   Confirm without prompt
 
-"""
-        )
-    )
+'''))
 
 
 def complete_repo_clearfilters(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_repo_clear("", True), text)
+    return tab_completer(self.do_repo_clear('', True), text)
 
 
 def do_repo_clearfilters(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-y", "--yes", default=False, action="store_true")
+    arg_parser.add_argument('-y', '--yes', default=False, action="store_true")
 
-    # pylint: disable-next=undefined-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_repo_clearfilters()
         return 1
 
-    if _options.yes or self.user_confirm(_("Remove these filters [y/N]:")):
+    if _options.yes or self.user_confirm(_('Remove these filters [y/N]:')):
         self.client.channel.software.clearRepoFilters(self.session, args[0])
 
     return 0
-
 
 ####################
 
 
 def help_repo_delete(self):
-    print(_("repo_delete: Delete a user repo"))
-    print(_("usage: repo_delete <repo ...>"))
+    print(_('repo_delete: Delete a user repo'))
+    print(_('usage: repo_delete <repo ...>'))
 
 
 def complete_repo_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_repo_list("", True), text)
+    return tab_completer(self.do_repo_list('', True), text)
 
 
 def do_repo_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -345,32 +306,27 @@ def do_repo_delete(self, args):
         return 1
 
     # allow globbing of repo names
-    # pylint: disable-next=undefined-variable
-    repos = filter_results(self.do_repo_list("", True), args)
+    repos = filter_results(self.do_repo_list('', True), args)
 
-    print(_("Repos"))
-    print("-----")
-    print("\n".join(sorted(repos)))
+    print(_('Repos'))
+    print('-----')
+    print('\n'.join(sorted(repos)))
 
-    if self.user_confirm(_("Delete these repos [y/N]:")):
+    if self.user_confirm(_('Delete these repos [y/N]:')):
         for repo in repos:
             try:
                 self.client.channel.software.removeRepo(self.session, repo)
             except xmlrpclib.Fault:
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("Failed to remove repo %s") % repo)
+                logging.error(_N('Failed to remove repo %s') % repo)
 
     return 0
-
 
 ####################
 
 
 def help_repo_create(self):
-    print(_("repo_create: Create a user repository"))
-    print(
-        _(
-            """usage: repo_create <options>)
+    print(_('repo_create: Create a user repository'))
+    print(_('''usage: repo_create <options>)
 
 options:
   -n, --name   name of repository
@@ -379,86 +335,68 @@ options:
 
   --ca         SSL CA certificate (not required)
   --cert       SSL Client certificate (not required)
-  --key        SSL Client key (not required)"""
-        )
-    )
+  --key        SSL Client key (not required)'''))
 
 
 def do_repo_create(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-u", "--url")
-    arg_parser.add_argument("-t", "--type")
-    arg_parser.add_argument("--ca", default="")
-    arg_parser.add_argument("--cert", default="")
-    arg_parser.add_argument("--key", default="")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-u', '--url')
+    arg_parser.add_argument('-t', '--type')
+    arg_parser.add_argument('--ca', default='')
+    arg_parser.add_argument('--cert', default='')
+    arg_parser.add_argument('--key', default='')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.url = prompt_user(_("URL:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.type = prompt_user(_("Type:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.ca = prompt_user(_("SSL CA cert:"))
-        # pylint: disable-next=undefined-variable
-        options.cert = prompt_user(_("SSL Client cert:"))
-        # pylint: disable-next=undefined-variable
-        options.key = prompt_user(_("SSL Client key:"))
+        options.name = prompt_user(_('Name:'), noblank=True)
+        options.url = prompt_user(_('URL:'), noblank=True)
+        options.type = prompt_user(_('Type:'), noblank=True)
+        options.ca = prompt_user(_('SSL CA cert:'))
+        options.cert = prompt_user(_('SSL Client cert:'))
+        options.key = prompt_user(_('SSL Client key:'))
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A name is required"))
+            logging.error(_N('A name is required'))
             return 1
 
         if not options.url:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A URL is required"))
+            logging.error(_N('A URL is required'))
             return 1
 
         if not options.type:
-            options.type = "yum"
+            options.type = 'yum'
 
-    self.client.channel.software.createRepo(
-        self.session,
-        options.name,
-        options.type,
-        options.url,
-        options.ca,
-        options.cert,
-        options.key,
-    )
+    self.client.channel.software.createRepo(self.session,
+                                            options.name,
+                                            options.type,
+                                            options.url,
+                                            options.ca,
+                                            options.cert,
+                                            options.key)
 
     return 0
-
 
 ####################
 
 
 def help_repo_rename(self):
-    print(_("repo_rename: Rename a user repository"))
-    print(_("usage: repo_rename OLDNAME NEWNAME"))
+    print(_('repo_rename: Rename a user repository'))
+    print(_('usage: repo_rename OLDNAME NEWNAME'))
 
 
 def complete_repo_rename(self, text, line, beg, end):
-    if len(line.split(" ")) <= 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_repo_list("", True), text)
+    if len(line.split(' ')) <= 2:
+        return tab_completer(self.do_repo_list('', True),
+                             text)
 
     return None
 
 
 def do_repo_rename(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -467,10 +405,9 @@ def do_repo_rename(self, args):
 
     try:
         details = self.client.channel.software.getRepoDetails(self.session, args[0])
-        oldname = details.get("id")
+        oldname = details.get('id')
     except xmlrpclib.Fault:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Could not find repo %s") % args[0])
+        logging.error(_N('Could not find repo %s') % args[0])
         return 1
 
     newname = args[1]
@@ -479,28 +416,25 @@ def do_repo_rename(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_repo_updateurl(self):
-    print(_("repo_updateurl: Change the URL of a user repository"))
-    print(_("usage: repo_updateurl <repo> <url>"))
+    print(_('repo_updateurl: Change the URL of a user repository'))
+    print(_('usage: repo_updateurl <repo> <url>'))
 
 
 def complete_repo_updateurl(self, text, line, beg, end):
-    if len(line.split(" ")) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_repo_list("", True), text)
+    if len(line.split(' ')) == 2:
+        return tab_completer(self.do_repo_list('', True),
+                             text)
 
     return None
 
 
 def do_repo_updateurl(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -514,47 +448,37 @@ def do_repo_updateurl(self, args):
 
 
 def help_repo_updatessl(self):
-    print(_("repo_updatessl: Change the SSL certificates of a user repository"))
-    print(
-        _(
-            """usage: repo_updatessl <options>)
+    print(_('repo_updatessl: Change the SSL certificates of a user repository'))
+    print(_('''usage: repo_updatessl <options>)
 options:
   --ca         SSL CA certificate (not required)
   --cert       SSL Client certificate (not required)
-  --key        SSL Client key (not required)"""
-        )
-    )
+  --key        SSL Client key (not required)'''))
 
 
 def do_repo_updatessl(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("--ca", default="")
-    arg_parser.add_argument("--cert", default="")
-    arg_parser.add_argument("--key", default="")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('--ca', default='')
+    arg_parser.add_argument('--cert', default='')
+    arg_parser.add_argument('--key', default='')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.ca = prompt_user(_("SSL CA cert:"))
-        # pylint: disable-next=undefined-variable
-        options.cert = prompt_user(_("SSL Client cert:"))
-        # pylint: disable-next=undefined-variable
-        options.key = prompt_user(_("SSL Client key:"))
+        options.name = prompt_user(_('Name:'), noblank=True)
+        options.ca = prompt_user(_('SSL CA cert:'))
+        options.cert = prompt_user(_('SSL Client cert:'))
+        options.key = prompt_user(_('SSL Client key:'))
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A name is required"))
+            logging.error(_N('A name is required'))
             return 1
 
-    self.client.channel.software.updateRepoSsl(
-        self.session, options.name, options.ca, options.cert, options.key
-    )
+    self.client.channel.software.updateRepoSsl(self.session,
+                                               options.name,
+                                               options.ca,
+                                               options.cert,
+                                               options.key)
 
     return 0

--- a/spacecmd/src/spacecmd/report.py
+++ b/spacecmd/src/spacecmd/report.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -35,23 +34,20 @@ from operator import itemgetter
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_report_inactivesystems(self):
-    print(_("report_inactivesystems: List all inactive systems"))
-    print(_("usage: report_inactivesystems [DAYS]"))
+    print(_('report_inactivesystems: List all inactive systems'))
+    print(_('usage: report_inactivesystems [DAYS]'))
 
 
 def do_report_inactivesystems(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     # allow the user to set a limit on the number of days
@@ -70,108 +66,89 @@ def do_report_inactivesystems(self, args):
         systems = self.client.system.listInactiveSystems(self.session)
 
     if systems:
-        # pylint: disable-next=undefined-variable
-        max_size = max_length([s.get("name") for s in systems])
+        max_size = max_length([s.get('name') for s in systems])
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s  %s" % ("System ID ", "System".ljust(max_size), "Last Checkin"))
-        print(("----------  " + "-" * max_size) + "  ------------")
+        print('%s  %s  %s' % ('System ID ', 'System'.ljust(max_size), 'Last Checkin'))
+        print(('----------  '+'-' * max_size) + '  ------------')
 
-        for s in sorted(systems, key=itemgetter("name")):
-            print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s  %s"
-                % (s.get("id"), s.get("name").ljust(max_size), s.get("last_checkin"))
-            )
+        for s in sorted(systems, key=itemgetter('name')):
+            print('%s  %s  %s' % (s.get('id'), s.get('name').ljust(max_size),
+                                  s.get('last_checkin')))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_report_outofdatesystems(self):
-    print(_("report_outofdatesystems: List all out-of-date systems"))
-    print(_("usage: report_outofdatesystems"))
+    print(_('report_outofdatesystems: List all out-of-date systems'))
+    print(_('usage: report_outofdatesystems'))
 
 
 def do_report_outofdatesystems(self, args):
     systems = self.client.system.listOutOfDateSystems(self.session)
 
-    # pylint: disable-next=undefined-variable
-    max_size = max_length([s.get("name") for s in systems])
+    max_size = max_length([s.get('name') for s in systems])
 
     report = {}
     for system in systems:
-        report[system.get("name")] = system.get("outdated_pkg_count")
+        report[system.get('name')] = system.get('outdated_pkg_count')
 
     if report:
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s" % ("System".ljust(max_size), "Packages"))
-        print(("-" * max_size) + "  --------")
+        print('%s  %s' % ('System'.ljust(max_size), 'Packages'))
+        print(('-' * max_size) + '  --------')
 
         for system in sorted(report):
-            print(
-                # pylint: disable-next=consider-using-f-string
-                "%s       %s"
-                % (system.ljust(max_size), str(report[system]).rjust(3))
-            )
+            print('%s       %s' %
+                  (system.ljust(max_size), str(report[system]).rjust(3)))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_report_ungroupedsystems(self):
-    print(_("report_ungroupedsystems: List all ungrouped systems"))
-    print(_("usage: report_ungroupedsystems"))
+    print(_('report_ungroupedsystems: List all ungrouped systems'))
+    print(_('usage: report_ungroupedsystems'))
 
 
 def do_report_ungroupedsystems(self, args):
     systems = self.client.system.listUngroupedSystems(self.session)
-    systems = [s.get("name") for s in systems]
+    systems = [s.get('name') for s in systems]
 
     if systems:
-        print("\n".join(sorted(systems)))
+        print('\n'.join(sorted(systems)))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_report_errata(self):
-    print(_("report_errata: List all errata and how many systems they affect"))
-    print(_("usage: report_errata [ERRATA|search:XXX ...]"))
-
+    print(_('report_errata: List all errata and how many systems they affect'))
+    print(_('usage: report_errata [ERRATA|search:XXX ...]'))
 
 # XXX: performance is terrible due to all the API calls
 
 
 def do_report_errata(self, args):
     partial_errata = True
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (_args, _options) = parse_command_arguments(args, arg_parser)
 
     if not _args:
-        print(
-            _("All errata requested - this may take a few minutes, please be patient!")
-        )
+        print(_('All errata requested - this may take a few minutes, please be patient!'))
         partial_errata = False
 
     errata_list = self.expand_errata(_args)
 
     report = {}
     for erratum in errata_list:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Getting affected systems for %s" % erratum)
+        logging.debug('Getting affected systems for %s' % erratum)
 
         affected = self.client.errata.listAffectedSystems(self.session, erratum)
 
@@ -187,15 +164,11 @@ def do_report_errata(self, args):
             max_size = size
 
     if report:
-        print(_("%s  # Systems") % _(("Errata").ljust(max_size)))
-        # pylint: disable-next=consider-using-f-string
-        print("%s  ---------" % ("------".ljust(max_size)))
+        print(_('%s  # Systems') % _(('Errata').ljust(max_size)))
+        print('%s  ---------' % ('------'.ljust(max_size)))
         for erratum in sorted(report):
-            print(
-                # pylint: disable-next=consider-using-f-string
-                "%s        %s"
-                % (erratum.ljust(max_size), str(report[erratum]).rjust(3))
-            )
+            print('%s        %s' %
+                  (erratum.ljust(max_size), str(report[erratum]).rjust(3)))
         return 0
     elif partial_errata:
         print(_("No errata found for '{}'").format(args))
@@ -203,28 +176,24 @@ def do_report_errata(self, args):
 
     return None
 
-
 ####################
 
 
 def help_report_ipaddresses(self):
-    print(_("report_ipaddresses: List the hostname and IP of each system"))
-    print(_("usage: report_ipaddresses [<SYSTEMS>]"))
-    print("")
+    print(_('report_ipaddresses: List the hostname and IP of each system'))
+    print(_('usage: report_ipaddresses [<SYSTEMS>]'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def do_report_ipaddresses(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
         # use the systems listed in the SSM
-        # pylint: disable-next=undefined-variable
-        if re.match("ssm", args[0], re.I):
+        if re.match('ssm', args[0], re.I):
             systems = self.ssm.keys()
         else:
             systems = self.expand_systems(args)
@@ -232,15 +201,15 @@ def do_report_ipaddresses(self, args):
         systems = self.get_system_names()
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     report = {}
     for system in sorted(systems):
         system_id = self.get_system_id(system)
         network = self.client.system.getNetwork(self.session, system_id)
-        report[system] = {"hostname": network.get("hostname"), "ip": network.get("ip")}
+        report[system] = {'hostname': network.get('hostname'),
+                          'ip': network.get('ip')}
 
     # XXX: max(list, key=len) in >2.5
     system_max_size = 0
@@ -250,61 +219,45 @@ def do_report_ipaddresses(self, args):
             system_max_size = size
 
     hostname_max_size = 0
-    # pylint: disable-next=consider-using-dict-items
-    for h in [report[h]["hostname"] for h in report]:
+    for h in [report[h]['hostname'] for h in report]:
         size = len(h)
         if size > hostname_max_size:
             hostname_max_size = size
 
     if report:
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  IP"
-            % ("System".ljust(system_max_size), "Hostname".ljust(hostname_max_size))
-        )
+        print('%s  %s  IP' % ('System'.ljust(system_max_size),
+                              'Hostname'.ljust(hostname_max_size)))
 
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  --"
-            % ("------".ljust(system_max_size), "--------".ljust(hostname_max_size))
-        )
+        print('%s  %s  --' % ('------'.ljust(system_max_size),
+                              '--------'.ljust(hostname_max_size)))
 
         for system in sorted(report):
-            print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s  %s"
-                % (
-                    system.ljust(system_max_size),
-                    report[system]["hostname"].ljust(hostname_max_size),
-                    report[system]["ip"].ljust(15).strip(),
-                )
-            )
+            print('%s  %s  %s' %
+                  (system.ljust(system_max_size),
+                   report[system]['hostname'].ljust(hostname_max_size),
+                   report[system]['ip'].ljust(15).strip()))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_report_kernels(self):
-    print(_("report_kernels: List the running kernel of each system"))
-    print(_("usage: report_kernels [<SYSTEMS>]"))
-    print("")
+    print(_('report_kernels: List the running kernel of each system'))
+    print(_('usage: report_kernels [<SYSTEMS>]'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def do_report_kernels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
         # use the systems listed in the SSM
-        # pylint: disable-next=undefined-variable
-        if re.match("ssm", args[0], re.I):
+        if re.match('ssm', args[0], re.I):
             systems = self.ssm.keys()
         else:
             systems = self.expand_systems(args)
@@ -312,8 +265,7 @@ def do_report_kernels(self, args):
         systems = self.get_system_names()
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     report = {}
@@ -330,25 +282,22 @@ def do_report_kernels(self, args):
             system_max_size = size
 
     if report:
-        print(_("%s  Kernel") % (_("System").ljust(system_max_size)))
+        print(_('%s  Kernel') % (_('System').ljust(system_max_size)))
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s  ------" % ("------".ljust(system_max_size)))
+        print('%s  ------' % ('------'.ljust(system_max_size)))
 
         for system in sorted(report):
-            # pylint: disable-next=consider-using-f-string
-            print("%s  %s" % (system.ljust(system_max_size), report[system]))
+            print('%s  %s' % (system.ljust(system_max_size), report[system]))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_report_duplicates(self):
-    print(_("report_duplicates: List duplicate system profiles"))
-    print(_("usage: report_duplicates"))
+    print(_('report_duplicates: List duplicate system profiles'))
+    print(_('usage: report_duplicates'))
 
 
 def do_report_duplicates(self, args):
@@ -364,24 +313,22 @@ def do_report_duplicates(self, args):
         add_separator = True
 
         for item in dupes_by_profile:
-            # pylint: disable-next=consider-using-f-string
-            print("%s:" % item)
+            print('%s:' % item)
 
             # get some details for each duplicate
-            # pylint: disable-next=consider-using-f-string
-            systems = self.client.system.searchByName(self.session, "^%s$" % item)
+            systems = self.client.system.searchByName(self.session,
+                                                      '^%s$' % item)
 
-            print(_("System ID   Last Checkin"))
-            print("----------  -----------------")
+            print(_('System ID   Last Checkin'))
+            print('----------  -----------------')
 
             for dupe in systems:
-                # pylint: disable-next=consider-using-f-string
-                print("%i  %s" % (dupe.get("id"), dupe.get("last_checkin")))
+                print('%i  %s' % (dupe.get('id'), dupe.get('last_checkin')))
 
             if len(dupes_by_profile) > 1:
-                print("")
+                print('')
 
-    if self.check_api_version("10.11"):
+    if self.check_api_version('10.11'):
         dupes_by_ip = self.client.system.listDuplicatesByIp(self.session)
         dupes_by_mac = self.client.system.listDuplicatesByMac(self.session)
         dupes_by_hostname = self.client.system.listDuplicatesByHostname(self.session)
@@ -392,18 +339,17 @@ def do_report_duplicates(self, args):
             add_separator = True
 
             for item in dupes_by_ip:
-                # pylint: disable-next=consider-using-f-string
-                print("%s:" % item.get("ip"))
+                print('%s:' % item.get('ip'))
 
-                print(_("System ID   Last Checkin"))
-                print("----------  -----------------")
+                print(_('System ID   Last Checkin'))
+                print('----------  -----------------')
 
-                for dupe in item.get("systems"):
-                    # pylint: disable-next=consider-using-f-string
-                    print("%i  %s" % (dupe.get("systemId"), dupe.get("last_checkin")))
+                for dupe in item.get('systems'):
+                    print('%i  %s' % (dupe.get('systemId'),
+                                      dupe.get('last_checkin')))
 
                 if len(dupes_by_ip) > 1:
-                    print("")
+                    print('')
 
         if dupes_by_mac:
             if add_separator:
@@ -411,18 +357,17 @@ def do_report_duplicates(self, args):
             add_separator = True
 
             for item in dupes_by_mac:
-                # pylint: disable-next=consider-using-f-string
-                print("%s:" % item.get("mac").upper())
+                print('%s:' % item.get('mac').upper())
 
-                print(_("System ID   Last Checkin"))
-                print("----------  -----------------")
+                print(_('System ID   Last Checkin'))
+                print('----------  -----------------')
 
-                for dupe in item.get("systems"):
-                    # pylint: disable-next=consider-using-f-string
-                    print("%i  %s" % (dupe.get("systemId"), dupe.get("last_checkin")))
+                for dupe in item.get('systems'):
+                    print('%i  %s' % (dupe.get('systemId'),
+                                      dupe.get('last_checkin')))
 
                 if len(dupes_by_mac) > 1:
-                    print("")
+                    print('')
 
         if dupes_by_hostname:
             if add_separator:
@@ -430,16 +375,15 @@ def do_report_duplicates(self, args):
             add_separator = True
 
             for item in dupes_by_hostname:
-                # pylint: disable-next=consider-using-f-string
-                print("%s:" % item.get("hostname"))
+                print('%s:' % item.get('hostname'))
 
-                print(_("System ID   Last Checkin"))
-                print("----------  -----------------")
+                print(_('System ID   Last Checkin'))
+                print('----------  -----------------')
 
-                for dupe in item.get("systems"):
-                    # pylint: disable-next=consider-using-f-string
-                    print("%i  %s" % (dupe.get("systemId"), dupe.get("last_checkin")))
+                for dupe in item.get('systems'):
+                    print('%i  %s' % (dupe.get('systemId'),
+                                      dupe.get('last_checkin')))
 
                 if len(dupes_by_hostname) > 1:
-                    print("")
+                    print('')
     return 0

--- a/spacecmd/src/spacecmd/scap.py
+++ b/spacecmd/src/spacecmd/scap.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -35,20 +34,15 @@ import gettext
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_scap_listxccdfscans(self):
-    print(
-        _(
-            "scap_listxccdfscans: Return a list of finished OpenSCAP scans for given systems"
-        )
-    )
-    print(_("usage: scap_listxccdfscans <SYSTEMS>"))
+    print(_('scap_listxccdfscans: Return a list of finished OpenSCAP scans for given systems'))
+    print(_('usage: scap_listxccdfscans <SYSTEMS>'))
 
 
 def complete_system_scap_listxccdfscans(self, text, line, beg, end):
@@ -56,10 +50,8 @@ def complete_system_scap_listxccdfscans(self, text, line, beg, end):
 
 
 def do_scap_listxccdfscans(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -67,15 +59,13 @@ def do_scap_listxccdfscans(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -86,8 +76,8 @@ def do_scap_listxccdfscans(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
-            print("")
+            print(_('System: %s') % system)
+            print('')
 
         system_id = self.get_system_id(system)
         if not system_id:
@@ -96,31 +86,22 @@ def do_scap_listxccdfscans(self, args):
         scan_list = self.client.system.scap.listXccdfScans(self.session, system_id)
 
         for s in scan_list:
-            print(
-                _("XID: %d Profile: %s Path: (%s) Completed: %s")
-                % (s["xid"], s["profile"], s["path"], s["completed"])
-            )
+            print(_('XID: %d Profile: %s Path: (%s) Completed: %s')
+                  % (s['xid'], s['profile'], s['path'], s['completed']))
 
     return 0
-
 
 ####################
 
 
 def help_scap_getxccdfscanruleresults(self):
-    print(
-        _(
-            "scap_getxccdfscanruleresults: Return a full list of RuleResults for given OpenSCAP XCCDF scan"
-        )
-    )
-    print(_("usage: scap_getxccdfscanruleresults <XID>"))
+    print(_('scap_getxccdfscanruleresults: Return a full list of RuleResults for given OpenSCAP XCCDF scan'))
+    print(_('usage: scap_getxccdfscanruleresults <XID>'))
 
 
 def do_scap_getxccdfscanruleresults(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -135,36 +116,28 @@ def do_scap_getxccdfscanruleresults(self, args):
         add_separator = True
 
         if len(args) > 1:
-            print(_("XID: %s") % xid)
-            print("")
+            print(_('XID: %s') % xid)
+            print('')
 
         xid = int(xid)
-        scan_results = self.client.system.scap.getXccdfScanRuleResults(
-            self.session, xid
-        )
+        scan_results = self.client.system.scap.getXccdfScanRuleResults(self.session, xid)
 
         for s in scan_results:
-            print(
-                _("IDref: %s Result: %s Idents: (%s)")
-                % (s["idref"], s["result"], s["idents"])
-            )
+            print(_('IDref: %s Result: %s Idents: (%s)') % (s['idref'], s['result'], s['idents']))
 
     return 0
-
 
 ####################
 
 
 def help_scap_getxccdfscandetails(self):
-    print(_("scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"))
-    print(_("usage: scap_getxccdfscandetails <XID>"))
+    print(_('scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan'))
+    print(_('usage: scap_getxccdfscandetails <XID>'))
 
 
 def do_scap_getxccdfscandetails(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -179,69 +152,43 @@ def do_scap_getxccdfscandetails(self, args):
         add_separator = True
 
         if len(args) > 1:
-            print(_("XID: %s") % xid)
-            print("")
+            print(_('XID: %s') % xid)
+            print('')
 
         xid = int(xid)
         scan_details = self.client.system.scap.getXccdfScanDetails(self.session, xid)
 
-        print(
-            _("XID:"),
-            scan_details["xid"],
-            _("SID:"),
-            scan_details["sid"],
-            _("Action_ID:"),
-            scan_details["action_id"],
-            _("Path:"),
-            scan_details["path"],
-            _("OSCAP_Parameters:"),
-            scan_details["oscap_parameters"],
-            _("Test_Result:"),
-            scan_details["test_result"],
-            _("Benchmark:"),
-            scan_details["benchmark"],
-            _("Benchmark_Version:"),
-            scan_details["benchmark_version"],
-            _("Profile:"),
-            scan_details["profile"],
-            _("Profile_Title:"),
-            scan_details["profile_title"],
-            _("Start_Time:"),
-            scan_details["start_time"],
-            _("End_Time:"),
-            scan_details["end_time"],
-            _("Errors:"),
-            scan_details["errors"],
-        )
+        print(_("XID:"), scan_details['xid'], _("SID:"), scan_details['sid'], _("Action_ID:"),
+              scan_details['action_id'], _("Path:"), scan_details['path'], \
+              _("OSCAP_Parameters:"), scan_details['oscap_parameters'], \
+              _("Test_Result:"), scan_details['test_result'], _("Benchmark:"), \
+              scan_details['benchmark'], _("Benchmark_Version:"), \
+              scan_details['benchmark_version'], _("Profile:"), scan_details['profile'], \
+              _("Profile_Title:"), scan_details['profile_title'], _("Start_Time:"), \
+              scan_details['start_time'], _("End_Time:"), scan_details['end_time'], \
+              _("Errors:"), scan_details['errors'])
 
     return 0
-
 
 ####################
 
 
 def help_scap_schedulexccdfscan(self):
-    print(_("scap_schedulexccdfscan: Schedule Scap XCCDF scan"))
-    print(_("usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"))
-    print(_("       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"))
-    print("")
-    print(_("Example:"))
-    print(
-        "> scap_schedulexccdfscan '/usr/share/openscap/scap-security-xccdf.xml'"
-        + " 'profile Web-Default' system-scap.example.com"
-    )
+    print(_('scap_schedulexccdfscan: Schedule Scap XCCDF scan'))
+    print(_('usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS'))
+    print(_('       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS'))
+    print('')
+    print(_('Example:'))
+    print('> scap_schedulexccdfscan \'/usr/share/openscap/scap-security-xccdf.xml\'' +
+          ' \'profile Web-Default\' system-scap.example.com')
     print(_('\nTo use systems in the ssm, pass the "ssm" keyword in front. Example:'))
-    print(
-        "> scap_schedulexccdfscan ssm '/usr/share/openscap/scap-security-xccdf.xml'"
-        + " 'profile Web-Default'"
-    )
+    print("> scap_schedulexccdfscan ssm '/usr/share/openscap/scap-security-xccdf.xml'" +
+          " 'profile Web-Default'")
 
 
 def do_scap_schedulexccdfscan(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
@@ -249,8 +196,7 @@ def do_scap_schedulexccdfscan(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
@@ -261,8 +207,7 @@ def do_scap_schedulexccdfscan(self, args):
     param += args[1]
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -33,7 +32,6 @@
 import base64
 import gettext
 from operator import itemgetter
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -41,41 +39,36 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def print_schedule_summary(self, action_type, args):
     args = args.split() or []
 
     if args:
-        # pylint: disable-next=undefined-variable
         begin_date = parse_time_input(args[0])
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Begin Date: %s" % begin_date)
+        logging.debug('Begin Date: %s' % begin_date)
     else:
         begin_date = None
 
     if len(args) > 1:
-        # pylint: disable-next=undefined-variable
         end_date = parse_time_input(args[1])
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("End Date:   %s" % end_date)
+        logging.debug('End Date:   %s' % end_date)
     else:
         end_date = None
 
-    if action_type == "pending":
+    if action_type == 'pending':
         actions = self.client.schedule.listInProgressActions(self.session)
-    elif action_type == "completed":
+    elif action_type == 'completed':
         actions = self.client.schedule.listCompletedActions(self.session)
-    elif action_type == "failed":
+    elif action_type == 'failed':
         actions = self.client.schedule.listFailedActions(self.session)
-    elif action_type == "archived":
+    elif action_type == 'archived':
         actions = self.client.schedule.listArchivedActions(self.session)
-    elif action_type == "all":
+    elif action_type == 'all':
         # get actions in all states except archived
         in_progress = self.client.schedule.listInProgressActions(self.session)
         completed = self.client.schedule.listCompletedActions(self.session)
@@ -84,90 +77,76 @@ def print_schedule_summary(self, action_type, args):
         actions = []
         added = []
         for action in in_progress + completed + failed:
-            if action.get("id") not in added:
+            if action.get('id') not in added:
                 actions.append(action)
-                added.append(action.get("id"))
+                added.append(action.get('id'))
     else:
         return
 
     if not actions:
         return
 
-    print(_("ID      Date                 C    F    P     Action"))
-    print("--      ----                ---  ---  ---    ------")
+    print(_('ID      Date                 C    F    P     Action'))
+    print('--      ----                ---  ---  ---    ------')
 
-    for action in sorted(actions, key=itemgetter("id"), reverse=True):
+    for action in sorted(actions, key=itemgetter('id'), reverse=True):
         if begin_date:
-            if action.get("earliest") < begin_date:
+            if action.get('earliest') < begin_date:
                 continue
 
         if end_date:
-            if action.get("earliest") > end_date:
+            if action.get('earliest') > end_date:
                 continue
 
-        if self.check_api_version("10.11"):
-            print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s   %s  %s  %s    %s"
-                % (
-                    str(action.get("id")).ljust(6),
-                    action.get("earliest"),
-                    str(action.get("completedSystems")).rjust(3),
-                    str(action.get("failedSystems")).rjust(3),
-                    str(action.get("inProgressSystems")).rjust(3),
-                    action.get("name"),
-                )
-            )
+        if self.check_api_version('10.11'):
+            print('%s  %s   %s  %s  %s    %s' %
+                  (str(action.get('id')).ljust(6),
+                   action.get('earliest'),
+                   str(action.get('completedSystems')).rjust(3),
+                   str(action.get('failedSystems')).rjust(3),
+                   str(action.get('inProgressSystems')).rjust(3),
+                   action.get('name')))
         else:
             # Satellite 5.3 compatibility
-            in_progress = self.client.schedule.listInProgressSystems(
-                self.session, action.get("id")
-            )
+            in_progress = \
+                self.client.schedule.listInProgressSystems(self.session,
+                                                           action.get('id'))
 
-            completed = self.client.schedule.listCompletedSystems(
-                self.session, action.get("id")
-            )
+            completed = \
+                self.client.schedule.listCompletedSystems(self.session,
+                                                          action.get('id'))
 
-            failed = self.client.schedule.listFailedSystems(
-                self.session, action.get("id")
-            )
+            failed = \
+                self.client.schedule.listFailedSystems(self.session,
+                                                       action.get('id'))
 
-            print(
-                # pylint: disable-next=consider-using-f-string
-                "%s  %s   %s  %s  %s    %s"
-                % (
-                    str(action.get("id")).ljust(6),
-                    action.get("earliest"),
-                    str(len(completed)).rjust(3),
-                    str(len(failed)).rjust(3),
-                    str(len(in_progress)).rjust(3),
-                    action.get("name"),
-                )
-            )
-
+            print('%s  %s   %s  %s  %s    %s' %
+                  (str(action.get('id')).ljust(6),
+                   action.get('earliest'),
+                   str(len(completed)).rjust(3),
+                   str(len(failed)).rjust(3),
+                   str(len(in_progress)).rjust(3),
+                   action.get('name')))
 
 ####################
 
 
 def help_schedule_cancel(self):
-    print(_("schedule_cancel: Cancel scheduled actions"))
-    print(_("usage: schedule_cancel ID|* ..."))
+    print(_('schedule_cancel: Cancel scheduled actions'))
+    print(_('usage: schedule_cancel ID|* ...'))
 
 
 def complete_schedule_cancel(self, text, line, beg, end):
     try:
         actions = self.client.schedule.listInProgressActions(self.session)
-        # pylint: disable-next=undefined-variable
-        return tab_completer([str(a.get("id")) for a in actions], text)
+        return tab_completer([str(a.get('id')) for a in actions], text)
     except xmlrpclib.Fault:
         return []
 
 
 def do_schedule_cancel(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -175,14 +154,13 @@ def do_schedule_cancel(self, args):
         return 1
 
     # cancel all actions
-    if ".*" in args:
-        if not self.user_confirm(_("Cancel all pending actions [y/N]:")):
-            # pylint: disable-next=undefined-variable
+    if '.*' in args:
+        if not self.user_confirm(_('Cancel all pending actions [y/N]:')):
             logging.info(_N("All pending actions left untouched"))
             return 1
 
         actions = self.client.schedule.listInProgressActions(self.session)
-        strings = [a.get("id") for a in actions]
+        strings = [a.get('id') for a in actions]
     else:
         strings = args
 
@@ -193,47 +171,40 @@ def do_schedule_cancel(self, args):
         try:
             actions.append(int(a))
         except ValueError:
-            # pylint: disable-next=undefined-variable
             logging.warning(_N('"%s" is not a valid ID') % str(a))
             failed_actions.append(a)
 
     if actions:
         self.client.schedule.cancelActions(self.session, actions)
         for a in actions:
-            # pylint: disable-next=undefined-variable
-            logging.info(_N("Canceled action: %i"), a)
+            logging.info(_N('Canceled action: %i'), a)
     if failed_actions:
         for action in failed_actions:
-            # pylint: disable-next=undefined-variable
             logging.info(_N("Failed action: %s"), action)
 
-    print(_("Canceled %i action(s)") % len(actions))
+    print(_('Canceled %i action(s)') % len(actions))
 
     return 0
-
 
 ####################
 
 
 def help_schedule_reschedule(self):
-    print(_("schedule_reschedule: Reschedule failed actions"))
-    print(_("usage: schedule_reschedule ID|* ..."))
+    print(_('schedule_reschedule: Reschedule failed actions'))
+    print(_('usage: schedule_reschedule ID|* ...'))
 
 
 def complete_schedule_reschedule(self, text, line, beg, end):
     try:
         actions = self.client.schedule.listFailedActions(self.session)
-        # pylint: disable-next=undefined-variable
-        return tab_completer([str(a.get("id")) for a in actions], text)
+        return tab_completer([str(a.get('id')) for a in actions], text)
     except xmlrpclib.Fault:
         return []
 
 
 def do_schedule_reschedule(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -241,13 +212,13 @@ def do_schedule_reschedule(self, args):
         return 1
 
     failed_actions = self.client.schedule.listFailedActions(self.session)
-    failed_actions = [a.get("id") for a in failed_actions]
+    failed_actions = [a.get('id') for a in failed_actions]
 
     to_reschedule = []
 
     # reschedule all failed actions
-    if ".*" in args:
-        if not self.user_confirm(_("Reschedule all failed actions [y/N]:")):
+    if '.*' in args:
+        if not self.user_confirm(_('Reschedule all failed actions [y/N]:')):
             return 1
         to_reschedule = failed_actions
     else:
@@ -259,37 +230,31 @@ def do_schedule_reschedule(self, args):
                 if action_id in failed_actions:
                     to_reschedule.append(action_id)
                 else:
-                    # pylint: disable-next=undefined-variable
                     logging.warning(_N('"%i" is not a failed action') % action_id)
             except ValueError:
-                # pylint: disable-next=undefined-variable
                 logging.warning(_N('"%s" is not a valid ID') % str(a))
                 continue
 
     if not to_reschedule:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No failed actions to reschedule"))
+        logging.warning(_N('No failed actions to reschedule'))
         return 1
     else:
         self.client.schedule.rescheduleActions(self.session, to_reschedule, True)
-        print(_("Rescheduled %i action(s)") % len(to_reschedule))
+        print(_('Rescheduled %i action(s)') % len(to_reschedule))
 
     return 0
-
 
 ####################
 
 
 def help_schedule_details(self):
-    print(_("schedule_details: Show the details of a scheduled action"))
-    print(_("usage: schedule_details ID"))
+    print(_('schedule_details: Show the details of a scheduled action'))
+    print(_('usage: schedule_details ID'))
 
 
 def do_schedule_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -301,71 +266,61 @@ def do_schedule_details(self, args):
     try:
         action_id = int(action_id)
     except ValueError:
-        # pylint: disable-next=undefined-variable
         logging.warning(_N('The ID "%s" is invalid') % action_id)
         return 1
 
     completed = self.client.schedule.listCompletedSystems(self.session, action_id)
     failed = self.client.schedule.listFailedSystems(self.session, action_id)
     pending = self.client.schedule.listInProgressSystems(self.session, action_id)
-    action = dict(
-        map(
-            lambda e: [e.get("id"), e],
-            self.client.schedule.listAllActions(self.session),
-        )
-    ).get(action_id)
+    action = dict(map(lambda e: [e.get("id"), e], self.client.schedule.listAllActions(self.session))).get(action_id)
 
     if action is not None:
-        print(_("ID:        %i") % action.get("id"))
-        print(_("Action:    %s") % action.get("name"))
-        print(_("User:      %s") % action.get("scheduler"))
-        print(_("Date:      %s") % action.get("earliest"))
-        print("")
-        print(_("Completed: %s") % str(len(completed)).rjust(3))
-        print(_("Failed:    %s") % str(len(failed)).rjust(3))
-        print(_("Pending:   %s") % str(len(pending)).rjust(3))
+        print(_('ID:        %i') % action.get('id'))
+        print(_('Action:    %s') % action.get('name'))
+        print(_('User:      %s') % action.get('scheduler'))
+        print(_('Date:      %s') % action.get('earliest'))
+        print('')
+        print(_('Completed: %s') % str(len(completed)).rjust(3))
+        print(_('Failed:    %s') % str(len(failed)).rjust(3))
+        print(_('Pending:   %s') % str(len(pending)).rjust(3))
 
         if completed:
-            print("")
-            print(_("Completed Systems"))
-            print("-----------------")
+            print('')
+            print(_('Completed Systems'))
+            print('-----------------')
             for s in completed:
-                print(s.get("server_name"))
+                print(s.get('server_name'))
 
         if failed:
-            print("")
-            print(_("Failed Systems"))
-            print("--------------")
+            print('')
+            print(_('Failed Systems'))
+            print('--------------')
             for s in failed:
-                print(s.get("server_name"))
+                print(s.get('server_name'))
 
         if pending:
-            print("")
-            print(_("Pending Systems"))
-            print("---------------")
+            print('')
+            print(_('Pending Systems'))
+            print('---------------')
             for s in pending:
-                print(s.get("server_name"))
+                print(s.get('server_name'))
     else:
-        # pylint: disable-next=undefined-variable
         logging.error(_N('No action found with the ID "%s"') % action_id)
         return 1
 
     return 0
 
-
 ####################
 
 
 def help_schedule_getoutput(self):
-    print(_("schedule_getoutput: Show the output from an action"))
-    print(_("usage: schedule_getoutput ID"))
+    print(_('schedule_getoutput: Show the output from an action'))
+    print(_('usage: schedule_getoutput ID'))
 
 
 def do_schedule_getoutput(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -375,7 +330,6 @@ def do_schedule_getoutput(self, args):
     try:
         action_id = int(args[0])
     except ValueError:
-        # pylint: disable-next=undefined-variable
         logging.error(_N('"%s" is not a valid action ID') % str(args[0]))
         return 1
 
@@ -383,7 +337,6 @@ def do_schedule_getoutput(self, args):
     try:
         script_results = self.client.system.getScriptResults(self.session, action_id)
     except xmlrpclib.Fault as exc:
-        # pylint: disable-next=undefined-variable
         logging.debug("Exception occurrect while get script results: %s", str(exc))
 
     # scripts have a different data structure than other actions
@@ -394,22 +347,22 @@ def do_schedule_getoutput(self, args):
                 print(self.SEPARATOR)
             add_separator = True
 
-            if r.get("serverId"):
-                system = self.get_system_name(r.get("serverId"))
+            if r.get('serverId'):
+                system = self.get_system_name(r.get('serverId'))
             else:
-                system = "UNKNOWN"
+                system = 'UNKNOWN'
 
-            print(_("System:      %s") % system)
-            print(_("Start Time:  %s") % r.get("startDate"))
-            print(_("Stop Time:   %s") % r.get("stopDate"))
-            print(_("Return Code: %i") % r.get("returnCode"))
-            print("")
-            print(_("Output"))
-            print("------")
-            if r.get("output_enc64"):
-                print(base64.b64decode(r.get("output") or b"Ti9B\n").decode("utf-8"))
+            print(_('System:      %s') % system)
+            print(_('Start Time:  %s') % r.get('startDate'))
+            print(_('Stop Time:   %s') % r.get('stopDate'))
+            print(_('Return Code: %i') % r.get('returnCode'))
+            print('')
+            print(_('Output'))
+            print('------')
+            if r.get('output_enc64'):
+                print(base64.b64decode(r.get('output') or b'Ti9B\n').decode("utf-8"))
             else:
-                print((r.get("output") or "N/A").encode("UTF8").decode("utf-8"))
+                print((r.get('output') or "N/A").encode('UTF8').decode("utf-8"))
 
     else:
         completed = self.client.schedule.listCompletedSystems(self.session, action_id)
@@ -423,126 +376,107 @@ def do_schedule_getoutput(self, args):
                     print(self.SEPARATOR)
                 add_separator = True
 
-                print(_("System:    %s") % action.get("server_name"))
-                print(_("Completed: %s") % action.get("timestamp"))
-                print("")
-                print(_("Output"))
-                print("------")
-                print(action.get("message"))
+                print(_('System:    %s') % action.get('server_name'))
+                print(_('Completed: %s') % action.get('timestamp'))
+                print('')
+                print(_('Output'))
+                print('------')
+                print(action.get('message'))
         else:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("No systems found"))
             return 1
 
     return 0
 
-
 ####################
 
 
 def help_schedule_listpending(self):
-    print(_("schedule_listpending: List pending actions"))
-    print(_("usage: schedule_listpending [BEGINDATE] [ENDDATE]"))
-    print("")
+    print(_('schedule_listpending: List pending actions'))
+    print(_('usage: schedule_listpending [BEGINDATE] [ENDDATE]'))
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def do_schedule_listpending(self, args):
-    return self.print_schedule_summary("pending", args)
-
+    return self.print_schedule_summary('pending', args)
 
 ####################
 
 
 def help_schedule_listcompleted(self):
-    print(_("schedule_listcompleted: List completed actions"))
-    print(_("usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"))
-    print("")
+    print(_('schedule_listcompleted: List completed actions'))
+    print(_('usage: schedule_listcompleted [BEGINDATE] [ENDDATE]'))
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def do_schedule_listcompleted(self, args):
-    return self.print_schedule_summary("completed", args)
-
+    return self.print_schedule_summary('completed', args)
 
 ####################
 
 
 def help_schedule_listfailed(self):
-    print(_("schedule_listfailed: List failed actions"))
-    print(_("usage: schedule_listfailed [BEGINDATE] [ENDDATE]"))
-    print("")
+    print(_('schedule_listfailed: List failed actions'))
+    print(_('usage: schedule_listfailed [BEGINDATE] [ENDDATE]'))
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def do_schedule_listfailed(self, args):
-    return self.print_schedule_summary("failed", args)
-
+    return self.print_schedule_summary('failed', args)
 
 ####################
 
 
 def help_schedule_listarchived(self):
-    print(_("schedule_listarchived: List archived actions"))
-    print(_("usage: schedule_listarchived [BEGINDATE] [ENDDATE]"))
-    print("")
+    print(_('schedule_listarchived: List archived actions'))
+    print(_('usage: schedule_listarchived [BEGINDATE] [ENDDATE]'))
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def do_schedule_listarchived(self, args):
-    return self.print_schedule_summary("archived", args)
-
+    return self.print_schedule_summary('archived', args)
 
 ####################
 
 
 def help_schedule_list(self):
-    print(_("schedule_list: List all actions"))
-    print(_("usage: schedule_list [BEGINDATE] [ENDDATE]"))
-    print("")
+    print(_('schedule_list: List all actions'))
+    print(_('usage: schedule_list [BEGINDATE] [ENDDATE]'))
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def do_schedule_list(self, args):
-    return self.print_schedule_summary("all", args)
-
+    return self.print_schedule_summary('all', args)
 
 ####################
 
-
 def help_schedule_deletearchived(self):
-    print(
-        _("schedule_deletearchived: Delete all archived actions older than given date.")
-    )
-    print(_("usage: schedule_deletearchived [yyyymmdd] [options]"))
-    print(
-        _(
-            """
+    print(_('schedule_deletearchived: Delete all archived actions older than given date.'))
+    print(_('usage: schedule_deletearchived [yyyymmdd] [options]'))
+    print(_('''
 options:
-  -y, --yes   Confirm without prompt"""
-        )
-    )
-    print("")
-    print(_("If no date is provided it will delete all archived actions"))
-
+  -y, --yes   Confirm without prompt'''))
+    print('')
+    print(_('If no date is provided it will delete all archived actions'))
 
 def do_schedule_deletearchived(self, args):
     """
     This method removes all of the archived actions older than provided date.
     If no date is provided it will delete all archived actions.
     """
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-y", "--yes", default=False, action="store_true")
+    arg_parser.add_argument('-y', '--yes', default=False, action="store_true")
 
-    # pylint: disable-next=undefined-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
-        # pylint: disable-next=undefined-variable
         date_limit = parse_time_input(args[0])
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Date limit: %s" % date_limit)
+        logging.debug('Date limit: %s' % date_limit)
     else:
         date_limit = None
 
@@ -550,23 +484,17 @@ def do_schedule_deletearchived(self, args):
 
     # Filter out actions by date if limit is set
     if date_limit:
-        actions = [action for action in actions if action.get("earliest") < date_limit]
+        actions = [action for action in actions if action.get('earliest') < date_limit]
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("actions: {}".format(actions))
     if actions:
         if not _options.yes:
-            # pylint: disable-next=undefined-variable
-            user_answer = prompt_user(
-                _("Do you want to delete ({}) archived actions? [y/N]").format(
-                    len(actions)
-                )
-            )
+            user_answer = prompt_user(_("Do you want to delete ({}) archived actions? [y/N]").format(len(actions)))
             if user_answer not in ("y", "Y", "yes", "Yes", "YES"):
                 return
 
         # Collect IDs of actions that should be deleted
-        action_ids = [action.get("id") for action in actions]
+        action_ids = [action.get('id') for action in actions]
 
         # Remove duplicates if any
         # set needs to be cast to list, since set cannot be marshalled
@@ -577,58 +505,37 @@ def do_schedule_deletearchived(self, args):
             BATCH_SIZE = 500
             for i in range(0, len(action_ids), BATCH_SIZE):
                 # Pass list of actions that should be deleted
-                self.client.schedule.deleteActions(
-                    self.session, action_ids[i : i + BATCH_SIZE]
-                )
-                processed = (
-                    i + BATCH_SIZE
-                    if i + BATCH_SIZE <= len(action_ids)
-                    else len(action_ids)
-                )
-                # pylint: disable-next=consider-using-f-string
+                self.client.schedule.deleteActions(self.session, action_ids[i:i + BATCH_SIZE])
+                processed = i + BATCH_SIZE if i + BATCH_SIZE <= len(action_ids) else len(action_ids)
                 print("Deleted {} actions of {}".format(processed, len(action_ids)))
     else:
         print(_("No archived actions found."))
-
 
 ####################
 
 
 def help_schedule_archivecompleted(self):
-    print(
-        _(
-            "schedule_archivecompleted: Archive all completed actions older than given date."
-        )
-    )
-    print(_("usage: schedule_archivecompleted [yyyymmdd] [options]"))
-    print(
-        _(
-            """
+    print(_('schedule_archivecompleted: Archive all completed actions older than given date.'))
+    print(_('usage: schedule_archivecompleted [yyyymmdd] [options]'))
+    print(_('''
 options:
-  -y, --yes   Confirm without prompt"""
-        )
-    )
-    print("")
-    print(_("If no date is provided it will archive all completed actions"))
-
+  -y, --yes   Confirm without prompt'''))
+    print('')
+    print(_('If no date is provided it will archive all completed actions'))
 
 def do_schedule_archivecompleted(self, args):
     """
     This method removes all of the completed actions older than provided date.
     If no date is provided it will archive all completed actions.
     """
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-y", "--yes", default=False, action="store_true")
+    arg_parser.add_argument('-y', '--yes', default=False, action="store_true")
 
-    # pylint: disable-next=undefined-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
-        # pylint: disable-next=undefined-variable
         date_limit = parse_time_input(args[0])
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Date limit: %s" % date_limit)
+        logging.debug('Date limit: %s' % date_limit)
     else:
         date_limit = None
 
@@ -636,23 +543,17 @@ def do_schedule_archivecompleted(self, args):
 
     # Filter out actions by date if limit is set
     if date_limit:
-        actions = [action for action in actions if action.get("earliest") < date_limit]
+        actions = [action for action in actions if action.get('earliest') < date_limit]
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("actions: {}".format(actions))
     if actions:
         if not _options.yes:
-            # pylint: disable-next=undefined-variable
-            user_answer = prompt_user(
-                _("Do you want to archive ({}) completed actions? [y/N]").format(
-                    len(actions)
-                )
-            )
+            user_answer = prompt_user(_("Do you want to archive ({}) completed actions? [y/N]").format(len(actions)))
             if user_answer not in ("y", "Y", "yes", "Yes", "YES"):
                 return
 
         # Collect IDs of actions that should be archived
-        action_ids = [action.get("id") for action in actions]
+        action_ids = [action.get('id') for action in actions]
 
         # Remove duplicates if any
         # set needs to be cast to list, since set cannot be marshalled
@@ -663,15 +564,8 @@ def do_schedule_archivecompleted(self, args):
             BATCH_SIZE = 500
             for i in range(0, len(action_ids), BATCH_SIZE):
                 # Pass list of actions that should be archived
-                self.client.schedule.archiveActions(
-                    self.session, action_ids[i : i + BATCH_SIZE]
-                )
-                processed = (
-                    i + BATCH_SIZE
-                    if i + BATCH_SIZE <= len(action_ids)
-                    else len(action_ids)
-                )
-                # pylint: disable-next=consider-using-f-string
+                self.client.schedule.archiveActions(self.session, action_ids[i:i + BATCH_SIZE])
+                processed = i + BATCH_SIZE if i + BATCH_SIZE <= len(action_ids) else len(action_ids)
                 print("Archived {} actions of {}".format(processed, len(action_ids)))
     else:
         print(_("No completed actions found."))

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -45,75 +44,51 @@ from cmd import Cmd
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
-
-
 class UnknownCallException(Exception):
+
     def __init__(self):
         Exception.__init__(self)
 
 
-# pylint: disable-next=missing-class-docstring
 class SpacewalkShell(Cmd):
-    __module_list = [
-        "activationkey",
-        "configchannel",
-        "cryptokey",
-        "custominfo",
-        "distribution",
-        "errata",
-        "filepreservation",
-        "group",
-        "kickstart",
-        "misc",
-        "org",
-        "package",
-        "proxy",
-        "repo",
-        "report",
-        "schedule",
-        "snippet",
-        "softwarechannel",
-        "ssm",
-        "api",
-        "system",
-        "user",
-        "utils",
-        "scap",
-    ]
+    __module_list = ['activationkey', 'configchannel', 'cryptokey',
+                     'custominfo', 'distribution', 'errata',
+                     'filepreservation', 'group', 'kickstart',
+                     'misc', 'org', 'package', 'proxy', 'repo', 'report', 'schedule',
+                     'snippet', 'softwarechannel', 'ssm', 'api',
+                     'system', 'user', 'utils', 'scap']
 
     # a SyntaxError is thrown if we don't wrap this in an 'exec'
     for module in __module_list:
-        # pylint: disable-next=consider-using-f-string
-        exec("from spacecmd.%s import *" % module)
+        exec('from spacecmd.%s import *' % module)
 
     # maximum length of history file
     HISTORY_LENGTH = 1024
 
     cmdqueue = []
-    completekey = "tab"
+    completekey = 'tab'
     stdout = sys.stdout
-    prompt_template = "spacecmd {SSM:##}> "
-    current_line = ""
+    prompt_template = 'spacecmd {SSM:##}> '
+    current_line = ''
 
     # do nothing on an empty line
-    # pylint: disable-next=unnecessary-lambda-assignment
     emptyline = lambda self: None
 
     def __init__(self, options, conf_dir, config_parser):
         Cmd.__init__(self)
 
-        self.session = ""
-        self.current_user = ""
-        self.server = ""
+        self.session = ''
+        self.current_user = ''
+        self.server = ''
         self.ssm = {}
         self.config = {}
 
-        self.postcmd(False, "")
+        self.postcmd(False, '')
 
         # make the options available everywhere
         self.options = options
@@ -124,12 +99,12 @@ class SpacewalkShell(Cmd):
         # this is used when loading and saving caches
         self.conf_dir = conf_dir
 
-        self.history_file = os.path.join(self.conf_dir, "history")
+        self.history_file = os.path.join(self.conf_dir, 'history')
 
         try:
             # don't split on hyphens or colons during tab completion
             newdelims = readline.get_completer_delims()
-            newdelims = re.sub(":|-|/", "", newdelims)
+            newdelims = re.sub(':|-|/', '', newdelims)
             readline.set_completer_delims(newdelims)
 
             if not options.nohistory:
@@ -140,9 +115,10 @@ class SpacewalkShell(Cmd):
                     readline.set_history_length(self.HISTORY_LENGTH)
 
                     # always write the history file on exit
-                    atexit.register(readline.write_history_file, self.history_file)
+                    atexit.register(readline.write_history_file,
+                                    self.history_file)
                 except IOError:
-                    logging.error(_N("Could not read history file"))
+                    logging.error(_N('Could not read history file'))
         # pylint: disable=broad-except
         except Exception as exc:
             logging.error(_N("Exception occurred: %s"), exc)
@@ -154,52 +130,51 @@ class SpacewalkShell(Cmd):
         # pylint: disable=R0911
 
         # remove leading/trailing whitespace
-        line = re.sub(r"^\s+|\s+$", "", line)
+        line = re.sub(r'^\s+|\s+$', '', line)
 
         # don't do anything on empty lines
-        if line == "":
-            return ""
+        if line == '':
+            return ''
 
         # terminate the shell
-        if re.match("quit|exit|eof", line, re.I):
-            print("")
+        if re.match('quit|exit|eof', line, re.I):
+            print('')
             sys.exit(0)
 
         # don't attempt to login for some commands
-        if re.match("help|login|logout|history|clear", line, re.I):
+        if re.match('help|login|logout|history|clear', line, re.I):
             # login required for clear_caches or it fails with:
             # "SpacewalkShell instance has no attribute 'system_cache_file'"
-            if not re.match("clear_caches", line, re.I):
+            if not re.match('clear_caches', line, re.I):
                 return line
 
         # Handle initial org and user creation
         # Get 'self.client' object without login or session caching
-        if re.match("org_createfirst", line, re.I):
-            self.do_login("")
+        if re.match('org_createfirst', line, re.I):
+            self.do_login('')
             return line
 
         # login before attempting to run a command
         if not self.session:
             # disable no-member error message
             # pylint: disable=E1101
-            self.do_login("")
-            if self.session == "":
-                return ""
+            self.do_login('')
+            if self.session == '':
+                return ''
 
         parts = shlex.split(line)
 
         if parts:
             command = parts[0]
         else:
-            return ""
+            return ''
 
         # print(the help message for a command if the user passed --help)
-        if "--help" in parts or "-h" in parts:
-            # pylint: disable-next=consider-using-f-string
-            return "help %s" % command
+        if '--help' in parts or '-h' in parts:
+            return 'help %s' % command
 
         # should we look for an item in the history?
-        if command[0] != "!" or len(command) < 2:
+        if command[0] != '!' or len(command) < 2:
             return line
 
         # remove the '!*' line from the history
@@ -209,14 +184,15 @@ class SpacewalkShell(Cmd):
 
         history_match = False
 
-        if command[1] == "!":
+        if command[1] == '!':
             # repeat the last command
-            line = readline.get_history_item(readline.get_current_history_length())
+            line = readline.get_history_item(
+                readline.get_current_history_length())
             if line:
                 history_match = True
             else:
-                logging.warning(_N("%s: event not found"), command)
-                return ""
+                logging.warning(_N('%s: event not found'), command)
+                return ''
 
         # attempt to find a numbered history item
         if not history_match:
@@ -226,7 +202,6 @@ class SpacewalkShell(Cmd):
                 if line:
                     history_match = True
                 else:
-                    # pylint: disable-next=broad-exception-raised
                     raise Exception
             except IndexError:
                 pass
@@ -249,22 +224,20 @@ class SpacewalkShell(Cmd):
         if history_match:
             if parts[1:]:
                 for arg in parts[1:]:
-                    # pylint: disable-next=consider-using-f-string
                     line += " '%s'" % arg
 
             readline.add_history(line)
             print(line)
             return line
         else:
-            logging.warning(_N("%s: event not found"), command)
-            return ""
+            logging.warning(_N('%s: event not found'), command)
+            return ''
 
     # update the prompt with the SSM size
     # pylint: disable=arguments-differ
-    # pylint: disable-next=arguments-renamed
     def postcmd(self, cmdresult, cmd):
         logging.debug("command=%s, return_value=%s", cmd, repr(cmdresult))
-        self.prompt = re.sub("##", str(len(self.ssm)), self.prompt_template)
+        self.prompt = re.sub('##', str(len(self.ssm)), self.prompt_template)
 
     def default(self, line):
         Cmd.default(self, line)

--- a/spacecmd/src/spacecmd/snippet.py
+++ b/spacecmd/src/spacecmd/snippet.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -34,48 +33,44 @@ import gettext
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_snippet_list(self):
-    print(_("snippet_list: List the available Kickstart snippets"))
-    print(_("usage: snippet_list"))
+    print(_('snippet_list: List the available Kickstart snippets'))
+    print(_('usage: snippet_list'))
 
 
 def do_snippet_list(self, args, doreturn=False):
     snippets = self.client.kickstart.snippet.listCustom(self.session)
-    snippets = sorted([s.get("name") for s in snippets])
+    snippets = sorted([s.get('name') for s in snippets])
 
     if doreturn:
         return snippets
     if snippets:
-        print("\n".join(snippets))
+        print('\n'.join(snippets))
 
     return None
-
 
 ####################
 
 
 def help_snippet_details(self):
-    print(_("snippet_details: Show the contents of a snippet"))
-    print(_("usage: snippet_details SNIPPET ..."))
+    print(_('snippet_details: Show the contents of a snippet'))
+    print(_('usage: snippet_details SNIPPET ...'))
 
 
 def complete_snippet_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_snippet_list("", True), text)
+    return tab_completer(self.do_snippet_list('', True),
+                         text)
 
 
 def do_snippet_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -89,57 +84,48 @@ def do_snippet_details(self, args):
     snippet = None
     for name in args:
         for s in snippets:
-            if s.get("name") == name:
+            if s.get('name') == name:
                 snippet = s
                 break
 
         if not snippet:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s is not a valid snippet") % name)
+            logging.warning(_N('%s is not a valid snippet') % name)
             continue
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("Name:   %s") % snippet.get("name"))
-        print(_("Macro:  %s") % snippet.get("fragment"))
-        print(_("File:   %s") % snippet.get("file"))
+        print(_('Name:   %s') % snippet.get('name'))
+        print(_('Macro:  %s') % snippet.get('fragment'))
+        print(_('File:   %s') % snippet.get('file'))
 
-        print("")
-        print(snippet.get("contents"))
+        print('')
+        print(snippet.get('contents'))
 
     return 0
-
 
 ####################
 
 
 def help_snippet_create(self):
-    print(_("snippet_create: Create a Kickstart snippet"))
-    print(
-        _(
-            """usage: snippet_create [options])
+    print(_('snippet_create: Create a Kickstart snippet'))
+    print(_('''usage: snippet_create [options])
 
 options:
   -n NAME
-  -f FILE"""
-        )
-    )
+  -f FILE'''))
 
 
-def do_snippet_create(self, args, update_name=""):
-    # pylint: disable-next=undefined-variable
+def do_snippet_create(self, args, update_name=''):
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    contents = ""
+    contents = ''
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
         # if update_name was passed, we're trying to update an existing snippet
         if update_name:
@@ -147,96 +133,82 @@ def do_snippet_create(self, args, update_name=""):
 
             snippets = self.client.kickstart.snippet.listCustom(self.session)
             for s in snippets:
-                if s.get("name") == update_name:
-                    contents = s.get("contents")
+                if s.get('name') == update_name:
+                    contents = s.get('contents')
                     break
 
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            options.name = prompt_user("Name:", noblank=True)
+            options.name = prompt_user('Name:', noblank=True)
 
-        if self.user_confirm(
-            _("Read an existing file [y/N]:"), nospacer=True, ignore_yes=True
-        ):
-            # pylint: disable-next=undefined-variable
-            options.file = prompt_user("File:")
+        if self.user_confirm(_('Read an existing file [y/N]:'),
+                             nospacer=True, ignore_yes=True):
+            options.file = prompt_user('File:')
         else:
-            # pylint: disable-next=undefined-variable,unused-variable
-            (contents, _ignore) = editor(template=contents, delete=True)
+            (contents, _ignore) = editor(template=contents,
+                                         delete=True)
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A name is required for the snippet"))
+            logging.error(_N('A name is required for the snippet'))
             return 1
 
         if not options.file:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A file is required"))
+            logging.error(_N('A file is required'))
             return 1
 
     if options.file:
-        # pylint: disable-next=undefined-variable
         contents = read_file(options.file)
 
-    print("")
-    print(_("Snippet: %s") % options.name)
-    print(_("Contents"))
-    print("--------")
+    print('')
+    print(_('Snippet: %s') % options.name)
+    print(_('Contents'))
+    print('--------')
     print(contents)
 
     if self.user_confirm():
-        self.client.kickstart.snippet.createOrUpdate(
-            self.session, options.name, contents
-        )
+        self.client.kickstart.snippet.createOrUpdate(self.session,
+                                                     options.name,
+                                                     contents)
 
     return 0
-
 
 ####################
 
 
 def help_snippet_update(self):
-    print(_("snippet_update: Update a Kickstart snippet"))
-    print(_("usage: snippet_update NAME"))
+    print(_('snippet_update: Update a Kickstart snippet'))
+    print(_('usage: snippet_update NAME'))
 
 
 def complete_snippet_update(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_snippet_list("", True), text)
+    return tab_completer(self.do_snippet_list('', True), text)
 
 
 def do_snippet_update(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_snippet_update()
         return 1
 
-    return self.do_snippet_create("", update_name=args[0])
-
+    return self.do_snippet_create('', update_name=args[0])
 
 ####################
 
 
 def help_snippet_delete(self):
-    print(_("snippet_delete: Delete a Kickstart snippet"))
-    print(_("usage: snippet_delete NAME"))
+    print(_('snippet_delete: Delete a Kickstart snippet'))
+    print(_('usage: snippet_delete NAME'))
 
 
 def complete_snippet_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_snippet_list("", True), text)
+    return tab_completer(self.do_snippet_list('', True), text)
 
 
 def do_snippet_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -245,7 +217,7 @@ def do_snippet_delete(self, args):
 
     snippet = args[0]
 
-    if self.user_confirm(_("Remove this snippet [y/N]:")):
+    if self.user_confirm(_('Remove this snippet [y/N]:')):
         self.client.kickstart.snippet.delete(self.session, snippet)
         return 0
     else:

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -32,7 +31,6 @@
 # pylint: disable=C0103
 
 import gettext
-
 try:
     from urllib import ContentTooShortError
 except ImportError:
@@ -48,46 +46,38 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-CHECKSUM = ["sha1", "sha256", "sha384", "sha512"]
-
+CHECKSUM = ['sha1', 'sha256', 'sha384', 'sha512']
 
 def help_softwarechannel_list(self):
-    print(_("softwarechannel_list: List all available software channels"))
-    print(
-        _(
-            """usage: softwarechannel_list [options]')
+    print(_('softwarechannel_list: List all available software channels'))
+    print(_('''usage: softwarechannel_list [options]')
 options:
   -v verbose (display label and summary)
   -t tree view (pretty-print(child-channels))
-"""
-        )
-    )
+'''))
 
 
 def do_softwarechannel_list(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-v", "--verbose", action="store_true")
-    arg_parser.add_argument("-t", "--tree", action="store_true")
+    arg_parser.add_argument('-v', '--verbose', action='store_true')
+    arg_parser.add_argument('-t', '--tree', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
 
     if options.tree:
         labels = self.list_base_channels()
     else:
         channels = self.client.channel.listAllChannels(self.session)
-        labels = [c.get("label") for c in channels]
+        labels = [c.get('label') for c in channels]
 
     # filter the list if arguments were passed
     if args:
-        # pylint: disable-next=undefined-variable
         labels = filter_results(labels, args, True)
     if labels:
         labels = sorted(labels)
@@ -98,62 +88,43 @@ def do_softwarechannel_list(self, args, doreturn=False):
     elif labels:
         if options.verbose:
             for l in labels:
-                details = self.client.channel.software.getDetails(self.session, l)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (l, details["summary"]))
+                details = self.client.channel.software.getDetails(
+                    self.session, l)
+                print("%s : %s" % (l, details['summary']))
                 if options.tree:
                     for c in self.list_child_channels(parent=l):
                         cdetails = self.client.channel.software.getDetails(
-                            self.session, c
-                        )
-                        # pylint: disable-next=consider-using-f-string
-                        print(" |-%s : %s" % (c, cdetails["summary"]))
+                            self.session, c)
+                        print(" |-%s : %s" % (c, cdetails['summary']))
         else:
             for l in labels:
-                # pylint: disable-next=consider-using-f-string
                 print("%s" % l)
                 if options.tree:
                     for c in self.list_child_channels(parent=l):
-                        # pylint: disable-next=consider-using-f-string
                         print(" |-%s" % c)
 
     return None
-
 
 ####################
 
 
 def help_softwarechannel_listmanageablechannels(self):
-    print(_("softwarechannel_listmanageablechannels: List all software channels"))
-    print(_("                                        manageable by current user"))
-    print(
-        _(
-            """usage: softwarechannel_listmanageablechannels [options]
+    print(_('softwarechannel_listmanageablechannels: List all software channels'))
+    print(_('                                        manageable by current user'))
+    print(_('''usage: softwarechannel_listmanageablechannels [options]
 options:
-  -v verbose (display label and summary)"""
-        )
-    )
+  -v verbose (display label and summary)'''))
 
 
 def do_softwarechannel_listmanageablechannels(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-v", "--verbose", action="store_true")
+    arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
-    labels = list(
-        sorted(
-            [
-                c.get("label")
-                for c in self.client.channel.listManageableChannels(self.session)
-            ]
-        )
-    )
+    labels = list(sorted([c.get('label') for c in self.client.channel.listManageableChannels(self.session)]))
 
     # filter the list if arguments were passed
     if args:
-        # pylint: disable-next=undefined-variable
         labels = filter_results(labels, args, True)
 
     if doreturn:
@@ -163,215 +134,166 @@ def do_softwarechannel_listmanageablechannels(self, args, doreturn=False):
         if options.verbose:
             for l in labels:
                 details = self.client.channel.software.getDetails(self.session, l)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (l, details["summary"]))
+                print("%s : %s" % (l, details['summary']))
         else:
             for l in labels:
-                # pylint: disable-next=consider-using-f-string
                 print("%s" % l)
 
     return None
-
 
 ####################
 
 
 def help_softwarechannel_listbasechannels(self):
-    print(_("softwarechannel_listbasechannels: List all base software channels"))
-    print(
-        _(
-            """usage: softwarechannel_listbasechannels [options])
+    print(_('softwarechannel_listbasechannels: List all base software channels'))
+    print(_('''usage: softwarechannel_listbasechannels [options])
 options:
-  -v verbose (display label and summary)"""
-        )
-    )
+  -v verbose (display label and summary)'''))
 
 
 def do_softwarechannel_listbasechannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-v", "--verbose", action="store_true")
+    arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     channels = self.list_base_channels()
 
     if channels:
-        if options.verbose:
+        if (options.verbose):
             for c in sorted(channels):
-                details = self.client.channel.software.getDetails(self.session, c)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (c, details["summary"]))
+                details = \
+                    self.client.channel.software.getDetails(self.session, c)
+                print("%s : %s" % (c, details['summary']))
         else:
-            print("\n".join(sorted(channels)))
+            print('\n'.join(sorted(channels)))
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_listchildchannels(self):
-    print(_("softwarechannel_listchildchannels: List child software channels"))
-    print(_("usage:"))
-    print(_("softwarechannel_listchildchannels [options]"))
-    print(_("softwarechannel_listchildchannels : List all child channels"))
-    print(
-        _(
-            "softwarechannel_listchildchannels CHANNEL : List children for a"
-            + "specific base channel"
-        )
-    )
-    print(_("options:\n -v verbose (display label and summary)"))
+    print(_('softwarechannel_listchildchannels: List child software channels'))
+    print(_('usage:'))
+    print(_('softwarechannel_listchildchannels [options]'))
+    print(_('softwarechannel_listchildchannels : List all child channels'))
+    print(_('softwarechannel_listchildchannels CHANNEL : List children for a' +
+            'specific base channel'))
+    print(_('options:\n -v verbose (display label and summary)'))
 
 
 def do_softwarechannel_listchildchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-v", "--verbose", action="store_true")
+    arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     args, options = parse_command_arguments(args, arg_parser)
-    channels = sorted(
-        self.list_child_channels()
-        if not args
-        else self.list_child_channels(parent=args[0])
-    )
+    channels = sorted(self.list_child_channels() if not args else self.list_child_channels(parent=args[0]))
 
     if channels:
         if options.verbose:
             for c in channels:
                 details = self.client.channel.software.getDetails(self.session, c)
-                # pylint: disable-next=consider-using-f-string
-                print("%s : %s" % (c, details["summary"]))
+                print("%s : %s" % (c, details['summary']))
         else:
-            print("\n".join(channels))
+            print('\n'.join(channels))
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_listsystems(self):
-    print(_("softwarechannel_listsystems: List all systems subscribed to"))
-    print(_("                             a software channel"))
-    print(_("usage: softwarechannel_listsystems CHANNEL"))
+    print(_('softwarechannel_listsystems: List all systems subscribed to'))
+    print(_('                             a software channel'))
+    print(_('usage: softwarechannel_listsystems CHANNEL'))
 
 
 def complete_softwarechannel_listsystems(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_listsystems(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable,unused-variable
     args, _options = parse_command_arguments(args, get_argument_parser())
 
     if len(args) != 1:
         self.help_softwarechannel_listsystems()
         return None
 
-    systems = sorted(
-        [
-            s.get("name")
-            for s in self.client.channel.software.listSubscribedSystems(
-                self.session, args[0]
-            )
-        ]
-    )
+    systems = sorted([s.get('name') for s in self.client.channel.software.listSubscribedSystems(self.session, args[0])])
 
     if doreturn:
         return systems
     if systems:
-        print("\n".join(systems))
+        print('\n'.join(systems))
 
     return None
-
 
 ####################
 
 
 def help_softwarechannel_listpackages(self):
-    print(_("softwarechannel_listpackages: List the most recent packages"))
-    print(_("                              available from a software channel"))
-    print(_("usage: softwarechannel_listpackages CHANNEL"))
+    print(_('softwarechannel_listpackages: List the most recent packages'))
+    print(_('                              available from a software channel'))
+    print(_('usage: softwarechannel_listpackages CHANNEL'))
 
 
 def complete_softwarechannel_listpackages(self, text, line, beg, end):
-    if len(line.split(" ")) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+    if len(line.split(' ')) == 2:
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
 
     return []
 
 
 def do_softwarechannel_listpackages(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     args, _ = parse_command_arguments(args, get_argument_parser())
 
     if len(args) != 1:
         self.help_softwarechannel_listpackages()
         return None
 
-    packages = list(
-        sorted(
-            # pylint: disable-next=undefined-variable
-            build_package_names(
-                self.client.channel.software.listLatestPackages(self.session, args[0])
-            )
-        )
-    )
+    packages = list(sorted(build_package_names(
+        self.client.channel.software.listLatestPackages(self.session, args[0]))))
 
     if doreturn:
         return packages
     if packages:
-        print("\n".join(packages))
+        print('\n'.join(packages))
 
     return None
-
 
 ####################
 
 
 def help_softwarechannel_listallpackages(self):
-    print(_("softwarechannel_listallpackages: List all packages in a channel"))
-    print(_("usage: softwarechannel_listallpackages CHANNEL"))
+    print(_('softwarechannel_listallpackages: List all packages in a channel'))
+    print(_('usage: softwarechannel_listallpackages CHANNEL'))
 
 
 def complete_softwarechannel_listallpackages(self, text, line, beg, end):
-    if len(line.split(" ")) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+    if len(line.split(' ')) == 2:
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
 
     return []
 
 
 def do_softwarechannel_listallpackages(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     args, _ = parse_command_arguments(args, get_argument_parser())
 
     if len(args) != 1:
         self.help_softwarechannel_listallpackages()
         return None
 
-    packages = list(
-        sorted(
-            # pylint: disable-next=undefined-variable
-            build_package_names(
-                self.client.channel.software.listAllPackages(self.session, args[0])
-            )
-        )
-    )
+    packages = list(sorted(build_package_names(self.client.channel.software.listAllPackages(self.session, args[0]))))
 
     if doreturn:
         return packages
     if packages:
-        print("\n".join(packages))
+        print('\n'.join(packages))
 
     return None
-
 
 ####################
 
@@ -385,12 +307,11 @@ def filter_latest_packages(pkglist):
     # for each arch.  This approach avoids nested loops :)
     latest = {}
     for p in pkglist:
-        tuplekey = p["name"], p.get("arch_label", p.get("arch"))
+        tuplekey = p['name'], p.get('arch_label', p.get("arch"))
         if tuplekey not in latest:
             latest[tuplekey] = p
         else:
             # Already have this package, is p newer?
-            # pylint: disable-next=undefined-variable
             if p == latest_pkg(p, latest[tuplekey]):
                 latest[tuplekey] = p
 
@@ -399,61 +320,41 @@ def filter_latest_packages(pkglist):
 
 
 def help_softwarechannel_listlatestpackages(self):
-    print(
-        _(
-            "softwarechannel_listlatestpackages: List the newest version of all packages in a channel"
-        )
-    )
-    print(_("usage: softwarechannel_listlatestpackages CHANNEL"))
+    print(_('softwarechannel_listlatestpackages: List the newest version of all packages in a channel'))
+    print(_('usage: softwarechannel_listlatestpackages CHANNEL'))
 
 
 def complete_softwarechannel_listlatestpackages(self, text, line, beg, end):
-    if len(line.split(" ")) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+    if len(line.split(' ')) == 2:
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
 
     return []
 
 
 def do_softwarechannel_listlatestpackages(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     args, _ = parse_command_arguments(args, get_argument_parser())
 
     if len(args) != 1:
         self.help_softwarechannel_listlatestpackages()
         return None
 
-    packages = list(
-        sorted(
-            # pylint: disable-next=undefined-variable
-            build_package_names(
-                list(
-                    filter_latest_packages(
-                        self.client.channel.software.listAllPackages(
-                            self.session, args[0]
-                        )
-                    )
-                )
-            )
-        )
-    )
+    packages = list(sorted(build_package_names(list(filter_latest_packages(
+        self.client.channel.software.listAllPackages(self.session, args[0]))))))
 
     if doreturn:
         return packages
     if packages:
-        print("\n".join(packages))
+        print('\n'.join(packages))
 
     return None
-
 
 ####################
 
 
 def help_softwarechannel_setdetails(self):
-    print(_("softwarechannel_setdetails: Modify details of a software channel"))
-    print(
-        _(
-            """usage: softwarechannel_setdetails [options] <CHANNEL ...>)
+    print(_('softwarechannel_setdetails: Modify details of a software channel'))
+    print(_('''usage: softwarechannel_setdetails [options] <CHANNEL ...>)
 
 options, at least one of which must be given:
   -n NAME
@@ -465,33 +366,27 @@ options, at least one of which must be given:
   -p MAINTAINER_PHONE
   -u GPG_URL
   -i GPG_ID
-  -f GPG_FINGERPRINT"""
-        )
-        % CHECKSUM
-    )
+  -f GPG_FINGERPRINT''') % CHECKSUM)
 
 
 def complete_softwarechannel_setdetails(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_setdetails(self, args):
     # pylint: disable=R0911
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-s", "--summary")
-    arg_parser.add_argument("-d", "--description")
-    arg_parser.add_argument("-c", "--checksum")
-    arg_parser.add_argument("-m", "--maintainer_name")
-    arg_parser.add_argument("-e", "--maintainer_email")
-    arg_parser.add_argument("-p", "--maintainer_phone")
-    arg_parser.add_argument("-u", "--gpg_url")
-    arg_parser.add_argument("-i", "--gpg_id")
-    arg_parser.add_argument("-f", "--gpg_fingerprint")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-s', '--summary')
+    arg_parser.add_argument('-d', '--description')
+    arg_parser.add_argument('-c', '--checksum')
+    arg_parser.add_argument('-m', '--maintainer_name')
+    arg_parser.add_argument('-e', '--maintainer_email')
+    arg_parser.add_argument('-p', '--maintainer_phone')
+    arg_parser.add_argument('-u', '--gpg_url')
+    arg_parser.add_argument('-i', '--gpg_id')
+    arg_parser.add_argument('-f', '--gpg_fingerprint')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -500,37 +395,34 @@ def do_softwarechannel_setdetails(self, args):
 
     new_details = {}
     if options.name:
-        new_details["name"] = options.name
+        new_details['name'] = options.name
     if options.summary:
-        new_details["summary"] = options.summary
+        new_details['summary'] = options.summary
     if options.description:
-        new_details["description"] = options.description
+        new_details['description'] = options.description
     if options.checksum:
-        new_details["checksum_label"] = options.checksum
+        new_details['checksum_label'] = options.checksum
     if options.maintainer_name:
-        new_details["maintainer_name"] = options.maintainer_name
+        new_details['maintainer_name'] = options.maintainer_name
     if options.maintainer_email:
-        new_details["maintainer_email"] = options.maintainer_email
+        new_details['maintainer_email'] = options.maintainer_email
     if options.maintainer_phone:
-        new_details["maintainer_phone"] = options.maintainer_phone
+        new_details['maintainer_phone'] = options.maintainer_phone
     if options.gpg_url:
-        new_details["gpg_key_url"] = options.gpg_url
+        new_details['gpg_key_url'] = options.gpg_url
     if options.gpg_id:
-        new_details["gpg_key_id"] = options.gpg_id
+        new_details['gpg_key_id'] = options.gpg_id
     if options.gpg_fingerprint:
-        new_details["gpg_key_fp"] = options.gpg_fingerprint
+        new_details['gpg_key_fp'] = options.gpg_fingerprint
 
     if not new_details:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("At least one attribute to set must be given"))
+        logging.error(_N('At least one attribute to set must be given'))
         return 1
 
     # allow globbing of software channel names
-    # pylint: disable-next=undefined-variable
-    channels = filter_results(self.do_softwarechannel_list("", True), args)
+    channels = filter_results(self.do_softwarechannel_list('', True), args)
     if len(channels) < 1:
-        # pylint: disable-next=undefined-variable
-        logging.info(_N("No channels matching that label"))
+        logging.info(_N('No channels matching that label'))
         return 1
 
     # channel names must be unique, so if we are asked to set it,
@@ -540,109 +432,93 @@ def do_softwarechannel_setdetails(self, args):
     # second: check if there's any other channel already using this name.
     # Not reusing softwarechannel_check_existing() here because it
     # also fails on same label.
-    if new_details.get("name"):
+    if new_details.get('name'):
         if len(channels) > 1:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N("Setting same name for more than " + "one channel will fail")
-            )
+            logging.error(_N('Setting same name for more than ' + \
+                          'one channel will fail'))
             return 1
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug('checking other channels for name "%s"' % new_details.get("name"))
+        logging.debug('checking other channels for name "%s"' %
+                      new_details.get('name'))
         for c in self.list_base_channels() + self.list_child_channels():
             cd = self.client.channel.software.getDetails(self.session, c)
-            if cd.get("name") == new_details.get("name"):
-                # pylint: disable-next=undefined-variable
-                logging.error(
-                    _N('Name "%s" already in use by channel %s')
-                    % (cd.get("name"), cd.get("label"))
-                )
+            if cd.get('name') == new_details.get('name'):
+                logging.error(_N('Name "%s" already in use by channel %s') %
+                              (cd.get('name'), cd.get('label')))
                 return 1
 
     # get confirmation
-    print(_("Setting following attributes..."))
-    print("")
-    if new_details.get("name"):
-        print(_("Name:             %s") % new_details.get("name"))
-    if new_details.get("summary"):
-        print(_("Summary:          %s") % new_details.get("summary"))
-    if new_details.get("description"):
-        print(_("Description:      %s") % new_details.get("description"))
-    if new_details.get("checksum_label"):
-        print(_("Checksum:         %s") % new_details.get("checksum_label"))
-    if new_details.get("maintainer_name"):
-        print(_("Maintainer name:  %s") % new_details.get("maintainer_name"))
-    if new_details.get("maintainer_email"):
-        print(_("Maintainer email: %s") % new_details.get("maintainer_email"))
-    if new_details.get("maintainer_phone"):
-        print(_("Maintainer phone: %s") % new_details.get("maintainer_phone"))
-    if new_details.get("gpg_key_id"):
-        print(_("GPG Key:          %s") % new_details.get("gpg_key_id"))
-    if new_details.get("gpg_key_fp"):
-        print(_("GPG Fingerprint:  %s") % new_details.get("gpg_key_fp"))
-    if new_details.get("gpg_key_url"):
-        print(_("GPG URL:          %s") % new_details.get("gpg_key_url"))
-    print("")
-    print(_("... for the following channels:"))
-    print("\n".join(channels))
-    print("")
-    if not self.user_confirm(_("Apply? [y/N]:")):
+    print(_('Setting following attributes...'))
+    print('')
+    if new_details.get('name'):
+        print(_('Name:             %s') % new_details.get('name'))
+    if new_details.get('summary'):
+        print(_('Summary:          %s') % new_details.get('summary'))
+    if new_details.get('description'):
+        print(_('Description:      %s') % new_details.get('description'))
+    if new_details.get('checksum_label'):
+        print(_('Checksum:         %s') % new_details.get('checksum_label'))
+    if new_details.get('maintainer_name'):
+        print(_('Maintainer name:  %s') % new_details.get('maintainer_name'))
+    if new_details.get('maintainer_email'):
+        print(_('Maintainer email: %s') % new_details.get('maintainer_email'))
+    if new_details.get('maintainer_phone'):
+        print(_('Maintainer phone: %s') % new_details.get('maintainer_phone'))
+    if new_details.get('gpg_key_id'):
+        print(_('GPG Key:          %s') % new_details.get('gpg_key_id'))
+    if new_details.get('gpg_key_fp'):
+        print(_('GPG Fingerprint:  %s') % new_details.get('gpg_key_fp'))
+    if new_details.get('gpg_key_url'):
+        print(_('GPG URL:          %s') % new_details.get('gpg_key_url'))
+    print('')
+    print(_('... for the following channels:'))
+    print('\n'.join(channels))
+    print('')
+    if not self.user_confirm(_('Apply? [y/N]:')):
         return 1
 
-    # pylint: disable-next=undefined-variable
-    logging.debug("new channel details dictionary:")
-    # pylint: disable-next=undefined-variable
+    logging.debug('new channel details dictionary:')
     logging.debug(new_details)
     num_changed = 0
     for channel in channels:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("getting ID for channel %s" % channel)
+        logging.debug('getting ID for channel %s' % channel)
         try:
-            details = self.client.channel.software.getDetails(self.session, channel)
+            details = self.client.channel.software.getDetails(self.session,
+                                                              channel)
         except xmlrpclib.Fault as e:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Could not get details for %s") % channel)
-            # pylint: disable-next=undefined-variable
+            logging.error(_N('Could not get details for %s') % channel)
             logging.error(e)
             return 1
-        channel_id = details.get("id")
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("setting details for channel %s (%d)" % (channel, channel_id))
+        channel_id = details.get('id')
+        logging.debug('setting details for channel %s (%d)' % (channel,
+                                                               channel_id))
         try:
-            self.client.channel.software.setDetails(
-                self.session, channel_id, new_details
-            )
+            self.client.channel.software.setDetails(self.session,
+                                                    channel_id,
+                                                    new_details)
             num_changed += 1
         except xmlrpclib.Fault as e:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Error while setting details for %s") % channel)
-            # pylint: disable-next=undefined-variable
+            logging.error(_N('Error while setting details for %s') % channel)
             logging.error(e)
             return 1
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Channels changed: %d") % num_changed)
+    logging.info(_N('Channels changed: %d') % num_changed)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_details(self):
-    print(_("softwarechannel_details: Show the details of a software channel"))
-    print(_("usage: softwarechannel_details <CHANNEL ...>"))
+    print(_('softwarechannel_details: Show the details of a software channel'))
+    print(_('usage: softwarechannel_details <CHANNEL ...>'))
 
 
 def complete_softwarechannel_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -650,93 +526,86 @@ def do_softwarechannel_details(self, args):
         return 1
 
     # allow globbing of software channel names
-    # pylint: disable-next=undefined-variable
-    channels = filter_results(self.do_softwarechannel_list("", True), args)
+    channels = filter_results(self.do_softwarechannel_list('', True), args)
 
     add_separator = False
 
     for channel in channels:
-        details = self.client.channel.software.getDetails(self.session, channel)
+        details = self.client.channel.software.getDetails(
+            self.session, channel)
 
-        systems = self.client.channel.software.listSubscribedSystems(
-            self.session, channel
-        )
+        systems = \
+            self.client.channel.software.listSubscribedSystems(
+                self.session, channel)
 
-        trees = self.client.kickstart.tree.list(self.session, channel)
+        trees = self.client.kickstart.tree.list(self.session,
+                                                channel)
 
-        packages = self.client.channel.software.listAllPackages(self.session, channel)
+        packages = \
+            self.client.channel.software.listAllPackages(
+                self.session, channel)
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("Label:              %s") % details.get("label"))
-        print(_("Name:               %s") % details.get("name"))
-        print(_("Architecture:       %s") % details.get("arch_name"))
-        print(_("Parent:             %s") % details.get("parent_channel_label"))
-        print(_("Systems Subscribed: %s") % len(systems))
-        print(_("Number of Packages: %i") % len(packages))
+        print(_('Label:              %s') % details.get('label'))
+        print(_('Name:               %s') % details.get('name'))
+        print(_('Architecture:       %s') % details.get('arch_name'))
+        print(_('Parent:             %s') % details.get('parent_channel_label'))
+        print(_('Systems Subscribed: %s') % len(systems))
+        print(_('Number of Packages: %i') % len(packages))
 
-        if details.get("summary"):
-            print("")
-            print(_("Summary"))
-            print("-------")
-            # pylint: disable-next=undefined-variable
-            print("\n".join(wrap(details.get("summary"))))
+        if details.get('summary'):
+            print('')
+            print(_('Summary'))
+            print('-------')
+            print('\n'.join(wrap(details.get('summary'))))
 
-        if details.get("description"):
-            print("")
-            print(_("Description"))
-            print("-----------")
-            # pylint: disable-next=undefined-variable
-            print("\n".join(wrap(details.get("description"))))
+        if details.get('description'):
+            print('')
+            print(_('Description'))
+            print('-----------')
+            print('\n'.join(wrap(details.get('description'))))
 
-        print("")
-        print(_("GPG Key:            %s") % details.get("gpg_key_id"))
-        print(_("GPG Fingerprint:    %s") % details.get("gpg_key_fp"))
-        print(_("GPG URL:            %s") % details.get("gpg_key_url"))
-        print(_("GPG CHECK:          %s") % details.get("gpg_check"))
+        print('')
+        print(_('GPG Key:            %s') % details.get('gpg_key_id'))
+        print(_('GPG Fingerprint:    %s') % details.get('gpg_key_fp'))
+        print(_('GPG URL:            %s') % details.get('gpg_key_url'))
+        print(_('GPG CHECK:          %s') % details.get('gpg_check'))
 
         if trees:
-            print("")
-            print(_("Kickstart Trees"))
-            print("---------------")
+            print('')
+            print(_('Kickstart Trees'))
+            print('---------------')
             for tree in trees:
-                print(tree.get("label"))
+                print(tree.get('label'))
 
-        if details.get("contentSources"):
-            print("")
-            print(_("Repos"))
-            print("-----")
-            for repo in details.get("contentSources"):
-                print(repo.get("label"))
+        if details.get('contentSources'):
+            print('')
+            print(_('Repos'))
+            print('-----')
+            for repo in details.get('contentSources'):
+                print(repo.get('label'))
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_listerrata(self):
-    print(_("softwarechannel_listerrata: List the errata associated with a"))
-    print(_("                            software channel"))
-    print(
-        _(
-            "usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
-        )
-    )
+    print(_('softwarechannel_listerrata: List the errata associated with a'))
+    print(_('                            software channel'))
+    print(_('usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]'))
 
 
 def complete_softwarechannel_listerrata(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_listerrata(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -749,10 +618,10 @@ def do_softwarechannel_listerrata(self, args):
     # iterate over args and alter a copy of it (channels)
     channels = args[:]
     for arg in args:
-        if arg[:5] == "from=":
+        if arg[:5] == 'from=':
             begin_date = arg[5:]
             channels.remove(arg)
-        elif arg[:3] == "to=":
+        elif arg[:3] == 'to=':
             end_date = arg[3:]
             channels.remove(arg)
 
@@ -760,29 +629,20 @@ def do_softwarechannel_listerrata(self, args):
 
     for channel in sorted(channels):
         if len(channels) > 1:
-            print(_("Channel: %s") % channel)
-            print("")
+            print(_('Channel: %s') % channel)
+            print('')
 
         if begin_date and end_date:
-            errata = self.client.channel.software.listErrata(
-                self.session,
-                channel,
-                # pylint: disable-next=undefined-variable
-                parse_time_input(begin_date),
-                # pylint: disable-next=undefined-variable
-                parse_time_input(end_date),
-            )
+            errata = self.client.channel.software.listErrata(self.session,
+                                                             channel, parse_time_input(begin_date),
+                                                             parse_time_input(end_date))
         elif begin_date:
-            errata = self.client.channel.software.listErrata(
-                self.session,
-                channel,
-                # pylint: disable-next=undefined-variable
-                parse_time_input(begin_date),
-            )
+            errata = self.client.channel.software.listErrata(self.session,
+                                                             channel, parse_time_input(begin_date))
         else:
-            errata = self.client.channel.software.listErrata(self.session, channel)
+            errata = self.client.channel.software.listErrata(self.session,
+                                                             channel)
 
-        # pylint: disable-next=undefined-variable
         print_errata_list(errata)
 
         if add_separator:
@@ -791,9 +651,7 @@ def do_softwarechannel_listerrata(self, args):
 
     return 0
 
-
 ####################
-
 
 def help_softwarechannel_listarches(self):
     print(_("softwarechannel_listarches: lists the potential software"))
@@ -802,46 +660,36 @@ def help_softwarechannel_listarches(self):
     print(_("options:"))
     print(_("    -v verbose (display label and name)"))
 
-
 def do_softwarechannel_listarches(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-v", "--verbose", action="store_true")
+    arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     arches = self.client.channel.software.listArches(self.session)
 
     for arch in sorted(arches):
-        if options.verbose:
-            # pylint: disable-next=consider-using-f-string
+        if (options.verbose):
             print("%s (%s)" % (arch["label"], arch["name"]))
         else:
-            # pylint: disable-next=consider-using-f-string
             print("%s" % arch["label"])
 
     return 0
 
-
 ####################
 
-
 def help_softwarechannel_delete(self):
-    print(_("softwarechannel_delete: Delete a software channel"))
-    print(_("usage: softwarechannel_delete <CHANNEL ...>"))
+    print(_('softwarechannel_delete: Delete a software channel'))
+    print(_('usage: softwarechannel_delete <CHANNEL ...>'))
 
 
 def complete_softwarechannel_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -851,17 +699,17 @@ def do_softwarechannel_delete(self, args):
     channels = args
 
     # find all matching channels
-    # pylint: disable-next=undefined-variable
-    to_delete = filter_results(self.do_softwarechannel_list("", True), channels)
+    to_delete = filter_results(
+        self.do_softwarechannel_list('', True), channels)
 
     if not to_delete:
         return 1
 
-    print(_("Channels"))
-    print("--------")
-    print("\n".join(sorted(to_delete)))
+    print(_('Channels'))
+    print('--------')
+    print('\n'.join(sorted(to_delete)))
 
-    if not self.user_confirm(_("Delete these channels [y/N]:")):
+    if not self.user_confirm(_('Delete these channels [y/N]:')):
         return 1
 
     # delete child channels first to avoid errors
@@ -871,26 +719,22 @@ def do_softwarechannel_delete(self, args):
     all_channels = self.client.channel.listSoftwareChannels(self.session)
 
     for channel in all_channels:
-        if channel.get("label") in to_delete:
-            if channel.get("parent_label"):
-                children.append(channel.get("label"))
+        if channel.get('label') in to_delete:
+            if channel.get('parent_label'):
+                children.append(channel.get('label'))
             else:
-                parents.append(channel.get("label"))
+                parents.append(channel.get('label'))
 
     for channel in children + parents:
         self.client.channel.software.delete(self.session, channel)
 
     return 0
 
-
 ####################
 
-
 def help_softwarechannel_update(self):
-    print(_("softwarechannel_update: Update a software channel"))
-    print(
-        _(
-            """usage: softwarechannel_update LABEL(To identify the channel) [options]
+    print(_('softwarechannel_update: Update a software channel'))
+    print(_('''usage: softwarechannel_update LABEL(To identify the channel) [options]
 options:
   -l LABEL(Required)
   -n NAME
@@ -900,147 +744,126 @@ options:
   -u GPG-URL
   -i GPG-ID
   -f GPG-FINGERPRINT
-  -g DISABLE-GPG-CHECK"""
-            % CHECKSUM
-        )
-    )
+  -g DISABLE-GPG-CHECK''' % CHECKSUM))
 
 
 def do_softwarechannel_update(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-l", "--label")
-    arg_parser.add_argument("-s", "--summary")
-    arg_parser.add_argument("-d", "--description")
-    arg_parser.add_argument("-c", "--checksum")
-    arg_parser.add_argument("-u", "--gpg_url")
-    arg_parser.add_argument("-i", "--gpg_id")
-    arg_parser.add_argument("-f", "--gpg_fingerprint")
-    arg_parser.add_argument("-g", "--disable_gpg_check")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-l', '--label')
+    arg_parser.add_argument('-s', '--summary')
+    arg_parser.add_argument('-d', '--description')
+    arg_parser.add_argument('-c', '--checksum')
+    arg_parser.add_argument('-u', '--gpg_url')
+    arg_parser.add_argument('-i', '--gpg_id')
+    arg_parser.add_argument('-f', '--gpg_fingerprint')
+    arg_parser.add_argument('-g', '--disable_gpg_check')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     vendor_channel = False
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.label = prompt_user(_("Channel Label:"), noblank=True)
-        # pylint: disable-next=undefined-variable
+
+        options.label = prompt_user(_('Channel Label:'), noblank=True)
         vendor_channel = is_vendor_channel(self, options.label)
 
         if not vendor_channel:
-            print("")
-            print(_("New Name (blank to keep unchanged)"))
-            print("------------")
-            print("")
-            # pylint: disable-next=undefined-variable
-            options.name = prompt_user(_("Name:"))
+            print('')
+            print(_('New Name (blank to keep unchanged)'))
+            print('------------')
+            print('')
+            options.name = prompt_user(_('Name:'))
 
-            print("")
-            print(_("New Summary (blank to keep unchanged)"))
-            print("------------")
-            print("")
-            # pylint: disable-next=undefined-variable
-            options.summary = prompt_user(_("Summary:"))
+            print('')
+            print(_('New Summary (blank to keep unchanged)'))
+            print('------------')
+            print('')
+            options.summary = prompt_user(_('Summary:'))
 
-            print("")
-            print(_("New Description (blank to keep unchanged)"))
-            print("------------")
-            print("")
-            # pylint: disable-next=undefined-variable
-            options.description = prompt_user(_("Description:"))
+            print('')
+            print(_('New Description (blank to keep unchanged)'))
+            print('------------')
+            print('')
+            options.description = prompt_user(_('Description:'))
 
-            print("")
-            print(_("New Checksum type (blank to keep unchanged)"))
-            print("------------")
-            print("\n".join(sorted(self.CHECKSUM)))
-            print("")
-            # pylint: disable-next=undefined-variable
-            options.checksum = prompt_user(_("Select:"))
+            print('')
+            print(_('New Checksum type (blank to keep unchanged)'))
+            print('------------')
+            print('\n'.join(sorted(self.CHECKSUM)))
+            print('')
+            options.checksum = prompt_user(_('Select:'))
 
-            print("")
-            print(_("New GPG URL (blank to keep unchanged)"))
-            print("------------")
-            print("")
-            # pylint: disable-next=undefined-variable
-            options.gpg_url = prompt_user(_("GPG URL:"))
+            print('')
+            print(_('New GPG URL (blank to keep unchanged)'))
+            print('------------')
+            print('')
+            options.gpg_url = prompt_user(_('GPG URL:'))
 
-            print("")
-            print(_("New GPG ID (blank to keep unchanged)"))
-            print("------------")
-            print("")
-            # pylint: disable-next=undefined-variable
-            options.gpg_id = prompt_user(_("GPG ID:"))
+            print('')
+            print(_('New GPG ID (blank to keep unchanged)'))
+            print('------------')
+            print('')
+            options.gpg_id = prompt_user(_('GPG ID:'))
 
-            print("")
-            print(_("New GPG Fingerprint (blank to keep unchanged)"))
-            print("------------")
-            print("")
-            # pylint: disable-next=undefined-variable
-            options.gpg_fingerprint = prompt_user(_("GPG Fingerprint:"))
+            print('')
+            print(_('New GPG Fingerprint (blank to keep unchanged)'))
+            print('------------')
+            print('')
+            options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
 
-        print("")
-        print(_("Disable GPG CHECK (blank to keep unchanged)"))
-        print("------------")
-        print("")
-        # pylint: disable-next=undefined-variable
-        options.disable_gpg_check = prompt_user(_("Disable GPG Check [yes/no]? "))
+        print('')
+        print(_('Disable GPG CHECK (blank to keep unchanged)'))
+        print('------------')
+        print('')
+        options.disable_gpg_check = prompt_user(_('Disable GPG Check [yes/no]? '))
 
     if not options.label:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("A channel label is required to identify the channel"))
+        logging.error(_N('A channel label is required to identify the channel'))
         return 1
-    if options.disable_gpg_check and options.disable_gpg_check not in ("yes", "no"):
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Only [yes/no] values are acceptable for --disable_gpg_check"))
+    if options.disable_gpg_check and options.disable_gpg_check not in ('yes','no'):
+        logging.error(_N('Only [yes/no] values are acceptable for --disable_gpg_check'))
         return 1
     details = {}
     if not vendor_channel:
-        # pylint: disable-next=undefined-variable
         vendor_channel = is_vendor_channel(self, options.label)
 
     if options.name:
-        details["name"] = options.name
+        details['name'] = options.name
 
     if options.summary:
-        details["summary"] = options.summary
+        details['summary'] = options.summary
 
     if options.description:
-        details["description"] = options.description
+        details['description'] = options.description
 
     if options.checksum:
-        details["checksum_label"] = options.checksum
+        details['checksum_label'] = options.checksum
 
     if options.gpg_id:
-        details["gpg_key_id"] = options.gpg_id
+        details['gpg_key_id'] = options.gpg_id
 
     if options.gpg_url:
-        details["gpg_key_url"] = options.gpg_url
+        details['gpg_key_url'] = options.gpg_url
 
     if options.gpg_fingerprint:
-        details["gpg_key_fp"] = options.gpg_fingerprint
+        details['gpg_key_fp'] = options.gpg_fingerprint
 
     if options.disable_gpg_check:
-        details["gpg_check"] = str(not options.disable_gpg_check.lower() == "yes")
+        details['gpg_check'] = str(not options.disable_gpg_check.lower() == "yes")
 
-    details["vendor_channel"] = str(vendor_channel)
+    details['vendor_channel'] = str(vendor_channel)
 
     self.client.channel.software.setDetails(self.session, options.label, details)
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_create(self):
-    print(_("softwarechannel_create: Create a software channel"))
-    print(
-        _(
-            """usage: softwarechannel_create [options])
+    print(_('softwarechannel_create: Create a software channel'))
+    print(_('''usage: softwarechannel_create [options])
 
 options:
   -n NAME
@@ -1052,113 +875,87 @@ options:
   -u GPG_URL
   -i GPG_ID
   -f GPG_FINGERPRINT
-  -g DISABLE_GPG_CHECK"""
-            % CHECKSUM
-        )
-    )
+  -g DISABLE_GPG_CHECK''' % CHECKSUM))
 
 
 def do_softwarechannel_create(self, args):
     arches = self.client.channel.software.listArches(self.session)
-    self.ARCH_LABELS = [x["label"].replace("channel-", "") for x in arches]
-    # pylint: disable-next=undefined-variable
+    self.ARCH_LABELS = [x["label"].replace("channel-","") for x in arches]
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-l", "--label")
-    arg_parser.add_argument("-s", "--summary")
-    arg_parser.add_argument("-p", "--parent-channel")
-    arg_parser.add_argument("-a", "--arch")
-    arg_parser.add_argument("-c", "--checksum")
-    arg_parser.add_argument("-u", "--gpg_url")
-    arg_parser.add_argument("-i", "--gpg_id")
-    arg_parser.add_argument("-f", "--gpg_fingerprint")
-    arg_parser.add_argument("-g", "--disable_gpg_check", action="store_true")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-l', '--label')
+    arg_parser.add_argument('-s', '--summary')
+    arg_parser.add_argument('-p', '--parent-channel')
+    arg_parser.add_argument('-a', '--arch')
+    arg_parser.add_argument('-c', '--checksum')
+    arg_parser.add_argument('-u', '--gpg_url')
+    arg_parser.add_argument('-i', '--gpg_id')
+    arg_parser.add_argument('-f', '--gpg_fingerprint')
+    arg_parser.add_argument('-g', '--disable_gpg_check', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Channel Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.label = prompt_user(_("Channel Label:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.summary = prompt_user(_("Channel Summary:"), noblank=True)
+        options.name = prompt_user(_('Channel Name:'), noblank=True)
+        options.label = prompt_user(_('Channel Label:'), noblank=True)
+        options.summary = prompt_user(_('Channel Summary:'), noblank=True)
 
-        print(_("Base Channels"))
-        print("-------------")
-        print("\n".join(sorted(self.list_base_channels())))
-        print("")
+        print(_('Base Channels'))
+        print('-------------')
+        print('\n'.join(sorted(self.list_base_channels())))
+        print('')
 
-        # pylint: disable-next=undefined-variable
-        options.parent_channel = prompt_user(
-            _("Select Parent [blank to create a base channel]:")
-        )
+        options.parent_channel = \
+            prompt_user(_('Select Parent [blank to create a base channel]:'))
 
-        print("")
-        print(_("Architecture"))
-        print("------------")
-        print("\n".join(sorted(self.ARCH_LABELS)))
-        print("")
-        # pylint: disable-next=undefined-variable
-        options.arch = prompt_user(_("Select:"))
+        print('')
+        print(_('Architecture'))
+        print('------------')
+        print('\n'.join(sorted(self.ARCH_LABELS)))
+        print('')
+        options.arch = prompt_user(_('Select:'))
 
-        print("")
-        print(_("Checksum type"))
-        print("------------")
-        print("\n".join(sorted(self.CHECKSUM)))
-        print("")
-        # pylint: disable-next=undefined-variable
-        options.checksum = prompt_user(_("Select:"))
+        print('')
+        print(_('Checksum type'))
+        print('------------')
+        print('\n'.join(sorted(self.CHECKSUM)))
+        print('')
+        options.checksum = prompt_user(_('Select:'))
 
-        print("")
-        print(_("GPG URL"))
-        print("------------")
-        print("")
-        # pylint: disable-next=undefined-variable
-        options.gpg_url = prompt_user(_("GPG URL:"))
+        print('')
+        print(_('GPG URL'))
+        print('------------')
+        print('')
+        options.gpg_url = prompt_user(_('GPG URL:'))
 
-        print("")
-        print(_("GPG ID"))
-        print("------------")
-        print("")
-        # pylint: disable-next=undefined-variable
-        options.gpg_id = prompt_user(_("GPG ID:"))
+        print('')
+        print(_('GPG ID'))
+        print('------------')
+        print('')
+        options.gpg_id = prompt_user(_('GPG ID:'))
 
-        print("")
-        print(_("GPG Fingerprint"))
-        print("---------------")
-        print("")
-        # pylint: disable-next=undefined-variable
-        options.gpg_fingerprint = prompt_user(_("GPG Fingerprint:"))
+        print('')
+        print(_('GPG Fingerprint'))
+        print('---------------')
+        print('')
+        options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
 
-        print("")
-        print(_("GPG CHECK"))
-        print("---------------")
-        print("")
-        options.disable_gpg_check = self.user_confirm(
-            _("Disable GPG Check [y/N]? "), nospacer=True, ignore_yes=True
-        )
+        print('')
+        print(_('GPG CHECK'))
+        print('---------------')
+        print('')
+        options.disable_gpg_check = self.user_confirm(_('Disable GPG Check [y/N]? '),
+                                                      nospacer=True, ignore_yes=True)
 
     if validate_required_data(options):
         set_default_data(options)
         gpgData = get_gpg_data(options)
-        self.client.channel.software.create(
-            self.session,
-            options.label,
-            options.name,
-            options.summary,
-            # pylint: disable-next=consider-using-f-string
-            "channel-%s" % options.arch,
-            options.parent_channel,
-            options.checksum,
-            gpgData,
-            not options.disable_gpg_check,
-        )
+        self.client.channel.software.create(self.session, options.label, options.name, options.summary,
+                                            'channel-%s' % options.arch, options.parent_channel,
+                                            options.checksum, gpgData, not options.disable_gpg_check
+                                           )
 
     return 0
-
 
 ####################
 
@@ -1167,54 +964,46 @@ def get_gpg_data(options):
     gpgData = {}
 
     if options.gpg_url:
-        gpgData["url"] = options.gpg_url
+        gpgData['url'] = options.gpg_url
 
     if options.gpg_id:
-        gpgData["id"] = options.gpg_id
+        gpgData['id'] = options.gpg_id
 
     if options.gpg_fingerprint:
-        gpgData["fingerprint"] = options.gpg_fingerprint
+        gpgData['fingerprint'] = options.gpg_fingerprint
 
     return gpgData
-
-
 ####################
 
 
 def set_default_data(options):
     if not options.arch:
-        options.arch = "x86_64"
+        options.arch = 'x86_64'
 
     if not options.checksum:
-        options.checksum = "sha256"
+        options.checksum = 'sha256'
 
     if not options.parent_channel:
-        options.parent_channel = ""
+        options.parent_channel = ''
 
     # Summary is a required field,
     # but we don't want to break the interface
     # then if it is not provided it is set to the 'name' value
     if not options.summary:
         options.summary = options.name
-
-
 ####################
 
 
 def validate_required_data(options):
     if not options.name:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("A channel name is required"))
+        logging.error(_N('A channel name is required'))
         return False
 
     if not options.label:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("A channel label is required"))
+        logging.error(_N('A channel label is required'))
         return False
 
     return True
-
-
 ######################
 
 
@@ -1223,29 +1012,21 @@ def softwarechannel_check_existing(self, name, label):
     # descriptive xmlrpc error, but duplicate name results in ISE
     for c in self.list_base_channels() + self.list_child_channels():
         cd = self.client.channel.software.getDetails(self.session, c)
-        if cd["name"] == name:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N("Name %s already in use by channel %s") % (name, cd["label"])
-            )
+        if cd['name'] == name:
+            logging.error(_N("Name %s already in use by channel %s") %
+                          (name, cd['label']))
             return True
-        if cd["label"] == label:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N("Label %s already in use by channel %s") % (label, cd["label"])
-            )
+        if cd['label'] == label:
+            logging.error(_N("Label %s already in use by channel %s") %
+                          (label, cd['label']))
             return True
     return False
-
-
 ########################
 
 
 def help_softwarechannel_clone(self):
-    print(_("softwarechannel_clone: Clone a software channel"))
-    print(
-        _(
-            """usage: softwarechannel_clone [options])
+    print(_('softwarechannel_clone: Clone a software channel'))
+    print(_('''usage: softwarechannel_clone [options])
 
 options:
   -s SOURCE_CHANNEL
@@ -1259,116 +1040,95 @@ options:
   --disable-gpg-check DISABLE_GPG_CHECK
   -o do not clone any patches
   --regex/-x "s/foo/bar" : Optional regex replacement,
-        replaces foo with bar in the clone name and label"""
-        )
-    )
+        replaces foo with bar in the clone name and label'''))
 
 
 def do_softwarechannel_clone(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-l", "--label")
-    arg_parser.add_argument("-s", "--source-channel")
-    arg_parser.add_argument("-p", "--parent-channel")
-    arg_parser.add_argument("-x", "--regex")
-    arg_parser.add_argument("-o", "--original-state", action="store_true")
-    arg_parser.add_argument("-g", "--gpg-copy", action="store_true")
-    arg_parser.add_argument("--gpg-url")
-    arg_parser.add_argument("--gpg-id")
-    arg_parser.add_argument("--gpg-fingerprint")
-    arg_parser.add_argument("--disable-gpg-check")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-l', '--label')
+    arg_parser.add_argument('-s', '--source-channel')
+    arg_parser.add_argument('-p', '--parent-channel')
+    arg_parser.add_argument('-x', '--regex')
+    arg_parser.add_argument('-o', '--original-state', action='store_true')
+    arg_parser.add_argument('-g', '--gpg-copy', action='store_true')
+    arg_parser.add_argument('--gpg-url')
+    arg_parser.add_argument('--gpg-id')
+    arg_parser.add_argument('--gpg-fingerprint')
+    arg_parser.add_argument('--disable-gpg-check')
 
-    # pylint: disable-next=undefined-variable
+
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        print(_("Source Channels:"))
-        print("\n".join(sorted(self.list_base_channels())))
-        print("\n".join(sorted(self.list_child_channels())))
+        print(_('Source Channels:'))
+        print('\n'.join(sorted(self.list_base_channels())))
+        print('\n'.join(sorted(self.list_child_channels())))
 
-        # pylint: disable-next=undefined-variable
-        options.source_channel = prompt_user(_("Select source channel:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Channel Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.label = prompt_user(_("Channel Label:"), noblank=True)
+        options.source_channel = prompt_user(_('Select source channel:'),noblank=True)
+        options.name = prompt_user(_('Channel Name:'), noblank=True)
+        options.label = prompt_user(_('Channel Label:'), noblank=True)
 
-        print(_("Base Channels:"))
-        print("\n".join(sorted(self.list_base_channels())))
-        print("")
+        print(_('Base Channels:'))
+        print('\n'.join(sorted(self.list_base_channels())))
+        print('')
 
-        # pylint: disable-next=undefined-variable
-        options.parent_channel = prompt_user(
-            _("Select Parent [blank to create a base channel]:")
-        )
+        options.parent_channel = \
+            prompt_user(_('Select Parent [blank to create a base channel]:'))
 
-        options.gpg_copy = self.user_confirm(
-            _("Copy source channel GPG details? [y/N]:"), ignore_yes=True
-        )
+        options.gpg_copy = \
+            self.user_confirm(_('Copy source channel GPG details? [y/N]:'),
+                              ignore_yes=True)
         if not options.gpg_copy:
-            # pylint: disable-next=undefined-variable
-            options.gpg_url = prompt_user(_("GPG URL:"))
-            # pylint: disable-next=undefined-variable
-            options.gpg_id = prompt_user(_("GPG ID:"))
-            # pylint: disable-next=undefined-variable
-            options.gpg_fingerprint = prompt_user(_("GPG Fingerprint:"))
-            # pylint: disable-next=undefined-variable
-            options.disable_gpg_check = prompt_user(_("Disable GPG Check [yes/no]? "))
+            options.gpg_url = prompt_user(_('GPG URL:'))
+            options.gpg_id = prompt_user(_('GPG ID:'))
+            options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
+            options.disable_gpg_check = prompt_user(_('Disable GPG Check [yes/no]? '))
 
-        options.original_state = self.user_confirm(
-            _("Original State (No Errata) [y/N]:"), ignore_yes=True
-        )
+        options.original_state = \
+            self.user_confirm(_('Original State (No Errata) [y/N]:'),
+                              ignore_yes=True)
     else:
         if not options.source_channel:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A source channel is required"))
+            logging.error(_N('A source channel is required'))
             return 1
 
         if not options.name and not options.regex:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A channel name is required"))
+            logging.error(_N('A channel name is required'))
             return 1
 
         if not options.label and not options.regex:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A channel label is required"))
+            logging.error(_N('A channel label is required'))
             return 1
 
         if not options.original_state:
             options.original_state = False
 
         if options.regex:
-            newvalues = do_regx_replacement(self, options.source_channel, options)
-            options.label = newvalues["label"]
+            newvalues =do_regx_replacement(self,options.source_channel, options)
+            options.label = newvalues['label']
             if not options.name:
-                options.name = newvalues["name"]
+                options.name = newvalues['name']
 
-    if options.disable_gpg_check and options.disable_gpg_check not in ("yes", "no"):
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Only [yes/no] values are acceptable for --disable-gpg-check"))
+    if options.disable_gpg_check and options.disable_gpg_check not in ('yes', 'no'):
+        logging.error(_N('Only [yes/no] values are acceptable for --disable-gpg-check'))
         return 1
     if self.softwarechannel_check_existing(options.name, options.label):
         return 1
 
-    details = {"name": options.name, "label": options.label}
+    details = {'name': options.name, 'label': options.label}
     if options.parent_channel:
-        details["parent_label"] = options.parent_channel
+        details['parent_label'] = options.parent_channel
 
-    clone_channel(self, options.source_channel, options, details)
+    clone_channel(self,options.source_channel, options, details)
 
     return 0
 
 
 ####################
 def help_softwarechannel_clonetree(self):
-    print(
-        _("softwarechannel_clonetree: Clone a software channel and its child channels")
-    )
-    print(
-        _(
-            """usage: softwarechannel_clonetree [options])
+    print(_('softwarechannel_clonetree: Clone a software channel and its child channels'))
+    print(_('''usage: softwarechannel_clonetree [options])
              e.g    softwarechannel_clonetree foobasechannel -p "my_"
                     softwarechannel_clonetree foobasechannel -x "s/foo/bar"
                     softwarechannel_clonetree foobasechannel -x "s/^/my_"
@@ -1383,112 +1143,84 @@ options:
   --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)
   -o do not clone any errata
   --regex/-x "s/foo/bar" : Optional regex replacement,
-        replaces foo with bar in the clone name, label and description"""
-        )
-    )
+        replaces foo with bar in the clone name, label and description'''))
 
 
-def do_softwarechannel_clonetree(
-    self, args
-):  # pylint: disable=too-many-return-statements
-    # pylint: disable-next=undefined-variable
+def do_softwarechannel_clonetree(self, args):                 # pylint: disable=too-many-return-statements
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--source-channel")
-    arg_parser.add_argument("-p", "--prefix")
-    arg_parser.add_argument("-x", "--regex")
-    arg_parser.add_argument("-o", "--original-state", action="store_true")
-    arg_parser.add_argument("-g", "--gpg-copy", action="store_true")
-    arg_parser.add_argument("--gpg-url")
-    arg_parser.add_argument("--gpg-id")
-    arg_parser.add_argument("--gpg-fingerprint")
-    arg_parser.add_argument("--disable-gpg-check")
+    arg_parser.add_argument('-s', '--source-channel')
+    arg_parser.add_argument('-p', '--prefix')
+    arg_parser.add_argument('-x', '--regex')
+    arg_parser.add_argument('-o', '--original-state', action='store_true')
+    arg_parser.add_argument('-g', '--gpg-copy', action='store_true')
+    arg_parser.add_argument('--gpg-url')
+    arg_parser.add_argument('--gpg-id')
+    arg_parser.add_argument('--gpg-fingerprint')
+    arg_parser.add_argument('--disable-gpg-check')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        print(_("Source Channels:"))
-        print("\n".join(sorted(self.list_base_channels())))
+        print(_('Source Channels:'))
+        print('\n'.join(sorted(self.list_base_channels())))
 
-        # pylint: disable-next=undefined-variable
-        options.source_channel = prompt_user(_("Select source channel:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.prefix = prompt_user(_("Prefix:"), noblank=True)
-        options.gpg_copy = self.user_confirm(
-            _("Copy source channel GPG details? [y/N]:"), ignore_yes=True
-        )
+        options.source_channel = prompt_user(_('Select source channel:'),noblank=True)
+        options.prefix = prompt_user(_('Prefix:'), noblank=True)
+        options.gpg_copy = \
+            self.user_confirm(_('Copy source channel GPG details? [y/N]:'), ignore_yes=True)
         if not options.gpg_copy:
-            # pylint: disable-next=undefined-variable
-            options.gpg_url = prompt_user(_("GPG URL:"))
-            # pylint: disable-next=undefined-variable
-            options.gpg_id = prompt_user(_("GPG ID:"))
-            # pylint: disable-next=undefined-variable
-            options.gpg_fingerprint = prompt_user(_("GPG Fingerprint:"))
-            # pylint: disable-next=undefined-variable
-            options.disable_gpg_check = prompt_user(_("Disable GPG Check [yes/no]? "))
+            options.gpg_url = prompt_user(_('GPG URL:'))
+            options.gpg_id = prompt_user(_('GPG ID:'))
+            options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
+            options.disable_gpg_check = prompt_user(_('Disable GPG Check [yes/no]? '))
 
-        options.original_state = self.user_confirm(
-            _("Original State (No Errata) [y/N]:"), ignore_yes=True
-        )
+        options.original_state = \
+            self.user_confirm(_('Original State (No Errata) [y/N]:'), ignore_yes=True)
     else:
         if not options.source_channel:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A source channel is required"))
+            logging.error(_N('A source channel is required'))
             return 1
 
         if not options.prefix and not options.regex:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A prefix or regex is required"))
+            logging.error(_N('A prefix or regex is required'))
             return 1
 
         if not options.original_state:
             options.original_state = False
 
-    if options.disable_gpg_check and options.disable_gpg_check not in ("yes", "no"):
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("Only [yes/no] values are acceptable for --disable-gpg-check"))
+    if options.disable_gpg_check and options.disable_gpg_check not in ('yes', 'no'):
+        logging.error(_N('Only [yes/no] values are acceptable for --disable-gpg-check'))
         return 1
 
     channels = [options.source_channel]
     if not options.source_channel in self.list_base_channels():
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_clonetree()
         return 1
-    # pylint: disable-next=undefined-variable
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "--child mode specified, finding children of %s\n"
-        % options.source_channel
-    )
+    logging.debug("--child mode specified, finding children of %s\n" % options.source_channel)
     children = self.list_child_channels(parent=options.source_channel)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Found children %s\n" % children)
     for c in children:
         channels.append(c)
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("channels=%s" % channels)
     parent_channel = None
     for ch in channels:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Cloning %s" % ch)
         label = None
         name = None
         if options.regex:
             # Expect option to be formatted like a sed-replacement, s/foo/bar
             newvalues = do_regx_replacement(self, ch, options)
-            label = newvalues["label"]
-            name = newvalues["name"]
+            label = newvalues['label']
+            name = newvalues['name']
 
         elif options.prefix:
             srcdetails = self.client.channel.software.getDetails(self.session, ch)
-            label = options.prefix + srcdetails["label"]
-            name = options.prefix + srcdetails["name"]
+            label = options.prefix + srcdetails['label']
+            name = options.prefix + srcdetails['name']
         else:
             # Shouldn't ever get here due to earlier checks
-            # pylint: disable-next=undefined-variable
             logging.error(_N("called without prefix or regex option!"))
             return 1
 
@@ -1496,79 +1228,73 @@ def do_softwarechannel_clonetree(
         if self.softwarechannel_check_existing(name, label):
             return 1
 
-        details = {"name": name, "label": label}
+        details = {'name': name, 'label': label}
         if parent_channel:
-            details["parent_label"] = parent_channel
+            details['parent_label'] = parent_channel
         clone_channel(self, ch, options, details)
 
         # If this is the first call we are on the base-channel clone and we
         # need to set parent_channel to the new cloned base-channel label
         if not parent_channel:
-            parent_channel = details["label"]
+            parent_channel = details['label']
 
     return 0
-
 
 ###################
 
 
-def clone_channel(self, channel, options, details):
+def clone_channel(self, channel, options, details) :
+
     if options.gpg_copy:
         srcdetails = self.client.channel.software.getDetails(self.session, channel)
         copy_gpg_values_from_source(details, srcdetails)
 
     if options.gpg_id:
-        details["gpg_id"] = options.gpg_id
+        details['gpg_id'] = options.gpg_id
 
     if options.gpg_url:
-        details["gpg_url"] = options.gpg_url
+        details['gpg_url'] = options.gpg_url
 
     if options.gpg_fingerprint:
-        details["gpg_fingerprint"] = options.gpg_fingerprint
+        details['gpg_fingerprint'] = options.gpg_fingerprint
 
     if options.disable_gpg_check:
-        details["gpg_check"] = str(not options.disable_gpg_check.lower() == "yes")
+        details['gpg_check'] = str(not options.disable_gpg_check.lower() == "yes")
 
     apiversion = self.client.api.getVersion()
     if apiversion and int(apiversion) <= 19:
-        details["summary"] = details["name"]
+        details['summary'] = details['name']
 
     # remove empty strings from the structure
     to_remove = []
     for key in details:
-        if details[key] == "":
+        if details[key] == '':
             to_remove.append(key)
 
     for key in to_remove:
         del details[key]
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Cloning %s as %s") % (channel, details["label"]))
-    self.client.channel.software.clone(
-        self.session, channel, details, options.original_state
-    )
-
+    logging.info(_N("Cloning %s as %s") % (channel, details['label']))
+    self.client.channel.software.clone(self.session,
+                                       channel,
+                                       details,
+                                       options.original_state)
 
 ###################
 
 
 def copy_gpg_values_from_source(details, srcdetails):
-    if srcdetails["gpg_key_url"]:
-        details["gpg_key_url"] = srcdetails["gpg_key_url"]
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("copying gpg_key_url=%s" % srcdetails["gpg_key_url"])
-    if srcdetails["gpg_key_id"]:
-        details["gpg_key_id"] = srcdetails["gpg_key_id"]
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("copying gpg_key_id=%s" % srcdetails["gpg_key_id"])
-    if srcdetails["gpg_key_fp"]:
-        details["gpg_key_fp"] = srcdetails["gpg_key_fp"]
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("copying gpg_key_fp=%s" % srcdetails["gpg_key_fp"])
-    if srcdetails["gpg_check"]:
-        details["gpg_check"] = str(srcdetails["gpg_check"])
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("copying gpg_check=%s" % srcdetails["gpg_check"])
-
+    if srcdetails['gpg_key_url']:
+        details['gpg_key_url'] = srcdetails['gpg_key_url']
+        logging.debug("copying gpg_key_url=%s" % srcdetails['gpg_key_url'])
+    if srcdetails['gpg_key_id']:
+        details['gpg_key_id'] = srcdetails['gpg_key_id']
+        logging.debug("copying gpg_key_id=%s" % srcdetails['gpg_key_id'])
+    if srcdetails['gpg_key_fp']:
+        details['gpg_key_fp'] = srcdetails['gpg_key_fp']
+        logging.debug("copying gpg_key_fp=%s" % srcdetails['gpg_key_fp'])
+    if srcdetails['gpg_check']:
+        details['gpg_check'] = str(srcdetails['gpg_check'])
+        logging.debug("copying gpg_check=%s" % srcdetails['gpg_check'])
 
 ####################
 
@@ -1577,59 +1303,43 @@ def copy_gpg_values_from_source(details, srcdetails):
 # the name, label and description. from the source channel to create
 # the name, label and description for the clone channel.
 # This makes it easier to clone based on a known naming convention
-def do_regx_replacement(self, channel, options):
-    newvalues = {}
+def do_regx_replacement(self,channel, options):
+    newvalues ={}
     # Expect option to be formatted like a sed-replacement, s/foo/bar
     findstr = options.regex.split("/")[1]
     replacestr = options.regex.split("/")[2]
-    # pylint: disable-next=undefined-variable
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "--regex selected with %s, replacing %s with %s"
-        % (options.regex, findstr, replacestr)
-    )
+    logging.debug("--regex selected with %s, replacing %s with %s" %(options.regex, findstr, replacestr))
     srcdetails = self.client.channel.software.getDetails(self.session, channel)
 
-    # pylint: disable-next=undefined-variable
-    newvalues["name"] = re.sub(findstr, replacestr, srcdetails["name"])
-    # pylint: disable-next=undefined-variable
-    newvalues["label"] = re.sub(findstr, replacestr, channel)
-    # pylint: disable-next=undefined-variable
-    logging.debug(
-        # pylint: disable-next=consider-using-f-string
-        "regex mode : %s %s %s"
-        % (options.source_channel, newvalues["name"], newvalues["label"])
-    )
+    newvalues['name'] = re.sub(findstr, replacestr, srcdetails['name'])
+    newvalues['label'] = re.sub(findstr, replacestr, channel)
+    logging.debug("regex mode : %s %s %s" % (options.source_channel,  newvalues['name'], newvalues['label']))
 
     return newvalues
-
 
 ####################
 
 
 def help_softwarechannel_addpackages(self):
-    print(_("softwarechannel_addpackages: Add packages to a software channel"))
-    print(_("usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"))
+    print(_('softwarechannel_addpackages: Add packages to a software channel'))
+    print(_('usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>'))
 
 
 def complete_softwarechannel_addpackages(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.get_package_names(True), text)
 
     return None
 
 
 def do_softwarechannel_addpackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1638,14 +1348,13 @@ def do_softwarechannel_addpackages(self, args):
 
     # Take the first argument as the channel and validate it
     channel = args.pop(0)
-    if not channel in self.do_softwarechannel_list("", True):
-        # pylint: disable-next=undefined-variable
+    if not channel in self.do_softwarechannel_list('', True):
         logging.error(_N("%s is not a valid channel") % channel)
         self.help_softwarechannel_addpackages()
         return 1
 
     # expand the arguments to search for packages
-    package_names = self.do_package_search(" ".join(args), True)
+    package_names = self.do_package_search(' '.join(args), True)
 
     # get the package IDs from the names
     package_ids = []
@@ -1653,72 +1362,63 @@ def do_softwarechannel_addpackages(self, args):
         package_ids += self.get_package_id(package)
 
     if not package_ids:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No packages to add"))
+        logging.warning(_N('No packages to add'))
         return 1
 
-    print(_("Packages"))
-    print("--------")
-    print("\n".join(sorted(package_names)))
+    print(_('Packages'))
+    print('--------')
+    print('\n'.join(sorted(package_names)))
 
-    if not self.user_confirm(_("Add these packages [y/N]:")):
+    if not self.user_confirm(_('Add these packages [y/N]:')):
         return 1
 
-    self.client.channel.software.addPackages(self.session, channel, package_ids)
+    self.client.channel.software.addPackages(self.session,
+                                             channel,
+                                             package_ids)
 
     return 0
 
-
 ####################
 
-
 def help_softwarechannel_mergepackages(self):
-    print(
-        _(
-            "softwarechannel_mergepackages: Merge packages from one software channel into another"
-        )
-    )
-    print(_("usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"))
-
+    print(_('softwarechannel_mergepackages: Merge packages from one software channel into another'))
+    print(_('usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL'))
 
 def complete_softwarechannel_mergepackages(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
     if len(parts) == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
 
     return None
 
-
 def do_softwarechannel_mergepackages(self, args):
-    """
+    '''
     Does the same thing as do_softwarechannel_sync
     with the exception of deleting packages from
     the target channel.
-    """
+    '''
     return self.do_softwarechannel_sync(args, deleteFromTarget=False)
-
 
 ####################
 
 
 def help_softwarechannel_removeerrata(self):
-    print(
-        _("softwarechannel_removeerrata: Remove patches from a " + "software channel")
-    )
-    print(_("usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"))
+    print(_('softwarechannel_removeerrata: Remove patches from a ' +
+            'software channel'))
+    print(_('usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>'))
 
 
 def complete_softwarechannel_removeerrata(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
     elif len(parts) > 2:
         return self.tab_complete_errata(text)
 
@@ -1726,10 +1426,8 @@ def complete_softwarechannel_removeerrata(self, text, line, beg, end):
 
 
 def do_softwarechannel_removeerrata(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1739,115 +1437,95 @@ def do_softwarechannel_removeerrata(self, args):
     channel = args[0]
     errata_wanted = self.expand_errata(args[1:])
 
-    # pylint: disable-next=undefined-variable
-    logging.debug("Retrieving the list of patches from source channel")
-    channel_errata = self.client.channel.software.listErrata(self.session, channel)
+    logging.debug('Retrieving the list of patches from source channel')
+    channel_errata = self.client.channel.software.listErrata(self.session,
+                                                             channel)
 
-    # pylint: disable-next=undefined-variable
-    errata = filter_results(
-        [e.get("advisory_name") for e in channel_errata], errata_wanted
-    )
+    errata = filter_results([e.get('advisory_name') for e in channel_errata],
+                            errata_wanted)
 
     # keep the details for our matching errata so we can use them later
     errata_details = []
     for erratum in channel_errata:
-        if erratum.get("advisory_name") in errata:
+        if erratum.get('advisory_name') in errata:
             errata_details.append(erratum)
 
     # get the packages that resolve these errata so we can add them
     # to the channel afterwards
     package_ids = []
     for erratum in errata:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Retrieving packages for patch %s" % erratum)
+        logging.debug('Retrieving packages for patch %s' % erratum)
 
         # get the packages affected by this errata
         packages = self.client.errata.listPackages(self.session, erratum)
 
         # only add packages that exist in the source channel
         for package in packages:
-            if channel in package.get("providing_channels"):
-                package_ids.append(package.get("id"))
+            if channel in package.get('providing_channels'):
+                package_ids.append(package.get('id'))
 
     if not errata_details:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No patches to remove"))
+        logging.warning(_N('No patches to remove'))
         return 1
 
-    # pylint: disable-next=undefined-variable
     print_errata_list(errata_details)
 
-    print("")
-    print(_("Packages"))
-    print("--------")
-    print(
-        "\n".join(
-            sorted(
-                [
-                    self.get_package_name(p)
-                    for p in package_ids
-                    if self.get_package_name(p)
-                ]
-            )
-        )
-    )
+    print('')
+    print(_('Packages'))
+    print('--------')
+    print('\n'.join(sorted([ self.get_package_name(p) for p in package_ids if self.get_package_name(p) ])))
 
-    print("")
-    print(_("Total Errata:   %s") % str(len(errata)).rjust(3))
-    print(_("Total Packages: %s") % str(len(package_ids)).rjust(3))
+    print('')
+    print(_('Total Errata:   %s') % str(len(errata)).rjust(3))
+    print(_('Total Packages: %s') % str(len(package_ids)).rjust(3))
 
-    if not self.user_confirm(_("Remove these patches [y/N]:")):
+    if not self.user_confirm(_('Remove these patches [y/N]:')):
         return 1
 
     # remove the errata and the packages they brought in
-    self.client.channel.software.removeErrata(self.session, channel, errata, True)
+    self.client.channel.software.removeErrata(self.session,
+                                              channel,
+                                              errata,
+                                              True)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_removepackages(self):
-    print(
-        _(
-            "softwarechannel_removepackages: Remove packages from a "
-            + "software channel"
-        )
-    )
-    print(_("usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"))
+    print(_('softwarechannel_removepackages: Remove packages from a ' +
+            'software channel'))
+    print(_('usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>'))
 
 
-def complete_softwarechannel_removepackages(self, text, line, beg, end):
-    parts = line.split(" ")
+def complete_softwarechannel_removepackages(self, text, line, beg,
+                                            end):
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
     elif len(parts) > 2:
         # only tab complete packages in the channel
         package_names = []
         try:
-            packages = self.client.channel.software.listAllPackages(
-                self.session, parts[1]
-            )
+            packages = \
+                self.client.channel.software.listAllPackages(self.session,
+                                                             parts[1])
 
-            # pylint: disable-next=undefined-variable
             package_names = build_package_names(packages)
         except xmlrpclib.Fault:
             package_names = []
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(package_names, text)
 
     return None
 
 
 def do_softwarechannel_removepackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1858,14 +1536,14 @@ def do_softwarechannel_removepackages(self, args):
     package_list = args
 
     # get all the packages in the channel
-    packages = self.client.channel.software.listAllPackages(self.session, channel)
+    packages = \
+        self.client.channel.software.listAllPackages(self.session,
+                                                     channel)
 
     # build full names for those packages
-    # pylint: disable-next=undefined-variable
     installed_packages = build_package_names(packages)
 
     # find matching packages that are in the channel
-    # pylint: disable-next=undefined-variable
     package_names = filter_results(installed_packages, package_list)
 
     # get the package IDs from the names
@@ -1874,58 +1552,48 @@ def do_softwarechannel_removepackages(self, args):
         package_ids += self.get_package_id(package)
 
     if not package_ids:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No packages to remove"))
+        logging.warning(_N('No packages to remove'))
         return 1
 
-    print(_("Packages"))
-    print("--------")
-    print("\n".join(sorted(package_names)))
+    print(_('Packages'))
+    print('--------')
+    print('\n'.join(sorted(package_names)))
 
-    if not self.user_confirm(_("Remove these packages [y/N]:")):
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
         return 1
 
-    self.client.channel.software.removePackages(self.session, channel, package_ids)
+    self.client.channel.software.removePackages(self.session,
+                                                channel,
+                                                package_ids)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_adderratabydate(self):
-    print(
-        _(
-            "softwarechannel_adderratabydate: Add errata from one channel "
-            + "into another channel based on a date range"
-        )
-    )
-    print(
-        _(
-            "usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE ENDDATE"
-        )
-    )
-    print(_("Date format : YYYYMMDD"))
-    print(_("Options:"))
-    print(_("        -p/--publish : Publish errata to the channel (don't clone)"))
+    print(_('softwarechannel_adderratabydate: Add errata from one channel ' +
+            'into another channel based on a date range'))
+    print(_('usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE ENDDATE'))
+    print(_('Date format : YYYYMMDD'))
+    print(_('Options:'))
+    print(_('        -p/--publish : Publish errata to the channel (don\'t clone)'))
 
 
 def complete_softwarechannel_adderratabydate(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) <= 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
 
     return None
 
 
 def do_softwarechannel_adderratabydate(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-p", "--publish", action="store_true")
+    arg_parser.add_argument('-p', '--publish', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 4:
@@ -1937,94 +1605,69 @@ def do_softwarechannel_adderratabydate(self, args):
     begin_date = args[2]
     end_date = args[3]
 
-    # pylint: disable-next=undefined-variable
-    if not re.match(r"\d{8}", begin_date):
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("%s is an invalid date") % begin_date)
+    if not re.match(r'\d{8}', begin_date):
+        logging.error(_N('%s is an invalid date') % begin_date)
         self.help_softwarechannel_adderratabydate()
         return 1
 
-    # pylint: disable-next=undefined-variable
-    if not re.match(r"\d{8}", end_date):
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("%s is an invalid date") % end_date)
+    if not re.match(r'\d{8}', end_date):
+        logging.error(_N('%s is an invalid date') % end_date)
         self.help_softwarechannel_adderratabydate()
         return 1
 
     # get the errata that are in the given date range
-    # pylint: disable-next=undefined-variable
-    logging.debug("Retrieving list of patches from source channel")
-    errata = self.client.channel.software.listErrata(
-        self.session,
-        source_channel,
-        # pylint: disable-next=undefined-variable
-        parse_time_input(begin_date),
-        # pylint: disable-next=undefined-variable
-        parse_time_input(end_date),
-    )
+    logging.debug('Retrieving list of patches from source channel')
+    errata = \
+        self.client.channel.software.listErrata(self.session,
+                                                source_channel,
+                                                parse_time_input(begin_date),
+                                                parse_time_input(end_date))
 
     if not errata:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No patches found between the given dates"))
+        logging.warning(_N('No patches found between the given dates'))
         return 1
 
     if options.publish:
         # Just publish the errata one-by-one, rather than calling
         # do_softwarechannel_adderrata which clones the errata
         for e in errata:
-            # pylint: disable-next=undefined-variable
-            logging.info(
-                _N("Publishing errata %s to %s")
-                % (e.get("advisory_name"), dest_channel)
-            )
-            self.client.errata.publish(
-                self.session, e.get("advisory_name"), [dest_channel]
-            )
+            logging.info(_N("Publishing errata %s to %s") %
+                         (e.get('advisory_name'), dest_channel))
+            self.client.errata.publish(self.session, e.get('advisory_name'),
+                                       [dest_channel])
     else:
         # call adderrata with the list of errata from the date range
         # this clones the errata and adds it to the channel
-        return self.do_softwarechannel_adderrata(
-            # pylint: disable-next=consider-using-f-string
-            "%s %s %s"
-            % (
-                source_channel,
-                dest_channel,
-                " ".join([e.get("advisory_name") for e in errata]),
-            )
-        )
+        return self.do_softwarechannel_adderrata('%s %s %s' % (
+            source_channel,
+            dest_channel,
+            ' '.join([e.get('advisory_name') for e in errata])))
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_listerratabydate(self):
-    print(
-        _(
-            "softwarechannel_listerratabydate: list errata from channel"
-            + "based on a date range"
-        )
-    )
-    print(_("usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"))
-    print(_("Date format : YYYYMMDD"))
+    print(_('softwarechannel_listerratabydate: list errata from channel' +
+            'based on a date range'))
+    print(_('usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE'))
+    print(_('Date format : YYYYMMDD'))
 
 
 def complete_softwarechannel_listerratabydate(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) <= 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
 
     return None
 
 
 def do_softwarechannel_listerratabydate(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 3:
@@ -2035,65 +1678,49 @@ def do_softwarechannel_listerratabydate(self, args):
     begin_date = args[1]
     end_date = args[2]
 
-    # pylint: disable-next=undefined-variable
-    if not re.match(r"\d{8}", begin_date):
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("%s is an invalid date") % begin_date)
+    if not re.match(r'\d{8}', begin_date):
+        logging.error(_N('%s is an invalid date') % begin_date)
         self.help_softwarechannel_listerratabydate()
         return 1
 
-    # pylint: disable-next=undefined-variable
-    if not re.match(r"\d{8}", end_date):
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("%s is an invalid date") % end_date)
+    if not re.match(r'\d{8}', end_date):
+        logging.error(_N('%s is an invalid date') % end_date)
         self.help_softwarechannel_listerratabydate()
         return 1
 
     # get the errata that are in the given date range
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("Retrieving list of errata from channel %s" % channel)
-    errata = self.client.channel.software.listErrata(
-        self.session,
-        channel,
-        # pylint: disable-next=undefined-variable
-        parse_time_input(begin_date),
-        # pylint: disable-next=undefined-variable
-        parse_time_input(end_date),
-    )
+    logging.debug('Retrieving list of errata from channel %s' % channel)
+    errata = \
+        self.client.channel.software.listErrata(self.session,
+                                                channel,
+                                                parse_time_input(begin_date),
+                                                parse_time_input(end_date))
 
     if not errata:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No errata found between the given dates"))
+        logging.warning(_N('No errata found between the given dates'))
         return 1
 
-    # pylint: disable-next=undefined-variable
     print_errata_list(errata)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_adderrata(self):
-    print(
-        _(
-            "softwarechannel_adderrata: Add patches from one channel "
-            + "into another channel"
-        )
-    )
-    print(_("usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"))
-    print(_("Options:"))
-    print(_("    -q/--quick : Don't display list of packages (slightly faster)"))
-    print(_("    -s/--skip :  Skip errata which appear to exist already in DEST"))
+    print(_('softwarechannel_adderrata: Add patches from one channel ' +
+            'into another channel'))
+    print(_('usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>'))
+    print(_('Options:'))
+    print(_('    -q/--quick : Don\'t display list of packages (slightly faster)'))
+    print(_('    -s/--skip :  Skip errata which appear to exist already in DEST'))
 
 
 def complete_softwarechannel_adderrata(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) <= 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     elif len(parts) > 3:
         return self.tab_complete_errata(text)
 
@@ -2101,73 +1728,59 @@ def complete_softwarechannel_adderrata(self, text, line, beg, end):
 
 
 def do_softwarechannel_adderrata(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-q", "--quick", action="store_true")
-    arg_parser.add_argument("-s", "--skip", action="store_true")
+    arg_parser.add_argument('-q', '--quick', action='store_true')
+    arg_parser.add_argument('-s', '--skip', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
         self.help_softwarechannel_adderrata()
         return 1
 
-    allchannels = self.do_softwarechannel_list("", True)
+    allchannels = self.do_softwarechannel_list('', True)
     source_channel = args[0]
     if not source_channel in allchannels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("source channel %s does not exist!") % source_channel)
         self.help_softwarechannel_adderrata()
         return 1
     dest_channel = args[1]
     if not dest_channel in allchannels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("dest channel %s does not exist!") % dest_channel)
         self.help_softwarechannel_adderrata()
         return 1
     errata_wanted = self.expand_errata(args[2:])
 
-    # pylint: disable-next=undefined-variable
-    logging.debug("Retrieving the list of patches from source channel")
-    source_errata = self.client.channel.software.listErrata(
-        self.session, source_channel
-    )
-    dest_errata = self.client.channel.software.listErrata(self.session, dest_channel)
+    logging.debug('Retrieving the list of patches from source channel')
+    source_errata = self.client.channel.software.listErrata(self.session,
+                                                            source_channel)
+    dest_errata = self.client.channel.software.listErrata(self.session,
+                                                          dest_channel)
 
-    # pylint: disable-next=undefined-variable
-    errata = filter_results(
-        [e.get("advisory_name") for e in source_errata], errata_wanted
-    )
-    # pylint: disable-next=undefined-variable,consider-using-f-string
+    errata = filter_results([e.get('advisory_name') for e in source_errata],
+                            errata_wanted)
     logging.debug("errata = %s" % errata)
     if options.skip:
         # We just match the NNNN:MMMM of the XXXX-NNNN:MMMM as the
         # source errata will be RH[BES]A and the DEST errata will be CLA
-        dest_errata_suffix = [x.get("advisory_name").split("-")[1] for x in dest_errata]
-        # pylint: disable-next=undefined-variable,consider-using-f-string
+        dest_errata_suffix = [x.get('advisory_name').split("-")[1]
+                              for x in dest_errata]
         logging.debug("dest_errata_suffix = %s" % dest_errata_suffix)
         toremove = []
         for e in errata:
             if e.split("-")[1] in dest_errata_suffix:
-                # pylint: disable-next=undefined-variable
-                logging.debug(
-                    # pylint: disable-next=consider-using-f-string
-                    "Skipping errata %s as it seems to be in %s"
-                    % (e, dest_channel)
-                )
+                logging.debug("Skipping errata %s as it seems to be in %s" %
+                              (e, dest_channel))
                 toremove.append(e)
         for e in toremove:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
             logging.debug("Removing %s from errata to be added" % e)
             errata.remove(e)
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("skip-mode : reduced errata = %s" % errata)
 
     # keep the details for our matching errata so we can use them later
     errata_details = []
     for erratum in source_errata:
-        if erratum.get("advisory_name") in errata:
+        if erratum.get('advisory_name') in errata:
             errata_details.append(erratum)
 
     if not options.quick:
@@ -2175,61 +1788,53 @@ def do_softwarechannel_adderrata(self, args):
         # to the channel afterwards
         package_ids = []
         for erratum in errata:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("Retrieving packages for patch %s" % erratum)
+            logging.debug('Retrieving packages for patch %s' % erratum)
 
             # get the packages affected by this errata
             packages = self.client.errata.listPackages(self.session, erratum)
 
             # only add packages that exist in the source channel
             for package in packages:
-                if source_channel in package.get("providing_channels"):
-                    package_ids.append(package.get("id"))
+                if source_channel in package.get('providing_channels'):
+                    package_ids.append(package.get('id'))
 
     if not errata:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No patch to add"))
+        logging.warning(_N('No patch to add'))
         return 1
 
     # show the user which errata will be added
-    # pylint: disable-next=undefined-variable
     print_errata_list(errata_details)
 
     if not options.quick:
-        print("")
-        print(_("Packages"))
-        print("--------")
-        print("\n".join(sorted([self.get_package_name(p) for p in package_ids])))
+        print('')
+        print(_('Packages'))
+        print('--------')
+        print('\n'.join(
+            sorted([self.get_package_name(p) for p in package_ids])))
 
-        print("")
-    print(_("Total Errata:   %s") % str(len(errata)).rjust(3))
+        print('')
+    print(_('Total Errata:   %s') % str(len(errata)).rjust(3))
 
     if not options.quick:
-        print(_("Total Packages: %s") % str(len(package_ids)).rjust(3))
+        print(_('Total Packages: %s') % str(len(package_ids)).rjust(3))
 
-    if not self.user_confirm(_("Add these patches [y/N]:")):
+    if not self.user_confirm(_('Add these patches [y/N]:')):
         return 1
 
     # clone each erratum individually because the process is slow and it can
     # lead to timeouts on the server
     for erratum in errata:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Cloning %s" % erratum)
-        if self.check_api_version("10.11"):
+        logging.debug('Cloning %s' % erratum)
+        if self.check_api_version('10.11'):
             # This call is poorly documented, but it stops errata.clone
             # pushing EL6 packages into EL5 channels when the errata
             # package list contains both versions, ref bz678721
-            self.client.errata.cloneAsOriginal(self.session, dest_channel, [erratum])
+            self.client.errata.cloneAsOriginal(self.session, dest_channel,
+                                               [erratum])
         else:
-            # pylint: disable-next=undefined-variable
             logging.warning(_N("Using the old errata.clone function"))
-            # pylint: disable-next=undefined-variable
-            logging.warning(
-                _N(
-                    "If you have base channels for multiple OS"
-                    + " versions, check no unexpected packages have been added"
-                )
-            )
+            logging.warning(_N("If you have base channels for multiple OS" +
+                               " versions, check no unexpected packages have been added"))
             self.client.errata.clone(self.session, dest_channel, [erratum])
 
     # regenerate the errata cache since we just cloned errata
@@ -2237,79 +1842,59 @@ def do_softwarechannel_adderrata(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_getorgaccess(self):
-    print(
-        _("softwarechannel_getorgaccess: Get the org-access for the software channel")
-    )
-    print(_("usage: softwarechannel_getorgaccess [CHANNEL ...]"))
+    print(_('softwarechannel_getorgaccess: Get the org-access for the software channel'))
+    print(_('usage: softwarechannel_getorgaccess [CHANNEL ...]'))
 
 
 def complete_softwarechannel_getorgaccess(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(
-        self.do_softwarechannel_listmanageablechannels("", doreturn=True), text
-    )
+    return tab_completer(self.do_softwarechannel_listmanageablechannels('', doreturn=True),
+                         text)
 
 
 def do_softwarechannel_getorgaccess(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     # If no args are passed, we dump the org access for all channels
     if not args:
-        channels = self.do_softwarechannel_listmanageablechannels("", doreturn=True)
+        channels = self.do_softwarechannel_listmanageablechannels('', doreturn=True)
     else:
         # allow globbing of software channel names
-        # pylint: disable-next=undefined-variable
         channels = filter_results(
-            self.do_softwarechannel_listmanageablechannels("", doreturn=True), args
-        )
+            self.do_softwarechannel_listmanageablechannels('', doreturn=True), args)
 
     for channel in channels:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         logging.debug("Getting org-access for channel %s" % channel)
-        sharing = self.client.channel.access.getOrgSharing(self.session, channel)
-        # pylint: disable-next=consider-using-f-string
+        sharing = self.client.channel.access.getOrgSharing(
+            self.session, channel)
         print("%s : %s" % (channel, sharing))
-        if sharing == "protected":
+        if sharing == 'protected':
             # for protected channels list each organization's access status
             channel_orgs = self.client.channel.org.list(self.session, channel)
             for org in channel_orgs:
-                # pylint: disable-next=consider-using-f-string
                 print("\t%s : %s" % (org["org_name"], org["access_enabled"]))
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_setorgaccess(self):
-    print(
-        _("softwarechannel_setorgaccess: Set the org-access for the software channel")
-    )
-    print(
-        _(
-            """usage : softwarechannel_setorgaccess <CHANNEL> [options])
+    print(_('softwarechannel_setorgaccess: Set the org-access for the software channel'))
+    print(_('''usage : softwarechannel_setorgaccess <CHANNEL> [options])
 -d,--disable : disable org access (private, no org sharing)
 -e,--enable : enable org access (public access to all trusted orgs)
--p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)"""
-        )
-    )
+-p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)'''))
 
 
 def complete_softwarechannel_setorgaccess(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(
-        self.do_softwarechannel_listmanageablechannels("", doreturn=True), text
-    )
+    return tab_completer(self.do_softwarechannel_listmanageablechannels('', doreturn=True),
+                         text)
 
 
 def do_softwarechannel_setorgaccess(self, args, options=None):
@@ -2317,13 +1902,11 @@ def do_softwarechannel_setorgaccess(self, args, options=None):
         self.help_softwarechannel_setorgaccess()
         return 1
     if not options:
-        # pylint: disable-next=undefined-variable
         arg_parser = get_argument_parser()
-        arg_parser.add_argument("-e", "--enable", action="store_true")
-        arg_parser.add_argument("-d", "--disable", action="store_true")
-        arg_parser.add_argument("-p", "--protected", action="append")
+        arg_parser.add_argument('-e', '--enable', action='store_true')
+        arg_parser.add_argument('-d', '--disable', action='store_true')
+        arg_parser.add_argument('-p', '--protected', action='append')
 
-        # pylint: disable-next=undefined-variable
         (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2331,78 +1914,61 @@ def do_softwarechannel_setorgaccess(self, args, options=None):
         return 1
 
     # allow globbing of software channel names
-    # pylint: disable-next=undefined-variable
-    channels = filter_results(
-        self.do_softwarechannel_listmanageablechannels("", doreturn=True), args
-    )
+    channels = filter_results(self.do_softwarechannel_listmanageablechannels('', doreturn=True),
+                              args)
 
     # get the list of trusted organizations when we are dealing with protected channels
-    if options.protected:
+    if (options.protected):
         org_trust_list = self.client.org.trusts.listOrgs(self.session)
 
     for channel in channels:
         # If they just specify a channel and --enable/--disable
         # this implies public/private access
-        if options.enable:
-            # pylint: disable-next=undefined-variable
-            logging.info(_("Making org sharing public for channel : %s ") % channel)
-            self.client.channel.access.setOrgSharing(self.session, channel, "public")
-        elif options.disable:
-            # pylint: disable-next=undefined-variable
-            logging.info(_("Making org sharing private for channel : %s ") % channel)
-            self.client.channel.access.setOrgSharing(self.session, channel, "private")
-        elif options.protected:
-            # pylint: disable-next=undefined-variable
-            logging.info(_("Making org sharing protected for channel : %s ") % channel)
-            self.client.channel.access.setOrgSharing(self.session, channel, "protected")
+        if (options.enable):
+            logging.info(
+                _("Making org sharing public for channel : %s ") % channel)
+            self.client.channel.access.setOrgSharing(
+                self.session, channel, 'public')
+        elif (options.disable):
+            logging.info(
+                _("Making org sharing private for channel : %s ") % channel)
+            self.client.channel.access.setOrgSharing(
+                self.session, channel, 'private')
+        elif (options.protected):
+            logging.info(
+                _("Making org sharing protected for channel : %s ") % channel)
+            self.client.channel.access.setOrgSharing(
+                self.session, channel, 'protected')
             for org in org_trust_list:
                 if org["org_name"] in options.protected:
-                    # pylint: disable-next=undefined-variable
                     logging.info(
-                        _("Enabling %s access for channel : %s ")
-                        % (org["org_name"], channel)
-                    )
+                        _("Enabling %s access for channel : %s ") % (org["org_name"],channel))
                     self.client.channel.org.enableAccess(
-                        self.session, channel, org["org_id"]
-                    )
+                        self.session, channel, org["org_id"])
                 else:
-                    # pylint: disable-next=undefined-variable
                     logging.info(
-                        _("Disabling %s access for channel : %s ")
-                        % (org["org_name"], channel)
-                    )
+                        _("Disabling %s access for channel : %s ") % (org["org_name"],channel))
                     self.client.channel.org.disableAccess(
-                        self.session, channel, org["org_id"]
-                    )
+                        self.session, channel, org["org_id"])
         else:
             self.help_softwarechannel_setorgaccess()
             return 1
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_getorgaccesstree(self):
-    print(
-        _(
-            "softwarechannel_getorgaccesstree: Get the org-access for a software base channel and its children"
-        )
-    )
-    print(_("usage: softwarechannel_getorgaccesstree [CHANNEL]"))
-
+    print(_('softwarechannel_getorgaccesstree: Get the org-access for a software base channel and its children'))
+    print(_('usage: softwarechannel_getorgaccesstree [CHANNEL]'))
 
 def complete_softwarechannel_getorgaccesstree(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.list_base_channels(), text)
 
-
 def do_softwarechannel_getorgaccesstree(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     # If no args are passed, we dump the org access for all base channels
@@ -2410,11 +1976,9 @@ def do_softwarechannel_getorgaccesstree(self, args):
         channels = self.list_base_channels()
     else:
         # allow globbing of software channel names
-        # pylint: disable-next=undefined-variable
         channels = filter_results(self.list_base_channels(), args)
 
     if not channels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_getorgaccesstree()
         return 1
@@ -2426,39 +1990,25 @@ def do_softwarechannel_getorgaccesstree(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_setorgaccesstree(self):
-    print(
-        _(
-            "softwarechannel_setorgaccesstree: set the org-access for a software base channel and its children"
-        )
-    )
-    print(
-        _(
-            """usage: softwarechannel_setorgaccesstree <CHANNEL> [options])
+    print(_('softwarechannel_setorgaccesstree: set the org-access for a software base channel and its children'))
+    print(_('''usage: softwarechannel_setorgaccesstree <CHANNEL> [options])
 -d,--disable : disable org access (private, no org sharing)
 -e,--enable : enable org access (public access to all trusted orgs)
--p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)"""
-        )
-    )
-
+-p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)'''))
 
 def complete_softwarechannel_setorgaccesstree(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.list_base_channels(), text)
 
-
 def do_softwarechannel_setorgaccesstree(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-e", "--enable", action="store_true")
-    arg_parser.add_argument("-d", "--disable", action="store_true")
-    arg_parser.add_argument("-p", "--protected", action="append")
+    arg_parser.add_argument('-e', '--enable', action='store_true')
+    arg_parser.add_argument('-d', '--disable', action='store_true')
+    arg_parser.add_argument('-p', '--protected', action='append')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args or not (options.enable or options.disable or options.protected):
@@ -2466,11 +2016,9 @@ def do_softwarechannel_setorgaccesstree(self, args):
         return 1
 
     # allow globbing of software channel names
-    # pylint: disable-next=undefined-variable
     channels = filter_results(self.list_base_channels(), args)
 
     if not channels:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_setorgaccesstree()
         return 1
@@ -2482,56 +2030,47 @@ def do_softwarechannel_setorgaccesstree(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_regenerateneededcache(self):
-    print(_("softwarechannel_regenerateneededcache: "))
-    print(_("Regenerate the needed errata and package cache for all systems"))
-    print("")
-    print(_("usage: softwarechannel_regenerateneededcache"))
+    print(_('softwarechannel_regenerateneededcache: '))
+    print(_('Regenerate the needed errata and package cache for all systems'))
+    print('')
+    print(_('usage: softwarechannel_regenerateneededcache'))
 
 
 def do_softwarechannel_regenerateneededcache(self, args):
-    if self.user_confirm("Are you sure [y/N]: "):
+    if self.user_confirm('Are you sure [y/N]: '):
         self.client.channel.software.regenerateNeededCache(self.session)
         return 0
     else:
         return 1
 
-
 ####################
 
 
 def help_softwarechannel_regenerateyumcache(self):
-    print(_("softwarechannel_regenerateyumcache: "))
-    print(_("Regenerate the YUM cache for a software channel"))
-    print("")
-    print(
-        _(
-            """usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>
+    print(_('softwarechannel_regenerateyumcache: '))
+    print(_('Regenerate the YUM cache for a software channel'))
+    print('')
+    print(_('''usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>
 
     options:
       -f force cache regeneration
-    """
-        )
-    )
-    print("")
+    '''))
+    print('')
 
 
 def complete_softwarechannel_regenerateyumcache(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_regenerateyumcache(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    arg_parser.add_argument("-f", "--force", action="store_true")
+    arg_parser.add_argument('-f', '--force', action="store_true")
 
-    # pylint: disable-next=undefined-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2539,18 +2078,13 @@ def do_softwarechannel_regenerateyumcache(self, args):
         return 1
 
     # allow globbing of software channel names
-    # pylint: disable-next=undefined-variable
-    channels = filter_results(self.do_softwarechannel_list("", True), args)
+    channels = filter_results(self.do_softwarechannel_list('', True), args)
 
     for channel in channels:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Regenerating YUM cache for %s" % channel)
-        self.client.channel.software.regenerateYumCache(
-            self.session, channel, _options.force
-        )
+        logging.debug('Regenerating YUM cache for %s' % channel)
+        self.client.channel.software.regenerateYumCache(self.session, channel, _options.force)
 
     return 0
-
 
 ####################
 # softwarechannel helper
@@ -2564,11 +2098,9 @@ def is_softwarechannel(self, name):
 
 def check_softwarechannel(self, name):
     if not name:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("no softwarechannel label given"))
         return False
     if not self.is_softwarechannel(name):
-        # pylint: disable-next=undefined-variable
         logging.error(_N("invalid softwarechannel label ") + name)
         return False
     return True
@@ -2578,42 +2110,36 @@ def dump_softwarechannel(self, name, replacedict=None, excludes=None):
     excludes = excludes or []
     content = self.do_softwarechannel_listallpackages(name, doreturn=True)
 
-    # pylint: disable-next=undefined-variable
-    content = get_normalized_text(content, replacedict=replacedict, excludes=excludes)
+    content = get_normalized_text(
+        content, replacedict=replacedict, excludes=excludes)
 
     return content
-
 
 ####################
 
 
 def help_softwarechannel_diff(self):
-    print(_("softwarechannel_diff: diff softwarechannel files"))
-    print("")
-    print(_("usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"))
+    print(_('softwarechannel_diff: diff softwarechannel files'))
+    print('')
+    print(_('usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_softwarechannel_diff(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     return []
 
 
 def do_softwarechannel_diff(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1 and len(args) != 2:
@@ -2629,7 +2155,8 @@ def do_softwarechannel_diff(self, args):
         target_channel = args[1]
     elif hasattr(self, "do_softwarechannel_getcorresponding"):
         # can a corresponding channel name be found automatically?
-        target_channel = self.do_softwarechannel_getcorresponding(source_channel)
+        target_channel = self.do_softwarechannel_getcorresponding(
+            source_channel)
     if not self.check_softwarechannel(target_channel):
         return None
 
@@ -2637,10 +2164,8 @@ def do_softwarechannel_diff(self, args):
     # therefore there is no need to use replace dicts
     source_data = self.dump_softwarechannel(source_channel, None)
     target_data = self.dump_softwarechannel(target_channel, None)
-    # pylint: disable-next=undefined-variable
     for line in diff(source_data, target_data, source_channel, target_channel):
         print(line)
-
 
 ####################
 
@@ -2649,46 +2174,35 @@ def dump_softwarechannel_errata(self, name):
     errata = self.client.channel.software.listErrata(self.session, name)
     result = []
     for erratum in errata:
-        result.append(
-            # pylint: disable-next=consider-using-f-string
-            "%s %s"
-            % (
-                erratum.get("advisory_name").ljust(14),
-                # pylint: disable-next=undefined-variable
-                wrap(erratum.get("advisory_synopsis"), 50)[0],
-            )
-        )
+        result.append('%s %s' % (
+            erratum.get('advisory_name').ljust(14),
+            wrap(erratum.get('advisory_synopsis'), 50)[0]))
     result.sort()
     return result
 
 
 def help_softwarechannel_errata_diff(self):
-    print(_("softwarechannel_errata_diff: diff softwarechannel files"))
-    print("")
-    print(_("usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"))
+    print(_('softwarechannel_errata_diff: diff softwarechannel files'))
+    print('')
+    print(_('usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_softwarechannel_errata_diff(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     return []
 
 
 def do_softwarechannel_errata_diff(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1 and len(args) != 2:
@@ -2704,7 +2218,8 @@ def do_softwarechannel_errata_diff(self, args):
         target_channel = args[1]
     elif hasattr(self, "do_softwarechannel_getcorresponding"):
         # try to find the corresponding channel automatically
-        target_channel = self.do_softwarechannel_getcorresponding(source_channel)
+        target_channel = self.do_softwarechannel_getcorresponding(
+            source_channel)
     if not self.check_softwarechannel(target_channel):
         return None
 
@@ -2712,52 +2227,41 @@ def do_softwarechannel_errata_diff(self, args):
     # therefore there is no need to use replace dicts
     source_data = self.dump_softwarechannel_errata(source_channel)
     target_data = self.dump_softwarechannel_errata(target_channel)
-    # pylint: disable-next=undefined-variable
     for line in diff(source_data, target_data, source_channel, target_channel):
         print(line)
-
 
 ####################
 
 
 def help_softwarechannel_sync(self):
-    print(_("softwarechannel_sync: "))
-    print(_("sync the packages of two software channels"))
-    print("")
-    print(
-        _(
-            """usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])
-    -q,--quiet : quiet mode (omits the output of common packages in both channels)"""
-        )
-    )
+    print(_('softwarechannel_sync: '))
+    print(_('sync the packages of two software channels'))
+    print('')
+    print(_('''usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])
+    -q,--quiet : quiet mode (omits the output of common packages in both channels)'''))
 
 
 def complete_softwarechannel_sync(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     return []
 
 
 def do_softwarechannel_sync(self, args, deleteFromTarget=True):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-q", "--quiet", action="store_true")
+    arg_parser.add_argument('-q', '--quiet', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1 and len(args) != 2:
-        self.help_softwarechannel_sync() if deleteFromTarget else self.help_softwarechannel_mergepackages()  # pylint: disable=expression-not-assigned
+        self.help_softwarechannel_sync() if deleteFromTarget else self.help_softwarechannel_mergepackages() # pylint: disable=expression-not-assigned
         return 1
 
     source_channel = args[0]
@@ -2769,54 +2273,47 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         target_channel = args[1]
     elif hasattr(self, "do_softwarechannel_getcorresponding"):
         # can a corresponding channel name be found automatically?
-        target_channel = self.do_softwarechannel_getcorresponding(source_channel)
+        target_channel = self.do_softwarechannel_getcorresponding(
+            source_channel)
     if not self.check_softwarechannel(target_channel):
         return 1
 
     command = "syncing" if deleteFromTarget else "merging"
-    # pylint: disable-next=undefined-variable
-    logging.info(
-        _N("%s packages from softwarechannel %s to %s"),
-        command,
-        source_channel,
-        target_channel,
-    )
+    logging.info(_N("%s packages from softwarechannel %s to %s"),
+                 command, source_channel, target_channel)
 
     # use API call instead of spacecmd function
     # to get detailed infos about the packages
     # and not just their names
     source_packages = self.client.channel.software.listAllPackages(
-        self.session, source_channel
-    )
+        self.session,
+        source_channel)
     target_packages = self.client.channel.software.listAllPackages(
-        self.session, target_channel
-    )
+        self.session,
+        target_channel)
 
     # get the package IDs
     source_ids = set()
     for package in source_packages:
         try:
-            source_ids.add(package["id"])
+            source_ids.add(package['id'])
         except KeyError:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("failed to read key id"))
             continue
 
     target_ids = set()
     for package in target_packages:
         try:
-            target_ids.add(package["id"])
+            target_ids.add(package['id'])
         except KeyError:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("failed to read key id"))
             continue
     if not options.quiet:
         print(_("packages common in both channels:"))
-        for i in source_ids & target_ids:
+        for i in (source_ids & target_ids):
             print(self.get_package_name(i))
-        print("")
+        print('')
     else:
-        # pylint: disable-next=undefined-variable
         logging.info(_N("Omitting common packages in both specified channels"))
 
     # check for packages only in the source channel
@@ -2825,7 +2322,7 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         print(_('packages to add to channel "') + target_channel + '":')
         for i in source_only:
             print(self.get_package_name(i))
-        print("")
+        print('')
 
     # check for packages only in the target channel
     target_only = target_ids.difference(source_ids)
@@ -2833,90 +2330,62 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         print(_('packages to remove from channel "') + target_channel + '":')
         for i in target_only:
             print(self.get_package_name(i))
-        print("")
+        print('')
 
     if source_only or target_only:
         print(_("summary:"))
-        print(
-            "  "
-            + source_channel
-            + ": "
-            + str(len(source_ids)).rjust(5)
-            + _(" packages")
-        )
-        print(
-            "  "
-            + target_channel
-            + ": "
-            + str(len(target_ids)).rjust(5)
-            + _(" packages")
-        )
-        print(
-            _("    add    ")
-            + str(len(source_only)).rjust(5)
-            + _(" packages to   ")
-            + target_channel
-        )
+        print("  " + source_channel + ": " + str(len(source_ids)).rjust(5) + _(" packages"))
+        print("  " + target_channel + ": " + str(len(target_ids)).rjust(5) + _(" packages"))
+        print(_("    add    ") + str(
+            len(source_only)).rjust(5) + _(" packages to   ") + target_channel)
 
         if deleteFromTarget:
-            print(
-                _("    remove ")
-                + str(len(target_only)).rjust(5)
-                + _(" packages from ")
-                + target_channel
-            )
+            print(_("    remove ") + str(
+                len(target_only)).rjust(5) + _(" packages from ") + target_channel)
 
-        if not self.user_confirm(
-            _("Perform these changes to channel ") + target_channel + " [y/N]:"
-        ):
+        if not self.user_confirm(_('Perform these changes to channel ') + target_channel + ' [y/N]:'):
             return None
 
         if deleteFromTarget:
-            self.client.channel.software.addPackages(
-                self.session, target_channel, list(source_only)
-            )
-            self.client.channel.software.removePackages(
-                self.session, target_channel, list(target_only)
-            )
+            self.client.channel.software.addPackages(self.session,
+                                                     target_channel,
+                                                     list(source_only))
+            self.client.channel.software.removePackages(self.session,
+                                                        target_channel,
+                                                        list(target_only))
         else:
-            self.client.channel.software.mergePackages(
-                self.session, source_channel, target_channel
-            )
+            self.client.channel.software.mergePackages(self.session,
+                                                       source_channel,
+                                                       target_channel)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_errata_sync(self):
-    print(_("softwarechannel_errata_sync: "))
-    print(_("sync errata of two software channels"))
-    print("")
-    print(_("usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"))
+    print(_('softwarechannel_errata_sync: '))
+    print(_('sync errata of two software channels'))
+    print('')
+    print(_('usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_softwarechannel_errata_sync(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     return []
 
 
 def do_softwarechannel_errata_sync(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1 and len(args) != 2:
@@ -2932,48 +2401,40 @@ def do_softwarechannel_errata_sync(self, args):
         target_channel = args[1]
     elif hasattr(self, "do_softwarechannel_getcorresponding"):
         # try to find a corresponding channel name automatically
-        target_channel = self.do_softwarechannel_getcorresponding(source_channel)
+        target_channel = self.do_softwarechannel_getcorresponding(
+            source_channel)
     if not self.check_softwarechannel(target_channel):
         return 1
 
-    # pylint: disable-next=undefined-variable
-    logging.info(
-        _N("syncing errata from softwarechannel ")
-        + source_channel
-        + _N(" to ")
-        + target_channel
-    )
+    logging.info(_N("syncing errata from softwarechannel ") + source_channel +
+                 _N(" to ") + target_channel)
 
     source_errata = self.client.channel.software.listErrata(
-        self.session, source_channel
-    )
+        self.session, source_channel)
     target_errata = self.client.channel.software.listErrata(
-        self.session, target_channel
-    )
+        self.session, target_channel)
 
     # store unique errata data in a set
     source_ids = set()
     for erratum in source_errata:
         try:
-            source_ids.add(erratum.get("advisory_name"))
+            source_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("failed to read key id"))
             continue
 
     target_ids = set()
     for erratum in target_errata:
         try:
-            target_ids.add(erratum.get("advisory_name"))
+            target_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("failed to read key id"))
             continue
 
     print(_("errata common in both channels:"))
-    for i in source_ids & target_ids:
+    for i in (source_ids & target_ids):
         print(i)
-    print("")
+    print('')
 
     # check for errata only in the source channel
     source_only = list(source_ids.difference(target_ids))
@@ -2982,7 +2443,7 @@ def do_softwarechannel_errata_sync(self, args):
         print(_('errata to add to channel "') + target_channel + '":')
         for i in source_only:
             print(i)
-        print("")
+        print('')
 
     # check for errata only in the target channel
     target_only = list(target_ids.difference(source_ids))
@@ -2991,28 +2452,18 @@ def do_softwarechannel_errata_sync(self, args):
         print(_('errata to remove from channel "') + target_channel + '":')
         for i in target_only:
             print(i)
-        print("")
+        print('')
 
     if source_only or target_only:
         print(_("summary:"))
         print("  " + source_channel + ": " + str(len(source_ids)).rjust(5), "errata")
         print("  " + target_channel + ": " + str(len(target_ids)).rjust(5), "errata")
-        print(
-            _("    add   "),
-            str(len(source_only)).rjust(5),
-            _("errata to  "),
-            target_channel,
-        )
-        print(
-            _("    remove"),
-            str(len(target_only)).rjust(5),
-            _("errata from"),
-            target_channel,
-        )
+        print(_("    add   "), str(
+            len(source_only)).rjust(5), _("errata to  "), target_channel)
+        print(_("    remove"), str(
+            len(target_only)).rjust(5), _("errata from"), target_channel)
 
-        if not self.user_confirm(
-            _("Perform these changes to channel ") + target_channel + " [y/N]:"
-        ):
+        if not self.user_confirm(_('Perform these changes to channel ') + target_channel + ' [y/N]:'):
             return 1
 
         for erratum in source_only:
@@ -3026,63 +2477,42 @@ def do_softwarechannel_errata_sync(self, args):
         #    array:
         #      string - advisoryName - name of an erratum to remove
         #    boolean removePackages - True to remove packages from the channel
-        self.client.channel.software.removeErrata(
-            self.session, target_channel, target_only, False
-        )
+        self.client.channel.software.removeErrata(self.session, target_channel,
+                                                  target_only, False)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_errata_merge(self):
-    print(_("softwarechannel_errata_merge: "))
-    print(_("merge errata of one software channel into another"))
-    print("")
-    print(
-        _(
-            "usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL [FROM_DATE] [TO_DATE]"
-        )
-    )
-    print(
-        _(
-            "example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel 2018-01-01"
-        )
-    )
-    print(_("note:    Providing only FROM_DATE will merge all errata since that date."))
-    print(_("note:    When no date is provided, all errata will be merged."))
-
+    print(_('softwarechannel_errata_merge: '))
+    print(_('merge errata of one software channel into another'))
+    print('')
+    print(_('usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL [FROM_DATE] [TO_DATE]'))
+    print(_('example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel 2018-01-01'))
+    print(_('note:    Providing only FROM_DATE will merge all errata since that date.'))
+    print(_('note:    When no date is provided, all errata will be merged.'))
 
 def complete_softwarechannel_errata_merge(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
     args = len(parts)
 
     if args == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     if args == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True), text)
     return []
 
-
-def do_softwarechannel_errata_merge(
-    self, args
-):  # pylint: disable=too-many-return-statements
-    # pylint: disable-next=undefined-variable
+def do_softwarechannel_errata_merge(self, args): # pylint: disable=too-many-return-statements
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     FROM_DATE = datetime.strptime("1970-01-01", "%Y-%m-%d")
-    # pylint: disable-next=undefined-variable
-    TO_DATE = datetime.now() + timedelta(1)  # tomorrow
+    TO_DATE   = datetime.now() + timedelta(1)   #tomorrow
 
     if len(args) < 2 or len(args) > 4:
         self.help_softwarechannel_errata_merge()
@@ -3090,256 +2520,191 @@ def do_softwarechannel_errata_merge(
 
     if len(args) >= 3:
         try:
-            # pylint: disable-next=undefined-variable
             FROM_DATE = datetime.strptime(args[2], "%Y-%m-%d")
         except ValueError:
-            print(
-                _("wrong dateformat: ") + args[2] + _(" please specify as: YYYY-MM-DD")
-            )
+            print(_('wrong dateformat: ') + args[2] + _(' please specify as: YYYY-MM-DD'))
             return 1
 
     if len(args) == 4:
         try:
-            # pylint: disable-next=undefined-variable
             TO_DATE = datetime.strptime(args[3], "%Y-%m-%d")
         except ValueError:
-            print(
-                _("wrong dateformat: ") + args[3] + _(" please specify as: YYYY-MM-DD")
-            )
+            print(_('wrong dateformat: ') + args[3] + _(' please specify as: YYYY-MM-DD'))
             return 1
 
     source_channel = args[0]
     target_channel = args[1]
 
-    if not self.check_softwarechannel(source_channel) or not self.check_softwarechannel(
-        target_channel
-    ):
+    if not self.check_softwarechannel(source_channel) or not self.check_softwarechannel(target_channel):
         return 1
 
-    # pylint: disable-next=undefined-variable
-    logging.info(
-        _N("merging errata from softwarechannel ")
-        + source_channel
-        + _N(" to ")
-        + target_channel
-    )
+    logging.info(_N("merging errata from softwarechannel ") + source_channel +
+                 _N(" to ") + target_channel)
 
     source_errata = self.client.channel.software.listErrata(
-        self.session, source_channel
-    )
+        self.session, source_channel)
 
     # filter out errata which are not in the specified timeframe (if given)
     for erratum in source_errata[:]:
-        # pylint: disable-next=undefined-variable
-        erratum_date = datetime.strptime(
-            erratum["issue_date"].split(" ")[0], "%Y-%m-%d"
-        )
+        erratum_date = datetime.strptime(erratum['issue_date'].split(' ')[0], "%Y-%m-%d")
 
-        # pylint: disable-next=superfluous-parens
         if not (FROM_DATE <= erratum_date <= TO_DATE):
             source_errata.remove(erratum)
 
     target_errata = self.client.channel.software.listErrata(
-        self.session, target_channel
-    )
+        self.session, target_channel)
 
     # store unique errata data in a set
     source_ids = set()
     for erratum in source_errata:
         try:
-            source_ids.add(erratum.get("advisory_name"))
+            source_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("failed to read key id"))
             continue
 
     target_ids = set()
     for erratum in target_errata:
         try:
-            target_ids.add(erratum.get("advisory_name"))
+            target_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            # pylint: disable-next=undefined-variable
             logging.error(_N("failed to read key id"))
             continue
 
     # check for errata only in the source channel
     source_only = list(source_ids.difference(target_ids))
 
-    if len(source_only) == 0:  # pylint: disable=len-as-condition
-        print(
-            _("{} contains no errata which is not already present in {}").format(
-                source_channel, target_channel
-            )
-        )
+    if len(source_only) == 0:     # pylint: disable=len-as-condition
+        print(_('{} contains no errata which is not already present in {}').format(source_channel, target_channel))
         return 1
 
     source_only.sort()
     if source_only:
-        print(_("errata to add to channel {}: ").format(target_channel))
+        print(_('errata to add to channel {}: ').format(target_channel))
         for i in source_only:
             print(i)
-        print("")
+        print('')
 
     print(_("summary:"))
     print("  " + source_channel + ": " + str(len(source_ids)).rjust(5) + _(" errata"))
     print("  " + target_channel + ": " + str(len(target_ids)).rjust(5) + _(" errata"))
-    print(
-        _("    add   ")
-        + str(len(source_only)).rjust(5)
-        + _(" errata to  ")
-        + target_channel
-    )
+    print (_("    add   ") + str(
+        len(source_only)).rjust(5) + _(" errata to  ") + target_channel)
 
-    if not self.user_confirm(
-        _("Perform these changes to channel {} [y/N]:").format(target_channel)
-    ):
+    if not self.user_confirm(_('Perform these changes to channel {} [y/N]:').format(target_channel)):
         return 1
 
-    self.client.channel.software.mergeErrata(
-        self.session, source_channel, target_channel, source_only
-    )
+    self.client.channel.software.mergeErrata(self.session, source_channel, target_channel, source_only)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_syncrepos(self):
-    print(_("softwarechannel_syncrepos: "))
-    print(_("Sync users repos for a software channel"))
-    print("")
-    print(_("usage: softwarechannel_syncrepos <CHANNEL ...>"))
-    print(_("Options:"))
-    print(_("    -e/--no-errata : Do not sync errata"))
-    print(_("    -f/--fail : Terminate upon any error"))
-    print(_("    -k/--sync-kickstart : Create kickstartable tree"))
-    print(_("    -l/--latest : Only download latest package versions when repo syncs"))
+    print(_('softwarechannel_syncrepos: '))
+    print(_('Sync users repos for a software channel'))
+    print('')
+    print(_('usage: softwarechannel_syncrepos <CHANNEL ...>'))
+    print(_('Options:'))
+    print(_('    -e/--no-errata : Do not sync errata'))
+    print(_('    -f/--fail : Terminate upon any error'))
+    print(_('    -k/--sync-kickstart : Create kickstartable tree'))
+    print(_('    -l/--latest : Only download latest package versions when repo syncs'))
 
 
 def complete_softwarechannel_syncrepos(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_syncrepos(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-e", "--no-errata", action="store_true", default=False)
-    arg_parser.add_argument("-f", "--fail", action="store_true", default=False)
-    arg_parser.add_argument(
-        "-k", "--sync-kickstart", action="store_true", default=False
-    )
-    arg_parser.add_argument("-l", "--latest", action="store_true", default=False)
+    arg_parser.add_argument('-e', '--no-errata', action='store_true', default=False)
+    arg_parser.add_argument('-f', '--fail', action='store_true', default=False)
+    arg_parser.add_argument('-k', '--sync-kickstart', action='store_true', default=False)
+    arg_parser.add_argument('-l', '--latest', action='store_true', default=False)
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    params = dict(
-        (i.replace("_", "-"), getattr(options, i))
-        for i in ["no_errata", "fail", "sync_kickstart", "latest"]
-    )
+    params = dict((i.replace('_', '-'), getattr(options, i)) for i in ['no_errata', 'fail', 'sync_kickstart', 'latest'])
 
     if not args:
         self.help_softwarechannel_syncrepos()
         return 1
 
     # allow globbing of software channel names
-    # pylint: disable-next=undefined-variable
-    channels = filter_results(self.do_softwarechannel_list("", True), args)
+    channels = filter_results(self.do_softwarechannel_list('', True), args)
 
     for channel in channels:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Syncing repos for %s" % channel)
+        logging.debug('Syncing repos for %s' % channel)
         self.client.channel.software.syncRepo(self.session, channel, params)
 
     return 0
-
 
 ####################
 
 
 def help_softwarechannel_setsyncschedule(self):
-    print(_("softwarechannel_setsyncschedule: "))
-    print(_("Sets the repo sync schedule for a software channel"))
-    print("")
-    print(_("usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"))
-    print(_("Options:"))
-    print(_("    -e/--no-errata : Do not sync errata"))
-    print(_("    -f/--fail : Terminate upon any error"))
-    print(_("    -k/--sync-kickstart : Create kickstartable tree"))
-    print(_("    -l/--latest : Only download latest package versions when repo syncs"))
-    print("")
-    print(
-        _(
-            "The schedule is specified in Quartz CronTrigger format without enclosing quotes."
-        )
-    )
-    print(
-        _(
-            "For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ?"
-        )
-    )
-    print(_("If <SCHEDULE> is left empty, it will be disabled."))
-    print("")
+    print(_('softwarechannel_setsyncschedule: '))
+    print(_('Sets the repo sync schedule for a software channel'))
+    print('')
+    print(_('usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>'))
+    print(_('Options:'))
+    print(_('    -e/--no-errata : Do not sync errata'))
+    print(_('    -f/--fail : Terminate upon any error'))
+    print(_('    -k/--sync-kickstart : Create kickstartable tree'))
+    print(_('    -l/--latest : Only download latest package versions when repo syncs'))
+    print('')
+    print(_('The schedule is specified in Quartz CronTrigger format without enclosing quotes.'))
+    print(_('For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ?'))
+    print(_('If <SCHEDULE> is left empty, it will be disabled.'))
+    print('')
 
 
 def complete_softwarechannel_setsyncschedule(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_setsyncschedule(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-e", "--no-errata", action="store_true", default=False)
-    arg_parser.add_argument("-f", "--fail", action="store_true", default=False)
-    arg_parser.add_argument(
-        "-k", "--sync-kickstart", action="store_true", default=False
-    )
-    arg_parser.add_argument("-l", "--latest", action="store_true", default=False)
+    arg_parser.add_argument('-e', '--no-errata', action='store_true', default=False)
+    arg_parser.add_argument('-f', '--fail', action='store_true', default=False)
+    arg_parser.add_argument('-k', '--sync-kickstart', action='store_true', default=False)
+    arg_parser.add_argument('-l', '--latest', action='store_true', default=False)
 
     # Set glob = false, otherwise this will generate a com.redhat.rhn.taskomatic.InvalidParamException: Cron trigger.
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser, glob=False)
 
-    params = dict(
-        (i.replace("_", "-"), getattr(options, i))
-        for i in ["no_errata", "fail", "sync_kickstart", "latest"]
-    )
+    params = dict((i.replace('_', '-'), getattr(options, i)) for i in ['no_errata', 'fail', 'sync_kickstart', 'latest'])
 
     if not len(args) in [1, 7]:
         self.help_softwarechannel_setsyncschedule()
         return 1
 
     channel = args[0]
-    schedule = " ".join(args[1:]) if len(args) == 7 else ""
+    schedule = ' '.join(args[1:]) if len(args) == 7 else ''
 
     self.client.channel.software.syncRepo(self.session, channel, schedule, params)
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_removesyncschedule(self):
-    print(_("softwarechannel_removesyncschedule: "))
-    print(_("Removes the repo sync schedule for a software channel"))
-    print("")
-    print(_("usage: softwarechannel_removesyncschedule <CHANNEL>"))
+    print(_('softwarechannel_removesyncschedule: '))
+    print(_('Removes the repo sync schedule for a software channel'))
+    print('')
+    print(_('usage: softwarechannel_removesyncschedule <CHANNEL>'))
 
 
 def complete_softwarechannel_removesyncschedule(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_removesyncschedule(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not len(args) == 1:
@@ -3348,25 +2713,20 @@ def do_softwarechannel_removesyncschedule(self, args):
 
     channel = args[0]
 
-    self.client.channel.software.syncRepo(self.session, channel, "")
+    self.client.channel.software.syncRepo(self.session, channel, '')
 
     return 0
 
-
 ####################
 
-
 def help_softwarechannel_listsyncschedule(self):
-    print(
-        _(
-            "softwarechannel_listsyncschedule: List sync schedules for all software channels"
-        )
-    )
-    print(_("usage:"))
-    print(_("softwarechannel_listsyncschedule : List all channels"))
+    print(_('softwarechannel_listsyncschedule: List sync schedules for all software channels'))
+    print(_('usage:'))
+    print(_('softwarechannel_listsyncschedule : List all channels'))
 
 
 def do_softwarechannel_listsyncschedule(self, args):
+
     # Get a list of all channels and sync schedules
     channels = self.client.channel.listAllChannels(self.session)
     schedules = self.client.taskomatic.org.listActiveSchedules(self.session)
@@ -3376,51 +2736,46 @@ def do_softwarechannel_listsyncschedule(self, args):
 
     # Build an array of channel names indexed by internal channel id number
     for c in channels:
-        chan_name[c["id"]] = c["label"]
-        chan_sched[c["id"]] = ""
+        chan_name[ c['id'] ] = c['label']
+        chan_sched[ c['id'] ] = ''
 
     # Build an array of schedules indexed by internal channel id number
     for s in schedules:
-        chan_sched[int(s["data_map"]["channel_id"])] = s["cron_expr"]
+        chan_sched[int(s['data_map']['channel_id'])] = s['cron_expr']
 
     # Print headers
-    csched_fmt = "{0:>5s}  {1:<40s} {2:<20s}"
-    print(csched_fmt.format(_("key"), _("Channel Name"), _("Update Schedule")))
-    print(csched_fmt.format("-----", "---------------------", "---------------"))
+    csched_fmt = '{0:>5s}  {1:<40s} {2:<20s}'
+    print(csched_fmt.format(_('key'), _('Channel Name'), _('Update Schedule')))
+    print(csched_fmt.format('-----', '---------------------', '---------------'))
 
     # Sort and print(the channel names and associated repo-sync schedule (if any))
-    for key, value in sorted(chan_name.items()):
+    for key,value in sorted(chan_name.items()):
         print(csched_fmt.format(str(key), value, chan_sched[int(key)]))
 
     return 0
 
-
 ####################
 
-
 def help_softwarechannel_addrepo(self):
-    print(_("softwarechannel_addrepo: Add a repo to a software channel"))
-    print(_("usage: softwarechannel_addrepo CHANNEL REPO"))
+    print(_('softwarechannel_addrepo: Add a repo to a software channel'))
+    print(_('usage: softwarechannel_addrepo CHANNEL REPO'))
 
 
 def complete_softwarechannel_addrepo(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
     elif len(parts) == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_repo_list("", True), text)
+        return tab_completer(self.do_repo_list('', True), text)
 
     return None
 
 
 def do_softwarechannel_addrepo(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -3434,39 +2789,36 @@ def do_softwarechannel_addrepo(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_removerepo(self):
-    print(_("softwarechannel_removerepo: Remove a repo from a software channel"))
-    print(_("usage: softwarechannel_removerepo CHANNEL REPO"))
+    print(_('softwarechannel_removerepo: Remove a repo from a software channel'))
+    print(_('usage: softwarechannel_removerepo CHANNEL REPO'))
 
 
 def complete_softwarechannel_removerepo(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_softwarechannel_list("", True), text)
+        return tab_completer(self.do_softwarechannel_list('', True),
+                             text)
     elif len(parts) == 3:
         try:
-            details = self.client.channel.software.getDetails(self.session, parts[1])
-            repos = [r.get("label") for r in details.get("contentSources")]
+            details = self.client.channel.software.getDetails(self.session,
+                                                              parts[1])
+            repos = [r.get('label') for r in details.get('contentSources')]
         except xmlrpclib.Fault:
             return None
 
-        # pylint: disable-next=undefined-variable
         return tab_completer(repos, text)
 
     return None
 
 
 def do_softwarechannel_removerepo(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -3480,25 +2832,21 @@ def do_softwarechannel_removerepo(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_softwarechannel_listrepos(self):
-    print(_("softwarechannel_listrepos: List the repos for a software channel"))
-    print(_("usage: softwarechannel_listrepos CHANNEL"))
+    print(_('softwarechannel_listrepos: List the repos for a software channel'))
+    print(_('usage: softwarechannel_listrepos CHANNEL'))
 
 
 def complete_softwarechannel_listrepos(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_listrepos(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -3506,57 +2854,52 @@ def do_softwarechannel_listrepos(self, args):
         return 1
     else:
         details = self.client.channel.software.getDetails(self.session, args[0])
-        repos = [r.get("label") for r in details.get("contentSources")]
+        repos = [r.get('label') for r in details.get('contentSources')]
 
         if repos:
-            print("\n".join(sorted(repos)))
+            print('\n'.join(sorted(repos)))
             return 0
         else:
             print(_("No repos have been found for this channel."))
             return 1
 
-
 ####################
 
 
 def help_softwarechannel_mirrorpackages(self):
-    print(_("softwarechannel_mirrorpackages: Download packages of a given channel"))
-    print(_("usage: softwarechannel_mirrorpackages CHANNEL"))
-    print(_("Options:"))
-    print(_("    -l/--latest : Only mirror latest package version"))
+    print(_('softwarechannel_mirrorpackages: Download packages of a given channel'))
+    print(_('usage: softwarechannel_mirrorpackages CHANNEL'))
+    print(_('Options:'))
+    print(_('    -l/--latest : Only mirror latest package version'))
 
 
 def complete_softwarechannel_mirrorpackages(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_softwarechannel_list("", True), text)
+    return tab_completer(self.do_softwarechannel_list('', True), text)
 
 
 def do_softwarechannel_mirrorpackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-l", "--latest", action="store_true")
+    arg_parser.add_argument('-l', '--latest', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_softwarechannel_mirrorpackages()
         return 1
     channel = args[0]
-    # pylint: disable-next=superfluous-parens
     if not (options.latest):
-        packages = self.client.channel.software.listAllPackages(self.session, channel)
+        packages = \
+            self.client.channel.software.listAllPackages(self.session, channel)
     else:
-        packages = self.client.channel.software.listLatestPackages(
-            self.session, channel
-        )
+        packages = \
+            self.client.channel.software.listLatestPackages(
+                self.session, channel)
 
     for package in packages:
-        package_url = self.client.packages.getPackageUrl(self.session, package["id"])
-        package_file = self.client.packages.getDetails(self.session, package["id"]).get(
-            "file"
-        )
-        # pylint: disable-next=undefined-variable
+        package_url = self.client.packages.getPackageUrl(
+            self.session, package['id'])
+        package_file = self.client.packages.getDetails(
+            self.session, package['id']).get('file')
         if os.path.isfile(package_file):
             print(_("Skipping"), package_file)
         else:
@@ -3564,21 +2907,13 @@ def do_softwarechannel_mirrorpackages(self, args):
             try:
                 urlretrieve(package_url, package_file)
             except ContentTooShortError:
-                # pylint: disable-next=undefined-variable
                 logging.error(
-                    _(
-                        "Received package %s from channel %s is broken. Content is too short"
-                    ),
-                    package_file,
-                    channel,
-                )
+                    _("Received package %s from channel %s is broken. Content is too short"),
+                    package_file, channel)
                 return 1
             except IOError:
-                # pylint: disable-next=undefined-variable
-                logging.error(
-                    _N("Could not fetch package %s from channel %s")
-                    % (package_file, channel)
-                )
+                logging.error(_N("Could not fetch package %s from channel %s") %
+                              (package_file, channel))
                 return 1
 
     return 0

--- a/spacecmd/src/spacecmd/ssm.py
+++ b/spacecmd/src/spacecmd/ssm.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -34,41 +33,39 @@ import gettext
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_ssm(self):
-    print(_("The System Set Manager (SSM) is a group of systems that you "))
-    print(_("can perform tasks on as a whole."))
-    print("")
-    print(_("Adding Systems:"))
-    print("> ssm_add group:rhel5-x86_64")
-    print("> ssm_add channel:rhel-x86_64-server-5")
-    print("> ssm_add search:device:vmware")
-    print("> ssm_add host.example.com")
-    print("")
-    print(_("Intersections:"))
-    print("> ssm_add group:rhel5-x86_64")
-    print("> ssm_intersect group:web-servers")
-    print("")
-    print(_("Using the SSM:"))
-    print("> system_installpackage ssm zsh")
-    print("> system_runscript ssm")
-
+    print(_('The System Set Manager (SSM) is a group of systems that you '))
+    print(_('can perform tasks on as a whole.'))
+    print('')
+    print(_('Adding Systems:'))
+    print('> ssm_add group:rhel5-x86_64')
+    print('> ssm_add channel:rhel-x86_64-server-5')
+    print('> ssm_add search:device:vmware')
+    print('> ssm_add host.example.com')
+    print('')
+    print(_('Intersections:'))
+    print('> ssm_add group:rhel5-x86_64')
+    print('> ssm_intersect group:web-servers')
+    print('')
+    print(_('Using the SSM:'))
+    print('> system_installpackage ssm zsh')
+    print('> system_runscript ssm')
 
 ####################
 
 
 def help_ssm_add(self):
-    print(_("ssm_add: Add systems to the SSM"))
-    print(_("usage: ssm_add <SYSTEMS>"))
-    print("")
+    print(_('ssm_add: Add systems to the SSM'))
+    print(_('usage: ssm_add <SYSTEMS>'))
+    print('')
     print(_("see 'help ssm' for more details"))
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -77,10 +74,8 @@ def complete_ssm_add(self, text, line, beg, end):
 
 
 def do_ssm_add(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -90,41 +85,35 @@ def do_ssm_add(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems found"))
+        logging.warning(_N('No systems found'))
         return 1
 
     for system in systems:
         if system in self.ssm:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s is already in the list") % system)
+            logging.warning(_N('%s is already in the list') % system)
             continue
         self.ssm[system] = self.get_system_id(system)
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Added %s" % system)
+        logging.debug('Added %s' % system)
 
     if self.ssm:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Systems Selected: %i" % len(self.ssm))
+        logging.debug('Systems Selected: %i' % len(self.ssm))
 
     # save the SSM for use between sessions
-    # pylint: disable-next=undefined-variable
     save_cache(self.ssm_cache_file, self.ssm)
 
     return 0
-
 
 ####################
 
 
 def help_ssm_intersect(self):
-    print(_("ssm_intersect: Replace the current SSM with the intersection"))
-    print(_("               of the current list of systems and the list of"))
-    print(_("               systems passed as arguments"))
-    print(_("usage: ssm_intersect <SYSTEMS>"))
-    print("")
+    print(_('ssm_intersect: Replace the current SSM with the intersection'))
+    print(_('               of the current list of systems and the list of'))
+    print(_('               systems passed as arguments'))
+    print(_('usage: ssm_intersect <SYSTEMS>'))
+    print('')
     print(_("see 'help ssm' for more details"))
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -133,10 +122,8 @@ def complete_ssm_intersect(self, text, line, beg, end):
 
 
 def do_ssm_intersect(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -146,8 +133,7 @@ def do_ssm_intersect(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems found"))
+        logging.warning(_N('No systems found'))
         return 1
 
     # tmp_ssm placeholder to gather systems that are both in original ssm
@@ -155,33 +141,29 @@ def do_ssm_intersect(self, args):
     tmp_ssm = {}
     for system in systems:
         if system in self.ssm:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("%s is in both groups: leaving in SSM" % system)
+            logging.debug('%s is in both groups: leaving in SSM' % system)
             tmp_ssm[system] = self.ssm[system]
 
     # set self.ssm to tmp_ssm, which now holds the intersection
     self.ssm = tmp_ssm
 
     # save the SSM for use between sessions
-    # pylint: disable-next=undefined-variable
     save_cache(self.ssm_cache_file, self.ssm)
 
     if self.ssm:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Systems Selected: %i" % len(self.ssm))
+        logging.debug('Systems Selected: %i' % len(self.ssm))
 
     return 0
-
 
 ####################
 
 
 def help_ssm_remove(self):
-    print(_("ssm_remove: Remove systems from the SSM"))
-    print(_("usage: ssm_remove <SYSTEMS>"))
-    print("")
+    print(_('ssm_remove: Remove systems from the SSM'))
+    print(_('usage: ssm_remove <SYSTEMS>'))
+    print('')
     print(_("see 'help ssm' for more details"))
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -190,10 +172,8 @@ def complete_ssm_remove(self, text, line, beg, end):
 
 
 def do_ssm_remove(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -203,34 +183,29 @@ def do_ssm_remove(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems found"))
+        logging.warning(_N('No systems found'))
         return 1
 
     for system in systems:
         # double-check for existance in case of duplicate names
         if system in self.ssm:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("Removed %s" % system)
+            logging.debug('Removed %s' % system)
             del self.ssm[system]
 
-    # pylint: disable-next=undefined-variable,consider-using-f-string
-    logging.debug("Systems Selected: %i" % len(self.ssm))
+    logging.debug('Systems Selected: %i' % len(self.ssm))
 
     # save the SSM for use between sessions
-    # pylint: disable-next=undefined-variable
     save_cache(self.ssm_cache_file, self.ssm)
 
     return 0
-
 
 ####################
 
 
 def help_ssm_list(self):
-    print(_("ssm_list: List the systems currently in the SSM"))
-    print(_("usage: ssm_list"))
-    print("")
+    print(_('ssm_list: List the systems currently in the SSM'))
+    print(_('usage: ssm_list'))
+    print('')
     print(_("see 'help ssm' for more details"))
 
 
@@ -238,27 +213,24 @@ def do_ssm_list(self, args):
     systems = sorted(self.ssm)
 
     if systems:
-        print("\n".join(systems))
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Systems Selected: %i" % len(systems))
+        print('\n'.join(systems))
+        logging.debug('Systems Selected: %i' % len(systems))
         return 0
     else:
         return 1
-
 
 ####################
 
 
 def help_ssm_clear(self):
-    print(_("ssm_clear: Remove all systems from the SSM"))
-    print(_("usage: ssm_clear"))
+    print(_('ssm_clear: Remove all systems from the SSM'))
+    print(_('usage: ssm_clear'))
 
 
 def do_ssm_clear(self, args):
     self.ssm = {}
 
     # save the SSM for use between sessions
-    # pylint: disable-next=undefined-variable
     save_cache(self.ssm_cache_file, self.ssm)
 
     return 0

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -34,7 +33,6 @@
 import gettext
 import shlex
 from datetime import datetime
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -45,81 +43,63 @@ from xml.parsers.expat import ExpatError
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-__PKG_COMPARISONS = {
-    0: _("Same"),
-    1: _("Only here"),
-    2: _("Newer here"),
-    3: _("Only there"),
-    4: _("Newer there"),
-}
+__PKG_COMPARISONS = {0: _('Same'),
+                     1: _('Only here'),
+                     2: _('Newer here'),
+                     3: _('Only there'),
+                     4: _('Newer there')}
 
 
 def print_package_comparison(self, results):
-    # pylint: disable-next=undefined-variable
-    max_name = max_length(map(itemgetter("package_name"), results), minimum=7)
+    max_name = max_length(map(itemgetter('package_name'), results), minimum=7)
 
     # sometimes 'this_system' or 'other_system' can be None
     tmp_this = []
     tmp_other = []
     for item in results:
-        tmp_this.append(str(item.get("this_system")))
-        tmp_other.append(str(item.get("other_system")))
+        tmp_this.append(str(item.get('this_system')))
+        tmp_other.append(str(item.get('other_system')))
 
-    # pylint: disable-next=undefined-variable
     max_this = max_length(tmp_this, minimum=11)
-    # pylint: disable-next=undefined-variable
     max_other = max_length(tmp_other, minimum=12)
 
     max_comparison = 10
 
     # print(headers)
-    print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % (
-            _("Package").ljust(max_name),
-            _("This System").ljust(max_this),
-            _("Other System").ljust(max_other),
-            _("Difference").ljust(max_comparison),
-        )
-    )
+    print('%s  %s  %s  %s' % (
+        _('Package').ljust(max_name),
+        _('This System').ljust(max_this),
+        _('Other System').ljust(max_other),
+        _('Difference').ljust(max_comparison)))
 
-    print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % ("-" * max_name, "-" * max_this, "-" * max_other, "-" * max_comparison)
-    )
+    print('%s  %s  %s  %s' % (
+        '-' * max_name,
+        '-' * max_this,
+        '-' * max_other,
+        '-' * max_comparison))
 
     for item in results:
         # don't show packages that are the same
-        if item.get("comparison") == 0:
+        if item.get('comparison') == 0:
             continue
 
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                item.get("package_name").ljust(max_name),
-                str(item.get("this_system")).ljust(max_this),
-                str(item.get("other_system")).ljust(max_other),
-                __PKG_COMPARISONS[item.get("comparison")],
-            )
-        )
-
+        print('%s  %s  %s  %s' % (
+            item.get('package_name').ljust(max_name),
+            str(item.get('this_system')).ljust(max_this),
+            str(item.get('other_system')).ljust(max_other),
+            __PKG_COMPARISONS[item.get('comparison')]))
 
 ####################
 
 
 def manipulate_child_channels(self, args, remove=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -130,8 +110,7 @@ def manipulate_child_channels(self, args, remove=False):
         return
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
@@ -139,20 +118,19 @@ def manipulate_child_channels(self, args, remove=False):
 
     new_channels = args
 
-    print(_("Systems"))
-    print("-------")
-    # pylint: disable-next=consider-using-f-string
-    print("\n".join(sorted(["%s" % x for x in systems])))
-    print("")
+    print(_('Systems'))
+    print('-------')
+    print('\n'.join(sorted(["%s" % x for x in systems])))
+    print('')
 
     if remove:
-        print(_("Removing Channels"))
-        print("-----------------")
+        print(_('Removing Channels'))
+        print('-----------------')
     else:
-        print(_("Adding Channels"))
-        print("---------------")
+        print(_('Adding Channels'))
+        print('---------------')
 
-    print("\n".join(sorted(new_channels)))
+    print('\n'.join(sorted(new_channels)))
 
     if not self.user_confirm():
         return
@@ -162,11 +140,11 @@ def manipulate_child_channels(self, args, remove=False):
         if not system_id:
             continue
 
-        child_channels = self.client.system.listSubscribedChildChannels(
-            self.session, system_id
-        )
+        child_channels = \
+            self.client.system.listSubscribedChildChannels(self.session,
+                                                           system_id)
 
-        child_channels = [c.get("label") for c in child_channels]
+        child_channels = [c.get('label') for c in child_channels]
 
         if remove:
             for channel in new_channels:
@@ -177,17 +155,18 @@ def manipulate_child_channels(self, args, remove=False):
                 if channel not in child_channels:
                     child_channels.append(channel)
 
-        self.client.system.setChildChannels(self.session, system_id, child_channels)
+        self.client.system.setChildChannels(self.session,
+                                            system_id,
+                                            child_channels)
 
     return
-
 
 ####################
 
 
 def help_system_list(self):
-    print(_("system_list: List all system profiles"))
-    print(_("usage: system_list"))
+    print(_('system_list: List all system profiles'))
+    print(_('usage: system_list'))
 
 
 def do_system_list(self, args, doreturn=False):
@@ -195,38 +174,23 @@ def do_system_list(self, args, doreturn=False):
         return self.get_system_names()
     else:
         if self.get_system_names():
-            print(
-                "\n".join(
-                    sorted(
-                        [
-                            # pylint: disable-next=consider-using-f-string
-                            "%s : %s" % (v, k)
-                            for k, v in self.get_system_names_ids().items()
-                        ]
-                    )
-                )
-            )
+            print('\n'.join(sorted(['%s : %s' % (v, k) for k, v in self.get_system_names_ids().items()])))
 
     return 0
-
 
 ####################
 
 
 def help_system_reboot(self):
-    print(_("system_reboot: Reboot a system"))
-    print(
-        _(
-            """usage: system_reboot <SYSTEMS> [options])
+    print(_('system_reboot: Reboot a system'))
+    print(_('''usage: system_reboot <SYSTEMS> [options])
 
 options:
-  -s START_TIME"""
-        )
-    )
+  -s START_TIME'''))
 
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
@@ -235,11 +199,9 @@ def complete_system_reboot(self, text, line, beg, end):
 
 
 def do_system_reboot(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -247,43 +209,36 @@ def do_system_reboot(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user("Start Time [now]:")
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user('Start Time [now]:')
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
-    print("")
+    print('')
 
-    print(_("Start Time: %s") % options.start_time)
-    print("")
-    print(_("Systems"))
-    print("-------")
-    print("\n".join(sorted(systems)))
+    print(_('Start Time: %s') % options.start_time)
+    print('')
+    print(_('Systems'))
+    print('-------')
+    print('\n'.join(sorted(systems)))
 
-    if not self.user_confirm(_("Reboot these systems [y/N]:")):
+    if not self.user_confirm(_('Reboot these systems [y/N]:')):
         return 1
 
     for system in systems:
@@ -295,27 +250,24 @@ def do_system_reboot(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_system_search(self):
-    print(_("system_search: List systems that match the given criteria"))
-    print(_("usage: system_search QUERY"))
-    print("")
-    print(_("Available Fields:"))
-    print("\n".join(self.SYSTEM_SEARCH_FIELDS))
-    print("")
-    print(_("Examples:"))
-    print(_("> system_search device:vmware"))
-    print(_("> system_search ip:192.168.82"))
+    print(_('system_search: List systems that match the given criteria'))
+    print(_('usage: system_search QUERY'))
+    print('')
+    print(_('Available Fields:'))
+    print('\n'.join(self.SYSTEM_SEARCH_FIELDS))
+    print('')
+    print(_('Examples:'))
+    print(_('> system_search device:vmware'))
+    print(_('> system_search ip:192.168.82'))
 
 
 def do_system_search(self, args, doreturn=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -324,89 +276,86 @@ def do_system_search(self, args, doreturn=False):
 
     query = args[0]
 
-    # pylint: disable-next=undefined-variable
-    if re.search(":", query):
+    if re.search(':', query):
         try:
-            (field, value) = query.split(":")
+            (field, value) = query.split(':')
         except ValueError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Invalid query"))
+            logging.error(_N('Invalid query'))
             return []
     else:
-        field = "name"
+        field = 'name'
         value = query
 
     if not value:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("Invalid query"))
+        logging.warning(_N('Invalid query'))
         return []
 
     results = []
-    if field == "name":
-        results = self.client.system.search.nameAndDescription(self.session, value)
-        key = "name"
-    elif field == "id":
+    if field == 'name':
+        results = self.client.system.search.nameAndDescription(self.session,
+                                                               value)
+        key = 'name'
+    elif field == 'id':
         # build an array of key/value pairs from our local system cache
         self.generate_system_cache()
-        results = [{"id": k, "name": self.all_systems[k]} for k in self.all_systems]
-        key = "id"
-    elif field == "ip":
+        results = [{'id': k, 'name': self.all_systems[k]}
+                   for k in self.all_systems]
+        key = 'id'
+    elif field == 'ip':
         results = self.client.system.search.ip(self.session, value)
-        key = "ip"
-    elif field == "hostname":
+        key = 'ip'
+    elif field == 'hostname':
         results = self.client.system.search.hostname(self.session, value)
-        key = "hostname"
-    elif field == "device":
-        results = self.client.system.search.deviceDescription(self.session, value)
-        key = "hw_description"
-    elif field == "vendor":
-        results = self.client.system.search.deviceVendorId(self.session, value)
-        key = "hw_vendor_id"
-    elif field == "driver":
-        results = self.client.system.search.deviceDriver(self.session, value)
-        key = "hw_driver"
-    elif field == "uuid":
+        key = 'hostname'
+    elif field == 'device':
+        results = self.client.system.search.deviceDescription(self.session,
+                                                              value)
+        key = 'hw_description'
+    elif field == 'vendor':
+        results = self.client.system.search.deviceVendorId(self.session,
+                                                           value)
+        key = 'hw_vendor_id'
+    elif field == 'driver':
+        results = self.client.system.search.deviceDriver(self.session,
+                                                         value)
+        key = 'hw_driver'
+    elif field == 'uuid':
         results = self.client.system.search.uuid(self.session, value)
-        key = "uuid"
+        key = 'uuid'
     else:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("Invalid search field"))
+        logging.warning(_N('Invalid search field'))
         return []
 
     systems = []
     max_size = 0
     for s in results:
         # only use real matches, not the fuzzy ones we get back
-        # pylint: disable-next=undefined-variable,consider-using-f-string
         if re.search(value, "%s" % s.get(key), re.I):
-            if len(s.get("name")) > max_size:
-                max_size = len(s.get("name"))
+            if len(s.get('name')) > max_size:
+                max_size = len(s.get('name'))
 
-            systems.append((s.get("name"), s.get(key), s.get("id")))
+            systems.append((s.get('name'), s.get(key), s.get('id')))
 
     if doreturn:
         return [s[2] for s in systems]
     else:
         if systems:
             for s in sorted(systems):
-                if key == "name":
+                if key == 'name':
                     print(s[0])
                 else:
-                    # pylint: disable-next=consider-using-f-string
-                    print("%s  %s" % (s[0].ljust(max_size), str(s[1]).strip()))
+                    print('%s  %s' % (s[0].ljust(max_size),
+                                      str(s[1]).strip()))
 
     return 0
-
 
 ####################
 
 
 def help_system_runscript(self):
-    print(_("system_runscript: Schedule a script to run on the list of"))
-    print(_("                  systems provided"))
-    print(
-        _(
-            """usage: system_runscript <SYSTEMS> [options])
+    print(_('system_runscript: Schedule a script to run on the list of'))
+    print(_('                  systems provided'))
+    print(_('''usage: system_runscript <SYSTEMS> [options])
 
 options:
   -u USER
@@ -414,12 +363,10 @@ options:
   -t TIMEOUT
   -s START_TIME
   -l LABEL
-  -f FILE"""
-        )
-    )
-    print("")
+  -f FILE'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
@@ -427,17 +374,15 @@ def complete_system_runscript(self, text, line, beg, end):
     return self.tab_complete_systems(text)
 
 
-def do_system_runscript(self, args):  # pylint: disable=too-many-return-statements
-    # pylint: disable-next=undefined-variable
+def do_system_runscript(self, args): # pylint: disable=too-many-return-statements
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-u", "--user")
-    arg_parser.add_argument("-g", "--group")
-    arg_parser.add_argument("-t", "--timeout")
-    arg_parser.add_argument("-s", "--start-time")
-    arg_parser.add_argument("-l", "--label")
-    arg_parser.add_argument("-f", "--file")
+    arg_parser.add_argument('-u', '--user')
+    arg_parser.add_argument('-g', '--group')
+    arg_parser.add_argument('-t', '--timeout')
+    arg_parser.add_argument('-s', '--start-time')
+    arg_parser.add_argument('-l', '--label')
+    arg_parser.add_argument('-f', '--file')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -445,76 +390,62 @@ def do_system_runscript(self, args):  # pylint: disable=too-many-return-statemen
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.user = prompt_user(_("User [root]:"))
-        # pylint: disable-next=undefined-variable
-        options.group = prompt_user(_("Group [root]:"))
+        options.user = prompt_user(_('User [root]:'))
+        options.group = prompt_user(_('Group [root]:'))
 
         # defaults
         if not options.user:
-            options.user = "root"
+            options.user = 'root'
         if not options.group:
-            options.group = "root"
+            options.group = 'root'
 
         try:
-            # pylint: disable-next=undefined-variable
-            options.timeout = prompt_user(_("Timeout (in seconds) [600]:"))
+            options.timeout = prompt_user(_('Timeout (in seconds) [600]:'))
             if options.timeout:
                 options.timeout = int(options.timeout)
             else:
                 options.timeout = 600
         except ValueError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Invalid timeout"))
+            logging.error(_N('Invalid timeout'))
             return 1
 
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
 
-        # pylint: disable-next=undefined-variable
-        options.label = prompt_user(_("Label/Short Description [default]:"))
+        options.label = prompt_user(_('Label/Short Description [default]:'))
         if options.label == "":
             options.label = None
 
-        # pylint: disable-next=undefined-variable
-        options.file = prompt_user(_("Script File [create]:"))
+        options.file = prompt_user(_('Script File [create]:'))
 
         # read the script provided by the user
         if options.file:
             keep_script_file = True
 
-            # pylint: disable-next=undefined-variable
             script_contents = read_file(os.path.abspath(options.file))
         else:
             # have the user write their script
-            # pylint: disable-next=undefined-variable
-            (script_contents, options.file) = editor("#!/bin/bash")
+            (script_contents, options.file) = editor('#!/bin/bash')
             keep_script_file = False
 
         if not script_contents:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("No script provided"))
+            logging.error(_N('No script provided'))
             return 1
     else:
         if not options.user:
-            options.user = "root"
+            options.user = 'root'
         if not options.group:
-            options.group = "root"
+            options.group = 'root'
         if not options.label:
             options.label = None
         if not options.timeout:
@@ -522,37 +453,33 @@ def do_system_runscript(self, args):  # pylint: disable=too-many-return-statemen
         else:
             options.timeout = int(options.timeout)
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
         if not options.file:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A script file is required"))
+            logging.error(_N('A script file is required'))
             return 1
 
-        # pylint: disable-next=undefined-variable
         script_contents = read_file(options.file)
         keep_script_file = True
 
     # display a summary
-    print("")
-    print(_("User:       %s") % options.user)
-    print(_("Group:      %s") % options.group)
-    print(_("Timeout:    %i seconds") % options.timeout)
-    print(_("Start Time: %s") % options.start_time)
-    print("")
+    print('')
+    print(_('User:       %s') % options.user)
+    print(_('Group:      %s') % options.group)
+    print(_('Timeout:    %i seconds') % options.timeout)
+    print(_('Start Time: %s') % options.start_time)
+    print('')
     if options.label:
-        print(_("Label:      %s") % options.label)
-    print(_("Script Contents"))
-    print("---------------")
+        print(_('Label:      %s') % options.label)
+    print(_('Script Contents'))
+    print('---------------')
     print(script_contents)
 
-    print(_("Systems"))
-    print("-------")
-    print("\n".join(sorted(systems)))
+    print(_('Systems'))
+    print('-------')
+    print('\n'.join(sorted(systems)))
 
     # have the user confirm
     if not self.user_confirm():
@@ -560,36 +487,31 @@ def do_system_runscript(self, args):  # pylint: disable=too-many-return-statemen
 
     scheduled = 0
 
-    if self.check_api_version("10.11"):
-        # pylint: disable-next=undefined-variable
-        logging.debug("Scheduling all systems for the same action")
+    if self.check_api_version('10.11'):
+        logging.debug('Scheduling all systems for the same action')
 
         # schedule all systems for the same action
         system_ids = [self.get_system_id(s) for s in systems]
         if not options.label:
-            action_id = self.client.system.scheduleScriptRun(
-                self.session,
-                system_ids,
-                options.user,
-                options.group,
-                options.timeout,
-                script_contents,
-                options.start_time,
-            )
+            action_id = self.client.system.scheduleScriptRun(self.session,
+                                                             system_ids,
+                                                             options.user,
+                                                             options.group,
+                                                             options.timeout,
+                                                             script_contents,
+                                                             options.start_time)
         else:
-            action_id = self.client.system.scheduleScriptRun(
-                self.session,
-                options.label,
-                system_ids,
-                options.user,
-                options.group,
-                options.timeout,
-                script_contents,
-                options.start_time,
-            )
+            action_id = self.client.system.scheduleScriptRun(self.session,
+                                                             options.label,
+                                                             system_ids,
+                                                             options.user,
+                                                             options.group,
+                                                             options.timeout,
+                                                             script_contents,
+                                                             options.start_time)
 
-        # pylint: disable-next=undefined-variable
-        logging.info(_N("Action ID: %i") % action_id)
+
+        logging.info(_N('Action ID: %i') % action_id)
         scheduled = len(system_ids)
     else:
         # older versions of the API require each system to be
@@ -600,49 +522,41 @@ def do_system_runscript(self, args):  # pylint: disable=too-many-return-statemen
                 continue
 
             try:
-                action_id = self.client.system.scheduleScriptRun(
-                    self.session,
-                    system_id,
-                    options.user,
-                    options.group,
-                    options.timeout,
-                    script_contents,
-                    options.start_time,
-                )
+                action_id = \
+                    self.client.system.scheduleScriptRun(self.session,
+                                                         system_id,
+                                                         options.user,
+                                                         options.group,
+                                                         options.timeout,
+                                                         script_contents,
+                                                         options.start_time)
 
-                # pylint: disable-next=undefined-variable
-                logging.info(_N("Action ID: %i") % action_id)
+                logging.info(_N('Action ID: %i') % action_id)
                 scheduled += 1
             except xmlrpclib.Fault as detail:
-                # pylint: disable-next=undefined-variable
                 logging.debug(detail)
-                # pylint: disable-next=undefined-variable
-                logging.error(_N("Failed to schedule %s") % system)
+                logging.error(_N('Failed to schedule %s') % system)
                 return 1
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Scheduled: %i system(s)") % scheduled)
+    logging.info(_N('Scheduled: %i system(s)') % scheduled)
 
     # don't delete a pre-existing script that the user provided
     if not keep_script_file:
         try:
-            # pylint: disable-next=undefined-variable
             os.remove(options.file)
         except OSError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Could not remove %s") % options.file)
+            logging.error(_N('Could not remove %s') % options.file)
             return 1
 
     return 0
-
 
 ####################
 
 
 def help_system_listhardware(self):
-    print(_("system_listhardware: List the hardware details of a system"))
-    print(_("usage: system_listhardware <SYSTEMS>"))
-    print("")
+    print(_('system_listhardware: List the hardware details of a system'))
+    print(_('usage: system_listhardware <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -651,9 +565,7 @@ def complete_system_listhardware(self, text, line, beg, end):
 
 
 def do_system_listhardware(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -663,15 +575,13 @@ def do_system_listhardware(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -682,12 +592,13 @@ def do_system_listhardware(self, args):
         cpu = self.client.system.getCpu(self.session, system_id)
         memory = self.client.system.getMemory(self.session, system_id)
         devices = self.client.system.getDevices(self.session, system_id)
-        network = self.client.system.getNetworkDevices(self.session, system_id)
+        network = self.client.system.getNetworkDevices(self.session,
+                                                       system_id)
 
         # Solaris systems don't have these value s
-        for v in ("cache", "vendor", "family", "stepping"):
+        for v in ('cache', 'vendor', 'family', 'stepping'):
             if not cpu.get(v):
-                cpu[v] = ""
+                cpu[v] = ''
 
         try:
             dmi = self.client.system.getDmi(self.session, system_id)
@@ -699,128 +610,114 @@ def do_system_listhardware(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
-            print("")
+            print(_('System: %s') % system)
+            print('')
 
         if network:
-            print(_("Network"))
-            print("-------")
+            print(_('Network'))
+            print('-------')
 
             count = 0
             for device in network:
                 if count:
-                    print("")
+                    print('')
                 count += 1
 
-                print(_("Interface:   %s") % device.get("interface"))
-                print(_("MAC Address: %s") % device.get("hardware_address").upper())
-                print(_("IP Address:  %s") % device.get("ip"))
-                print(_("Netmask:     %s") % device.get("netmask"))
-                print(_("Broadcast:   %s") % device.get("broadcast"))
-                print(_("Module:      %s") % device.get("module"))
+                print(_('Interface:   %s') % device.get('interface'))
+                print(_('MAC Address: %s') % device.get('hardware_address').upper())
+                print(_('IP Address:  %s') % device.get('ip'))
+                print(_('Netmask:     %s') % device.get('netmask'))
+                print(_('Broadcast:   %s') % device.get('broadcast'))
+                print(_('Module:      %s') % device.get('module'))
 
-            print("")
+            print('')
 
-        print(_("CPU"))
-        print("---")
-        print(_("Count:    %i") % cpu.get("count"))
-        print(_("Arch:     %s") % cpu.get("arch"))
-        print(_("MHz:      %s") % cpu.get("mhz"))
-        print(_("Cache:    %s") % cpu.get("cache"))
-        print(_("Vendor:   %s") % cpu.get("vendor"))
-        # pylint: disable-next=undefined-variable
-        print(_("Model:    %s") % re.sub(r"\s+", " ", cpu.get("model")))
+        print(_('CPU'))
+        print('---')
+        print(_('Count:    %i') % cpu.get('count'))
+        print(_('Arch:     %s') % cpu.get('arch'))
+        print(_('MHz:      %s') % cpu.get('mhz'))
+        print(_('Cache:    %s') % cpu.get('cache'))
+        print(_('Vendor:   %s') % cpu.get('vendor'))
+        print(_('Model:    %s') % re.sub(r'\s+', ' ', cpu.get('model')))
 
-        print("")
-        print(_("Memory"))
-        print("------")
-        print(_("RAM:  %i") % memory.get("ram"))
-        print(_("Swap: %i") % memory.get("swap"))
+        print('')
+        print(_('Memory'))
+        print('------')
+        print(_('RAM:  %i') % memory.get('ram'))
+        print(_('Swap: %i') % memory.get('swap'))
 
         if dmi:
-            print("")
-            print(_("DMI"))
-            print(_("Vendor:       %s") % dmi.get("vendor"))
-            print(_("System:       %s") % dmi.get("system"))
-            print(_("Product:      %s") % dmi.get("product"))
-            print(_("Board:        %s") % dmi.get("board"))
+            print('')
+            print(_('DMI'))
+            print(_('Vendor:       %s') % dmi.get('vendor'))
+            print(_('System:       %s') % dmi.get('system'))
+            print(_('Product:      %s') % dmi.get('product'))
+            print(_('Board:        %s') % dmi.get('board'))
 
-            print("")
-            print(_("Asset"))
-            print("-----")
-            for asset in dmi.get("asset").split(") ("):
-                # pylint: disable-next=undefined-variable
-                print(re.sub(r"\)|\(", "", asset))
+            print('')
+            print(_('Asset'))
+            print('-----')
+            for asset in dmi.get('asset').split(') ('):
+                print(re.sub(r'\)|\(', '', asset))
 
-            print("")
-            print(_("BIOS Release: %s") % dmi.get("bios_release"))
-            print(_("BIOS Vendor:  %s") % dmi.get("bios_vendor"))
-            print(_("BIOS Version: %s") % dmi.get("bios_version"))
+            print('')
+            print(_('BIOS Release: %s') % dmi.get('bios_release'))
+            print(_('BIOS Vendor:  %s') % dmi.get('bios_vendor'))
+            print(_('BIOS Version: %s') % dmi.get('bios_version'))
 
         if devices:
-            print("")
-            print(_("Devices"))
-            print("-------")
+            print('')
+            print(_('Devices'))
+            print('-------')
 
             count = 0
             for device in devices:
                 if count:
-                    print("")
+                    print('')
                 count += 1
 
-                if device.get("description") is None:
-                    print(_("Description: None"))
+                if device.get('description') is None:
+                    print(_('Description: None'))
                 else:
-                    print(
-                        _("Description: %s")
-                        # pylint: disable-next=undefined-variable
-                        % (wrap(device.get("description"), 60)[0])
-                    )
-                print(_("Driver:      %s") % device.get("driver"))
-                print(_("Class:       %s") % device.get("device_class"))
-                print(_("Bus:         %s") % device.get("bus"))
+                    print(_('Description: %s') % (
+                        wrap(device.get('description'), 60)[0]))
+                print(_('Driver:      %s') % device.get('driver'))
+                print(_('Class:       %s') % device.get('device_class'))
+                print(_('Bus:         %s') % device.get('bus'))
 
     return 0
-
 
 ####################
 
 
 def help_system_installpackage(self):
-    print(_("system_installpackage: Install a package on a system"))
-    print(
-        _(
-            """usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])
+    print(_('system_installpackage: Install a package on a system'))
+    print(_('''usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME'''))
 
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def complete_system_installpackage(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.get_package_names(), text)
 
     return None
 
-
 def do_system_installpackage(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -830,23 +727,17 @@ def do_system_installpackage(self, args):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
 
         # remove 'ssm' from the argument list
@@ -855,8 +746,7 @@ def do_system_installpackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     packages_to_install = args
@@ -871,52 +761,46 @@ def do_system_installpackage(self, args):
 
     jobs = {}
 
-    if self.check_api_version("10.11"):
+    if self.check_api_version('10.11'):
         for package in packages_to_install:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("Finding the latest version of %s" % package)
+            logging.debug('Finding the latest version of %s' % package)
 
-            avail_packages = self.client.system.listLatestAvailablePackage(
-                self.session, system_ids, package
-            )
+            avail_packages = \
+                self.client.system.listLatestAvailablePackage(self.session,
+                                                              system_ids,
+                                                              package)
 
             for system in avail_packages:
-                system_id = system.get("id")
+                system_id = system.get('id')
                 if system_id not in jobs:
                     jobs[system_id] = []
 
                 # add this package to the system's queue
-                jobs[system_id].append(system.get("package").get("id"))
+                jobs[system_id].append(system.get('package').get('id'))
     else:
         # XXX: Satellite 5.3 compatibility
         for system_id in system_ids:
-            # pylint: disable-next=undefined-variable
-            logging.debug(
-                # pylint: disable-next=consider-using-f-string
-                "Getting available packages for %s"
-                % self.get_system_name(system_id)
-            )
+            logging.debug('Getting available packages for %s' %
+                          self.get_system_name(system_id))
 
-            avail_packages = self.client.system.listLatestInstallablePackages(
-                self.session, system_id
-            )
+            avail_packages = \
+                self.client.system.listLatestInstallablePackages(self.session,
+                                                                 system_id)
 
             for package in avail_packages:
-                if package.get("name") in packages_to_install:
+                if package.get('name') in packages_to_install:
                     if system_id not in jobs:
                         jobs[system_id] = []
 
-                    jobs[system_id].append(package.get("id"))
+                    jobs[system_id].append(package.get('id'))
 
     if not jobs:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No packages to install"))
+        logging.warning(_N('No packages to install'))
         return 1
 
     add_separator = False
 
     warnings = []
-    # pylint: disable-next=consider-using-dict-items
     for system_id in jobs:
         if add_separator:
             print(self.SEPARATOR)
@@ -927,84 +811,69 @@ def do_system_installpackage(self, args):
             # stash the warnings and show at the end so the user can see them
             warnings.append(system_id)
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s:" % self.get_system_name(system_id))
+        print('%s:' % self.get_system_name(system_id))
         for package_id in jobs[system_id]:
             print(self.get_package_name(package_id))
 
     # show the warnings to the user
     if warnings:
-        print("")
+        print('')
     for system_id in warnings:
-        # pylint: disable-next=undefined-variable
-        logging.warning(
-            _N("%s does not have access to all requested packages")
-            % self.get_system_name(system_id)
-        )
+        logging.warning(_N('%s does not have access to all requested packages') %
+                        self.get_system_name(system_id))
 
-    print("")
-    print(_("Start Time: %s") % options.start_time)
+    print('')
+    print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm(_("Install these packages [y/N]:")):
+    if not self.user_confirm(_('Install these packages [y/N]:')):
         return 1
 
     scheduled = 0
-    # pylint: disable-next=consider-using-dict-items
     for system_id in jobs:
         try:
-            self.client.system.schedulePackageInstall(
-                self.session, system_id, jobs[system_id], options.start_time
-            )
+            self.client.system.schedulePackageInstall(self.session,
+                                                      system_id,
+                                                      jobs[system_id],
+                                                      options.start_time)
 
             scheduled += 1
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to schedule %s") % self.get_system_name(system_id))
+            logging.error(_N('Failed to schedule %s') % self.get_system_name(system_id))
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Scheduled %i system(s)") % scheduled)
+    logging.info(_N('Scheduled %i system(s)') % scheduled)
 
     return 0
-
 
 ####################
 
 
 def help_system_removepackage(self):
-    print(_("system_removepackage: Remove a package from a system"))
-    print(
-        _(
-            """usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])
+    print(_('system_removepackage: Remove a package from a system'))
+    print(_('''usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME'''))
 
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def complete_system_removepackage(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.get_package_names(), text)
 
     return None
 
-
 def do_system_removepackage(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1014,23 +883,17 @@ def do_system_removepackage(self, args):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
 
         # remove 'ssm' from the argument list
@@ -1039,35 +902,29 @@ def do_system_removepackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     package_list = args
 
     # get all matching package names
-    # pylint: disable-next=undefined-variable
-    logging.debug("Finding matching packages")
-    # pylint: disable-next=undefined-variable
-    matching_packages = filter_results(self.get_package_names(True), package_list, True)
+    logging.debug('Finding matching packages')
+    matching_packages = \
+        filter_results(self.get_package_names(True), package_list, True)
 
     jobs = {}
     for package_name in matching_packages:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("Finding systems with %s" % package_name)
+        logging.debug('Finding systems with %s' % package_name)
 
         installed_systems = {}
         for package_id in self.get_package_id(package_name):
-            for system in self.client.system.listSystemsWithPackage(
-                self.session, package_id
-            ):
-                installed_systems[system.get("name")] = package_id
+            for system in self.client.system.listSystemsWithPackage(self.session, package_id):
+                installed_systems[system.get('name')] = package_id
 
         # each system has a list of packages to remove so that only one
         # API call needs to be made to schedule all the package removals
         # for each system
         for system in systems:
-            # pylint: disable-next=consider-iterating-dictionary
             if system in installed_systems.keys():
                 if system not in jobs:
                     jobs[system] = []
@@ -1076,93 +933,80 @@ def do_system_removepackage(self, args):
 
     add_separator = False
 
-    # pylint: disable-next=consider-using-dict-items
     for system in jobs:
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s:" % system)
+        print('%s:' % system)
         for package in jobs[system]:
             print(self.get_package_name(package))
 
     if not jobs:
         return 1
 
-    print("")
-    print(_("Start Time: %s") % options.start_time)
+    print('')
+    print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm(_("Remove these packages [y/N]:")):
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
         return 1
 
     scheduled = 0
-    # pylint: disable-next=consider-using-dict-items
     for system in jobs:
         system_id = self.get_system_id(system)
         if not system_id:
             continue
 
         try:
-            action_id = self.client.system.schedulePackageRemove(
-                self.session, system_id, jobs[system], options.start_time
-            )
+            action_id = self.client.system.schedulePackageRemove(self.session,
+                                                                 system_id,
+                                                                 jobs[system],
+                                                                 options.start_time)
 
-            # pylint: disable-next=undefined-variable
-            logging.info(_N("Action ID: %i") % action_id)
+            logging.info(_N('Action ID: %i') % action_id)
             scheduled += 1
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to schedule %s") % system)
+            logging.error(_N('Failed to schedule %s') % system)
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Scheduled %i system(s)") % scheduled)
+    logging.info(_N('Scheduled %i system(s)') % scheduled)
 
     return 0
-
 
 ####################
 
 
 def help_system_upgradepackage(self):
-    print(_("system_upgradepackage: Upgrade a package on a system"))
-    print(
-        _(
-            """usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')
+    print(_('system_upgradepackage: Upgrade a package on a system'))
+    print(_('''usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME'''))
 
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def complete_system_upgradepackage(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.get_package_names(), text)
 
     return None
 
 
 def do_system_upgradepackage(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
     # this will come handy for individual packages, as we call
     # self.do_system_installpackage anyway
     orig_args = args
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1170,29 +1014,23 @@ def do_system_upgradepackage(self, args):
         return 1
 
     # install and upgrade for individual packages are the same
-    if not ".*" in args[1:]:
+    if not '.*' in args[1:]:
         return self.do_system_installpackage(orig_args)
 
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
 
         # remove 'ssm' from the argument list
@@ -1201,8 +1039,7 @@ def do_system_upgradepackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # make a dictionary of each system and the package IDs to install
@@ -1213,36 +1050,32 @@ def do_system_upgradepackage(self, args):
         if not system_id:
             continue
         details = self.client.system.getDetails(self.session, system_id)
-        if (
-            self.check_api_version("25.0")
-            and details.get("base_entitlement", "") == "salt_entitled"
-        ):
+        if self.check_api_version('25.0') and \
+           details.get('base_entitlement', '') == 'salt_entitled':
             minions[system] = system_id
         else:
-            packages = self.client.system.listLatestUpgradablePackages(
-                self.session, system_id
-            )
+            packages = \
+                self.client.system.listLatestUpgradablePackages(self.session,
+                                                                system_id)
 
             if packages:
-                package_ids = [p.get("to_package_id") for p in packages]
+                package_ids = [p.get('to_package_id') for p in packages]
                 jobs[system] = package_ids
             else:
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("No upgrades available for %s") % system)
+                logging.warning(_N('No upgrades available for %s') % system)
 
     if not jobs and not minions:
         return 1
 
     add_separator = False
 
-    # pylint: disable-next=consider-using-dict-items
     for system in jobs:
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
         print(system)
-        print("-" * len(system))
+        print('-' * len(system))
 
         # build a temporary list so we can sort by package name
         package_names = []
@@ -1252,67 +1085,63 @@ def do_system_upgradepackage(self, args):
             if name:
                 package_names.append(name)
             else:
-                # pylint: disable-next=undefined-variable
                 logging.error(_N("Couldn't get name for package %i") % package)
 
-        print("\n".join(sorted(package_names)))
+        print('\n'.join(sorted(package_names)))
 
     for system in minions:
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        hdr = _("Full package update on systems:")
+        hdr = _('Full package update on systems:')
         print(hdr)
-        print("-" * len(hdr))
-        # pylint: disable-next=consider-using-f-string
-        print("- {}".format(system))
+        print('-' * len(hdr))
+        print('- {}'.format(system))
 
-    print("")
-    print(_("Start Time: %s") % options.start_time)
 
-    if not self.user_confirm(_("Upgrade these systems/packages [y/N]:")):
+    print('')
+    print(_('Start Time: %s') % options.start_time)
+
+    if not self.user_confirm(_('Upgrade these systems/packages [y/N]:')):
         return 1
 
     scheduled = 0
-    # pylint: disable-next=consider-using-dict-items
     for system in jobs:
         system_id = self.get_system_id(system)
 
         try:
-            self.client.system.schedulePackageInstall(
-                self.session, system_id, jobs[system], options.start_time
-            )
+            self.client.system.schedulePackageInstall(self.session,
+                                                      system_id,
+                                                      jobs[system],
+                                                      options.start_time)
 
             scheduled += 1
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to schedule %s") % system)
+            logging.error(_N('Failed to schedule %s') % system)
 
     if minions:
         try:
             sids = list(minions.values())
-            self.client.system.schedulePackageUpdate(
-                self.session, sids, options.start_time
-            )
+            self.client.system.schedulePackageUpdate(self.session,
+                                                     sids,
+                                                     options.start_time)
             scheduled += len(sids)
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to schedule %s") % system)
+             logging.error(_N('Failed to schedule %s') % system)
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Scheduled %i system(s)") % scheduled)
+
+    logging.info(_N('Scheduled %i system(s)') % scheduled)
 
     return 0
-
 
 ####################
 
 
 def help_system_listupgrades(self):
-    print(_("system_listupgrades: List the available upgrades for a system"))
-    print(_("usage: system_listupgrades <SYSTEMS>"))
-    print("")
+    print(_('system_listupgrades: List the available upgrades for a system'))
+    print(_('usage: system_listupgrades <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -1321,10 +1150,8 @@ def complete_system_listupgrades(self, text, line, beg, end):
 
 
 def do_system_listupgrades(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1334,15 +1161,13 @@ def do_system_listupgrades(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1350,13 +1175,12 @@ def do_system_listupgrades(self, args):
         if not system_id:
             continue
 
-        packages = self.client.system.listLatestUpgradablePackages(
-            self.session, system_id
-        )
+        packages = \
+            self.client.system.listLatestUpgradablePackages(self.session,
+                                                            system_id)
 
         if not packages:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("No upgrades available for %s") % system)
+            logging.warning(_N('No upgrades available for %s') % system)
             continue
 
         if add_separator:
@@ -1365,37 +1189,29 @@ def do_system_listupgrades(self, args):
 
         if len(systems) > 1:
             print(system)
-            print("-" * len(system))
+            print('-' * len(system))
 
-        latest_packages = filter_latest_packages(
-            packages, "to_version", "to_release", "to_epoch"
-        )
+        latest_packages = filter_latest_packages(packages, 'to_version', 'to_release', 'to_epoch')
 
-        for package in sorted(latest_packages.values(), key=itemgetter("name")):
-            print(
-                # pylint: disable-next=undefined-variable
-                build_package_names(
-                    {
-                        "name": package["name"],
-                        "version": package["to_version"],
-                        "release": package["to_release"],
-                        "epoch": package["to_epoch"],
-                        "arch": package["to_arch"],
-                    }
-                )
-            )
+        for package in sorted(latest_packages.values(), key=itemgetter('name')):
+            print(build_package_names({
+                'name': package['name'],
+                'version': package['to_version'],
+                'release': package['to_release'],
+                'epoch': package['to_epoch'],
+                'arch': package['to_arch']
+            }))
 
     return 0
-
 
 ####################
 
 
 def help_system_listinstalledpackages(self):
-    print(_("system_listinstalledpackages: List the installed packages on a"))
-    print(_("                              system"))
-    print(_("usage: system_listinstalledpackages <SYSTEMS>"))
-    print("")
+    print(_('system_listinstalledpackages: List the installed packages on a'))
+    print(_('                              system'))
+    print(_('usage: system_listinstalledpackages <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -1404,10 +1220,8 @@ def complete_system_listinstalledpackages(self, text, line, beg, end):
 
 
 def do_system_listinstalledpackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1417,15 +1231,13 @@ def do_system_listinstalledpackages(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1433,29 +1245,28 @@ def do_system_listinstalledpackages(self, args):
         if not system_id:
             continue
 
-        packages = self.client.system.listPackages(self.session, system_id)
+        packages = self.client.system.listPackages(self.session,
+                                                   system_id)
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
-            print("")
+            print(_('System: %s') % system)
+            print('')
 
-        # pylint: disable-next=undefined-variable
-        print("\n".join(build_package_names(packages)))
+        print('\n'.join(build_package_names(packages)))
 
     return 0
-
 
 ####################
 
 
 def help_system_listconfigchannels(self):
-    print(_("system_listconfigchannels: List the config channels of a system"))
-    print(_("usage: system_listconfigchannels <SYSTEMS>"))
-    print("")
+    print(_('system_listconfigchannels: List the config channels of a system'))
+    print(_('usage: system_listconfigchannels <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -1464,10 +1275,8 @@ def complete_system_listconfigchannels(self, text, line, beg, end):
 
 
 def do_system_listconfigchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1477,15 +1286,13 @@ def do_system_listconfigchannels(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1498,72 +1305,57 @@ def do_system_listconfigchannels(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
         try:
-            channels = self.client.system.config.listChannels(self.session, system_id)
+            channels = self.client.system.config.listChannels(self.session,
+                                                              system_id)
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s does not support configuration channels") % system)
+            logging.warning(_N('%s does not support configuration channels') %
+                            system)
             continue
 
-        print("\n".join([c.get("label") for c in channels]))
+        print('\n'.join([c.get('label') for c in channels]))
 
     return 0
-
 
 ####################
 
 
 def print_configfiles(self, quiet, filelist):
+
     # Figure out correct indentation to allow pretty table output
-    # pylint: disable-next=undefined-variable
-    max_path = max_length([f["path"] for f in filelist], minimum=10)
-    # pylint: disable-next=undefined-variable
+    max_path = max_length([f['path'] for f in filelist], minimum=10)
     max_type = max_length(["file", "directory", "symlink"], minimum=10)
-    # pylint: disable-next=undefined-variable
-    max_label = max_length([f["channel_label"] for f in filelist], minimum=15)
+    max_label = max_length([f['channel_label'] for f in filelist], minimum=15)
 
     # print(header when not in quiet mode)
     if not quiet:
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s"
-            % (
-                "path".ljust(max_path),
-                "type".ljust(max_type),
-                "label/type".ljust(max_label),
-            )
-        )
+        print('%s  %s  %s' % (
+            'path'.ljust(max_path),
+            'type'.ljust(max_type),
+            'label/type'.ljust(max_label)))
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %s  %s" % ("-" * max_path, "-" * max_type, "-" * max_label))
+        print('%s  %s  %s' % (
+            '-' * max_path,
+            '-' * max_type,
+            '-' * max_label))
 
     for f in filelist:
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s"
-            % (
-                f["path"].ljust(max_path),
-                f["type"].ljust(max_type),
-                f["channel_label"].ljust(max_label),
-            )
-        )
+        print('%s  %s  %s' % (f['path'].ljust(max_path),
+                              f['type'].ljust(max_type),
+                              f['channel_label'].ljust(max_label)))
 
 
 def help_system_listconfigfiles(self):
-    print(_("system_listconfigfiles: List the managed config files of a system"))
-    print(
-        _(
-            """usage: system_listconfigfiles <SYSTEMS>')
+    print(_('system_listconfigfiles: List the managed config files of a system'))
+    print(_('''usage: system_listconfigfiles <SYSTEMS>')
 options:
   -s/--sandbox : list only system-sandbox files
   -l/--local   : list only locally managed files
   -c/--central : list only centrally managed files
-  -q/--quiet   : quiet mode (omits the header)"""
-        )
-    )
-    print("")
+  -q/--quiet   : quiet mode (omits the header)'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -1572,18 +1364,15 @@ def complete_system_listconfigfiles(self, text, line, beg, end):
 
 
 def do_system_listconfigfiles(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--sandbox", action="store_true")
-    arg_parser.add_argument("-l", "--local", action="store_true")
-    arg_parser.add_argument("-c", "--central", action="store_true")
-    arg_parser.add_argument("-q", "--quiet", action="store_true")
+    arg_parser.add_argument('-s', '--sandbox', action='store_true')
+    arg_parser.add_argument('-l', '--local', action='store_true')
+    arg_parser.add_argument('-c', '--central', action='store_true')
+    arg_parser.add_argument('-q', '--quiet', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not options.sandbox and not options.local and not options.central:
-        # pylint: disable-next=undefined-variable
         logging.debug("No sandbox/local/central option specified, listing ALL")
         options.sandbox = True
         options.local = True
@@ -1596,15 +1385,13 @@ def do_system_listconfigfiles(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1617,59 +1404,55 @@ def do_system_listconfigfiles(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
         try:
             # Pass 0 for system-sandbox files
             # Pass 1 for locally managed or centrally managed
-            files = self.client.system.config.listFiles(self.session, system_id, 0)
-            files += self.client.system.config.listFiles(self.session, system_id, 1)
+            files = self.client.system.config.listFiles(self.session,
+                                                        system_id, 0)
+            files += self.client.system.config.listFiles(self.session,
+                                                         system_id, 1)
         except xmlrpclib.Fault:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s does not support configuration channels") % system)
+            logging.warning(_N('%s does not support configuration channels') %
+                            system)
             continue
 
         # For system sandbox or locally managed files, there is no
         # channel_label so we add a descriptive label for these files
         toprint = []
         for f in files:
-            if f["channel_type"]["label"] == "server_import":
-                f["channel_label"] = "system_sandbox"
+            if f['channel_type']['label'] == 'server_import':
+                f['channel_label'] = "system_sandbox"
                 if options.sandbox:
                     toprint.append(f)
 
-            elif f["channel_type"]["label"] == "local_override":
-                f["channel_label"] = "locally_managed"
+            elif f['channel_type']['label'] == 'local_override':
+                f['channel_label'] = "locally_managed"
                 if options.local:
                     toprint.append(f)
 
-            elif f["channel_type"]["label"] == "normal":
+            elif f['channel_type']['label'] == 'normal':
                 if options.central:
                     toprint.append(f)
 
             else:
-                # pylint: disable-next=undefined-variable
-                logging.error(
-                    _N("Error, unexpected channel type label %s")
-                    % f["channel_type"]["label"]
-                )
+                logging.error(_N("Error, unexpected channel type label %s") %
+                              f['channel_type']['label'])
                 return 1
 
         self.print_configfiles(options.quiet, toprint)
 
     return 0
 
-
 ####################
 
 
 def help_system_addconfigfile(self):
-    print(_("system_addconfigfile: Create a configuration file"))
-    print(_("Note this is only for system sandbox or locally-managed files"))
-    print(_("Centrally managed files should be created via configchannel_addfile"))
-    print(
-        _(
-            """usage: system_addconfigfile [SYSTEM] [options]
+    print(_('system_addconfigfile: Create a configuration file'))
+    print(_('Note this is only for system sandbox or locally-managed files'))
+    print(_('Centrally managed files should be created via configchannel_addfile'))
+    print(_('''usage: system_addconfigfile [SYSTEM] [options]
 
 options:
   -S/--sandbox : list only system-sandbox files
@@ -1690,33 +1473,29 @@ options:
   newlines, those containing ASCII escape characters (or other charaters not
   allowed in XML) need to be sent as binary (-b).  Some effort is made to auto-
   detect files which require this, but you may need to explicitly specify.
-"""
-        )
-    )
+'''))
 
 
 def complete_system_addconfigfile(self, text, line, beg, end):
     return self.tab_complete_systems(text)
 
 
-def do_system_addconfigfile(self, args, update_path=""):
-    # pylint: disable-next=undefined-variable
+def do_system_addconfigfile(self, args, update_path=''):
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-S", "--sandbox", action="store_true")
-    arg_parser.add_argument("-L", "--local", action="store_true")
-    arg_parser.add_argument("-p", "--path")
-    arg_parser.add_argument("-o", "--owner")
-    arg_parser.add_argument("-g", "--group")
-    arg_parser.add_argument("-m", "--mode")
-    arg_parser.add_argument("-x", "--selinux-ctx")
-    arg_parser.add_argument("-t", "--target-path")
-    arg_parser.add_argument("-f", "--file")
-    arg_parser.add_argument("-r", "--revision")
-    arg_parser.add_argument("-s", "--symlink", action="store_true")
-    arg_parser.add_argument("-b", "--binary", action="store_true")
-    arg_parser.add_argument("-d", "--directory", action="store_true")
+    arg_parser.add_argument('-S', '--sandbox', action='store_true')
+    arg_parser.add_argument('-L', '--local', action='store_true')
+    arg_parser.add_argument('-p', '--path')
+    arg_parser.add_argument('-o', '--owner')
+    arg_parser.add_argument('-g', '--group')
+    arg_parser.add_argument('-m', '--mode')
+    arg_parser.add_argument('-x', '--selinux-ctx')
+    arg_parser.add_argument('-t', '--target-path')
+    arg_parser.add_argument('-f', '--file')
+    arg_parser.add_argument('-r', '--revision')
+    arg_parser.add_argument('-s', '--symlink', action='store_true')
+    arg_parser.add_argument('-b', '--binary', action='store_true')
+    arg_parser.add_argument('-d', '--directory', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     file_info = None
@@ -1725,139 +1504,111 @@ def do_system_addconfigfile(self, args, update_path=""):
     if args:
         options.system = args[0]
 
-    # pylint: disable-next=undefined-variable
     interactive = is_interactive(options)
     if interactive:
         if not options.system:
             while True:
-                print(_("Systems"))
-                print("----------------------")
-                print("\n".join(sorted(self.do_system_list("", True))))
-                print("")
+                print(_('Systems'))
+                print('----------------------')
+                print('\n'.join(sorted(self.do_system_list('', True))))
+                print('')
 
-                # pylint: disable-next=undefined-variable
-                options.system = prompt_user("Select:", noblank=True)
+                options.system = prompt_user('Select:', noblank=True)
 
                 # ensure the user enters a valid system
-                if options.system in self.do_system_list("", True):
+                if options.system in self.do_system_list('', True):
                     break
-                print("")
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("%s is not a valid system") % options.system)
-                print("")
+                print('')
+                logging.warning(_N('%s is not a valid system') %
+                                options.system)
+                print('')
 
         if update_path:
             options.path = update_path
         else:
-            # pylint: disable-next=undefined-variable
-            options.path = prompt_user("Path:", noblank=True)
+            options.path = prompt_user('Path:', noblank=True)
 
         while not options.local and not options.sandbox:
-            # pylint: disable-next=undefined-variable
-            answer = prompt_user(_("System-Sandbox or Locally-Managed? [S/L]:"))
-            # pylint: disable-next=undefined-variable
-            if re.match("L", answer, re.I):
+            answer = prompt_user(_('System-Sandbox or Locally-Managed? [S/L]:'))
+            if re.match('L', answer, re.I):
                 options.local = True
                 localopt = 1
-            # pylint: disable-next=undefined-variable
-            elif re.match("S", answer, re.I):
+            elif re.match('S', answer, re.I):
                 options.sandbox = True
                 localopt = 0
 
     # Set the int variable (required by the API calls) for sandbox/local
     localopt = 0
     if options.local:
-        # pylint: disable-next=undefined-variable
         logging.debug("Selected locally-managed")
         localopt = 1
     elif options.sandbox:
-        # pylint: disable-next=undefined-variable
         logging.debug("Selected system-sandbox")
     else:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Must choose system-sandbox or locally-managed option"))
         self.help_system_addconfigfile()
         return 1
 
     if not options.system:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Must provide system"))
         self.help_system_addconfigfile()
         return 1
 
     system_id = self.get_system_id(options.system)
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     logging.debug("Got ID %s for system %s" % (system_id, options.system))
 
     # check if this file already exists
     try:
-        file_info = self.client.system.config.lookupFileInfo(
-            self.session, system_id, [options.path], localopt
-        )
+        file_info = self.client.system.config.lookupFileInfo(self.session,
+                                                             system_id, [options.path], localopt)
         if file_info:
-            # pylint: disable-next=undefined-variable,consider-using-f-string
             logging.debug("Found existing file_info %s" % file_info)
     except xmlrpclib.Fault:
-        # pylint: disable-next=undefined-variable,consider-using-f-string
-        logging.debug("No existing file information found for %s" % options.path)
+        logging.debug("No existing file information found for %s" %
+                      options.path)
 
     file_info = self.configfile_getinfo(args, options, file_info, interactive)
 
     if self.user_confirm():
         if options.symlink:
-            self.client.system.config.createOrUpdateSymlink(
-                self.session, system_id, options.path, file_info, localopt
-            )
+            self.client.system.config.createOrUpdateSymlink(self.session,
+                                                            system_id, options.path, file_info, localopt)
         else:
-            self.client.system.config.createOrUpdatePath(
-                self.session,
-                system_id,
-                options.path,
-                options.directory,
-                file_info,
-                localopt,
-            )
+            self.client.system.config.createOrUpdatePath(self.session,
+                                                         system_id, options.path, options.directory, file_info,
+                                                         localopt)
 
     return 0
-
 
 ####################
 
 
 def help_system_addconfigchannels(self):
-    print(_("system_addconfigchannels: Add config channels to a system"))
-    print(
-        _(
-            """usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]
+    print(_('system_addconfigchannels: Add config channels to a system'))
+    print(_('''usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]
 
 options:
   -t add channels to the top of the list
-  -b add channels to the bottom of the list"""
-        )
-    )
-    print("")
+  -b add channels to the bottom of the list'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
-
 def complete_system_addconfigchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
 
     return None
 
-
 def do_system_addconfigchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-t", "--top", action="store_true")
-    arg_parser.add_argument("-b", "--bottom", action="store_true")
+    arg_parser.add_argument('-t', '--top', action='store_true')
+    arg_parser.add_argument('-b', '--bottom', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1865,26 +1616,21 @@ def do_system_addconfigchannels(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     channels = args
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        answer = prompt_user(_("Add to top or bottom? [T/b]:"))
-        # pylint: disable-next=undefined-variable
-        if re.match("b", answer, re.I):
+        answer = prompt_user(_('Add to top or bottom? [T/b]:'))
+        if re.match('b', answer, re.I):
             options.top = False
         else:
             options.top = True
@@ -1896,40 +1642,37 @@ def do_system_addconfigchannels(self, args):
 
     system_ids = [self.get_system_id(s) for s in systems]
 
-    self.client.system.config.addChannels(
-        self.session, system_ids, channels, options.top
-    )
+    self.client.system.config.addChannels(self.session,
+                                          system_ids,
+                                          channels,
+                                          options.top)
 
     return 0
-
 
 ####################
 
 
 def help_system_removeconfigchannels(self):
-    print(_("system_removeconfigchannels: Remove config channels from a system"))
-    print(_("usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"))
-    print("")
+    print(_('system_removeconfigchannels: Remove config channels from a system'))
+    print(_('usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_removeconfigchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_configchannel_list("", True), text)
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
 
     return None
 
-
 def do_system_removeconfigchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -1937,38 +1680,33 @@ def do_system_removeconfigchannels(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     channels = args
 
     system_ids = [self.get_system_id(s) for s in systems]
 
-    self.client.system.config.removeChannels(self.session, system_ids, channels)
+    self.client.system.config.removeChannels(self.session,
+                                             system_ids,
+                                             channels)
 
     return 0
-
 
 ####################
 
 
 def help_system_setconfigchannelorder(self):
-    print(
-        _(
-            "system_setconfigchannelorder: Set the ranked order of configuration channels"
-        )
-    )
-    print(_("usage: system_setconfigchannelorder <SYSTEMS>"))
-    print("")
+    print(_('system_setconfigchannelorder: Set the ranked order of configuration channels'))
+    print(_('usage: system_setconfigchannelorder <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -1977,10 +1715,8 @@ def complete_system_setconfigchannelorder(self, text, line, beg, end):
 
 
 def do_system_setconfigchannelorder(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -1988,63 +1724,57 @@ def do_system_setconfigchannelorder(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = list(self.ssm.keys())
         args.pop(0)
     else:
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # get the current configuration channels from the first system
     # in the list
     system_id = self.get_system_id(systems[0])
-    new_channels = self.client.system.config.listChannels(self.session, system_id)
-    new_channels = [c.get("label") for c in new_channels]
+    new_channels = self.client.system.config.listChannels(self.session,
+                                                          system_id)
+    new_channels = [c.get('label') for c in new_channels]
 
     # call an interface for the user to make selections
-    all_channels = self.do_configchannel_list("", True)
-    # pylint: disable-next=undefined-variable
+    all_channels = self.do_configchannel_list('', True)
     new_channels = config_channel_order(all_channels, new_channels)
 
-    print("")
-    print(_("New Configuration Channels"))
-    print("--------------------------")
+    print('')
+    print(_('New Configuration Channels'))
+    print('--------------------------')
     for i, new_channel in enumerate(new_channels, 1):
-        # pylint: disable-next=consider-using-f-string
-        print("[%i] %s" % (i, new_channel))
+        print('[%i] %s' % (i, new_channel))
 
     if not self.user_confirm():
         return 1
 
     system_ids = [self.get_system_id(s) for s in systems]
 
-    self.client.system.config.setChannels(self.session, system_ids, new_channels)
+    self.client.system.config.setChannels(self.session,
+                                          system_ids,
+                                          new_channels)
 
     return 0
-
 
 ####################
 
 
 def help_system_deployconfigfiles(self):
-    print(_("system_deployconfigfiles: Deploy all configuration files for a system"))
-    print(
-        _(
-            """usage: system_deployconfigfiles <SYSTEMS> [options]
+    print(_('system_deployconfigfiles: Deploy all configuration files for a system'))
+    print(_('''usage: system_deployconfigfiles <SYSTEMS> [options]
 
 options:
-    -s START_TIME"""
-        )
-    )
+    -s START_TIME'''))
 
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
@@ -2053,11 +1783,9 @@ def complete_system_deployconfigfiles(self, text, line, beg, end):
 
 
 def do_system_deployconfigfiles(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2067,71 +1795,60 @@ def do_system_deployconfigfiles(self, args):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
-    print("")
-    print(_("Start Time: %s") % options.start_time)
-    print("")
-    print(_("Systems"))
-    print("-------")
-    print("\n".join(sorted(systems)))
+    print('')
+    print(_('Start Time: %s') % options.start_time)
+    print('')
+    print(_('Systems'))
+    print('-------')
+    print('\n'.join(sorted(systems)))
 
-    message = _("Deploy ALL configuration files to these systems [y/N]:")
+    message = _('Deploy ALL configuration files to these systems [y/N]:')
     if not self.user_confirm(message):
         return 1
 
     system_ids = [self.get_system_id(s) for s in systems]
 
-    self.client.system.config.deployAll(self.session, system_ids, options.start_time)
+    self.client.system.config.deployAll(self.session,
+                                        system_ids,
+                                        options.start_time)
 
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("Scheduled deployment for %i system(s)") % len(system_ids))
+    logging.info(_N('Scheduled deployment for %i system(s)') % len(system_ids))
 
     return 0
-
 
 ####################
 
 
 def help_system_delete(self):
-    print(_("system_delete: Delete a system profile"))
-    print(
-        _(
-            """usage: system_delete [options] <SYSTEMS>
+    print(_('system_delete: Delete a system profile'))
+    print(_('''usage: system_delete [options] <SYSTEMS>
 
     options:
           -c TYPE - Possible values:
              *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,
              *  'NO_CLEANUP' - do not cleanup, just delete,
              *  'FORCE_DELETE' - Try cleanup first but delete server anyway in case of error
-    """
-        )
-    )
-    print("")
+    '''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2140,16 +1857,10 @@ def complete_system_delete(self, text, line, beg, end):
 
 
 def do_system_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument(
-        "-c",
-        "--cleanuptype",
-        default="NO_CLEANUP",
-        choices=["FAIL_ON_CLEANUP_ERR", "NO_CLEANUP", "FORCE_DELETE"],
-    )
+    arg_parser.add_argument('-c', '--cleanuptype', default='NO_CLEANUP',
+                            choices=['FAIL_ON_CLEANUP_ERR', 'NO_CLEANUP', 'FORCE_DELETE'])
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2159,8 +1870,7 @@ def do_system_delete(self, args):
     system_ids = []
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
@@ -2174,36 +1884,30 @@ def do_system_delete(self, args):
         system_ids.append(system_id)
 
     if not system_ids:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems to delete"))
+        logging.warning(_N('No systems to delete'))
         return 1
 
     # make the column the right size
-    # pylint: disable-next=undefined-variable
     colsize = max_length([self.get_system_name(s) for s in system_ids])
     if colsize < 7:
         colsize = 7
 
-    print(_("%s  System ID") % _("Profile").ljust(colsize))
-    # pylint: disable-next=consider-using-f-string
-    print("%s  ---------" % ("-" * colsize))
+    print(_('%s  System ID') % _('Profile').ljust(colsize))
+    print('%s  ---------' % ('-' * colsize))
 
     # print(a summary for the user)
     for system_id in system_ids:
-        # pylint: disable-next=consider-using-f-string
-        print("%s  %i" % (self.get_system_name(system_id).ljust(colsize), system_id))
+        print('%s  %i' %
+              (self.get_system_name(system_id).ljust(colsize), system_id))
 
-    if not self.user_confirm(_("Delete these systems [y/N]:")):
+    if not self.user_confirm(_('Delete these systems [y/N]:')):
         return 1
 
-    # pylint: disable-next=undefined-variable
     logging.debug("System IDs to remove: %s", system_ids)
-    # pylint: disable-next=undefined-variable
     logging.debug("System names to IDs: %s", systems)
 
     self.client.system.deleteSystems(self.session, system_ids, options.cleanuptype)
-    # pylint: disable-next=undefined-variable
-    logging.info(_N("%i system(s) scheduled for removal"), len(system_ids))
+    logging.info(_N('%i system(s) scheduled for removal'), len(system_ids))
 
     # regenerate the system name cache
     self.generate_system_cache(True, delay=1)
@@ -2212,24 +1916,20 @@ def do_system_delete(self, args):
     for system_name in list(systems):
         if system_name in self.ssm:
             self.ssm.pop(system_name)
-    # pylint: disable-next=undefined-variable
     logging.debug("SSM stack updated")
 
-    # pylint: disable-next=undefined-variable
     save_cache(self.ssm_cache_file, self.ssm)
-    # pylint: disable-next=undefined-variable
     logging.debug("SSM cache saved")
 
     return 0
-
 
 ####################
 
 
 def help_system_lock(self):
-    print(_("system_lock: Lock a system"))
-    print(_("usage: system_lock <SYSTEMS>"))
-    print("")
+    print(_('system_lock: Lock a system'))
+    print(_('usage: system_lock <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2238,10 +1938,8 @@ def complete_system_lock(self, text, line, beg, end):
 
 
 def do_system_lock(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2249,15 +1947,13 @@ def do_system_lock(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2269,14 +1965,13 @@ def do_system_lock(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_system_unlock(self):
-    print(_("system_unlock: Unlock a system"))
-    print(_("usage: system_unlock <SYSTEMS>"))
-    print("")
+    print(_('system_unlock: Unlock a system'))
+    print(_('usage: system_unlock <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2285,10 +1980,8 @@ def complete_system_unlock(self, text, line, beg, end):
 
 
 def do_system_unlock(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2296,15 +1989,13 @@ def do_system_unlock(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2316,28 +2007,23 @@ def do_system_unlock(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_system_rename(self):
-    print(_("system_rename: Rename a system profile"))
-    print(_("usage: system_rename OLDNAME NEWNAME"))
-
+    print(_('system_rename: Rename a system profile'))
+    print(_('usage: system_rename OLDNAME NEWNAME'))
 
 def complete_system_rename(self, text, line, beg, end):
-    if len(line.split(" ")) == 2:
-        # pylint: disable-next=undefined-variable
+    if len(line.split(' ')) == 2:
         return tab_completer(self.get_system_names(), text)
 
     return None
 
 
 def do_system_rename(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -2350,12 +2036,13 @@ def do_system_rename(self, args):
     if not system_id:
         return 1
 
-    # pylint: disable-next=consider-using-f-string
-    print("%s (%s) -> %s" % (old_name, system_id, new_name))
+    print('%s (%s) -> %s' % (old_name, system_id, new_name))
     if not self.user_confirm():
         return 1
 
-    self.client.system.setProfileName(self.session, system_id, new_name)
+    self.client.system.setProfileName(self.session,
+                                      system_id,
+                                      new_name)
 
     # regenerate the cache of systems
     self.generate_system_cache(True)
@@ -2367,14 +2054,13 @@ def do_system_rename(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_system_listcustomvalues(self):
-    print(_("system_listcustomvalues: List the custom values for a system"))
-    print(_("usage: system_listcustomvalues <SYSTEMS>"))
-    print("")
+    print(_('system_listcustomvalues: List the custom values for a system'))
+    print(_('usage: system_listcustomvalues <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2383,10 +2069,8 @@ def complete_system_listcustomvalues(self, text, line, beg, end):
 
 
 def do_system_listcustomvalues(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2394,15 +2078,13 @@ def do_system_listcustomvalues(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2413,52 +2095,47 @@ def do_system_listcustomvalues(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
-            print("")
+            print(_('System: %s') % system)
+            print('')
 
         system_id = self.get_system_id(system)
         if not system_id:
             continue
 
-        values = self.client.system.getCustomValues(self.session, system_id)
+        values = self.client.system.getCustomValues(self.session,
+                                                    system_id)
 
         for v in values:
-            # pylint: disable-next=consider-using-f-string
-            print("%s = %s" % (v, values[v]))
+            print('%s = %s' % (v, values[v]))
 
     return 0
-
 
 ####################
 
 
 def help_system_addcustomvalue(self):
-    print(_("system_addcustomvalue: Set a custom value for a system"))
-    print(_("usage: system_addcustomvalue KEY VALUE <SYSTEMS>"))
-    print("")
+    print(_('system_addcustomvalue: Set a custom value for a system'))
+    print(_('usage: system_addcustomvalue KEY VALUE <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_addcustomvalue(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_custominfo_listkeys("", True), text)
+        return tab_completer(self.do_custominfo_listkeys('', True), text)
     elif len(parts) >= 4:
         return self.tab_complete_systems(text)
 
     return None
 
-
 def do_system_addcustomvalue(self, args):
     if not isinstance(args, list):
-        # pylint: disable-next=undefined-variable
         arg_parser = get_argument_parser()
 
-        # pylint: disable-next=undefined-variable,unused-variable
         (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
@@ -2469,15 +2146,13 @@ def do_system_addcustomvalue(self, args):
     value = args[1]
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args[2:])
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -2485,29 +2160,28 @@ def do_system_addcustomvalue(self, args):
         if not system_id:
             continue
 
-        self.client.system.setCustomValues(self.session, system_id, {key: value})
+        self.client.system.setCustomValues(self.session,
+                                           system_id,
+                                           {key: value})
 
     return 0
-
 
 ####################
 
 
 def help_system_updatecustomvalue(self):
-    print(_("system_updatecustomvalue: Update a custom value for a system"))
-    print(_("usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"))
-    print("")
+    print(_('system_updatecustomvalue: Update a custom value for a system'))
+    print(_('usage: system_updatecustomvalue KEY VALUE <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-
 
 def complete_system_updatecustomvalue(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_custominfo_listkeys("", True), text)
+        return tab_completer(self.do_custominfo_listkeys('', True), text)
     elif len(parts) >= 4:
         return self.tab_complete_systems(text)
 
@@ -2515,10 +2189,8 @@ def complete_system_updatecustomvalue(self, text, line, beg, end):
 
 
 def do_system_updatecustomvalue(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
@@ -2527,34 +2199,29 @@ def do_system_updatecustomvalue(self, args):
 
     return self.do_system_addcustomvalue(args)
 
-
 ####################
 
 
 def help_system_removecustomvalues(self):
-    print(_("system_removecustomvalues: Remove a custom value for a system"))
-    print(_("usage: system_removecustomvalues <SYSTEMS> <KEY ...>"))
-    print("")
+    print(_('system_removecustomvalues: Remove a custom value for a system'))
+    print(_('usage: system_removecustomvalues <SYSTEMS> <KEY ...>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
-
 def complete_system_removecustomvalues(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_custominfo_listkeys("", True), text)
+        return tab_completer(self.do_custominfo_listkeys('', True),
+                             text)
 
     return None
 
-
 def do_system_removecustomvalues(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -2562,20 +2229,18 @@ def do_system_removecustomvalues(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     keys = args[1:]
 
-    if not self.user_confirm(_("Delete these values [y/N]:")):
+    if not self.user_confirm(_('Delete these values [y/N]:')):
         return 1
 
     for system in systems:
@@ -2583,26 +2248,23 @@ def do_system_removecustomvalues(self, args):
         if not system_id:
             continue
 
-        self.client.system.deleteCustomValues(self.session, system_id, keys)
+        self.client.system.deleteCustomValues(self.session,
+                                              system_id,
+                                              keys)
 
     return 0
-
 
 ####################
 
 
 def help_system_addnote(self):
-    print(_("system_addnote: Set a note for a system"))
-    print(
-        _(
-            """usage: system_addnote <SYSTEM> [options]
+    print(_('system_addnote: Set a note for a system'))
+    print(_('''usage: system_addnote <SYSTEM> [options]
 
 options:
   -s SUBJECT
-  -b BODY"""
-        )
-    )
-    print("")
+  -b BODY'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2611,12 +2273,10 @@ def complete_system_addnote(self, text, line, beg, end):
 
 
 def do_system_addnote(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--subject")
-    arg_parser.add_argument("-b", "--body")
+    arg_parser.add_argument('-s', '--subject')
+    arg_parser.add_argument('-b', '--body')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 1:
@@ -2624,34 +2284,27 @@ def do_system_addnote(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.subject = prompt_user(_("Subject of the Note:"), noblank=True)
+        options.subject = prompt_user(_('Subject of the Note:'), noblank=True)
 
-        message = _("Note Body (ctrl-D to finish):")
-        # pylint: disable-next=undefined-variable
+        message = _('Note Body (ctrl-D to finish):')
         options.body = prompt_user(message, noblank=True, multiline=True)
     else:
         if not options.subject:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A subject is required"))
+            logging.error(_N('A subject is required'))
             return 1
 
         if not options.body:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A body is required"))
+            logging.error(_N('A body is required'))
             return 1
 
     for system in systems:
@@ -2659,20 +2312,20 @@ def do_system_addnote(self, args):
         if not system_id:
             continue
 
-        self.client.system.addNote(
-            self.session, system_id, options.subject, options.body
-        )
+        self.client.system.addNote(self.session,
+                                   system_id,
+                                   options.subject,
+                                   options.body)
 
     return 0
-
 
 ####################
 
 
 def help_system_deletenotes(self):
-    print(_("system_deletenotes: Delete notes from a system"))
-    print(_("usage: system_deletenotes <SYSTEM> <ID|*>"))
-    print("")
+    print(_('system_deletenotes: Delete notes from a system'))
+    print(_('usage: system_deletenotes <SYSTEM> <ID|*>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2681,10 +2334,8 @@ def complete_system_deletenotes(self, text, line, beg, end):
 
 
 def do_system_deletenotes(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2692,23 +2343,20 @@ def do_system_deletenotes(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     note_ids = args
 
     if not args:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No notes to delete"))
+        logging.warning(_N('No notes to delete'))
         return None
 
     for system in systems:
@@ -2716,15 +2364,14 @@ def do_system_deletenotes(self, args):
         if not system_id:
             continue
 
-        if ".*" in note_ids:
+        if '.*' in note_ids:
             self.client.system.deleteNotes(self.session, system_id)
         else:
             for note_id in note_ids:
                 try:
                     note_id = int(note_id)
                 except ValueError:
-                    # pylint: disable-next=undefined-variable
-                    logging.warning(_N("%s is not a valid note ID") % note_id)
+                    logging.warning(_N('%s is not a valid note ID') % note_id)
                     continue
 
                 # deleteNote does not throw an exception
@@ -2732,14 +2379,13 @@ def do_system_deletenotes(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_system_listnotes(self):
-    print(_("system_listnotes: List the available notes for a system"))
-    print(_("usage: system_listnotes <SYSTEM>"))
-    print("")
+    print(_('system_listnotes: List the available notes for a system'))
+    print(_('usage: system_listnotes <SYSTEM>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2748,10 +2394,8 @@ def complete_system_listnotes(self, text, line, beg, end):
 
 
 def do_system_listnotes(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2759,15 +2403,13 @@ def do_system_listnotes(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2778,8 +2420,8 @@ def do_system_listnotes(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
-            print("")
+            print(_('System: %s') % system)
+            print('')
 
         system_id = self.get_system_id(system)
         if not system_id:
@@ -2788,13 +2430,11 @@ def do_system_listnotes(self, args):
         notes = self.client.system.listNotes(self.session, system_id)
 
         for n in notes:
-            # pylint: disable-next=consider-using-f-string
-            print("%d. %s (%s)" % (n["id"], n["subject"], n["creator"]))
-            print(n["note"])
-            print("")
+            print('%d. %s (%s)' % (n['id'], n['subject'], n['creator']))
+            print(n['note'])
+            print('')
 
     return 0
-
 
 ####################
 
@@ -2802,8 +2442,8 @@ def do_system_listnotes(self, args):
 
 
 def help_system_listfqdns(self):
-    print(_("system_listfqdns: List the associated FQDNs for a system"))
-    print(_("usage: system_listfqdns <SYSTEM>"))
+    print(_('system_listfqdns: List the associated FQDNs for a system'))
+    print(_('usage: system_listfqdns <SYSTEM>'))
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2812,10 +2452,8 @@ def complete_system_listfqdns(self, text, line, beg, end):
 
 
 def do_system_listfqdns(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -2823,15 +2461,13 @@ def do_system_listfqdns(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2842,8 +2478,8 @@ def do_system_listfqdns(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
-            print("")
+            print(_('System: %s') % system)
+            print('')
 
         system_id = self.get_system_id(system)
         if not system_id:
@@ -2856,32 +2492,27 @@ def do_system_listfqdns(self, args):
 
     return 0
 
-
 ####################
-
 
 def help_system_setbasechannel(self):
     print(_("system_setbasechannel: Set a system's base software channel"))
-    print(_("usage: system_setbasechannel <SYSTEMS> CHANNEL"))
-    print("")
+    print(_('usage: system_setbasechannel <SYSTEMS> CHANNEL'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_setbasechannel(self, text, line, beg, end):
-    if len(line.split(" ")) == 2:
+    if len(line.split(' ')) == 2:
         return self.tab_complete_systems(text)
-    elif len(line.split(" ")) == 3:
-        # pylint: disable-next=undefined-variable
+    elif len(line.split(' ')) == 3:
         return tab_completer(self.list_base_channels(), text)
 
     return None
 
 
 def do_system_setbasechannel(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -2891,15 +2522,13 @@ def do_system_setbasechannel(self, args):
     new_channel = args.pop()
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2909,15 +2538,16 @@ def do_system_setbasechannel(self, args):
         if not system_id:
             continue
 
-        old = self.client.system.getSubscribedBaseChannel(self.session, system_id)
+        old = self.client.system.getSubscribedBaseChannel(self.session,
+                                                          system_id)
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("System:           %s") % system)
-        print(_("Old Base Channel: %s") % old.get("label"))
-        print(_("New Base Channel: %s") % new_channel)
+        print(_('System:           %s') % system)
+        print(_('Old Base Channel: %s') % old.get('label'))
+        print(_('New Base Channel: %s') % new_channel)
 
     if not self.user_confirm():
         return 1
@@ -2927,48 +2557,38 @@ def do_system_setbasechannel(self, args):
         if not system_id:
             continue
 
-        self.client.system.setBaseChannel(self.session, system_id, new_channel)
+        self.client.system.setBaseChannel(self.session,
+                                          system_id,
+                                          new_channel)
 
     return 0
 
-
 ####################
 
-
 def help_system_schedulechangechannels(self):
-    print(
-        _(
-            "system_schedulechangechannels: Schedule changing a system's software channels"
-        )
-    )
-    print(
-        _(
-            """usage: system_setbasechannel <SYSTEMS> [options]
+    print(_("system_schedulechangechannels: Schedule changing a system's software channels"))
+    print(_('''usage: system_setbasechannel <SYSTEMS> [options]
 
 options:
   -b BASE_CHANNEL base channel label
   -c CHILD_CHANNEL child channel labels (allowed multiple times)
-  -s START_TIME time defaults to now"""
-        )
-    )
+  -s START_TIME time defaults to now'''))
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_schedulechangechannels(self, text, line, beg, end):
-    if len(line.split(" ")) == 2:
+
+    if len(line.split(' ')) == 2:
         return self.tab_complete_systems(text)
 
     return None
 
-
 def do_system_schedulechangechannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-b", "--base")
-    arg_parser.add_argument("-c", "--child", action="append", default=[])
-    arg_parser.add_argument("-s", "--start-time", action="store")
+    arg_parser.add_argument('-b', '--base')
+    arg_parser.add_argument('-c', '--child', action='append', default=[])
+    arg_parser.add_argument('-s', '--start-time', action='store')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
     # import pdb;
     # pdb.set_trace()
@@ -2977,27 +2597,22 @@ def do_system_schedulechangechannels(self, args):
         return 1
 
     if not options.base:
-        # pylint: disable-next=undefined-variable
-        logging.error(_N("A base channel is required"))
+        logging.error(_N('A base channel is required'))
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     if not options.start_time:
-        # pylint: disable-next=undefined-variable
-        options.start_time = parse_time_input("now")
+        options.start_time = parse_time_input('now')
     else:
-        # pylint: disable-next=undefined-variable
         options.start_time = parse_time_input(options.start_time)
 
     baseChannel = options.base
@@ -3010,22 +2625,20 @@ def do_system_schedulechangechannels(self, args):
         if not system_id:
             continue
 
-        oldBase = self.client.system.getSubscribedBaseChannel(self.session, system_id)
+        oldBase = self.client.system.getSubscribedBaseChannel(self.session,
+                                                              system_id)
 
-        oldKids = self.client.system.listSubscribedChildChannels(
-            self.session, system_id
-        )
+        oldKids = self.client.system.listSubscribedChildChannels(self.session,
+                                                                 system_id)
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("System:           %s") % system)
-        print(_("Old Base Channel: %s") % oldBase.get("label"))
-        print(
-            _("Old Child Channels: %s") % ", ".join([k.get("label") for k in oldKids])
-        )
-        print(_("New Base Channel: %s") % baseChannel)
-        print(_("New Child channels %s") % ", ".join(childChannels))
+        print(_('System:           %s') % system)
+        print(_('Old Base Channel: %s') % oldBase.get('label'))
+        print(_('Old Child Channels: %s') % ', '.join([k.get('label') for k in oldKids]))
+        print(_('New Base Channel: %s') % baseChannel)
+        print(_('New Child channels %s') % ', '.join(childChannels))
 
     if not self.user_confirm():
         return 1
@@ -3035,21 +2648,21 @@ def do_system_schedulechangechannels(self, args):
         if not system_id:
             continue
 
-        actionId = self.client.system.scheduleChangeChannels(
-            self.session, system_id, baseChannel, childChannels, options.start_time
-        )
-        print(_("Scheduled action id: %s") % actionId)
+        actionId = self.client.system.scheduleChangeChannels(self.session,
+                                                             system_id,
+                                                             baseChannel,
+                                                             childChannels,
+                                                             options.start_time)
+        print(_('Scheduled action id: %s') % actionId)
 
     return 0
 
-
 ####################
 
-
 def help_system_listbasechannel(self):
-    print(_("system_listbasechannel: List the base channel for a system"))
-    print(_("usage: system_listbasechannel <SYSTEMS>"))
-    print("")
+    print(_('system_listbasechannel: List the base channel for a system'))
+    print(_('usage: system_listbasechannel <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -3058,10 +2671,8 @@ def complete_system_listbasechannel(self, text, line, beg, end):
 
 
 def do_system_listbasechannel(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -3071,15 +2682,13 @@ def do_system_listbasechannel(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3092,22 +2701,23 @@ def do_system_listbasechannel(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
-        channel = self.client.system.getSubscribedBaseChannel(self.session, system_id)
+        channel = \
+            self.client.system.getSubscribedBaseChannel(self.session,
+                                                        system_id)
 
-        print(channel.get("label"))
+        print(channel.get('label'))
 
     return 0
-
 
 ####################
 
 
 def help_system_listchildchannels(self):
-    print(_("system_listchildchannels: List the child channels for a system"))
-    print(_("usage: system_listchildchannels <SYSTEMS>"))
-    print("")
+    print(_('system_listchildchannels: List the child channels for a system'))
+    print(_('usage: system_listchildchannels <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -3116,10 +2726,8 @@ def complete_system_listchildchannels(self, text, line, beg, end):
 
 
 def do_system_listchildchannels(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -3129,15 +2737,13 @@ def do_system_listchildchannels(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3150,112 +2756,82 @@ def do_system_listchildchannels(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
-        channels = self.client.system.listSubscribedChildChannels(
-            self.session, system_id
-        )
+        channels = \
+            self.client.system.listSubscribedChildChannels(self.session,
+                                                           system_id)
 
-        print("\n".join(sorted([c.get("label") for c in channels])))
+        print('\n'.join(sorted([c.get('label') for c in channels])))
 
     return 0
-
 
 ####################
 
 
 def help_system_addchildchannels(self):
     print(_("system_addchildchannels: Add child channels to a system"))
-    print(_("usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"))
-    print("")
+    print(_('usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_addchildchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.list_child_channels(), text)
 
     return None
-
 
 def do_system_addchildchannels(self, args):
     self.manipulate_child_channels(args)
     return 0
 
-
 ####################
 
 
 def _crashes_api_removed(check_api_version):
-    crashes_api_removed_version = "25"
+    crashes_api_removed_version = '25'
     if check_api_version(crashes_api_removed_version):
-        # pylint: disable-next=undefined-variable
-        logging.error(
-            _("This method was removed since API version %s")
-            % crashes_api_removed_version
-        )
+        logging.error(_("This method was removed since API version %s") % crashes_api_removed_version)
         return True
     else:
-        # pylint: disable-next=undefined-variable
-        logging.warning(
-            _("This method is deprecated and will be removed in API version %s"),
-            crashes_api_removed_version,
-        )
+        logging.warning(_("This method is deprecated and will be removed in API version %s"),
+                        crashes_api_removed_version)
     return False
 
-
 def help_system_listcrashedsystems(self):
-    print(
-        _(
-            "system_listcrashedsystems: List all systems that have experienced a crash and reported by spacewalk-abrt"
-        )
-    )
-    print(_("usage: system_listcrashedsystems"))
-    print("")
+    print(_("system_listcrashedsystems: List all systems that have experienced a crash and reported by spacewalk-abrt"))
+    print(_('usage: system_listcrashedsystems'))
+    print('')
 
 
 def do_system_listcrashedsystems(self, args):
     if _crashes_api_removed(self.check_api_version):
         return 1
-    print("")
-    print(_("Count | System ID | Profile Name"))
-    print("--------------------------------")
+    print('')
+    print(_('Count | System ID | Profile Name'))
+    print('--------------------------------')
     res = self.client.system.listUserSystems(self.session)
     for s in res:
-        res_crash = self.client.system.crash.listSystemCrashes(self.session, s["id"])
+        res_crash = self.client.system.crash.listSystemCrashes(self.session, s['id'])
         if res_crash:
-            # pylint: disable-next=consider-using-f-string
-            print("%d : %s : %s" % (len(res_crash), s["id"], s["name"]))
+            print("%d : %s : %s" % (len(res_crash), s['id'], s['name']))
 
     return 0
-
 
 ######
 
 
 def help_system_deletecrashes(self):
-    print(_("system_deletecrashes: Delete crashes reported by spacewalk-abrt."))
-    print(
-        _(
-            "usage: Delete all crashes for all systems    : system_deletecrashes [--verbose]"
-        )
-    )
-    print(
-        _(
-            "usage: Delete all crashes for a single system: system_deletecrashes -i sys_id [--verbose]"
-        )
-    )
-    print(
-        _(
-            "usage: Delete a single crash record          : system_deletecrashes -c crash_id [--verbose]"
-        )
-    )
-    print("")
+    print(_('system_deletecrashes: Delete crashes reported by spacewalk-abrt.'))
+    print(_('usage: Delete all crashes for all systems    : system_deletecrashes [--verbose]'))
+    print(_('usage: Delete all crashes for a single system: system_deletecrashes -i sys_id [--verbose]'))
+    print(_('usage: Delete a single crash record          : system_deletecrashes -c crash_id [--verbose]'))
+    print('')
 
 
 def print_msg(string_msg, flag_verbose):
@@ -3266,13 +2842,11 @@ def print_msg(string_msg, flag_verbose):
 def do_system_deletecrashes(self, args):
     if _crashes_api_removed(self.check_api_version):
         return 1
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-i", "--sysid")
-    arg_parser.add_argument("-c", "--crashid")
-    arg_parser.add_argument("-v", "--verbose", action="store_true")
+    arg_parser.add_argument('-i', '--sysid')
+    arg_parser.add_argument('-c', '--crashid')
+    arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if options.crashid:
@@ -3283,51 +2857,40 @@ def do_system_deletecrashes(self, args):
     sys_id = []
     if options.sysid:
         sys_id.append(options.sysid)
-        prompt_string = (
-            _("Deleting all crashes from system with systemid %s [y/N]:")
-            % options.sysid
-        )
+        prompt_string = _("Deleting all crashes from system with systemid %s [y/N]:") % options.sysid
     else:  # all systems
-        prompt_string = _("Deleting all crashes from all systems [y/N]:")
+        prompt_string = _('Deleting all crashes from all systems [y/N]:')
         systems = self.client.system.listUserSystems(self.session)
         for s in systems:
-            sys_id.append(s["id"])
+            sys_id.append(s['id'])
 
-    # pylint: disable-next=undefined-variable
     confirm = prompt_user(prompt_string)
-    # pylint: disable-next=undefined-variable
-    if re.match("n", confirm, re.I):
+    if re.match('n', confirm, re.I):
         return 1
 
     for s_id in sys_id:
         list_crash = self.client.system.crash.listSystemCrashes(self.session, int(s_id))
         for crash in list_crash:
-            print_msg(
-                _("Deleting crash with id %s from system %s.") % (crash["id"], s_id),
-                options.verbose,
-            )
-            self.client.system.crash.deleteCrash(self.session, int(crash["id"]))
+            print_msg(_("Deleting crash with id %s from system %s.") % (crash['id'], s_id), options.verbose)
+            self.client.system.crash.deleteCrash(self.session, int(crash['id']))
 
     return 0
-
 
 #######
 
 
 def help_system_listcrashesbysystem(self):
-    print(_("system_listcrashesbysystem: List all reported crashes for a system."))
-    print(_("usage: system_listcrashesbysystem -i sys_id"))
-    print("")
+    print(_('system_listcrashesbysystem: List all reported crashes for a system.'))
+    print(_('usage: system_listcrashesbysystem -i sys_id'))
+    print('')
 
 
 def do_system_listcrashesbysystem(self, args):
     if _crashes_api_removed(self.check_api_version):
         return 1
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-i", "--sysid")
+    arg_parser.add_argument('-i', '--sysid')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not options.sysid:
@@ -3335,125 +2898,99 @@ def do_system_listcrashesbysystem(self, args):
         print(_("usage: system_listcrashesbysystem -i sys_id"))
         return 1
 
-    l_crashes = self.client.system.crash.listSystemCrashes(
-        self.session, int(options.sysid)
-    )
-    print("")
-    print(_("Crash ID | Crash Name"))
-    print("---------------------")
+    l_crashes = self.client.system.crash.listSystemCrashes(self.session, int(options.sysid))
+    print('')
+    print(_('Crash ID | Crash Name'))
+    print('---------------------')
 
     for cr in l_crashes:
-        # pylint: disable-next=consider-using-f-string
-        print("| %s  | %s" % (cr["id"], cr["crash"]))
+        print("| %s  | %s" % (cr['id'], cr['crash']))
 
     return 0
 
-
 #######
 
-
 def help_system_getcrashfiles(self):
-    print(_("system_getcrashfiles: Download all files for a crash record."))
-    print(_("usage: system_getcrashfiles -c crash_id [--verbose]"))
-    print(
-        _(
-            "usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]"
-        )
-    )
-    print("")
+    print(_('system_getcrashfiles: Download all files for a crash record.'))
+    print(_('usage: system_getcrashfiles -c crash_id [--verbose]'))
+    print(_('usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]'))
+    print('')
 
 
 def do_system_getcrashfiles(self, args):
     if _crashes_api_removed(self.check_api_version):
         return 1
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-c", "--crashid")
-    arg_parser.add_argument("-d", "--dest_folder")
-    arg_parser.add_argument("-v", "--verbose", action="store_true")
+    arg_parser.add_argument('-c', '--crashid')
+    arg_parser.add_argument('-d', '--dest_folder')
+    arg_parser.add_argument('-v', '--verbose', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not options.crashid:
         print(_("# Crash id must be provided."))
-        print(
-            _(
-                "usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]"
-            )
-        )
+        print(_("usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]"))
         return 1
 
     if not options.verbose:
         options.verbose = "&>/dev/null"
 
     # create date stamp
-    date_stamp = datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+    date_stamp = datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
 
     if not options.dest_folder:
-        options.dest_folder = (
-            "files_for_" + "crashid_" + options.crashid + "_" + date_stamp
-        )
+        options.dest_folder = "files_for_" + "crashid_" + options.crashid + "_" + date_stamp
     else:
         options.dest_folder += "_" + date_stamp
 
     # create folder
-    # pylint: disable-next=undefined-variable,consider-using-f-string
     os.system("mkdir %s" % options.dest_folder)
-    l_files = self.client.system.crash.listSystemCrashFiles(
-        self.session, int(options.crashid)
-    )
+    l_files = self.client.system.crash.listSystemCrashFiles(self.session, int(options.crashid))
 
     for f in l_files:
-        file_url = self.client.system.crash.getCrashFileUrl(self.session, f["id"])
-        # pylint: disable-next=undefined-variable
-        os.system(
-            # pylint: disable-next=consider-using-f-string
-            "wget  --directory-prefix=%s --tries=1 --no-check-certificate %s %s"
-            % (options.dest_folder, file_url, options.verbose)
-        )
+        file_url = self.client.system.crash.getCrashFileUrl(self.session, f['id'])
+        os.system("wget  --directory-prefix=%s --tries=1 --no-check-certificate %s %s" % (
+            options.dest_folder,
+            file_url,
+            options.verbose))
 
-    print("")
+    print('')
     print(_("# All files we downloaded to %s.") % options.dest_folder)
-    print("")
+    print('')
 
     return 0
-
 
 ####################
 
 
 def help_system_removechildchannels(self):
     print(_("system_removechildchannels: Remove child channels from a system"))
-    print(_("usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"))
-    print("")
+    print(_('usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_removechildchannels(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.list_child_channels(), text)
 
     return None
-
 
 def do_system_removechildchannels(self, args):
     self.manipulate_child_channels(args, True)
     return 0
 
-
 ####################
 
 
 def help_system_details(self):
-    print(_("system_details: Show the details of a system profile"))
-    print(_("usage: system_details <SYSTEMS>"))
-    print("")
+    print(_('system_details: Show the details of a system profile'))
+    print(_('usage: system_details <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -3462,10 +2999,8 @@ def complete_system_details(self, text, line, beg, end):
 
 
 def do_system_details(self, args, short=False):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -3475,15 +3010,13 @@ def do_system_details(self, args, short=False):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3491,36 +3024,37 @@ def do_system_details(self, args, short=False):
         if not system_id:
             continue
 
-        last_checkin = self.client.system.getName(self.session, system_id).get(
-            "last_checkin"
-        )
+        last_checkin = \
+            self.client.system.getName(self.session,
+                                       system_id).get('last_checkin')
 
         details = self.client.system.getDetails(self.session, system_id)
 
-        if self.check_api_version("10.16"):
+        if self.check_api_version('10.16'):
             uuid = self.client.system.getUuid(self.session, system_id)
         else:
             uuid = None
 
-        registered = self.client.system.getRegistrationDate(self.session, system_id)
+        registered = self.client.system.getRegistrationDate(self.session,
+                                                            system_id)
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("Name:          %s") % details.get("profile_name"))
-        print(_("System ID:     %i") % system_id)
+        print(_('Name:          %s') % details.get('profile_name'))
+        print(_('System ID:     %i') % system_id)
 
         if uuid:
-            print(_("UUID:          %s") % uuid)
+            print(_('UUID:          %s') % uuid)
 
-        print(_("Locked:        %s") % details.get("lock_status"))
-        print(_("Registered:    %s") % registered)
-        print(_("Last Checkin:  %s") % last_checkin)
-        print(_("OSA Status:    %s") % details.get("osa_status"))
-        print(_("Last Boot:     %s") % details.get("last_boot"))
-        if "contact_method" in details:
-            print(_("Contact Method:%s") % details.get("contact_method"))
+        print(_('Locked:        %s') % details.get('lock_status'))
+        print(_('Registered:    %s') % registered)
+        print(_('Last Checkin:  %s') % last_checkin)
+        print(_('OSA Status:    %s') % details.get('osa_status'))
+        print(_('Last Boot:     %s') % details.get('last_boot'))
+        if 'contact_method' in details:
+            print(_('Contact Method:%s') % details.get('contact_method'))
 
         # only print(basic information if requested)
         if short:
@@ -3528,89 +3062,88 @@ def do_system_details(self, args, short=False):
 
         network = self.client.system.getNetwork(self.session, system_id)
 
-        entitlements = self.client.system.getEntitlements(self.session, system_id)
+        entitlements = self.client.system.getEntitlements(self.session,
+                                                          system_id)
 
-        base_channel = self.client.system.getSubscribedBaseChannel(
-            self.session, system_id
-        )
+        base_channel = \
+            self.client.system.getSubscribedBaseChannel(self.session,
+                                                        system_id)
 
-        child_channels = self.client.system.listSubscribedChildChannels(
-            self.session, system_id
-        )
+        child_channels = \
+            self.client.system.listSubscribedChildChannels(self.session,
+                                                           system_id)
 
-        groups = self.client.system.listGroups(self.session, system_id)
+        groups = self.client.system.listGroups(self.session,
+                                               system_id)
 
-        kernel = self.client.system.getRunningKernel(self.session, system_id)
+        kernel = self.client.system.getRunningKernel(self.session,
+                                                     system_id)
 
-        keys = self.client.system.listActivationKeys(self.session, system_id)
+        keys = self.client.system.listActivationKeys(self.session,
+                                                     system_id)
 
         ranked_config_channels = []
 
         try:
-            config_channels = self.client.system.config.listChannels(
-                self.session, system_id
-            )
+            config_channels = \
+                self.client.system.config.listChannels(self.session, system_id)
         except xmlrpclib.Fault as exc:
             # 10003 - unsupported operation
             if exc.faultCode == 10003:
-                # pylint: disable-next=undefined-variable
                 logging.debug(exc.faultString)
             else:
-                # pylint: disable-next=undefined-variable
                 logging.warning(exc.faultString)
         else:
             for channel in config_channels:
-                ranked_config_channels.append(channel.get("label"))
+                ranked_config_channels.append(channel.get('label'))
 
-        print("")
-        print(_("Hostname:      %s") % network.get("hostname"))
-        print(_("IP Address:    %s") % network.get("ip"))
-        print(_("Kernel:        %s") % kernel)
+        print('')
+        print(_('Hostname:      %s') % network.get('hostname'))
+        print(_('IP Address:    %s') % network.get('ip'))
+        print(_('Kernel:        %s') % kernel)
 
         if keys:
-            print("")
-            print(_("Activation Keys"))
-            print("---------------")
-            print("\n".join(sorted(keys)))
+            print('')
+            print(_('Activation Keys'))
+            print('---------------')
+            print('\n'.join(sorted(keys)))
 
-        print("")
-        print(_("Software Channels"))
-        print("-----------------")
-        print(base_channel.get("label"))
+        print('')
+        print(_('Software Channels'))
+        print('-----------------')
+        print(base_channel.get('label'))
 
         for channel in child_channels:
-            # pylint: disable-next=consider-using-f-string
-            print("  |-- %s" % channel.get("label"))
+            print('  |-- %s' % channel.get('label'))
 
         if ranked_config_channels:
-            print("")
-            print(_("Configuration Channels"))
-            print("----------------------")
-            print("\n".join(ranked_config_channels))
+            print('')
+            print(_('Configuration Channels'))
+            print('----------------------')
+            print('\n'.join(ranked_config_channels))
 
-        print("")
-        print(_("Entitlements"))
-        print("------------")
-        print("\n".join(sorted(entitlements)))
+        print('')
+        print(_('Entitlements'))
+        print('------------')
+        print('\n'.join(sorted(entitlements)))
 
         if groups:
-            print("")
-            print(_("System Groups"))
-            print("-------------")
+            print('')
+            print(_('System Groups'))
+            print('-------------')
             for group in groups:
-                if group.get("subscribed") == 1:
-                    print(group.get("system_group_name"))
+                if group.get('subscribed') == 1:
+                    print(group.get('system_group_name'))
 
     return 0
-
 
 ####################
 
 
 def help_system_listerrata(self):
-    print(_("system_listerrata: List available errata for a system"))
-    print(_("usage: system_listerrata <SYSTEMS>"))
-    print("")
+    print(_('system_listerrata: List available errata for a system'))
+    print(_('usage: system_listerrata <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -3619,10 +3152,8 @@ def complete_system_listerrata(self, text, line, beg, end):
 
 
 def do_system_listerrata(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -3632,15 +3163,13 @@ def do_system_listerrata(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3653,39 +3182,33 @@ def do_system_listerrata(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
-            print("")
+            print(_('System: %s') % system)
+            print('')
 
-        errata = self.client.system.getRelevantErrata(self.session, system_id)
+        errata = self.client.system.getRelevantErrata(self.session,
+                                                      system_id)
 
-        # pylint: disable-next=undefined-variable
         print_errata_list(errata)
 
     return 0
-
 
 ####################
 
 
 def help_system_applyerrata(self):
-    print(_("system_applyerrata: Apply errata to a system"))
-    print(
-        _(
-            """usage: system_applyerrata [options] <SYSTEMS>
+    print(_('system_applyerrata: Apply errata to a system'))
+    print(_('''usage: system_applyerrata [options] <SYSTEMS>
 [ERRATA|search:XXX ...]
 
 options:
-  -s START_TIME"""
-        )
-    )
-    print("")
+  -s START_TIME'''))
+    print('')
     print(self.HELP_TIME_OPTS)
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
-
 def complete_system_applyerrata(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
@@ -3694,16 +3217,13 @@ def complete_system_applyerrata(self, text, line, beg, end):
 
     return None
 
-
 def do_system_applyerrata(self, args):
     # this is really just an entry point to do_errata_apply
     # and the whole parsing of the start time needed is done
     # there; here we only make sure we accept this option
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -3711,16 +3231,14 @@ def do_system_applyerrata(self, args):
         return 1
 
     # use the systems applyed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # allow globbing and searching of errata
@@ -3732,27 +3250,21 @@ def do_system_applyerrata(self, args):
     # reconstruct options so we can pass them to do_errata_apply
     opts = []
     if options.start_time:
-        opts.append("-s " + options.start_time)
+        opts.append('-s ' + options.start_time)
 
-    return self.do_errata_apply(" ".join(opts), errata_list, systems)
-
+    return self.do_errata_apply(' '.join(opts), errata_list, systems)
 
 ####################
 
 
 def help_system_listevents(self):
-    if self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
-        logging.warning(
-            _(
-                "This method is deprecated and will be removed in a future API version. "
-                "Please use system_listeventhistory instead.\n"
-            )
-        )
+    if self.check_api_version('25.0'):
+        logging.warning(_('This method is deprecated and will be removed in a future API version. '
+        'Please use system_listeventhistory instead.\n'))
 
-    print(_("system_listevents: List the event history for a system"))
-    print(_("usage: system_listevents <SYSTEMS>"))
-    print("")
+    print(_('system_listevents: List the event history for a system'))
+    print(_('usage: system_listevents <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -3761,35 +3273,26 @@ def complete_system_listevents(self, text, line, beg, end):
 
 
 def do_system_listevents(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
         self.help_system_listevents()
         return 1
 
-    if self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
-        logging.warning(
-            _(
-                "This method is deprecated and will be removed in a future API version. "
-                "Please use system_listeventhistory instead.\n"
-            )
-        )
+    if self.check_api_version('25.0'):
+        logging.warning(_('This method is deprecated and will be removed in a future API version. '
+        'Please use system_listeventhistory instead.\n'))
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -3804,35 +3307,30 @@ def do_system_listevents(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
         events = self.client.system.getEventHistory(self.session, system_id)
 
         for e in events:
-            print("")
-            print(_("Summary:   %s") % e.get("summary"))
-            print(_("Completed: %s") % e.get("completed"))
-            print(_("Details:   %s") % e.get("details"))
+            print('')
+            print(_('Summary:   %s') % e.get('summary'))
+            print(_('Completed: %s') % e.get('completed'))
+            print(_('Details:   %s') % e.get('details'))
 
     return 0
-
 
 ####################
 
 
 def help_system_listeventhistory(self):
-    print(_("system_listeventhistory: List the event history for a system"))
-    print(
-        _(
-            """usage: system_listeventhistory <SYSTEMS> [options]
+    print(_('system_listeventhistory: List the event history for a system'))
+    print(_('''usage: system_listeventhistory <SYSTEMS> [options]
 
 options:
   -s START_TIME list only the events happened after the specified time. [Default: returns all events]
   -o OFFSET skip the first events. Ignored if -l is not specified as well. [Default: 0]
-  -l LIMIT limit the results to the specified number of events. [Default: no limit]"""
-        )
-    )
-    print("")
+  -l LIMIT limit the results to the specified number of events. [Default: no limit]'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -3841,18 +3339,15 @@ def complete_system_listeventhistory(self, text, line, beg, end):
 
 
 def do_system_listeventhistory(self, args):
-    if not self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
+    if not self.check_api_version('25.0'):
         logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
-    arg_parser.add_argument("-o", "--offset")
-    arg_parser.add_argument("-l", "--limit")
+    arg_parser.add_argument('-s', '--start-time')
+    arg_parser.add_argument('-o', '--offset')
+    arg_parser.add_argument('-l', '--limit')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -3860,21 +3355,18 @@ def do_system_listeventhistory(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     if not options.start_time:
         options.start_time = datetime(1970, 1, 1)
     else:
-        # pylint: disable-next=undefined-variable
         options.start_time = parse_time_input(options.start_time)
         if not options.start_time:
             return 1
@@ -3885,16 +3377,14 @@ def do_system_listeventhistory(self, args):
         try:
             options.offset = int(options.offset)
         except ValueError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_("Invalid offset"))
+            logging.error(_('Invalid offset'))
             return 1
 
     if options.limit:
         try:
             options.limit = int(options.limit)
         except ValueError:
-            # pylint: disable-next=undefined-variable
-            logging.error(_("Invalid limit"))
+            logging.error(_('Invalid limit'))
             return 1
 
     add_separator = False
@@ -3909,44 +3399,36 @@ def do_system_listeventhistory(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
         if options.limit:
-            events = self.client.system.getEventHistory(
-                self.session,
-                system_id,
-                options.start_time,
-                options.offset,
-                options.limit,
-            )
+            events = self.client.system.getEventHistory(self.session, system_id,
+                                                        options.start_time, options.offset, options.limit)
         else:
-            events = self.client.system.getEventHistory(
-                self.session, system_id, options.start_time
-            )
+            events = self.client.system.getEventHistory(self.session, system_id, options.start_time)
 
         for e in events:
-            print("")
-            print(_("Id:           %s") % e.get("id"))
-            print(_("History type: %s") % e.get("history_type"))
-            print(_("Status:       %s") % e.get("status"))
-            print(_("Summary:      %s") % e.get("summary"))
-            print(_("Completed:    %s") % e.get("completed"))
+            print('')
+            print(_('Id:           %s') % e.get('id'))
+            print(_('History type: %s') % e.get('history_type'))
+            print(_('Status:       %s') % e.get('status'))
+            print(_('Summary:      %s') % e.get('summary'))
+            print(_('Completed:    %s') % e.get('completed'))
 
     return 0
-
 
 ####################
 
 
 def help_system_eventdetails(self):
-    print(_("system_eventdetails: Retrieve the details of an event for a system"))
-    print(_("usage: system_eventdetails <SYSTEM> <EVENT>"))
-    print("")
+    print(_('system_eventdetails: Retrieve the details of an event for a system'))
+    print(_('usage: system_eventdetails <SYSTEM> <EVENT>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_eventdetails(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
@@ -3955,15 +3437,12 @@ def complete_system_eventdetails(self, text, line, beg, end):
 
 
 def do_system_eventdetails(self, args):
-    if not self.check_api_version("25.0"):
-        # pylint: disable-next=undefined-variable
+    if not self.check_api_version('25.0'):
         logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -3971,28 +3450,24 @@ def do_system_eventdetails(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     if not args:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No event specified"))
+        logging.warning(_N('No event specified'))
         return 1
 
     try:
         event_id = int(args.pop(0))
     except ValueError:
-        # pylint: disable-next=undefined-variable
-        logging.error(_("Invalid event id"))
+        logging.error(_('Invalid event id'))
         return 1
 
     add_separator = False
@@ -4007,65 +3482,56 @@ def do_system_eventdetails(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
-        print("")
+        print('')
 
         try:
-            detail = self.client.system.getEventDetails(
-                self.session, system_id, event_id
-            )
+            detail = self.client.system.getEventDetails(self.session, system_id, event_id)
         except xmlrpclib.Fault:
-            print(
-                _(
-                    # pylint: disable-next=consider-using-f-string
-                    "No event %s found in the history of system %s"
-                    % (event_id, system_id)
-                )
-            )
+            print(_('No event %s found in the history of system %s' % (event_id, system_id)))
             continue
 
-        print(_("Id:              %s") % detail.get("id"))
-        print("")
-        print(_("History type:    %s") % detail.get("history_type"))
-        print(_("Status:          %s") % detail.get("status"))
-        print(_("Summary:         %s") % detail.get("summary"))
-        print("")
-        print(_("Created:         %s") % detail.get("created"))
-        print(_("Picked up:       %s") % detail.get("picked_up"))
-        print(_("Completed:       %s") % detail.get("completed"))
+        print(_('Id:              %s') % detail.get('id'))
+        print('')
+        print(_('History type:    %s') % detail.get('history_type'))
+        print(_('Status:          %s') % detail.get('status'))
+        print(_('Summary:         %s') % detail.get('summary'))
+        print('')
+        print(_('Created:         %s') % detail.get('created'))
+        print(_('Picked up:       %s') % detail.get('picked_up'))
+        print(_('Completed:       %s') % detail.get('completed'))
 
-        if detail.get("history_type") != "History Event":
-            print("")
-            print(_("Earliest action: %s") % detail.get("earliest_action"))
-            print(_("Result message:  %s") % detail.get("result_msg"))
-            print(_("Result code:     %s") % detail.get("result_code"))
+        if detail.get('history_type') != 'History Event':
+            print('')
+            print(_('Earliest action: %s') % detail.get('earliest_action'))
+            print(_('Result message:  %s') % detail.get('result_msg'))
+            print(_('Result code:     %s') % detail.get('result_code'))
 
-            additional_info = detail.get("additional_info")
+            additional_info = detail.get('additional_info')
             if additional_info and additional_info:
-                print("")
-                print(_("Additional info:"))
+                print('')
+                print(_('Additional info:'))
 
                 info_separator = False
 
                 for info in additional_info:
                     if info_separator:
-                        print("")
+                        print('')
                     info_separator = True
 
-                    print(_("    Result:          %s") % info.get("result"))
-                    print(_("    Detail:          %s") % info.get("detail"))
+                    print(_('    Result:          %s') % info.get('result'))
+                    print(_('    Detail:          %s') % info.get('detail'))
 
     return 0
-
 
 ####################
 
 
 def help_system_listentitlements(self):
-    print(_("system_listentitlements: List the entitlements for a system"))
-    print(_("usage: system_listentitlements <SYSTEMS>"))
-    print("")
+    print(_('system_listentitlements: List the entitlements for a system'))
+    print(_('usage: system_listentitlements <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -4074,10 +3540,8 @@ def complete_system_listentitlements(self, text, line, beg, end):
 
 
 def do_system_listentitlements(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -4087,15 +3551,13 @@ def do_system_listentitlements(self, args):
     add_separator = False
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -4108,40 +3570,37 @@ def do_system_listentitlements(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print(_("System: %s") % system)
+            print(_('System: %s') % system)
 
-        entitlements = self.client.system.getEntitlements(self.session, system_id)
+        entitlements = self.client.system.getEntitlements(self.session,
+                                                          system_id)
 
-        print("\n".join(sorted(entitlements)))
+        print('\n'.join(sorted(entitlements)))
 
     return 0
-
 
 ####################
 
 
 def help_system_addentitlements(self):
-    print(_("system_addentitlements: Add entitlements to a system"))
-    print(_("usage: system_addentitlements <SYSTEMS> ENTITLEMENT"))
-    print("")
+    print(_('system_addentitlements: Add entitlements to a system'))
+    print(_('usage: system_addentitlements <SYSTEMS> ENTITLEMENT'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_addentitlements(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
 
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.ENTITLEMENTS, text)
 
 
 def do_system_addentitlements(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -4151,21 +3610,18 @@ def do_system_addentitlements(self, args):
     entitlement = args.pop()
 
     for e in self.ENTITLEMENTS:
-        # pylint: disable-next=undefined-variable
         if re.match(entitlement, e, re.I):
             entitlement = e
             break
 
     # use the systems applyed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -4173,36 +3629,34 @@ def do_system_addentitlements(self, args):
         if not system_id:
             continue
 
-        self.client.system.addEntitlements(self.session, system_id, [entitlement])
+        self.client.system.addEntitlements(self.session,
+                                           system_id,
+                                           [entitlement])
 
     return 0
-
 
 ####################
 
 
 def help_system_removeentitlement(self):
-    print(_("system_removeentitlement: Remove an entitlement from a system"))
-    print(_("usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"))
-    print("")
+    print(_('system_removeentitlement: Remove an entitlement from a system'))
+    print(_('usage: system_removeentitlement <SYSTEMS> ENTITLEMENT'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_removeentitlement(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
 
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.ENTITLEMENTS, text)
 
 
 def do_system_removeentitlement(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -4212,21 +3666,18 @@ def do_system_removeentitlement(self, args):
     entitlement = args.pop()
 
     for e in self.ENTITLEMENTS:
-        # pylint: disable-next=undefined-variable
         if re.match(entitlement, e, re.I):
             entitlement = e
             break
 
     # use the systems applyed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -4234,58 +3685,53 @@ def do_system_removeentitlement(self, args):
         if not system_id:
             continue
 
-        self.client.system.removeEntitlements(self.session, system_id, [entitlement])
+        self.client.system.removeEntitlements(self.session,
+                                              system_id,
+                                              [entitlement])
 
     return 0
-
 
 ####################
 
 
 def help_system_listpackageprofiles(self):
-    print(_("system_listpackageprofiles: List all package profiles"))
-    print(_("usage: system_listpackageprofiles"))
+    print(_('system_listpackageprofiles: List all package profiles'))
+    print(_('usage: system_listpackageprofiles'))
 
 
 def do_system_listpackageprofiles(self, args, doreturn=False):
     profiles = self.client.system.listPackageProfiles(self.session)
-    profiles = [p.get("name") for p in profiles]
+    profiles = [p.get('name') for p in profiles]
 
     if doreturn:
         return profiles
     else:
         if profiles:
-            print("\n".join(sorted(profiles)))
+            print('\n'.join(sorted(profiles)))
 
     return 0
-
 
 ####################
 
 
 def help_system_deletepackageprofile(self):
-    print(_("system_deletepackageprofile: Delete a package profile"))
-    print(_("usage: system_deletepackageprofile PROFILE"))
-
+    print(_('system_deletepackageprofile: Delete a package profile'))
+    print(_('usage: system_deletepackageprofile PROFILE'))
 
 def complete_system_deletepackageprofile(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
         return self.tab_complete_systems(
-            self.do_system_listpackageprofiles("", True), text
-        )
+            self.do_system_listpackageprofiles('', True), text)
 
     return None
 
-
 def do_system_deletepackageprofile(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -4294,58 +3740,49 @@ def do_system_deletepackageprofile(self, args):
 
     label = args[0]
 
-    if not self.user_confirm(_("Delete this profile [y/N]:")):
+    if not self.user_confirm(_('Delete this profile [y/N]:')):
         return 1
 
     all_profiles = self.client.system.listPackageProfiles(self.session)
 
     profile_id = 0
     for profile in all_profiles:
-        if label == profile.get("name"):
-            profile_id = profile.get("id")
+        if label == profile.get('name'):
+            profile_id = profile.get('id')
 
     if not profile_id:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("%s is not a valid profile") % label)
+        logging.warning(_N('%s is not a valid profile') % label)
         return 1
 
     self.client.system.deletePackageProfile(self.session, profile_id)
 
     return 0
 
-
 ####################
 
 
 def help_system_createpackageprofile(self):
-    print(_("system_createpackageprofile: Create a package profile"))
-    print(
-        _(
-            """usage: system_createpackageprofile SYSTEM [options]
+    print(_('system_createpackageprofile: Create a package profile'))
+    print(_('''usage: system_createpackageprofile SYSTEM [options]
 
 options:
   -n NAME
-  -d DESCRIPTION"""
-        )
-    )
+  -d DESCRIPTION'''))
 
 
 def complete_system_createpackageprofile(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
 
     return None
 
-
 def do_system_createpackageprofile(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-n", "--name")
-    arg_parser.add_argument("-d", "--description")
+    arg_parser.add_argument('-n', '--name')
+    arg_parser.add_argument('-d', '--description')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -4356,63 +3793,52 @@ def do_system_createpackageprofile(self, args):
     if not system_id:
         return 1
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.name = prompt_user(_("Profile Label:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.description = prompt_user(_("Description:"), multiline=True)
+        options.name = prompt_user(_('Profile Label:'), noblank=True)
+        options.description = prompt_user(_('Description:'), multiline=True)
     else:
         if not options.name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A profile name is required"))
+            logging.error(_N('A profile name is required'))
             return 1
 
         if not options.description:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A profile description is required"))
+            logging.error(_N('A profile description is required'))
             return 1
 
-    self.client.system.createPackageProfile(
-        self.session, system_id, options.name, options.description
-    )
+    self.client.system.createPackageProfile(self.session,
+                                            system_id,
+                                            options.name,
+                                            options.description)
 
-    # pylint: disable-next=undefined-variable
     logging.info(_N("Created package profile '%s'") % options.name)
 
     return 0
-
 
 ####################
 
 
 def help_system_comparepackageprofile(self):
-    print(_("system_comparepackageprofile: Compare a system against a package profile"))
-    print(_("usage: system_comparepackageprofile <SYSTEMS> PROFILE"))
-    print("")
+    print(_('system_comparepackageprofile: Compare a system against a package profile'))
+    print(_('usage: system_comparepackageprofile <SYSTEMS> PROFILE'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-
 
 def complete_system_comparepackageprofile(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     elif len(parts) > 2:
         return self.tab_complete_systems(
-            self.do_system_listpackageprofiles("", True), parts[-1]
-        )
+            self.do_system_listpackageprofiles('', True), parts[-1])
 
     return None
 
-
 def do_system_comparepackageprofile(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -4420,16 +3846,14 @@ def do_system_comparepackageprofile(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
         args.pop(0)
     else:
         systems = self.expand_systems(args[:-1])
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     profile = args[-1]
@@ -4441,39 +3865,34 @@ def do_system_comparepackageprofile(self, args):
         if not system_id:
             continue
 
-        results = self.client.system.comparePackageProfile(
-            self.session, system_id, profile
-        )
+        results = self.client.system.comparePackageProfile(self.session,
+                                                           system_id,
+                                                           profile)
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        # pylint: disable-next=consider-using-f-string
-        print("%s:" % system)
+        print('%s:' % system)
         self.print_package_comparison(results)
 
     return 0
-
 
 ####################
 
 
 def help_system_comparepackages(self):
-    print(_("system_comparepackages: Compare the packages between two systems"))
-    print(_("usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"))
+    print(_('system_comparepackages: Compare the packages between two systems'))
+    print(_('usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM'))
 
 
 def complete_system_comparepackages(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.get_system_names(), text)
 
 
 def do_system_comparepackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -4483,43 +3902,35 @@ def do_system_comparepackages(self, args):
     this_system = self.get_system_id(args[0])
     other_system = self.get_system_id(args[1])
 
-    results = self.client.system.comparePackages(
-        self.session, this_system, other_system
-    )
+    results = self.client.system.comparePackages(self.session,
+                                                 this_system,
+                                                 other_system)
 
     self.print_package_comparison(results)
 
     return 0
 
-
 ####################
 
 
 def help_system_syncpackages(self):
-    print(_("system_syncpackages: Sync packages between two systems"))
-    print(
-        _(
-            """usage: system_syncpackages SOURCE TARGET [options]
+    print(_('system_syncpackages: Sync packages between two systems'))
+    print(_('''usage: system_syncpackages SOURCE TARGET [options]
 
 options:
-    -s START_TIME"""
-        )
-    )
-    print("")
+    -s START_TIME'''))
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def complete_system_syncpackages(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.get_system_names(), text)
 
 
 def do_system_syncpackages(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -4537,34 +3948,27 @@ def do_system_syncpackages(self, args):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # show a comparison and ask for confirmation
-    # pylint: disable-next=consider-using-f-string
-    self.do_system_comparepackages("%s %s" % (source_id, target_id))
+    self.do_system_comparepackages('%s %s' % (source_id, target_id))
 
-    print("")
-    print(_("Start Time: %s") % options.start_time)
+    print('')
+    print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm(_("Sync packages [y/N]:")):
+    if not self.user_confirm(_('Sync packages [y/N]:')):
         return 1
 
     # get package IDs
     packages = self.client.system.listPackages(self.session, source_id)
 
-    # pylint: disable-next=undefined-variable
     package_names = build_package_names(packages)
 
     package_ids = []
@@ -4576,54 +3980,47 @@ def do_system_syncpackages(self, args):
         if p_ids:
             package_ids += p_ids
 
-    self.client.system.scheduleSyncPackagesWithSystem(
-        self.session, target_id, source_id, package_ids, options.start_time
-    )
+    self.client.system.scheduleSyncPackagesWithSystem(self.session,
+                                                      target_id,
+                                                      source_id,
+                                                      package_ids,
+                                                      options.start_time)
 
     return 0
-
 
 ####################
 
 
-def filter_latest_packages(
-    pkglist, version_key="version", release_key="release", epoch_key="epoch"
-):
+def filter_latest_packages(pkglist, version_key='version',
+                           release_key='release', epoch_key='epoch'):
     # Returns a dict, indexed by a compound (tuple) key based on
     # arch and name, so we can store the latest version of each package
     # for each arch.  This approach avoids nested loops :)
     latest = {}
     for p in pkglist:
-        if "arch_label" in p:
-            tuplekey = p["name"], p["arch_label"]
-        elif "arch" in p:
+        if 'arch_label' in p:
+            tuplekey = p['name'], p['arch_label']
+        elif 'arch' in p:
             # Fixup arch==AMD64 which is returned for some reason
-            # pylint: disable-next=undefined-variable
-            p["arch"] = re.sub("AMD64", "x86_64", p["arch"])
-            tuplekey = p["name"], p["arch"]
+            p['arch'] = re.sub('AMD64', 'x86_64', p['arch'])
+            tuplekey = p['name'], p['arch']
         else:
-            # pylint: disable-next=undefined-variable
-            logging.error(
-                _N("Failed to filter package list, package %s") % p
-                + _N("found with no arch or arch_label")
-            )
+            logging.error(_N("Failed to filter package list, package %s") % p
+                          + _N("found with no arch or arch_label"))
             return None
         if not tuplekey in latest:
             latest[tuplekey] = p
         else:
             # Already have this package, is p newer?
-            # pylint: disable-next=undefined-variable
-            if p == latest_pkg(
-                p, latest[tuplekey], version_key, release_key, epoch_key
-            ):
+            if p == latest_pkg(p, latest[tuplekey], version_key, release_key, epoch_key):
                 latest[tuplekey] = p
 
     return latest
 
 
-def print_comparison_withchannel(
-    self, channelnewer, systemnewer, channelmissing, channel_latest
-):
+def print_comparison_withchannel(self, channelnewer, systemnewer,
+                                 channelmissing, channel_latest):
+
     # Figure out correct indentation to allow pretty table output
     results = channelnewer + systemnewer + channelmissing
 
@@ -4631,119 +4028,85 @@ def print_comparison_withchannel(
     tmp_system = []
     tmp_channel = []
     for item in results:
-        # pylint: disable-next=consider-using-f-string
         name_string = "%(name)s.%(arch)s" % item
         tmp_names.append(name_string)
         # Create two version-string lists, one for the version in the results
         # list, and another with the version string from the channel_latest
         # dict, if the channel contains a matching package
-        # pylint: disable-next=consider-using-f-string
         version_string = "%(version)s-%(release)s" % item
         tmp_system.append(version_string)
-        key = item["name"], item["arch"]
+        key = item['name'], item['arch']
         if key in channel_latest:
-            # pylint: disable-next=consider-using-f-string
             version_string = "%(version)s-%(release)s" % channel_latest[key]
             tmp_channel.append(version_string)
 
-    # pylint: disable-next=undefined-variable
     max_name = max_length(tmp_names, minimum=7)
-    # pylint: disable-next=undefined-variable
     max_system = max_length(tmp_system, minimum=11)
-    # pylint: disable-next=undefined-variable
     max_channel = max_length(tmp_channel, minimum=15)
     max_comparison = 25
 
     # print(headers)
-    print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % (
-            _("Package").ljust(max_name),
-            _("System Version").ljust(max_system),
-            _("Channel Version").ljust(max_channel),
-            _("Difference").ljust(max_comparison),
-        )
-    )
+    print('%s  %s  %s  %s' % (
+        _('Package').ljust(max_name),
+        _('System Version').ljust(max_system),
+        _('Channel Version').ljust(max_channel),
+        _('Difference').ljust(max_comparison)))
 
-    print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % ("-" * max_name, "-" * max_system, "-" * max_channel, "-" * max_comparison)
-    )
+    print('%s  %s  %s  %s' % (
+        '-' * max_name,
+        '-' * max_system,
+        '-' * max_channel,
+        '-' * max_comparison))
 
     # Then print(the packages)
     for item in channelnewer:
-        # pylint: disable-next=consider-using-f-string
         name_string = "%(name)s.%(arch)s" % item
-        # pylint: disable-next=consider-using-f-string
         version_string = "%(version)s-%(release)s" % item
-        key = item["name"], item["arch"]
+        key = item['name'], item['arch']
         if key in channel_latest:
-            # pylint: disable-next=consider-using-f-string
             channel_version = "%(version)s-%(release)s" % channel_latest[key]
         else:
-            channel_version = "-"
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                name_string.ljust(max_name),
-                version_string.ljust(max_system),
-                channel_version.ljust(max_channel),
-                _("Channel_newer_than_system").ljust(max_comparison),
-            )
-        )
+            channel_version = '-'
+        print('%s  %s  %s  %s' % (
+            name_string.ljust(max_name),
+            version_string.ljust(max_system),
+            channel_version.ljust(max_channel),
+            _("Channel_newer_than_system").ljust(max_comparison)))
     for item in systemnewer:
-        # pylint: disable-next=consider-using-f-string
         name_string = "%(name)s.%(arch)s" % item
-        # pylint: disable-next=consider-using-f-string
         version_string = "%(version)s-%(release)s" % item
-        key = item["name"], item["arch"]
+        key = item['name'], item['arch']
         if key in channel_latest:
-            # pylint: disable-next=consider-using-f-string
             channel_version = "%(version)s-%(release)s" % channel_latest[key]
         else:
-            channel_version = "-"
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                name_string.ljust(max_name),
-                version_string.ljust(max_system),
-                channel_version.ljust(max_channel),
-                _("System_newer_than_channel").ljust(max_comparison),
-            )
-        )
+            channel_version = '-'
+        print('%s  %s  %s  %s' % (
+            name_string.ljust(max_name),
+            version_string.ljust(max_system),
+            channel_version.ljust(max_channel),
+            _("System_newer_than_channel").ljust(max_comparison)))
     for item in channelmissing:
-        # pylint: disable-next=consider-using-f-string
         name_string = "%(name)s.%(arch)s" % item
-        # pylint: disable-next=consider-using-f-string
         version_string = "%(version)s-%(release)s" % item
-        channel_version = "-"
-        print(
-            # pylint: disable-next=consider-using-f-string
-            "%s  %s  %s  %s"
-            % (
-                name_string.ljust(max_name),
-                version_string.ljust(max_system),
-                channel_version.ljust(max_channel),
-                _("Missing_in_channel").ljust(max_comparison),
-            )
-        )
+        channel_version = '-'
+        print('%s  %s  %s  %s' % (
+            name_string.ljust(max_name),
+            version_string.ljust(max_system),
+            channel_version.ljust(max_channel),
+            _("Missing_in_channel").ljust(max_comparison)))
 
 
 def help_system_comparewithchannel(self):
-    print(_("system_comparewithchannel: Compare the installed packages on a"))
-    print(_("                           system with those in the channels it is"))
-    print(_("                           registerd to, or optionally some other"))
-    print(_("                           channel"))
-    print(_("usage: system_comparewithchannel <SYSTEMS> [options]"))
-    print(_("options:"))
-    print(_("         -c/--channel : Specific channel to compare against,"))
-    print(_("                        default is those subscribed to, including"))
-    print(_("                        child channels"))
-    print("")
+    print(_('system_comparewithchannel: Compare the installed packages on a'))
+    print(_('                           system with those in the channels it is'))
+    print(_('                           registerd to, or optionally some other'))
+    print(_('                           channel'))
+    print(_('usage: system_comparewithchannel <SYSTEMS> [options]'))
+    print(_('options:'))
+    print(_('         -c/--channel : Specific channel to compare against,'))
+    print(_('                        default is those subscribed to, including'))
+    print(_('                        child channels'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -4752,11 +4115,9 @@ def complete_system_comparewithchannel(self, text, line, beg, end):
 
 
 def do_system_comparewithchannel(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-c", "--channel")
+    arg_parser.add_argument('-c', '--channel')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -4764,15 +4125,13 @@ def do_system_comparewithchannel(self, args):
         return 1
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     channel_latest = {}
@@ -4781,71 +4140,52 @@ def do_system_comparewithchannel(self, args):
         if not system_id:
             continue
 
-        instpkgs = self.client.system.listPackages(self.session, system_id)
-        # pylint: disable-next=undefined-variable
-        logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "Got %d packages installed in system %s"
-            % (len(instpkgs), system)
-        )
+        instpkgs = self.client.system.listPackages(self.session,
+                                                   system_id)
+        logging.debug("Got %d packages installed in system %s" %
+                      (len(instpkgs), system))
         # We need to filter to get only the latest installed packages,
         # because multiple versions (e.g kernel) can be installed
         packages = filter_latest_packages(instpkgs)
-        # pylint: disable-next=undefined-variable
-        logging.debug(
-            # pylint: disable-next=consider-using-f-string
-            "Got latest %d packages installed in system %s"
-            % (len(packages.keys()), system)
-        )
+        logging.debug("Got latest %d packages installed in system %s" %
+                      (len(packages.keys()), system))
 
         channels = []
         if options.channel:
             # User specified a specific channel, check it exists
             allch = self.client.channel.listSoftwareChannels(self.session)
-            allch_labels = [c["label"] for c in allch]
+            allch_labels = [c['label'] for c in allch]
             if not options.channel in allch_labels:
-                # pylint: disable-next=undefined-variable
                 logging.error(_N("Specified channel does not exist"))
                 self.help_system_comparewithchannel()
                 return None
             channels = [options.channel]
-            # pylint: disable-next=undefined-variable,consider-using-f-string
             logging.debug("User specified channel %s" % options.channel)
         else:
             # No specified channel, so we create a list of all channels the
             # system is subscribed to
-            basech = self.client.system.getSubscribedBaseChannel(
-                self.session, system_id
-            )
+            basech = self.client.system.getSubscribedBaseChannel(self.session,
+                                                                 system_id)
             if not basech:
-                # pylint: disable-next=undefined-variable
-                logging.error(
-                    _N("system %s is not subscribed to any channel!") % system
-                )
-                # pylint: disable-next=undefined-variable
-                logging.error(
-                    _N(
-                        "Please subscribe to a channel, or specify a"
-                        + "channel to compare with"
-                    )
-                )
+                logging.error(_N("system %s is not subscribed to any channel!")
+                              % system)
+                logging.error(_N("Please subscribe to a channel, or specify a" +
+                                 "channel to compare with"))
                 return 1
-            # pylint: disable-next=undefined-variable,consider-using-f-string
-            logging.debug("base channel %s for %s" % (basech["name"], system))
+            logging.debug("base channel %s for %s" % (basech['name'], system))
             childch = self.client.system.listSubscribedChildChannels(
-                self.session, system_id
-            )
-            channels = [basech["label"]]
+                self.session, system_id)
+            channels = [basech['label']]
             for c in childch:
-                channels.append(c["label"])
+                channels.append(c['label'])
 
         # Get the latest packages in each channel
         latestpkgs = {}
         for c in channels:
             if not c in channel_latest:
-                # pylint: disable-next=undefined-variable,consider-using-f-string
                 logging.debug("Getting packages for channel %s" % c)
-                pkgs = self.client.channel.software.listAllPackages(self.session, c)
+                pkgs = self.client.channel.software.listAllPackages(
+                    self.session, c)
                 # filter_latest_packages Returns a dict of latest packages
                 # indexed by name,arch tuple, which we add to the dict-of-dict
                 # channel_latest, to avoid getting the same channel data
@@ -4859,12 +4199,11 @@ def do_system_comparewithchannel(self, args):
                 if not key in latestpkgs:
                     latestpkgs[key] = channel_latest[c][key]
                 else:
-                    # pylint: disable-next=undefined-variable
                     p_newest = latest_pkg(channel_latest[c][key], latestpkgs[key])
                     latestpkgs[key] = p_newest
 
         if len(systems) > 1:
-            print(_("\nSystem: %s") % system)
+            print(_('\nSystem: %s') % system)
 
         # Iterate over the installed packages
         channelnewer = []
@@ -4874,7 +4213,6 @@ def do_system_comparewithchannel(self, args):
             syspkg = packages.get(key)
             if key in latestpkgs:
                 chpkg = latestpkgs.get(key)
-                # pylint: disable-next=undefined-variable
                 newest = latest_pkg(syspkg, chpkg)
                 if syspkg == newest:
                     systemnewer.append(syspkg)
@@ -4882,30 +4220,24 @@ def do_system_comparewithchannel(self, args):
                     channelnewer.append(syspkg)
             else:
                 channelmissing.append(syspkg)
-        self.print_comparison_withchannel(
-            channelnewer, systemnewer, channelmissing, latestpkgs
-        )
+        self.print_comparison_withchannel(channelnewer, systemnewer,
+                                          channelmissing, latestpkgs)
 
     return 0
-
 
 ####################
 
 
 def help_system_schedulehardwarerefresh(self):
-    print(_("system_schedulehardwarerefresh: Schedule a hardware refresh for a system"))
-    print(
-        _(
-            """usage: system_schedulehardwarerefresh <SYSTEMS> [options]
+    print(_('system_schedulehardwarerefresh: Schedule a hardware refresh for a system'))
+    print(_('''usage: system_schedulehardwarerefresh <SYSTEMS> [options]
 
 options:
-  -s START_TIME"""
-        )
-    )
+  -s START_TIME'''))
 
-    print("")
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
@@ -4914,11 +4246,9 @@ def complete_system_schedulehardwarerefresh(self, text, line, beg, end):
 
 
 def do_system_schedulehardwarerefresh(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -4928,30 +4258,23 @@ def do_system_schedulehardwarerefresh(self, args):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -4959,33 +4282,24 @@ def do_system_schedulehardwarerefresh(self, args):
         if not system_id:
             continue
 
-        self.client.system.scheduleHardwareRefresh(
-            self.session, system_id, options.start_time
-        )
+        self.client.system.scheduleHardwareRefresh(self.session,
+                                                   system_id,
+                                                   options.start_time)
 
     return 0
-
 
 ####################
 
 
 def help_system_schedulepackagerefresh(self):
-    print(
-        _(
-            "system_schedulepackagerefresh: Schedule a software package refresh for a system"
-        )
-    )
-    print(
-        _(
-            """usage: system_schedulepackagerefresh <SYSTEMS> [options])
+    print(_('system_schedulepackagerefresh: Schedule a software package refresh for a system'))
+    print(_('''usage: system_schedulepackagerefresh <SYSTEMS> [options])
 
 options:
-  -s START_TIME"""
-        )
-    )
-    print("")
+  -s START_TIME'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
@@ -4994,11 +4308,9 @@ def complete_system_schedulepackagerefresh(self, text, line, beg, end):
 
 
 def do_system_schedulepackagerefresh(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
+    arg_parser.add_argument('-s', '--start-time')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -5008,30 +4320,23 @@ def do_system_schedulepackagerefresh(self, args):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -5039,57 +4344,47 @@ def do_system_schedulepackagerefresh(self, args):
         if not system_id:
             continue
 
-        self.client.system.schedulePackageRefresh(
-            self.session, system_id, options.start_time
-        )
+        self.client.system.schedulePackageRefresh(self.session,
+                                                  system_id,
+                                                  options.start_time)
 
     return 0
-
 
 ####################
 
 
 def help_system_show_packageversion(self):
-    print(
-        _(
-            "system_show_packageversion: Shows version of installed package on given system(s)"
-        )
-    )
-    print(_("usage: system_show_packageversion <SYSTEM> <PACKAGE>"))
-    print("")
+    print(_('system_show_packageversion: Shows version of installed package on given system(s)'))
+    print(_('usage: system_show_packageversion <SYSTEM> <PACKAGE>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_show_packageversion(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
 
-    # pylint: disable-next=undefined-variable
     return tab_completer(self.get_package_names(), text)
 
 
 def do_system_show_packageversion(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
         self.help_system_show_packageversion()
         return 1
 
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     print(_("Package\tVersion\tRelease\tEpoch\tArch\tSystem"))
@@ -5102,49 +4397,35 @@ def do_system_show_packageversion(self, args):
         instpkgs = self.client.system.listPackages(self.session, system_id)
         searchpkg = args[1]
         for pkg in instpkgs:
-            if pkg.get("name") == searchpkg:
-                print(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s\t%s\t%s\t%s\t%s\t%s"
-                    % (
-                        pkg.get("name"),
-                        pkg.get("version"),
-                        pkg.get("release"),
-                        pkg.get("epoch"),
-                        pkg.get("arch_label"),
-                        system,
-                    )
-                )
+            if pkg.get('name') == searchpkg:
+                print("%s\t%s\t%s\t%s\t%s\t%s" % (pkg.get('name'), pkg.get('version'), pkg.get('release'),
+                                                  pkg.get('epoch'), pkg.get('arch_label'), system))
 
     return 0
-
 
 ####################
 
 
 def help_system_setcontactmethod(self):
-    print(_("system_setcontactmethod: Set the contact method for given system(s)."))
-    print(_("Available contact methods: " + str(self.CONTACT_METHODS)))
-    print(_("usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"))
-    print("")
+    print(_('system_setcontactmethod: Set the contact method for given system(s).'))
+    print(_('Available contact methods: ' + str(self.CONTACT_METHODS)))
+    print(_('usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_setcontactmethod(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
         return self.tab_complete_systems(text)
     else:
-        # pylint: disable-next=undefined-variable
         return tab_completer(self.CONTACT_METHODS, text)
 
 
 def do_system_setcontactmethod(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -5152,18 +4433,16 @@ def do_system_setcontactmethod(self, args):
         return 1
 
     contact_method = args.pop()
-    details = {"contact_method": contact_method}
+    details = {'contact_method': contact_method}
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -5175,37 +4454,28 @@ def do_system_setcontactmethod(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_system_scheduleapplyconfigchannels(self):
-    print(
-        _(
-            "system_scheduleapplyconfigchannels: "
-            "Schedule applying the assigned config channels to the System (Minion only)"
-        )
-    )
-    print(
-        _(
-            """usage: scheduleapplyconfigchannels <SYSTEMS> [options]
+    print(_("system_scheduleapplyconfigchannels: "
+            "Schedule applying the assigned config channels to the System (Minion only)"))
+    print(_('''usage: scheduleapplyconfigchannels <SYSTEMS> [options]
 
     options:
-        -s START_TIME"""
-        )
-    )
-    print("")
+        -s START_TIME'''))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
-    print("")
+    print('')
     print(self.HELP_TIME_OPTS)
 
 
 def do_system_scheduleapplyconfigchannels(self, args):
-    # pylint: disable-next=undefined-variable
-    arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
 
-    # pylint: disable-next=undefined-variable
+
+    arg_parser = get_argument_parser()
+    arg_parser.add_argument('-s', '--start-time')
+
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -5215,72 +4485,57 @@ def do_system_scheduleapplyconfigchannels(self, args):
     # get the start time option
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
-    # pylint: disable-next=undefined-variable
     if is_interactive(options) and self.options.yes is not True:
-        # pylint: disable-next=undefined-variable
-        options.start_time = prompt_user(_("Start Time [now]:"))
-        # pylint: disable-next=undefined-variable
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
-            # pylint: disable-next=undefined-variable
-            options.start_time = parse_time_input("now")
+            options.start_time = parse_time_input('now')
         else:
-            # pylint: disable-next=undefined-variable
             options.start_time = parse_time_input(options.start_time)
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args)
 
     if not systems:
-        # pylint: disable-next=undefined-variable
-        logging.warning(_N("No systems selected"))
+        logging.warning(_N('No systems selected'))
         return 1
 
-    print("")
-    print(_("Start Time: %s") % options.start_time)
-    print("")
-    print(_("Systems"))
-    print("-------")
-    print("\n".join(sorted(systems)))
+    print('')
+    print(_('Start Time: %s') % options.start_time)
+    print('')
+    print(_('Systems'))
+    print('-------')
+    print('\n'.join(sorted(systems)))
 
-    message = _("Schedule applying config channels to these systems [y/N]:")
+    message = _('Schedule applying config channels to these systems [y/N]:')
     if not self.user_confirm(message):
         return 1
 
     system_ids = [self.get_system_id(s) for s in systems]
 
-    actionId = self.client.system.config.scheduleApplyConfigChannel(
-        self.session, system_ids, options.start_time, False
-    )
-    print(_("Scheduled action id: %s") % actionId)
+    actionId = self.client.system.config.scheduleApplyConfigChannel(self.session,
+                                                                    system_ids,
+                                                                    options.start_time, False)
+    print(_('Scheduled action id: %s') % actionId)
 
     return 0
-
 
 ####################
 
 
 def help_system_listmigrationtargets(self):
-    print(
-        _(
-            "system_listmigrationtargets: List possible migration targets for given systems."
-        )
-    )
-    print(_("usage: system_listmigrationtargets <SYSTEMS>"))
-    print("")
+    print(_('system_listmigrationtargets: List possible migration targets for given systems.'))
+    print(_('usage: system_listmigrationtargets <SYSTEMS>'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
-
 def do_system_listmigrationtargets(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -5288,92 +4543,65 @@ def do_system_listmigrationtargets(self, args):
         return
 
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args[0])
 
     if not systems:
-        print(_("No systems found"))
+        print(_('No systems found'))
         return
 
     for system in sorted(systems):
         system_id = self.get_system_id(system)
         if not system_id:
-            print(_("WARN: Cannot find system ") + str(system))
+            print(_('WARN: Cannot find system ') + str(system))
             continue
 
-        print(_("System ") + str(system))
+        print(_('System ') + str(system))
         tgts = self.client.system.listMigrationTargets(self.session, system_id)
 
         if not tgts:
-            print(_("  No migration targets"))
+            print(_('  No migration targets'))
 
         for num, tgt in enumerate(tgts, start=1):
-            print(_("  Target #") + str(num) + ":")
-            print(_("    IDs: ") + tgt["ident"])
-            print(_("    Friendly names: ") + tgt["friendly"])
+            print(_('  Target #') + str(num) + ":")
+            print(_('    IDs: ') + tgt['ident'])
+            print(_('    Friendly names: ') + tgt['friendly'])
 
     return
-
 
 ####################
 
 
 def help_system_schedulespmigration(self):
-    print(
-        _(
-            "This method is deprecated and will be removed in a future API version. "
-            "Please use system_scheduleproductmigration instead."
-        )
-    )
-    # pylint: disable-next=undefined-variable
-    logging.warning(
-        _("This method is deprecated and will be removed in a future API version")
-    )
-    print(
-        _("system_schedulespmigration: Schedule a Service Pack migration for systems.")
-    )
-    print(
-        _(
-            "usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
+    print(_('This method is deprecated and will be removed in a future API version. '
+            'Please use system_scheduleproductmigration instead.'))
+    logging.warning(_("This method is deprecated and will be removed in a future API version"))
+    print(_('system_schedulespmigration: Schedule a Service Pack migration for systems.'))
+    print(_('usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
 \n    For MIGRATION_TARGET parameter see system_listmigrationtargets. \
 \n    The MIGRATION_TARGET parameter must be passed in the following format: [3143,3146,3147,3145,3144,3148,3062]. \
 \n    Options: \
 \n        -s START_TIME \
 \n        -d pass this flag, if you want to do a dry run \
-\n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))"
-        )
-    )
-    print("")
+\n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def do_system_schedulespmigration(self, args):
-    print(
-        _(
-            "This method is deprecated and will be removed in a future API version. "
-            "Please use system_scheduleproductmigration instead."
-        )
-    )
-    # pylint: disable-next=undefined-variable
-    logging.warning(
-        _("This method is deprecated and will be removed in a future API version")
-    )
+    print(_('This method is deprecated and will be removed in a future API version. '
+            'Please use system_scheduleproductmigration instead.'))
+    logging.warning(_("This method is deprecated and will be removed in a future API version"))
     self.do_system_scheduleproductmigration(self, args)
-
 
 ####################
 
 
 def help_system_scheduleproductmigration(self):
-    print(
-        _("system_scheduleproductmigration: Schedule a Product migration for systems.")
-    )
-    print(
-        _(
-            "usage: system_scheduleproductmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
+    print(_('system_scheduleproductmigration: Schedule a Product migration for systems.'))
+    print(_('usage: system_scheduleproductmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
 \n    For MIGRATION_TARGET parameter see system_listmigrationtargets. \
 \n    The MIGRATION_TARGET parameter must be passed in the following format: [3143,3146,3147,3145,3144,3148,3062]. \
 \n    Options: \
@@ -5381,25 +4609,19 @@ def help_system_scheduleproductmigration(self):
 \n        -d pass this flag, if you want to do a dry run \
 \n        --allow-vendor-change pass this flag if you want to allow vendor change \
 \n        -r pass this flag if you want to remove remove products which have no successors \
-\n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))"
-        )
-    )
-    print("")
+\n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))'))
+    print('')
     print(self.HELP_SYSTEM_OPTS)
 
 
 def do_system_scheduleproductmigration(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-s", "--start-time")
-    arg_parser.add_argument("-d", "--dry-run", action="store_true", default=False)
-    arg_parser.add_argument("-c", "--child-channels")
-    arg_parser.add_argument("--allow-vendor-change", action="store_true", default=False)
-    arg_parser.add_argument(
-        "-r", "--remove-products-without-successor", action="store_true", default=False
-    )
+    arg_parser.add_argument('-s', '--start-time')
+    arg_parser.add_argument('-d', '--dry-run', action='store_true', default=False)
+    arg_parser.add_argument('-c', '--child-channels')
+    arg_parser.add_argument('--allow-vendor-change', action='store_true', default=False)
+    arg_parser.add_argument('-r', '--remove-products-without-successor', action='store_true', default=False)
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
@@ -5408,14 +4630,13 @@ def do_system_scheduleproductmigration(self, args):
 
     # POSITIONAL ARGS
     # use the systems listed in the SSM
-    # pylint: disable-next=undefined-variable
-    if re.match("ssm", args[0], re.I):
+    if re.match('ssm', args[0], re.I):
         systems = self.ssm.keys()
     else:
         systems = self.expand_systems(args[0])
 
     if not systems:
-        print(_("No systems found"))
+        print(_('No systems found'))
         return
 
     base_channel_label = args[1]
@@ -5423,59 +4644,39 @@ def do_system_scheduleproductmigration(self, args):
 
     # OPTIONAL NAMED ARGS
     if options.start_time:
-        # pylint: disable-next=undefined-variable
         options.start_time = parse_time_input(options.start_time)
     else:
-        # pylint: disable-next=undefined-variable
-        options.start_time = parse_time_input("now")
+        options.start_time = parse_time_input('now')
 
     child_channels = []
     if options.child_channels:
-        child_channels = [cnl.strip() for cnl in options.child_channels.split(",")]
+        child_channels = [cnl.strip() for cnl in options.child_channels.split(',')]
 
     for system in sorted(systems):
         system_id = self.get_system_id(system)
         if not system_id:
-            # pylint: disable-next=undefined-variable
-            logging.warning(
-                _N("Cannot find system ") + str(system) + _(". Skipping it.")
-            )
+            logging.warning(_N('Cannot find system ') + str(system) + _('. Skipping it.'))
             continue
 
-        print(_("Scheduling Product migration for system ") + str(system))
-        print(_("Migration target ") + str(migration_target))
+        print(_('Scheduling Product migration for system ') + str(system))
+        print(_('Migration target ') + str(migration_target))
         try:
-            result = self.client.system.scheduleProductMigration(
-                self.session,
-                system_id,
-                migration_target,
-                base_channel_label,
-                child_channels,
-                options.dry_run,
-                options.allow_vendor_change,
-                options.remove_products_without_successor,
-                options.start_time,
-            )
-            print(_("Scheduled action ID: ") + str(result))
+            result = self.client.system.scheduleProductMigration(self.session,
+                                                            system_id, migration_target, base_channel_label,
+                                                            child_channels, options.dry_run, options.allow_vendor_change,
+                                                            options.remove_products_without_successor, options.start_time)
+            print(_('Scheduled action ID: ') + str(result))
         except xmlrpclib.Fault as detail:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("Failed to schedule %s") % detail)
+            logging.error(_N('Failed to schedule %s') % detail)
 
     return
-
 
 ####################
 
 
 def help_system_bootstrap(self):
-    print(
-        _(
-            "system_bootstrap: Bootstrap a system for management via either Salt or Salt SSH."
-        )
-    )
-    print(
-        _(
-            """usage: bootstrap [options]
+    print(_("system_bootstrap: Bootstrap a system for management via either Salt or Salt SSH."))
+    print(_('''usage: bootstrap [options]
 
     options:
         -H HOSTNAME
@@ -5488,119 +4689,85 @@ def help_system_bootstrap(self):
         -r REACTIVATION_KEY
         --proxyid PROXY_SYSID
         --saltssh
-        """
-        )
-    )
-    print("")
+        '''))
+    print('')
 
 
 def do_system_bootstrap(self, args):
-    # pylint: disable-next=undefined-variable
-    arg_parser = get_argument_parser()
-    arg_parser.add_argument("-H", "--hostname")
-    arg_parser.add_argument("-p", "--port", default=22)
-    arg_parser.add_argument("-u", "--ssh-user", default="root")
-    arg_parser.add_argument("-P", "--ssh-password")
-    arg_parser.add_argument("-k", "--ssh-privatekey-file")
-    arg_parser.add_argument("-S", "--ssh-privatekey-password", default="")
-    arg_parser.add_argument("-a", "--activation-key", default="")
-    arg_parser.add_argument("-r", "--reactivation-key")
-    arg_parser.add_argument("--proxyid")
-    arg_parser.add_argument("--saltssh", action="store_true", default=False)
 
-    # pylint: disable-next=undefined-variable
+    arg_parser = get_argument_parser()
+    arg_parser.add_argument('-H', '--hostname')
+    arg_parser.add_argument('-p', '--port', default=22)
+    arg_parser.add_argument('-u', '--ssh-user', default="root")
+    arg_parser.add_argument('-P', '--ssh-password')
+    arg_parser.add_argument('-k', '--ssh-privatekey-file')
+    arg_parser.add_argument('-S', '--ssh-privatekey-password', default="")
+    arg_parser.add_argument('-a', '--activation-key', default="")
+    arg_parser.add_argument('-r', '--reactivation-key')
+    arg_parser.add_argument('--proxyid')
+    arg_parser.add_argument('--saltssh', action='store_true', default=False)
+
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not (options.hostname or options.ssh_password or options.ssh_privatekey_file):
-        # pylint: disable-next=undefined-variable
-        options.hostname = prompt_user(_("Hostname:"))
-        # pylint: disable-next=undefined-variable
-        options.port = prompt_user(_("Port [22]:"))
+        options.hostname = prompt_user(_('Hostname:'))
+        options.port = prompt_user(_('Port [22]:'))
         if not options.port:
             options.port = 22
-        # pylint: disable-next=undefined-variable
-        options.ssh_user = prompt_user(_("SSH User [root]:"))
+        options.ssh_user = prompt_user(_('SSH User [root]:'))
         if not options.ssh_user:
             options.ssh_user = "root"
-        options.ssh_password = getpass(_("SSH Password:"))
+        options.ssh_password = getpass(_('SSH Password:'))
         if not options.ssh_password:
-            # pylint: disable-next=undefined-variable
-            options.ssh_privatekey_file = prompt_user(_("SSH Private Key File:"))
-            options.ssh_privatekey_password = getpass(_("SSH Private Key Password:"))
+            options.ssh_privatekey_file = prompt_user(_('SSH Private Key File:'))
+            options.ssh_privatekey_password = getpass(_('SSH Private Key Password:'))
             if not options.ssh_privatekey_password:
                 options.ssh_privatekey_password = ""
-        # pylint: disable-next=undefined-variable
-        options.activation_key = prompt_user(_("Activation Key:"))
+        options.activation_key = prompt_user(_('Activation Key:'))
         if not options.activation_key:
             options.activation_key = ""
-        # pylint: disable-next=undefined-variable
-        options.reactivation_key = prompt_user(_("Reactivation Key:"))
-        # pylint: disable-next=undefined-variable
-        options.proxyid = prompt_user(_("Proxy System ID:"))
+        options.reactivation_key = prompt_user(_('Reactivation Key:'))
+        options.proxyid = prompt_user(_('Proxy System ID:'))
         options.saltssh = False
-        # pylint: disable-next=undefined-variable
-        answer = prompt_user(_("Manage with Salt SSH") + " [y/N]:")
-        if answer in ["y", "Y"]:
+        answer = prompt_user(_('Manage with Salt SSH') + ' [y/N]:')
+        if answer in ['y', 'Y']:
             options.saltssh = True
 
     if not options.hostname:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Hostname must be provided"))
         return 1
     if not (options.ssh_password or options.ssh_privatekey_file):
-        # pylint: disable-next=undefined-variable
         logging.error(_N("Either a SSH Password or a private key must be provided"))
         return 1
 
     args = []
-    if self.check_api_version("25.0"):
+    if self.check_api_version('25.0'):
         if options.reactivation_key:
             args.append(options.reactivation_key)
     elif options.reactivation_key:
-        # pylint: disable-next=undefined-variable
-        logging.error(
-            _N("Server is not supporting reactivation keys at bootstrap time")
-        )
+        logging.error(_N("Server is not supporting reactivation keys at bootstrap time"))
         return 1
 
     if options.proxyid:
         args.append(int(options.proxyid))
     args.append(options.saltssh)
 
-    # pylint: disable-next=consider-using-f-string
     print(_("Bootstrapping '{}'. This may take a while.".format(options.hostname)))
     if options.ssh_password:
-        self.client.system.bootstrap(
-            self.session,
-            options.hostname,
-            options.port,
-            options.ssh_user,
-            options.ssh_password,
-            options.activation_key,
-            *args,
-        )
+        self.client.system.bootstrap(self.session, options.hostname, options.port,
+                options.ssh_user, options.ssh_password, options.activation_key,
+                *args)
     else:
-        # pylint: disable-next=unspecified-encoding
         with open(options.ssh_privatekey_file, "r") as key:
             pkey = key.read()
 
             # use ssh key
-            self.client.system.bootstrapWithPrivateSshKey(
-                self.session,
-                options.hostname,
-                options.port,
-                options.ssh_user,
-                pkey,
-                options.ssh_privatekey_password,
-                options.activation_key,
-                *args,
-            )
-    print(
-        _(
-            "Initial phase successfully finished. Check event history for actions still running"
-        )
-    )
+            self.client.system.bootstrapWithPrivateSshKey(self.session,
+                    options.hostname, options.port, options.ssh_user,
+                    pkey, options.ssh_privatekey_password, options.activation_key,
+                    *args)
+    print(_("Initial phase successfully finished. Check event history for actions still running"))
     return 0
 
-
 ####################
+

--- a/spacecmd/src/spacecmd/user.py
+++ b/spacecmd/src/spacecmd/user.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -34,7 +33,6 @@
 import gettext
 import shlex
 from getpass import getpass
-
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
@@ -42,18 +40,15 @@ except ImportError:
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 def help_user_create(self):
-    print(_("user_create: Create an user"))
-    print(
-        _(
-            """usage: user_create [options])
+    print(_('user_create: Create an user'))
+    print(_('''usage: user_create [options])
 
 options:
   -u USERNAME
@@ -61,75 +56,60 @@ options:
   -l LAST_NAME
   -e EMAIL
   -p PASSWORD
-  --pam enable PAM authentication"""
-        )
-    )
+  --pam enable PAM authentication'''))
 
 
 def do_user_create(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
-    arg_parser.add_argument("-u", "--username")
-    arg_parser.add_argument("-f", "--first-name")
-    arg_parser.add_argument("-l", "--last-name")
-    arg_parser.add_argument("-e", "--email")
-    arg_parser.add_argument("-p", "--password")
-    arg_parser.add_argument("--pam", action="store_true")
+    arg_parser.add_argument('-u', '--username')
+    arg_parser.add_argument('-f', '--first-name')
+    arg_parser.add_argument('-l', '--last-name')
+    arg_parser.add_argument('-e', '--email')
+    arg_parser.add_argument('-p', '--password')
+    arg_parser.add_argument('--pam', action='store_true')
 
-    # pylint: disable-next=undefined-variable
     (args, options) = parse_command_arguments(args, arg_parser)
 
-    # pylint: disable-next=undefined-variable
     if is_interactive(options):
-        # pylint: disable-next=undefined-variable
-        options.username = prompt_user(_("Username:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.first_name = prompt_user(_("First Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.last_name = prompt_user(_("Last Name:"), noblank=True)
-        # pylint: disable-next=undefined-variable
-        options.email = prompt_user(_("Email:"), noblank=True)
-        options.pam = self.user_confirm(
-            _("PAM Authentication [y/N]:"), nospacer=True, integer=True, ignore_yes=True
-        )
+        options.username = prompt_user(_('Username:'), noblank=True)
+        options.first_name = prompt_user(_('First Name:'), noblank=True)
+        options.last_name = prompt_user(_('Last Name:'), noblank=True)
+        options.email = prompt_user(_('Email:'), noblank=True)
+        options.pam = self.user_confirm(_('PAM Authentication [y/N]:'),
+                                        nospacer=True,
+                                        integer=True,
+                                        ignore_yes=True)
 
-        options.password = ""
-        while options.password == "":
-            password1 = getpass(_("Password: "))
-            password2 = getpass(_("Repeat Password: "))
+        options.password = ''
+        while options.password == '':
+            password1 = getpass(_('Password: '))
+            password2 = getpass(_('Repeat Password: '))
 
             if password1 == password2:
                 options.password = password1
-            elif password1 == "":
-                # pylint: disable-next=undefined-variable
-                logging.warning(_N("Password must be at least 5 characters"))
+            elif password1 == '':
+                logging.warning(_N('Password must be at least 5 characters'))
             else:
-                # pylint: disable-next=undefined-variable
                 logging.warning(_N("Passwords don't match"))
     else:
         if not options.username:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A username is required"))
+            logging.error(_N('A username is required'))
             return 1
 
         if not options.first_name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A first name is required"))
+            logging.error(_N('A first name is required'))
             return 1
 
         if not options.last_name:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A last name is required"))
+            logging.error(_N('A last name is required'))
             return 1
 
         if not options.email:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("An email address is required"))
+            logging.error(_N('An email address is required'))
             return 1
 
         if not options.password and not options.pam:
-            # pylint: disable-next=undefined-variable
-            logging.error(_N("A password is required"))
+            logging.error(_N('A password is required'))
             return 1
 
         if options.pam:
@@ -137,43 +117,36 @@ def do_user_create(self, args):
             # API requires a non-None password even though it's not used
             # when PAM is enabled
             if options.password:
-                # pylint: disable-next=undefined-variable
                 logging.warning(_N("Note: password was ignored due to PAM mode"))
             options.password = ""
         else:
             options.pam = 0
 
-    self.client.user.create(
-        self.session,
-        options.username,
-        options.password,
-        options.first_name,
-        options.last_name,
-        options.email,
-        options.pam,
-    )
+    self.client.user.create(self.session,
+                            options.username,
+                            options.password,
+                            options.first_name,
+                            options.last_name,
+                            options.email,
+                            options.pam)
 
     return 0
-
 
 ####################
 
 
 def help_user_delete(self):
-    print(_("user_delete: Delete an user"))
-    print(_("usage: user_delete NAME"))
+    print(_('user_delete: Delete an user'))
+    print(_('usage: user_delete NAME'))
 
 
 def complete_user_delete(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_user_list("", True), text)
+    return tab_completer(self.do_user_list('', True), text)
 
 
 def do_user_delete(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -182,31 +155,27 @@ def do_user_delete(self, args):
 
     name = args[0]
 
-    if self.options.yes or self.user_confirm("Delete this user [y/N]:"):
+    if self.options.yes or self.user_confirm('Delete this user [y/N]:'):
         self.client.user.delete(self.session, name)
         return 0
     else:
         return 1
 
-
 ####################
 
 
 def help_user_disable(self):
-    print(_("user_disable: Disable an user account"))
-    print(_("usage: user_disable NAME"))
+    print(_('user_disable: Disable an user account'))
+    print(_('usage: user_disable NAME'))
 
 
 def complete_user_disable(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_user_list("", True), text)
+    return tab_completer(self.do_user_list('', True), text)
 
 
 def do_user_disable(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -219,25 +188,21 @@ def do_user_disable(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_user_enable(self):
-    print(_("user_enable: Enable an user account"))
-    print(_("usage: user_enable NAME"))
+    print(_('user_enable: Enable an user account'))
+    print(_('usage: user_enable NAME'))
 
 
 def complete_user_enable(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_user_list("", True), text)
+    return tab_completer(self.do_user_list('', True), text)
 
 
 def do_user_enable(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 1:
@@ -250,33 +215,31 @@ def do_user_enable(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_user_list(self):
-    print(_("user_list: List all users"))
-    print(_("usage: user_list"))
+    print(_('user_list: List all users'))
+    print(_('usage: user_list'))
 
 
 def do_user_list(self, args, doreturn=False):
     users = self.client.user.listUsers(self.session)
-    users = sorted([u.get("login") for u in users])
+    users = sorted([u.get('login') for u in users])
 
     if doreturn:
         return users
     if users:
-        print("\n".join(users))
+        print('\n'.join(users))
 
     return None
-
 
 ####################
 
 
 def help_user_listavailableroles(self):
-    print(_("user_listavailableroles: List all available roles for users"))
-    print(_("usage: user_listavailableroles"))
+    print(_('user_listavailableroles: List all available roles for users'))
+    print(_('usage: user_listavailableroles'))
 
 
 def do_user_listavailableroles(self, args, doreturn=False):
@@ -285,40 +248,35 @@ def do_user_listavailableroles(self, args, doreturn=False):
     if doreturn:
         return roles
     if roles:
-        print("\n".join(sorted(roles)))
+        print('\n'.join(sorted(roles)))
     else:
-        # pylint: disable-next=undefined-variable
         logging.error(_N("No roles has been found"))
 
     return None
-
 
 ####################
 
 
 def help_user_addrole(self):
-    print(_("user_addrole: Add a role to an user account"))
-    print(_("usage: user_addrole USER ROLE"))
+    print(_('user_addrole: Add a role to an user account'))
+    print(_('usage: user_addrole USER ROLE'))
 
 
 def complete_user_addrole(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
     elif len(parts) == 3:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_listavailableroles("", True), text)
+        return tab_completer(self.do_user_listavailableroles('', True),
+                             text)
 
     return None
 
 
 def do_user_addrole(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -332,35 +290,30 @@ def do_user_addrole(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_user_removerole(self):
-    print(_("user_removerole: Remove a role from an user account"))
-    print(_("usage: user_removerole USER ROLE"))
+    print(_('user_removerole: Remove a role from an user account'))
+    print(_('usage: user_removerole USER ROLE'))
 
 
 def complete_user_removerole(self, text, line, beg, end):
-    parts = line.split(" ")
+    parts = line.split(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
     elif len(parts) == 3:
         # only list the roles currently assigned to this user
         roles = self.client.user.listRoles(self.session, parts[1])
-        # pylint: disable-next=undefined-variable
         return tab_completer(roles, text)
 
     return None
 
 
 def do_user_removerole(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -374,25 +327,21 @@ def do_user_removerole(self, args):
 
     return 0
 
-
 ####################
 
 
 def help_user_details(self):
-    print(_("user_details: Show the details of an user"))
-    print(_("usage: user_details USER ..."))
+    print(_('user_details: Show the details of an user'))
+    print(_('usage: user_details USER ...'))
 
 
 def complete_user_details(self, text, line, beg, end):
-    # pylint: disable-next=undefined-variable
-    return tab_completer(self.do_user_list("", True), text)
+    return tab_completer(self.do_user_list('', True), text)
 
 
 def do_user_details(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
@@ -407,89 +356,78 @@ def do_user_details(self, args):
 
             roles = self.client.user.listRoles(self.session, user)
 
-            groups = self.client.user.listAssignedSystemGroups(self.session, user)
+            groups = \
+                self.client.user.listAssignedSystemGroups(self.session,
+                                                          user)
 
-            default_groups = self.client.user.listDefaultSystemGroups(
-                self.session, user
-            )
+            default_groups = \
+                self.client.user.listDefaultSystemGroups(self.session,
+                                                         user)
         except xmlrpclib.Fault as exc:
-            # pylint: disable-next=undefined-variable
-            logging.warning(_N("%s is not a valid user") % user)
-            # pylint: disable-next=undefined-variable
-            logging.debug(
-                # pylint: disable-next=consider-using-f-string
-                "Error '{}' while getting data about user '{}': {}".format(
-                    exc.faultCode, user, exc.faultString
-                )
-            )
+            logging.warning(_N('%s is not a valid user') % user)
+            logging.debug("Error '{}' while getting data about user '{}': {}".format(
+                exc.faultCode, user, exc.faultString))
             continue
 
-        org_name = self.client.org.getDetails(self.session, details.get("org_id")).get(
-            "name"
-        )
+        org_name = self.client.org.getDetails(self.session, details.get('org_id')).get("name")
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print(_("Username:      %s") % user)
-        print(_("First Name:    %s") % details.get("first_name"))
-        print(_("Last Name:     %s") % details.get("last_name"))
-        print(_("Email Address: %s") % details.get("email"))
-        print(_("Organisation:  %s") % org_name)
-        print(_("Last Login:    %s") % details.get("last_login_date"))
-        print(_("Created:       %s") % details.get("created_date"))
-        print(_("Enabled:       %s") % details.get("enabled"))
+        print(_('Username:      %s') % user)
+        print(_('First Name:    %s') % details.get('first_name'))
+        print(_('Last Name:     %s') % details.get('last_name'))
+        print(_('Email Address: %s') % details.get('email'))
+        print(_('Organisation:  %s') % org_name)
+        print(_('Last Login:    %s') % details.get('last_login_date'))
+        print(_('Created:       %s') % details.get('created_date'))
+        print(_('Enabled:       %s') % details.get('enabled'))
 
         if roles:
-            print("")
-            print(_("Roles"))
-            print("-----")
-            print("\n".join(sorted(roles)))
+            print('')
+            print(_('Roles'))
+            print('-----')
+            print('\n'.join(sorted(roles)))
 
         if groups:
-            print("")
-            print(_("Assigned Groups"))
-            print("---------------")
-            print("\n".join(sorted([g.get("name") for g in groups])))
+            print('')
+            print(_('Assigned Groups'))
+            print('---------------')
+            print('\n'.join(sorted([g.get('name') for g in groups])))
 
         if default_groups:
-            print("")
-            print(_("Default Groups"))
-            print("--------------")
-            print("\n".join(sorted([g.get("name") for g in default_groups])))
+            print('')
+            print(_('Default Groups'))
+            print('--------------')
+            print('\n'.join(sorted([g.get('name') for g in default_groups])))
 
     return 0
-
 
 ####################
 
 
 def help_user_addgroup(self):
-    print(_("user_addgroup: Add a group to an user account"))
-    print(_("usage: user_addgroup USER <GROUP ...>"))
+    print(_('user_addgroup: Add a group to an user account'))
+    print(_('usage: user_addgroup USER <GROUP ...>'))
 
 
 def complete_user_addgroup(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_group_list("", True), parts[-1])
+        return tab_completer(self.do_group_list('', True), parts[-1])
 
     return None
 
 
 def do_user_addgroup(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -499,39 +437,37 @@ def do_user_addgroup(self, args):
     user = args.pop(0)
     groups = args
 
-    self.client.user.addAssignedSystemGroups(self.session, user, groups, False)
+    self.client.user.addAssignedSystemGroups(self.session,
+                                             user,
+                                             groups,
+                                             False)
 
     return 0
-
 
 ####################
 
 
 def help_user_adddefaultgroup(self):
-    print(_("user_adddefaultgroup: Add a default group to an user account"))
-    print(_("usage: user_adddefaultgroup USER <GROUP ...>"))
+    print(_('user_adddefaultgroup: Add a default group to an user account'))
+    print(_('usage: user_adddefaultgroup USER <GROUP ...>'))
 
 
 def complete_user_adddefaultgroup(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
     elif len(parts) > 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_group_list("", True), parts[-1])
+        return tab_completer(self.do_group_list('', True), parts[-1])
 
     return None
 
 
 def do_user_adddefaultgroup(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -541,41 +477,39 @@ def do_user_adddefaultgroup(self, args):
     user = args.pop(0)
     groups = args
 
-    self.client.user.addDefaultSystemGroups(self.session, user, groups)
+    self.client.user.addDefaultSystemGroups(self.session,
+                                            user,
+                                            groups)
 
     return 0
-
 
 ####################
 
 
 def help_user_removegroup(self):
-    print(_("user_removegroup: Remove a group to an user account"))
-    print(_("usage: user_removegroup USER <GROUP ...>"))
+    print(_('user_removegroup: Remove a group to an user account'))
+    print(_('usage: user_removegroup USER <GROUP ...>'))
 
 
 def complete_user_removegroup(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
     elif len(parts) > 2:
         # only list the groups currently assigned to this user
-        groups = self.client.user.listAssignedSystemGroups(self.session, parts[1])
-        # pylint: disable-next=undefined-variable
-        return tab_completer([g.get("name") for g in groups], parts[-1])
+        groups = self.client.user.listAssignedSystemGroups(self.session,
+                                                           parts[1])
+        return tab_completer([g.get('name') for g in groups], parts[-1])
 
     return None
 
 
 def do_user_removegroup(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -585,43 +519,41 @@ def do_user_removegroup(self, args):
     user = args.pop(0)
     groups = args
 
-    self.client.user.removeAssignedSystemGroups(self.session, user, groups, True)
+    self.client.user.removeAssignedSystemGroups(self.session,
+                                                user,
+                                                groups,
+                                                True)
 
     return 0
-
 
 ####################
 
 
 def help_user_removedefaultgroup(self):
-    print(
-        _("user_removedefaultgroup: Remove a default group from an " + "user account")
-    )
-    print(_("usage: user_removedefaultgroup USER <GROUP ...>"))
+    print(_('user_removedefaultgroup: Remove a default group from an ' +
+            'user account'))
+    print(_('usage: user_removedefaultgroup USER <GROUP ...>'))
 
 
 def complete_user_removedefaultgroup(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append("")
+    if line[-1] == ' ':
+        parts.append('')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
     elif len(parts) > 2:
         # only list the groups currently assigned to this user
-        groups = self.client.user.listDefaultSystemGroups(self.session, parts[1])
-        # pylint: disable-next=undefined-variable
-        return tab_completer([g.get("name") for g in groups], parts[-1])
+        groups = self.client.user.listDefaultSystemGroups(self.session,
+                                                          parts[1])
+        return tab_completer([g.get('name') for g in groups], parts[-1])
 
     return None
 
 
 def do_user_removedefaultgroup(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 2:
@@ -631,36 +563,34 @@ def do_user_removedefaultgroup(self, args):
     user = args.pop(0)
     groups = args
 
-    self.client.user.removeDefaultSystemGroups(self.session, user, groups)
+    self.client.user.removeDefaultSystemGroups(self.session,
+                                               user,
+                                               groups)
 
     return 0
-
 
 ####################
 
 
 def help_user_setfirstname(self):
-    print(_("user_setfirstname: Set an user accounts first name field"))
-    print(_("usage: user_setfirstname USER FIRST_NAME"))
+    print(_('user_setfirstname: Set an user accounts first name field'))
+    print(_('usage: user_setfirstname USER FIRST_NAME'))
 
 
 def complete_user_setfirstname(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append(" ")
+    if line[-1] == ' ':
+        parts.append(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
 
     return None
 
 
 def do_user_setfirstname(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -668,38 +598,34 @@ def do_user_setfirstname(self, args):
         return 1
 
     user = args.pop(0)
-    details = {"first_name": args.pop(0)}
+    details = {'first_name': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
 
     return 0
 
-
 ####################
 
 
 def help_user_setlastname(self):
-    print(_("user_setlastname: Set an user accounts last name field"))
-    print(_("usage: user_setlastname USER LAST_NAME"))
+    print(_('user_setlastname: Set an user accounts last name field'))
+    print(_('usage: user_setlastname USER LAST_NAME'))
 
 
 def complete_user_setlastname(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append(" ")
+    if line[-1] == ' ':
+        parts.append(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
 
     return None
 
 
 def do_user_setlastname(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -707,38 +633,34 @@ def do_user_setlastname(self, args):
         return 1
 
     user = args.pop(0)
-    details = {"last_name": args.pop(0)}
+    details = {'last_name': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
 
     return 0
 
-
 ####################
 
 
 def help_user_setemail(self):
-    print(_("user_setemail: Set an user accounts email field"))
-    print(_("usage: user_setemail USER EMAIL"))
+    print(_('user_setemail: Set an user accounts email field'))
+    print(_('usage: user_setemail USER EMAIL'))
 
 
 def complete_user_setemail(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append(" ")
+    if line[-1] == ' ':
+        parts.append(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
 
     return None
 
 
 def do_user_setemail(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -746,38 +668,35 @@ def do_user_setemail(self, args):
         return 1
 
     user = args.pop(0)
-    details = {"email": args.pop(0)}
+    details = {'email': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
 
     return 0
 
-
 ####################
 
 
 def help_user_setprefix(self):
-    print(_("user_setprefix: Set an user accounts name prefix field"))
-    print(_("usage: user_setprefix USER PREFIX"))
+    print(_('user_setprefix: Set an user accounts name prefix field'))
+    print(_('usage: user_setprefix USER PREFIX'))
 
 
 def complete_user_setprefix(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append(" ")
+    if line[-1] == ' ':
+        parts.append(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
 
     return None
 
 
 def do_user_setprefix(self, args):
-    # pylint: disable-next=undefined-variable
     args, _ = parse_command_arguments(args, get_argument_parser())
 
-    if not 0 < len(args) < 3:  # pylint: disable=len-as-condition
+    if not 0 < len(args) < 3:             # pylint: disable=len-as-condition
         self.help_user_setprefix()
         return 1
 
@@ -787,40 +706,36 @@ def do_user_setprefix(self, args):
         # spacewalk requires a space to clear the prefix but the
         # space seems to be stripped when submitted to the API gateway
         # attempts to use %x20 and \u0020 (among others) also fail
-        details = {"prefix": " "}
+        details = {'prefix': ' '}
     else:
-        details = {"prefix": args.pop(0)}
+        details = {'prefix': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
 
     return 0
 
-
 ####################
 
 
 def help_user_setpassword(self):
-    print(_("user_setpassword: Set an user accounts name prefix field"))
-    print(_("usage: user_setpassword USER PASSWORD"))
+    print(_('user_setpassword: Set an user accounts name prefix field'))
+    print(_('usage: user_setpassword USER PASSWORD'))
 
 
 def complete_user_setpassword(self, text, line, beg, end):
     parts = shlex.split(line)
-    if line[-1] == " ":
-        parts.append(" ")
+    if line[-1] == ' ':
+        parts.append(' ')
 
     if len(parts) == 2:
-        # pylint: disable-next=undefined-variable
-        return tab_completer(self.do_user_list("", True), text)
+        return tab_completer(self.do_user_list('', True), text)
 
     return None
 
 
 def do_user_setpassword(self, args):
-    # pylint: disable-next=undefined-variable
     arg_parser = get_argument_parser()
 
-    # pylint: disable-next=undefined-variable,unused-variable
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if len(args) != 2:
@@ -828,7 +743,7 @@ def do_user_setpassword(self, args):
         return 1
 
     user = args.pop(0)
-    details = {"password": args.pop(0)}
+    details = {'password': args.pop(0)}
 
     self.client.user.setDetails(self.session, user, details)
 

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -1,4 +1,3 @@
-#  pylint: disable=missing-module-docstring
 #
 # Licensed under the GNU General Public License Version 3
 #
@@ -64,28 +63,24 @@ import rpm
 from spacecmd.argumentparser import SpacecmdArgumentParser
 from spacecmd.i18n import _N
 
-__EDITORS = ["vim", "vi", "emacs", "nano"]
+__EDITORS = ['vim', 'vi', "emacs", 'nano']
 
-translation = gettext.translation("spacecmd", fallback=True)
+translation = gettext.translation('spacecmd', fallback=True)
 try:
     _ = translation.ugettext
 except AttributeError:
     _ = translation.gettext
 
-
 class CustomJsonEncoder(json.JSONEncoder):
-    # pylint: disable-next=arguments-renamed
-    def default(self, obj):  # pylint: disable=arguments-differ,method-hidden
-        if isinstance(obj, xmlrpclib.DateTime):
-            return datetime.fromtimestamp(time.mktime(obj.timetuple())).strftime(
-                "%F %T"
-            )
+
+    def default(self, obj): # pylint: disable=arguments-differ,method-hidden
+        if isinstance(obj,xmlrpclib.DateTime):
+            return datetime.fromtimestamp(time.mktime(obj.timetuple())).strftime("%F %T")
         return json.JSONEncoder.default(self, obj)
 
 
 def get_argument_parser():
     return SpacecmdArgumentParser()
-
 
 def parse_command_arguments(command_args, argument_parser, glob=True):
     try:
@@ -93,9 +88,10 @@ def parse_command_arguments(command_args, argument_parser, glob=True):
 
         # allow simple globbing
         if glob:
-            parts = [re.sub(r"\*", ".*", a) for a in parts]
+            parts = [re.sub(r'\*', '.*', a) for a in parts]
 
-        argument_parser.add_argument("leftovers", nargs="*", help=argparse.SUPPRESS)
+        argument_parser.add_argument('leftovers', nargs='*',
+                                     help=argparse.SUPPRESS)
         opts = argument_parser.parse_args(args=parts)
         if opts.leftovers:
             leftovers = opts.leftovers
@@ -104,8 +100,7 @@ def parse_command_arguments(command_args, argument_parser, glob=True):
         return leftovers, opts
     except IndexError:
         return None, None
-
-
+ 
 def is_interactive(options):
     """
     check if any named options were passed to the function, and if so,
@@ -131,11 +126,11 @@ def load_cache(cachefile):
     data = {}
     expire = datetime.now()
 
-    logging.debug("Loading cache from %s", cachefile)
+    logging.debug('Loading cache from %s', cachefile)
 
     if os.path.isfile(cachefile):
         try:
-            inputfile = open(cachefile, "rb")
+            inputfile = open(cachefile, 'rb')
             data = pickle.load(inputfile)
             inputfile.close()
         except (EOFError, pickle.UnpicklingError) as exc:
@@ -145,40 +140,36 @@ def load_cache(cachefile):
             # If you don't do this then spacecmd will fail with an unhandled
             # exception until the partial file is manually removed
             logging.warning(_N("Loading cache file %s failed"), cachefile)
-            logging.warning(
-                _N(
-                    "Cache generation was probably interrupted," + "removing corrupt %s"
-                ),
-                cachefile,
-            )
+            logging.warning(_N("Cache generation was probably interrupted," +
+                               "removing corrupt %s"), cachefile)
             logging.debug(str(exc))
             os.remove(cachefile)
         except IOError:
             logging.error(_N("Couldn't load cache from %s"), cachefile)
 
         if isinstance(data, (list, dict)):
-            if "expire" in data:
-                expire = data["expire"]
-                del data["expire"]
+            if 'expire' in data:
+                expire = data['expire']
+                del data['expire']
     else:
-        logging.debug("%s does not exist", cachefile)
+        logging.debug('%s does not exist', cachefile)
 
     return data, expire
 
 
 def save_cache(cachefile, data, expire=None):
     if expire:
-        data["expire"] = expire
+        data['expire'] = expire
 
     try:
-        output = open(cachefile, "wb")
+        output = open(cachefile, 'wb')
         pickle.dump(data, output, pickle.HIGHEST_PROTOCOL)
         output.close()
     except IOError:
         logging.error(_N("Couldn't write to %s"), cachefile)
 
-    if "expire" in data:
-        del data["expire"]
+    if 'expire' in data:
+        del data['expire']
 
 
 def tab_completer(options, text):
@@ -210,30 +201,31 @@ def filter_results(items, patterns, search=False):
     return matches
 
 
-def editor(template="", delete=False):
+def editor(template='', delete=False):
     # create a temporary file
-    (descriptor, file_name) = mkstemp(prefix="spacecmd.")
+    (descriptor, file_name) = mkstemp(prefix='spacecmd.')
 
     if template and descriptor:
         try:
-            handle = os.fdopen(descriptor, "w")
+            handle = os.fdopen(descriptor, 'w')
             handle.write(template)
             handle.close()
         except IOError as exc:
-            logging.warning(_N("Could not open the temporary file"))
+            logging.warning(_N('Could not open the temporary file'))
             logging.error(str(exc))
             return None
 
     # use the user's specified editor
-    if "EDITOR" in os.environ:
-        if __EDITORS[0] != os.environ["EDITOR"]:
-            __EDITORS.insert(0, os.environ["EDITOR"])
+    if 'EDITOR' in os.environ:
+        if __EDITORS[0] != os.environ['EDITOR']:
+            __EDITORS.insert(0, os.environ['EDITOR'])
 
     success = False
     exit_code = -1
     for editor_cmd in __EDITORS:
         try:
-            exit_code = os.spawnlp(os.P_WAIT, editor_cmd, editor_cmd, file_name)
+            exit_code = os.spawnlp(os.P_WAIT, editor_cmd,
+                                   editor_cmd, file_name)
 
             if exit_code == 0:
                 success = True
@@ -243,28 +235,27 @@ def editor(template="", delete=False):
             logging.error(_N("General failure running editor: %s"), str(exc))
 
     if not success:
-        logging.error(_N("No editors found"))
-        return ""
+        logging.error(_N('No editors found'))
+        return ''
 
     if os.path.isfile(file_name) and exit_code == 0:
         try:
             # read the session (format = username:session)
-            # pylint: disable-next=unspecified-encoding
-            handle = open(file_name, "r")
+            handle = open(file_name, 'r')
             contents = handle.read()
             handle.close()
 
             if delete:
                 try:
                     os.remove(file_name)
-                    file_name = ""
+                    file_name = ''
                 except OSError:
-                    logging.error(_N("Could not remove %s"), file_name)
+                    logging.error(_N('Could not remove %s'), file_name)
 
             return contents, file_name
         except IOError:
-            logging.error(_N("Could not read %s"), file_name)
-            return [], ""
+            logging.error(_N('Could not read %s'), file_name)
+            return [], ''
 
     return None
 
@@ -280,23 +271,21 @@ def prompt_user(prompt, noblank=False, multiline=False):
                     # python 2 must call raw_input() because input()
                     # also evaluates the user input and that causes
                     # problems.
-                    # pylint: disable-next=consider-using-f-string
-                    userinput = raw_input("%s " % prompt)
+                    userinput = raw_input('%s ' % prompt)
                 except NameError:
                     # python 3 replaced raw_input() with input()...
                     # it no longer evaulates the user input.
-                    # pylint: disable-next=consider-using-f-string
-                    userinput = input("%s " % prompt)
+                    userinput = input('%s ' % prompt)
             if noblank:
-                if userinput != "":
+                if userinput != '':
                     break
             else:
                 break
     except EOFError:
-        print("")
-        return ""
+        print('')
+        return ''
 
-    if userinput != "":
+    if userinput != '':
         last = readline.get_current_history_length() - 1
 
         if last >= 0:
@@ -304,94 +293,79 @@ def prompt_user(prompt, noblank=False, multiline=False):
 
     return userinput
 
-
-def parse_time_input(userinput=""):
+def parse_time_input(userinput=''):
     """Parse time input from the user and return xmlrpclib.DateTime"""
     timestamp = None
 
-    if userinput == "" or re.match("now", userinput, re.I):
+    if userinput == '' or re.match('now', userinput, re.I):
         timestamp = datetime.now()
 
     # handle YYYYMMDDHHMM times
     if not timestamp:
-        match = re.match(r"^(\d{4})(\d{2})(\d{2})(\d{2})?(\d{2})?(\d{2})?$", userinput)
+        match = re.match(r'^(\d{4})(\d{2})(\d{2})(\d{2})?(\d{2})?(\d{2})?$', userinput)
 
         if match:
-            date_format = "%Y%m%d"
+            date_format = '%Y%m%d'
 
             # YYYYMMDD
             if not match.group(4) and not match.group(5):
-                timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s" % (match.group(1), match.group(2), match.group(3)),
-                    date_format,
-                )
+                timestamp = time.strptime('%s%s%s' % (match.group(1),
+                                                      match.group(2),
+                                                      match.group(3)),
+                                          date_format)
             # YYYYMMDDHH
             elif not match.group(5):
-                date_format += "%H"
+                date_format += '%H'
 
-                timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s%s"
-                    % (match.group(1), match.group(2), match.group(3), match.group(4)),
-                    date_format,
-                )
+                timestamp = time.strptime('%s%s%s%s' % (match.group(1),
+                                                        match.group(2),
+                                                        match.group(3),
+                                                        match.group(4)),
+                                          date_format)
             # YYYYMMDDHHMM
             elif not match.group(6):
-                date_format += "%H%M"
+                date_format += '%H%M'
 
-                timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s%s%s"
-                    % (
-                        match.group(1),
-                        match.group(2),
-                        match.group(3),
-                        match.group(4),
-                        match.group(5),
-                    ),
-                    date_format,
-                )
+                timestamp = time.strptime('%s%s%s%s%s' % (match.group(1),
+                                                          match.group(2),
+                                                          match.group(3),
+                                                          match.group(4),
+                                                          match.group(5)),
+                                          date_format)
             # YYYYMMDDHHMMSS
             else:
-                date_format += "%H%M%S"
+                date_format += '%H%M%S'
 
-                timestamp = time.strptime(
-                    # pylint: disable-next=consider-using-f-string
-                    "%s%s%s%s%s%s"
-                    % (
-                        match.group(1),
-                        match.group(2),
-                        match.group(3),
-                        match.group(4),
-                        match.group(5),
-                        match.group(6),
-                    ),
-                    date_format,
-                )
+                timestamp = time.strptime('%s%s%s%s%s%s' % (match.group(1),
+                                                            match.group(2),
+                                                            match.group(3),
+                                                            match.group(4),
+                                                            match.group(5),
+                                                            match.group(6)),
+                                          date_format)
             if timestamp:
                 # 2.5 has a nice little datetime.strptime() function...
                 timestamp = datetime(*(timestamp)[0:7])
 
     # handle time differences (e.g., +1m, +2h)
     if not timestamp:
-        match = re.search(r"^(\+|-)?(\d+)(s|m|h|d)$", userinput, re.I)
+        match = re.search(r'^(\+|-)?(\d+)(s|m|h|d)$', userinput, re.I)
 
         if match and len(match.groups()) >= 2:
             sign = match.group(1)
             number = int(match.group(2))
             unit = match.group(3)
 
-            if sign == "-":
+            if sign == '-':
                 number = -number
 
-            if re.match("s", unit, re.I):
+            if re.match('s', unit, re.I):
                 delta = timedelta(seconds=number)
-            elif re.match("m", unit, re.I):
+            elif re.match('m', unit, re.I):
                 delta = timedelta(minutes=number)
-            elif re.match("h", unit, re.I):
+            elif re.match('h', unit, re.I):
                 delta = timedelta(hours=number)
-            elif re.match("d", unit, re.I):
+            elif re.match('d', unit, re.I):
                 delta = timedelta(days=number)
 
             timestamp = datetime.now() + delta
@@ -399,13 +373,11 @@ def parse_time_input(userinput=""):
     if timestamp:
         return xmlrpclib.DateTime(timestamp.timetuple())
 
-    logging.error(_N("Invalid time provided"))
+    logging.error(_N('Invalid time provided'))
     return None
 
-
-def latest_pkg(
-    pkg1, pkg2, version_key="version", release_key="release", epoch_key="epoch"
-):
+def latest_pkg(pkg1, pkg2, version_key='version',
+               release_key='release', epoch_key='epoch'):
     """
     Compares 2 package objects (dicts) and returns the newest one.
 
@@ -419,20 +391,19 @@ def latest_pkg(
         Returns:
             pkg (dict): Returns pkg1 if the package passed as first parameter is newer than the package passed as second parameter.
             Returns pkg2 in case it's the opposite. Finally, returns None if the two packages are the same version
-    """
+    """           
     # Sometimes empty epoch is a space, sometimes its an empty string, which
     # breaks the comparison, strip it here to fix
     t1 = (pkg1[epoch_key].strip(), pkg1[version_key], pkg1[release_key])
     t2 = (pkg2[epoch_key].strip(), pkg2[version_key], pkg2[release_key])
 
-    result = rpm.labelCompare(t1, t2)  # pylint: disable=no-member
+    result = rpm.labelCompare(t1, t2) # pylint: disable=no-member
     if result == 1:
         return pkg1
     if result == -1:
         return pkg2
 
     return None
-
 
 def build_package_names(packages):
     """build a proper RPM name from the various parts"""
@@ -444,23 +415,20 @@ def build_package_names(packages):
 
     package_names = []
     for p in packages:
-        # pylint: disable-next=consider-using-f-string
-        package = "%s-%s-%s" % (p.get("name"), p.get("version"), p.get("release"))
+        package = '%s-%s-%s' % (
+            p.get('name'), p.get('version'), p.get('release'))
 
         epoch = p.get("epoch", "").strip()
         if epoch:
-            # pylint: disable-next=consider-using-f-string
-            package += ":%s" % epoch
+            package += ':%s' % epoch
 
-        if p.get("arch"):
+        if p.get('arch'):
             # system.listPackages uses AMD64 instead of x86_64
-            arch = re.sub("amd64", "x86_64", p.get("arch", "").lower())
+            arch = re.sub('amd64', 'x86_64', p.get('arch', "").lower())
 
-            # pylint: disable-next=consider-using-f-string
-            package += ".%s" % arch
-        elif p.get("arch_label", "").strip():
-            # pylint: disable-next=consider-using-f-string
-            package += ".%s" % p.get("arch_label")
+            package += '.%s' % arch
+        elif p.get('arch_label', "").strip():
+            package += '.%s' % p.get('arch_label')
 
         package_names.append(package)
 
@@ -474,25 +442,20 @@ def build_package_names(packages):
 def print_errata_summary(erratum):
     # Workaround - recent spacewalk lacks the "date" key
     # on some listErrata calls
-    if erratum.get("date") is None:
-        erratum["date"] = erratum.get("issue_date")
-    if erratum["date"] is None:
-        erratum["date"] = "N/A"
-    date_parts = erratum["date"].split()
+    if erratum.get('date') is None:
+        erratum['date'] = erratum.get('issue_date')
+    if erratum['date'] is None:
+        erratum['date'] = "N/A"
+    date_parts = erratum['date'].split()
 
     if len(date_parts) > 1:
-        erratum["date"] = date_parts[0]
+        erratum['date'] = date_parts[0]
 
-    print(
-        # pylint: disable-next=consider-using-f-string
-        "%s  %s  %s  %s"
-        % (
-            erratum.get("advisory_name").ljust(14),
-            wrap(erratum.get("advisory_synopsis"), 49)[0].ljust(49),
-            (erratum.get("advisory_status") or "").ljust(9),
-            erratum.get("date").rjust(8),
-        )
-    )
+    print('%s  %s  %s  %s' % (
+        erratum.get('advisory_name').ljust(14),
+        wrap(erratum.get('advisory_synopsis'), 49)[0].ljust(49),
+        (erratum.get('advisory_status') or '').ljust(9),
+        erratum.get('date').rjust(8)))
 
 
 def print_errata_list(errata):
@@ -501,42 +464,41 @@ def print_errata_list(errata):
     rhba = []
 
     for erratum in errata:
-        if re.match("security", erratum.get("advisory_type"), re.I):
+        if re.match('security', erratum.get('advisory_type'), re.I):
             rhsa.append(erratum)
-        elif re.match("bug fix", erratum.get("advisory_type"), re.I):
+        elif re.match('bug fix', erratum.get('advisory_type'), re.I):
             rhba.append(erratum)
-        elif re.match("product enhancement", erratum.get("advisory_type"), re.I):
+        elif re.match('product enhancement', erratum.get('advisory_type'), re.I):
             rhea.append(erratum)
         else:
-            logging.warning(
-                _N("%s is an unknown errata type"), erratum.get("advisory_name")
-            )
+            logging.warning(_N('%s is an unknown errata type'),
+                            erratum.get('advisory_name'))
             continue
 
     if not errata:
         return
 
     if rhsa:
-        print(_("Security Errata"))
-        print("---------------")
+        print(_('Security Errata'))
+        print('---------------')
         for erratum in rhsa:
             print_errata_summary(erratum)
 
     if rhba:
         if rhsa:
-            print("")
+            print('')
 
-        print(_("Bug Fix Errata"))
-        print("--------------")
+        print(_('Bug Fix Errata'))
+        print('--------------')
         for erratum in rhba:
             print_errata_summary(erratum)
 
     if rhea:
         if rhsa or rhba:
-            print("")
+            print('')
 
-        print(_("Enhancement Errata"))
-        print("------------------")
+        print(_('Enhancement Errata'))
+        print('------------------')
         for erratum in rhea:
             print_errata_summary(erratum)
 
@@ -545,77 +507,76 @@ def config_channel_order(all_channels=None, new_channels=None):
     all_channels = all_channels or []
     new_channels = new_channels or []
     while True:
-        print(_("Current Selections"))
-        print("------------------")
+        print(_('Current Selections'))
+        print('------------------')
         for i, new_channel in enumerate(new_channels, 1):
-            # pylint: disable-next=consider-using-f-string
-            print("%i. %s" % (i, new_channel))
+            print('%i. %s' % (i, new_channel))
 
-        print("")
-        action = prompt_user("a[dd], r[emove], c[lear], d[one]:")
+        print('')
+        action = prompt_user('a[dd], r[emove], c[lear], d[one]:')
 
-        if re.match("a", action, re.I):
-            print("")
-            print(_("Available Configuration Channels"))
-            print("--------------------------------")
+        if re.match('a', action, re.I):
+            print('')
+            print(_('Available Configuration Channels'))
+            print('--------------------------------')
             for c in sorted(all_channels):
                 print(c)
 
-            print("")
-            channel = prompt_user(_("Channel:"))
+            print('')
+            channel = prompt_user(_('Channel:'))
 
             if channel not in all_channels:
-                logging.warning(_N("Invalid channel"))
+                logging.warning(_N('Invalid channel'))
                 continue
 
             try:
-                rank = int(prompt_user(_("New Rank:")))
+                rank = int(prompt_user(_('New Rank:')))
 
                 if channel in new_channels:
                     new_channels.remove(channel)
 
                 new_channels.insert(rank - 1, channel)
             except IndexError:
-                logging.warning(_N("Invalid rank"))
+                logging.warning(_N('Invalid rank'))
                 continue
             except ValueError:
-                logging.warning(_N("Invalid rank"))
+                logging.warning(_N('Invalid rank'))
                 continue
-        elif re.match("r", action, re.I):
-            channel = prompt_user(_("Channel:"))
+        elif re.match('r', action, re.I):
+            channel = prompt_user(_('Channel:'))
 
             if channel not in all_channels:
-                logging.warning(_N("Invalid channel"))
+                logging.warning(_N('Invalid channel'))
                 continue
 
             new_channels.remove(channel)
-        elif re.match("c", action, re.I):
-            print(_("Clearing current selections"))
+        elif re.match('c', action, re.I):
+            print(_('Clearing current selections'))
             new_channels = []
             continue
-        elif re.match("d", action, re.I):
+        elif re.match('d', action, re.I):
             break
 
-        print("")
+        print('')
 
     return new_channels
 
 
 def list_locales():
-    if not os.path.isdir("/usr/share/zoneinfo"):
+    if not os.path.isdir('/usr/share/zoneinfo'):
         return []
 
     zones = []
 
-    for item in os.listdir("/usr/share/zoneinfo"):
-        path = os.path.join("/usr/share/zoneinfo", item)
+    for item in os.listdir('/usr/share/zoneinfo'):
+        path = os.path.join('/usr/share/zoneinfo', item)
 
         if os.path.isdir(path):
             try:
                 for subitem in os.listdir(path):
                     zones.append(os.path.join(item, subitem))
             except IOError:
-                logging.error(_N("Could not read %s"), path)
+                logging.error(_N('Could not read %s'), path)
         else:
             zones.append(item)
 
@@ -634,7 +595,6 @@ def max_length(items, minimum=0):
 
     return max_size
 
-
 def read_file(filename):
     """
     Read file.
@@ -644,7 +604,6 @@ def read_file(filename):
 
         Returns:
     """
-    # pylint: disable-next=unspecified-encoding
     with open(filename, "r") as fhd:
         return fhd.read()
 
@@ -674,14 +633,13 @@ def parse_str(s, type_to=None):
         if type_to is not None and isinstance(type_to, type):
             return type_to(s)
 
-        if re.match(r"[1-9]\d*", s):
+        if re.match(r'[1-9]\d*', s):
             return int(s)
 
         if s in ("False", "True"):
-            # pylint: disable-next=eval-used
             return eval(s)
 
-        if re.match(r"{.*}", s):
+        if re.match(r'{.*}', s):
             return json.loads(s)  # retry with json module
 
         return str(s)
@@ -711,7 +669,7 @@ def parse_list_str(list_s, sep=","):
     return list_s.split(sep)
 
 
-def parse_api_args(args, sep=","):
+def parse_api_args(args, sep=','):
     """
     Simple JSON-like expression parser.
 
@@ -777,14 +735,11 @@ def json_dump_to_file(obj, filename):
         logging.error(_N("Could not generate json data object!"))
     else:
         try:
-            # pylint: disable-next=unspecified-encoding
-            with open(filename, "w") as fdh:
+            with open(filename, 'w') as fdh:
                 fdh.write(json_data)
             out = True
         except IOError as exc:
-            logging.error(
-                _N("Could not open file %s for writing: %s"), filename, str(exc)
-            )
+            logging.error(_N("Could not open file %s for writing: %s"), filename, str(exc))
 
     return out
 
@@ -792,14 +747,13 @@ def json_dump_to_file(obj, filename):
 def json_read_from_file(filename):
     data = None
     try:
-        # pylint: disable-next=unspecified-encoding
         with open(filename) as fhd:
             data = json.loads(fhd.read())
     except IOError as exc:
         logging.error(_N("Could not open file %s for reading: %s"), filename, str(exc))
     except ValueError as exc:
         logging.error(_N("Could not parse JSON data from %s: %s"), filename, str(exc))
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as exc: # pylint: disable=broad-except
         logging.error(_N("Error processing file %s: %s"), filename, str(exc))
 
     return data
@@ -831,7 +785,7 @@ def get_string_diff_dicts(string1, string2, sep="-"):
 
         Returns:
             A list of two dictonaries of regular expressions. The first dictionary can be used to transform
-            string1 into string2. The second dictionary can also be used  to transform string2 to string1.
+            string1 into string2. The second dictionary can also be used  to transform string2 to string1. 
     """
     replace1 = {}
     replace2 = {}
@@ -850,16 +804,10 @@ def get_string_diff_dicts(string1, string2, sep="-"):
             pass
         else:
             # TODO: replace only if len(sub1) == len(sub2) ?
-            replace1["(^|-)" + sub1 + "(-|$)"] = (
-                r"\1" + "DIFF(" + sub1 + "|" + sub2 + ")" + r"\2"
-            )
-            replace2["(^|-)" + sub2 + "(-|$)"] = (
-                r"\1" + "DIFF(" + sub1 + "|" + sub2 + ")" + r"\2"
-            )
+            replace1['(^|-)' + sub1 + '(-|$)'] = r'\1' + "DIFF(" + sub1 + "|" + sub2 + ")" + r'\2'
+            replace2['(^|-)' + sub2 + '(-|$)'] = r'\1' + "DIFF(" + sub1 + "|" + sub2 + ")" + r'\2'
     if substrings1 or substrings2:
-        logging.info(
-            _N("Skipping usage of common strings: number of substrings differ")
-        )
+        logging.info(_N("Skipping usage of common strings: number of substrings differ"))
         return [None, None]
     return [replace1, replace2]
 
@@ -919,7 +867,7 @@ def diff(source_data, target_data, source_channel, target_channel):
 
 def file_is_binary(self, path):
     """Tries to determine whether the file is a binary.
-    Assumes binary if it can't categorize the file as plaintext"""
+       Assumes binary if it can't categorize the file as plaintext"""
     try:
         process = Popen(["file", "-b", "--mime-type", path], stdout=PIPE)
         output = process.communicate()[0]
@@ -936,26 +884,22 @@ def file_is_binary(self, path):
         pass
     return True
 
-
 def string_to_bool(input_string):
     """
     Convert string of "true" or "false", "yes" or "no" to boolean.
 
         Parameters:
             input_string (str): The string to be converted to boolean
-
+        
         Returns:
             A boolean value converted from the input_string parameter
     """
     if not isinstance(input_string, str):
-        raise IOError(
-            _("Parameter {} not a string type, but {}.").format(
-                repr(input_string), type(input_string)
-            )
-        )
+        raise IOError(_("Parameter {} not a string type, but {}.").format(
+            repr(input_string), type(input_string)
+        ))
 
-    return input_string.lower().strip() in ["true", "yes"]
-
+    return input_string.lower().strip() in ['true', 'yes']
 
 def is_vendor_channel(self, label):
     """Return true if channel is vendor channel false otherwise"""
@@ -974,7 +918,6 @@ class DictToDefault:
             get(value, default=None):
                 Returns a value from the target dict
     """
-
     def __init__(self, target, default=None):
         self.__target = target
         self.__default = default

--- a/spacecmd/tests/helpers.py
+++ b/spacecmd/tests/helpers.py
@@ -13,7 +13,6 @@ class FileHandleMock(StringIO):
     """
     Filehandle mock
     """
-
     def __init__(self):
         self._init_params = None
         StringIO.__init__(self)
@@ -77,10 +76,7 @@ def assert_expect(calls, *expectations):
     expectations = list(expectations)
     for call in calls:
         expectation = next(iter(expectations))
-        # pylint: disable-next=consider-using-f-string
-        assert call[0][0] == expectation, "Expected '{}', got '{}'".format(
-            expectation, call[0][0]
-        )
+        assert call[0][0] == expectation, "Expected '{}', got '{}'".format(expectation, call[0][0])
         expectations.pop(0)
     assert not expectations
 
@@ -114,11 +110,8 @@ def assert_args_expect(calls, expectations):
     """
     for call in calls:
         args, kw = call
-        # pylint: disable-next=invalid-name
         _args, _kw = next(iter(expectations))
-        # pylint: disable-next=consider-using-f-string
         assert args == _args, "{} is not as expected {}".format(str(args), str(_args))
-        # pylint: disable-next=consider-using-f-string
         assert kw == _kw, "{} is not as expected {}".format(str(kw), str(_kw))
         expectations.pop(0)
     assert not expectations

--- a/spacecmd/tests/test_activationkey.py
+++ b/spacecmd/tests/test_activationkey.py
@@ -4,16 +4,10 @@ Test activation key methods.
 """
 from mock import MagicMock, patch
 import pytest
-
-# pylint: disable-next=unused-import
 import time
-
-# pylint: disable-next=unused-import
 import hashlib
 import spacecmd.activationkey
 from xmlrpc import client as xmlrpclib
-
-# pylint: disable-next=unused-import
 from helpers import shell, exc2str, assert_list_args_expect
 
 
@@ -21,8 +15,6 @@ class TestSCActivationKey:
     """
     Test activation key.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_completer_ak_addpackages(self, shell):
         """
         Test tab completer activation keys on addpackages.
@@ -30,9 +22,7 @@ class TestSCActivationKey:
         text = "Communications satellite used by the military for star wars."
         completer = MagicMock()
         with patch("spacecmd.activationkey.tab_completer", completer):
-            spacecmd.activationkey.complete_activationkey_addpackages(
-                shell, text, "do this", None, None
-            )
+            spacecmd.activationkey.complete_activationkey_addpackages(shell, text, "do this", None, None)
             assert completer.called
             call_id, ret_text = completer.call_args_list[0][0]
             assert call_id == "do_activation_list"
@@ -43,8 +33,6 @@ class TestSCActivationKeyMethods:
     """
     Test actuvation key methods.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addpackages_noargs(self, shell):
         """
         Test add packages method call shows help on no args.
@@ -55,7 +43,6 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_addpackages(shell, "")
         assert shell.help_activationkey_addpackages.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addpackages_help_args(self, shell):
         """
         Test add packages method call shows help on help args passed.
@@ -66,7 +53,6 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_addpackages(shell, "help")
         assert shell.help_activationkey_addpackages.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addpackages_args(self, shell):
         """
         Test add packages method call shows help on args passed.
@@ -74,9 +60,7 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_addpackages = MagicMock()
         shell.client.activationkey.addPackages = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_addpackages(
-            shell, "call something here"
-        )
+        spacecmd.activationkey.do_activationkey_addpackages(shell, "call something here")
         assert not shell.help_activationkey_addpackages.called
         assert shell.client.activationkey.addPackages.called
         session, fun, args = shell.client.activationkey.addPackages.call_args_list[0][0]
@@ -87,7 +71,6 @@ class TestSCActivationKeyMethods:
         for arg in args:
             assert arg["name"] in ["something", "here"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removepackages_noargs(self, shell):
         """
         Test remove packages method call shows help on no args.
@@ -99,7 +82,6 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_removepackages(shell, "")
         assert not shell.help_activationkey_removePackages.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removepackages_help_args(self, shell):
         """
         Test remove packages method call shows help if only one argument is passed.
@@ -110,7 +92,6 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_removepackages(shell, "key")
         assert shell.help_activationkey_removepackages.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removepackages_args(self, shell):
         """
         Test remove packages method calls "removePackages" API call.
@@ -121,9 +102,7 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_removepackages(shell, "key package")
         assert not shell.help_activationkey_removepackages.called
         assert shell.client.activationkey.removePackages.called
-        session, fun, args = shell.client.activationkey.removePackages.call_args_list[
-            0
-        ][0]
+        session, fun, args = shell.client.activationkey.removePackages.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
@@ -131,7 +110,6 @@ class TestSCActivationKeyMethods:
         assert "name" in args[0]
         assert args[0]["name"] == "package"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addgroups_noargs(self, shell):
         """
         Test addgroup without args calls help.
@@ -142,7 +120,6 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_addgroups(shell, "")
         assert shell.help_activationkey_addgroups.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addgroups_help_args(self, shell):
         """
         Test add groups method call shows help if only one argument is passed.
@@ -153,7 +130,6 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_addgroups(shell, "key")
         assert shell.help_activationkey_addgroups.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addgroups_args(self, shell):
         """
         Test "addgroups" method calls "addServerGroups" API call.
@@ -165,16 +141,13 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_addgroups(shell, "key group")
         assert not shell.help_activationkey_addgroups.called
         assert shell.client.activationkey.addServerGroups.called
-        session, fun, args = shell.client.activationkey.addServerGroups.call_args_list[
-            0
-        ][0]
+        session, fun, args = shell.client.activationkey.addServerGroups.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
         assert len(args) == 1
         assert args == [42]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removegroups_noargs(self, shell):
         """
         Test removegroup without args calls help.
@@ -185,7 +158,6 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_removegroups(shell, "")
         assert shell.help_activationkey_removegroups.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removegroups_help_args(self, shell):
         """
         Test remove groups method call shows help if only one argument is passed.
@@ -197,7 +169,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_removegroups.called
         assert not shell.client.activationkey.removeServerGroups.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removegroups_args(self, shell):
         """
         Test "removegroups" method calls "removeServerGroups" API call.
@@ -209,18 +180,13 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_removegroups(shell, "key group")
         assert not shell.help_activationkey_removegroups.called
         assert shell.client.activationkey.removeServerGroups.called
-        (
-            session,
-            fun,
-            args,
-        ) = shell.client.activationkey.removeServerGroups.call_args_list[0][0]
+        session, fun, args = shell.client.activationkey.removeServerGroups.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
         assert len(args) == 1
         assert args == [42]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addentitlements_noargs(self, shell):
         """
         Test addentitlements without args calls help.
@@ -232,7 +198,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_addentitlements.called
         assert not shell.client.activationkey.addEntitlements.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addentitlements_help_args(self, shell):
         """
         Test addentitlements method call shows help if only one argument is passed.
@@ -244,7 +209,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_addentitlements.called
         assert not shell.client.activationkey.addEntitlements.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addentitlements_args(self, shell):
         """
         Test "addentitlements" method calls "addEntitlements" API call.
@@ -252,21 +216,16 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_addentitlements = MagicMock()
         shell.client.activationkey.addEntitlements = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_addentitlements(
-            shell, "key entitlement"
-        )
+        spacecmd.activationkey.do_activationkey_addentitlements(shell, "key entitlement")
         assert not shell.help_activationkey_addentitlements.called
         assert shell.client.activationkey.addEntitlements.called
-        session, fun, args = shell.client.activationkey.addEntitlements.call_args_list[
-            0
-        ][0]
+        session, fun, args = shell.client.activationkey.addEntitlements.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
         assert len(args) == 1
-        assert args == ["entitlement"]
+        assert args == ['entitlement']
 
-    # pylint: disable-next=function-redefined,redefined-outer-name
     def test_do_activationkey_addentitlements_noargs(self, shell):
         """
         Test addentitlements without args calls help.
@@ -278,7 +237,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_addentitlements.called
         assert not shell.client.activationkey.addEntitlements.called
 
-    # pylint: disable-next=function-redefined,redefined-outer-name
     def test_do_activationkey_addentitlements_help_args(self, shell):
         """
         Test addentitlements method call shows help if only one argument is passed.
@@ -290,7 +248,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_addentitlements.called
         assert not shell.client.activationkey.addEntitlements.called
 
-    # pylint: disable-next=function-redefined,redefined-outer-name
     def test_do_activationkey_addentitlements_args(self, shell):
         """
         Test "addentitlements" method calls "addEntitlements" API call.
@@ -298,21 +255,16 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_addentitlements = MagicMock()
         shell.client.activationkey.addEntitlements = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_addentitlements(
-            shell, "key entitlement"
-        )
+        spacecmd.activationkey.do_activationkey_addentitlements(shell, "key entitlement")
         assert not shell.help_activationkey_addentitlements.called
         assert shell.client.activationkey.addEntitlements.called
-        session, fun, args = shell.client.activationkey.addEntitlements.call_args_list[
-            0
-        ][0]
+        session, fun, args = shell.client.activationkey.addEntitlements.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
         assert len(args) == 1
-        assert args == ["entitlement"]
+        assert args == ['entitlement']
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removeentitlements_noargs(self, shell):
         """
         Test removeentitlements without args calls help.
@@ -324,7 +276,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_removeentitlements.called
         assert not shell.client.activationkey.removeEntitlements.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removeentitlements_help_args(self, shell):
         """
         Test removeentitlements method call shows help if only one argument is passed.
@@ -336,7 +287,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_removeentitlements.called
         assert not shell.client.activationkey.removeEntitlements.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removeentitlements_args(self, shell):
         """
         Test "removeentitlements" method calls "removeEntitlements" API call.
@@ -344,23 +294,16 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_removeentitlements = MagicMock()
         shell.client.activationkey.removeEntitlements = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_removeentitlements(
-            shell, "key entitlement"
-        )
+        spacecmd.activationkey.do_activationkey_removeentitlements(shell, "key entitlement")
         assert not shell.help_activationkey_removeentitlements.called
         assert shell.client.activationkey.removeEntitlements.called
-        (
-            session,
-            fun,
-            args,
-        ) = shell.client.activationkey.removeEntitlements.call_args_list[0][0]
+        session, fun, args = shell.client.activationkey.removeEntitlements.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
         assert len(args) == 1
-        assert args == ["entitlement"]
+        assert args == ['entitlement']
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addchildchannels_noargs(self, shell):
         """
         Test addchildchannels without args calls help.
@@ -372,7 +315,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_addchildchannels.called
         assert not shell.client.activationkey.addChildChannels.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addchildchannels_help_args(self, shell):
         """
         Test addchildchannels method call shows help if only one argument is passed.
@@ -384,7 +326,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_addchildchannels.called
         assert not shell.client.activationkey.addChildChannels.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addchildchannels_args(self, shell):
         """
         Test "addchildchannels" method calls "addChildChannels" API call.
@@ -392,21 +333,16 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_addchildchannels = MagicMock()
         shell.client.activationkey.addChildChannels = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_addchildchannels(
-            shell, "key some_channel"
-        )
+        spacecmd.activationkey.do_activationkey_addchildchannels(shell, "key some_channel")
         assert not shell.help_activationkey_addchildchannels.called
         assert shell.client.activationkey.addChildChannels.called
-        session, fun, args = shell.client.activationkey.addChildChannels.call_args_list[
-            0
-        ][0]
+        session, fun, args = shell.client.activationkey.addChildChannels.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
         assert len(args) == 1
-        assert args == ["some_channel"]
+        assert args == ['some_channel']
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removechildchannels_noargs(self, shell):
         """
         Test removechildchannels without args calls help.
@@ -418,7 +354,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_removechildchannels.called
         assert not shell.client.activationkey.removeChildChannels.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removechildchannels_help_args(self, shell):
         """
         Test removechildchannels method call shows help if only one argument is passed.
@@ -430,7 +365,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_removechildchannels.called
         assert not shell.client.activationkey.removeChildChannels.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removechildchannels_args(self, shell):
         """
         Test "removechildchannels" method calls "removeChildChannels" API call.
@@ -438,109 +372,85 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_removechildchannels = MagicMock()
         shell.client.activationkey.removeChildChannels = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_removechildchannels(
-            shell, "key some_channel"
-        )
+        spacecmd.activationkey.do_activationkey_removechildchannels(shell, "key some_channel")
         assert not shell.help_activationkey_removechildchannels.called
         assert shell.client.activationkey.removeChildChannels.called
-        (
-            session,
-            fun,
-            args,
-        ) = shell.client.activationkey.removeChildChannels.call_args_list[0][0]
+        session, fun, args = shell.client.activationkey.removeChildChannels.call_args_list[0][0]
         assert session == shell.session
         assert fun == "key"
         assert isinstance(args, list)
         assert len(args) == 1
-        assert args == ["some_channel"]
+        assert args == ['some_channel']
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listchildchannels_noargs(self, shell):
         """
         Test listchildchannels command triggers help on no args
         """
         shell.help_activationkey_listchildchannels = MagicMock()
-        shell.client.activationkey.getDetails = MagicMock(
-            return_value={"child_channel_labels"}
-        )
+        shell.client.activationkey.getDetails = MagicMock(return_value={"child_channel_labels"})
 
         spacecmd.activationkey.do_activationkey_listchildchannels(shell, "")
         assert shell.help_activationkey_listchildchannels.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listchildchannels_args(self, shell):
         """
         Test listchildchannels command prints child channels by the activation key passed.
         """
         shell.help_activationkey_listchildchannels = MagicMock()
-        shell.client.activationkey.getDetails = MagicMock(
-            return_value={"child_channel_labels": ["one", "two", "three"]}
-        )
+        shell.client.activationkey.getDetails = MagicMock(return_value={
+            "child_channel_labels": ["one", "two", "three"]
+        })
 
         mprint = MagicMock()
         with patch("spacecmd.activationkey.print", mprint):
             spacecmd.activationkey.do_activationkey_listchildchannels(shell, "key")
         assert mprint.call_args_list[0][0][0] == "one\nthree\ntwo"  # Sorted
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listbasechannel_noargs(self, shell):
         """
         Test listbasechannels command triggers help on no args
         """
         shell.help_activationkey_listbasechannel = MagicMock()
-        shell.client.activationkey.getDetails = MagicMock(
-            return_value={"base_channel_label"}
-        )
+        shell.client.activationkey.getDetails = MagicMock(return_value={"base_channel_label"})
 
         spacecmd.activationkey.do_activationkey_listbasechannel(shell, "")
         assert shell.help_activationkey_listbasechannel.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listbasechannel_args(self, shell):
         """
         Test listbasechannels command prints base channel by the activation key passed.
         """
         shell.help_activationkey_listbasechannel = MagicMock()
-        shell.client.activationkey.getDetails = MagicMock(
-            return_value={
-                "base_channel_label": "Darth Vader",
-            }
-        )
+        shell.client.activationkey.getDetails = MagicMock(return_value={
+            "base_channel_label": "Darth Vader",
+        })
 
         mprint = MagicMock()
         with patch("spacecmd.activationkey.print", mprint):
             spacecmd.activationkey.do_activationkey_listbasechannel(shell, "key")
         assert mprint.call_args_list[0][0][0] == "Darth Vader"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listgroups_noargs(self, shell):
         """
         Test listgroups command triggers help on no args
         """
         shell.help_activationkey_listgroups = MagicMock()
         shell.client.activationkey.getDetails = MagicMock()
-        shell.client.systemgroup.getDetails = MagicMock(
-            site_effect=[{"name": "RD-2D"}, {"name": "C-3PO"}]
-        )
+        shell.client.systemgroup.getDetails = MagicMock(site_effect=[{"name": "RD-2D"}, {"name": "C-3PO"}])
 
         spacecmd.activationkey.do_activationkey_listgroups(shell, "")
         assert shell.help_activationkey_listgroups.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listgroups_args(self, shell):
         """
         Test listgroups command prints groups by the activation key passed.
         """
         shell.help_activationkey_listgroups = MagicMock()
-        shell.client.activationkey.getDetails = MagicMock(
-            return_value={"server_group_ids": [2, 3]}
-        )
-        shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=[{"name": "RD-2D"}, {"name": "C-3PO"}]
-        )
+        shell.client.activationkey.getDetails = MagicMock(return_value={"server_group_ids": [2, 3]})
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[{"name": "RD-2D"}, {"name": "C-3PO"}])
 
         mprint = MagicMock()
         with patch("spacecmd.activationkey.print", mprint):
@@ -549,7 +459,6 @@ class TestSCActivationKeyMethods:
         assert mprint.call_args_list[0][0][0] == "RD-2D"
         assert mprint.call_args_list[1][0][0] == "C-3PO"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listentitlements_noargs(self, shell):
         """
         Test listentitlements command triggers help on no args
@@ -561,22 +470,18 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_listentitlements.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listentitlements_args(self, shell):
         """
         Test listentitlements command prints entitlements by the activation key passed.
         """
         shell.help_activationkey_listentitlements = MagicMock()
-        shell.client.activationkey.getDetails = MagicMock(
-            return_value={"entitlements": ["one", "two", "three"]}
-        )
+        shell.client.activationkey.getDetails = MagicMock(return_value={"entitlements": ["one", "two", "three"]})
 
         mprint = MagicMock()
         with patch("spacecmd.activationkey.print", mprint):
             spacecmd.activationkey.do_activationkey_listentitlements(shell, "key")
-        assert mprint.call_args_list[0][0][0] == "one\ntwo\nthree"
+        assert mprint.call_args_list[0][0][0] == 'one\ntwo\nthree'
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listpackages_noargs(self, shell):
         """
         Test listpackages command triggers help on no args
@@ -588,19 +493,16 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_listpackages.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listpackages_args_arch(self, shell):
         """
         Test listpackages command prints packages by the activation key passed with the arch included.
         """
         shell.help_activationkey_listpackages = MagicMock()
         shell.client.activationkey.getDetails = MagicMock(
-            return_value={
-                "packages": [
-                    {"name": "libzypp", "arch": "ZX80"},
-                    {"name": "java-11-openjdk-devel", "arch": "CBM64"},
-                ]
-            }
+            return_value={"packages": [
+                {"name": "libzypp", "arch": "ZX80"},
+                {"name": "java-11-openjdk-devel", "arch": "CBM64"},
+            ]}
         )
 
         mprint = MagicMock()
@@ -612,19 +514,16 @@ class TestSCActivationKeyMethods:
         assert mprint.call_args_list[0][0][0] == "libzypp.ZX80"
         assert mprint.call_args_list[1][0][0] == "java-11-openjdk-devel.CBM64"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listpackages_args_noarch(self, shell):
         """
         Test listpackages command prints packages by the activation key passed without architecture included.
         """
         shell.help_activationkey_listpackages = MagicMock()
         shell.client.activationkey.getDetails = MagicMock(
-            return_value={
-                "packages": [
-                    {"name": "libzypp"},
-                    {"name": "java-11-openjdk-devel"},
-                ]
-            }
+            return_value={"packages": [
+                {"name": "libzypp"},
+                {"name": "java-11-openjdk-devel"},
+            ]}
         )
 
         mprint = MagicMock()
@@ -636,7 +535,6 @@ class TestSCActivationKeyMethods:
         assert mprint.call_args_list[0][0][0] == "libzypp"
         assert mprint.call_args_list[1][0][0] == "java-11-openjdk-devel"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listconfigchannels_noargs(self, shell):
         """
         Test listconfigchannels command triggers help on no args
@@ -648,7 +546,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_listconfigchannels.called
         assert not shell.client.activationkey.listConfigChannels.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listconfigchannels_args(self, shell):
         """
         Test listconfigchannels command prints entitlements by the activation key passed.
@@ -656,7 +553,7 @@ class TestSCActivationKeyMethods:
         channels = [
             {"label": "commodore64"},
             {"label": "pascal_for_msdos"},
-            {"label": "lightsaber_patches"},
+            {"label": "lightsaber_patches"}
         ]
         shell.help_activationkey_listconfigchannels = MagicMock()
         shell.client.activationkey.listConfigChannels = MagicMock(return_value=channels)
@@ -665,12 +562,8 @@ class TestSCActivationKeyMethods:
         with patch("spacecmd.activationkey.print", mprint):
             spacecmd.activationkey.do_activationkey_listconfigchannels(shell, "key")
         assert mprint.called
-        assert (
-            mprint.call_args_list[0][0][0]
-            == "commodore64\nlightsaber_patches\npascal_for_msdos"
-        )
+        assert mprint.call_args_list[0][0][0] == 'commodore64\nlightsaber_patches\npascal_for_msdos'
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_noargs(self, shell):
         """
         Test addconfigchannels command triggers help on no args.
@@ -682,7 +575,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_addconfigchannels.called
         assert not shell.client.activationkey.addConfigChannels.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_unknown_noargs(self, shell):
         """
         Test addconfigchannels command raises an Exception on unknown passed args.
@@ -691,16 +583,13 @@ class TestSCActivationKeyMethods:
         shell.client.activationkey.addConfigChannels = MagicMock()
 
         with pytest.raises(Exception) as exc:
-            spacecmd.activationkey.do_activationkey_addconfigchannels(
-                shell, "--you-shall-not-pass=True"
-            )
+            spacecmd.activationkey.do_activationkey_addconfigchannels(shell, "--you-shall-not-pass=True")
 
         assert "unrecognized arguments" in exc2str(exc)
         assert not shell.help_activationkey_addconfigchannels.called
         assert not shell.client.activationkey.addConfigChannels.called
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_check_args_noninteractive(self, shell):
         """
         Test addconfigchannels command calls addConfigChannels API function on params added.
@@ -708,19 +597,12 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_addconfigchannels = MagicMock()
         shell.client.activationkey.addConfigChannels = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_addconfigchannels(
-            shell, "key rd2d-upgrade -b"
-        )
+        spacecmd.activationkey.do_activationkey_addconfigchannels(shell, "key rd2d-upgrade -b")
 
         assert not shell.help_activationkey_addconfigchannels.called
         assert shell.client.activationkey.addConfigChannels.called
 
-        (
-            session,
-            keys,
-            channels,
-            order,
-        ) = shell.client.activationkey.addConfigChannels.call_args_list[0][0]
+        session, keys, channels, order = shell.client.activationkey.addConfigChannels.call_args_list[0][0]
         assert shell.session == session
         assert len(keys) == len(channels) == 1
         assert "key" in keys
@@ -729,15 +611,8 @@ class TestSCActivationKeyMethods:
         assert not order
 
         shell.client.activationkey.addConfigChannels = MagicMock()
-        spacecmd.activationkey.do_activationkey_addconfigchannels(
-            shell, "key rd2d-upgrade"
-        )
-        (
-            session,
-            keys,
-            channels,
-            order,
-        ) = shell.client.activationkey.addConfigChannels.call_args_list[0][0]
+        spacecmd.activationkey.do_activationkey_addconfigchannels(shell, "key rd2d-upgrade")
+        session, keys, channels, order = shell.client.activationkey.addConfigChannels.call_args_list[0][0]
         assert shell.session == session
         assert len(keys) == len(channels) == 1
         assert "key" in keys
@@ -746,15 +621,8 @@ class TestSCActivationKeyMethods:
         assert order
 
         shell.client.activationkey.addConfigChannels = MagicMock()
-        spacecmd.activationkey.do_activationkey_addconfigchannels(
-            shell, "key rd2d-upgrade -t"
-        )
-        (
-            session,
-            keys,
-            channels,
-            order,
-        ) = shell.client.activationkey.addConfigChannels.call_args_list[0][0]
+        spacecmd.activationkey.do_activationkey_addconfigchannels(shell, "key rd2d-upgrade -t")
+        session, keys, channels, order = shell.client.activationkey.addConfigChannels.call_args_list[0][0]
         assert shell.session == session
         assert len(keys) == len(channels) == 1
         assert "key" in keys
@@ -762,7 +630,6 @@ class TestSCActivationKeyMethods:
         assert bool == type(order)
         assert order
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removeconfigchannels_noargs(self, shell):
         """
         Test removeconfigchannels command triggers help on no args.
@@ -773,8 +640,7 @@ class TestSCActivationKeyMethods:
         spacecmd.activationkey.do_activationkey_removeconfigchannels(shell, "")
         assert shell.help_activationkey_removeconfigchannels.called
         assert not shell.client.activationkey.removeConfigChannels.called
-
-    # pylint: disable-next=redefined-outer-name
+    
     def test_do_activationkey_removeconfigchannels_insuff_args(self, shell):
         """
         Test removeconfigchannels command triggers help on insufficient args.
@@ -786,7 +652,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_removeconfigchannels.called
         assert not shell.client.activationkey.removeConfigChannels.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_removeconfigchannels_args(self, shell):
         """
         Test removeconfigchannels command is calling removeConfigChannels API by the activation key passed.
@@ -794,29 +659,19 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_removeconfigchannels = MagicMock()
         shell.client.activationkey.removeConfigChannels = MagicMock()
 
-        # pylint: disable-next=unused-variable
         mprint = MagicMock()
-        spacecmd.activationkey.do_activationkey_removeconfigchannels(
-            shell, "key some_patches"
-        )
+        spacecmd.activationkey.do_activationkey_removeconfigchannels(shell, "key some_patches")
         assert not shell.help_activationkey_removeconfigchannels.called
         assert shell.client.activationkey.removeConfigChannels.called
 
-        (
-            session,
-            keys,
-            channels,
-        ) = shell.client.activationkey.removeConfigChannels.call_args_list[0][0]
+        session, keys, channels = shell.client.activationkey.removeConfigChannels.call_args_list[0][0]
         assert shell.session == session
         assert "key" in keys
         assert "some_patches" in channels
         assert len(keys) == len(channels) == 1
 
-    @patch(
-        "spacecmd.activationkey.config_channel_order",
-        MagicMock(return_value=["lightsaber_patches", "rd2d_upgrade"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.config_channel_order",
+           MagicMock(return_value=["lightsaber_patches", "rd2d_upgrade"]))
     def test_do_activationkey_setconfigchannelorder_noargs(self, shell):
         """
         Test setconfigchannelorder command triggers help on no args.
@@ -831,11 +686,8 @@ class TestSCActivationKeyMethods:
             assert shell.help_activationkey_setconfigchannelorder.called
             assert not shell.client.activationkey.setConfigChannels.called
 
-    @patch(
-        "spacecmd.activationkey.config_channel_order",
-        MagicMock(return_value=["lightsaber_patches", "rd2d_upgrade"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.config_channel_order",
+           MagicMock(return_value=["lightsaber_patches", "rd2d_upgrade"]))
     def test_do_activationkey_setconfigchannelorder_args(self, shell):
         """
         Test setconfigchannelorder command triggers setConfigChannels API call with proper function
@@ -855,15 +707,12 @@ class TestSCActivationKeyMethods:
         assert mprint.call_args_list[3][0][0] == "[2] rd2d_upgrade"
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_create_nointeract_argstest(self, shell):
         """
         Test call activation key API "create".
         """
         shell.client.activationkey.create = MagicMock(return_value="superglue")
-        shell.list_base_channels = MagicMock(
-            return_value=["lightsaber_patches_sle42sp8"]
-        )
+        shell.list_base_channels = MagicMock(return_value=["lightsaber_patches_sle42sp8"])
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
@@ -873,47 +722,27 @@ class TestSCActivationKeyMethods:
         assert shell.client.activationkey.create.called
         assert logger.info.call_args_list[0][0][0] == "Created activation key superglue"
 
-        (
-            session,
-            name,
-            descr,
-            bch,
-            entl,
-            universal,
-        ) = shell.client.activationkey.create.call_args_list[0][0]
+        session, name, descr, bch, entl, universal = shell.client.activationkey.create.call_args_list[0][0]
         assert shell.session == session
         assert name == descr == bch == ""
         assert entl == []
         assert not universal
 
         shell.client.activationkey.create = MagicMock(return_value="woodblock")
-        shell.list_base_channels = MagicMock(
-            return_value=["lightsaber_patches_sle42sp8"]
-        )
+        shell.list_base_channels = MagicMock(return_value=["lightsaber_patches_sle42sp8"])
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
             spacecmd.activationkey.do_activationkey_create(
-                shell,
-                (
-                    "--name lightsaber --description 'The signature weapon of the Jedi Order' "
-                    "--base-channel lightsaber_patches_sle42sp8 --entitlements expanded,universe "
-                    "--universal"
-                ),
-            )
+                shell, ("--name lightsaber --description 'The signature weapon of the Jedi Order' "
+                        "--base-channel lightsaber_patches_sle42sp8 --entitlements expanded,universe "
+                        "--universal"))
 
         assert logger.info.called
         assert shell.client.activationkey.create.called
         assert logger.info.call_args_list[0][0][0] == "Created activation key woodblock"
 
-        (
-            session,
-            name,
-            descr,
-            bch,
-            entl,
-            universal,
-        ) = shell.client.activationkey.create.call_args_list[0][0]
+        session, name, descr, bch, entl, universal = shell.client.activationkey.create.call_args_list[0][0]
         assert shell.session == session
         assert name == "lightsaber"
         assert "Jedi Order" in descr
@@ -921,7 +750,6 @@ class TestSCActivationKeyMethods:
         assert entl == ["expanded", "universe"]
         assert universal
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_activationkey_delete_insuff_args(self, shell):
         """
         Test activationkey_delete command triggers help on insufficient args.
@@ -933,11 +761,7 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_delete.called
         assert not shell.client.activationkey.delete.called
 
-    @patch(
-        "spacecmd.activationkey.filter_results",
-        MagicMock(return_value=["some_patches", "some_stuff"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.filter_results", MagicMock(return_value=["some_patches", "some_stuff"]))
     def test_do_activationkey_activationkey_delete_args(self, shell):
         """
         Test activationkey_delete command is calling "delete" (key) API.
@@ -947,21 +771,15 @@ class TestSCActivationKeyMethods:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.activationkey.print", mprint) as mpr, patch(
-            "spacecmd.activationkey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.activationkey.print", mprint) as mpr, \
+             patch("spacecmd.activationkey.logging", logger) as lgr:
             spacecmd.activationkey.do_activationkey_delete(shell, "key some*")
             assert not shell.help_activationkey_delete.called
 
         assert not logger.error.called
         assert logger.debug.called
-        assert logger.debug.call_args_list[0][0][0] == (
-            "activationkey_delete called with args"
-            " ['key', 'some.*'], keys=['some_patches', 'some_stuff']"
-        )
+        assert logger.debug.call_args_list[0][0][0] == ("activationkey_delete called with args"
+                                                        " ['key', 'some.*'], keys=['some_patches', 'some_stuff']")
         assert logger.debug.call_args_list[1][0][0] == "Deleting key some_patches"
         assert logger.debug.call_args_list[2][0][0] == "Deleting key some_stuff"
 
@@ -974,11 +792,7 @@ class TestSCActivationKeyMethods:
             keys.pop(keys.index(keyname))
         assert not keys
 
-    @patch(
-        "spacecmd.activationkey.filter_results",
-        MagicMock(return_value=["some_patches", "some_stuff"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.filter_results", MagicMock(return_value=["some_patches", "some_stuff"]))
     def test_do_activationkey_activationkey_list_args(self, shell):
         """
         Test activationkey_list command is calling listActivationKeys API.
@@ -987,25 +801,16 @@ class TestSCActivationKeyMethods:
             return_value=[
                 {"key": "some_patches", "description": "Some key"},
                 {"key": "some_stuff", "description": "Some other key"},
-                {
-                    "key": "some_reactivation",
-                    "description": "Kickstart re-activation key",
-                },
+                {"key": "some_reactivation", "description": "Kickstart re-activation key"},
             ]
         )
 
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.activationkey.print", mprint) as mpr:
-            ret = sorted(
-                spacecmd.activationkey.do_activationkey_list(
-                    shell, "key some*", doreturn=True
-                )
-            )
+            ret = sorted(spacecmd.activationkey.do_activationkey_list(shell, "key some*", doreturn=True))
         assert len(ret) == 2
-        assert ret == ["some_patches", "some_stuff"]
+        assert ret == ['some_patches', 'some_stuff']
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listsystems_noargs(self, shell):
         """
         Test activationkey_listsystems command is invoking help message on insufficient arguments.
@@ -1017,7 +822,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_listsystems.called
         assert not shell.client.activationkey.listActivatedSystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_listsystems_args(self, shell):
         """
         Test activationkey_listsystems command is calling listActivatedSystems API function.
@@ -1031,15 +835,13 @@ class TestSCActivationKeyMethods:
         )
 
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.activationkey.print", mprint) as mpr:
             spacecmd.activationkey.do_activationkey_listsystems(shell, "key")
         assert not shell.help_activationkey_listsystems.called
         assert shell.client.activationkey.listActivatedSystems.called
         assert mprint.called
-        assert mprint.call_args_list[0][0][0] == "chair.lan\nhouseshoe.lan"
+        assert mprint.call_args_list[0][0][0] == 'chair.lan\nhouseshoe.lan'
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_details_noargs(self, shell):
         """
         Test activationkey_details shows a help screen if no sufficient arguments has been passed.
@@ -1057,7 +859,6 @@ class TestSCActivationKeyMethods:
         assert not shell.client.activationkey.listConfigChannels.called
         assert not shell.client.activationkey.checkConfigDeployment.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_details_args(self, shell):
         """
         Test activationkey_details returns key details if proper arguments passed.
@@ -1094,47 +895,23 @@ class TestSCActivationKeyMethods:
         )
 
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.activationkey.print", mprint) as mpr:
+        with patch("spacecmd.activationkey.print", mprint) as mpr:        
             out = spacecmd.activationkey.do_activationkey_details(shell, "somekey")
         assert mprint.called
 
-        expectation = [
-            "Key:                    somekey",
-            "Description:            Key description",
-            "Universal Default:      yes",
-            "Usage Limit:            42",
-            "Deploy Config Channels: False",
-            "Contact Method:         230V/AC",
-            "",
-            "Software Channels",
-            "-----------------",
-            "base_channel",
-            " |-- child_channel_1",
-            " |-- child_channel_2",
-            "",
-            "Configuration Channels",
-            "----------------------",
-            "somekey_config_channel_1",
-            "somekey_config_channel_2",
-            "",
-            "Entitlements",
-            "------------",
-            "entitlement_1\nentitlement_2",
-            "",
-            "System Groups",
-            "-------------",
-            "group_a\ngroup_b\ngroup_c",
-            "",
-            "Packages",
-            "--------",
-            "emacs",
-        ]
+        expectation = ['Key:                    somekey',
+                       'Description:            Key description', 'Universal Default:      yes',
+                       'Usage Limit:            42', 'Deploy Config Channels: False',
+                       'Contact Method:         230V/AC', '', 'Software Channels', '-----------------',
+                       'base_channel', ' |-- child_channel_1', ' |-- child_channel_2', '',
+                       'Configuration Channels', '----------------------', 'somekey_config_channel_1',
+                       'somekey_config_channel_2', '', 'Entitlements', '------------',
+                       'entitlement_1\nentitlement_2', '', 'System Groups', '-------------',
+                       'group_a\ngroup_b\ngroup_c', '', 'Packages', '--------', 'emacs']
         assert len(out) == len(expectation)
         for idx, line in enumerate(out):
             assert line == expectation[idx]
-
-    # pylint: disable-next=redefined-outer-name
+    
     def test_do_activationkey_enableconfigdeployment_noargs(self, shell):
         """
         Test activationkey_enableconfigdeployment command is invoking help message on insufficient arguments.
@@ -1146,7 +923,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_enableconfigdeployment.called
         assert not shell.client.activationkey.enableConfigDeployment.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_enableconfigdeployment_args(self, shell):
         """
         Test activationkey_enableconfigdeployment command is invoking enableConfigDeployment API call.
@@ -1156,23 +932,12 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            spacecmd.activationkey.do_activationkey_enableconfigdeployment(
-                shell, "foo bar baz"
-            )
+            spacecmd.activationkey.do_activationkey_enableconfigdeployment(shell, "foo bar baz")
 
         assert logger.debug.called
-        assert (
-            logger.debug.call_args_list[0][0][0]
-            == "Enabling config file deployment for foo"
-        )
-        assert (
-            logger.debug.call_args_list[1][0][0]
-            == "Enabling config file deployment for bar"
-        )
-        assert (
-            logger.debug.call_args_list[2][0][0]
-            == "Enabling config file deployment for baz"
-        )
+        assert logger.debug.call_args_list[0][0][0] == "Enabling config file deployment for foo"
+        assert logger.debug.call_args_list[1][0][0] == "Enabling config file deployment for bar"
+        assert logger.debug.call_args_list[2][0][0] == "Enabling config file deployment for baz"
 
         keynames = ["foo", "bar", "baz"]
         assert shell.client.activationkey.enableConfigDeployment.called
@@ -1181,10 +946,8 @@ class TestSCActivationKeyMethods:
             assert shell.session == session
             assert keyname in keynames
             keynames.pop(keynames.index(keyname))
-        # pylint: disable-next=use-implicit-booleaness-not-comparison
         assert keynames == []
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_disableconfigdeployment_noargs(self, shell):
         """
         Test activationkey_disableconfigdeployment command is invoking help message on insufficient arguments.
@@ -1196,7 +959,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_disableconfigdeployment.called
         assert not shell.client.activationkey.disableConfigDeployment.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_disableconfigdeployment_args(self, shell):
         """
         Test activationkey_disableconfigdeployment command is invoking disableConfigDeployment API call.
@@ -1206,23 +968,12 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            spacecmd.activationkey.do_activationkey_disableconfigdeployment(
-                shell, "foo bar baz"
-            )
+            spacecmd.activationkey.do_activationkey_disableconfigdeployment(shell, "foo bar baz")
 
         assert logger.debug.called
-        assert (
-            logger.debug.call_args_list[0][0][0]
-            == "Disabling config file deployment for foo"
-        )
-        assert (
-            logger.debug.call_args_list[1][0][0]
-            == "Disabling config file deployment for bar"
-        )
-        assert (
-            logger.debug.call_args_list[2][0][0]
-            == "Disabling config file deployment for baz"
-        )
+        assert logger.debug.call_args_list[0][0][0] == "Disabling config file deployment for foo"
+        assert logger.debug.call_args_list[1][0][0] == "Disabling config file deployment for bar"
+        assert logger.debug.call_args_list[2][0][0] == "Disabling config file deployment for baz"
 
         keynames = ["foo", "bar", "baz"]
         assert shell.client.activationkey.disableConfigDeployment.called
@@ -1231,10 +982,8 @@ class TestSCActivationKeyMethods:
             assert shell.session == session
             assert keyname in keynames
             keynames.pop(keynames.index(keyname))
-        # pylint: disable-next=use-implicit-booleaness-not-comparison
         assert keynames == []
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_setbasechannel_noargs(self, shell):
         """
         Test do_activationkey_addconfigchannels_setbasechannel involes help message on issuficient arguments.
@@ -1253,7 +1002,6 @@ class TestSCActivationKeyMethods:
         assert not shell.client.activationkey.setDetails.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_setbasechannel_args(self, shell):
         """
         Test do_activationkey_addconfigchannels_setbasechannel calls setDetails API call on proper args.
@@ -1268,14 +1016,8 @@ class TestSCActivationKeyMethods:
         shell.client.activationkey.setDetails = MagicMock()
         shell.client.activationkey.getDetails = MagicMock(return_value=key_details)
 
-        spacecmd.activationkey.do_activationkey_setbasechannel(
-            shell, "red_key death_star_patches_channel"
-        )
-        (
-            session,
-            keyname,
-            details,
-        ) = shell.client.activationkey.setDetails.call_args_list[0][0]
+        spacecmd.activationkey.do_activationkey_setbasechannel(shell, "red_key death_star_patches_channel")
+        session, keyname, details = shell.client.activationkey.setDetails.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "red_key"
 
@@ -1284,7 +1026,6 @@ class TestSCActivationKeyMethods:
             assert key_details[dkey] == details[dkey]
         assert details["base_channel_label"] == "death_star_patches_channel"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_setbasechannel_usage_limit(self, shell):
         """
         Test do_activationkey_addconfigchannels_setbasechannel resets usage limit from 0 to -1.
@@ -1299,14 +1040,8 @@ class TestSCActivationKeyMethods:
         shell.client.activationkey.setDetails = MagicMock()
         shell.client.activationkey.getDetails = MagicMock(return_value=key_details)
 
-        spacecmd.activationkey.do_activationkey_setbasechannel(
-            shell, "red_key death_star_patches_channel"
-        )
-        (
-            session,
-            keyname,
-            details,
-        ) = shell.client.activationkey.setDetails.call_args_list[0][0]
+        spacecmd.activationkey.do_activationkey_setbasechannel(shell, "red_key death_star_patches_channel")
+        session, keyname, details = shell.client.activationkey.setDetails.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "red_key"
 
@@ -1316,7 +1051,6 @@ class TestSCActivationKeyMethods:
         assert details["base_channel_label"] == "death_star_patches_channel"
         assert details["usage_limit"] == -1
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_setusagelimit_noargs(self, shell):
         """
         Test do_activationkey_addconfigchannels_setusagelimit involes help message on issuficient arguments.
@@ -1335,7 +1069,6 @@ class TestSCActivationKeyMethods:
         assert not shell.client.activationkey.setDetails.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_setusagelimit_args(self, shell):
         """
         Test do_activationkey_addconfigchannels_setbasechannel resets usage limit from 0 to -1.
@@ -1351,22 +1084,16 @@ class TestSCActivationKeyMethods:
         shell.client.activationkey.getDetails = MagicMock(return_value=key_details)
 
         spacecmd.activationkey.do_activationkey_setusagelimit(shell, "red_key 42")
-        (
-            session,
-            keyname,
-            details,
-        ) = shell.client.activationkey.setDetails.call_args_list[0][0]
+        session, keyname, details = shell.client.activationkey.setDetails.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "red_key"
 
         for dkey in ["description", "universal_default", "base_channel_label"]:
             assert dkey in details
             assert key_details[dkey] == details[dkey]
-        # pylint: disable-next=unidiomatic-typecheck
         assert type(details["usage_limit"]) == int
         assert details["usage_limit"] == 42
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_setuniversaldefault_noargs(self, shell):
         """
         Test do_activationkey_addconfigchannels_setuniversaldefault involes help message on issuficient arguments.
@@ -1380,7 +1107,6 @@ class TestSCActivationKeyMethods:
         assert not shell.client.activationkey.setDetails.called
         assert not shell.client.activationkey.getDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_addconfigchannels_setuniversaldefault_args(self, shell):
         """
         Test do_activationkey_addconfigchannels_setuniversaldefault calls API to set the key settings.
@@ -1396,46 +1122,35 @@ class TestSCActivationKeyMethods:
         shell.client.activationkey.getDetails = MagicMock(return_value=key_details)
 
         spacecmd.activationkey.do_activationkey_setuniversaldefault(shell, "red_key 42")
-        (
-            session,
-            keyname,
-            details,
-        ) = shell.client.activationkey.setDetails.call_args_list[0][0]
+        session, keyname, details = shell.client.activationkey.setDetails.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "red_key"
 
         for dkey in ["description", "usage_limit", "base_channel_label"]:
             assert dkey in details
             assert key_details[dkey] == details[dkey]
-        # pylint: disable-next=unidiomatic-typecheck
         assert type(details["universal_default"]) == bool
         assert details["universal_default"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_export_activationkey_getdetails_exception_handling(self, shell):
         """
         Test export_activationkey_getdetails XMLRPC failure.
         """
-
+    
         key_details = {
             "server_group_ids": [],
         }
         logger = MagicMock()
         shell.client.activationkey.getDetails = MagicMock()
-        shell.client.activationkey.listConfigChannels = MagicMock(
-            side_effect=xmlrpclib.Fault("boom", "box")
-        )
+        shell.client.activationkey.listConfigChannels = MagicMock(side_effect=xmlrpclib.Fault("boom", "box"))
         shell.client.activationkey.checkConfigDeployment = MagicMock()
         shell.client.systemgroup.getDetails = MagicMock(return_value=key_details)
 
         with patch("spacecmd.activationkey.logging", logger):
             spacecmd.activationkey.export_activationkey_getdetails(shell, "")
-        assert logger.debug.call_args_list[1][0][0] == (
-            "activationkey.listConfigChannel threw an exeception, "
-            "setting config_channels=False"
-        )
-
-    # pylint: disable-next=redefined-outer-name
+        assert logger.debug.call_args_list[1][0][0] == ("activationkey.listConfigChannel threw an exeception, "
+                                                        "setting config_channels=False")
+        
     def test_export_activationkey_getdetails(self, shell):
         """
         Test export_activationkey_getdetails.
@@ -1462,33 +1177,31 @@ class TestSCActivationKeyMethods:
         shell.client.systemgroup.getDetails = MagicMock(side_effect=gr_details)
 
         with patch("spacecmd.activationkey.logging", logger):
-            out = spacecmd.activationkey.export_activationkey_getdetails(
-                shell, "red_key"
-            )
+            out = spacecmd.activationkey.export_activationkey_getdetails(shell, "red_key")
 
-        # pylint: disable-next=pointless-statement
         {
-            "server_group_ids": [1, 2, 3],
-            "config_channels": ["rd2d_patches_channel", "k_2so_firmware_channel"],
-            "config_deploy": True,
-            "server_groups": ["first", "second", "third"],
+            'server_group_ids': [1, 2, 3],
+            'config_channels': ['rd2d_patches_channel',
+                                'k_2so_firmware_channel'],
+            'config_deploy': True,
+            'server_groups': ['first', 'second', 'third']
         }
 
         assert "server_group_ids" in out
         assert out["server_group_ids"] == [1, 2, 3]
         assert "config_channels" in out
-        for cfg_channel in ["rd2d_patches_channel", "k_2so_firmware_channel"]:
+        for cfg_channel in ['rd2d_patches_channel',
+                            'k_2so_firmware_channel']:
             assert cfg_channel in out["config_channels"]
         assert "config_deploy" in out
         assert out["config_deploy"]
         assert "server_groups" in out
         assert len(out["server_groups"]) == 3
-        for srv_group in ["first", "second", "third"]:
+        for srv_group in ['first', 'second', 'third']:
             assert srv_group in out["server_groups"]
 
     @patch("spacecmd.activationkey.json_dump_to_file", MagicMock())
     @patch("spacecmd.activationkey.os.path.isfile", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_export_noarg(self, shell):
         """
         Test do_activationkey_export exports to 'akey_all.json' if not specified otherwise.
@@ -1505,27 +1218,20 @@ class TestSCActivationKeyMethods:
         assert logger.error.called
         assert logger.info.called
 
-        assert (
-            logger.error.call_args_list[0][0][0]
-            == "Failed to save exported keys to file: akey_all.json"
-        )
-        assert (
-            logger.debug.call_args_list[0][0][0]
-            == "About to dump 3 keys to akey_all.json"
-        )
+        assert logger.error.call_args_list[0][0][0] == "Failed to save exported keys to file: akey_all.json"
+        assert logger.debug.call_args_list[0][0][0] == "About to dump 3 keys to akey_all.json"
 
         expectation = [
-            "Exporting ALL activation keys to akey_all.json",
-            "Exporting key one to akey_all.json",
-            "Exporting key two to akey_all.json",
-            "Exporting key three to akey_all.json",
+            'Exporting ALL activation keys to akey_all.json',
+            'Exporting key one to akey_all.json',
+            'Exporting key two to akey_all.json',
+            'Exporting key three to akey_all.json',
         ]
         for idx, call in enumerate(logger.info.call_args_list):
             assert call[0][0] == expectation[idx]
 
     @patch("spacecmd.activationkey.json_dump_to_file", MagicMock())
     @patch("spacecmd.activationkey.os.path.isfile", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_export_filename_arg(self, shell):
         """
         Test do_activationkey_export exports to 'akey_all.json' if not specified otherwise.
@@ -1542,25 +1248,18 @@ class TestSCActivationKeyMethods:
         assert logger.error.called
         assert logger.info.called
 
-        assert (
-            logger.error.call_args_list[0][0][0]
-            == "Failed to save exported keys to file: somefile.json"
-        )
-        assert (
-            logger.debug.call_args_list[0][0][0]
-            == "Passed filename do_activationkey_export somefile.json"
-        )
+        assert logger.error.call_args_list[0][0][0] == "Failed to save exported keys to file: somefile.json"
+        assert logger.debug.call_args_list[0][0][0] == "Passed filename do_activationkey_export somefile.json"
 
         expectation = [
-            "Exporting ALL activation keys to somefile.json",
-            "Exporting key one to somefile.json",
-            "Exporting key two to somefile.json",
-            "Exporting key three to somefile.json",
+            'Exporting ALL activation keys to somefile.json',
+            'Exporting key one to somefile.json',
+            'Exporting key two to somefile.json',
+            'Exporting key three to somefile.json',
         ]
         for idx, call in enumerate(logger.info.call_args_list):
             assert call[0][0] == expectation[idx]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_import_noargs(self, shell):
         """
         Test activationkey_import command is invoking help message on insufficient arguments.
@@ -1575,9 +1274,8 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_import.called
         assert not shell.import_activationkey_fromdetails.called
         assert logger.error.called
-        assert logger.error.call_args_list[0][0][0] == "No filename passed"
+        assert logger.error.call_args_list[0][0][0] == 'No filename passed'
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_fromdetails_existingkey(self, shell):
         """
         Test import_activationkey_fromdetails does not import anything if key already exist.
@@ -1593,9 +1291,7 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            ret = spacecmd.activationkey.import_activationkey_fromdetails(
-                shell, {"key": "somekey"}
-            )
+            ret = spacecmd.activationkey.import_activationkey_fromdetails(shell, {"key": "somekey"})
         assert not shell.client.activationkey.create.called
         assert shell.do_activationkey_list.called
         assert not shell.client.activationkey.addChildChannels.called
@@ -1607,15 +1303,10 @@ class TestSCActivationKeyMethods:
         assert not shell.client.activationkey.addPackages.called
 
         assert logger.warning.called
-        assert (
-            logger.warning.call_args_list[0][0][0]
-            == "somekey already exists! Skipping!"
-        )
-        # pylint: disable-next=unidiomatic-typecheck
+        assert logger.warning.call_args_list[0][0][0] == 'somekey already exists! Skipping!'
         assert type(ret) == bool
         assert not ret
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_fromdetails_newkey_no_usage_limit(self, shell):
         """
         Test import_activationkey_fromdetails no usage limit.
@@ -1631,7 +1322,6 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            # pylint: disable-next=unused-variable
             ret = spacecmd.activationkey.import_activationkey_fromdetails(
                 shell,
                 {
@@ -1641,7 +1331,7 @@ class TestSCActivationKeyMethods:
                     "description": "Key description",
                     "entitlements": ["one", "two", "three"],
                     "universal_default": True,
-                },
+                }
             )
         assert shell.do_activationkey_list.called
         assert shell.client.activationkey.create.called
@@ -1652,20 +1342,10 @@ class TestSCActivationKeyMethods:
         assert not shell.client.activationkey.addServerGroups.called
         assert not shell.client.activationkey.addServerGroups.called
         assert not shell.client.activationkey.addPackages.called
-        assert (
-            logger.debug.call_args_list[0][0][0]
-            == "Found key somekey, importing as somekey"
-        )
+        assert logger.debug.call_args_list[0][0][0] == "Found key somekey, importing as somekey"
 
         assert len(shell.client.activationkey.create.call_args_list[0][0]) == 6
-        (
-            session,
-            keyname,
-            descr,
-            basech,
-            entl,
-            udef,
-        ) = shell.client.activationkey.create.call_args_list[0][0]
+        session, keyname, descr, basech, entl, udef = shell.client.activationkey.create.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "somekey"
         assert descr == "Key description"
@@ -1673,7 +1353,6 @@ class TestSCActivationKeyMethods:
         assert entl == ["one", "two", "three"]
         assert udef
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_fromdetails_newkey_fixed_usage_limit(self, shell):
         """
         Test import_activationkey_fromdetails usage limit given.
@@ -1689,7 +1368,6 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            # pylint: disable-next=unused-variable
             ret = spacecmd.activationkey.import_activationkey_fromdetails(
                 shell,
                 {
@@ -1699,18 +1377,10 @@ class TestSCActivationKeyMethods:
                     "description": "Key description",
                     "entitlements": ["one", "two", "three"],
                     "universal_default": True,
-                },
+                }
             )
         assert len(shell.client.activationkey.create.call_args_list[0][0]) == 7
-        (
-            session,
-            keyname,
-            descr,
-            basech,
-            ulim,
-            entl,
-            udef,
-        ) = shell.client.activationkey.create.call_args_list[0][0]
+        session, keyname, descr, basech, ulim, entl, udef = shell.client.activationkey.create.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "somekey"
         assert descr == "Key description"
@@ -1720,9 +1390,8 @@ class TestSCActivationKeyMethods:
         assert udef
 
         # This is expected: see mock return on API call "create".
-        assert logger.error.call_args_list[0][0][0] == "Failed to import key somekey"
+        assert logger.error.call_args_list[0][0][0] == 'Failed to import key somekey'
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_fromdetails_no_cfgdeploy(self, shell):
         """
         Test import_activationkey_fromdetails no configuration deployment.
@@ -1746,7 +1415,6 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            # pylint: disable-next=unused-variable
             ret = spacecmd.activationkey.import_activationkey_fromdetails(
                 shell,
                 {
@@ -1761,18 +1429,14 @@ class TestSCActivationKeyMethods:
                     "server_groups": ["one", "two", "three"],
                     "packages": ["emacs"],
                     "config_deploy": 0,
-                },
+                }
             )
         assert not shell.client.activationkey.enableConfigDeployment.called
         assert shell.client.activationkey.disableConfigDeployment.called
-        (
-            session,
-            keydata,
-        ) = shell.client.activationkey.disableConfigDeployment.call_args_list[0][0]
+        session, keydata = shell.client.activationkey.disableConfigDeployment.call_args_list[0][0]
         assert shell.session == session
         assert keydata == shell.client.activationkey.create()
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_fromdetails_cfgdeploy(self, shell):
         """
         Test import_activationkey_fromdetails configuration deployment was set.
@@ -1796,7 +1460,6 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            # pylint: disable-next=unused-variable
             ret = spacecmd.activationkey.import_activationkey_fromdetails(
                 shell,
                 {
@@ -1811,18 +1474,14 @@ class TestSCActivationKeyMethods:
                     "server_groups": ["one", "two", "three"],
                     "packages": ["emacs"],
                     "config_deploy": 1,
-                },
+                }
             )
         assert shell.client.activationkey.enableConfigDeployment.called
         assert not shell.client.activationkey.disableConfigDeployment.called
-        (
-            session,
-            keydata,
-        ) = shell.client.activationkey.enableConfigDeployment.call_args_list[0][0]
+        session, keydata = shell.client.activationkey.enableConfigDeployment.call_args_list[0][0]
         assert shell.session == session
         assert keydata == shell.client.activationkey.create()
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_fromdetails_groups_pkgs(self, shell):
         """
         Test import_activationkey_fromdetails groups and packages processed.
@@ -1846,7 +1505,6 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            # pylint: disable-next=unused-variable
             ret = spacecmd.activationkey.import_activationkey_fromdetails(
                 shell,
                 {
@@ -1861,28 +1519,18 @@ class TestSCActivationKeyMethods:
                     "server_groups": ["one", "two", "three"],
                     "packages": ["emacs"],
                     "config_deploy": 1,
-                },
+                }
             )
-        (
-            session,
-            keyprm,
-            gids,
-        ) = shell.client.activationkey.addServerGroups.call_args_list[0][0]
+        session, keyprm, gids = shell.client.activationkey.addServerGroups.call_args_list[0][0]
         assert shell.session == session
-        assert keyprm == {"name": "whatever"}
+        assert keyprm == {'name': 'whatever'}
         assert gids == [1, 2, 3]
 
-        session, keyprm, pkgs = shell.client.activationkey.addPackages.call_args_list[
-            0
-        ][0]
+        session, keyprm, pkgs = shell.client.activationkey.addPackages.call_args_list[0][0]
         assert pkgs == ["emacs"]
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    @patch(
-        "spacecmd.activationkey.prompt_user",
-        MagicMock(side_effect=["original_key", "cloned_key"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))
     def test_do_activationkey_clone_noargs(self, shell):
         """
         Test do_activationkey_clone no arguments requires some.
@@ -1908,17 +1556,10 @@ class TestSCActivationKeyMethods:
         assert not shell.do_configchannel_list.called
         assert not shell.import_activtionkey_fromdetails.called
         assert ret is 1
-        assert (
-            logger.error.call_args_list[0][0][0]
-            == "Error - must specify either -c or -x options!"
-        )
+        assert logger.error.call_args_list[0][0][0] == 'Error - must specify either -c or -x options!'
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    @patch(
-        "spacecmd.activationkey.prompt_user",
-        MagicMock(side_effect=["original_key", "cloned_key"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))
     def test_do_activationkey_clone_wrongargs(self, shell):
         """
         Test do_activationkey_clone wrong arguments prompts for correction.
@@ -1937,11 +1578,7 @@ class TestSCActivationKeyMethods:
         assert "unrecognized arguments: --nonsense=true" in exc2str(exc)
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    @patch(
-        "spacecmd.activationkey.prompt_user",
-        MagicMock(side_effect=["original_key", "cloned_key"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))
     def test_do_activationkey_clone_existing_clone_arg(self, shell):
         """
         Test do_activationkey_clone existing clone name passed to the arguments.
@@ -1956,9 +1593,7 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            ret = spacecmd.activationkey.do_activationkey_clone(
-                shell, "-c key_clone_name"
-            )
+            ret = spacecmd.activationkey.do_activationkey_clone(shell, "-c key_clone_name")
 
         assert logger.error.called
         assert not shell.help_activationkey_clone.called
@@ -1968,17 +1603,11 @@ class TestSCActivationKeyMethods:
         assert not shell.list_child_channels.called
         assert not shell.do_configchannel_list.called
         assert not shell.import_activtionkey_fromdetails.called
-        assert (
-            logger.error.call_args_list[0][0][0] == "Key key_clone_name already exists"
-        )
+        assert logger.error.call_args_list[0][0][0] == "Key key_clone_name already exists"
         assert ret is 1
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    @patch(
-        "spacecmd.activationkey.prompt_user",
-        MagicMock(side_effect=["original_key", "cloned_key"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))
     def test_do_activationkey_clone_noargs_to_clone(self, shell):
         """
         Test do_activationkey_clone no arguments to a clone name passed to the arguments.
@@ -1993,9 +1622,7 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            ret = spacecmd.activationkey.do_activationkey_clone(
-                shell, "-c key_clone_name"
-            )
+            ret = spacecmd.activationkey.do_activationkey_clone(shell, "-c key_clone_name")
 
         assert logger.error.called
         assert shell.help_activationkey_clone.called
@@ -2005,18 +1632,11 @@ class TestSCActivationKeyMethods:
         assert not shell.list_child_channels.called
         assert not shell.do_configchannel_list.called
         assert not shell.import_activtionkey_fromdetails.called
-        assert (
-            logger.error.call_args_list[0][0][0]
-            == "Error no activationkey to clone passed!"
-        )
+        assert logger.error.call_args_list[0][0][0] == "Error no activationkey to clone passed!"
         assert ret is 1
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    @patch(
-        "spacecmd.activationkey.prompt_user",
-        MagicMock(side_effect=["original_key", "cloned_key"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))
     def test_do_activationkey_clone_keyargs_to_clone_filtered(self, shell):
         """
         Test do_activationkey_clone filtered out keys.
@@ -2031,10 +1651,7 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            # pylint: disable-next=unused-variable
-            ret = spacecmd.activationkey.do_activationkey_clone(
-                shell, "orig_key -c key_clone_name"
-            )
+            ret = spacecmd.activationkey.do_activationkey_clone(shell, "orig_key -c key_clone_name")
 
         assert not logger.error.called
         assert not shell.help_activationkey_clone.called
@@ -2054,11 +1671,7 @@ class TestSCActivationKeyMethods:
             assert call[0][0] == expectations[idx]
 
     @patch("spacecmd.activationkey.is_interactive", MagicMock(return_value=False))
-    @patch(
-        "spacecmd.activationkey.prompt_user",
-        MagicMock(side_effect=["original_key", "cloned_key"]),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.activationkey.prompt_user", MagicMock(side_effect=["original_key", "cloned_key"]))
     def test_do_activationkey_clone_keyargs_unfiltered(self, shell):
         """
         Test do_activationkey_clone not filtered out keys.
@@ -2073,10 +1686,7 @@ class TestSCActivationKeyMethods:
 
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            # pylint: disable-next=unused-variable
-            ret = spacecmd.activationkey.do_activationkey_clone(
-                shell, "key_some* -c key_clone_name"
-            )
+            ret = spacecmd.activationkey.do_activationkey_clone(shell, "key_some* -c key_clone_name")
         expectations = [
             "Got args=['key_some.*'] 1",
             "Filtered akeys ['key_some_clone_name']",
@@ -2086,7 +1696,6 @@ class TestSCActivationKeyMethods:
         for idx, call in enumerate(logger.debug.call_args_list):
             assert call[0][0] == expectations[idx]
 
-    # pylint: disable-next=redefined-outer-name
     def test_check_activationkey_nokey(self, shell):
         """
         Test check activation key helper returns False on no key.
@@ -2096,9 +1705,8 @@ class TestSCActivationKeyMethods:
         with patch("spacecmd.activationkey.logging", logger):
             assert not spacecmd.activationkey.check_activationkey(shell, "")
         assert logger.error.called
-        assert logger.error.call_args_list[0][0][0] == "no activationkey label given"
+        assert logger.error.call_args_list[0][0][0] == 'no activationkey label given'
 
-    # pylint: disable-next=redefined-outer-name
     def test_check_activationkey_not_a_key(self, shell):
         """
         Test check activation key helper returns False on not a key.
@@ -2106,16 +1714,10 @@ class TestSCActivationKeyMethods:
         shell.is_activationkey = MagicMock(return_value=False)
         logger = MagicMock()
         with patch("spacecmd.activationkey.logging", logger):
-            assert not spacecmd.activationkey.check_activationkey(
-                shell, "some_not_a_key"
-            )
+            assert not spacecmd.activationkey.check_activationkey(shell, "some_not_a_key")
         assert logger.error.called
-        assert (
-            logger.error.call_args_list[0][0][0]
-            == "invalid activationkey label some_not_a_key"
-        )
+        assert logger.error.call_args_list[0][0][0] == 'invalid activationkey label some_not_a_key'
 
-    # pylint: disable-next=redefined-outer-name
     def test_check_activationkey_correct_key(self, shell):
         """
         Test check activation key helper returns True if a key is correct.
@@ -2126,19 +1728,16 @@ class TestSCActivationKeyMethods:
             assert spacecmd.activationkey.check_activationkey(shell, "some_not_a_key")
         assert not logger.error.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_activationkey_diff_noarg(self, shell):
         """
         Test dump activation key helper invokes help message on insufficient arguments.
         """
-        # pylint: disable-next=unused-variable
         for args in ["", "one two three", "some more args here"]:
             shell.help_activationkey_diff = MagicMock()
             shell.dump_activationkey = MagicMock()
             shell.check_activationkey = MagicMock()
             shell.do_activationkey_getcorresponding = MagicMock()
 
-            # pylint: disable-next=invalid-name
             _diff = MagicMock()
             with patch("spacecmd.activationkey.diff", _diff):
                 spacecmd.activationkey.do_activationkey_diff(shell, "")
@@ -2149,7 +1748,6 @@ class TestSCActivationKeyMethods:
             assert not shell.do_activationkey_getcorresponding.called
             assert not _diff.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_activationkey_diff_arg(self, shell):
         """
         Test dump activation key helper invokes expected sequence of function calls.
@@ -2159,7 +1757,6 @@ class TestSCActivationKeyMethods:
         shell.check_activationkey = MagicMock()
         shell.do_activationkey_getcorresponding = MagicMock()
 
-        # pylint: disable-next=invalid-name
         _diff = MagicMock()
         with patch("spacecmd.activationkey.diff", _diff):
             spacecmd.activationkey.do_activationkey_diff(shell, "some_key")
@@ -2170,41 +1767,25 @@ class TestSCActivationKeyMethods:
         assert shell.do_activationkey_getcorresponding.called
         assert _diff.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_activationkey_diff(self, shell):
         """
         Test dump activation key helper returns key diffs.
         """
         shell.help_activationkey_diff = MagicMock()
-        shell.dump_activationkey = MagicMock(
-            side_effect=[["some data"], ["some data again"]]
-        )
+        shell.dump_activationkey = MagicMock(side_effect=[["some data"], ["some data again"]])
         shell.check_activationkey = MagicMock(return_value=True)
         shell.do_activationkey_getcorresponding = MagicMock(return_value="some_channel")
 
-        gsdd = MagicMock(
-            return_value=(
-                {"one": "two", "three": "three"},
-                {"one": "two", "three": "four"},
-            )
-        )
-        with patch("spacecmd.activationkey.get_string_diff_dicts", gsdd), patch(
-            "spacecmd.activationkey.print"
-        ) as mprint:
+        gsdd = MagicMock(return_value=({"one": "two", "three": "three"}, {"one": "two", "three": "four"}))
+        with patch("spacecmd.activationkey.get_string_diff_dicts", gsdd), \
+             patch("spacecmd.activationkey.print") as mprint:
             spacecmd.activationkey.do_activationkey_diff(shell, "some_key")
 
         assert_list_args_expect(
             mprint.call_args_list,
-            [
-                "--- some_key\n",
-                "+++ some_channel\n",
-                "@@ -1 +1 @@\n",
-                "-some data",
-                "+some data again",
-            ],
+            ['--- some_key\n', '+++ some_channel\n', '@@ -1 +1 @@\n', '-some data', '+some data again']
         )
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_diable_noargs(self, shell):
         """
         Test do_activationkey_disable command triggers help on no args.
@@ -2216,7 +1797,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_disable.called
         assert not shell.client.activationkey.setDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_diable_args(self, shell):
         """
         Test do_activationkey_disable command triggers activationkey.setDetails API call.
@@ -2237,7 +1817,6 @@ class TestSCActivationKeyMethods:
             assert "disabled" in arg
             assert arg["disabled"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_enable_noargs(self, shell):
         """
         Test do_activationkey_enable command triggers help on no args.
@@ -2249,7 +1828,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_enable.called
         assert not shell.client.activationkey.setDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_enable_args(self, shell):
         """
         Test do_activationkey_enable command triggers activationkey.setDetails API call.
@@ -2270,7 +1848,6 @@ class TestSCActivationKeyMethods:
             assert "disabled" in arg
             assert not arg["disabled"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_setdescription_noargs(self, shell):
         """
         Test do_activationkey_setdescription command triggers help on no args.
@@ -2282,7 +1859,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_setdescription.called
         assert not shell.client.activationkey.setDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_setdescription_args(self, shell):
         """
         Test do_activationkey_setdescription command triggers activationkey.setDetails API call.
@@ -2290,20 +1866,16 @@ class TestSCActivationKeyMethods:
         shell.help_activationkey_enable = MagicMock()
         shell.client.activationkey.setDetails = MagicMock()
 
-        spacecmd.activationkey.do_activationkey_setdescription(
-            shell, "key_one some description of it here"
-        )
+        spacecmd.activationkey.do_activationkey_setdescription(shell, "key_one some description of it here")
         assert not shell.help_activationkey_enable.called
         assert shell.client.activationkey.setDetails.called
 
         for call in shell.client.activationkey.setDetails.call_args_list:
-            # pylint: disable-next=unused-variable
             session, key, arg = call[0]
             assert shell.session == session
             assert "description" in arg
             assert arg["description"] == "some description of it here"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_setcontactmethod_noargs(self, shell):
         """
         Test do_activationkey_setcontactmethod command triggers help on no args.
@@ -2315,7 +1887,6 @@ class TestSCActivationKeyMethods:
         assert shell.help_activationkey_setcontactmethod.called
         assert not shell.client.activationkey.setDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_activationkey_setcontactmethod_args(self, shell):
         """
         Test do_activationkey_setdescription command triggers activationkey.setDetails API call.
@@ -2328,8 +1899,9 @@ class TestSCActivationKeyMethods:
         assert shell.client.activationkey.setDetails.called
 
         for call in shell.client.activationkey.setDetails.call_args_list:
-            # pylint: disable-next=unused-variable
             session, key, arg = call[0]
             assert shell.session == session
             assert "contact_method" in arg
             assert arg["contact_method"] == "230V"
+
+    

--- a/spacecmd/tests/test_api.py
+++ b/spacecmd/tests/test_api.py
@@ -2,7 +2,6 @@
 """
 Test suite for spacecmd.api
 """
-# pylint: disable-next=unused-import
 from mock import MagicMock, patch, mock_open
 from spacecmd import api
 import helpers
@@ -13,7 +12,6 @@ class TestSCAPI:
     """
     Test class for testing spacecmd API.
     """
-
     def test_no_args(self):
         """
         Test calling API without any arguments.
@@ -34,18 +32,14 @@ class TestSCAPI:
 
         log = MagicMock()
         out = helpers.FileHandleMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.api.open", out, create=True) as mop, patch(
-            "spacecmd.api.logging", log
-        ) as mlog:
+        with patch("spacecmd.api.open", out, create=True) as mop, \
+             patch("spacecmd.api.logging", log) as mlog:
             api.do_api(shell, "call -o /tmp/spacecmd.log")
 
         assert not mlog.warning.called
         assert out.get_content() == '[\n  "one",\n  "two",\n  "three"\n]'
-        # pylint: disable-next=use-implicit-booleaness-not-comparison
         assert out.get_init_kwargs() == {}
-        assert out.get_init_args() == ("/tmp/spacecmd.log", "w")
-        # pylint: disable-next=protected-access
+        assert out.get_init_args() == ('/tmp/spacecmd.log', 'w')
         assert out._closed
 
     def test_args_format(self):
@@ -59,18 +53,14 @@ class TestSCAPI:
 
         log = MagicMock()
         out = helpers.FileHandleMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.api.open", out, create=True) as mop, patch(
-            "spacecmd.api.logging", log
-        ) as mlog:
+        with patch("spacecmd.api.open", out, create=True) as mop, \
+             patch("spacecmd.api.logging", log) as mlog:
             api.do_api(shell, "call -o /tmp/spacecmd.log -F '>>> %s'")
 
         assert not mlog.warning.called
-        assert out.get_content() == ">>> one\n>>> two\n>>> three\n"
-        # pylint: disable-next=use-implicit-booleaness-not-comparison
+        assert out.get_content() == '>>> one\n>>> two\n>>> three\n'
         assert out.get_init_kwargs() == {}
-        assert out.get_init_args() == ("/tmp/spacecmd.log", "w")
-        # pylint: disable-next=protected-access
+        assert out.get_init_args() == ('/tmp/spacecmd.log', 'w')
         assert out._closed
 
     def test_args_args(self):
@@ -85,21 +75,11 @@ class TestSCAPI:
 
         log = MagicMock()
         out = helpers.FileHandleMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.api.open", out, create=True) as mop, patch(
-            "spacecmd.api.logging",
-            log
-            # pylint: disable-next=unused-variable
-        ) as mlog:
+        with patch("spacecmd.api.open", out, create=True) as mop, \
+             patch("spacecmd.api.logging", log) as mlog:
             api.do_api(shell, "call -A first,second,123 -o /tmp/spacecmd.log")
         assert shell.client.call.called
-        assert shell.client.call.call_args_list[0][0] == (
-            "session",
-            "first",
-            "second",
-            123,
-        )
-        # pylint: disable-next=protected-access
+        assert shell.client.call.call_args_list[0][0] == ('session', 'first', 'second', 123)
         assert out._closed
 
     def test_args_datetime(self):
@@ -114,21 +94,12 @@ class TestSCAPI:
 
         log = MagicMock()
         out = helpers.FileHandleMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.api.open", out, create=True) as mop, patch(
-            "spacecmd.api.logging",
-            log
-            # pylint: disable-next=unused-variable
-        ) as mlog:
+        with patch("spacecmd.api.open", out, create=True) as mop, \
+                patch("spacecmd.api.logging", log) as mlog:
             api.do_api(shell, "call -A first,second,2022-05-05 -o /tmp/spacecmd.log")
         assert shell.client.call.called
-        assert shell.client.call.call_args_list[0][0] == (
-            "session",
-            "first",
-            "second",
-            datetime.datetime(2022, 5, 5, 0, 0),
-        )
-        # pylint: disable-next=protected-access
+        assert shell.client.call.call_args_list[0][0] == ('session', 'first', 'second',
+                                                          datetime.datetime(2022, 5, 5, 0, 0))
         assert out._closed
 
     def test_args_json(self):
@@ -143,23 +114,10 @@ class TestSCAPI:
 
         log = MagicMock()
         out = helpers.FileHandleMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.api.open", out, create=True) as mop, patch(
-            "spacecmd.api.logging",
-            log
-            # pylint: disable-next=unused-variable
-        ) as mlog:
-            api.do_api(
-                shell,
-                'call -A \'["first","second","2022-05-05",4]\' -o /tmp/spacecmd.log',
-            )
+        with patch("spacecmd.api.open", out, create=True) as mop, \
+                patch("spacecmd.api.logging", log) as mlog:
+            api.do_api(shell, "call -A '[\"first\",\"second\",\"2022-05-05\",4]' -o /tmp/spacecmd.log")
         assert shell.client.call.called
-        assert shell.client.call.call_args_list[0][0] == (
-            "session",
-            "first",
-            "second",
-            datetime.datetime(2022, 5, 5, 0, 0),
-            4,
-        )
-        # pylint: disable-next=protected-access
+        assert shell.client.call.call_args_list[0][0] == ('session', 'first', 'second',
+                                                          datetime.datetime(2022, 5, 5, 0, 0),4)
         assert out._closed

--- a/spacecmd/tests/test_argumentparser.py
+++ b/spacecmd/tests/test_argumentparser.py
@@ -11,7 +11,6 @@ class TestSCArgumentParser:
     """
     Test argument parser subclass.
     """
-
     def test_argparse_raise_exception(self):
         """
         Test argparse raise exception.

--- a/spacecmd/tests/test_configchannel.py
+++ b/spacecmd/tests/test_configchannel.py
@@ -5,8 +5,6 @@ Configchannel module unit tests.
 
 import os
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.configchannel
 
@@ -16,7 +14,6 @@ class TestSCConfigChannel:
     Test configuration channel.
     """
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_list_noret(self, shell):
         """
         Test configuration channel list, no data return.
@@ -24,34 +21,23 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        shell.client.configchannel.listGlobals = MagicMock(
-            return_value=[
-                {"label": "base_channel"},
-                {"label": "boese_channel"},
-                {"label": "other_channel"},
-                {"label": "ze_channel"},
-                {"label": "and_some_channel"},
-                {"label": "another_channel"},
-            ]
-        )
+        shell.client.configchannel.listGlobals = MagicMock(return_value=[
+            {"label": "base_channel"}, {"label": "boese_channel"},
+            {"label": "other_channel"}, {"label": "ze_channel"},
+            {"label": "and_some_channel"}, {"label": "another_channel"}
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.configchannel.print", mprint) as prt:
-            ret = spacecmd.configchannel.do_configchannel_list(
-                shell, "", doreturn=False
-            )
+            ret = spacecmd.configchannel.do_configchannel_list(shell, "", doreturn=False)
 
         assert ret is None
         assert mprint.called
         assert shell.client.configchannel.listGlobals.called
 
-        assert_expect(
-            mprint.call_args_list,
-            "and_some_channel\nanother_channel\nbase_channel"
-            "\nboese_channel\nother_channel\nze_channel",
-        )
+        assert_expect(mprint.call_args_list,
+                      'and_some_channel\nanother_channel\nbase_channel'
+                      '\nboese_channel\nother_channel\nze_channel')
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_list_data(self, shell):
         """
         Test configuration channel list, return data.
@@ -59,34 +45,21 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        shell.client.configchannel.listGlobals = MagicMock(
-            return_value=[
-                {"label": "base_channel"},
-                {"label": "boese_channel"},
-                {"label": "other_channel"},
-                {"label": "ze_channel"},
-                {"label": "and_some_channel"},
-                {"label": "another_channel"},
-            ]
-        )
+        shell.client.configchannel.listGlobals = MagicMock(return_value=[
+            {"label": "base_channel"}, {"label": "boese_channel"},
+            {"label": "other_channel"}, {"label": "ze_channel"},
+            {"label": "and_some_channel"}, {"label": "another_channel"}
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.configchannel.print", mprint) as prt:
             ret = spacecmd.configchannel.do_configchannel_list(shell, "", doreturn=True)
 
         assert not mprint.called
         assert ret is not None
         assert shell.client.configchannel.listGlobals.called
-        assert ret == [
-            "and_some_channel",
-            "another_channel",
-            "base_channel",
-            "boese_channel",
-            "other_channel",
-            "ze_channel",
-        ]
+        assert ret == ['and_some_channel', 'another_channel', 'base_channel',
+                       'boese_channel', 'other_channel', 'ze_channel']
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_listsystems_api_version_handling(self, shell):
         """
         Test configchannel listsystems function. Check version limitation.
@@ -97,19 +70,14 @@ class TestSCConfigChannel:
         shell.check_api_version = MagicMock(return_value=False)
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_listsystems(shell, "")
 
         assert not mprint.called
         assert not shell.client.configchannel.listSubscribedSystems.called
         assert not shell.help_configchannel_listsystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_listsystems_api_noarg(self, shell):
         """
         Test configchannel listsystems function. No arguments passed.
@@ -120,19 +88,14 @@ class TestSCConfigChannel:
         shell.check_api_version = MagicMock(return_value=True)
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_listsystems(shell, "")
 
         assert not mprint.called
         assert not shell.client.configchannel.listSubscribedSystems.called
         assert shell.help_configchannel_listsystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_listsystems_api_sorted_output(self, shell):
         """
         Test configchannel listsystems function. Output must be sorted.
@@ -142,38 +105,25 @@ class TestSCConfigChannel:
         """
         shell.client.configchannel.listSubscribedSystems = MagicMock(
             return_value=[
-                {"name": "sisteme"},
-                {"name": "system"},
-                {"name": "exbox"},
-                {"name": "zitrix"},
-                {"name": "paystation-4"},
-                {"name": "azure"},
-                {"name": "quakearena"},
-                {"name": "awsbox"},
-                {"name": "beigebox"},
+                {"name": "sisteme"}, {"name": "system"}, {"name": "exbox"},
+                {"name": "zitrix"}, {"name": "paystation-4"}, {"name": "azure"},
+                {"name": "quakearena"}, {"name": "awsbox"}, {"name": "beigebox"},
             ]
         )
         shell.check_api_version = MagicMock(return_value=True)
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_listsystems(shell, "some_channel")
 
         assert not shell.help_configchannel_listsystems.called
         assert mprint.called
         assert shell.client.configchannel.listSubscribedSystems.called
-        assert_expect(
-            mprint.call_args_list,
-            "awsbox\nazure\nbeigebox\nexbox\npaystation-4"
-            "\nquakearena\nsisteme\nsystem\nzitrix",
-        )
+        assert_expect(mprint.call_args_list,
+                      'awsbox\nazure\nbeigebox\nexbox\npaystation-4'
+                      '\nquakearena\nsisteme\nsystem\nzitrix')
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_listfiles_noarg(self, shell):
         """
         Test configchannel_listfiles function. No args.
@@ -183,19 +133,14 @@ class TestSCConfigChannel:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_listfiles(shell, "")
 
         assert not shell.client.configchannel.listFiles.called
         assert not mprint.called
         assert shell.help_configchannel_listfiles.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_listfiles_sorted_data(self, shell):
         """
         Test configchannel_listfiles function. Data is sorted for STDOUT.
@@ -205,37 +150,22 @@ class TestSCConfigChannel:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        shell.client.configchannel.listFiles = MagicMock(
-            return_value=[
-                {"path": "/tmp/somefile.txt"},
-                {"path": "/tmp/zypper.rpm"},
-                {"path": "/tmp/aaa_base.rpm"},
-                {"path": "/tmp/someother.txt"},
-                {"path": "/etc/whatever.conf"},
-                {"path": "/etc/ssh.conf"},
-            ]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            # pylint: disable-next=unused-variable
-            data = spacecmd.configchannel.do_configchannel_listfiles(
-                shell, "some_channel"
-            )
+        shell.client.configchannel.listFiles = MagicMock(return_value=[
+            {"path": "/tmp/somefile.txt"}, {"path": "/tmp/zypper.rpm"},
+            {"path": "/tmp/aaa_base.rpm"}, {"path": "/tmp/someother.txt"},
+            {"path": "/etc/whatever.conf"}, {"path": "/etc/ssh.conf"},
+        ])
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
+            data = spacecmd.configchannel.do_configchannel_listfiles(shell, "some_channel")
 
         assert not shell.help_configchannel_listfiles.called
         assert shell.client.configchannel.listFiles.called
         assert mprint.called
-        assert_expect(
-            mprint.call_args_list,
-            "/etc/ssh.conf\n/etc/whatever.conf\n/tmp/aaa_base.rpm"
-            "\n/tmp/somefile.txt\n/tmp/someother.txt\n/tmp/zypper.rpm",
-        )
+        assert_expect(mprint.call_args_list,
+                      "/etc/ssh.conf\n/etc/whatever.conf\n/tmp/aaa_base.rpm"
+                      "\n/tmp/somefile.txt\n/tmp/someother.txt\n/tmp/zypper.rpm")
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_listfiles_sorted_data_out(self, shell):
         """
         Test configchannel_listfiles function. Data is sorted as a type.
@@ -245,40 +175,22 @@ class TestSCConfigChannel:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        shell.client.configchannel.listFiles = MagicMock(
-            return_value=[
-                {"path": "/tmp/somefile.txt"},
-                {"path": "/tmp/zypper.rpm"},
-                {"path": "/tmp/aaa_base.rpm"},
-                {"path": "/tmp/someother.txt"},
-                {"path": "/etc/whatever.conf"},
-                {"path": "/etc/ssh.conf"},
-            ]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            data = spacecmd.configchannel.do_configchannel_listfiles(
-                shell, "some_channel", doreturn=True
-            )
+        shell.client.configchannel.listFiles = MagicMock(return_value=[
+            {"path": "/tmp/somefile.txt"}, {"path": "/tmp/zypper.rpm"},
+            {"path": "/tmp/aaa_base.rpm"}, {"path": "/tmp/someother.txt"},
+            {"path": "/etc/whatever.conf"}, {"path": "/etc/ssh.conf"},
+        ])
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
+            data = spacecmd.configchannel.do_configchannel_listfiles(shell, "some_channel", doreturn=True)
 
         assert not mprint.called
         assert not shell.help_configchannel_listfiles.called
         assert shell.client.configchannel.listFiles.called
 
-        assert data == [
-            "/etc/ssh.conf",
-            "/etc/whatever.conf",
-            "/tmp/aaa_base.rpm",
-            "/tmp/somefile.txt",
-            "/tmp/someother.txt",
-            "/tmp/zypper.rpm",
-        ]
+        assert data == ['/etc/ssh.conf', '/etc/whatever.conf', '/tmp/aaa_base.rpm',
+                        '/tmp/somefile.txt', '/tmp/someother.txt', '/tmp/zypper.rpm']
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_forcedeploy_noargs(self, shell):
         """
         Test configchannel_forcedeploy function. No arguments.
@@ -289,12 +201,8 @@ class TestSCConfigChannel:
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_forcedeploy(shell, "")
 
         assert not mprint.called
@@ -306,7 +214,6 @@ class TestSCConfigChannel:
         assert not shell.client.configchannel.deployAllSystems.called
         assert shell.help_configchannel_forcedeploy.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_forcedeploy_too_much_args(self, shell):
         """
         Test configchannel_forcedeploy function. Too much arguments.
@@ -317,15 +224,10 @@ class TestSCConfigChannel:
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_forcedeploy(
-                shell, "base_channel illegally_entered_channel"
-            )
+                shell, "base_channel illegally_entered_channel")
 
         assert not mprint.called
         assert not logger.error.called
@@ -336,7 +238,6 @@ class TestSCConfigChannel:
         assert not shell.client.configchannel.deployAllSystems.called
         assert shell.help_configchannel_forcedeploy.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_forcedeploy_no_files(self, shell):
         """
         Test configchannel_forcedeploy function. No files found (or incomplete data).
@@ -344,20 +245,14 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        shell.client.configchannel.listFiles = MagicMock(
-            return_value=[
-                {"pfad": "/der/hund"},
-            ]
-        )
+        shell.client.configchannel.listFiles = MagicMock(return_value=[
+            {"pfad": "/der/hund"},
+        ])
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_forcedeploy(shell, "base_channel")
 
         assert not shell.help_configchannel_forcedeploy.called
@@ -368,9 +263,9 @@ class TestSCConfigChannel:
         assert not shell.client.configchannel.deployAllSystems.called
         assert shell.client.configchannel.listFiles.called
         assert mprint.called
-        assert_expect(mprint.call_args_list, "No files within selected configchannel.")
+        assert_expect(mprint.call_args_list,
+                      "No files within selected configchannel.")
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_forcedeploy_no_systems(self, shell):
         """
         Test configchannel_forcedeploy function. No subscribed systems.
@@ -378,22 +273,16 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        shell.client.configchannel.listFiles = MagicMock(
-            return_value=[
-                {"path": "/tmp/file1.txt"},
-                {"path": "/tmp/file2.txt"},
-            ]
-        )
+        shell.client.configchannel.listFiles = MagicMock(return_value=[
+            {"path": "/tmp/file1.txt"},
+            {"path": "/tmp/file2.txt"},
+        ])
         shell.client.configchannel.listSubscribedSystems(return_value=[])
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_forcedeploy(shell, "base_channel")
 
         assert not shell.help_configchannel_forcedeploy.called
@@ -404,9 +293,9 @@ class TestSCConfigChannel:
         assert shell.client.configchannel.listSubscribedSystems.called
         assert shell.client.configchannel.listFiles.called
         assert mprint.called
-        assert_expect(mprint.call_args_list, "Channel has no subscribed Systems")
+        assert_expect(mprint.call_args_list,
+                      "Channel has no subscribed Systems")
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_forcedeploy_deploy_output(self, shell):
         """
         Test configchannel_forcedeploy function. Output test.
@@ -414,27 +303,19 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        shell.client.configchannel.listFiles = MagicMock(
-            return_value=[
-                {"path": "/tmp/file1.txt"},
-                {"path": "/tmp/file2.txt"},
-            ]
-        )
-        shell.client.configchannel.listSubscribedSystems = MagicMock(
-            return_value=[
-                {"name": "butterfly.acme.org"},
-                {"name": "beigebox.acme.org"},
-            ]
-        )
+        shell.client.configchannel.listFiles = MagicMock(return_value=[
+            {"path": "/tmp/file1.txt"},
+            {"path": "/tmp/file2.txt"},
+        ])
+        shell.client.configchannel.listSubscribedSystems = MagicMock(return_value=[
+            {"name": "butterfly.acme.org"},
+            {"name": "beigebox.acme.org"},
+        ])
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_forcedeploy(shell, "base_channel")
 
         assert not shell.help_configchannel_forcedeploy.called
@@ -445,17 +326,12 @@ class TestSCConfigChannel:
         assert shell.client.configchannel.listSubscribedSystems.called
         assert shell.client.configchannel.listFiles.called
         assert mprint.called
-        assert_expect(
-            mprint.call_args_list,
-            "Force deployment of the following configfiles:",
-            "==============================================",
-            "/tmp/file1.txt\n/tmp/file2.txt",
-            "\nOn these systems:",
-            "=================",
-            "beigebox.acme.org\nbutterfly.acme.org",
-        )
+        assert_expect(mprint.call_args_list,
+                      'Force deployment of the following configfiles:',
+                      '==============================================',
+                      '/tmp/file1.txt\n/tmp/file2.txt', '\nOn these systems:',
+                      '=================', 'beigebox.acme.org\nbutterfly.acme.org')
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_filedetails_no_args(self, shell):
         """
         Test configchannel_filedetails function with no arguments.
@@ -466,12 +342,8 @@ class TestSCConfigChannel:
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_filedetails(shell, "")
 
         assert not shell.client.configchannel.lookupFileInfo.called
@@ -482,7 +354,6 @@ class TestSCConfigChannel:
         assert not logger.info.called
         assert shell.help_configchannel_filedetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_filedetails_wrong_amt_args(self, shell):
         """
         Test configchannel_filedetails function with wrong amount of arguments.
@@ -494,12 +365,8 @@ class TestSCConfigChannel:
             mprint = MagicMock()
             logger = MagicMock()
             shell.user_confirm = MagicMock()
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-                "spacecmd.configchannel.logging",
-                logger
-                # pylint: disable-next=unused-variable
-            ) as lgr:
+            with patch("spacecmd.configchannel.print", mprint) as prt, \
+                    patch("spacecmd.configchannel.logging", logger) as lgr:
                 spacecmd.configchannel.do_configchannel_filedetails(shell, args)
 
             assert not shell.client.configchannel.lookupFileInfo.called
@@ -510,7 +377,6 @@ class TestSCConfigChannel:
             assert not logger.info.called
             assert shell.help_configchannel_filedetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_filedetails_wrong_revision(self, shell):
         """
         Test configchannel_filedetails function with wrong amount of arguments.
@@ -521,15 +387,10 @@ class TestSCConfigChannel:
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_filedetails(
-                shell, "base_channel /tmp/file.txt kaboom"
-            )
+                shell, "base_channel /tmp/file.txt kaboom")
 
         assert not shell.client.configchannel.lookupFileInfo.called
         assert not shell.do_configchannel_listfiles.called
@@ -539,11 +400,9 @@ class TestSCConfigChannel:
         assert not shell.help_configchannel_filedetails.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.error.call_args_list, [(("Invalid revision: %s", "kaboom"), {})]
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Invalid revision: %s', 'kaboom'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_filedetails_invalid_files(self, shell):
         """
         Test configchannel_filedetails function with invalid files.
@@ -554,21 +413,13 @@ class TestSCConfigChannel:
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        shell.do_configchannel_listfiles = MagicMock(
-            return_value=[
-                "/tmp/valid.file",
-                "/tmp/another-valid.file",
-            ]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        shell.do_configchannel_listfiles = MagicMock(return_value=[
+            "/tmp/valid.file", "/tmp/another-valid.file",
+        ])
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_filedetails(
-                shell, "base_channel /tmp/file.txt"
-            )
+                shell, "base_channel /tmp/file.txt")
 
         assert not shell.client.configchannel.lookupFileInfo.called
         assert not mprint.called
@@ -578,7 +429,6 @@ class TestSCConfigChannel:
         assert shell.do_configchannel_listfiles.called
         assert logger.warning.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_filedetails_with_invalid_revision(self, shell):
         """
         Test configchannel_filedetails function with invalid revision
@@ -589,18 +439,13 @@ class TestSCConfigChannel:
         mprint = MagicMock()
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        shell.do_configchannel_listfiles = MagicMock(
-            return_value=["/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        shell.do_configchannel_listfiles = MagicMock(return_value=[
+            "/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"
+        ])
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_filedetails(
-                shell, "base_channel /tmp/file.txt 0.3"
-            )
+                shell, "base_channel /tmp/file.txt 0.3")
 
         assert not logger.info.called
         assert not shell.help_configchannel_filedetails.called
@@ -610,11 +455,9 @@ class TestSCConfigChannel:
         assert not shell.do_configchannel_listfiles.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.error.call_args_list, [(("Invalid revision: %s", "0.3"), {})]
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(("Invalid revision: %s", "0.3"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_filedetails_with_correct_revision_na(self, shell):
         """
         Test configchannel_filedetails function with correct revision, data N/A.
@@ -624,21 +467,16 @@ class TestSCConfigChannel:
         """
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        shell.client.configchannel.lookupFileInfo = MagicMock(
-            return_value={"path": "/tmp.file.txt"}
-        )
-        shell.do_configchannel_listfiles = MagicMock(
-            return_value=["/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"]
-        )
-        with patch("spacecmd.configchannel.print") as mprint, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            # pylint: disable-next=unused-variable
+        shell.client.configchannel.lookupFileInfo = MagicMock(return_value={
+            "path": "/tmp.file.txt"
+        })
+        shell.do_configchannel_listfiles = MagicMock(return_value=[
+            "/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"
+        ])
+        with patch("spacecmd.configchannel.print") as mprint, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             result = spacecmd.configchannel.do_configchannel_filedetails(
-                shell, "base_channel /tmp/file.txt 3"
-            )
+                shell, "base_channel /tmp/file.txt 3")
 
         assert not logger.info.called
         assert not shell.help_configchannel_filedetails.called
@@ -650,20 +488,19 @@ class TestSCConfigChannel:
         assert_list_args_expect(
             mprint.call_args_list,
             [
-                "Path:     /tmp.file.txt",
-                "Type:     N/A",
-                "Revision: N/A",
-                "Created:  N/A",
-                "Modified: N/A",
-                "",
-                "Owner:           N/A",
-                "Group:           N/A",
-                "Mode:            N/A",
-                "SELinux Context: N/A",
-            ],
+                'Path:     /tmp.file.txt',
+                'Type:     N/A',
+                'Revision: N/A',
+                'Created:  N/A',
+                'Modified: N/A',
+                '',
+                'Owner:           N/A',
+                'Group:           N/A',
+                'Mode:            N/A',
+                'SELinux Context: N/A'
+            ]
         )
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_filedetails_with_correct_revision_data(self, shell):
         """
         Test configchannel_filedetails function with correct revision, data available.
@@ -673,34 +510,20 @@ class TestSCConfigChannel:
         """
         logger = MagicMock()
         shell.user_confirm = MagicMock()
-        shell.client.configchannel.lookupFileInfo = MagicMock(
-            return_value={
-                "path": "/tmp.file.txt",
-                "type": "file",
-                "revision": "3",
-                "creation": "2019.01.01",
-                "modified": "2019.01.02",
-                "owner": "Fred",
-                "group": "lusers",
-                "permissions_mode": "0700",
-                "selinux_ctx": "system_u",
-                "sha256": "1234567",
-                "binary": False,
-                "contents": "Improper keyboard linear orientation",
-            }
-        )
-        shell.do_configchannel_listfiles = MagicMock(
-            return_value=["/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"]
-        )
-        with patch("spacecmd.configchannel.print") as mprint, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            # pylint: disable-next=unused-variable
+        shell.client.configchannel.lookupFileInfo = MagicMock(return_value={
+            "path": "/tmp.file.txt", "type": "file", "revision": "3",
+            "creation": "2019.01.01", "modified": "2019.01.02",
+            "owner": "Fred", "group": "lusers", "permissions_mode": "0700",
+            "selinux_ctx": "system_u", "sha256": "1234567", "binary": False,
+            "contents": "Improper keyboard linear orientation"
+        })
+        shell.do_configchannel_listfiles = MagicMock(return_value=[
+            "/tmp/valid.file", "/tmp/another-valid.file", "/tmp/file.txt"
+        ])
+        with patch("spacecmd.configchannel.print") as mprint, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             result = spacecmd.configchannel.do_configchannel_filedetails(
-                shell, "base_channel /tmp/file.txt 3"
-            )
+                shell, "base_channel /tmp/file.txt 3")
 
         assert not logger.info.called
         assert not shell.help_configchannel_filedetails.called
@@ -711,27 +534,25 @@ class TestSCConfigChannel:
 
         assert_list_args_expect(
             mprint.call_args_list,
-            [
-                "Path:     /tmp.file.txt",
-                "Type:     file",
-                "Revision: 3",
-                "Created:  2019.01.01",
-                "Modified: 2019.01.02",
-                "",
-                "Owner:           Fred",
-                "Group:           lusers",
-                "Mode:            0700",
-                "SELinux Context: system_u",
-                "SHA256:          1234567",
-                "Binary:          False",
-                "",
-                "Contents",
-                "--------",
-                "Improper keyboard linear orientation",
-            ],
+            ['Path:     /tmp.file.txt',
+             'Type:     file',
+             'Revision: 3',
+             'Created:  2019.01.01',
+             'Modified: 2019.01.02',
+             '',
+             'Owner:           Fred',
+             'Group:           lusers',
+             'Mode:            0700',
+             'SELinux Context: system_u',
+             'SHA256:          1234567',
+             'Binary:          False',
+             '',
+             'Contents',
+             '--------',
+             'Improper keyboard linear orientation'
+            ]
         )
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_backup_noargs(self, shell):
         """
         Test configchannel_backup function without args.
@@ -741,19 +562,12 @@ class TestSCConfigChannel:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=invalid-name
         _datetime = MagicMock()
-        # pylint: disable-next=invalid-name
         _os = MagicMock()
-        with patch("spacecmd.configchannel.open", create=True) as mopen, patch(
-            "spacecmd.configchannel.os",
-            _os
-            # pylint: disable-next=unused-variable
-        ) as mck_os, patch("spacecmd.configchannel.print", mprint) as mck_prt, patch(
-            "spacecmd.configchannel.logging",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as mck_lgr:
+        with patch("spacecmd.configchannel.open", create=True) as mopen, \
+                patch("spacecmd.configchannel.os", _os) as mck_os, \
+                patch("spacecmd.configchannel.print", mprint) as mck_prt, \
+                patch("spacecmd.configchannel.logging", mprint) as mck_lgr:
             mopen.return_value = MagicMock(spec=open)
             spacecmd.configchannel.do_configchannel_backup(shell, "")
 
@@ -767,7 +581,6 @@ class TestSCConfigChannel:
         assert not _datetime.called
         assert shell.help_configchannel_backup.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_backup_outputdir_failure(self, shell):
         """
         Test configchannel_backup function with output directory failed to be created.
@@ -777,26 +590,17 @@ class TestSCConfigChannel:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=invalid-name
         _datetime = MagicMock()
-        # pylint: disable-next=invalid-name
         _os = MagicMock()
         _os.path.expanduser = MagicMock(return_value="/dev/null/bofh")
         _os.path.isdir = MagicMock(return_value=False)
         _os.makedirs = MagicMock(side_effect=OSError("Fractal learning curve"))
-        with patch("spacecmd.configchannel.open", create=True) as mopen, patch(
-            "spacecmd.configchannel.os",
-            _os
-            # pylint: disable-next=unused-variable
-        ) as mck_os, patch("spacecmd.configchannel.dir", mprint) as mck_prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as mck_lgr:
+        with patch("spacecmd.configchannel.open", create=True) as mopen, \
+                patch("spacecmd.configchannel.os", _os) as mck_os, \
+                patch("spacecmd.configchannel.dir", mprint) as mck_prt, \
+                patch("spacecmd.configchannel.logging", logger) as mck_lgr:
             mopen.return_value = MagicMock(spec=open)
-            spacecmd.configchannel.do_configchannel_backup(
-                shell, "base_channel /tmp/somewhere"
-            )
+            spacecmd.configchannel.do_configchannel_backup(shell, "base_channel /tmp/somewhere")
 
         assert not shell.help_configchannel_backup.called
         assert not mprint.called
@@ -808,12 +612,10 @@ class TestSCConfigChannel:
         assert _os.path.expanduser.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [(("Could not create output directory: %s", "Fractal learning curve"), {})],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not create output directory: %s',
+                              'Fractal learning curve'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_backup_outputdir_metainfo_failure(self, shell):
         """
         Test configchannel_backup function with output directory, failed to create metainfo.
@@ -823,30 +625,17 @@ class TestSCConfigChannel:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=invalid-name
         _datetime = MagicMock()
-        # pylint: disable-next=invalid-name
         _os = MagicMock()
         _os.path.expanduser = MagicMock(return_value="/dev/null/bofh")
         _os.path.isdir = MagicMock(return_value=False)
         _os.path.join = os.path.join
         _os.makedirs = MagicMock()
-        with patch(
-            "spacecmd.configchannel.open",
-            MagicMock(side_effect=IOError("Bugs in the RAID")),
-            # pylint: disable-next=unused-variable
-        ) as mopen, patch("spacecmd.configchannel.os", _os) as mck_os, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as mck_prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as mck_lgr:
-            spacecmd.configchannel.do_configchannel_backup(
-                shell, "base_channel /tmp/somewhere"
-            )
+        with patch("spacecmd.configchannel.open", MagicMock(side_effect=IOError("Bugs in the RAID"))) as mopen, \
+                patch("spacecmd.configchannel.os", _os) as mck_os, \
+                patch("spacecmd.configchannel.print", mprint) as mck_prt, \
+                patch("spacecmd.configchannel.logging", logger) as mck_lgr:
+            spacecmd.configchannel.do_configchannel_backup(shell, "base_channel /tmp/somewhere")
 
         assert not shell.help_configchannel_backup.called
         assert not mprint.called
@@ -857,21 +646,11 @@ class TestSCConfigChannel:
         assert _os.path.expanduser.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        'Could not create "%s" file: %s',
-                        "/dev/null/bofh/.metainfo",
-                        "Bugs in the RAID",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not create "%s" file: %s',
+                              '/dev/null/bofh/.metainfo',
+                              'Bugs in the RAID'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_details_noargs(self, shell):
         """
         Test configchannel_details without directory.
@@ -882,12 +661,8 @@ class TestSCConfigChannel:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             out = spacecmd.configchannel.do_configchannel_details(shell, "")
 
         assert out is None
@@ -896,7 +671,6 @@ class TestSCConfigChannel:
         assert not shell.client.configchannel.listFiles.called
         assert shell.help_configchannel_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_details_channel(self, shell):
         """
         Test configchannel_details.
@@ -906,28 +680,19 @@ class TestSCConfigChannel:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        shell.client.configchannel.getDetails = MagicMock(
-            return_value={
-                "label": "base_channel",
-                "name": "Base Channel",
-                "description": "Base channel with some stuff",
-                "configChannelType": {"label": "Stuff"},
-            }
-        )
-        shell.client.configchannel.listFiles = MagicMock(
-            return_value=[
-                {"path": "/dev/null/vim.rpm"},
-                {"path": "/dev/null/pico.rpm"},
-                {"path": "/dev/null/java.rpm"},
-            ]
-        )
+        shell.client.configchannel.getDetails = MagicMock(return_value={
+            "label": "base_channel", "name": "Base Channel",
+            "description": "Base channel with some stuff",
+            "configChannelType": {"label": "Stuff"}
+        })
+        shell.client.configchannel.listFiles = MagicMock(return_value=[
+            {"path": "/dev/null/vim.rpm"},
+            {"path": "/dev/null/pico.rpm"},
+            {"path": "/dev/null/java.rpm"},
+        ])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.print", mprint) as prt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.print", mprint) as prt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             out = spacecmd.configchannel.do_configchannel_details(shell, "base_channel")
 
         assert not mprint.called
@@ -936,20 +701,10 @@ class TestSCConfigChannel:
         assert shell.client.configchannel.getDetails.called
         assert shell.client.configchannel.listFiles.called
 
-        assert out == [
-            "Label:       base_channel",
-            "Name:        Base Channel",
-            "Description: Base channel with some stuff",
-            "Type:        Stuff",
-            "",
-            "Files",
-            "-----",
-            "/dev/null/vim.rpm",
-            "/dev/null/pico.rpm",
-            "/dev/null/java.rpm",
-        ]
+        assert out == ['Label:       base_channel', 'Name:        Base Channel',
+                       'Description: Base channel with some stuff', 'Type:        Stuff', '',
+                       'Files', '-----', '/dev/null/vim.rpm', '/dev/null/pico.rpm', '/dev/null/java.rpm']
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_create_noargs(self, shell):
         """
         Test configchannel_create, without arguments (turns into interactive).
@@ -957,38 +712,19 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        puser = MagicMock(
-            side_effect=[
-                "John Smith",
-                "config_channel",
-                "Not ISO 9000 compliant",
-                "normal",
-            ]
-        )
-        # pylint: disable-next=unused-variable
+        puser = MagicMock(side_effect=[
+            "John Smith", "config_channel", "Not ISO 9000 compliant", "normal",
+        ])
         with patch("spacecmd.configchannel.prompt_user", puser) as pmt:
             spacecmd.configchannel.do_configchannel_create(shell, "")
 
         assert puser.called
         assert shell.client.configchannel.create.called
 
-        assert_args_expect(
-            shell.client.configchannel.create.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "config_channel",
-                        "John Smith",
-                        "Not ISO 9000 compliant",
-                        "normal",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.configchannel.create.call_args_list,
+                           [((shell.session, 'config_channel', 'John Smith',
+                              'Not ISO 9000 compliant', 'normal'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_create_noargs_type_state(self, shell):
         """
         Test configchannel_create, interactive, testing "state" type.
@@ -996,38 +732,19 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        puser = MagicMock(
-            side_effect=[
-                "John Smith",
-                "config_channel",
-                "Not ISO 9000 compliant",
-                "state",
-            ]
-        )
-        # pylint: disable-next=unused-variable
+        puser = MagicMock(side_effect=[
+            "John Smith", "config_channel", "Not ISO 9000 compliant", "state",
+        ])
         with patch("spacecmd.configchannel.prompt_user", puser) as pmt:
             spacecmd.configchannel.do_configchannel_create(shell, "")
 
         assert puser.called
         assert shell.client.configchannel.create.called
 
-        assert_args_expect(
-            shell.client.configchannel.create.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "config_channel",
-                        "John Smith",
-                        "Not ISO 9000 compliant",
-                        "state",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.configchannel.create.call_args_list,
+                           [((shell.session, 'config_channel', 'John Smith',
+                              'Not ISO 9000 compliant', 'state'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_create_noargs_wrong_type(self, shell):
         """
         Test configchannel_create, interactive, stop on wrong type
@@ -1036,31 +753,19 @@ class TestSCConfigChannel:
         :return:
         """
         logger = MagicMock()
-        puser = MagicMock(
-            side_effect=[
-                "John Smith",
-                "config_channel",
-                "Not ISO 9000 compliant",
-                "sausage",
-            ]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.prompt_user", puser) as pmt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        puser = MagicMock(side_effect=[
+            "John Smith", "config_channel", "Not ISO 9000 compliant", "sausage",
+        ])
+        with patch("spacecmd.configchannel.prompt_user", puser) as pmt, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_create(shell, "")
 
         assert not shell.client.configchannel.create.called
         assert puser.called
         assert logger.error.called
-        assert_args_expect(
-            logger.error.call_args_list,
-            [(("Only [normal/state] values are acceptable for type",), {})],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Only [normal/state] values are acceptable for type', ), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_delete_noargs(self, shell):
         """
         Delete channel, no args.
@@ -1071,12 +776,8 @@ class TestSCConfigChannel:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_delete(shell, "")
 
         assert not logger.error.called
@@ -1086,7 +787,6 @@ class TestSCConfigChannel:
         assert not shell.do_configchannel_list.called
         assert shell.help_configchannel_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_delete_wrong_channel(self, shell):
         """
         Delete channel, missing channel
@@ -1097,13 +797,11 @@ class TestSCConfigChannel:
 
         logger = MagicMock()
         mprint = MagicMock()
-        shell.do_configchannel_list = MagicMock(return_value=["base_channel"])
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        shell.do_configchannel_list = MagicMock(return_value=[
+            "base_channel"
+        ])
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_delete(shell, "funny_channel")
 
         assert not mprint.called
@@ -1112,23 +810,11 @@ class TestSCConfigChannel:
         assert logger.error.called
         assert logger.debug.called
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (
-                    (
-                        "configchannel_delete called with args ['funny_channel'], channels=[]",
-                    ),
-                    {},
-                )
-            ],
-        )
-        assert_args_expect(
-            logger.error.call_args_list,
-            [(("No channels matched argument(s): funny_channel",), {})],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(("configchannel_delete called with args ['funny_channel'], channels=[]", ), {})])
+        assert_args_expect(logger.error.call_args_list,
+                           [(('No channels matched argument(s): funny_channel', ), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_delete(self, shell):
         """
         Test configchannel_delete
@@ -1139,13 +825,11 @@ class TestSCConfigChannel:
 
         logger = MagicMock()
         mprint = MagicMock()
-        shell.do_configchannel_list = MagicMock(return_value=["base_channel"])
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        shell.do_configchannel_list = MagicMock(return_value=[
+            "base_channel"
+        ])
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_delete(shell, "base*")
 
         assert not shell.help_configchannel_delete.called
@@ -1154,23 +838,11 @@ class TestSCConfigChannel:
         assert shell.client.configchannel.deleteChannels.called
         assert logger.debug.called
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (
-                    (
-                        "configchannel_delete called with args ['base.*'], channels=['base_channel']",
-                    ),
-                    {},
-                )
-            ],
-        )
-        assert_args_expect(
-            shell.client.configchannel.deleteChannels.call_args_list,
-            [((shell.session, ["base_channel"]), {})],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(("configchannel_delete called with args ['base.*'], channels=['base_channel']", ), {})])
+        assert_args_expect(shell.client.configchannel.deleteChannels.call_args_list,
+                           [((shell.session, ['base_channel']), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_addfile_interactive_wrong_channels_abrt(self, shell):
         """
         Test configchannel_addfile, interactive. Abort keep asking user about
@@ -1182,12 +854,9 @@ class TestSCConfigChannel:
         logger = MagicMock()
         mprint = MagicMock()
         prompter = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.configchannel.print", mprint) as prt:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.prompt_user", prompter) as pmt, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_addfile(shell, "")
 
         assert not shell.client.configchannel.createOrUpdate.called
@@ -1198,31 +867,11 @@ class TestSCConfigChannel:
         assert logger.warning.called
         assert shell.do_configchannel_list.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Configuration Channels",
-                "----------------------",
-                "",
-                "",
-                "",
-                "",
-                "Configuration Channels",
-                "----------------------",
-                "",
-                "",
-                "",
-                "",
-                "Configuration Channels",
-                "----------------------",
-                "",
-                "",
-                "",
-                "",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Configuration Channels', '----------------------', '', '', '', '',
+                                 'Configuration Channels', '----------------------', '', '', '', '',
+                                 'Configuration Channels', '----------------------', '', '', '', ''])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_addfile_interactive_update_path(self, shell):
         """
         Test configchannel_addfile, interactive. Update path.
@@ -1233,19 +882,19 @@ class TestSCConfigChannel:
         logger = MagicMock()
         mprint = MagicMock()
         shell.check_api_version = MagicMock(return_value=False)
-        shell.configfile_getinfo = MagicMock(
-            return_value={"selinux_ctx": None, "revision": "3", "contents": None}
-        )
-        prompter = MagicMock(side_effect=["cfg_channel", "/tmp/cfgch"])
-        shell.do_configchannel_list = MagicMock(
-            return_value=["cfg_channel", "another_cfg_channel", "perfect_cfg_channel"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.configchannel.print", mprint) as prt:
+        shell.configfile_getinfo = MagicMock(return_value={
+            "selinux_ctx": None, "revision": "3",
+            "contents": None
+        })
+        prompter = MagicMock(side_effect=[
+            "cfg_channel", "/tmp/cfgch"
+        ])
+        shell.do_configchannel_list = MagicMock(return_value=[
+            "cfg_channel", "another_cfg_channel", "perfect_cfg_channel"
+        ])
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.prompt_user", prompter) as pmt, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_addfile(shell, "")
 
         assert not shell.client.configchannel.createOrUpdateSymlink.called
@@ -1259,32 +908,13 @@ class TestSCConfigChannel:
         assert mprint.called
         assert shell.do_configchannel_list.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Configuration Channels",
-                "----------------------",
-                "another_cfg_channel\ncfg_channel\nperfect_cfg_channel",
-                "",
-            ],
-        )
-        assert_args_expect(
-            shell.client.configchannel.createOrUpdatePath.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "cfg_channel",
-                        "/tmp/cfgch",
-                        False,
-                        {"contents": None},
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Configuration Channels', '----------------------',
+                                 'another_cfg_channel\ncfg_channel\nperfect_cfg_channel', ''])
+        assert_args_expect(shell.client.configchannel.createOrUpdatePath.call_args_list,
+                           [((shell.session, "cfg_channel", "/tmp/cfgch", False,
+                              {"contents": None}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_addfile_interactive_update_symlink(self, shell):
         """
         Test configchannel_addfile, interactive. Update path.
@@ -1295,19 +925,19 @@ class TestSCConfigChannel:
         logger = MagicMock()
         mprint = MagicMock()
         shell.check_api_version = MagicMock(return_value=False)
-        shell.configfile_getinfo = MagicMock(
-            return_value={"selinux_ctx": None, "revision": "3", "contents": None}
-        )
-        prompter = MagicMock(side_effect=["cfg_channel", "/tmp/cfgch"])
-        shell.do_configchannel_list = MagicMock(
-            return_value=["cfg_channel", "another_cfg_channel", "perfect_cfg_channel"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.configchannel.print", mprint) as prt:
+        shell.configfile_getinfo = MagicMock(return_value={
+            "selinux_ctx": None, "revision": "3",
+            "contents": None
+        })
+        prompter = MagicMock(side_effect=[
+            "cfg_channel", "/tmp/cfgch"
+        ])
+        shell.do_configchannel_list = MagicMock(return_value=[
+            "cfg_channel", "another_cfg_channel", "perfect_cfg_channel"
+        ])
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.prompt_user", prompter) as pmt, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_addfile(shell, "-s -c cfg_channel")
 
         assert not logger.warning.called
@@ -1321,22 +951,10 @@ class TestSCConfigChannel:
         assert shell.client.configchannel.createOrUpdateSymlink.called
         assert shell.configfile_getinfo.called
 
-        assert_args_expect(
-            shell.client.configchannel.createOrUpdateSymlink.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "cfg_channel",
-                        None,
-                        {"selinux_ctx": None, "revision": "3", "contents": None},
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.configchannel.createOrUpdateSymlink.call_args_list,
+                           [((shell.session, 'cfg_channel', None,
+                              {'selinux_ctx': None, 'revision': '3', 'contents': None}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_removefiles_noargs(self, shell):
         """
         Test do_configchannel_removefiles no args.
@@ -1349,7 +967,6 @@ class TestSCConfigChannel:
         assert not shell.client.configchannel.deleteFiles.called
         assert shell.help_configchannel_removefiles.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_removefiles_no_interactive(self, shell):
         """
         Test do_configchannel_removefiles non interactive (options.yes = True)
@@ -1357,18 +974,13 @@ class TestSCConfigChannel:
         :param shell:
         :return:
         """
-        spacecmd.configchannel.do_configchannel_removefiles(
-            shell, "somechannel /tmp/deleteme"
-        )
+        spacecmd.configchannel.do_configchannel_removefiles(shell, "somechannel /tmp/deleteme")
 
         assert not shell.help_configchannel_removefiles.called
         assert shell.client.configchannel.deleteFiles.called
-        assert_args_expect(
-            shell.client.configchannel.deleteFiles.call_args_list,
-            [((shell.session, "somechannel", ["/tmp/deleteme"]), {})],
-        )
+        assert_args_expect(shell.client.configchannel.deleteFiles.call_args_list,
+                           [((shell.session, 'somechannel', ['/tmp/deleteme']), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_removefiles_interactive(self, shell):
         """
         Test do_configchannel_removefiles interactive (options.yes = False)
@@ -1378,18 +990,13 @@ class TestSCConfigChannel:
         """
         shell.options.yes = False
         shell.user_confirm = MagicMock(return_value=True)
-        spacecmd.configchannel.do_configchannel_removefiles(
-            shell, "somechannel /tmp/deleteme"
-        )
+        spacecmd.configchannel.do_configchannel_removefiles(shell, "somechannel /tmp/deleteme")
 
         assert not shell.help_configchannel_removefiles.called
         assert shell.client.configchannel.deleteFiles.called
-        assert_args_expect(
-            shell.client.configchannel.deleteFiles.call_args_list,
-            [((shell.session, "somechannel", ["/tmp/deleteme"]), {})],
-        )
+        assert_args_expect(shell.client.configchannel.deleteFiles.call_args_list,
+                           [((shell.session, 'somechannel', ['/tmp/deleteme']), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_verifyfile_noargs(self, shell):
         """
         Test do_configchannel_verifyfile no args.
@@ -1398,7 +1005,6 @@ class TestSCConfigChannel:
         :return:
         """
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_verifyfile(shell, "")
 
@@ -1410,7 +1016,6 @@ class TestSCConfigChannel:
         assert not shell.get_system_id.called
         assert shell.help_configchannel_verifyfile.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_verifyfile_valid_args(self, shell):
         """
         Test do_configchannel_verifyfile, args validation.
@@ -1420,7 +1025,6 @@ class TestSCConfigChannel:
         """
         for arg in ["base_channel", "base_channel /tmp/somefile"]:
             logger = MagicMock()
-            # pylint: disable-next=unused-variable
             with patch("spacecmd.configchannel.logging", logger) as lgr:
                 spacecmd.configchannel.do_configchannel_verifyfile(shell, arg)
 
@@ -1432,7 +1036,6 @@ class TestSCConfigChannel:
             assert not shell.get_system_id.called
             assert shell.help_configchannel_verifyfile.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_verifyfile_ssm_no_systems(self, shell):
         """
         Test do_configchannel_verifyfile, SSM used. No systems has been found.
@@ -1442,11 +1045,9 @@ class TestSCConfigChannel:
         """
         logger = MagicMock()
         shell.ssm.keys = MagicMock(return_value={})
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_verifyfile(
-                shell, "base_channel /tmp/somefile ssm"
-            )
+                shell, "base_channel /tmp/somefile ssm")
 
         assert not shell.client.configchannel.scheduleFileComparisons.called
         assert not logger.info.called
@@ -1456,9 +1057,9 @@ class TestSCConfigChannel:
         assert logger.error.called
         assert shell.ssm.keys.called
 
-        assert_expect(logger.error.call_args_list, "No valid system selected")
+        assert_expect(logger.error.call_args_list,
+                      "No valid system selected")
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_verifyfile_ssm_no_valid_systems(self, shell):
         """
         Test do_configchannel_verifyfile, SSM used. No valid systems found (ID 0).
@@ -1469,11 +1070,9 @@ class TestSCConfigChannel:
         logger = MagicMock()
         shell.ssm.keys = MagicMock(return_value={"acme": {}, "beigebox": {}})
         shell.get_system_id = MagicMock(return_value=0)
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_verifyfile(
-                shell, "base_channel /tmp/somefile ssm"
-            )
+                shell, "base_channel /tmp/somefile ssm")
 
         assert not shell.client.configchannel.scheduleFileComparisons.called
         assert not logger.info.called
@@ -1483,9 +1082,9 @@ class TestSCConfigChannel:
         assert logger.error.called
         assert shell.ssm.keys.called
 
-        assert_expect(logger.error.call_args_list, "No valid system selected")
+        assert_expect(logger.error.call_args_list,
+                      "No valid system selected")
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_verifyfile_no_valid_systems(self, shell):
         """
         Test do_configchannel_verifyfile, direct systems request. No valid systems found.
@@ -1496,11 +1095,9 @@ class TestSCConfigChannel:
         logger = MagicMock()
         shell.expand_systems = MagicMock(return_value={"acme": {}, "beigebox": {}})
         shell.get_system_id = MagicMock(return_value=0)
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_verifyfile(
-                shell, "base_channel /tmp/somefile acme box"
-            )
+                shell, "base_channel /tmp/somefile acme box")
 
         assert not shell.client.configchannel.scheduleFileComparisons.called
         assert not logger.info.called
@@ -1510,9 +1107,9 @@ class TestSCConfigChannel:
         assert shell.get_system_id.called
         assert logger.error.called
 
-        assert_expect(logger.error.call_args_list, "No valid system selected")
+        assert_expect(logger.error.call_args_list,
+                      "No valid system selected")
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_verifyfile(self, shell):
         """
         Test do_configchannel_verifyfile, direct systems request. Systems found.
@@ -1524,11 +1121,9 @@ class TestSCConfigChannel:
         shell.expand_systems = MagicMock(return_value={"acme": {}, "beigebox": {}})
         shell.get_system_id = MagicMock(side_effect=[100100, 100200])
         shell.client.configchannel.scheduleFileComparisons = MagicMock(return_value=42)
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_verifyfile(
-                shell, "base_channel /tmp/somefile acme box"
-            )
+                shell, "base_channel /tmp/somefile acme box")
 
         assert not logger.error.called
         assert not shell.help_configchannel_verifyfile.called
@@ -1538,9 +1133,9 @@ class TestSCConfigChannel:
         assert shell.expand_systems.called
         assert shell.get_system_id.called
 
-        assert_args_expect(logger.info.call_args_list, [(("Action ID: 42",), {})])
+        assert_args_expect(logger.info.call_args_list,
+                           [(("Action ID: 42",), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_export_noargs_new_file(self, shell):
         """
         Test do_configchannel_export no arguments.
@@ -1552,14 +1147,10 @@ class TestSCConfigChannel:
         shell.user_confirm = MagicMock(return_value=False)
         json_dumper = MagicMock(return_value=True)
         shell.do_configchannel_list = MagicMock(
-            return_value=["cfg_1_channel", "cfg_2_channel"]
-        )
+            return_value=["cfg_1_channel", "cfg_2_channel"])
 
-        with patch(
-            "spacecmd.configchannel.json_dump_to_file",
-            json_dumper
-            # pylint: disable-next=unused-variable
-        ) as jdmp, patch("spacecmd.configchannel.logging", logger) as lgr:
+        with patch("spacecmd.configchannel.json_dump_to_file", json_dumper) as jdmp, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_export(shell, "")
 
         assert not logger.error.called
@@ -1567,7 +1158,6 @@ class TestSCConfigChannel:
         assert logger.info.called
         assert json_dumper.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_export_noargs_new_file_dump_failed(self, shell):
         """
         Test do_configchannel_export no arguments.
@@ -1579,14 +1169,10 @@ class TestSCConfigChannel:
         shell.user_confirm = MagicMock(return_value=False)
         json_dumper = MagicMock(return_value=False)
         shell.do_configchannel_list = MagicMock(
-            return_value=["cfg_1_channel", "cfg_2_channel"]
-        )
+            return_value=["cfg_1_channel", "cfg_2_channel"])
 
-        with patch(
-            "spacecmd.configchannel.json_dump_to_file",
-            json_dumper
-            # pylint: disable-next=unused-variable
-        ) as jdmp, patch("spacecmd.configchannel.logging", logger) as lgr:
+        with patch("spacecmd.configchannel.json_dump_to_file", json_dumper) as jdmp, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_export(shell, "")
 
         assert logger.debug.called
@@ -1594,20 +1180,10 @@ class TestSCConfigChannel:
         assert json_dumper.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Error saving exported config channels to file: %s",
-                        "cc_all.json",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(("Error saving exported config channels to file: %s",
+                              "cc_all.json"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_import_noargs(self, shell):
         """
         Test do_configchannel_import no arguments.
@@ -1617,24 +1193,18 @@ class TestSCConfigChannel:
         """
         logger = MagicMock()
         json_reader = MagicMock()
-        with patch(
-            "spacecmd.configchannel.json_read_from_file",
-            json_reader
-            # pylint: disable-next=unused-variable
-        ) as jrdr, patch("spacecmd.configchannel.logging", logger) as lgr:
+        with patch("spacecmd.configchannel.json_read_from_file", json_reader) as jrdr, \
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_import(shell, "")
 
         assert not logger.debug.called
         assert not shell.import_configchannel_fromdetails.called
         assert logger.error.called
         assert shell.help_configchannel_import.called
-        assert_expect(logger.error.call_args_list, "Error, no filename passed")
+        assert_expect(logger.error.call_args_list,
+                      "Error, no filename passed")
 
-    @patch(
-        "spacecmd.utils.open",
-        MagicMock(side_effect=IOError("Bits self replicate too fast")),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.utils.open", MagicMock(side_effect=IOError("Bits self replicate too fast")))
     def test_configchannel_import_one_file_noexists_ioerror(self, shell):
         """
         Test do_configchannel_import with one file that does not exists.
@@ -1643,50 +1213,26 @@ class TestSCConfigChannel:
         :return:
         """
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.utils.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as ulgr:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.utils.logging", logger) as ulgr:
             spacecmd.configchannel.do_configchannel_import(shell, "/tmp/somefile.txt")
 
         assert not shell.import_configchannel_fromdetails.called
         assert logger.debug.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [(("Passed filename do_configchannel_import %s", "/tmp/somefile.txt"), {})],
-        )
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Could not open file %s for reading: %s",
-                        "/tmp/somefile.txt",
-                        "Bits self replicate too fast",
-                    ),
-                    {},
-                ),
-                (
-                    (
-                        "Error, could not read json data from %s",
-                        "/tmp/somefile.txt",
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Passed filename do_configchannel_import %s',
+                              '/tmp/somefile.txt'), {})])
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not open file %s for reading: %s',
+                              '/tmp/somefile.txt',
+                              'Bits self replicate too fast'), {}),
+                            (('Error, could not read json data from %s',
+                              '/tmp/somefile.txt',), {})])
 
-    @patch(
-        "spacecmd.utils.open",
-        MagicMock(
-            side_effect=ValueError("All curly braces were replaced with parenthesis")
-        ),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.utils.open", MagicMock(
+        side_effect=ValueError("All curly braces were replaced with parenthesis")))
     def test_configchannel_import_one_file_parse_error(self, shell):
         """
         Test do_configchannel_import with one file that cannot be parsed
@@ -1695,48 +1241,26 @@ class TestSCConfigChannel:
         :return:
         """
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.utils.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as ulgr:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.utils.logging", logger) as ulgr:
             spacecmd.configchannel.do_configchannel_import(shell, "/tmp/somefile.txt")
 
         assert not shell.import_configchannel_fromdetails.called
         assert logger.debug.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [(("Passed filename do_configchannel_import %s", "/tmp/somefile.txt"), {})],
-        )
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Could not parse JSON data from %s: %s",
-                        "/tmp/somefile.txt",
-                        "All curly braces were replaced with parenthesis",
-                    ),
-                    {},
-                ),
-                (
-                    (
-                        "Error, could not read json data from %s",
-                        "/tmp/somefile.txt",
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Passed filename do_configchannel_import %s',
+                              '/tmp/somefile.txt'), {})])
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not parse JSON data from %s: %s',
+                              '/tmp/somefile.txt',
+                              'All curly braces were replaced with parenthesis'), {}),
+                            (('Error, could not read json data from %s',
+                              '/tmp/somefile.txt',), {})])
 
-    @patch(
-        "spacecmd.utils.open",
-        MagicMock(side_effect=Exception("Feature was not beta-tested")),
-    )
-    # pylint: disable-next=redefined-outer-name
+    @patch("spacecmd.utils.open", MagicMock(
+        side_effect=Exception("Feature was not beta-tested")))
     def test_configchannel_import_one_file_general_error(self, shell):
         """
         Test do_configchannel_import with one file, general exception occurs
@@ -1745,44 +1269,24 @@ class TestSCConfigChannel:
         :return:
         """
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.utils.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as ulgr:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.utils.logging", logger) as ulgr:
             spacecmd.configchannel.do_configchannel_import(shell, "/tmp/somefile.txt")
 
         assert not shell.import_configchannel_fromdetails.called
         assert logger.debug.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [(("Passed filename do_configchannel_import %s", "/tmp/somefile.txt"), {})],
-        )
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Error processing file %s: %s",
-                        "/tmp/somefile.txt",
-                        "Feature was not beta-tested",
-                    ),
-                    {},
-                ),
-                (
-                    (
-                        "Error, could not read json data from %s",
-                        "/tmp/somefile.txt",
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Passed filename do_configchannel_import %s',
+                              "/tmp/somefile.txt"), {})])
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Error processing file %s: %s',
+                              '/tmp/somefile.txt',
+                              'Feature was not beta-tested'), {}),
+                            (('Error, could not read json data from %s',
+                              '/tmp/somefile.txt',), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_sync_noargs(self, shell):
         """
         Test configchannel_sync with no args.
@@ -1794,12 +1298,8 @@ class TestSCConfigChannel:
             mprint = MagicMock()
             logger = MagicMock()
 
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-                "spacecmd.configchannel.print",
-                mprint
-                # pylint: disable-next=unused-variable
-            ) as prt:
+            with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                    patch("spacecmd.configchannel.print", mprint) as prt:
                 spacecmd.configchannel.do_configchannel_sync(shell, arg)
             assert not mprint.called
             assert not logger.info.called
@@ -1815,7 +1315,6 @@ class TestSCConfigChannel:
             assert not shell.do_configchannel_removefiles.called
             assert shell.help_configchannel_sync.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_sync_check_configchannel_failure(self, shell):
         """
         Test configchannel_sync check configchannel failure.
@@ -1827,12 +1326,8 @@ class TestSCConfigChannel:
         logger = MagicMock()
         shell.check_configchannel = MagicMock(return_value=False)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_sync(shell, "lightning_channel")
         assert not mprint.called
         assert not logger.info.called
@@ -1848,7 +1343,6 @@ class TestSCConfigChannel:
         assert not shell.help_configchannel_sync.called
         assert shell.check_configchannel.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_sync_check_configchannel_nosync(self, shell):
         """
         Test configchannel_sync check configchannel, no sync.
@@ -1861,22 +1355,14 @@ class TestSCConfigChannel:
         shell.options.yes = False
         shell.user_confirm = MagicMock(return_value=False)
         shell.check_configchannel = MagicMock(return_value=True)
-        shell.do_configchannel_getcorresponding = MagicMock(
-            return_value="corresponding_channel"
-        )
-        shell.do_configchannel_listfiles = MagicMock(
-            side_effect=[
-                ["/etc/some.conf", "/etc/some_other.conf"],
-                ["/etc/third.conf", "/etc/some.conf"],
-            ]
-        )
+        shell.do_configchannel_getcorresponding = MagicMock(return_value="corresponding_channel")
+        shell.do_configchannel_listfiles = MagicMock(side_effect=[
+            ["/etc/some.conf", "/etc/some_other.conf"],
+            ["/etc/third.conf", "/etc/some.conf"]
+        ])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_sync(shell, "cfg_channel")
         assert not logger.debug.called
         assert not logger.warning.called
@@ -1892,25 +1378,15 @@ class TestSCConfigChannel:
         assert shell.do_configchannel_listfiles.called
         assert shell.check_configchannel.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "files common in both channels:",
-                "/etc/some.conf",
-                "",
-                "files only in source cfg_channel",
-                "/etc/some_other.conf",
-                "",
-                "files only in target corresponding_channel",
-                "/etc/third.conf",
-                "",
-                "files that are in both channels will be overwritten in the target channel",
-                "files only in the source channel will be added to the target channel",
-                "files only in the target channel will be deleted",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['files common in both channels:', '/etc/some.conf', '',
+                                 'files only in source cfg_channel', '/etc/some_other.conf', '',
+                                 'files only in target corresponding_channel', '/etc/third.conf', '',
+                                 'files that are in both channels will be overwritten in the target channel',
+                                 'files only in the source channel will be added to the target channel',
+                                 'files only in the target channel will be deleted']
+                                )
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_sync_check_configchannel_full_sync_files_only(self, shell):
         """
         Test configchannel_sync check configchannel, with full sync, non interactive,
@@ -1924,50 +1400,29 @@ class TestSCConfigChannel:
         shell.options.yes = True
         shell.user_confirm = MagicMock(return_value=False)
         shell.check_configchannel = MagicMock(return_value=True)
-        shell.do_configchannel_getcorresponding = MagicMock(
-            return_value="corresponding_channel"
-        )
-        shell.do_configchannel_listfiles = MagicMock(
-            side_effect=[
-                ["/etc/some.conf", "/etc/some_other.conf"],
-                ["/etc/third.conf", "/etc/some.conf"],
-            ]
-        )
-        shell.client.configchannel.lookupFileInfo = MagicMock(
-            return_value=[
-                {
-                    "type": "file",
-                    "contents": "Firmware update in the coffee machine",
-                    "binary": True,
-                    "owner": "gr00t",
-                    "group": "guardians",
-                    "permissions_mode": 0o0644,
-                    "selinux_ctx": "",
-                    "macro-start-delimeter": "{",
-                    "macro-end-delimeter": "}",
-                    "path": "/etc/some.conf",
-                },
-                {
-                    "type": "file",
-                    "binary": False,
-                    "contents": b"Y\xeb\xde\xa6'$y\xd0\x8e\x04\xe2\xda\xb2\xd8^\x95\xa9\xe0\xb9\xa8\x1e\xa1\xf7!\xa2'\x1e",
-                    "owner": "gr00t",
-                    "group": "guardians",
-                    "permissions_mode": 0o0644,
-                    "selinux_ctx": "",
-                    "macro-start-delimeter": "{",
-                    "macro-end-delimeter": "}",
-                    "path": "/etc/some.conf",
-                },
-            ]
-        )
+        shell.do_configchannel_getcorresponding = MagicMock(return_value="corresponding_channel")
+        shell.do_configchannel_listfiles = MagicMock(side_effect=[
+            ["/etc/some.conf", "/etc/some_other.conf"],
+            ["/etc/third.conf", "/etc/some.conf"]
+        ])
+        shell.client.configchannel.lookupFileInfo = MagicMock(return_value=[
+            {
+                "type": "file", "contents": "Firmware update in the coffee machine", "binary": True,
+                "owner": "gr00t", "group": "guardians", "permissions_mode": 0o0644,
+                "selinux_ctx": "", "macro-start-delimeter": "{",
+                "macro-end-delimeter": "}", "path": "/etc/some.conf"
+            },
+            {
+                "type": "file", "binary": False,
+                "contents": b"Y\xeb\xde\xa6'$y\xd0\x8e\x04\xe2\xda\xb2\xd8^\x95\xa9\xe0\xb9\xa8\x1e\xa1\xf7!\xa2'\x1e",
+                "owner": "gr00t", "group": "guardians", "permissions_mode": 0o0644,
+                "selinux_ctx": "", "macro-start-delimeter": "{",
+                "macro-end-delimeter": "}", "path": "/etc/some.conf"
+            },
+        ])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_sync(shell, "cfg_channel")
 
         assert logger.debug.called
@@ -1984,62 +1439,18 @@ class TestSCConfigChannel:
         assert shell.do_configchannel_listfiles.called
         assert shell.check_configchannel.called
 
-        assert_args_expect(
-            shell.client.configchannel.lookupFileInfo.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "cfg_channel",
-                        ["/etc/some.conf", "/etc/some_other.conf"],
-                    ),
-                    {},
-                )
-            ],
-        )
-        assert_args_expect(
-            shell.client.configchannel.createOrUpdatePath.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "corresponding_channel",
-                        "/etc/some.conf",
-                        False,
-                        {
-                            "contents": "Firmware update in the coffee machine",
-                            "contents_enc64": True,
-                            "owner": "gr00t",
-                            "group": "guardians",
-                            "permissions": 420,
-                        },
-                    ),
-                    {},
-                ),
-                (
-                    (
-                        shell.session,
-                        "corresponding_channel",
-                        "/etc/some.conf",
-                        False,
-                        {
-                            "contents": b"WevepickedCOBOLasthelanguageofchoice\n",
-                            "contents_enc64": True,
-                            "owner": "gr00t",
-                            "group": "guardians",
-                            "permissions": 420,
-                        },
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_args_expect(shell.client.configchannel.lookupFileInfo.call_args_list,
+                           [((shell.session, 'cfg_channel', ['/etc/some.conf',
+                                                             '/etc/some_other.conf']), {})])
+        assert_args_expect(shell.client.configchannel.createOrUpdatePath.call_args_list,
+                           [((shell.session, 'corresponding_channel', '/etc/some.conf', False,
+                              {'contents': 'Firmware update in the coffee machine', 'contents_enc64': True,
+                               'owner': 'gr00t', 'group': 'guardians', 'permissions': 420}), {}),
+                            ((shell.session, 'corresponding_channel', '/etc/some.conf', False,
+                              {'contents': b'WevepickedCOBOLasthelanguageofchoice\n', 'contents_enc64': True,
+                               'owner': 'gr00t', 'group': 'guardians', 'permissions': 420}), {})])
 
-    def test_configchannel_sync_check_configchannel_full_sync_symlinks_only(
-        self,
-        # pylint: disable-next=redefined-outer-name
-        shell,
-    ):
+    def test_configchannel_sync_check_configchannel_full_sync_symlinks_only(self, shell):
         """
         Test configchannel_sync check configchannel, with full sync, non interactive,
         symlinks only.
@@ -2052,38 +1463,24 @@ class TestSCConfigChannel:
         shell.options.yes = True
         shell.user_confirm = MagicMock(return_value=False)
         shell.check_configchannel = MagicMock(return_value=True)
-        shell.do_configchannel_getcorresponding = MagicMock(
-            return_value="corresponding_channel"
-        )
-        shell.do_configchannel_listfiles = MagicMock(
-            side_effect=[
-                ["/etc/some.conf", "/etc/some_other.conf"],
-                ["/etc/third.conf", "/etc/some.conf"],
-            ]
-        )
-        shell.client.configchannel.lookupFileInfo = MagicMock(
-            return_value=[
-                {
-                    "type": "symlink",
-                    "target_path": "/etc/some_other.conf",
-                    "selinux_ctx": "bananapie",
-                    "path": "/etc/some.conf",
-                },
-                {
-                    "type": "symlink",
-                    "target_path": "/etc/something.conf",
-                    "selinux_ctx": "coffeemachine",
-                    "path": "/etc/some.conf",
-                },
-            ]
-        )
+        shell.do_configchannel_getcorresponding = MagicMock(return_value="corresponding_channel")
+        shell.do_configchannel_listfiles = MagicMock(side_effect=[
+            ["/etc/some.conf", "/etc/some_other.conf"],
+            ["/etc/third.conf", "/etc/some.conf"]
+        ])
+        shell.client.configchannel.lookupFileInfo = MagicMock(return_value=[
+            {
+                "type": "symlink", "target_path": "/etc/some_other.conf",
+                "selinux_ctx": "bananapie", "path": "/etc/some.conf"
+            },
+            {
+                "type": "symlink", "target_path": "/etc/something.conf",
+                "selinux_ctx": "coffeemachine",  "path": "/etc/some.conf"
+            },
+        ])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.logging", logger) as lgr, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        with patch("spacecmd.configchannel.logging", logger) as lgr, \
+                patch("spacecmd.configchannel.print", mprint) as prt:
             spacecmd.configchannel.do_configchannel_sync(shell, "cfg_channel")
 
         assert logger.debug.called
@@ -2100,50 +1497,15 @@ class TestSCConfigChannel:
         assert shell.do_configchannel_listfiles.called
         assert shell.check_configchannel.called
 
-        assert_args_expect(
-            shell.client.configchannel.lookupFileInfo.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "cfg_channel",
-                        ["/etc/some.conf", "/etc/some_other.conf"],
-                    ),
-                    {},
-                )
-            ],
-        )
-        assert_args_expect(
-            shell.client.configchannel.createOrUpdateSymlink.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "corresponding_channel",
-                        "/etc/some.conf",
-                        {
-                            "target_path": "/etc/some_other.conf",
-                            "selinux_ctx": "bananapie",
-                        },
-                    ),
-                    {},
-                ),
-                (
-                    (
-                        shell.session,
-                        "corresponding_channel",
-                        "/etc/some.conf",
-                        {
-                            "target_path": "/etc/something.conf",
-                            "selinux_ctx": "coffeemachine",
-                        },
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_args_expect(shell.client.configchannel.lookupFileInfo.call_args_list,
+                           [((shell.session, 'cfg_channel', ['/etc/some.conf',
+                                                             '/etc/some_other.conf']), {})])
+        assert_args_expect(shell.client.configchannel.createOrUpdateSymlink.call_args_list,
+                           [((shell.session, 'corresponding_channel', '/etc/some.conf',
+                              {'target_path': '/etc/some_other.conf', 'selinux_ctx': 'bananapie'}), {}),
+                            ((shell.session, 'corresponding_channel', '/etc/some.conf',
+                              {'target_path': '/etc/something.conf', 'selinux_ctx': 'coffeemachine'}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_diff_args(self, shell):
         """
         Test do_configchannel_diff on arguments call.
@@ -2153,7 +1515,6 @@ class TestSCConfigChannel:
         """
         for arg in ["", "one two three"]:
             differ = MagicMock()
-            # pylint: disable-next=unused-variable
             with patch("spacecmd.configchannel.get_string_diff_dicts", differ) as dfr:
                 spacecmd.configchannel.do_configchannel_diff(shell, arg)
             assert not differ.called
@@ -2162,7 +1523,6 @@ class TestSCConfigChannel:
             assert not shell.dump_configchannel.called
             assert shell.help_configchannel_diff.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_clone_interactive_no_channels(self, shell):
         """
         Test do_configchannel_clone on interactive, no channels.
@@ -2173,12 +1533,8 @@ class TestSCConfigChannel:
         shell.do_configchannel_list = MagicMock(return_value=[])
         prompter = MagicMock(side_effect=["basic_config_channel", "bcc_channel"])
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.prompt_user", prompter) as pmt, patch(
-            "spacecmd.configchannel.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.configchannel.prompt_user", prompter) as pmt,\
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_clone(shell, "")
 
         assert not shell.help_configchannel_clone.called
@@ -2189,7 +1545,6 @@ class TestSCConfigChannel:
 
         assert_expect(logger.error.call_args_list, "No config channels found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_configchannel_clone_interactive_no_channels_matches(self, shell):
         """
         Test do_configchannel_clone on interactive, no channels matches.
@@ -2201,12 +1556,9 @@ class TestSCConfigChannel:
         prompter = MagicMock(side_effect=["basic_config_channel", "bcc_channel"])
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.configchannel.prompt_user", prompter) as pmt, patch(
-            "spacecmd.configchannel.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt, patch("spacecmd.configchannel.logging", logger) as lgr:
+        with patch("spacecmd.configchannel.prompt_user", prompter) as pmt,\
+                patch("spacecmd.configchannel.print", mprint) as prt,\
+                patch("spacecmd.configchannel.logging", logger) as lgr:
             spacecmd.configchannel.do_configchannel_clone(shell, "")
 
         assert not shell.export_configchannel_getdetails.called
@@ -2218,10 +1570,8 @@ class TestSCConfigChannel:
         assert logger.error.called
         assert mprint.called
 
-        assert_expect(
-            logger.error.call_args_list, "No suitable channels to clone has been found."
-        )
-        assert_list_args_expect(
-            mprint.call_args_list,
-            ["", "Config Channels", "------------------", "some_channel", ""],
-        )
+        assert_expect(logger.error.call_args_list,
+                      "No suitable channels to clone has been found.")
+        assert_list_args_expect(mprint.call_args_list,
+                                ['', 'Config Channels', '------------------', 'some_channel', ''])
+

--- a/spacecmd/tests/test_cryptokey.py
+++ b/spacecmd/tests/test_cryptokey.py
@@ -3,13 +3,9 @@
 Test suite for cryptokey.
 """
 from mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 import pytest
 from xmlrpc import client as xmlrpclib
 import spacecmd.cryptokey
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect
 
 
@@ -17,8 +13,6 @@ class TestSCCryptokey:
     """
     Test cryptokey API.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_create_no_keytype(self, shell):
         """
         Test do_cryptokey_create without correct key type.
@@ -34,16 +28,10 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_create(shell, "")
 
         assert not shell.help_cryptokey_create.called
@@ -55,7 +43,6 @@ class TestSCCryptokey:
 
         assert_expect(logger.error.call_args_list, "Invalid key type")
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_create_interactive_no_contents(self, shell):
         """
         Test do_cryptokey_create without arguments (interactive, no contents given).
@@ -71,16 +58,10 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_create(shell, "")
 
         assert not shell.help_cryptokey_create.called
@@ -92,7 +73,6 @@ class TestSCCryptokey:
 
         assert_expect(logger.error.call_args_list, "No contents of the file")
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_create_interactive_wrong_key_type(self, shell):
         """
         Test do_cryptokey_create without arguments (interactive, wrong key type).
@@ -108,16 +88,10 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_create(shell, "")
 
         assert not shell.help_cryptokey_create.called
@@ -129,7 +103,6 @@ class TestSCCryptokey:
 
         assert_expect(logger.error.call_args_list, "Invalid key type")
 
-    # pylint: disable-next=invalid-name,redefined-outer-name
     def test_cryptokey_create_GPG_key(self, shell):
         """
         Test do_cryptokey_create with parameters, calling GPG key type.
@@ -145,19 +118,11 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            spacecmd.cryptokey.do_cryptokey_create(
-                shell, "-t g -d description -f /tmp/file.txt"
-            )
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_create(shell, "-t g -d description -f /tmp/file.txt")
 
         assert not editor.called
         assert not shell.help_cryptokey_create.called
@@ -172,7 +137,6 @@ class TestSCCryptokey:
             assert args == (shell.session, "description", "GPG", "contents")
             assert not kw
 
-    # pylint: disable-next=invalid-name,redefined-outer-name
     def test_cryptokey_create_SSL_key(self, shell):
         """
         Test do_cryptokey_create with parameters, calling SSL key type.
@@ -188,19 +152,11 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            spacecmd.cryptokey.do_cryptokey_create(
-                shell, "-t s -d description -f /tmp/file.txt"
-            )
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_create(shell, "-t s -d description -f /tmp/file.txt")
 
         assert not editor.called
         assert not shell.help_cryptokey_create.called
@@ -215,7 +171,6 @@ class TestSCCryptokey:
             assert args == (shell.session, "description", "SSL", "contents")
             assert not kw
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_update_no_keytype(self, shell):
         """
         Test do_cryptokey_update without correct key type.
@@ -231,16 +186,10 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_update(shell, "")
 
         assert not shell.help_cryptokey_update.called
@@ -252,7 +201,6 @@ class TestSCCryptokey:
 
         assert_expect(logger.error.call_args_list, "Invalid key type")
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_update_interactive_no_contents(self, shell):
         """
         Test do_cryptokey_update without arguments (interactive, no contents given).
@@ -268,16 +216,10 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_update(shell, "")
 
         assert not shell.help_cryptokey_update.called
@@ -289,7 +231,6 @@ class TestSCCryptokey:
 
         assert_expect(logger.error.call_args_list, "No contents of the file")
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_update_interactive_wrong_key_type(self, shell):
         """
         Test do_cryptokey_update without arguments (interactive, wrong key type).
@@ -305,16 +246,10 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_update(shell, "")
 
         assert not shell.help_cryptokey_update.called
@@ -326,7 +261,6 @@ class TestSCCryptokey:
 
         assert_expect(logger.error.call_args_list, "Invalid key type")
 
-    # pylint: disable-next=invalid-name,redefined-outer-name
     def test_cryptokey_update_GPG_key(self, shell):
         """
         Test do_cryptokey_update with parameters, calling GPG key type.
@@ -342,19 +276,11 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            spacecmd.cryptokey.do_cryptokey_update(
-                shell, "-t g -d description -f /tmp/file.txt"
-            )
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_update(shell, "-t g -d description -f /tmp/file.txt")
 
         assert not editor.called
         assert not shell.help_cryptokey_update.called
@@ -369,7 +295,6 @@ class TestSCCryptokey:
             assert args == (shell.session, "description", "GPG", "contents")
             assert not kw
 
-    # pylint: disable-next=invalid-name,redefined-outer-name
     def test_cryptokey_update_SSL_key(self, shell):
         """
         Test do_cryptokey_update with parameters, calling SSL key type.
@@ -385,19 +310,11 @@ class TestSCCryptokey:
         editor = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, patch(
-            "spacecmd.cryptokey.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch("spacecmd.cryptokey.editor", editor) as edt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            spacecmd.cryptokey.do_cryptokey_update(
-                shell, "-t s -d description -f /tmp/file.txt"
-            )
+        with patch("spacecmd.cryptokey.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.cryptokey.read_file", read_file) as rfl, \
+            patch("spacecmd.cryptokey.editor", editor) as edt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
+            spacecmd.cryptokey.do_cryptokey_update(shell, "-t s -d description -f /tmp/file.txt")
 
         assert not editor.called
         assert not shell.help_cryptokey_update.called
@@ -412,7 +329,6 @@ class TestSCCryptokey:
             assert args == (shell.session, "description", "SSL", "contents")
             assert not kw
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_delete_noargs(self, shell):
         """
         Test do_cryptokey_delete without parameters, so help should be displayed.
@@ -426,12 +342,8 @@ class TestSCCryptokey:
         filter_results = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.logging", logger) as lgr, patch(
-            "spacecmd.cryptokey.filter_results",
-            filter_results
-            # pylint: disable-next=unused-variable
-        ) as frl:
+        with patch("spacecmd.cryptokey.logging", logger) as lgr, \
+            patch("spacecmd.cryptokey.filter_results", filter_results) as frl:
             spacecmd.cryptokey.do_cryptokey_delete(shell, "")
 
         assert not logger.error.called
@@ -441,7 +353,6 @@ class TestSCCryptokey:
         assert not shell.do_cryptokey_list.called
         assert shell.help_cryptokey_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_delete_no_exist(self, shell):
         """
         Test do_cryptokey_delete with non-existing key.
@@ -455,12 +366,8 @@ class TestSCCryptokey:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.logging", logger) as lgr, patch(
-            "spacecmd.cryptokey.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
+        with patch("spacecmd.cryptokey.logging", logger) as lgr, \
+            patch("spacecmd.cryptokey.print", mprint) as prn:
             spacecmd.cryptokey.do_cryptokey_delete(shell, "foo*")
 
         assert not shell.client.kickstart.keys.delete.called
@@ -471,7 +378,6 @@ class TestSCCryptokey:
 
         assert_expect(logger.error.call_args_list, "No keys matched argument ['foo.*']")
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_delete_not_confirmed(self, shell):
         """
         Test do_cryptokey_delete with non-existing key.
@@ -485,12 +391,8 @@ class TestSCCryptokey:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.logging", logger) as lgr, patch(
-            "spacecmd.cryptokey.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
+        with patch("spacecmd.cryptokey.logging", logger) as lgr, \
+            patch("spacecmd.cryptokey.print", mprint) as prn:
             spacecmd.cryptokey.do_cryptokey_delete(shell, "t*")
 
         assert not shell.client.kickstart.keys.delete.called
@@ -499,9 +401,8 @@ class TestSCCryptokey:
         assert shell.user_confirm.called
         assert mprint.called
 
-        assert_expect(mprint.call_args_list, "three\ntwo")
+        assert_expect(mprint.call_args_list, 'three\ntwo')
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_delete_confirmed_deleted(self, shell):
         """
         Test do_cryptokey_delete with non-existing key.
@@ -515,12 +416,8 @@ class TestSCCryptokey:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.logging", logger) as lgr, patch(
-            "spacecmd.cryptokey.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
+        with patch("spacecmd.cryptokey.logging", logger) as lgr, \
+            patch("spacecmd.cryptokey.print", mprint) as prn:
             spacecmd.cryptokey.do_cryptokey_delete(shell, "t*")
 
         assert not logger.error.called
@@ -529,16 +426,10 @@ class TestSCCryptokey:
         assert shell.user_confirm.called
         assert mprint.called
 
-        assert_expect(mprint.call_args_list, "three\ntwo")
+        assert_expect(mprint.call_args_list, 'three\ntwo')
         exp = [
-            (
-                shell.session,
-                "two",
-            ),
-            (
-                shell.session,
-                "three",
-            ),
+            (shell.session, "two",),
+            (shell.session, "three",),
         ]
 
         for call in shell.client.kickstart.keys.delete.call_args_list:
@@ -548,7 +439,6 @@ class TestSCCryptokey:
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_list_no_stdout(self, shell):
         """
         Test do_cryptokey_list no STDOUT.
@@ -563,16 +453,14 @@ class TestSCCryptokey:
             ]
         )
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.cryptokey.print", mprint) as prn:
             out = spacecmd.cryptokey.do_cryptokey_list(shell, "", doreturn=True)
 
         assert not mprint.called
         assert bool(out)
         assert shell.client.kickstart.keys.listAllKeys.called
-        assert out == ["keydescr-1", "keydescr-2"]
+        assert out == ['keydescr-1', 'keydescr-2']
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_list_stdout(self, shell):
         """
         Test do_cryptokey_list to STDOUT.
@@ -587,7 +475,6 @@ class TestSCCryptokey:
             ]
         )
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.cryptokey.print", mprint) as prn:
             out = spacecmd.cryptokey.do_cryptokey_list(shell, "", doreturn=False)
 
@@ -597,7 +484,6 @@ class TestSCCryptokey:
 
         assert_expect(mprint.call_args_list, "keydescr-1\nkeydescr-2")
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_details_noargs(self, shell):
         """
         Test do_cryptokey_details with no parameters.
@@ -611,12 +497,8 @@ class TestSCCryptokey:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.print", mprint) as mpt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.print", mprint) as mpt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_details(shell, "")
 
         assert not mprint.called
@@ -624,7 +506,6 @@ class TestSCCryptokey:
         assert not shell.do_cryptokey_list.called
         assert shell.help_cryptokey_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_details_not_found(self, shell):
         """
         Test do_cryptokey_details key not found.
@@ -638,12 +519,8 @@ class TestSCCryptokey:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.print", mprint) as mpt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.print", mprint) as mpt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_details(shell, "somekey")
 
         assert not mprint.called
@@ -652,11 +529,8 @@ class TestSCCryptokey:
         assert shell.do_cryptokey_list.called
         assert logger.error.called
 
-        assert_expect(
-            logger.error.call_args_list, "No keys matched argument ['somekey']"
-        )
+        assert_expect(logger.error.call_args_list, "No keys matched argument ['somekey']")
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_details_listing(self, shell):
         """
         Test do_cryptokey_details key listing
@@ -664,26 +538,18 @@ class TestSCCryptokey:
         :param shell:
         :return:
         """
-        shell.client.kickstart.keys.getDetails = MagicMock(
-            side_effect=[
-                {"description": "first descr", "type": "SSL", "content": "one data"},
-                {"description": "second descr", "type": "GPG", "content": "two data"},
-            ]
-        )
-        shell.do_cryptokey_list = MagicMock(
-            return_value=["key-one", "key-two", "three"]
-        )
+        shell.client.kickstart.keys.getDetails = MagicMock(side_effect=[
+            {"description": "first descr", "type": "SSL", "content": "one data"},
+            {"description": "second descr", "type": "GPG", "content": "two data"},
+        ])
+        shell.do_cryptokey_list = MagicMock(return_value=["key-one", "key-two", "three"])
         shell.SEPARATOR = "---"
         shell.help_cryptokey_details = MagicMock()
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.print", mprint) as mpt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.print", mprint) as mpt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_details(shell, "key*")
 
         assert not shell.help_cryptokey_details.called
@@ -694,15 +560,10 @@ class TestSCCryptokey:
         assert shell.do_cryptokey_list.called
 
         exp = [
-            "Description: first descr",
-            "Type:        SSL",
-            "",
-            "one data",
-            "---",
-            "Description: second descr",
-            "Type:        GPG",
-            "",
-            "two data",
+            'Description: first descr',
+            'Type:        SSL', '', 'one data', '---',
+            'Description: second descr',
+            'Type:        GPG', '', 'two data',
         ]
 
         for call in mprint.call_args_list:
@@ -710,7 +571,6 @@ class TestSCCryptokey:
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_cryptokey_details_rpc_error(self, shell):
         """
         Test do_cryptokey_details captures xmlrpc failure.
@@ -726,12 +586,8 @@ class TestSCCryptokey:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.cryptokey.print", mprint) as mpt, patch(
-            "spacecmd.cryptokey.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.cryptokey.print", mprint) as mpt, \
+            patch("spacecmd.cryptokey.logging", logger) as lgr:
             spacecmd.cryptokey.do_cryptokey_details(shell, "somekey")
 
         assert not mprint.called
@@ -741,6 +597,4 @@ class TestSCCryptokey:
         assert shell.do_cryptokey_list.called
         assert logger.warning.called
 
-        assert_expect(
-            logger.warning.call_args_list, "somekey is not a valid crypto key"
-        )
+        assert_expect(logger.warning.call_args_list, "somekey is not a valid crypto key")

--- a/spacecmd/tests/test_custominfo.py
+++ b/spacecmd/tests/test_custominfo.py
@@ -2,11 +2,8 @@
 """
 Test suite for custominfo source
 """
-# pylint: disable-next=unused-import
 from mock import MagicMock, patch, mock_open
 from spacecmd import custominfo
-
-# pylint: disable-next=unused-import
 from helpers import shell, exc2str
 import pytest
 
@@ -15,8 +12,6 @@ class TestSCCusomInfo:
     """
     Test for custominfo API.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_createkey_no_keyname(self, shell):
         """
         Test do_custominfo_createkey do not break on no key name provided, falling back to interactive mode.
@@ -30,7 +25,7 @@ class TestSCCusomInfo:
 
         assert "Empty key" in exc2str(exc)
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_do_custominfo_createkey_no_descr(self, shell):
         """
         Test do_custominfo_createkey description gets the name of the key, if not provided.
@@ -42,15 +37,10 @@ class TestSCCusomInfo:
             custominfo.do_custominfo_createkey(shell, "")
 
         assert shell.client.system.custominfo.createKey.called
-        (
-            session,
-            keyname,
-            descr,
-        ) = shell.client.system.custominfo.createKey.call_args_list[0][0]
+        session, keyname, descr = shell.client.system.custominfo.createKey.call_args_list[0][0]
         assert shell.session == session
         assert keyname == descr
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_createkey_descr_interactive(self, shell):
         """
         Test do_custominfo_createkey description gets the name of the key from interactive prompt.
@@ -62,39 +52,28 @@ class TestSCCusomInfo:
             custominfo.do_custominfo_createkey(shell, "")
 
         assert shell.client.system.custominfo.createKey.called
-        (
-            session,
-            keyname,
-            descr,
-        ) = shell.client.system.custominfo.createKey.call_args_list[0][0]
+        session, keyname, descr = shell.client.system.custominfo.createKey.call_args_list[0][0]
         assert shell.session == session
         assert keyname != descr
         assert keyname == "keyname"
         assert descr == "keydescr"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_createkey_descr_args(self, shell):
         """
         Test do_custominfo_createkey description gets the name of the key from the args.
         """
         shell.client.system.custominfo.createKey = MagicMock()
-        # pylint: disable-next=unused-variable
         prompter = MagicMock(side_effect=Exception("Kaboom"))
 
         custominfo.do_custominfo_createkey(shell, "keyname keydescr")
 
         assert shell.client.system.custominfo.createKey.called
-        (
-            session,
-            keyname,
-            descr,
-        ) = shell.client.system.custominfo.createKey.call_args_list[0][0]
+        session, keyname, descr = shell.client.system.custominfo.createKey.call_args_list[0][0]
         assert shell.session == session
         assert keyname != descr
         assert keyname == "keyname"
         assert descr == "keydescr"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_deletekey_noargs(self, shell):
         """
         Test do_custominfo_deletekey shows help on no args.
@@ -113,7 +92,6 @@ class TestSCCusomInfo:
         assert errmsg in exc2str(exc)
 
     @patch("spacecmd.custominfo.print", MagicMock())
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_deletekey_args(self, shell):
         """
         Test do_custominfo_deletekey calls deleteKey API function.
@@ -137,12 +115,11 @@ class TestSCCusomInfo:
         assert len(keylist) == 1
         assert "this_key_stays" in keylist
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_listkeys_stdout(self, shell):
         """
         Test do_custominfo_listkeys calls lists all keys calling listAllKeys API function to STDOUT.
         """
-        keylist = [
+        keylist=[
             {"label": "some_key"},
             {"label": "some_other_key"},
             {"label": "this_key_stays"},
@@ -155,12 +132,11 @@ class TestSCCusomInfo:
         assert ret is None
         assert mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_listkeys_as_data(self, shell):
         """
         Test do_custominfo_listkeys calls lists all keys calling listAllKeys API function as data.
         """
-        keylist = [
+        keylist=[
             {"label": "some_key"},
             {"label": "some_other_key"},
             {"label": "this_key_stays"},
@@ -175,12 +151,11 @@ class TestSCCusomInfo:
         for key in keylist:
             assert key["label"] in ret
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_details_noarg(self, shell):
         """
         Test do_custominfo_details shows help when no arguments has been passed.
         """
-        keylist = ["some_key", "some_other_key", "this_key_stays"]
+        keylist=["some_key", "some_other_key", "this_key_stays"]
         shell.help_custominfo_details = MagicMock(side_effect=Exception("Help info"))
         shell.client.system.custominfo.listAllKeys = MagicMock()
         shell.do_custominfo_listkeys = MagicMock(return_value=keylist)
@@ -195,7 +170,6 @@ class TestSCCusomInfo:
         assert not logger.error.called
         assert not shell.client.system.custominfo.listAllKeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_details_no_key(self, shell):
         """
         Test do_custominfo_details shows error to the log if key name doesn't match.
@@ -210,16 +184,9 @@ class TestSCCusomInfo:
                 custominfo.do_custominfo_details(shell, "keyname")
 
         assert not shell.client.system.custominfo.listAllKeys.called
-        assert (
-            logger.debug.call_args_list[0][0][0]
-            == "customkey_details called with args: 'keyname', keys: ''."
-        )
-        assert (
-            logger.error.call_args_list[0][0][0]
-            == "No keys matched argument 'keyname'."
-        )
+        assert logger.debug.call_args_list[0][0][0] == "customkey_details called with args: 'keyname', keys: ''."
+        assert logger.error.call_args_list[0][0][0] == "No keys matched argument 'keyname'."
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_details_keydetails_notfound(self, shell):
         """
         Test do_custominfo_details nothing happens if keydetails missing.
@@ -236,7 +203,6 @@ class TestSCCusomInfo:
         assert shell.client.system.custominfo.listAllKeys.called
         assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_details_keydetails_na(self, shell):
         """
         Test do_custominfo_details prints key details not available in format.
@@ -257,15 +223,15 @@ class TestSCCusomInfo:
                 custominfo.do_custominfo_details(shell, "key*")
 
         expectations = [
-            "Label:        key_one",
-            "Description:  N/A",
-            "Modified:     N/A",
-            "System Count: 0",
-            "***",
-            "Label:        key_two",
-            "Description:  N/A",
-            "Modified:     N/A",
-            "System Count: 0",
+            'Label:        key_one',
+            'Description:  N/A',
+            'Modified:     N/A',
+            'System Count: 0',
+            '***',
+            'Label:        key_two',
+            'Description:  N/A',
+            'Modified:     N/A',
+            'System Count: 0'
         ]
 
         assert shell.client.system.custominfo.listAllKeys.called
@@ -273,7 +239,6 @@ class TestSCCusomInfo:
         for idx, call in enumerate(mprint.call_args_list):
             assert call[0][0] == expectations[idx]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_custominfo_details_keydetails(self, shell):
         """
         Test do_custominfo_details prints key details not available in format.
@@ -281,18 +246,8 @@ class TestSCCusomInfo:
         shell.SEPARATOR = "***"
         shell.client.system.custominfo.listAllKeys = MagicMock(
             return_value=[
-                {
-                    "label": "key_one",
-                    "description": "descr one",
-                    "last_modified": "123",
-                    "system_count": 1,
-                },
-                {
-                    "label": "key_two",
-                    "description": "descr two",
-                    "last_modified": "234",
-                    "system_count": 2,
-                },
+                {"label": "key_one", "description": "descr one", "last_modified": "123", "system_count": 1},
+                {"label": "key_two", "description": "descr two", "last_modified": "234", "system_count": 2},
             ]
         )
         shell.do_custominfo_listkeys = MagicMock(return_value=["key_one", "key_two"])
@@ -304,15 +259,15 @@ class TestSCCusomInfo:
                 custominfo.do_custominfo_details(shell, "key*")
 
         expectations = [
-            "Label:        key_one",
-            "Description:  descr one",
-            "Modified:     123",
-            "System Count: 1",
-            "***",
-            "Label:        key_two",
-            "Description:  descr two",
-            "Modified:     234",
-            "System Count: 2",
+            'Label:        key_one',
+            'Description:  descr one',
+            'Modified:     123',
+            'System Count: 1',
+            '***',
+            'Label:        key_two',
+            'Description:  descr two',
+            'Modified:     234',
+            'System Count: 2'
         ]
 
         assert shell.client.system.custominfo.listAllKeys.called
@@ -320,7 +275,6 @@ class TestSCCusomInfo:
         for idx, call in enumerate(mprint.call_args_list):
             assert call[0][0] == expectations[idx]
 
-    # pylint: disable-next=redefined-outer-name
     def test_custominfo_updatekey_noarg_name(self, shell):
         """
         Test do_custominfo_updatekey with no arguments falls to the interactive prompt.
@@ -333,22 +287,18 @@ class TestSCCusomInfo:
 
         assert "interactive mode" in exc2str(exc)
 
-    # pylint: disable-next=redefined-outer-name
     def test_custominfo_updatekey_noarg_descr(self, shell):
         """
         Test do_custominfo_updatekey with no arguments falls to the interactive prompt.
         """
         shell.client.system.custominfo.updateKey = MagicMock()
-        prompt = MagicMock(
-            side_effect=["keyname", Exception("interactive mode for descr")]
-        )
+        prompt = MagicMock(side_effect=["keyname", Exception("interactive mode for descr")])
         with patch("spacecmd.custominfo.prompt_user", prompt):
             with pytest.raises(Exception) as exc:
                 custominfo.do_custominfo_updatekey(shell, "")
 
         assert "interactive mode for descr" in exc2str(exc)
 
-    # pylint: disable-next=redefined-outer-name
     def test_custominfo_updatekey_keyonly_arg(self, shell):
         """
         Test do_custominfo_updatekey description is taken interactively.
@@ -361,7 +311,6 @@ class TestSCCusomInfo:
 
         assert "interactive mode for descr" in exc2str(exc)
 
-    # pylint: disable-next=redefined-outer-name
     def test_custominfo_updatekey_all_args(self, shell):
         """
         Test do_custominfo_updatekey description is taken by arguments, interactive mode is not initiated.
@@ -369,16 +318,10 @@ class TestSCCusomInfo:
         shell.client.system.custominfo.updateKey = MagicMock()
         prompt = MagicMock(side_effect=[Exception("interactive mode for descr")])
         with patch("spacecmd.custominfo.prompt_user", prompt):
-            custominfo.do_custominfo_updatekey(
-                shell, "keyname 'some key description here'"
-            )
+            custominfo.do_custominfo_updatekey(shell, "keyname 'some key description here'")
 
         assert shell.client.system.custominfo.updateKey.called
-        (
-            session,
-            keyname,
-            description,
-        ) = shell.client.system.custominfo.updateKey.call_args_list[0][0]
+        session, keyname, description = shell.client.system.custominfo.updateKey.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "keyname"
         assert description == "some key description here"

--- a/spacecmd/tests/test_distribution.py
+++ b/spacecmd/tests/test_distribution.py
@@ -4,11 +4,7 @@ Test distribution
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect
-
-# pylint: disable-next=unused-import
 import pytest
 import spacecmd.distribution
 
@@ -17,8 +13,6 @@ class TestSCDistribution:
     """
     Test suite for distribution commands of the spacecmd.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_create_no_args(self, shell):
         """
         Test do_distribution_create with no args.
@@ -26,25 +20,22 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.tree.listInstallTypes = MagicMock(
-            return_value=[
-                {"label": "image"},
-            ]
-        )
+        shell.client.kickstart.tree.listInstallTypes = MagicMock(return_value=[
+            {"label": "image"},
+        ])
         shell.client.kickstart.tree.update = MagicMock()
         shell.client.kickstart.tree.create = MagicMock()
         shell.list_base_channels = MagicMock(return_value=["base-channel"])
 
         mprint = MagicMock()
-        prompt = MagicMock(side_effect=["name", "/path/tree", "base-channel", "image"])
+        prompt = MagicMock(side_effect=[
+            "name", "/path/tree", "base-channel", "image"
+        ])
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.prompt_user",
-            prompt
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.distribution.logging", logger) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+            patch("spacecmd.distribution.prompt_user", prompt) as prmt, \
+            patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_create(shell, "")
 
         assert mprint.called
@@ -55,16 +46,9 @@ class TestSCDistribution:
 
         # Check STDOUT consistency
         exp = [
-            "",
-            "Base Channels",
-            "-------------",
-            "base-channel",
-            "",
-            "",
-            "Install Types",
-            "-------------",
-            "image",
-            "",
+            '', 'Base Channels',
+            '-------------', 'base-channel', '', '',
+            'Install Types', '-------------', 'image', ''
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
@@ -73,20 +57,12 @@ class TestSCDistribution:
 
         for call in shell.client.kickstart.tree.create.call_args_list:
             args, kw = call
-            assert args == (
-                shell.session,
-                "name",
-                "/path/tree",
-                "base-channel",
-                "image",
-            )
+            assert args == (shell.session, "name", "/path/tree", "base-channel", "image")
             assert not kw
 
-        assert_expect(
-            shell.client.kickstart.tree.listInstallTypes.call_args_list, shell.session
-        )
+        assert_expect(shell.client.kickstart.tree.listInstallTypes.call_args_list,
+                      shell.session)
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_create_no_args_update_mode(self, shell):
         """
         Test do_distribution_create with no args with update mode.
@@ -94,25 +70,22 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.tree.listInstallTypes = MagicMock(
-            return_value=[
-                {"label": "image"},
-            ]
-        )
+        shell.client.kickstart.tree.listInstallTypes = MagicMock(return_value=[
+            {"label": "image"},
+        ])
         shell.client.kickstart.tree.update = MagicMock()
         shell.client.kickstart.tree.create = MagicMock()
         shell.list_base_channels = MagicMock(return_value=["base-channel"])
 
         mprint = MagicMock()
-        prompt = MagicMock(side_effect=["name", "/path/tree", "base-channel", "image"])
+        prompt = MagicMock(side_effect=[
+            "name", "/path/tree", "base-channel", "image"
+        ])
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.prompt_user",
-            prompt
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.distribution.logging", logger) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+            patch("spacecmd.distribution.prompt_user", prompt) as prmt, \
+            patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_create(shell, "", update=True)
 
         assert not mprint.called
@@ -122,11 +95,8 @@ class TestSCDistribution:
         assert not shell.client.kickstart.tree.update.called
         assert logger.error.called
 
-        assert_expect(
-            logger.error.call_args_list, "The name of the distribution is required"
-        )
+        assert_expect(logger.error.call_args_list, "The name of the distribution is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_create_args_ds_update_mode(self, shell):
         """
         Test do_distribution_create with distribution name in update mode.
@@ -134,33 +104,17 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.tree.listInstallTypes = MagicMock(
-            return_value=[
-                {"label": "image"},
-            ]
-        )
-        shell.client.kickstart.tree.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "channel_id": "ch-id-1",
-                    "label": "myname",
-                    "abs_path": "/path/tree_old",
-                    "install_type": {"label": "image_old"},
-                },
-                {
-                    "channel_id": "ch-id-2",
-                    "label": "dist-2",
-                    "abs_path": "/tmp/d2",
-                    "install_type": {"label": "image_old"},
-                },
-            ]
-        )
-        shell.client.channel.software.getDetails = MagicMock(
-            side_effect=[
-                {"label": "base-channel-old"},
-                {"label": "channel-two"},
-            ]
-        )
+        shell.client.kickstart.tree.listInstallTypes = MagicMock(return_value=[
+            {"label": "image"},
+        ])
+        shell.client.kickstart.tree.getDetails = MagicMock(side_effect=[
+            {"channel_id": "ch-id-1", "label": "myname", "abs_path": "/path/tree_old", "install_type": {"label": "image_old"}},
+            {"channel_id": "ch-id-2", "label": "dist-2", "abs_path": "/tmp/d2", "install_type": {"label": "image_old"}},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"label": "base-channel-old"},
+            {"label": "channel-two"},
+        ])
         shell.client.kickstart.tree.update = MagicMock()
         shell.client.kickstart.tree.create = MagicMock()
         shell.list_base_channels = MagicMock(return_value=["base-channel"])
@@ -169,15 +123,10 @@ class TestSCDistribution:
         prompt = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.prompt_user",
-            prompt
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.distribution.logging", logger) as lgr:
-            spacecmd.distribution.do_distribution_create(
-                shell, "-n myname", update=True
-            )
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+            patch("spacecmd.distribution.prompt_user", prompt) as prmt, \
+            patch("spacecmd.distribution.logging", logger) as lgr:
+            spacecmd.distribution.do_distribution_create(shell, "-n myname", update=True)
 
         assert not mprint.called
         assert not prompt.called
@@ -187,16 +136,10 @@ class TestSCDistribution:
 
         for call in shell.client.kickstart.tree.update.call_args_list:
             args, kw = call
-            assert args == (
-                shell.session,
-                "myname",
-                "/path/tree_old",
-                "base-channel-old",
-                "image_old",
-            )
+            assert args == (shell.session, "myname", "/path/tree_old", "base-channel-old", "image_old")
             assert not kw
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_distribution_create_args_dspt_update_mode(self, shell):
         """
         Test do_distribution_create with distribution name and path in update mode.
@@ -204,33 +147,17 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.tree.listInstallTypes = MagicMock(
-            return_value=[
-                {"label": "image"},
-            ]
-        )
-        shell.client.kickstart.tree.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "channel_id": "ch-id-1",
-                    "label": "dist-1",
-                    "abs_path": "/tmp/d1",
-                    "install_type": {"label": "image_old"},
-                },
-                {
-                    "channel_id": "ch-id-2",
-                    "label": "dist-2",
-                    "abs_path": "/tmp/d2",
-                    "install_type": {"label": "image_old"},
-                },
-            ]
-        )
-        shell.client.channel.software.getDetails = MagicMock(
-            side_effect=[
-                {"label": "base-channel-old"},
-                {"label": "channel-two"},
-            ]
-        )
+        shell.client.kickstart.tree.listInstallTypes = MagicMock(return_value=[
+            {"label": "image"},
+        ])
+        shell.client.kickstart.tree.getDetails = MagicMock(side_effect=[
+            {"channel_id": "ch-id-1", "label": "dist-1", "abs_path": "/tmp/d1", "install_type": {"label": "image_old"}},
+            {"channel_id": "ch-id-2", "label": "dist-2", "abs_path": "/tmp/d2", "install_type": {"label": "image_old"}},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"label": "base-channel-old"},
+            {"label": "channel-two"},
+        ])
         shell.client.kickstart.tree.update = MagicMock()
         shell.client.kickstart.tree.create = MagicMock()
         shell.list_base_channels = MagicMock(return_value=["base-channel"])
@@ -239,15 +166,11 @@ class TestSCDistribution:
         prompt = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.prompt_user",
-            prompt
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.distribution.logging", logger) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+            patch("spacecmd.distribution.prompt_user", prompt) as prmt, \
+            patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_create(
-                shell, "-n myname -p /path/tree", update=True
-            )
+                shell, "-n myname -p /path/tree", update=True)
 
         assert not mprint.called
         assert not prompt.called
@@ -257,16 +180,10 @@ class TestSCDistribution:
 
         for call in shell.client.kickstart.tree.update.call_args_list:
             args, kw = call
-            assert args == (
-                shell.session,
-                "myname",
-                "/path/tree",
-                "base-channel-old",
-                "image_old",
-            )
+            assert args == (shell.session, "myname", "/path/tree", "base-channel-old", "image_old")
             assert not kw
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_distribution_create_args_dsptbc_update_mode(self, shell):
         """
         Test do_distribution_create with distribution name, path and base channel
@@ -275,33 +192,17 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.tree.listInstallTypes = MagicMock(
-            return_value=[
-                {"label": "image"},
-            ]
-        )
-        shell.client.kickstart.tree.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "channel_id": "ch-id-1",
-                    "label": "dist-1",
-                    "abs_path": "/tmp/d1",
-                    "install_type": {"label": "image_old"},
-                },
-                {
-                    "channel_id": "ch-id-2",
-                    "label": "dist-2",
-                    "abs_path": "/tmp/d2",
-                    "install_type": {"label": "image_old"},
-                },
-            ]
-        )
-        shell.client.channel.software.getDetails = MagicMock(
-            side_effect=[
-                {"label": "base-channel-old"},
-                {"label": "channel-two"},
-            ]
-        )
+        shell.client.kickstart.tree.listInstallTypes = MagicMock(return_value=[
+            {"label": "image"},
+        ])
+        shell.client.kickstart.tree.getDetails = MagicMock(side_effect=[
+            {"channel_id": "ch-id-1", "label": "dist-1", "abs_path": "/tmp/d1", "install_type": {"label": "image_old"}},
+            {"channel_id": "ch-id-2", "label": "dist-2", "abs_path": "/tmp/d2", "install_type": {"label": "image_old"}},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"label": "base-channel-old"},
+            {"label": "channel-two"},
+        ])
         shell.client.kickstart.tree.update = MagicMock()
         shell.client.kickstart.tree.create = MagicMock()
         shell.list_base_channels = MagicMock(return_value=["base-channel"])
@@ -310,15 +211,11 @@ class TestSCDistribution:
         prompt = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.prompt_user",
-            prompt
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.distribution.logging", logger) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+            patch("spacecmd.distribution.prompt_user", prompt) as prmt, \
+            patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_create(
-                shell, "-n myname -p /path/tree -b base-channel", update=True
-            )
+                shell, "-n myname -p /path/tree -b base-channel", update=True)
 
         assert not mprint.called
         assert not prompt.called
@@ -328,16 +225,10 @@ class TestSCDistribution:
 
         for call in shell.client.kickstart.tree.update.call_args_list:
             args, kw = call
-            assert args == (
-                shell.session,
-                "myname",
-                "/path/tree",
-                "base-channel",
-                "image_old",
-            )
+            assert args == (shell.session, "myname", "/path/tree", "base-channel", "image_old")
             assert not kw
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_distribution_create_args_dsptbcit_update_mode(self, shell):
         """
         Test do_distribution_create with distribution name, path, base channel
@@ -346,33 +237,17 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.tree.listInstallTypes = MagicMock(
-            return_value=[
-                {"label": "image"},
-            ]
-        )
-        shell.client.kickstart.tree.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "channel_id": "ch-id-1",
-                    "label": "dist-1",
-                    "abs_path": "/tmp/d1",
-                    "install_type": {"label": "image_old"},
-                },
-                {
-                    "channel_id": "ch-id-2",
-                    "label": "dist-2",
-                    "abs_path": "/tmp/d2",
-                    "install_type": {"label": "image_old"},
-                },
-            ]
-        )
-        shell.client.channel.software.getDetails = MagicMock(
-            side_effect=[
-                {"label": "base-channel-old"},
-                {"label": "channel-two"},
-            ]
-        )
+        shell.client.kickstart.tree.listInstallTypes = MagicMock(return_value=[
+            {"label": "image"},
+        ])
+        shell.client.kickstart.tree.getDetails = MagicMock(side_effect=[
+            {"channel_id": "ch-id-1", "label": "dist-1", "abs_path": "/tmp/d1", "install_type": {"label": "image_old"}},
+            {"channel_id": "ch-id-2", "label": "dist-2", "abs_path": "/tmp/d2", "install_type": {"label": "image_old"}},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"label": "base-channel-old"},
+            {"label": "channel-two"},
+        ])
         shell.client.kickstart.tree.update = MagicMock()
         shell.client.kickstart.tree.create = MagicMock()
         shell.list_base_channels = MagicMock(return_value=["base-channel"])
@@ -381,15 +256,11 @@ class TestSCDistribution:
         prompt = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.prompt_user",
-            prompt
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.distribution.logging", logger) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+            patch("spacecmd.distribution.prompt_user", prompt) as prmt, \
+            patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_create(
-                shell, "-n myname -p /path/tree -b base-channel -t image", update=True
-            )
+                shell, "-n myname -p /path/tree -b base-channel -t image", update=True)
 
         assert not mprint.called
         assert not prompt.called
@@ -400,16 +271,9 @@ class TestSCDistribution:
 
         for call in shell.client.kickstart.tree.update.call_args_list:
             args, kw = call
-            assert args == (
-                shell.session,
-                "myname",
-                "/path/tree",
-                "base-channel",
-                "image",
-            )
+            assert args == (shell.session, "myname", "/path/tree", "base-channel", "image")
             assert not kw
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_list_noarg_noret(self, shell):
         """
         Test do_distribution_list without argumnets, no return option.
@@ -417,19 +281,14 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.listAutoinstallableChannels = MagicMock(
-            return_value=[
-                {"label": "channel-name"},
-            ]
-        )
-        shell.client.kickstart.tree.list = MagicMock(
-            return_value=[
-                {"label": "some-channel"},
-                {"label": "some-other-channel"},
-            ]
-        )
+        shell.client.kickstart.listAutoinstallableChannels = MagicMock(return_value=[
+            {"label": "channel-name"},
+        ])
+        shell.client.kickstart.tree.list = MagicMock(return_value=[
+            {"label": "some-channel"},
+            {"label": "some-other-channel"},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.distribution.print", mprint) as prn:
             out = spacecmd.distribution.do_distribution_list(shell, "")
 
@@ -437,7 +296,6 @@ class TestSCDistribution:
         assert mprint.called
         assert_expect(mprint.call_args_list, "some-channel\nsome-other-channel")
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_list_noarg_ret(self, shell):
         """
         Test do_distribution_list without argumnets, return data mode.
@@ -445,29 +303,22 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        shell.client.kickstart.listAutoinstallableChannels = MagicMock(
-            return_value=[
-                {"label": "channel-name"},
-            ]
-        )
-        shell.client.kickstart.tree.list = MagicMock(
-            return_value=[
-                {"label": "some-channel"},
-                {"label": "some-other-channel"},
-            ]
-        )
+        shell.client.kickstart.listAutoinstallableChannels = MagicMock(return_value=[
+            {"label": "channel-name"},
+        ])
+        shell.client.kickstart.tree.list = MagicMock(return_value=[
+            {"label": "some-channel"},
+            {"label": "some-other-channel"},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.distribution.print", mprint) as prn:
             out = spacecmd.distribution.do_distribution_list(shell, "", doreturn=True)
 
         assert out is not None
-        # pylint: disable-next=unidiomatic-typecheck
         assert type(out) == list
         assert not mprint.called
-        assert out == ["some-channel", "some-other-channel"]
+        assert out == ['some-channel', 'some-other-channel']
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_delete_noargs(self, shell):
         """
         Test do_distribution_delete with no arguments.
@@ -482,12 +333,8 @@ class TestSCDistribution:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+                patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_delete(shell, "")
 
         assert not logger.debug.called
@@ -498,7 +345,6 @@ class TestSCDistribution:
         assert not shell.user_confirm.called
         assert shell.help_distribution_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_delete_args_no_match(self, shell):
         """
         Test do_distribution_delete with wrong arguments.
@@ -513,12 +359,8 @@ class TestSCDistribution:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+                patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_delete(shell, "foo*")
 
         assert logger.debug.called
@@ -528,15 +370,11 @@ class TestSCDistribution:
         assert not shell.user_confirm.called
         assert not shell.help_distribution_delete.called
 
-        assert_expect(
-            logger.debug.call_args_list,
-            "distribution_delete called with args ['foo.*'], dists=[]",
-        )
-        assert_expect(
-            logger.error.call_args_list, "No distributions matched argument ['foo.*']"
-        )
+        assert_expect(logger.debug.call_args_list,
+                      "distribution_delete called with args ['foo.*'], dists=[]")
+        assert_expect(logger.error.call_args_list,
+                      "No distributions matched argument ['foo.*']")
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_delete_args_match_no_confirm(self, shell):
         """
         Test do_distribution_delete with correct arguments, not confirmed to delete.
@@ -551,12 +389,8 @@ class TestSCDistribution:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+                patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_delete(shell, "b*")
 
         assert not logger.error.called
@@ -566,16 +400,12 @@ class TestSCDistribution:
         assert mprint.called
         assert shell.user_confirm.called
 
-        assert_expect(
-            logger.debug.call_args_list,
-            "distribution_delete called with args ['b.*'], dists=['bar']",
-        )
-        assert_expect(
-            shell.user_confirm.call_args_list, "Delete distribution tree(s) [y/N]:"
-        )
+        assert_expect(logger.debug.call_args_list,
+                      "distribution_delete called with args ['b.*'], dists=['bar']")
+        assert_expect(shell.user_confirm.call_args_list,
+                      "Delete distribution tree(s) [y/N]:")
         assert_expect(mprint.call_args_list, "bar")
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_delete_args_match_confirm(self, shell):
         """
         Test do_distribution_delete with correct arguments, confirmed to delete.
@@ -590,12 +420,8 @@ class TestSCDistribution:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+                patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_delete(shell, "b*")
 
         assert not logger.error.called
@@ -605,24 +431,16 @@ class TestSCDistribution:
         assert mprint.called
         assert shell.user_confirm.called
 
-        assert_expect(
-            logger.debug.call_args_list,
-            "distribution_delete called with args ['b.*'], dists=['bar']",
-        )
-        assert_expect(
-            shell.user_confirm.call_args_list, "Delete distribution tree(s) [y/N]:"
-        )
+        assert_expect(logger.debug.call_args_list,
+                      "distribution_delete called with args ['b.*'], dists=['bar']")
+        assert_expect(shell.user_confirm.call_args_list,
+                      "Delete distribution tree(s) [y/N]:")
         assert_expect(mprint.call_args_list, "bar")
 
         for call in shell.client.kickstart.tree.delete.call_args_list:
-            # pylint: disable-next=unused-variable
             args, kw = call
-            assert args == (
-                shell.session,
-                "bar",
-            )
+            assert args == (shell.session, "bar",)
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_details_noargs(self, shell):
         """
         Test do_distribution_details with no arguments.
@@ -637,12 +455,8 @@ class TestSCDistribution:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+                patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_details(shell, "")
 
         assert not logger.error.called
@@ -652,7 +466,6 @@ class TestSCDistribution:
         assert not shell.do_distribution_list.called
         assert shell.help_distribution_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_details_no_dists(self, shell):
         """
         Test do_distribution_details with no distributions found.
@@ -667,12 +480,8 @@ class TestSCDistribution:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+                patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_details(shell, "test*")
 
         assert not shell.client.kickstart.tree.getDetails.called
@@ -683,15 +492,11 @@ class TestSCDistribution:
         assert logger.error.called
         assert shell.do_distribution_list.called
 
-        assert_expect(
-            logger.debug.call_args_list,
-            "distribution_details called with args ['test.*'], dists=[]",
-        )
-        assert_expect(
-            logger.error.call_args_list, "No distributions matched argument ['test.*']"
-        )
+        assert_expect(logger.debug.call_args_list,
+                      "distribution_details called with args ['test.*'], dists=[]")
+        assert_expect(logger.error.call_args_list,
+                      "No distributions matched argument ['test.*']")
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_details_list(self, shell):
         """
         Test do_distribution_details lister.
@@ -700,29 +505,21 @@ class TestSCDistribution:
         :return:
         """
         shell.help_distribution_details = MagicMock()
-        shell.client.kickstart.tree.getDetails = MagicMock(
-            side_effect=[
-                {"channel_id": "ch-id-1", "label": "dist-1", "abs_path": "/tmp/d1"},
-                {"channel_id": "ch-id-2", "label": "dist-2", "abs_path": "/tmp/d2"},
-            ]
-        )
-        shell.client.channel.software.getDetails = MagicMock(
-            side_effect=[
-                {"label": "channel-one"},
-                {"label": "channel-two"},
-            ]
-        )
+        shell.client.kickstart.tree.getDetails = MagicMock(side_effect=[
+            {"channel_id": "ch-id-1", "label": "dist-1", "abs_path": "/tmp/d1"},
+            {"channel_id": "ch-id-2", "label": "dist-2", "abs_path": "/tmp/d2"},
+        ])
+        shell.client.channel.software.getDetails = MagicMock(side_effect=[
+            {"label": "channel-one"},
+            {"label": "channel-two"},
+        ])
         shell.do_distribution_list = MagicMock(return_value=["dist-1", "dist-2"])
         shell.SEPARATOR = "---"
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.distribution.print", mprint) as prn, patch(
-            "spacecmd.distribution.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.distribution.print", mprint) as prn, \
+                patch("spacecmd.distribution.logging", logger) as lgr:
             spacecmd.distribution.do_distribution_details(shell, "dist*")
 
         assert not shell.help_distribution_details.called
@@ -734,20 +531,19 @@ class TestSCDistribution:
         assert mprint.called
 
         exp = [
-            "Name:    dist-1",
-            "Path:    /tmp/d1",
-            "Channel: channel-one",
-            "---",
-            "Name:    dist-2",
-            "Path:    /tmp/d2",
-            "Channel: channel-two",
+            'Name:    dist-1',
+            'Path:    /tmp/d1',
+            'Channel: channel-one',
+            '---',
+            'Name:    dist-2',
+            'Path:    /tmp/d2',
+            'Channel: channel-two'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_rename_noargs(self, shell):
         """
         Test do_distribution_rename without arguments.
@@ -755,7 +551,6 @@ class TestSCDistribution:
         :param shell:
         :return:
         """
-        # pylint: disable-next=unused-variable
         for args in ["", "foo"]:
             shell.help_distribution_rename = MagicMock()
             shell.client.kickstart.tree.rename = MagicMock()
@@ -765,7 +560,6 @@ class TestSCDistribution:
             assert not shell.client.kickstart.tree.rename.called
             assert shell.help_distribution_rename.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_rename(self, shell):
         """
         Test do_distribution_rename.
@@ -782,11 +576,9 @@ class TestSCDistribution:
         assert shell.client.kickstart.tree.rename.called
 
         for call in shell.client.kickstart.tree.rename.call_args_list:
-            # pylint: disable-next=unused-variable
             args, kw = call
             assert args == (shell.session, "source", "destination")
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_update_noargs(self, shell):
         """
         Test do_distribution_update without arguments.
@@ -803,7 +595,6 @@ class TestSCDistribution:
         assert shell.do_distribution_create.called
         assert not shell.help_distribution_update.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_update(self, shell):
         """
         Test do_distribution_update.
@@ -822,10 +613,9 @@ class TestSCDistribution:
 
         for call in shell.do_distribution_create.call_args_list:
             args, kw = call
-            assert args == ("my-distro",)
+            assert args == ("my-distro", )
             assert kw == {"update": True}
 
-    # pylint: disable-next=redefined-outer-name
     def test_distribution_update_with_options(self, shell):
         """
         Test do_distribution_update with options.
@@ -844,5 +634,5 @@ class TestSCDistribution:
 
         for call in shell.do_distribution_create.call_args_list:
             args, kw = call
-            assert args == ("my-distro -p /tmp/distro",)
+            assert args == ("my-distro -p /tmp/distro", )
             assert kw == {"update": True}

--- a/spacecmd/tests/test_errata.py
+++ b/spacecmd/tests/test_errata.py
@@ -4,8 +4,6 @@ Test suite for the errata module.
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.errata
 from xmlrpc import client as xmlrpclib
@@ -16,8 +14,6 @@ class TestSCErrata:
     """
     Test suite for "errata" module.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_errata_list_nodata(self, shell):
         """
         Test do_errata_list return no data
@@ -29,7 +25,6 @@ class TestSCErrata:
         shell.all_errata = {"one": None, "two": None}
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             out = spacecmd.errata.do_errata_list(shell, "")
 
@@ -37,7 +32,6 @@ class TestSCErrata:
         assert shell.generate_errata_cache.called
         assert_expect(mprint.call_args_list, "one\ntwo")
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_list_with_data(self, shell):
         """
         Test do_errata_list return data for further processing
@@ -49,7 +43,6 @@ class TestSCErrata:
         shell.all_errata = {"one": None, "two": None}
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             out = spacecmd.errata.do_errata_list(shell, "", doreturn=True)
 
@@ -58,7 +51,6 @@ class TestSCErrata:
         assert sorted(out) == ["one", "two"]
         assert shell.generate_errata_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_listaffectedsystems_noargs(self, shell):
         """
         Test do_errata_listaffectedsystems without an arguments.
@@ -72,7 +64,6 @@ class TestSCErrata:
         shell.client.errata.listAffectedSystems = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_listaffectedsystems(shell, "")
 
@@ -81,7 +72,6 @@ class TestSCErrata:
         assert not mprint.called
         assert shell.help_errata_listaffectedsystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_listaffectedsystems_by_errata_name(self, shell):
         """
         Test do_errata_listaffectedsystems with errata name.
@@ -92,23 +82,12 @@ class TestSCErrata:
 
         shell.help_errata_listaffectedsystems = MagicMock()
         shell.expand_errata = MagicMock(return_value=["webstack", "databases"])
-        shell.client.errata.listAffectedSystems = MagicMock(
-            side_effect=[
-                [
-                    {"name": "web1.suse.com"},
-                    {"name": "web2.suse.com"},
-                    {"name": "web3.suse.com"},
-                ],
-                [
-                    {"name": "db1.suse.com"},
-                    {"name": "db2.suse.com"},
-                    {"name": "db3.suse.com"},
-                ],
-            ]
-        )
+        shell.client.errata.listAffectedSystems = MagicMock(side_effect=[
+            [{"name": "web1.suse.com"}, {"name": "web2.suse.com"}, {"name": "web3.suse.com"}],
+            [{"name": "db1.suse.com"}, {"name": "db2.suse.com"}, {"name": "db3.suse.com"}],
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_listaffectedsystems(shell, "foo")
 
@@ -117,18 +96,10 @@ class TestSCErrata:
         assert shell.expand_errata.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "webstack:",
-                "web1.suse.com\nweb2.suse.com\nweb3.suse.com",
-                "----------",
-                "databases:",
-                "db1.suse.com\ndb2.suse.com\ndb3.suse.com",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['webstack:', 'web1.suse.com\nweb2.suse.com\nweb3.suse.com',
+                                 '----------', 'databases:', 'db1.suse.com\ndb2.suse.com\ndb3.suse.com'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_listcves_noargs(self, shell):
         """
         Test do_errata_listcves without arguments.
@@ -141,7 +112,6 @@ class TestSCErrata:
         shell.expand_errata = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_listcves(shell, "")
 
@@ -150,7 +120,6 @@ class TestSCErrata:
         assert not mprint.called
         assert shell.help_errata_listcves.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_listcves_not_found(self, shell):
         """
         Test do_errata_listcves not found.
@@ -163,7 +132,6 @@ class TestSCErrata:
         shell.expand_errata = MagicMock(return_value=[])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_listcves(shell, "invalid")
 
@@ -173,7 +141,6 @@ class TestSCErrata:
         assert mprint.called
         assert_expect(mprint.call_args_list, "No errata has been found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_listcves_expanded(self, shell):
         """
         Test do_errata_listcves data print check.
@@ -182,16 +149,13 @@ class TestSCErrata:
         :return:
         """
         shell.help_errata_listcves = MagicMock()
-        shell.client.errata.listCves = MagicMock(
-            side_effect=[
-                ["CVE-1", "CVE-2", "CVE-3"],
-                ["CVE-11", "CVE-22", "CVE-33"],
-            ]
-        )
+        shell.client.errata.listCves = MagicMock(side_effect=[
+            ["CVE-1", "CVE-2", "CVE-3"],
+            ["CVE-11", "CVE-22", "CVE-33"],
+        ])
         shell.expand_errata = MagicMock(return_value=["one", "two"])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_listcves(shell, "CVE*")
 
@@ -200,18 +164,10 @@ class TestSCErrata:
         assert shell.expand_errata.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "one:",
-                "CVE-1\nCVE-2\nCVE-3",
-                "----------",
-                "two:",
-                "CVE-11\nCVE-22\nCVE-33",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['one:', 'CVE-1\nCVE-2\nCVE-3', '----------',
+                                 'two:', 'CVE-11\nCVE-22\nCVE-33'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_findbycve_noargs(self, shell):
         """
         Test do_errata_findbycve without arguments.
@@ -223,7 +179,6 @@ class TestSCErrata:
         shell.client.errata.findByCve = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_findbycve(shell, "")
 
@@ -231,7 +186,6 @@ class TestSCErrata:
         assert not mprint.called
         assert shell.help_errata_findbycve.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_findbycve_cvelist(self, shell):
         """
         Test do_errata_findbycve with CVE list.
@@ -240,20 +194,13 @@ class TestSCErrata:
         :return:
         """
         shell.help_errata_findbycve = MagicMock()
-        shell.client.errata.findByCve = MagicMock(
-            side_effect=[
-                [{"advisory_name": "CVE-123-a"}, {"advisory_name": "CVE-123-b"}],
-                [
-                    {"advisory_name": "CVE-234-a"},
-                    {"advisory_name": "CVE-234-b"},
-                    {"advisory_name": "CVE-234-c"},
-                ],
-                [{"advisory_name": "CVE-345-a"}],
-            ]
-        )
+        shell.client.errata.findByCve = MagicMock(side_effect=[
+            [{"advisory_name": "CVE-123-a"}, {"advisory_name": "CVE-123-b"}],
+            [{"advisory_name": "CVE-234-a"}, {"advisory_name": "CVE-234-b"}, {"advisory_name": "CVE-234-c"}],
+            [{"advisory_name": "CVE-345-a"}],
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_findbycve(shell, "123 234 345")
 
@@ -261,24 +208,11 @@ class TestSCErrata:
         assert shell.client.errata.findByCve.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "123:",
-                "CVE-123-a",
-                "CVE-123-b",
-                "----------",
-                "234:",
-                "CVE-234-a",
-                "CVE-234-b",
-                "CVE-234-c",
-                "----------",
-                "345:",
-                "CVE-345-a",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['123:', 'CVE-123-a', 'CVE-123-b', '----------',
+                                 '234:', 'CVE-234-a', 'CVE-234-b', 'CVE-234-c',
+                                 '----------', '345:', 'CVE-345-a'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_details_noargs(self, shell):
         """
         Test do_errata_details without arguments.
@@ -295,7 +229,6 @@ class TestSCErrata:
         shell.expand_errata = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.errata.print", mprint) as prt:
             spacecmd.errata.do_errata_details(shell, "")
 
@@ -308,7 +241,6 @@ class TestSCErrata:
         assert not mprint.called
         assert shell.help_errata_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_details_erratum_failure(self, shell):
         """
         Test do_errata_details erratum failure.
@@ -317,9 +249,7 @@ class TestSCErrata:
         :return:
         """
         shell.help_errata_details = MagicMock()
-        shell.client.errata.getDetails = MagicMock(
-            side_effect=xmlrpclib.Fault(faultCode=42, faultString="Kaboom!")
-        )
+        shell.client.errata.getDetails = MagicMock(side_effect=xmlrpclib.Fault(faultCode=42, faultString="Kaboom!"))
         shell.client.errata.listPackages = MagicMock()
         shell.client.errata.listAffectedSystems = MagicMock()
         shell.client.errata.listCves = MagicMock()
@@ -328,12 +258,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_details(shell, "cve*")
 
         assert shell.client.errata.getDetails.called
@@ -345,15 +271,12 @@ class TestSCErrata:
         assert logger.warning.called
         assert not shell.help_errata_details.called
 
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [
-                (("cve-one is not a valid erratum",), {}),
-                (("cve-two is not a valid erratum",), {}),
-            ],
-        )
+        assert_args_expect(logger.warning.call_args_list,
+                           [
+                               (("cve-one is not a valid erratum",), {}),
+                               (("cve-two is not a valid erratum",), {}),
+                           ])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_details_erratum_data(self, shell):
         """
         Test do_errata_details erratum data.
@@ -362,116 +285,101 @@ class TestSCErrata:
         :return:
         """
         shell.help_errata_details = MagicMock()
-        shell.client.errata.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "product": "PRODUCT-1",
-                    "type": "TYPE-1",
-                    "issue_date": "DATE-1",
-                    "topic": "The quick brown fox jumped over the lazy dog",
-                    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-                    "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
-                    "Vestibulum id ultrices nisi, mattis laoreet turpis. "
-                    "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
-                    "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
-                    "auctor aliquet leo porta. Integer ac justo arcu.",
-                    "notes": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-                    "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
-                    "Vestibulum id ultrices nisi, mattis laoreet turpis. Vestibulum ante "
-                    "ipsum primis in faucibus orci luctus et ultrices posuere cubilia "
-                    "Curae; Nam tincidunt quam quis tellus convallis, auctor aliquet leo porta. "
-                    "Integer ac justo arcu.",
-                    "solution": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-                    "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
-                    "Vestibulum id ultrices nisi, mattis laoreet turpis. "
-                    "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
-                    "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
-                    "auctor aliquet leo porta. Integer ac justo arcu.",
-                    "references": "AAA:AAA00-00.00 "
-                    "URL:http://foo.test.com/pub/advisory/00 "
-                    "BID:0000 "
-                    "URL:http://www.securityfocus.com/bid/0000 "
-                    "XF:weblogic-http-response-information(00000) "
-                    "URL:http://www.iss.net/security_center/static/00000.php ",
-                    "advisory_status": "retracted",
-                    "vendor_advisory": "https://www.test.com/support/update/update-up-123456-1",
-                },
-                {
-                    "product": "PRODUCT-2",
-                    "type": "TYPE-2",
-                    "issue_date": "DATE-2",
-                    "topic": "The quick brown fox jumped over the lazy dog",
-                    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-                    "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
-                    "Vestibulum id ultrices nisi, mattis laoreet turpis. "
-                    "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
-                    "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
-                    "auctor aliquet leo porta. Integer ac justo arcu.",
-                    "notes": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-                    "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
-                    "Vestibulum id ultrices nisi, mattis laoreet turpis. Vestibulum ante "
-                    "ipsum primis in faucibus orci luctus et ultrices posuere cubilia "
-                    "Curae; Nam tincidunt quam quis tellus convallis, auctor aliquet leo porta. "
-                    "Integer ac justo arcu.",
-                    "solution": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
-                    "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
-                    "Vestibulum id ultrices nisi, mattis laoreet turpis. "
-                    "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
-                    "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
-                    "auctor aliquet leo porta. Integer ac justo arcu.",
-                    "references": "AAA:AAA11-11.11 "
-                    "URL:http://foo.test.com/pub/advisory/11 "
-                    "BID:1111 "
-                    "URL:http://www.securityfocus.com/bid/1111 "
-                    "XF:weblogic-http-response-information(11111) "
-                    "URL:http://www.iss.net/security_center/static/11111.php ",
-                    "vendor_advisory": "https://www.test.com/support/update/update-up-123456-2",
-                },
-            ]
-        )
-        shell.client.errata.listPackages = MagicMock(
-            side_effect=[
-                [
-                    {"name": "vim", "version": "42", "release": "123", "arch": "x86"},
-                    {"name": "pico", "version": "1", "release": "234", "arch": "x86"},
-                ],
-                [
-                    {"name": "vim", "version": "28", "release": "45", "arch": "x86"},
-                    {"name": "pico", "version": "2", "release": "12", "arch": "x86"},
-                ],
-            ]
-        )
-        shell.client.errata.listAffectedSystems = MagicMock(
-            side_effect=[
-                [10001000, 10001002, 10001005],
-                [10001000, 10001001],
-            ]
-        )
-        shell.client.errata.listCves = MagicMock(
-            side_effect=[
-                ["CVE-1", "CVE-1a"],
-                ["CVE-2", "CVE-2a", "CVE-2b"],
-            ]
-        )
-        shell.client.errata.applicableToChannels = MagicMock(
-            side_effect=[
-                [{"label": "base_channel"}, {"label": "editors_channel"}],
-                [
-                    {"label": "another_base_channel"},
-                    {"label": "special_editors_channel"},
-                ],
-            ]
-        )
+        shell.client.errata.getDetails = MagicMock(side_effect=[
+            {
+                "product": "PRODUCT-1", "type": "TYPE-1", "issue_date": "DATE-1",
+                "topic": "The quick brown fox jumped over the lazy dog",
+                "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                               "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
+                               "Vestibulum id ultrices nisi, mattis laoreet turpis. "
+                               "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
+                               "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
+                               "auctor aliquet leo porta. Integer ac justo arcu.",
+                "notes": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                         "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
+                         "Vestibulum id ultrices nisi, mattis laoreet turpis. Vestibulum ante "
+                         "ipsum primis in faucibus orci luctus et ultrices posuere cubilia "
+                         "Curae; Nam tincidunt quam quis tellus convallis, auctor aliquet leo porta. "
+                         "Integer ac justo arcu.",
+                "solution": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                            "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
+                            "Vestibulum id ultrices nisi, mattis laoreet turpis. "
+                            "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
+                            "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
+                            "auctor aliquet leo porta. Integer ac justo arcu.",
+                "references": "AAA:AAA00-00.00 "
+                              "URL:http://foo.test.com/pub/advisory/00 "
+                              "BID:0000 "
+                              "URL:http://www.securityfocus.com/bid/0000 "
+                              "XF:weblogic-http-response-information(00000) "
+                              "URL:http://www.iss.net/security_center/static/00000.php ",
+                "advisory_status": "retracted",
+                "vendor_advisory": "https://www.test.com/support/update/update-up-123456-1",
+
+            },
+            {
+                "product": "PRODUCT-2", "type": "TYPE-2", "issue_date": "DATE-2",
+                "topic": "The quick brown fox jumped over the lazy dog",
+                "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                               "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
+                               "Vestibulum id ultrices nisi, mattis laoreet turpis. "
+                               "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
+                               "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
+                               "auctor aliquet leo porta. Integer ac justo arcu.",
+                "notes": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                         "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
+                         "Vestibulum id ultrices nisi, mattis laoreet turpis. Vestibulum ante "
+                         "ipsum primis in faucibus orci luctus et ultrices posuere cubilia "
+                         "Curae; Nam tincidunt quam quis tellus convallis, auctor aliquet leo porta. "
+                         "Integer ac justo arcu.",
+                "solution": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "
+                            "Morbi volutpat felis sem, nec condimentum magna facilisis sed. "
+                            "Vestibulum id ultrices nisi, mattis laoreet turpis. "
+                            "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices "
+                            "posuere cubilia Curae; Nam tincidunt quam quis tellus convallis, "
+                            "auctor aliquet leo porta. Integer ac justo arcu.",
+                "references": "AAA:AAA11-11.11 "
+                              "URL:http://foo.test.com/pub/advisory/11 "
+                              "BID:1111 "
+                              "URL:http://www.securityfocus.com/bid/1111 "
+                              "XF:weblogic-http-response-information(11111) "
+                              "URL:http://www.iss.net/security_center/static/11111.php ",
+                "vendor_advisory": "https://www.test.com/support/update/update-up-123456-2",
+
+            },
+        ])
+        shell.client.errata.listPackages = MagicMock(side_effect=[
+            [
+                {"name": "vim", "version": "42", "release": "123", "arch": "x86"},
+                {"name": "pico", "version": "1", "release": "234", "arch": "x86"},
+            ],
+            [
+                {"name": "vim", "version": "28", "release": "45", "arch": "x86"},
+                {"name": "pico", "version": "2", "release": "12", "arch": "x86"},
+            ],
+        ])
+        shell.client.errata.listAffectedSystems = MagicMock(side_effect=[
+            [10001000, 10001002, 10001005],
+            [10001000, 10001001],
+        ])
+        shell.client.errata.listCves = MagicMock(side_effect=[
+            ["CVE-1", "CVE-1a"],
+            ["CVE-2", "CVE-2a", "CVE-2b"],
+        ])
+        shell.client.errata.applicableToChannels = MagicMock(side_effect=[
+            [
+                {"label": "base_channel"}, {"label": "editors_channel"}
+            ],
+            [
+                {"label": "another_base_channel"}, {"label": "special_editors_channel"}
+            ],
+        ])
         shell.expand_errata = MagicMock(return_value=["cve-one", "cve-two"])
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_details(shell, "cve*")
 
         assert not logger.warning.called
@@ -483,132 +391,61 @@ class TestSCErrata:
         assert shell.client.errata.applicableToChannels.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Name:       cve-one",
-                "Product:    PRODUCT-1",
-                "Type:       TYPE-1",
-                "Status:     retracted",
-                "Issue Date: DATE-1",
-                "",
-                "Topic",
-                "-----",
-                "The quick brown fox jumped over the lazy dog",
-                "",
-                "Description",
-                "-----------",
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, "
-                "nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet "
-                "turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere "
-                "cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. "
-                "Integer ac justo\narcu.",
-                "",
-                "Notes",
-                "-----",
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, "
-                "nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet "
-                "turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere "
-                "cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. "
-                "Integer ac justo\narcu.",
-                "",
-                "CVEs",
-                "----",
-                "CVE-1\nCVE-1a",
-                "",
-                "Vendor Advisory",
-                "---------------",
-                "https://www.test.com/support/update/update-up-123456-1",
-                "",
-                "Solution",
-                "--------",
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, "
-                "nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet "
-                "turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere "
-                "cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. "
-                "Integer ac justo\narcu.",
-                "",
-                "References",
-                "----------",
-                "AAA:AAA00-00.00 URL:http://foo.test.com/pub/advisory/00 BID:0000\n"
-                "URL:http://www.securityfocus.com/bid/0000 XF:weblogic-http-response-\n"
-                "information(00000)\nURL:http://www.iss.net/security_center/static/00000.php",
-                "",
-                "Affected Channels",
-                "-----------------",
-                "base_channel\neditors_channel",
-                "",
-                "Affected Systems",
-                "----------------",
-                "3",
-                "",
-                "Affected Packages",
-                "-----------------",
-                "pico-1-234.x86\nvim-42-123.x86",
-                "----------",
-                "Name:       cve-two",
-                "Product:    PRODUCT-2",
-                "Type:       TYPE-2",
-                "Status:     N/A",
-                "Issue Date: DATE-2",
-                "",
-                "Topic",
-                "-----",
-                "The quick brown fox jumped over the lazy dog",
-                "",
-                "Description",
-                "-----------",
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, "
-                "nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet "
-                "turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere "
-                "cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. "
-                "Integer ac justo\narcu.",
-                "",
-                "Notes",
-                "-----",
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, "
-                "nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet "
-                "turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere "
-                "cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. "
-                "Integer ac justo\narcu.",
-                "",
-                "CVEs",
-                "----",
-                "CVE-2\nCVE-2a\nCVE-2b",
-                "",
-                "Vendor Advisory",
-                "---------------",
-                "https://www.test.com/support/update/update-up-123456-2",
-                "",
-                "Solution",
-                "--------",
-                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, "
-                "nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet "
-                "turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere "
-                "cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. "
-                "Integer ac justo\narcu.",
-                "",
-                "References",
-                "----------",
-                "AAA:AAA11-11.11 URL:http://foo.test.com/pub/advisory/11 BID:1111\n"
-                "URL:http://www.securityfocus.com/bid/1111 XF:weblogic-http-response-\n"
-                "information(11111)\nURL:http://www.iss.net/security_center/static/11111.php",
-                "",
-                "Affected Channels",
-                "-----------------",
-                "another_base_channel\n" "special_editors_channel",
-                "",
-                "Affected Systems",
-                "----------------",
-                "2",
-                "",
-                "Affected Packages",
-                "-----------------",
-                "pico-2-12.x86\nvim-28-45.x86",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Name:       cve-one', 'Product:    PRODUCT-1', 'Type:       TYPE-1',
+                                 'Status:     retracted', 'Issue Date: DATE-1', '', 'Topic', '-----',
+                                 'The quick brown fox jumped over the lazy dog', '', 'Description', '-----------',
+                                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, '
+                                 'nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet '
+                                 'turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere '
+                                 'cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. '
+                                 'Integer ac justo\narcu.', '', 'Notes', '-----',
+                                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, '
+                                 'nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet '
+                                 'turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere '
+                                 'cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. '
+                                 'Integer ac justo\narcu.',
+                                 '', 'CVEs', '----', 'CVE-1\nCVE-1a', '', 'Vendor Advisory', '---------------',
+                                 'https://www.test.com/support/update/update-up-123456-1', '', 'Solution', '--------',
+                                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, '
+                                 'nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet '
+                                 'turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere '
+                                 'cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. '
+                                 'Integer ac justo\narcu.', '', 'References', '----------',
+                                 'AAA:AAA00-00.00 URL:http://foo.test.com/pub/advisory/00 BID:0000\n'
+                                 'URL:http://www.securityfocus.com/bid/0000 XF:weblogic-http-response-\n'
+                                 'information(00000)\nURL:http://www.iss.net/security_center/static/00000.php', '',
+                                 'Affected Channels', '-----------------', 'base_channel\neditors_channel', '',
+                                 'Affected Systems', '----------------', '3', '', 'Affected Packages',
+                                 '-----------------', 'pico-1-234.x86\nvim-42-123.x86', '----------',
+                                 'Name:       cve-two', 'Product:    PRODUCT-2', 'Type:       TYPE-2',
+                                 'Status:     N/A', 'Issue Date: DATE-2', '', 'Topic', '-----',
+                                 'The quick brown fox jumped over the lazy dog', '', 'Description', '-----------',
+                                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, '
+                                 'nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet '
+                                 'turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere '
+                                 'cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. '
+                                 'Integer ac justo\narcu.', '', 'Notes', '-----',
+                                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, '
+                                 'nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet '
+                                 'turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere '
+                                 'cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. '
+                                 'Integer ac justo\narcu.',
+                                 '', 'CVEs', '----', 'CVE-2\nCVE-2a\nCVE-2b', '', 'Vendor Advisory', '---------------',
+                                 'https://www.test.com/support/update/update-up-123456-2', '', 'Solution', '--------',
+                                 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi\nvolutpat felis sem, '
+                                 'nec condimentum magna facilisis sed. Vestibulum id\nultrices nisi, mattis laoreet '
+                                 'turpis. Vestibulum ante ipsum primis in\nfaucibus orci luctus et ultrices posuere '
+                                 'cubilia Curae; Nam tincidunt\nquam quis tellus convallis, auctor aliquet leo porta. '
+                                 'Integer ac justo\narcu.', '', 'References', '----------',
+                                 'AAA:AAA11-11.11 URL:http://foo.test.com/pub/advisory/11 BID:1111\n'
+                                 'URL:http://www.securityfocus.com/bid/1111 XF:weblogic-http-response-\n'
+                                 'information(11111)\nURL:http://www.iss.net/security_center/static/11111.php',
+                                 '', 'Affected Channels', '-----------------', 'another_base_channel\n'
+                                                                               'special_editors_channel',
+                                 '', 'Affected Systems', '----------------', '2', '', 'Affected Packages',
+                                 '-----------------', 'pico-2-12.x86\nvim-28-45.x86'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_details_erratum_none_data(self, shell):
         """
         Test do_errata_details erratum none data.
@@ -618,33 +455,25 @@ class TestSCErrata:
         """
         shell.help_errata_details = MagicMock()
         shell.client.errata.getDetails = MagicMock(side_effect=[{}, {}])
-        shell.client.errata.listPackages = MagicMock(
-            side_effect=[
-                [
-                    {"name": "vim", "version": "42", "release": "123", "arch": "x86"},
-                    {"name": "pico", "version": "1", "release": "234", "arch": "x86"},
-                ],
-                [
-                    {"name": "vim", "version": "28", "release": "45", "arch": "x86"},
-                    {"name": "pico", "version": "2", "release": "12", "arch": "x86"},
-                ],
-            ]
-        )
+        shell.client.errata.listPackages = MagicMock(side_effect=[
+            [
+                {"name": "vim", "version": "42", "release": "123", "arch": "x86"},
+                {"name": "pico", "version": "1", "release": "234", "arch": "x86"},
+            ],
+            [
+                {"name": "vim", "version": "28", "release": "45", "arch": "x86"},
+                {"name": "pico", "version": "2", "release": "12", "arch": "x86"},
+            ],
+        ])
         shell.client.errata.listAffectedSystems = MagicMock(side_effect=[[], []])
         shell.client.errata.listCves = MagicMock(side_effect=[[], []])
-        shell.client.errata.applicableToChannels = MagicMock(
-            side_effect=[[{}, {}], [{}, {}]]
-        )
+        shell.client.errata.applicableToChannels = MagicMock(side_effect=[[{}, {}], [{}, {}]])
         shell.expand_errata = MagicMock(return_value=["cve-one", "cve-two"])
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_details(shell, "cve*")
 
         assert not logger.warning.called
@@ -656,96 +485,22 @@ class TestSCErrata:
         assert shell.client.errata.applicableToChannels.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Name:       cve-one",
-                "Product:    N/A",
-                "Type:       N/A",
-                "Status:     N/A",
-                "Issue Date: N/A",
-                "",
-                "Topic",
-                "-----",
-                "N/A",
-                "",
-                "Description",
-                "-----------",
-                "N/A",
-                "",
-                "CVEs",
-                "----",
-                "",
-                "",
-                "Vendor Advisory",
-                "---------------",
-                "N/A",
-                "",
-                "Solution",
-                "--------",
-                "N/A",
-                "",
-                "References",
-                "----------",
-                "N/A",
-                "",
-                "Affected Channels",
-                "-----------------",
-                "",
-                "",
-                "Affected Systems",
-                "----------------",
-                "0",
-                "",
-                "Affected Packages",
-                "-----------------",
-                "pico-1-234.x86\nvim-42-123.x86",
-                "----------",
-                "Name:       cve-two",
-                "Product:    N/A",
-                "Type:       N/A",
-                "Status:     N/A",
-                "Issue Date: N/A",
-                "",
-                "Topic",
-                "-----",
-                "N/A",
-                "",
-                "Description",
-                "-----------",
-                "N/A",
-                "",
-                "CVEs",
-                "----",
-                "",
-                "",
-                "Vendor Advisory",
-                "---------------",
-                "N/A",
-                "",
-                "Solution",
-                "--------",
-                "N/A",
-                "",
-                "References",
-                "----------",
-                "N/A",
-                "",
-                "Affected Channels",
-                "-----------------",
-                "",
-                "",
-                "Affected Systems",
-                "----------------",
-                "0",
-                "",
-                "Affected Packages",
-                "-----------------",
-                "pico-2-12.x86\nvim-28-45.x86",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Name:       cve-one', 'Product:    N/A', 'Type:       N/A', 'Status:     N/A',
+                                 'Issue Date: N/A', '', 'Topic', '-----', 'N/A', '', 'Description', '-----------', 'N/A',
+                                 '', 'CVEs', '----', '', '', 'Vendor Advisory', '---------------', 'N/A',
+                                 '', 'Solution', '--------', 'N/A', '', 'References',
+                                 '----------', 'N/A', '', 'Affected Channels',
+                                 '-----------------', '', '', 'Affected Systems', '----------------', '0', '',
+                                 'Affected Packages', '-----------------', 'pico-1-234.x86\nvim-42-123.x86',
+                                 '----------', 'Name:       cve-two', 'Product:    N/A', 'Type:       N/A',
+                                 'Status:     N/A', 'Issue Date: N/A', '', 'Topic', '-----', 'N/A', '', 'Description',
+                                 '-----------', 'N/A', '', 'CVEs', '----', '', '', 'Vendor Advisory', '---------------',
+                                 'N/A', '', 'Solution', '--------', 'N/A', '',
+                                 'References', '----------', 'N/A', '', 'Affected Channels', '-----------------', '',
+                                 '', 'Affected Systems', '----------------', '0', '', 'Affected Packages',
+                                 '-----------------', 'pico-2-12.x86\nvim-28-45.x86'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_delete_noargs(self, shell):
         """
         Test do_errata_delete without arguments.
@@ -762,12 +517,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_delete(shell, "")
 
         assert not shell.expand_errata.called
@@ -780,7 +531,6 @@ class TestSCErrata:
         assert not logger.warning.called
         assert shell.help_errata_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_delete_no_errata(self, shell):
         """
         Test do_errata_delete without errata.
@@ -797,12 +547,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_delete(shell, "CVE-X")
 
         assert not shell.user_confirm.called
@@ -815,9 +561,9 @@ class TestSCErrata:
         assert logger.warning.called
         assert shell.expand_errata.called
 
-        assert_expect(logger.warning.call_args_list, "No patches to delete")
+        assert_expect(logger.warning.call_args_list,
+                      "No patches to delete")
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_delete_no_errata_non_interactive(self, shell):
         """
         Test do_errata_delete without errata (non-interactive mode).
@@ -828,24 +574,18 @@ class TestSCErrata:
         shell.help_errata_delete = MagicMock()
         shell.expand_errata = MagicMock(return_value=["CVE-1", "CVE-2"])
         shell.user_confirm = MagicMock()
-        shell.client.errata.applicableToChannels = MagicMock(
-            side_effect=[
-                ["base_channel", "special_channel"],
-                ["vim_users_channel"],
-            ]
-        )
+        shell.client.errata.applicableToChannels = MagicMock(side_effect=[
+            ["base_channel", "special_channel"],
+            ["vim_users_channel"],
+        ])
         shell.client.errata.delete = MagicMock()
         shell.generate_errata_cache = MagicMock()
         shell.options.yes = True
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_delete(shell, "CVE-X")
 
         assert not shell.help_errata_delete.called
@@ -858,37 +598,15 @@ class TestSCErrata:
         assert logger.info.called
         assert shell.expand_errata.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Erratum            Channels",
-                "-------            --------",
-                "CVE-1                     2",
-                "CVE-2                     1",
-            ],
-        )
-        assert_list_args_expect(logger.info.call_args_list, ["Deleted 2 patches"])
-        assert_args_expect(
-            shell.client.errata.delete.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "CVE-1",
-                    ),
-                    {},
-                ),
-                (
-                    (
-                        shell.session,
-                        "CVE-2",
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Erratum            Channels',
+                                 '-------            --------',
+                                 'CVE-1                     2',
+                                 'CVE-2                     1'])
+        assert_list_args_expect(logger.info.call_args_list, ['Deleted 2 patches'])
+        assert_args_expect(shell.client.errata.delete.call_args_list,
+                           [((shell.session, "CVE-1",), {}), ((shell.session, "CVE-2",), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_publish_noargs(self, shell):
         """
         Test do_errata_publish without arguments.
@@ -903,12 +621,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_publish(shell, "")
 
         assert not shell.expand_errata.called
@@ -918,7 +632,6 @@ class TestSCErrata:
         assert not logger.warning.called
         assert shell.help_errata_publish.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_publish_no_errata(self, shell):
         """
         Test do_errata_publish no errata found.
@@ -933,12 +646,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_publish(shell, "CVE-1 base_channel")
 
         assert not shell.user_confirm.called
@@ -947,11 +656,9 @@ class TestSCErrata:
         assert not shell.help_errata_publish.called
         assert shell.expand_errata.called
         assert logger.warning.called
-        assert_list_args_expect(
-            logger.warning.call_args_list, ["No patches to publish"]
-        )
+        assert_list_args_expect(logger.warning.call_args_list,
+                                ["No patches to publish"])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_publish_no_interactive(self, shell):
         """
         Test do_errata_publish publish to channel without interactive mode
@@ -967,12 +674,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_publish(shell, "CVE-1 base_channel")
 
         assert not logger.warning.called
@@ -981,17 +684,12 @@ class TestSCErrata:
         assert shell.client.errata.publish.called
         assert mprint.called
         assert shell.expand_errata.called
-        assert_expect(mprint.call_args_list, "one\nthree\ntwo")
-        assert_args_expect(
-            shell.client.errata.publish.call_args_list,
-            [
-                ((shell.session, "one", ["base_channel"]), {}),
-                ((shell.session, "two", ["base_channel"]), {}),
-                ((shell.session, "three", ["base_channel"]), {}),
-            ],
-        )
+        assert_expect(mprint.call_args_list, 'one\nthree\ntwo')
+        assert_args_expect(shell.client.errata.publish.call_args_list,
+                           [((shell.session, 'one', ['base_channel']), {}),
+                            ((shell.session, 'two', ['base_channel']), {}),
+                            ((shell.session, 'three', ['base_channel']), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_search_noargs(self, shell):
         """
         Test do_errata_search without arguments.
@@ -1007,12 +705,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_search(shell, "")
 
         assert not shell.expand_errata.called
@@ -1022,7 +716,6 @@ class TestSCErrata:
         assert not logger.warning.called
         assert shell.help_errata_search.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_search_by_cve_no_data(self, shell):
         """
         Test do_errata_search without arguments.
@@ -1033,16 +726,10 @@ class TestSCErrata:
         shell.help_errata_search = MagicMock()
         shell.expand_errata = MagicMock()
         shell.generate_errata_cache = MagicMock()
-        shell.client.errata.findByCve = MagicMock(
-            return_value=[
-                {
-                    "date": None,
-                    "issue_date": "2019 01 01",
-                    "advisory_name": "CVE-123",
-                    "advisory_synopsis": "<SYNOPSIS>",
-                }
-            ]
-        )
+        shell.client.errata.findByCve = MagicMock(return_value=[
+            {"date": None, "issue_date": "2019 01 01", "advisory_name": "CVE-123",
+             "advisory_synopsis": "<SYNOPSIS>"}
+        ])
         shell.all_errata = {}
         mprint = MagicMock()
         logger = MagicMock()
@@ -1058,12 +745,9 @@ class TestSCErrata:
             """
             mp_out.append(erratum)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.print_errata_summary",
-            prn_err_summary
-            # pylint: disable-next=unused-variable
-        ) as pes, patch("spacecmd.errata.logging", logger) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.print_errata_summary", prn_err_summary) as pes, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             out = spacecmd.errata.do_errata_search(shell, "CVE-123-23456")
 
         assert not shell.expand_errata.called
@@ -1073,19 +757,13 @@ class TestSCErrata:
         assert not shell.help_errata_search.called
         assert out is None
         assert shell.client.errata.findByCve.called
-        # pylint: disable-next=unidiomatic-typecheck
         assert type(mp_out) == list
         assert len(mp_out) == 1
-        for key, value in {
-            "date": None,
-            "issue_date": "2019 01 01",
-            "advisory_name": "CVE-123",
-            "advisory_synopsis": "<SYNOPSIS>",
-        }.items():
+        for key, value in {'date': None, 'issue_date': '2019 01 01',
+                           'advisory_name': 'CVE-123', 'advisory_synopsis': '<SYNOPSIS>'}.items():
             assert key in mp_out[0]
             assert mp_out[0][key] == value
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_search_by_cve_with_data(self, shell):
         """
         Test do_errata_search with data return
@@ -1096,30 +774,19 @@ class TestSCErrata:
         shell.help_errata_search = MagicMock()
         shell.expand_errata = MagicMock()
         shell.generate_errata_cache = MagicMock()
-        shell.client.errata.findByCve = MagicMock(
-            return_value=[
-                {
-                    "date": None,
-                    "issue_date": "2019 01 01",
-                    "advisory_name": "CVE-123",
-                    "advisory_synopsis": "<SYNOPSIS>",
-                }
-            ]
-        )
+        shell.client.errata.findByCve = MagicMock(return_value=[
+            {"date": None, "issue_date": "2019 01 01", "advisory_name": "CVE-123",
+             "advisory_synopsis": "<SYNOPSIS>"}
+        ])
         shell.all_errata = {}
         mprint = MagicMock()
         logger = MagicMock()
         prn_err_summary = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.print_errata_summary",
-            prn_err_summary
-            # pylint: disable-next=unused-variable
-        ) as pes, patch("spacecmd.errata.logging", logger) as lgr:
-            out = spacecmd.errata.do_errata_search(
-                shell, "CVE-123-23456", doreturn=True
-            )
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.print_errata_summary", prn_err_summary) as pes, \
+                patch("spacecmd.errata.logging", logger) as lgr:
+            out = spacecmd.errata.do_errata_search(shell, "CVE-123-23456", doreturn=True)
 
         assert not shell.expand_errata.called
         assert not shell.generate_errata_cache.called
@@ -1129,9 +796,8 @@ class TestSCErrata:
         assert not prn_err_summary.called
         assert out is not None
         assert shell.client.errata.findByCve.called
-        assert out == ["CVE-123"]
+        assert out == ['CVE-123']
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_apply_noargs(self, shell):
         """
         Test do_errata_apply without arguments.
@@ -1151,12 +817,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_apply(shell, "")
 
         assert not shell.user_confirm.called
@@ -1170,7 +832,6 @@ class TestSCErrata:
         assert not logger.warning.called
         assert shell.help_errata_apply.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_apply_non_interactive_no_errata(self, shell):
         """
         Test do_errata_apply non-interactive, no patches to apply.
@@ -1192,12 +853,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_apply(shell, "foo -s 201901011030")
 
         assert not shell.help_errata_apply.called
@@ -1210,9 +867,9 @@ class TestSCErrata:
         assert not mprint.called
         assert logger.warning.called
 
-        assert_expect(logger.warning.call_args_list, "No patches to apply")
+        assert_expect(logger.warning.call_args_list,
+                      "No patches to apply")
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_apply_non_interactive_affects_no_system(self, shell):
         """
         Test do_errata_apply non-interactive, no systems affected.
@@ -1224,9 +881,7 @@ class TestSCErrata:
         shell.user_confirm = MagicMock()
         shell.check_api_version = MagicMock()
         shell.get_system_id = MagicMock()
-        shell.expand_errata = MagicMock(
-            return_value=["cve-one", "cve-two", "cve-three"]
-        )
+        shell.expand_errata = MagicMock(return_value=["cve-one", "cve-two", "cve-three"])
         shell.client.errata.listAffectedSystems = MagicMock(return_value=[])
         shell.client.system.getUnscheduledErrata = MagicMock()
         shell.client.system.scheduleApplyErrata = MagicMock()
@@ -1236,12 +891,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_apply(shell, "cve* -s 201901011030")
 
         assert not shell.help_errata_apply.called
@@ -1256,17 +907,13 @@ class TestSCErrata:
         assert logger.warning.called
         assert logger.debug.called
 
-        assert_list_args_expect(
-            logger.debug.call_args_list,
-            [
-                "cve-one does not affect any systems",
-                "cve-two does not affect any systems",
-                "cve-three does not affect any systems",
-            ],
-        )
-        assert_expect(logger.warning.call_args_list, "No patches to apply")
+        assert_list_args_expect(logger.debug.call_args_list,
+                                ['cve-one does not affect any systems',
+                                 'cve-two does not affect any systems',
+                                 'cve-three does not affect any systems'])
+        assert_expect(logger.warning.call_args_list,
+                      "No patches to apply")
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_apply_non_interactive_api_10_11(self, shell):
         """
         Test do_errata_apply non-interactive, API 10.11 version.
@@ -1277,37 +924,30 @@ class TestSCErrata:
         shell.help_errata_apply = MagicMock()
         shell.user_confirm = MagicMock(return_value=True)
         shell.check_api_version = MagicMock(return_value=True)
-        shell.get_system_id = (
-            lambda data: zlib.adler32(data.encode("utf-8")) & 0xFFFFFFFF
-        )
-        # pylint: disable-next=unnecessary-lambda,consider-using-f-string
+        shell.get_system_id = lambda data: zlib.adler32(data.encode("utf-8")) & 0xffffffff
         shell.get_erratum_name = lambda data: "CVE-{}-name".format(data)
         shell.expand_errata = MagicMock(return_value=["CVE-1", "CVE-2"])
-        shell.client.errata.listAffectedSystems = MagicMock(
-            side_effect=[
-                [{"name": "web1.foo.com"}, {"name": "web2.foo.com"}],
-                [{"name": "db1.foo.com"}, {"name": "db2.foo.com"}],
-            ]
-        )
-        shell.client.system.getUnscheduledErrata = MagicMock(
-            side_effect=[
-                [
-                    {"id": "1", "advisory_name": "CVE-1"},
-                    {"id": "2", "advisory_name": "CVE-2"},
-                ],
-                [
-                    {"id": "1", "advisory_name": "CVE-1"},
-                    {"id": "2", "advisory_name": "CVE-2"},
-                    {"id": "3", "advisory_name": "CVE-3"},
-                ],
-                [
-                    {"id": "1", "advisory_name": "CVE-1"},
-                ],
-                [
-                    {"id": "4", "advisory_name": "CVE-4"},
-                ],
-            ]
-        )
+        shell.client.errata.listAffectedSystems = MagicMock(side_effect=[
+            [{"name": "web1.foo.com"}, {"name": "web2.foo.com"}],
+            [{"name": "db1.foo.com"}, {"name": "db2.foo.com"}],
+        ])
+        shell.client.system.getUnscheduledErrata = MagicMock(side_effect=[
+            [
+                {"id": "1", "advisory_name": "CVE-1"},
+                {"id": "2", "advisory_name": "CVE-2"},
+            ],
+            [
+                {"id": "1", "advisory_name": "CVE-1"},
+                {"id": "2", "advisory_name": "CVE-2"},
+                {"id": "3", "advisory_name": "CVE-3"},
+            ],
+            [
+                {"id": "1", "advisory_name": "CVE-1"},
+            ],
+            [
+                {"id": "4", "advisory_name": "CVE-4"},
+            ],
+        ])
         shell.client.system.scheduleApplyErrata = MagicMock()
         shell.all_errata = {}
         shell.options = MagicMock()
@@ -1315,12 +955,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_apply(shell, "cve* -s 201901011030")
 
         assert not shell.help_errata_apply.called
@@ -1334,35 +970,20 @@ class TestSCErrata:
         assert shell.client.errata.listAffectedSystems.called
         assert shell.expand_errata.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Errata             Systems",
-                "--------------     -------",
-                "CVE-1                    2\nCVE-2                    2",
-                "",
-                "Start Time: 20190101T10:30:00",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Errata             Systems', '--------------     -------',
+                                 'CVE-1                    2\nCVE-2                    2', '',
+                                 'Start Time: 20190101T10:30:00'])
 
-        assert_list_args_expect(
-            logger.info.call_args_list,
-            [
-                "Scheduled 3 system(s) for CVE-1-name",
-                "Scheduled 2 system(s) for CVE-2-name",
-            ],
-        )
+        assert_list_args_expect(logger.info.call_args_list,
+                                ['Scheduled 3 system(s) for CVE-1-name',
+                                 'Scheduled 2 system(s) for CVE-2-name'])
 
         dt = spacecmd.errata.parse_time_input("201901011030")
-        assert_args_expect(
-            shell.client.system.scheduleApplyErrata.call_args_list,
-            [
-                ((shell.session, [370082775, 370672600, 464454735], ["1"], dt), {}),
-                ((shell.session, [370082775, 370672600], ["2"], dt), {}),
-            ],
-        )
+        assert_args_expect(shell.client.system.scheduleApplyErrata.call_args_list,
+                           [((shell.session, [370082775, 370672600, 464454735], ['1'], dt), {}),
+                            ((shell.session, [370082775, 370672600], ['2'], dt), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_errata_apply_non_interactive_api_non1011_version(self, shell):
         """
         Test do_errata_apply non-interactive, API non-10.11 version.
@@ -1373,37 +994,30 @@ class TestSCErrata:
         shell.help_errata_apply = MagicMock()
         shell.user_confirm = MagicMock(return_value=True)
         shell.check_api_version = MagicMock(return_value=False)
-        shell.get_system_id = (
-            lambda data: zlib.adler32(data.encode("utf-8")) & 0xFFFFFFFF
-        )
-        # pylint: disable-next=unnecessary-lambda,consider-using-f-string
+        shell.get_system_id = lambda data: zlib.adler32(data.encode("utf-8")) & 0xffffffff
         shell.get_erratum_name = lambda data: "CVE-{}-name".format(data)
         shell.expand_errata = MagicMock(return_value=["CVE-1", "CVE-2"])
-        shell.client.errata.listAffectedSystems = MagicMock(
-            side_effect=[
-                [{"name": "web1.foo.com"}, {"name": "web2.foo.com"}],
-                [{"name": "db1.foo.com"}, {"name": "db2.foo.com"}],
-            ]
-        )
-        shell.client.system.getUnscheduledErrata = MagicMock(
-            side_effect=[
-                [
-                    {"id": "1", "advisory_name": "CVE-1"},
-                    {"id": "2", "advisory_name": "CVE-2"},
-                ],
-                [
-                    {"id": "1", "advisory_name": "CVE-1"},
-                    {"id": "2", "advisory_name": "CVE-2"},
-                    {"id": "3", "advisory_name": "CVE-3"},
-                ],
-                [
-                    {"id": "1", "advisory_name": "CVE-1"},
-                ],
-                [
-                    {"id": "4", "advisory_name": "CVE-4"},
-                ],
-            ]
-        )
+        shell.client.errata.listAffectedSystems = MagicMock(side_effect=[
+            [{"name": "web1.foo.com"}, {"name": "web2.foo.com"}],
+            [{"name": "db1.foo.com"}, {"name": "db2.foo.com"}],
+        ])
+        shell.client.system.getUnscheduledErrata = MagicMock(side_effect=[
+            [
+                {"id": "1", "advisory_name": "CVE-1"},
+                {"id": "2", "advisory_name": "CVE-2"},
+            ],
+            [
+                {"id": "1", "advisory_name": "CVE-1"},
+                {"id": "2", "advisory_name": "CVE-2"},
+                {"id": "3", "advisory_name": "CVE-3"},
+            ],
+            [
+                {"id": "1", "advisory_name": "CVE-1"},
+            ],
+            [
+                {"id": "4", "advisory_name": "CVE-4"},
+            ],
+        ])
         shell.client.system.scheduleApplyErrata = MagicMock()
         shell.all_errata = {}
         shell.options = MagicMock()
@@ -1411,12 +1025,8 @@ class TestSCErrata:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.errata.print", mprint) as prt, patch(
-            "spacecmd.errata.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.errata.print", mprint) as prt, \
+                patch("spacecmd.errata.logging", logger) as lgr:
             spacecmd.errata.do_errata_apply(shell, "cve* -s 201901011030")
 
         assert not shell.help_errata_apply.called
@@ -1430,33 +1040,18 @@ class TestSCErrata:
         assert shell.client.errata.listAffectedSystems.called
         assert shell.expand_errata.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Errata             Systems",
-                "--------------     -------",
-                "CVE-1                    2\nCVE-2                    2",
-                "",
-                "Start Time: 20190101T10:30:00",
-            ],
-        )
-        assert_list_args_expect(
-            logger.warning.call_args_list, ["No patches to schedule for web2.foo.com"]
-        )
-        assert_list_args_expect(
-            logger.info.call_args_list,
-            [
-                "Scheduled 2 patches for db1.foo.com",
-                "Scheduled 2 patches for db2.foo.com",
-                "Scheduled 1 patches for web1.foo.com",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Errata             Systems', '--------------     -------',
+                                 'CVE-1                    2\nCVE-2                    2','',
+                                 'Start Time: 20190101T10:30:00'])
+        assert_list_args_expect(logger.warning.call_args_list,
+                                ['No patches to schedule for web2.foo.com'])
+        assert_list_args_expect(logger.info.call_args_list,
+                                ['Scheduled 2 patches for db1.foo.com',
+                                 'Scheduled 2 patches for db2.foo.com',
+                                 'Scheduled 1 patches for web1.foo.com'])
         dt = spacecmd.errata.parse_time_input("201901011030")
-        assert_args_expect(
-            shell.client.system.scheduleApplyErrata.call_args_list,
-            [
-                ((shell.session, 370082775, ["1", "2"], dt), {}),
-                ((shell.session, 370672600, ["1", "2"], dt), {}),
-                ((shell.session, 464454735, ["1"], dt), {}),
-            ],
-        )
+        assert_args_expect(shell.client.system.scheduleApplyErrata.call_args_list,
+                           [((shell.session, 370082775, ['1', '2'], dt), {}),
+                            ((shell.session, 370672600, ['1', '2'], dt), {}),
+                            ((shell.session, 464454735, ['1'], dt), {})])

--- a/spacecmd/tests/test_filepreservation.py
+++ b/spacecmd/tests/test_filepreservation.py
@@ -2,11 +2,8 @@
 """
 Test suite for spacecmd.filepreservation
 """
-# pylint: disable-next=unused-import
 from unittest.mock import MagicMock, patch, mock_open
 import spacecmd.filepreservation
-
-# pylint: disable-next=unused-import
 from helpers import shell
 
 
@@ -14,8 +11,6 @@ class TestSCFilePreservation:
     """
     Test class for testing spacecmd file preservation.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_do_filepreservation_list_noreturn(self, shell):
         """
         Test do_filepreservation_list return to the STDOUT
@@ -30,13 +25,10 @@ class TestSCFilePreservation:
 
         mprint = MagicMock()
         with patch("spacecmd.filepreservation.print", mprint):
-            ret = spacecmd.filepreservation.do_filepreservation_list(
-                shell, "", doreturn=False
-            )
+            ret = spacecmd.filepreservation.do_filepreservation_list(shell, "", doreturn=False)
         assert ret is None
         assert mprint.call_args_list[0][0][0] == "list_one\nlist_three\nlist_two"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_filepreservation_list_return(self, shell):
         """
         Test do_filepreservation_list return data.
@@ -51,13 +43,10 @@ class TestSCFilePreservation:
 
         mprint = MagicMock()
         with patch("spacecmd.filepreservation.print", mprint):
-            ret = spacecmd.filepreservation.do_filepreservation_list(
-                shell, "", doreturn=True
-            )
+            ret = spacecmd.filepreservation.do_filepreservation_list(shell, "", doreturn=True)
         assert not mprint.called
-        assert ret == ["list_one", "list_two", "list_three"]
+        assert ret == ['list_one', 'list_two', 'list_three']
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_filepreservation_create_noargs_prompted_name(self, shell):
         """
         Test do_filepreservation_create no args passed so prompt appears.
@@ -66,36 +55,19 @@ class TestSCFilePreservation:
 
         mprint = MagicMock()
         prmt = MagicMock(side_effect=["prompted_name", "file_one", "file_two", ""])
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.filepreservation.prompt_user", prmt) as pmt, patch(
-            "spacecmd.filepreservation.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as mpt:
+        with patch("spacecmd.filepreservation.prompt_user", prmt) as pmt, \
+             patch("spacecmd.filepreservation.print", mprint) as mpt:
             spacecmd.filepreservation.do_filepreservation_create(shell, "")
 
         expectations = [
-            "File List",
-            "---------",
-            "",
-            "",
-            "File List",
-            "---------",
-            "file_one",
-            "",
-            "File List",
-            "---------",
-            "file_one\nfile_two",
-            "",
-            "",
-            "File List",
-            "---------",
-            "file_one\nfile_two",
+            'File List', '---------', '', '',
+            'File List', '---------', 'file_one', '',
+            'File List', '---------', 'file_one\nfile_two', '', '',
+            'File List', '---------', 'file_one\nfile_two'
         ]
         for idx, call in enumerate(mprint.call_args_list):
             assert call[0][0] == expectations[idx]
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_filepreservation_delete_noargs(self, shell):
         """
         Test do_filepreservation_delete no args.
@@ -110,7 +82,6 @@ class TestSCFilePreservation:
         assert not shell.client.kickstart.filepreservation.delete.called
         assert not shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_filepreservation_delete_args(self, shell):
         """
         Test do_filepreservation_delete key name passed.
@@ -125,14 +96,10 @@ class TestSCFilePreservation:
         assert shell.client.kickstart.filepreservation.delete.called
         assert shell.user_confirm.called
 
-        (
-            session,
-            keyname,
-        ) = shell.client.kickstart.filepreservation.delete.call_args_list[0][0]
+        session, keyname = shell.client.kickstart.filepreservation.delete.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "some_key"
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_filepreservation_details_noargs(self, shell):
         """
         Test do_filepreservation_details no args.
@@ -146,7 +113,6 @@ class TestSCFilePreservation:
         assert not shell.client.kickstart.filepreservation.details.called
 
     @patch("spacecmd.filepreservation.print", MagicMock())
-    # pylint: disable-next=redefined-outer-name
     def test_do_filepreservation_details_args(self, shell):
         """
         Test do_filepreservation_details key passed.
@@ -159,9 +125,6 @@ class TestSCFilePreservation:
         assert not shell.help_filepreservation_details.called
         assert shell.client.kickstart.filepreservation.getDetails.called
 
-        (
-            session,
-            keyname,
-        ) = shell.client.kickstart.filepreservation.getDetails.call_args_list[0][0]
+        session, keyname = shell.client.kickstart.filepreservation.getDetails.call_args_list[0][0]
         assert shell.session == session
         assert keyname == "somekey"

--- a/spacecmd/tests/test_group.py
+++ b/spacecmd/tests/test_group.py
@@ -6,8 +6,6 @@ Test suite for group module of spacecmd
 import datetime
 import os
 from unittest.mock import MagicMock, patch, mock_open, call, ANY
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.group
 from xmlrpc import client as xmlrpclib
@@ -18,7 +16,6 @@ class TestSCGroup:
     Test suite for "group" module.
     """
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_addsystems_noargs(self, shell):
         """
         Test do_group_addsystems without arguments.
@@ -34,12 +31,8 @@ class TestSCGroup:
         shell.ssm.keys = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_addsystems(shell, "")
 
         assert not shell.get_system_id.called
@@ -50,7 +43,6 @@ class TestSCGroup:
         assert not logger.error.called
         assert shell.help_group_addsystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_addsystems_ssm_no_systems(self, shell):
         """
         Test do_group_addsystems with SSM argument, without systems.
@@ -65,12 +57,8 @@ class TestSCGroup:
         shell.ssm.keys = MagicMock(return_value=[])
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_addsystems(shell, "groupname ssm")
 
         assert not shell.get_system_id.called
@@ -81,7 +69,6 @@ class TestSCGroup:
         assert not shell.help_group_addsystems.called
         assert shell.ssm.keys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_addsystems_expand_no_systems(self, shell):
         """
         Test do_group_addsystems with API call to find systems, without success getting one.
@@ -96,12 +83,8 @@ class TestSCGroup:
         shell.ssm.keys = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_addsystems(shell, "groupname something*")
 
         assert not shell.get_system_id.called
@@ -112,7 +95,6 @@ class TestSCGroup:
         assert not shell.ssm.keys.called
         assert shell.expand_systems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_addsystems(self, shell):
         """
         Test do_group_addsystems with API call to find systems.
@@ -127,12 +109,8 @@ class TestSCGroup:
         shell.ssm.keys = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_addsystems(shell, "groupname something*")
 
         assert not mprint.called
@@ -143,12 +121,9 @@ class TestSCGroup:
         assert shell.client.systemgroup.addOrRemoveSystems.called
         assert shell.expand_systems.called
 
-        assert_args_expect(
-            shell.client.systemgroup.addOrRemoveSystems.call_args_list,
-            [((shell.session, "groupname", ["1000010000", "1000010001"], True), {})],
-        )
+        assert_args_expect(shell.client.systemgroup.addOrRemoveSystems.call_args_list,
+                           [((shell.session, 'groupname', ['1000010000', '1000010001'], True), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_removesystems_noargs(self, shell):
         """
         Test do_group_removesystems without arguments.
@@ -165,12 +140,8 @@ class TestSCGroup:
         shell.user_confirm = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_removesystems(shell, "")
 
         assert not shell.get_system_id.called
@@ -182,7 +153,6 @@ class TestSCGroup:
         assert not logger.error.called
         assert shell.help_group_removesystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_removesystems_ssm_nosys(self, shell):
         """
         Test do_group_removesystems with SSM and without found systems.
@@ -199,12 +169,8 @@ class TestSCGroup:
         shell.user_confirm = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_removesystems(shell, "somegroup ssm")
 
         assert not shell.get_system_id.called
@@ -218,7 +184,6 @@ class TestSCGroup:
 
         assert_expect(mprint.call_args_list, "No systems found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_removesystems_nossm_nosys(self, shell):
         """
         Test do_group_removesystems with filters and without found systems.
@@ -235,12 +200,8 @@ class TestSCGroup:
         shell.user_confirm = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_removesystems(shell, "somegroup somesystem")
 
         assert not shell.get_system_id.called
@@ -254,7 +215,6 @@ class TestSCGroup:
 
         assert_expect(mprint.call_args_list, "No systems found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_removesystems_nossm_sys(self, shell):
         """
         Test do_group_removesystems with filters and found systems.
@@ -271,12 +231,8 @@ class TestSCGroup:
         shell.user_confirm = MagicMock(return_value=True)
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_removesystems(shell, "somegroup somesystem")
 
         assert not logger.error.called
@@ -288,15 +244,11 @@ class TestSCGroup:
         assert shell.expand_systems.called
         assert shell.client.systemgroup.addOrRemoveSystems.called
 
-        assert_args_expect(
-            shell.client.systemgroup.addOrRemoveSystems.call_args_list,
-            [((shell.session, "somegroup", ["1000010000", "1000010001"], False), {})],
-        )
-        assert_list_args_expect(
-            mprint.call_args_list, ["Systems", "-------", "one\ntwo"]
-        )
+        assert_args_expect(shell.client.systemgroup.addOrRemoveSystems.call_args_list,
+                           [((shell.session, 'somegroup', ['1000010000', '1000010001'], False), {})])
+        assert_list_args_expect(mprint.call_args_list,
+                                ["Systems", "-------", "one\ntwo"])
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_create_noarg(self, shell):
         """
         Test do_group_create without no arguments (fall-back to the interactive mode).
@@ -314,12 +266,9 @@ class TestSCGroup:
         assert prompter.called
         assert shell.client.systemgroup.create.called
 
-        assert_args_expect(
-            shell.client.systemgroup.create.call_args_list,
-            [((shell.session, "Jeff", msg), {})],
-        )
+        assert_args_expect(shell.client.systemgroup.create.call_args_list,
+                           [((shell.session, 'Jeff', msg), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_create_name_only(self, shell):
         """
         Test do_group_create with name argument (half-fall back to interactive).
@@ -337,12 +286,9 @@ class TestSCGroup:
         assert prompter.called
         assert shell.client.systemgroup.create.called
 
-        assert_args_expect(
-            shell.client.systemgroup.create.call_args_list,
-            [((shell.session, "Jeff", msg), {})],
-        )
+        assert_args_expect(shell.client.systemgroup.create.call_args_list,
+                           [((shell.session, 'Jeff', msg), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_create_descr_only(self, shell):
         """
         Test do_group_create with all arguments.
@@ -355,18 +301,14 @@ class TestSCGroup:
         prompter = MagicMock(return_value=msg)
 
         with patch("spacecmd.group.prompt_user", prompter):
-            # pylint: disable-next=consider-using-f-string
             spacecmd.group.do_group_create(shell, "Jeff {}".format(msg))
 
         assert not prompter.called
         assert shell.client.systemgroup.create.called
 
-        assert_args_expect(
-            shell.client.systemgroup.create.call_args_list,
-            [((shell.session, "Jeff", msg), {})],
-        )
+        assert_args_expect(shell.client.systemgroup.create.call_args_list,
+                           [((shell.session, 'Jeff', msg), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_delete_noarg(self, shell):
         """
         Test do_group_delete without no arguments
@@ -384,7 +326,6 @@ class TestSCGroup:
         assert not shell.user_confirm.called
         assert shell.help_group_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_delete_no_confirm(self, shell):
         """
         Test do_group_delete no confirmation
@@ -402,7 +343,6 @@ class TestSCGroup:
         assert not shell.help_group_delete.called
         assert shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_delete(self, shell):
         """
         Test do_group_delete with confirmation
@@ -420,12 +360,9 @@ class TestSCGroup:
         assert shell.client.systemgroup.delete.called
         assert shell.user_confirm.called
 
-        groups = [
-            [((shell.session, "groupone"), {})],
-            [((shell.session, "grouptwo"), {})],
-            [((shell.session, "groupthree"), {})],
-        ]
-        # pylint: disable-next=redefined-outer-name
+        groups = [[((shell.session, "groupone"), {})],
+                  [((shell.session, "grouptwo"), {})],
+                  [((shell.session, "groupthree"), {})],]
         for call in shell.client.systemgroup.delete.call_args_list:
             assert_args_expect([call], next(iter(groups)))
             groups.pop(0)
@@ -433,7 +370,6 @@ class TestSCGroup:
 
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.makedirs", MagicMock())
-    # pylint: disable-next=redefined-outer-name
     def test_group_backup_noarg(self, shell):
         """
         Test do_group_backup without no arguments
@@ -446,12 +382,8 @@ class TestSCGroup:
         shell.client.systemgroup.getDetails = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_backup(shell, "")
 
         assert not shell.do_group_list.called
@@ -462,7 +394,6 @@ class TestSCGroup:
 
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.makedirs", MagicMock())
-    # pylint: disable-next=redefined-outer-name
     def test_group_backup_all_group_list(self, shell):
         """
         Test do_group_backup with all groups lookup
@@ -470,7 +401,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def exp_user(path):
             """
             Fake expand user
@@ -488,39 +418,28 @@ class TestSCGroup:
                 {"description": "Group B description", "id": 1},
             ]
         )
-        shell.client.formula.getFormulasByGroupId = MagicMock(side_effect=[[], ["pxe"]])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [[], ['pxe']]
+            )
         shell.client.formula.getGroupFormulaData = MagicMock(
-            return_value={
-                "pxe": {
-                    "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
-                    "initrd_name": "initrd",
-                    "kernel_name": "linux",
-                    "pxe_root_directory": "/srv/saltboot",
-                }
-            }
-        )
+            return_value = {"pxe": {
+                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                "initrd_name": "initrd",
+                "kernel_name": "linux",
+                "pxe_root_directory": "/srv/saltboot"
+            }})
         mprint = MagicMock()
         logger = MagicMock()
         dumper = MagicMock()
 
-        # pylint: disable-next=invalid-name
         _datetime = MagicMock()
         _datetime.now = MagicMock(return_value=datetime.datetime(2019, 1, 1))
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.os.path.expanduser", exp_user) as exu, patch(
-            "spacecmd.group.json_dump_to_file",
-            dumper
-            # pylint: disable-next=unused-variable
-        ) as opr, patch(
-            "spacecmd.group.datetime",
-            _datetime
-            # pylint: disable-next=unused-variable
-        ) as dtm:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.os.path.expanduser", exp_user) as exu, \
+            patch("spacecmd.group.json_dump_to_file", dumper) as opr, \
+            patch("spacecmd.group.datetime", _datetime) as dtm:
             spacecmd.group.do_group_backup(shell, "ALL")
 
         assert not logger.called
@@ -530,42 +449,36 @@ class TestSCGroup:
         assert mprint.called
         assert dumper.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Backup Group: group-a",
-                "Output File: /opt/spacecmd/spacecmd-backup/group/2019-01-01/group-a",
-                "Backup Group: group-b",
-                "Output File: /opt/spacecmd/spacecmd-backup/group/2019-01-01/group-b",
-            ],
-        )
-        calls = [
-            call(
-                {"description": "Group A description", "formulas": {}},
-                "/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-a",
-            ),
-            call(
-                {
-                    "description": "Group B description",
-                    "formulas": {
-                        "pxe": {
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Backup Group: group-a',
+                                 'Output File: /opt/spacecmd/spacecmd-backup/group/2019-01-01/group-a',
+                                 'Backup Group: group-b',
+                                 'Output File: /opt/spacecmd/spacecmd-backup/group/2019-01-01/group-b'
+                                 ])
+        calls = [call({
+                        "description": "Group A description",
+                        "formulas": {}
+                    },
+                    '/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-a'),
+                call({
+                        "description": "Group B description",
+                        "formulas": {
                             "pxe": {
-                                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
-                                "initrd_name": "initrd",
-                                "kernel_name": "linux",
-                                "pxe_root_directory": "/srv/saltboot",
+                                "pxe": {
+                                    "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                                    "initrd_name": "initrd",
+                                    "kernel_name": "linux",
+                                    "pxe_root_directory": "/srv/saltboot"
+                                }
                             }
                         }
                     },
-                },
-                "/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-b",
-            ),
-        ]
+                    '/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-b')
+                ]
         dumper.assert_has_calls(calls)
 
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=False))
     @patch("spacecmd.group.os.makedirs", MagicMock(side_effect=OSError))
-    # pylint: disable-next=redefined-outer-name
     def test_group_backup_all_group_list_makedirs_failure_handling(self, shell):
         """
         Test do_group_backup with all groups lookup, making directories failure handling.
@@ -573,7 +486,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def exp_user(path):
             """
             Fake expand user
@@ -594,27 +506,16 @@ class TestSCGroup:
         mprint = MagicMock()
         logger = MagicMock()
         opener = MagicMock()
-        # pylint: disable-next=invalid-name
         _open = MagicMock(return_value=opener)
 
-        # pylint: disable-next=invalid-name
         _datetime = MagicMock()
         _datetime.now = MagicMock(return_value=datetime.datetime(2019, 1, 1))
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.os.path.expanduser", exp_user) as exu, patch(
-            "spacecmd.group.open",
-            _open
-            # pylint: disable-next=unused-variable
-        ) as opr, patch(
-            "spacecmd.group.datetime",
-            _datetime
-            # pylint: disable-next=unused-variable
-        ) as dtm:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.os.path.expanduser", exp_user) as exu, \
+            patch("spacecmd.group.open", _open) as opr, \
+            patch("spacecmd.group.datetime", _datetime) as dtm:
             spacecmd.group.do_group_backup(shell, "ALL")
 
         assert not shell.help_group_backup.called
@@ -625,22 +526,12 @@ class TestSCGroup:
         assert logger.error.called
         assert shell.do_group_list.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Could not create output directory: %s",
-                        "/opt/spacecmd/spacecmd-backup/group/2019-01-01",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not create output directory: %s',
+                              '/opt/spacecmd/spacecmd-backup/group/2019-01-01'), {})])
 
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=False))
     @patch("spacecmd.group.os.makedirs", MagicMock(side_effect=OSError))
-    # pylint: disable-next=redefined-outer-name
     def test_group_backup_all_group_list_custom_destination(self, shell):
         """
         Test do_group_backup with all groups lookup, custom destination, handling error.
@@ -648,7 +539,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def exp_user(path):
             """
             Fake expand user
@@ -669,27 +559,16 @@ class TestSCGroup:
         mprint = MagicMock()
         logger = MagicMock()
         opener = MagicMock()
-        # pylint: disable-next=invalid-name
         _open = MagicMock(return_value=opener)
 
-        # pylint: disable-next=invalid-name
         _datetime = MagicMock()
         _datetime.now = MagicMock(return_value=datetime.datetime(2019, 1, 1, 15, 0, 0))
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.os.path.expanduser", exp_user) as exu, patch(
-            "spacecmd.group.open",
-            _open
-            # pylint: disable-next=unused-variable
-        ) as opr, patch(
-            "spacecmd.group.datetime",
-            _datetime
-            # pylint: disable-next=unused-variable
-        ) as dtm:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.os.path.expanduser", exp_user) as exu, \
+            patch("spacecmd.group.open", _open) as opr, \
+            patch("spacecmd.group.datetime", _datetime) as dtm:
             spacecmd.group.do_group_backup(shell, "ALL /dev/null/%Y-%m-%T")
 
         assert not shell.help_group_backup.called
@@ -700,23 +579,13 @@ class TestSCGroup:
         assert logger.error.called
         assert shell.do_group_list.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Could not create output directory: %s",
-                        "/opt/spacecmd/dev/null/2019-01-15:00:00",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not create output directory: %s',
+                              '/opt/spacecmd/dev/null/2019-01-15:00:00'), {})])
 
     @patch("spacecmd.group.os.path.abspath", MagicMock(return_value="/opt/backup"))
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=[]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_noargs(self, shell):
         """
         test do_group_restore with no arguments.
@@ -732,12 +601,8 @@ class TestSCGroup:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_restore(shell, "")
 
         assert not shell.do_group_list.called
@@ -753,7 +618,6 @@ class TestSCGroup:
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=[]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=False))
     @patch("spacecmd.group.os.path.exists", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_catch_not_existing_path(self, shell):
         """
         test do_group_restore catch path that does not exists
@@ -761,7 +625,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def _abspath(path):
             """
             Fake os.path.abspath that expands to /tmp/test
@@ -779,12 +642,9 @@ class TestSCGroup:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.os.path.abspath", _abspath) as abp:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "ALL")
 
         assert not shell.do_group_list.called
@@ -797,16 +657,14 @@ class TestSCGroup:
         assert logger.debug.called
         assert logger.error.called
 
-        assert_expect(logger.debug.call_args_list, "Input Directory: /tmp/test/ALL")
-        assert_expect(
-            logger.error.call_args_list,
-            "Restore dir /tmp/test/ALL does not exits or is not a directory",
-        )
+        assert_expect(logger.debug.call_args_list,
+                      "Input Directory: /tmp/test/ALL")
+        assert_expect(logger.error.call_args_list,
+                      'Restore dir /tmp/test/ALL does not exits or is not a directory')
 
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=[]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_catch_empty_directory(self, shell):
         """
         test do_group_restore catch empty directory.
@@ -814,7 +672,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def _abspath(path):
             """
             Fake os.path.abspath that expands to /tmp/test
@@ -832,12 +689,9 @@ class TestSCGroup:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.os.path.abspath", _abspath) as abp:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "ALL")
 
         assert not shell.do_group_list.called
@@ -850,17 +704,15 @@ class TestSCGroup:
         assert logger.debug.called
         assert logger.error.called
 
-        assert_expect(logger.debug.call_args_list, "Input Directory: /tmp/test/ALL")
-        assert_expect(
-            logger.error.call_args_list,
-            "Restore dir /tmp/test/ALL has no restore items",
-        )
+        assert_expect(logger.debug.call_args_list,
+                      "Input Directory: /tmp/test/ALL")
+        assert_expect(logger.error.call_args_list,
+                      'Restore dir /tmp/test/ALL has no restore items')
 
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=["group-a"]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.isfile", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_catch_missing_groups(self, shell):
         """
         test do_group_restore catch missing groups
@@ -868,7 +720,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def _abspath(path):
             """
             Fake os.path.abspath that expands to /tmp/test
@@ -886,19 +737,12 @@ class TestSCGroup:
         logger = MagicMock()
         mprint = MagicMock()
         opener = MagicMock()
-        # pylint: disable-next=invalid-name
         _open = MagicMock(return_value=opener)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.open", _open) as opn, patch(
-            "spacecmd.group.os.path.abspath",
-            _abspath
-            # pylint: disable-next=unused-variable
-        ) as abp:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.open", _open) as opn, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "/opt/backup group-a group-b")
 
         assert not shell.do_group_list.called
@@ -911,19 +755,14 @@ class TestSCGroup:
         assert logger.debug.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (("Group group-b was not found in backup",), {}),
-                (("Found %s missing groups, terminating", 1), {}),
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Group group-b was not found in backup',), {}),
+                            (('Found %s missing groups, terminating', 1), {})])
 
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=["group-a"]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.isfile", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_catch_indempotent_recovery(self, shell):
         """
         Test do_group_restore indempotent recovery
@@ -931,7 +770,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def _abspath(path):
             """
             Fake os.path.abspath that expands to /tmp/test
@@ -943,55 +781,42 @@ class TestSCGroup:
 
         shell.help_group_restore = MagicMock()
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
-        shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=[
-                {"description": "Description of Group A", "id": 1},
-                {"description": "Description of Group B", "id": 1},
-            ]
-        )
-        shell.client.formula.getFormulasByGroupId = MagicMock(side_effect=[["pxe"], []])
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
+        ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [['pxe'], []]
+            )
         shell.client.formula.getGroupFormulaData = MagicMock(
-            side_effect=[
-                {
-                    "pxe": {
-                        "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
-                        "initrd_name": "initrd",
-                        "kernel_name": "linux",
-                        "pxe_root_directory": "/srv/saltboot",
-                    }
-                }
-            ]
-        )
+            side_effect = [{"pxe": {
+                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                "initrd_name": "initrd",
+                "kernel_name": "linux",
+                "pxe_root_directory": "/srv/saltboot"
+            }}])
         shell.client.systemgroup.update = MagicMock()
         shell.client.systemgroup.create = MagicMock()
         logger = MagicMock()
         mprint = MagicMock()
-        json = MagicMock(
-            return_value={
-                "description": "Description of Group A",
-                "formulas": {
-                    "pxe": {
+        json = MagicMock(return_value={
+                    "description": "Description of Group A",
+                    "formulas": {
                         "pxe": {
-                            "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
-                            "initrd_name": "initrd",
-                            "kernel_name": "linux",
-                            "pxe_root_directory": "/srv/saltboot",
+                            "pxe": {
+                                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                                "initrd_name": "initrd",
+                                "kernel_name": "linux",
+                                "pxe_root_directory": "/srv/saltboot"
+                            }
                         }
                     }
-                },
-            }
-        )
+                })
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.json_read_from_file", json) as opr, patch(
-            "spacecmd.group.os.path.abspath",
-            _abspath
-            # pylint: disable-next=unused-variable
-        ) as abp:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
 
         assert not shell.client.systemgroup.update.called
@@ -1006,13 +831,13 @@ class TestSCGroup:
 
         json.assert_called_once()
 
-        assert_expect(logger.error.call_args_list, "Group group-a already restored")
+        assert_expect(logger.error.call_args_list,
+                      "Group group-a already restored")
 
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=["group-a"]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.isfile", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_catch_existing_group_description_changed(self, shell):
         """
         Test do_group_restore indempotent recovery
@@ -1020,7 +845,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def _abspath(path):
             """
             Fake os.path.abspath that expands to /tmp/test
@@ -1032,31 +856,26 @@ class TestSCGroup:
 
         shell.help_group_restore = MagicMock()
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
-        shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=[
-                {"description": "Description of Group A", "id": 1},
-                {"description": "Description of Group B", "id": 1},
-            ]
-        )
-        shell.client.formula.getFormulasByGroupId = MagicMock(side_effect=[[], []])
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
+        ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [[], []]
+            )
         shell.client.systemgroup.update = MagicMock()
         shell.client.systemgroup.create = MagicMock()
         logger = MagicMock()
         mprint = MagicMock()
-        json = MagicMock(
-            return_value={"description": "Group A description", "formulas": {}}
-        )
+        json = MagicMock(return_value={
+                    "description": "Group A description",
+                    "formulas": {}
+                })
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.json_read_from_file", json) as opr, patch(
-            "spacecmd.group.os.path.abspath",
-            _abspath
-            # pylint: disable-next=unused-variable
-        ) as abp:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
 
         assert not shell.client.systemgroup.create.called
@@ -1071,13 +890,13 @@ class TestSCGroup:
 
         json.assert_called_once()
 
-        assert_expect(logger.info.call_args_list, "Updating data for group: group-a")
+        assert_expect(logger.info.call_args_list,
+                      'Updating data for group: group-a')
 
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=["group-a"]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.isfile", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_catch_existing_formulas_changed(self, shell):
         """
         Test do_group_restore indempotent recovery
@@ -1085,7 +904,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def _abspath(path):
             """
             Fake os.path.abspath that expands to /tmp/test
@@ -1097,56 +915,43 @@ class TestSCGroup:
 
         shell.help_group_restore = MagicMock()
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
-        shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=[
-                {"description": "Description of Group A", "id": 1},
-                {"description": "Description of Group B", "id": 1},
-            ]
-        )
-        shell.client.formula.getFormulasByGroupId = MagicMock(side_effect=[["pxe"], []])
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
+        ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [['pxe'], []]
+            )
         shell.client.formula.getGroupFormulaData = MagicMock(
-            side_effect=[
-                {
-                    "pxe": {
-                        "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
-                        "initrd_name": "initrd",
-                        "kernel_name": "linux",
-                        "pxe_root_directory": "/srv/saltboot",
-                    }
-                }
-            ]
-        )
+            side_effect = [{"pxe": {
+                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                "initrd_name": "initrd",
+                "kernel_name": "linux",
+                "pxe_root_directory": "/srv/saltboot"
+            }}])
         shell.client.systemgroup.update = MagicMock()
         shell.client.systemgroup.create = MagicMock()
         shell.client.formula.setGroupFormulaData = MagicMock()
 
         logger = MagicMock()
         mprint = MagicMock()
-        json = MagicMock(
-            return_value={
-                "description": "Group A description",
-                "formulas": {
+        json = MagicMock(return_value={
+                    "description": "Group A description",
+                    "formulas": {
                     "pxe": {
                         "pxe": {
                             "initrd_name": "initrd",
                             "kernel_name": "linux",
-                            "pxe_root_directory": "/srv/tftpboot",
+                            "pxe_root_directory": "/srv/tftpboot"
                         }
                     }
-                },
-            }
-        )
+                }
+            })
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.json_read_from_file", json) as opr, patch(
-            "spacecmd.group.os.path.abspath",
-            _abspath
-            # pylint: disable-next=unused-variable
-        ) as abp:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
 
         assert not shell.client.systemgroup.create.called
@@ -1162,25 +967,21 @@ class TestSCGroup:
         json.assert_called_once()
 
         shell.client.formula.setGroupFormulaData.assert_called_with(
-            ANY,
-            1,
-            "pxe",
-            {
-                "pxe": {
-                    "initrd_name": "initrd",
-                    "kernel_name": "linux",
-                    "pxe_root_directory": "/srv/tftpboot",
-                }
-            },
-        )
+                    ANY,
+                    1, 'pxe',
+                    { "pxe": {
+                        "initrd_name": "initrd",
+                        "kernel_name": "linux",
+                        "pxe_root_directory": "/srv/tftpboot"
+                    }})
 
-        assert_expect(logger.info.call_args_list, "Updating data for group: group-a")
+        assert_expect(logger.info.call_args_list,
+                      'Updating data for group: group-a')
 
     @patch("spacecmd.group.os.listdir", MagicMock(return_value=["group-a"]))
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.isfile", MagicMock(return_value=True))
     @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
-    # pylint: disable-next=redefined-outer-name
     def test_group_restore_accept_old_format_description_changed(self, shell):
         """
         Test do_group_restore indempotent recovery
@@ -1188,7 +989,6 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-
         def _abspath(path):
             """
             Fake os.path.abspath that expands to /tmp/test
@@ -1200,34 +1000,25 @@ class TestSCGroup:
 
         shell.help_group_restore = MagicMock()
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
-        shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=[
-                {"description": "Description of Group A", "id": 1},
-                {"description": "Description of Group B", "id": 1},
-            ]
-        )
-        shell.client.formula.getFormulasByGroupId = MagicMock(side_effect=[[], []])
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
+        ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [[], []]
+            )
         shell.client.systemgroup.update = MagicMock()
         shell.client.systemgroup.create = MagicMock()
         logger = MagicMock()
         mprint = MagicMock()
         json = MagicMock(return_value=None)
-        opener = mock_open(read_data="Group A description newer")
+        opener = mock_open(read_data = 'Group A description newer')
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prn, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.group.json_read_from_file", json) as opr, patch(
-            "spacecmd.group.open",
-            opener
-            # pylint: disable-next=unused-variable
-        ) as opn, patch(
-            "spacecmd.group.os.path.abspath",
-            _abspath
-            # pylint: disable-next=unused-variable
-        ) as abp:
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
+            patch("spacecmd.group.open", opener) as opn, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
 
         assert not shell.client.systemgroup.create.called
@@ -1240,15 +1031,11 @@ class TestSCGroup:
         assert shell.client.systemgroup.getDetails.called
         assert logger.debug.called
 
-        assert_list_args_expect(
-            logger.info.call_args_list,
-            [
-                "Assuming group to be in old plain text format",
-                "Updating data for group: group-a",
-            ],
-        )
+        assert_list_args_expect(logger.info.call_args_list,
+                      ['Assuming group to be in old plain text format',
+                       'Updating data for group: group-a'])
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_group_list_data(self, shell):
         """
         Test do_group_list with data return.
@@ -1256,9 +1043,9 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-        shell.client.systemgroup.listAllGroups = MagicMock(
-            return_value=[{"name": "group-a"}, {"name": "group-b"}]
-        )
+        shell.client.systemgroup.listAllGroups = MagicMock(return_value=[
+            {"name": "group-a"}, {"name": "group-b"}
+        ])
         mprint = MagicMock()
         with patch("spacecmd.group.print", mprint):
             out = spacecmd.group.do_group_list(shell, "", doreturn=True)
@@ -1268,7 +1055,6 @@ class TestSCGroup:
         assert len(out) == 2
         assert out == ["group-a", "group-b"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_list_no_data(self, shell):
         """
         Test do_group_list with no data return.
@@ -1276,9 +1062,9 @@ class TestSCGroup:
         :param shell:
         :return:
         """
-        shell.client.systemgroup.listAllGroups = MagicMock(
-            return_value=[{"name": "group-a"}, {"name": "group-b"}]
-        )
+        shell.client.systemgroup.listAllGroups = MagicMock(return_value=[
+            {"name": "group-a"}, {"name": "group-b"}
+        ])
         mprint = MagicMock()
         with patch("spacecmd.group.print", mprint):
             out = spacecmd.group.do_group_list(shell, "", doreturn=False)
@@ -1287,9 +1073,9 @@ class TestSCGroup:
         assert out is None
         assert mprint.called
 
-        assert_expect(mprint.call_args_list, "group-a\ngroup-b")
+        assert_expect(mprint.call_args_list,
+                      "group-a\ngroup-b")
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_listsystems_noargs(self, shell):
         """
         Test do_group_listsystems with no arguments passed.
@@ -1302,12 +1088,8 @@ class TestSCGroup:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prt, \
+            patch("spacecmd.group.logging", logger) as lgr:
             out = spacecmd.group.do_group_listsystems(shell, "", doreturn=True)
 
         assert not shell.client.systemgroup.listSystems.called
@@ -1316,7 +1098,6 @@ class TestSCGroup:
         assert out is None
         assert shell.help_group_listsystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_listsystems_with_data(self, shell):
         """
         Test do_group_listsystems with data return.
@@ -1325,23 +1106,15 @@ class TestSCGroup:
         :return:
         """
         shell.help_group_listsystems = MagicMock()
-        shell.client.systemgroup.listSystems = MagicMock(
-            return_value=[
-                {"profile_name": "system-d"},
-                {"profile_name": "system-c"},
-                {"profile_name": "system-b"},
-                {"profile_name": "system-a"},
-            ]
-        )
+        shell.client.systemgroup.listSystems = MagicMock(return_value=[
+            {"profile_name": "system-d"}, {"profile_name": "system-c"},
+            {"profile_name": "system-b"}, {"profile_name": "system-a"},
+        ])
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prt, \
+            patch("spacecmd.group.logging", logger) as lgr:
             out = spacecmd.group.do_group_listsystems(shell, "group-a", doreturn=True)
 
         assert not shell.help_group_listsystems.called
@@ -1351,7 +1124,6 @@ class TestSCGroup:
         assert out is not None
         assert out == ["system-d", "system-c", "system-b", "system-a"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_listsystems_nodata(self, shell):
         """
         Test do_group_listsystems without data return, but STDOUT.
@@ -1360,23 +1132,15 @@ class TestSCGroup:
         :return:
         """
         shell.help_group_listsystems = MagicMock()
-        shell.client.systemgroup.listSystems = MagicMock(
-            return_value=[
-                {"profile_name": "system-d"},
-                {"profile_name": "system-c"},
-                {"profile_name": "system-b"},
-                {"profile_name": "system-a"},
-            ]
-        )
+        shell.client.systemgroup.listSystems = MagicMock(return_value=[
+            {"profile_name": "system-d"}, {"profile_name": "system-c"},
+            {"profile_name": "system-b"}, {"profile_name": "system-a"},
+        ])
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prt, \
+            patch("spacecmd.group.logging", logger) as lgr:
             out = spacecmd.group.do_group_listsystems(shell, "group-a", doreturn=False)
 
         assert not shell.help_group_listsystems.called
@@ -1386,7 +1150,6 @@ class TestSCGroup:
         assert mprint.called
         assert_expect(mprint.call_args_list, "system-a\nsystem-b\nsystem-c\nsystem-d")
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_listsystems_too_much_parameters(self, shell):
         """
         Test do_group_listsystems with too much groups specified.
@@ -1399,15 +1162,9 @@ class TestSCGroup:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            out = spacecmd.group.do_group_listsystems(
-                shell, "group-a group-b", doreturn=True
-            )
+        with patch("spacecmd.group.print", mprint) as prt, \
+                patch("spacecmd.group.logging", logger) as lgr:
+            out = spacecmd.group.do_group_listsystems(shell, "group-a group-b", doreturn=True)
 
         assert not logger.warning.called
         assert not shell.client.systemgroup.listSystems.called
@@ -1415,7 +1172,6 @@ class TestSCGroup:
         assert not mprint.called
         assert shell.help_group_listsystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_details_noargs(self, shell):
         """
         Test do_group_details with no arguments.
@@ -1429,12 +1185,8 @@ class TestSCGroup:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prt, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_details(shell, "")
 
         assert not logger.warning.called
@@ -1443,7 +1195,6 @@ class TestSCGroup:
         assert not mprint.called
         assert shell.help_group_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_details_no_valid_group(self, shell):
         """
         Test do_group_details with no arguments.
@@ -1453,18 +1204,13 @@ class TestSCGroup:
         """
         shell.help_group_details = MagicMock()
         shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=xmlrpclib.Fault(faultCode=42, faultString="kaboom!")
-        )
+            side_effect=xmlrpclib.Fault(faultCode=42, faultString="kaboom!"))
         shell.client.systemgroup.listSystems = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prt, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_details(shell, "cucumber-group")
 
         assert not shell.client.systemgroup.listSystems.called
@@ -1473,11 +1219,9 @@ class TestSCGroup:
         assert logger.warning.called
         assert shell.client.systemgroup.getDetails.called
 
-        assert_expect(
-            logger.warning.call_args_list, 'The group "cucumber-group" is invalid'
-        )
+        assert_expect(logger.warning.call_args_list,
+                      'The group "cucumber-group" is invalid')
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_details_short_report(self, shell):
         """
         Test do_group_details short report.
@@ -1486,47 +1230,22 @@ class TestSCGroup:
         :return:
         """
         shell.help_group_details = MagicMock()
-        shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "id": 1,
-                    "name": "Group A",
-                    "description": "Test group A",
-                    "system_count": 5,
-                },
-                {
-                    "id": 2,
-                    "name": "Group B",
-                    "description": "Test group B",
-                    "system_count": 10,
-                },
-                {
-                    "id": 3,
-                    "name": "Group C",
-                    "description": "Test group C",
-                    "system_count": 25,
-                },
-            ]
-        )
-        shell.client.systemgroup.listSystems = MagicMock(
-            side_effect=[
-                [{"profile_name": "prf-a"}, {"profile_name": "prf-b"}],
-                [{"profile_name": "prf-c"}, {"profile_name": "prf-d"}],
-                [{"profile_name": "prf-e"}, {"profile_name": "prf-f"}],
-            ]
-        )
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"id": 1, "name": "Group A", "description": "Test group A", "system_count": 5},
+            {"id": 2, "name": "Group B", "description": "Test group B", "system_count": 10},
+            {"id": 3, "name": "Group C", "description": "Test group C", "system_count": 25}
+        ])
+        shell.client.systemgroup.listSystems = MagicMock(side_effect=[
+            [{"profile_name": "prf-a"}, {"profile_name": "prf-b"}],
+            [{"profile_name": "prf-c"}, {"profile_name": "prf-d"}],
+            [{"profile_name": "prf-e"}, {"profile_name": "prf-f"}],
+        ])
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            spacecmd.group.do_group_details(
-                shell, "group-a group-b group-c", short=True
-            )
+        with patch("spacecmd.group.print", mprint) as prt, \
+            patch("spacecmd.group.logging", logger) as lgr:
+            spacecmd.group.do_group_details(shell, "group-a group-b group-c", short=True)
 
         assert not shell.help_group_details.called
         assert not logger.warning.called
@@ -1534,27 +1253,22 @@ class TestSCGroup:
         assert shell.client.systemgroup.listSystems.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "ID:                1",
-                "Name:              Group A",
-                "Description:       Test group A",
-                "Number of Systems: 5",
-                "----------",
-                "ID:                2",
-                "Name:              Group B",
-                "Description:       Test group B",
-                "Number of Systems: 10",
-                "----------",
-                "ID:                3",
-                "Name:              Group C",
-                "Description:       Test group C",
-                "Number of Systems: 25",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['ID:                1',
+                                 'Name:              Group A',
+                                 'Description:       Test group A',
+                                 'Number of Systems: 5',
+                                 '----------',
+                                 'ID:                2',
+                                 'Name:              Group B',
+                                 'Description:       Test group B',
+                                 'Number of Systems: 10',
+                                 '----------',
+                                 'ID:                3',
+                                 'Name:              Group C',
+                                 'Description:       Test group C',
+                                 'Number of Systems: 25'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_group_details_long_report(self, shell):
         """
         Test do_group_details long report.
@@ -1563,44 +1277,21 @@ class TestSCGroup:
         :return:
         """
         shell.help_group_details = MagicMock()
-        shell.client.systemgroup.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "id": 1,
-                    "name": "Group A",
-                    "description": "Test group A",
-                    "system_count": 5,
-                },
-                {
-                    "id": 2,
-                    "name": "Group B",
-                    "description": "Test group B",
-                    "system_count": 10,
-                },
-                {
-                    "id": 3,
-                    "name": "Group C",
-                    "description": "Test group C",
-                    "system_count": 25,
-                },
-            ]
-        )
-        shell.client.systemgroup.listSystems = MagicMock(
-            side_effect=[
-                [{"profile_name": "prf-a"}, {"profile_name": "prf-b"}],
-                [{"profile_name": "prf-c"}, {"profile_name": "prf-d"}],
-                [{"profile_name": "prf-e"}, {"profile_name": "prf-f"}],
-            ]
-        )
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"id": 1, "name": "Group A", "description": "Test group A", "system_count": 5},
+            {"id": 2, "name": "Group B", "description": "Test group B", "system_count": 10},
+            {"id": 3, "name": "Group C", "description": "Test group C", "system_count": 25}
+        ])
+        shell.client.systemgroup.listSystems = MagicMock(side_effect=[
+            [{"profile_name": "prf-a"}, {"profile_name": "prf-b"}],
+            [{"profile_name": "prf-c"}, {"profile_name": "prf-d"}],
+            [{"profile_name": "prf-e"}, {"profile_name": "prf-f"}],
+        ])
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.group.print", mprint) as prt, patch(
-            "spacecmd.group.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.group.print", mprint) as prt, \
+            patch("spacecmd.group.logging", logger) as lgr:
             spacecmd.group.do_group_details(shell, "group-a group-b group-c")
 
         assert not shell.help_group_details.called
@@ -1609,34 +1300,30 @@ class TestSCGroup:
         assert shell.client.systemgroup.listSystems.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "ID:                1",
-                "Name:              Group A",
-                "Description:       Test group A",
-                "Number of Systems: 5",
-                "",
-                "Members",
-                "-------",
-                "prf-a\nprf-b",
-                "----------",
-                "ID:                2",
-                "Name:              Group B",
-                "Description:       Test group B",
-                "Number of Systems: 10",
-                "",
-                "Members",
-                "-------",
-                "prf-c\nprf-d",
-                "----------",
-                "ID:                3",
-                "Name:              Group C",
-                "Description:       Test group C",
-                "Number of Systems: 25",
-                "",
-                "Members",
-                "-------",
-                "prf-e\nprf-f",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['ID:                1',
+                                 'Name:              Group A',
+                                 'Description:       Test group A',
+                                 'Number of Systems: 5',
+                                 '',
+                                 'Members',
+                                 '-------',
+                                 'prf-a\nprf-b',
+                                 '----------',
+                                 'ID:                2',
+                                 'Name:              Group B',
+                                 'Description:       Test group B',
+                                 'Number of Systems: 10',
+                                 '',
+                                 'Members',
+                                 '-------',
+                                 'prf-c\nprf-d',
+                                 '----------',
+                                 'ID:                3',
+                                 'Name:              Group C',
+                                 'Description:       Test group C',
+                                 'Number of Systems: 25',
+                                 '',
+                                 'Members',
+                                 '-------',
+                                 'prf-e\nprf-f'])

--- a/spacecmd/tests/test_kickstart.py
+++ b/spacecmd/tests/test_kickstart.py
@@ -7,12 +7,8 @@ NOTE: This module is quite rarely used within Uyuni/SLE,
       and then deleting them.
 """
 import copy
-
-# pylint: disable-next=unused-import
 import os
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.kickstart
 
@@ -21,8 +17,6 @@ class TestSCKickStart:
     """
     Test kickstart.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_clone_interactive_no_profiles(self, shell):
         """
         Test do_kickstart_clone interactive. No profiles found.
@@ -32,20 +26,16 @@ class TestSCKickStart:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_clone(shell, "")
 
         assert not mprint.called
         assert not shell.client.kickstart.cloneProfile.called
         assert logger.error.called
-        assert_expect(logger.error.call_args_list, "No kickstart profiles available")
+        assert_expect(logger.error.call_args_list,
+                      "No kickstart profiles available")
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_clone_interactive_wrong_profile_entered(self, shell):
         """
         Test do_kickstart_clone interactive. Wrong profile has been entered.
@@ -55,16 +45,13 @@ class TestSCKickStart:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        prompter = MagicMock(side_effect=["posix_compliance_problem", "POSIX"])
-        shell.do_kickstart_list = MagicMock(
-            return_value=["default_kickstart_profile", "some_other_profile"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
+        prompter = MagicMock(side_effect=[
+            "posix_compliance_problem", "POSIX"])
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "default_kickstart_profile", "some_other_profile"])
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr, \
+                patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
             spacecmd.kickstart.do_kickstart_clone(shell, "")
 
         assert not shell.client.kickstart.cloneProfile.called
@@ -72,29 +59,15 @@ class TestSCKickStart:
         assert prompter.called
         assert logger.error.called
 
-        assert_expect(
-            logger.error.call_args_list,
-            "Kickstart profile you've entered was not found",
-        )
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "",
-                "Kickstart Profiles",
-                "------------------",
-                "default_kickstart_profile\nsome_other_profile",
-                "",
-            ],
-        )
-        assert_args_expect(
-            prompter.call_args_list,
-            [
-                (("Original Profile:",), {"noblank": True}),
-                (("Cloned Profile:",), {"noblank": True}),
-            ],
-        )
+        assert_expect(logger.error.call_args_list,
+                      "Kickstart profile you've entered was not found")
+        assert_list_args_expect(mprint.call_args_list,
+                                ['', 'Kickstart Profiles', '------------------',
+                                 'default_kickstart_profile\nsome_other_profile', ''])
+        assert_args_expect(prompter.call_args_list,
+                           [(('Original Profile:',), {"noblank": True}),
+                            (('Cloned Profile:',), {"noblank": True})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_clone_arg_wrong_profile_entered(self, shell):
         """
         Test do_kickstart_clone with args. Wrong profile has been entered.
@@ -105,30 +78,21 @@ class TestSCKickStart:
         mprint = MagicMock()
         logger = MagicMock()
         prompter = MagicMock()
-        shell.do_kickstart_list = MagicMock(
-            return_value=["default_kickstart_profile", "some_other_profile"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
-            spacecmd.kickstart.do_kickstart_clone(
-                shell, "-n posix_compliance_problem -c POSIX"
-            )
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "default_kickstart_profile", "some_other_profile"])
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr, \
+                patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
+            spacecmd.kickstart.do_kickstart_clone(shell, "-n posix_compliance_problem -c POSIX")
 
         assert not prompter.called
         assert not shell.client.kickstart.cloneProfile.called
         assert not mprint.called
         assert logger.error.called
 
-        assert_expect(
-            logger.error.call_args_list,
-            "Kickstart profile you've entered was not found",
-        )
+        assert_expect(logger.error.call_args_list,
+                      "Kickstart profile you've entered was not found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_clone_arg_no_name_entered(self, shell):
         """
         Test do_kickstart_clone with args. No kickstart profile name entered.
@@ -139,15 +103,11 @@ class TestSCKickStart:
         mprint = MagicMock()
         logger = MagicMock()
         prompter = MagicMock()
-        shell.do_kickstart_list = MagicMock(
-            return_value=["default_kickstart_profile", "some_other_profile"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "default_kickstart_profile", "some_other_profile"])
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr, \
+                patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
             spacecmd.kickstart.do_kickstart_clone(shell, "-c POSIX")
 
         assert not prompter.called
@@ -156,7 +116,6 @@ class TestSCKickStart:
         assert logger.error.called
         assert_expect(logger.error.call_args_list, "The Kickstart name is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_clone_arg_no_target_entered(self, shell):
         """
         Test do_kickstart_clone with args. No kickstart target profile name entered.
@@ -167,26 +126,19 @@ class TestSCKickStart:
         mprint = MagicMock()
         logger = MagicMock()
         prompter = MagicMock()
-        shell.do_kickstart_list = MagicMock(
-            return_value=["default_kickstart_profile", "some_other_profile"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "default_kickstart_profile", "some_other_profile"])
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr, \
+                patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
             spacecmd.kickstart.do_kickstart_clone(shell, "-n whatever_profile")
 
         assert not prompter.called
         assert not shell.client.kickstart.cloneProfile.called
         assert not mprint.called
         assert logger.error.called
-        assert_expect(
-            logger.error.call_args_list, "The Kickstart clone name is required"
-        )
+        assert_expect(logger.error.call_args_list, "The Kickstart clone name is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_clone_args(self, shell):
         """
         Test do_kickstart_clone with args.
@@ -197,33 +149,23 @@ class TestSCKickStart:
         mprint = MagicMock()
         logger = MagicMock()
         prompter = MagicMock()
-        shell.do_kickstart_list = MagicMock(
-            return_value=["default_kickstart_profile", "some_other_profile"]
-        )
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "default_kickstart_profile", "some_other_profile"])
         name, clone = "default_kickstart_profile", "new_default_profile"
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr, \
+                patch("spacecmd.kickstart.prompt_user", prompter) as pmt:
             spacecmd.kickstart.do_kickstart_clone(
-                shell,
-                # pylint: disable-next=consider-using-f-string
-                "-n {} -c {}".format(name, clone),
-            )
+                shell, "-n {} -c {}".format(name, clone))
 
         assert not prompter.called
         assert not mprint.called
         assert not logger.error.called
         assert shell.client.kickstart.cloneProfile.called
 
-        assert_args_expect(
-            shell.client.kickstart.cloneProfile.call_args_list,
-            [((shell.session, name, clone), {})],
-        )
+        assert_args_expect(shell.client.kickstart.cloneProfile.call_args_list,
+                           [((shell.session, name, clone), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listscripts_noarg(self, shell):
         """
         Test do_kickstart_listscripts without arguments.
@@ -233,18 +175,13 @@ class TestSCKickStart:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_listscripts(shell, "")
 
         assert not shell.client.kickstart.profile.listScripts.called
         assert shell.help_kickstart_listscripts.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listscripts_no_scripts(self, shell):
         """
         Test do_kickstart_listscripts list scripts for the specified profile. No scripts attached.
@@ -255,24 +192,18 @@ class TestSCKickStart:
         mprint = MagicMock()
         logger = MagicMock()
         shell.client.kickstart.profile.listScripts = MagicMock(return_value=[])
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_listscripts(shell, "some_profile")
 
         assert not shell.help_kickstart_listscripts.called
         assert not mprint.called
         assert shell.client.kickstart.profile.listScripts.called
         assert logger.error.called
-        assert_args_expect(
-            logger.error.call_args_list,
-            [(("No scripts has been found for profile '%s'", "some_profile"), {})],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(("No scripts has been found for profile '%s'",
+                              "some_profile"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listscripts_scripts_found(self, shell):
         """
         Test do_kickstart_listscripts list scripts for the specified profile.
@@ -284,32 +215,20 @@ class TestSCKickStart:
         logger = MagicMock()
         shell.client.kickstart.profile.listScripts = MagicMock(
             return_value=[
-                {
-                    "id": 1,
-                    "script_type": "shell",
-                    "chroot": "/dev/null",
-                    "interpreter": "/bin/bash",
-                    "contents": """#!/bin/bash
+                {"id": 1, "script_type": "shell",
+                 "chroot": "/dev/null", "interpreter": "/bin/bash",
+                 "contents": """#!/bin/bash
 echo 'Hello there!'
-                 """,
-                },
-                {
-                    "id": 2,
-                    "script_type": "shell",
-                    "chroot": "/dev/null",
-                    "interpreter": "/bin/bash",
-                    "contents": """#!/bin/bash
+                 """},
+                {"id": 2, "script_type": "shell",
+                 "chroot": "/dev/null", "interpreter": "/bin/bash",
+                 "contents": """#!/bin/bash
 echo 'some more hello'
-                 """,
-                },
-            ]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+                 """
+                 },
+            ])
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_listscripts(shell, "some_profile")
 
         assert not shell.help_kickstart_listscripts.called
@@ -317,30 +236,15 @@ echo 'some more hello'
         assert mprint.called
         assert shell.client.kickstart.profile.listScripts.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "ID:          1",
-                "Type:        shell",
-                "Chroot:      /dev/null",
-                "Interpreter: /bin/bash",
-                "",
-                "Contents",
-                "--------",
-                "#!/bin/bash\necho 'Hello there!'\n                 ",
-                "----------",
-                "ID:          2",
-                "Type:        shell",
-                "Chroot:      /dev/null",
-                "Interpreter: /bin/bash",
-                "",
-                "Contents",
-                "--------",
-                "#!/bin/bash\necho 'some more hello'\n                 ",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['ID:          1', 'Type:        shell',
+                                 'Chroot:      /dev/null', 'Interpreter: /bin/bash', '',
+                                 'Contents', '--------', "#!/bin/bash\necho 'Hello there!'\n                 ",
+                                 '----------', 'ID:          2', 'Type:        shell',
+                                 'Chroot:      /dev/null', 'Interpreter: /bin/bash', '',
+                                 'Contents', '--------', "#!/bin/bash\necho 'some more hello'\n                 "]
+                                )
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_list_nodata(self, shell):
         """
         Test do_kickstart_list. Return no data, print to STDOUT.
@@ -350,30 +254,20 @@ echo 'some more hello'
         """
         mprint = MagicMock()
         logger = MagicMock()
-        shell.client.kickstart.listKickstarts = MagicMock(
-            return_value=[
-                {"name": "default_kickstart"},
-                {"name": "whatever_kickstart"},
-                {"name": "some_profile_kickstart"},
-            ]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        shell.client.kickstart.listKickstarts = MagicMock(return_value=[
+            {"name": "default_kickstart"}, {"name": "whatever_kickstart"},
+            {"name": "some_profile_kickstart"}
+        ])
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             out = spacecmd.kickstart.do_kickstart_list(shell, "", doreturn=False)
 
         assert not logger.error.called
         assert out is None
         assert mprint.called
-        assert_expect(
-            mprint.call_args_list,
-            "default_kickstart\nsome_profile_kickstart\nwhatever_kickstart",
-        )
+        assert_expect(mprint.call_args_list,
+                      'default_kickstart\nsome_profile_kickstart\nwhatever_kickstart')
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_list_nodata_noprofiles(self, shell):
         """
         Test do_kickstart_list. Return no data, print to STDOUT. No profiles has been found.
@@ -384,20 +278,16 @@ echo 'some more hello'
         mprint = MagicMock()
         logger = MagicMock()
         shell.client.kickstart.listKickstarts = MagicMock(return_value=[])
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             out = spacecmd.kickstart.do_kickstart_list(shell, "", doreturn=False)
 
         assert not mprint.called
         assert logger.error.called
         assert out is None
-        assert_expect(logger.error.call_args_list, "No kickstart profiles available")
+        assert_expect(logger.error.call_args_list,
+                      "No kickstart profiles available")
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_list_data(self, shell):
         """
         Test do_kickstart_list. Return data, no printing to STDOUT.
@@ -407,32 +297,20 @@ echo 'some more hello'
         """
         mprint = MagicMock()
         logger = MagicMock()
-        shell.client.kickstart.listKickstarts = MagicMock(
-            return_value=[
-                {"name": "default_kickstart"},
-                {"name": "whatever_kickstart"},
-                {"name": "some_profile_kickstart"},
-            ]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        shell.client.kickstart.listKickstarts = MagicMock(return_value=[
+            {"name": "default_kickstart"}, {"name": "whatever_kickstart"},
+            {"name": "some_profile_kickstart"}
+        ])
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             out = spacecmd.kickstart.do_kickstart_list(shell, "", doreturn=True)
 
         assert not mprint.called
         assert not logger.error.called
         assert out is not None
         assert len(out) == 3
-        assert out == [
-            "default_kickstart",
-            "some_profile_kickstart",
-            "whatever_kickstart",
-        ]
+        assert out == ["default_kickstart", "some_profile_kickstart", "whatever_kickstart"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_list_data_no_profiles(self, shell):
         """
         Test do_kickstart_list. Return data, no printing to STDOUT. No profiles found.
@@ -443,12 +321,8 @@ echo 'some more hello'
         mprint = MagicMock()
         logger = MagicMock()
         shell.client.kickstart.listKickstarts = MagicMock(return_value=[])
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             out = spacecmd.kickstart.do_kickstart_list(shell, "", doreturn=True)
 
         assert not mprint.called
@@ -456,7 +330,6 @@ echo 'some more hello'
         assert out is not None
         assert out == []
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_delete_noargs(self, shell):
         """
         Test do_kickstart_delete without arguments.
@@ -465,7 +338,6 @@ echo 'some more hello'
         :return:
         """
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_delete(shell, "")
 
@@ -475,7 +347,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.deleteProfile.called
         assert shell.help_kickstart_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_delete_invalid_profile(self, shell):
         """
         Test do_kickstart_delete invalid profile (not found).
@@ -483,11 +354,10 @@ echo 'some more hello'
         :param shell:
         :return:
         """
-        shell.do_kickstart_list = MagicMock(
-            return_value=["first_profile", "second_profile", "third_profile"]
-        )
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "first_profile", "second_profile", "third_profile"
+        ])
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_delete(shell, "fourth_profile")
 
@@ -497,14 +367,13 @@ echo 'some more hello'
         assert shell.do_kickstart_list.called
         assert shell.help_kickstart_delete.called
 
-        assert_expect(
-            logger.error.call_args_list,
-            "No valid kickstart labels passed as arguments!",
-        )
-        assert_expect(logger.debug.call_args_list, "Got labels to delete of []")
-        assert_args_expect(shell.do_kickstart_list.call_args_list, [(("", True), {})])
+        assert_expect(logger.error.call_args_list,
+                      'No valid kickstart labels passed as arguments!')
+        assert_expect(logger.debug.call_args_list,
+                      'Got labels to delete of []')
+        assert_args_expect(shell.do_kickstart_list.call_args_list,
+                           [(('', True), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_delete_some_invalid_profile(self, shell):
         """
         Test do_kickstart_delete invalid profile (not found).
@@ -512,15 +381,13 @@ echo 'some more hello'
         :param shell:
         :return:
         """
-        shell.do_kickstart_list = MagicMock(
-            return_value=["first_profile", "second_profile", "third_profile"]
-        )
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "first_profile", "second_profile", "third_profile"
+        ])
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_delete(
-                shell, "fourth_profile zero_profile first_profile second_profile"
-            )
+                shell, "fourth_profile zero_profile first_profile second_profile")
 
         assert not shell.client.kickstart.deleteProfile.called
         assert not shell.help_kickstart_delete.called
@@ -528,24 +395,12 @@ echo 'some more hello'
         assert shell.do_kickstart_list.called
         assert logger.debug.called
 
-        assert_expect(
-            logger.debug.call_args_list,
-            "Got labels to delete of ['first_profile', 'second_profile']",
-        )
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "The following kickstart labels are invalid:",
-                        "fourth_profile, zero_profile",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_expect(logger.debug.call_args_list,
+                      "Got labels to delete of ['first_profile', 'second_profile']")
+        assert_args_expect(logger.error.call_args_list,
+                           [(('The following kickstart labels are invalid:',
+                              'fourth_profile, zero_profile'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_delete_profile_all_yes(self, shell):
         """
         Test do_kickstart_delete profile, yes=true. This should not cause interactive prompt.
@@ -554,15 +409,13 @@ echo 'some more hello'
         :return:
         """
         shell.options.yes = True
-        shell.do_kickstart_list = MagicMock(
-            return_value=["first_profile", "second_profile", "third_profile"]
-        )
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "first_profile", "second_profile", "third_profile"
+        ])
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_delete(
-                shell, "first_profile second_profile"
-            )
+                shell, "first_profile second_profile")
 
         assert not shell.help_kickstart_delete.called
         assert not logger.error.called
@@ -571,15 +424,10 @@ echo 'some more hello'
         assert shell.do_kickstart_list.called
         assert logger.debug.called
 
-        assert_args_expect(
-            shell.client.kickstart.deleteProfile.call_args_list,
-            [
-                ((shell.session, "first_profile"), {}),
-                ((shell.session, "second_profile"), {}),
-            ],
-        )
+        assert_args_expect(shell.client.kickstart.deleteProfile.call_args_list,
+                           [((shell.session, "first_profile"), {}),
+                            ((shell.session, "second_profile"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_delete_profile_interactive(self, shell):
         """
         Test do_kickstart_delete profile, yes=false. Should start interactive confirmation prompt.
@@ -589,15 +437,13 @@ echo 'some more hello'
         """
         shell.options.yes = False
         shell.user_confirm = MagicMock(return_value=True)
-        shell.do_kickstart_list = MagicMock(
-            return_value=["first_profile", "second_profile", "third_profile"]
-        )
+        shell.do_kickstart_list = MagicMock(return_value=[
+            "first_profile", "second_profile", "third_profile"
+        ])
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_delete(
-                shell, "first_profile second_profile"
-            )
+                shell, "first_profile second_profile")
 
         assert not shell.help_kickstart_delete.called
         assert not logger.error.called
@@ -606,15 +452,10 @@ echo 'some more hello'
         assert shell.do_kickstart_list.called
         assert logger.debug.called
 
-        assert_args_expect(
-            shell.client.kickstart.deleteProfile.call_args_list,
-            [
-                ((shell.session, "first_profile"), {}),
-                ((shell.session, "second_profile"), {}),
-            ],
-        )
+        assert_args_expect(shell.client.kickstart.deleteProfile.call_args_list,
+                           [((shell.session, "first_profile"), {}),
+                            ((shell.session, "second_profile"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listcryptokeys_noargs(self, shell):
         """
         Test do_kickstart_listcryptokeys no args.
@@ -623,7 +464,6 @@ echo 'some more hello'
         :return:
         """
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.print", mprint) as prt:
             data = spacecmd.kickstart.do_kickstart_listcryptokeys(shell, "")
 
@@ -632,7 +472,6 @@ echo 'some more hello'
         assert data is None
         assert shell.help_kickstart_listcryptokeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listcryptokeys_cryptokeys_to_stdout(self, shell):
         """
         Test do_kickstart_listcryptokeys cryptokeys to stdout.
@@ -640,17 +479,14 @@ echo 'some more hello'
         :param shell:
         :return:
         """
-        shell.client.kickstart.profile.system.listKeys = MagicMock(
-            return_value=[
-                {"description": "c_key"},
-                {"description": "b_key"},
-                {"description": "a_key"},
-                {"description": "z_key"},
-                {"description": "x_key"},
-            ]
-        )
+        shell.client.kickstart.profile.system.listKeys = MagicMock(return_value=[
+            {"description": "c_key"},
+            {"description": "b_key"},
+            {"description": "a_key"},
+            {"description": "z_key"},
+            {"description": "x_key"},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.print", mprint) as prt:
             data = spacecmd.kickstart.do_kickstart_listcryptokeys(shell, "some_profile")
 
@@ -659,9 +495,9 @@ echo 'some more hello'
         assert data is None
         assert shell.client.kickstart.profile.system.listKeys.called
 
-        assert_expect(mprint.call_args_list, "a_key\nb_key\nc_key\nx_key\nz_key")
+        assert_expect(mprint.call_args_list,
+                      'a_key\nb_key\nc_key\nx_key\nz_key')
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listcryptokeys_cryptokeys_as_data(self, shell):
         """
         Test do_kickstart_listcryptokeys cryptokeys as data.
@@ -669,29 +505,24 @@ echo 'some more hello'
         :param shell:
         :return:
         """
-        shell.client.kickstart.profile.system.listKeys = MagicMock(
-            return_value=[
-                {"description": "c_key"},
-                {"description": "b_key"},
-                {"description": "a_key"},
-                {"description": "z_key"},
-                {"description": "x_key"},
-            ]
-        )
+        shell.client.kickstart.profile.system.listKeys = MagicMock(return_value=[
+            {"description": "c_key"},
+            {"description": "b_key"},
+            {"description": "a_key"},
+            {"description": "z_key"},
+            {"description": "x_key"},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.print", mprint) as prt:
             data = spacecmd.kickstart.do_kickstart_listcryptokeys(
-                shell, "some_profile", doreturn=True
-            )
+                shell, "some_profile", doreturn=True)
 
         assert not shell.help_kickstart_listcryptokeys.called
         assert not mprint.called
         assert data is not None
-        assert data == ["a_key", "b_key", "c_key", "x_key", "z_key"]
+        assert data == ['a_key', 'b_key', 'c_key', 'x_key', 'z_key']
         assert shell.client.kickstart.profile.system.listKeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listcryptokeys_no_cryptokeys(self, shell):
         """
         Test do_kickstart_listcryptokeys no cryptokeys.
@@ -702,15 +533,10 @@ echo 'some more hello'
         shell.client.kickstart.profile.system.listKeys = MagicMock(return_value=[])
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.kickstart.print", mprint) as prt, patch(
-            "spacecmd.kickstart.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.kickstart.print", mprint) as prt, \
+                patch("spacecmd.kickstart.logging", logger) as lgr:
             data = spacecmd.kickstart.do_kickstart_listcryptokeys(
-                shell, "some_profile", doreturn=False
-            )
+                shell, "some_profile", doreturn=False)
 
         assert not shell.help_kickstart_listcryptokeys.called
         assert not mprint.called
@@ -718,9 +544,9 @@ echo 'some more hello'
         assert data is None
         assert shell.client.kickstart.profile.system.listKeys.called
 
-        assert_expect(logger.error.call_args_list, "No crypto keys has been found")
+        assert_expect(logger.error.call_args_list,
+                      "No crypto keys has been found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_addcryptokeys_noarg(self, shell):
         """
         Test do_kickstart_addcryptokeys no arguments
@@ -732,7 +558,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.system.addKeys.called
         assert shell.help_kickstart_addcryptokeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_addcryptokeys(self, shell):
         """
         Test do_kickstart_addcryptokeys
@@ -744,12 +569,9 @@ echo 'some more hello'
         assert not shell.help_kickstart_addcryptokeys.called
         assert shell.client.kickstart.profile.system.addKeys.called
 
-        assert_args_expect(
-            shell.client.kickstart.profile.system.addKeys.call_args_list,
-            [((shell.session, "my_profile", ["key1", "key2"]), {})],
-        )
+        assert_args_expect(shell.client.kickstart.profile.system.addKeys.call_args_list,
+                           [((shell.session, "my_profile", ["key1", "key2"]), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removecryptokeys_noargs(self, shell):
         """
         Test do_kickstart_removecryptokeys with no args.
@@ -761,7 +583,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.system.removeKeys.called
         assert shell.help_kickstart_removecryptokeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removecryptokeys_wrongargs(self, shell):
         """
         Test do_kickstart_removecryptokeys with wrong args
@@ -773,7 +594,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.system.removeKeys.called
         assert shell.help_kickstart_removecryptokeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removecryptokeys(self, shell):
         """
         Test do_kickstart_removecryptokeys standard call.
@@ -785,7 +605,6 @@ echo 'some more hello'
         assert not shell.help_kickstart_removecryptokeys.called
         assert shell.client.kickstart.profile.system.removeKeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listactivationkeys_noarg(self, shell):
         """
         Test do_kickstart_listactivationkeys with no arguments.
@@ -794,7 +613,6 @@ echo 'some more hello'
         :return:
         """
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.kickstart.print", mprint) as prt:
             out = spacecmd.kickstart.do_kickstart_listactivationkeys(shell, "")
 
@@ -803,7 +621,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.keys.getActivationKeys.called
         assert shell.help_kickstart_listactivationkeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listactivationkeys_nokey_data(self, shell):
         """
         Test do_kickstart_listactivationkeys with no key data in them.
@@ -812,17 +629,15 @@ echo 'some more hello'
         :return:
         """
         mprint = MagicMock()
-        shell.client.kickstart.profile.keys.getActivationKeys = MagicMock(
-            return_value=[{}, {}, {}, {}]
-        )
-        # pylint: disable-next=unused-variable
+        shell.client.kickstart.profile.keys.getActivationKeys = MagicMock(return_value=[
+            {}, {}, {}, {}
+        ])
         with patch("spacecmd.kickstart.print", mprint) as prt:
             out = spacecmd.kickstart.do_kickstart_listactivationkeys(shell, "")
 
         assert out is None
         assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listactivationkeys_nodata_sorted(self, shell):
         """
         Test do_kickstart_listactivationkeys with no key data in them.
@@ -831,23 +646,17 @@ echo 'some more hello'
         :return:
         """
         mprint = MagicMock()
-        shell.client.kickstart.profile.keys.getActivationKeys = MagicMock(
-            return_value=[
-                {"key": "zettakey"},
-                {"key": "one"},
-                {"key": "two"},
-                {"key": "andthree"},
-            ]
-        )
-        # pylint: disable-next=unused-variable
+        shell.client.kickstart.profile.keys.getActivationKeys = MagicMock(return_value=[
+            {"key": "zettakey"}, {"key": "one"}, {"key": "two"}, {"key": "andthree"}
+        ])
         with patch("spacecmd.kickstart.print", mprint) as prt:
             out = spacecmd.kickstart.do_kickstart_listactivationkeys(shell, "profile")
 
         assert out is None
         assert mprint.called
-        assert_expect(mprint.call_args_list, "andthree\none\ntwo\nzettakey")
+        assert_expect(mprint.call_args_list,
+                      'andthree\none\ntwo\nzettakey')
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_listactivationkeys_data_sorted(self, shell):
         """
         Test do_kickstart_listactivationkeys with no key data in them.
@@ -856,26 +665,17 @@ echo 'some more hello'
         :return:
         """
         mprint = MagicMock()
-        shell.client.kickstart.profile.keys.getActivationKeys = MagicMock(
-            return_value=[
-                {"key": "zettakey"},
-                {"key": "one"},
-                {"key": "two"},
-                {"key": "andthree"},
-            ]
-        )
-        # pylint: disable-next=unused-variable
+        shell.client.kickstart.profile.keys.getActivationKeys = MagicMock(return_value=[
+            {"key": "zettakey"}, {"key": "one"}, {"key": "two"}, {"key": "andthree"}
+        ])
         with patch("spacecmd.kickstart.print", mprint) as prt:
-            out = spacecmd.kickstart.do_kickstart_listactivationkeys(
-                shell, "profile", doreturn=True
-            )
+            out = spacecmd.kickstart.do_kickstart_listactivationkeys(shell, "profile", doreturn=True)
 
         assert not mprint.called
         assert out is not None
         assert len(out) == 4
-        assert out == ["andthree", "one", "two", "zettakey"]
+        assert out == ['andthree', 'one', 'two', 'zettakey']
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_addactivationkeys_noarg(self, shell):
         """
         Test do_kickstart_addactivationkeys add activation keys.
@@ -887,7 +687,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.keys.addActivationKey.called
         assert shell.help_kickstart_addactivationkeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_addactivationkeys_wrong_args(self, shell):
         """
         Test do_kickstart_addactivationkeys add activation keys with wrong amount of args.
@@ -899,7 +698,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.keys.addActivationKey.called
         assert shell.help_kickstart_addactivationkeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_addactivationkeys(self, shell):
         """
         Test do_kickstart_addactivationkeys
@@ -911,7 +709,6 @@ echo 'some more hello'
         assert not shell.help_kickstart_addactivationkeys.called
         assert shell.client.kickstart.profile.keys.addActivationKey.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removeactivationkeys_noargs_nointeractive(self, shell):
         """
         Test do_kickstart_removeactivationkeys no args, no interactive.
@@ -925,7 +722,6 @@ echo 'some more hello'
         assert not shell.user_confirm.called
         assert shell.help_kickstart_removeactivationkeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removeactivationkeys_noargs_wrongargs_nointeractive(self, shell):
         """
         Test do_kickstart_removeactivationkeys wrong args, no interactive.
@@ -939,7 +735,6 @@ echo 'some more hello'
         assert not shell.user_confirm.called
         assert shell.help_kickstart_removeactivationkeys.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removeactivationkeys_nointeractive(self, shell):
         """
         Test do_kickstart_removeactivationkeys wrong args, no interactive.
@@ -955,7 +750,6 @@ echo 'some more hello'
         assert shell.client.kickstart.profile.keys.removeActivationKey.called
         assert shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removeactivationkeys_interactive_abort(self, shell):
         """
         Test do_kickstart_removeactivationkeys wrong args, interactive, abort.
@@ -971,7 +765,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.keys.removeActivationKey.called
         assert shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removeactivationkeys_interactive_accept(self, shell):
         """
         Test do_kickstart_removeactivationkeys wrong args, interactive, accept.
@@ -987,7 +780,6 @@ echo 'some more hello'
         assert shell.client.kickstart.profile.keys.removeActivationKey.called
         assert shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removeactivationkeys_noninteractive_abort(self, shell):
         """
         Test do_kickstart_removeactivationkeys wrong args, non interactive, abort.
@@ -1003,7 +795,6 @@ echo 'some more hello'
         assert not shell.client.kickstart.profile.keys.removeActivationKey.called
         assert shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_kickstart_removeactivationkeys_noninteractive_accept(self, shell):
         """
         Test do_kickstart_removeactivationkeys wrong args, non interactive, accept.
@@ -1019,7 +810,6 @@ echo 'some more hello'
         assert not shell.user_confirm.called
         assert shell.client.kickstart.profile.keys.removeActivationKey.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_export_kickstart_getdetails_sort_all_lists(self, shell):
         """
         Test export_kickstart_getdetails for sorting list of dicts
@@ -1040,18 +830,11 @@ echo 'some more hello'
             return_value=copy.deepcopy(advanced_opts)
         )
         shell.kickstart_getcontents = MagicMock(return_value="")
-        details = spacecmd.kickstart.export_kickstart_getdetails(
-            shell,
-            "testing-testing",
-            [
-                {
-                    "label": "testing-testing",
-                }
-            ],
-        )
+        details = spacecmd.kickstart.export_kickstart_getdetails(shell, "testing-testing", [{
+            "label": "testing-testing",
+        }])
         assert details["advanced_opts"] == expected
 
-    # pylint: disable-next=redefined-outer-name
     def test_help_kickstart_importjson(self, shell):
         """
         Test do_kickstart_importjson showing proper help if no arguments

--- a/spacecmd/tests/test_misc.py
+++ b/spacecmd/tests/test_misc.py
@@ -3,8 +3,6 @@
 Test spacecmd.misc
 """
 from unittest.mock import MagicMock, patch, mock_open
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.misc
 from xmlrpc import client as xmlrpclib
@@ -15,8 +13,6 @@ class TestSCMisc:
     """
     Test suite for misc methods/funtions.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_clear_caches(self, shell):
         """
         Test clear caches.
@@ -34,7 +30,6 @@ class TestSCMisc:
         assert shell.clear_package_cache.called
         assert shell.clear_errata_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_api_version(self, shell):
         """
         Get API version.
@@ -43,13 +38,11 @@ class TestSCMisc:
         :return:
         """
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.print", mprint) as prt:
             spacecmd.misc.do_get_serverversion(shell, "")
         assert mprint.called
         assert shell.client.api.systemVersion.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_list_proxies(self, shell):
         """
         Test proxy listing.
@@ -67,7 +60,6 @@ class TestSCMisc:
         assert_expect(mprint.call_args_list, "Print me")
         assert shell.client.proxy.listProxies.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_session(self, shell):
         """
         Test getting current user session.
@@ -77,19 +69,14 @@ class TestSCMisc:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.do_get_session(shell, "")
 
         assert not logger.error.called
         assert mprint.called
         assert_expect(mprint.call_args_list, shell.session)
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_session_missing(self, shell):
         """
         Test handling missing current user session.
@@ -99,12 +86,8 @@ class TestSCMisc:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             shell.session = None
             spacecmd.misc.do_get_session(shell, "")
 
@@ -114,7 +97,6 @@ class TestSCMisc:
 
     # No test for listing history, as it is just lister from the readline.
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_toggle_confirmations(self, shell):
         """
         Test confirmation messages toggle
@@ -124,20 +106,14 @@ class TestSCMisc:
         """
         mprint = MagicMock()
         shell.options.yes = True
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.print", mprint) as prt:
             spacecmd.misc.do_toggle_confirmations(shell, "")
             spacecmd.misc.do_toggle_confirmations(shell, "")
 
-        assert_args_expect(
-            mprint.call_args_list,
-            [
-                (("Confirmation messages are", "enabled"), {}),
-                (("Confirmation messages are", "disabled"), {}),
-            ],
-        )
+        assert_args_expect(mprint.call_args_list,
+                           [(("Confirmation messages are", "enabled"), {}),
+                            (("Confirmation messages are", "disabled"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_login_already_logged_in(self, shell):
         """
         Test login (already logged in).
@@ -152,20 +128,11 @@ class TestSCMisc:
         mkd = MagicMock()
         shell.config = {}
         shell.conf_dir = "/tmp"
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not shell.load_config_section.called
@@ -182,9 +149,9 @@ class TestSCMisc:
         assert out
         assert logger.warning.called
 
-        assert_expect(logger.warning.call_args_list, "You are already logged in")
+        assert_expect(logger.warning.call_args_list,
+                      "You are already logged in")
 
-    # pylint: disable-next=redefined-outer-name
     def test_login_no_server_specified(self, shell):
         """
         Test login without specified server.
@@ -202,20 +169,11 @@ class TestSCMisc:
         shell.config = {}
         shell.conf_dir = "/tmp"
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not shell.load_config_section.called
@@ -232,9 +190,9 @@ class TestSCMisc:
         assert not out
         assert logger.warning.called
 
-        assert_expect(logger.warning.call_args_list, "No server specified")
+        assert_expect(logger.warning.call_args_list,
+                      "No server specified")
 
-    # pylint: disable-next=redefined-outer-name
     def test_login_connection_error(self, shell):
         """
         Test handling connection error at login.
@@ -257,24 +215,12 @@ class TestSCMisc:
         shell.conf_dir = "/tmp"
         client.api.getVersion = MagicMock(side_effect=Exception("Insert coin"))
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not logger.info.called
@@ -292,26 +238,13 @@ class TestSCMisc:
         assert logger.error.called
         assert shell.client is None
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [(("Failed to connect to %s", "https://no.mans.land/rpc/api"), {})],
-        )
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (("Connecting to %s", "https://no.mans.land/rpc/api"), {}),
-                (
-                    (
-                        "Error while connecting to the server %s: %s",
-                        "https://no.mans.land/rpc/api",
-                        "Insert coin",
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Failed to connect to %s', 'https://no.mans.land/rpc/api'), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Connecting to %s', 'https://no.mans.land/rpc/api'), {}),
+                            (('Error while connecting to the server %s: %s',
+                              'https://no.mans.land/rpc/api', 'Insert coin'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_login_api_version_mismatch(self, shell):
         """
         Test handling API version mismatch error at login.
@@ -335,24 +268,12 @@ class TestSCMisc:
         shell.MINIMUM_API_VERSION = 10.8
         client.api.getVersion = MagicMock(return_value=1.5)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not logger.info.called
@@ -370,13 +291,10 @@ class TestSCMisc:
         assert logger.error.called
         assert shell.client is None
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [(("API (%s) is too old (>= %s required)", 1.5, 10.8), {})],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('API (%s) is too old (>= %s required)', 1.5, 10.8), {})])
 
     @patch("spacecmd.misc.os.path.isfile", MagicMock(return_value=True))
-    # pylint: disable-next=redefined-outer-name
     def test_login_reuse_cached_session(self, shell):
         """
         Test handling cached available session.
@@ -403,29 +321,14 @@ class TestSCMisc:
         client.api.getVersion = MagicMock(return_value=11.5)
         client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.open",
-            new_callable=mock_open,
-            read_data="bofh:5adf5cc50929f71a899b81c2c2eb0979",
-            # pylint: disable-next=unused-variable
-        ) as fmk, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.open", new_callable=mock_open,
+                  read_data="bofh:5adf5cc50929f71a899b81c2c2eb0979") as fmk, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not client.auth.login.called
@@ -446,21 +349,14 @@ class TestSCMisc:
         assert shell.server == "no.mans.land"
         assert out
 
-        assert_args_expect(
-            logger.info.call_args_list,
-            [(("Connected to %s as %s", "https://no.mans.land/rpc/api", "bofh"), {})],
-        )
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (("Connecting to %s", "https://no.mans.land/rpc/api"), {}),
-                (("Server API Version = %s", 11.5), {}),
-                (("Using cached credentials from %s", "/tmp/no.mans.land/session"), {}),
-            ],
-        )
+        assert_args_expect(logger.info.call_args_list,
+                           [(('Connected to %s as %s', 'https://no.mans.land/rpc/api', 'bofh'), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Connecting to %s', 'https://no.mans.land/rpc/api'), {}),
+                            (('Server API Version = %s', 11.5), {}),
+                            (('Using cached credentials from %s', '/tmp/no.mans.land/session'), {})])
 
     @patch("spacecmd.misc.os.path.isfile", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_login_no_cached_session_opt_pwd(self, shell):
         """
         Test create new session, password from the options.
@@ -489,28 +385,13 @@ class TestSCMisc:
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
         client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.open",
-            file_writer
-            # pylint: disable-next=unused-variable
-        ) as fmk, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.open", file_writer) as fmk, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not gpass.called
@@ -531,25 +412,19 @@ class TestSCMisc:
         assert out
         assert mkd.called
 
-        assert_args_expect(client.auth.login.call_args_list, [(("bofh", "foobar"), {})])
-        assert_args_expect(mkd.call_args_list, [(("/tmp/no.mans.land", 448), {})])
-        assert_args_expect(
-            shell.load_caches.call_args_list, [(("no.mans.land", "bofh"), {})]
-        )
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (("Connecting to %s", "https://no.mans.land/rpc/api"), {}),
-                (("Server API Version = %s", 11.5), {}),
-            ],
-        )
-        assert_args_expect(
-            logger.info.call_args_list,
-            [(("Connected to %s as %s", "https://no.mans.land/rpc/api", "bofh"), {})],
-        )
+        assert_args_expect(client.auth.login.call_args_list,
+                           [(('bofh', "foobar"), {})])
+        assert_args_expect(mkd.call_args_list,
+                           [(('/tmp/no.mans.land', 448), {})])
+        assert_args_expect(shell.load_caches.call_args_list,
+                           [(('no.mans.land', 'bofh'), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Connecting to %s', 'https://no.mans.land/rpc/api'), {}),
+                            (('Server API Version = %s', 11.5), {})])
+        assert_args_expect(logger.info.call_args_list,
+                           [(('Connected to %s as %s', 'https://no.mans.land/rpc/api', 'bofh'), {})])
 
     @patch("spacecmd.misc.os.path.isfile", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_login_no_cached_session_cfg_pwd(self, shell):
         """
         Test create new session, password from the command line interface.
@@ -578,28 +453,13 @@ class TestSCMisc:
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
         client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.open",
-            file_writer
-            # pylint: disable-next=unused-variable
-        ) as fmk, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.open", file_writer) as fmk, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not mprint.called
@@ -620,25 +480,19 @@ class TestSCMisc:
         assert out
         assert mkd.called
 
-        assert_args_expect(client.auth.login.call_args_list, [(("bofh", "foobar"), {})])
-        assert_args_expect(mkd.call_args_list, [(("/tmp/no.mans.land", 448), {})])
-        assert_args_expect(
-            shell.load_caches.call_args_list, [(("no.mans.land", "bofh"), {})]
-        )
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (("Connecting to %s", "https://no.mans.land/rpc/api"), {}),
-                (("Server API Version = %s", 11.5), {}),
-            ],
-        )
-        assert_args_expect(
-            logger.info.call_args_list,
-            [(("Connected to %s as %s", "https://no.mans.land/rpc/api", "bofh"), {})],
-        )
+        assert_args_expect(client.auth.login.call_args_list,
+                           [(('bofh', "foobar"), {})])
+        assert_args_expect(mkd.call_args_list,
+                           [(('/tmp/no.mans.land', 448), {})])
+        assert_args_expect(shell.load_caches.call_args_list,
+                           [(('no.mans.land', 'bofh'), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Connecting to %s', 'https://no.mans.land/rpc/api'), {}),
+                            (('Server API Version = %s', 11.5), {})])
+        assert_args_expect(logger.info.call_args_list,
+                           [(('Connected to %s as %s', 'https://no.mans.land/rpc/api', 'bofh'), {})])
 
     @patch("spacecmd.misc.os.path.isfile", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_login_no_cached_session_cli_pwd(self, shell):
         """
         Test create new session, password from the configuration.
@@ -667,28 +521,13 @@ class TestSCMisc:
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
         client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.open",
-            file_writer
-            # pylint: disable-next=unused-variable
-        ) as fmk, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.open", file_writer) as fmk, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not gpass.called
@@ -709,25 +548,19 @@ class TestSCMisc:
         assert out
         assert mkd.called
 
-        assert_args_expect(client.auth.login.call_args_list, [(("bofh", "foobar"), {})])
-        assert_args_expect(mkd.call_args_list, [(("/tmp/no.mans.land", 448), {})])
-        assert_args_expect(
-            shell.load_caches.call_args_list, [(("no.mans.land", "bofh"), {})]
-        )
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (("Connecting to %s", "https://no.mans.land/rpc/api"), {}),
-                (("Server API Version = %s", 11.5), {}),
-            ],
-        )
-        assert_args_expect(
-            logger.info.call_args_list,
-            [(("Connected to %s as %s", "https://no.mans.land/rpc/api", "bofh"), {})],
-        )
+        assert_args_expect(client.auth.login.call_args_list,
+                           [(('bofh', "foobar"), {})])
+        assert_args_expect(mkd.call_args_list,
+                           [(('/tmp/no.mans.land', 448), {})])
+        assert_args_expect(shell.load_caches.call_args_list,
+                           [(('no.mans.land', 'bofh'), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Connecting to %s', 'https://no.mans.land/rpc/api'), {}),
+                            (('Server API Version = %s', 11.5), {})])
+        assert_args_expect(logger.info.call_args_list,
+                           [(('Connected to %s as %s', 'https://no.mans.land/rpc/api', 'bofh'), {})])
 
     @patch("spacecmd.misc.os.path.isfile", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_login_no_cached_session_bad_credentials(self, shell):
         """
         Test fail to create new session due to wrong credentials.
@@ -753,32 +586,15 @@ class TestSCMisc:
         shell.conf_dir = "/tmp"
         shell.MINIMUM_API_VERSION = 10.8
         client.api.getVersion = MagicMock(return_value=11.5)
-        client.auth.login = MagicMock(
-            side_effect=xmlrpclib.Fault(faultCode=42, faultString="Click harder")
-        )
+        client.auth.login = MagicMock(side_effect=xmlrpclib.Fault(faultCode=42, faultString="Click harder"))
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.open",
-            file_writer
-            # pylint: disable-next=unused-variable
-        ) as fmk, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.open", file_writer) as fmk, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not gpass.called
@@ -797,21 +613,16 @@ class TestSCMisc:
         assert not out
         assert not mkd.called
 
-        assert_args_expect(client.auth.login.call_args_list, [(("bofh", "foobar"), {})])
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (("Connecting to %s", "https://no.mans.land/rpc/api"), {}),
-                (("Server API Version = %s", 11.5), {}),
-                (("Login error: %s (%s)", "Click harder", 42), {}),
-            ],
-        )
-        assert_args_expect(
-            logger.error.call_args_list, [(("Invalid credentials",), {})]
-        )
+        assert_args_expect(client.auth.login.call_args_list,
+                           [(('bofh', "foobar"), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Connecting to %s', 'https://no.mans.land/rpc/api'), {}),
+                            (('Server API Version = %s', 11.5), {}),
+                            (('Login error: %s (%s)', 'Click harder', 42), {})])
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Invalid credentials', ), {})])
 
     @patch("spacecmd.misc.os.path.isfile", MagicMock(return_value=False))
-    # pylint: disable-next=redefined-outer-name
     def test_login_handle_cache_write_error_mkdir(self, shell):
         """
         Test fail to save session due to directory permission denial
@@ -840,28 +651,13 @@ class TestSCMisc:
         client.auth.login = MagicMock(return_value="5adf5cc50929f71a899b81c2c2eb0979")
         client.system.hasTraditionalSystems = MagicMock(return_value=False)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.misc.getpass", gpass) as gtp, patch(
-            "spacecmd.misc.os.mkdir",
-            mkd
-            # pylint: disable-next=unused-variable
-        ) as mkdr, patch(
-            "spacecmd.misc.xmlrpclib.Server",
-            rpc_server
-            # pylint: disable-next=unused-variable
-        ) as rpcs, patch(
-            "spacecmd.misc.open",
-            file_writer
-            # pylint: disable-next=unused-variable
-        ) as fmk, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.prompt_user", prompter) as pmt, \
+            patch("spacecmd.misc.getpass", gpass) as gtp, \
+            patch("spacecmd.misc.os.mkdir", mkd) as mkdr, \
+            patch("spacecmd.misc.xmlrpclib.Server", rpc_server) as rpcs, \
+            patch("spacecmd.misc.open", file_writer) as fmk, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             out = spacecmd.misc.do_login(shell, "")
 
         assert not mprint.called
@@ -882,28 +678,20 @@ class TestSCMisc:
         assert out
         assert mkd.called
 
-        assert_args_expect(client.auth.login.call_args_list, [(("bofh", "foobar"), {})])
-        assert_args_expect(mkd.call_args_list, [(("/tmp/no.mans.land", 448), {})])
-        assert_args_expect(
-            shell.load_caches.call_args_list, [(("no.mans.land", "bofh"), {})]
-        )
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (("Connecting to %s", "https://no.mans.land/rpc/api"), {}),
-                (("Server API Version = %s", 11.5), {}),
-            ],
-        )
-        assert_args_expect(
-            logger.info.call_args_list,
-            [(("Connected to %s as %s", "https://no.mans.land/rpc/api", "bofh"), {})],
-        )
-        assert_args_expect(
-            logger.error.call_args_list,
-            [(("Could not write session file: %s", "Intel inside"), {})],
-        )
+        assert_args_expect(client.auth.login.call_args_list,
+                           [(('bofh', "foobar"), {})])
+        assert_args_expect(mkd.call_args_list,
+                           [(('/tmp/no.mans.land', 448), {})])
+        assert_args_expect(shell.load_caches.call_args_list,
+                           [(('no.mans.land', 'bofh'), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Connecting to %s', 'https://no.mans.land/rpc/api'), {}),
+                            (('Server API Version = %s', 11.5), {})])
+        assert_args_expect(logger.info.call_args_list,
+                           [(('Connected to %s as %s', 'https://no.mans.land/rpc/api', 'bofh'), {})])
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not write session file: %s', 'Intel inside'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_logout(self, shell):
         """
         Test logout.
@@ -920,9 +708,8 @@ class TestSCMisc:
         assert not shell.current_user
         assert not shell.server
         assert shell.do_clear_caches.called
-        assert_args_expect(shell.do_clear_caches.call_args_list, [(("",), {})])
+        assert_args_expect(shell.do_clear_caches.call_args_list, [(("", ), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_whoami_negative(self, shell):
         """
         Test whoami
@@ -932,15 +719,14 @@ class TestSCMisc:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        with patch("spacecmd.misc.print", mprint), patch.object(
-            shell, "current_user", None
-        ), patch("spacecmd.misc.logging", logger):
+        with patch("spacecmd.misc.print", mprint), \
+            patch.object(shell, "current_user", None), \
+            patch("spacecmd.misc.logging", logger):
             spacecmd.misc.do_whoami(shell, "")
 
         assert not mprint.called
         assert logger.warning.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_whoami_positive(self, shell):
         """
         Test whoami
@@ -950,15 +736,13 @@ class TestSCMisc:
         """
         mprint = MagicMock()
         logger = MagicMock()
-        with patch("spacecmd.misc.print", mprint), patch(
-            "spacecmd.misc.logging", logger
-        ):
+        with patch("spacecmd.misc.print", mprint), \
+                patch("spacecmd.misc.logging", logger):
             spacecmd.misc.do_whoami(shell, "")
 
         assert mprint.called
         assert not logger.warning.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_whoamitalkingto(self, shell):
         """
         Test to display what server is connected.
@@ -969,19 +753,14 @@ class TestSCMisc:
         shell.server = "no.mans.land"
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.do_whoamitalkingto(shell, "")
 
         assert not logger.warning.called
         assert mprint.called
-        assert_args_expect(mprint.call_args_list, [((shell.server,), {})])
+        assert_args_expect(mprint.call_args_list, [((shell.server, ), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_whoamitalkingto_no_session(self, shell):
         """
         Test to display no server is connected yet.
@@ -992,19 +771,14 @@ class TestSCMisc:
         shell.server = None
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.print", mprint) as prt, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.print", mprint) as prt, \
+            patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.do_whoamitalkingto(shell, "")
 
         assert not mprint.called
         assert logger.warning.called
-        assert_args_expect(logger.warning.call_args_list, [(("Yourself",), {})])
+        assert_args_expect(logger.warning.call_args_list, [(("Yourself", ), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_clear_errata_cache(self, shell):
         """
         Test errata cache cleared.
@@ -1024,7 +798,6 @@ class TestSCMisc:
         assert shell.errata_cache_expire > tst
         assert shell.save_errata_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_sorted_errata_names(self, shell):
         """
         Test getting errata names.
@@ -1032,18 +805,11 @@ class TestSCMisc:
         :param shell:
         :return:
         """
-        shell.all_errata = [
-            {"advisory_name": "cve-123"},
-            {"advisory_name": "cve-aaa"},
-            {"advisory_name": "cve-zzz"},
-        ]
-        assert spacecmd.misc.get_errata_names(shell) == [
-            "cve-123",
-            "cve-aaa",
-            "cve-zzz",
-        ]
+        shell.all_errata = [{"advisory_name": "cve-123"},
+                            {"advisory_name": "cve-aaa"},
+                            {"advisory_name": "cve-zzz"}]
+        assert spacecmd.misc.get_errata_names(shell) == ['cve-123', 'cve-aaa', 'cve-zzz']
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_erratum_id(self, shell):
         """
         Test to get erratum ID.
@@ -1054,7 +820,6 @@ class TestSCMisc:
         shell.all_errata = {"cve-zzz": {"id": 3}}
         assert spacecmd.misc.get_erratum_id(shell, "cve-zzz") == 3
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_erratum_name(self, shell):
         """
         Test to get erratum name.
@@ -1065,7 +830,6 @@ class TestSCMisc:
         shell.all_errata = {"cve-zzz": {"id": 3}}
         assert spacecmd.misc.get_erratum_name(shell, 3) == "cve-zzz"
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_errata_cache_no_expired(self, shell):
         """
         Test generate errata cache (no expired, i.e. should not be generated).
@@ -1081,7 +845,6 @@ class TestSCMisc:
         assert not shell.replace_line_buffer.called
         assert not shell.save_errata_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_errata_cache_force(self, shell):
         """
         Test generate errata cache, forced
@@ -1092,29 +855,20 @@ class TestSCMisc:
         shell.all_errata = {}
         shell.options.quiet = False
         shell.errata_cache_expire = datetime.datetime(2099, 1, 1)
-        shell.client.channel.listSoftwareChannels = MagicMock(
-            return_value=[{"label": "locked_channel"}, {"label": "base_channel"}]
-        )
-        shell.client.channel.software.listErrata = MagicMock(
-            side_effect=[
-                xmlrpclib.Fault(
-                    faultCode=42,
-                    faultString="Sales staff sold a product we don't offer",
-                ),
-                [
-                    {
-                        "id": 123,
-                        "advisory_name": "cve-123",
-                        "advisory_type": "mockery",
-                        "date": "2019.1.1",
-                        "advisory_synopsis": "some text here",
-                    }
-                ],
-            ]
-        )
+        shell.client.channel.listSoftwareChannels = MagicMock(return_value=[
+            {"label": "locked_channel"}, {"label": "base_channel"}
+        ])
+        shell.client.channel.software.listErrata = MagicMock(side_effect=[
+            xmlrpclib.Fault(faultCode=42, faultString="Sales staff sold a product we don't offer"),
+            [{
+                "id": 123,
+                "advisory_name": "cve-123",
+                "advisory_type": "mockery", "date": "2019.1.1",
+                "advisory_synopsis": "some text here",
+            }]
+        ])
 
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.generate_errata_cache(shell, force=True)
 
@@ -1130,22 +884,10 @@ class TestSCMisc:
         assert shell.all_errata["cve-123"]["advisory_synopsis"] == "some text here"
         assert shell.all_errata["cve-123"]["advisory_name"] == "cve-123"
         assert shell.all_errata["cve-123"]["date"] == "2019.1.1"
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (
-                    (
-                        "No access to %s (%s): %s",
-                        "locked_channel",
-                        42,
-                        "Sales staff sold a product we don't offer",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('No access to %s (%s): %s', 'locked_channel',
+                              42, "Sales staff sold a product we don't offer"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_clear_package_cache(self, shell):
         """
         Test clear package cache.
@@ -1165,7 +907,6 @@ class TestSCMisc:
         assert shell.package_cache_expire != tst
         assert shell.save_package_caches.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_package_cache_cache_not_expired(self, shell):
         """
         Test generate package cache is not yet expired.
@@ -1184,12 +925,8 @@ class TestSCMisc:
         shell.package_cache_expire = tst
         shell.PACKAGE_CACHE_TTL = 8000
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.build_package_names", pkgbuild) as pkgb, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.build_package_names", pkgbuild) as pkgb, \
+                patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.generate_package_cache(shell, force=False)
 
         assert not shell.client.channel.listSoftwareChannels.called
@@ -1200,7 +937,6 @@ class TestSCMisc:
         assert not shell.save_package_caches.called
         assert shell.package_cache_expire == tst
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_package_cache_cache_not_expired_forced(self, shell):
         """
         Test generate package cache not expired, but forced to.
@@ -1220,12 +956,8 @@ class TestSCMisc:
         shell.PACKAGE_CACHE_TTL = 8000
         shell.client.channel.listSoftwareChannels = MagicMock(return_value=[])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.build_package_names", pkgbuild) as pkgb, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.build_package_names", pkgbuild) as pkgb, \
+                patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.generate_package_cache(shell, force=True)
 
         assert not shell.client.channel.software.listAllPackages.called
@@ -1237,7 +969,6 @@ class TestSCMisc:
         assert shell.package_cache_expire != tst
         assert shell.package_cache_expire is not None
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_package_cache_verbose(self, shell):
         """
         Test generate package cache verbose mode.
@@ -1257,12 +988,8 @@ class TestSCMisc:
         shell.PACKAGE_CACHE_TTL = 8000
         shell.client.channel.listSoftwareChannels = MagicMock(return_value=[])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.misc.build_package_names", pkgbuild) as pkgb, patch(
-            "spacecmd.misc.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.misc.build_package_names", pkgbuild) as pkgb, \
+                patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.generate_package_cache(shell, force=False)
 
         assert not logger.debug.called
@@ -1274,7 +1001,6 @@ class TestSCMisc:
         assert shell.package_cache_expire != tst
         assert shell.package_cache_expire is not None
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_package_cache_uqid(self, shell):
         """
         Test generate package cache, unique IDs.
@@ -1297,10 +1023,8 @@ class TestSCMisc:
                     {"name": "emacs", "version": 42, "release": 3, "id": 42},
                     {"name": "gedit", "version": 1, "release": 2, "id": 69},
                 ],
-                xmlrpclib.Fault(
-                    faultString="Interrupt configuration interference error",
-                    faultCode=13,
-                ),
+                xmlrpclib.Fault(faultString="Interrupt configuration interference error",
+                                faultCode=13)
             ]
         )
         shell.client.channel.listSoftwareChannels = MagicMock(
@@ -1310,7 +1034,6 @@ class TestSCMisc:
             ]
         )
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.generate_package_cache(shell, force=False)
 
@@ -1327,10 +1050,8 @@ class TestSCMisc:
             assert shell.all_packages[pkgname] == [pkgid]
             assert pkgid in shell.all_packages_by_id
             assert shell.all_packages_by_id[pkgid] == pkgname
-            # pylint: disable-next=use-maxsplit-arg
             assert pkgname.split("-")[0] in shell.all_packages_short
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_package_cache_duplicate_ids(self, shell):
         """
         Test generate package cache, handling duplicate IDs.
@@ -1354,10 +1075,8 @@ class TestSCMisc:
                     {"name": "gedit", "version": 1, "release": 2, "id": 69},
                     {"name": "vim", "version": 1, "release": 2, "id": 69},
                 ],
-                xmlrpclib.Fault(
-                    faultString="Interrupt configuration interference error",
-                    faultCode=13,
-                ),
+                xmlrpclib.Fault(faultString="Interrupt configuration interference error",
+                                faultCode=13)
             ]
         )
         shell.client.channel.listSoftwareChannels = MagicMock(
@@ -1367,7 +1086,6 @@ class TestSCMisc:
             ]
         )
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.logging", logger) as lgr:
             spacecmd.misc.generate_package_cache(shell, force=False)
 
@@ -1379,35 +1097,18 @@ class TestSCMisc:
         assert shell.package_cache_expire != tst
         assert shell.package_cache_expire is not None
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (
-                    (
-                        "No access to %s",
-                        "locked_channel",
-                    ),
-                    {},
-                ),
-                (
-                    (
-                        'Non-unique package id "69" is detected. '
-                        'Taking "vim-1-2" instead of "gedit-1-2"',
-                    ),
-                    {},
-                ),
-            ],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('No access to %s', 'locked_channel',), {}),
+                            (('Non-unique package id "69" is detected. '
+                              'Taking "vim-1-2" instead of "gedit-1-2"',), {})])
 
         for pkgname, pkgid in [("emacs-42-3", 42), ("vim-1-2", 69)]:
             assert pkgname in shell.all_packages
             assert shell.all_packages[pkgname] == [pkgid]
             assert pkgid in shell.all_packages_by_id
             assert shell.all_packages_by_id[pkgid] == pkgname
-            # pylint: disable-next=use-maxsplit-arg
             assert pkgname.split("-")[0] in shell.all_packages_short
 
-    # pylint: disable-next=redefined-outer-name
     def test_save_package_caches(self, shell):
         """
         Test saving package caches.
@@ -1428,21 +1129,17 @@ class TestSCMisc:
         tst = datetime.datetime(2019, 1, 1, 0, 0)
         shell.package_cache_expire = tst
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.save_cache", savecache) as savc:
             spacecmd.misc.save_package_caches(shell)
 
         assert shell.package_cache_expire == tst
-        assert_args_expect(
-            savecache.call_args_list,
-            [
-                (("/tmp/psc.f", {"emacs": ""}, tst), {}),
-                (("/tmp/plc.f", {"emacs-41-1": [42]}, tst), {}),
-                (("/tmp/bic.f", {42: "emacs-41-1"}, tst), {}),
-            ],
-        )
+        assert_args_expect(savecache.call_args_list,
+                           [
+                               (('/tmp/psc.f', {'emacs': ''}, tst), {}),
+                               (('/tmp/plc.f', {'emacs-41-1': [42]}, tst), {}),
+                               (('/tmp/bic.f', {42: 'emacs-41-1'}, tst), {}),
+                           ])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_confirm_bool_positive(self, shell):
         """
         Test interactive user confirmation UI. Boolean, positive.
@@ -1452,14 +1149,12 @@ class TestSCMisc:
         shell.options.yes = False
         for answer in ["yop", "yeah", "yes", "y", "Yes", "Yo"]:
             pmt = MagicMock(return_value=answer)
-            # pylint: disable-next=unused-variable
             with patch("spacecmd.misc.prompt_user", pmt) as prompter:
                 out = spacecmd.misc.user_confirm(shell)
 
             assert isinstance(out, bool)
             assert out
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_confirm_bool_negative(self, shell):
         """
         Test interactive user confirmation UI. Boolean, negative.
@@ -1469,14 +1164,12 @@ class TestSCMisc:
         shell.options.yes = False
         for answer in ["whatever", "nope", "no", "n", "Nada", "go away"]:
             pmt = MagicMock(return_value=answer)
-            # pylint: disable-next=unused-variable
             with patch("spacecmd.misc.prompt_user", pmt) as prompter:
                 out = spacecmd.misc.user_confirm(shell)
 
             assert isinstance(out, bool)
             assert not out
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_confirm_int_positive(self, shell):
         """
         Test interactive user confirmation UI. Integer, positive.
@@ -1486,14 +1179,12 @@ class TestSCMisc:
         shell.options.yes = False
         for answer in ["yop", "yeah", "yes", "y", "Yes", "Yo"]:
             pmt = MagicMock(return_value=answer)
-            # pylint: disable-next=unused-variable
             with patch("spacecmd.misc.prompt_user", pmt) as prompter:
                 out = spacecmd.misc.user_confirm(shell, integer=True)
 
             assert isinstance(out, int)
             assert out == 1
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_confirm_int_negative(self, shell):
         """
         Test interactive user confirmation UI. Integer, negative.
@@ -1503,14 +1194,12 @@ class TestSCMisc:
         shell.options.yes = False
         for answer in ["whatever", "nope", "no", "n", "Nada", "go away"]:
             pmt = MagicMock(return_value=answer)
-            # pylint: disable-next=unused-variable
             with patch("spacecmd.misc.prompt_user", pmt) as prompter:
                 out = spacecmd.misc.user_confirm(shell, integer=True)
 
             assert isinstance(out, int)
             assert out == 0
 
-    # pylint: disable-next=redefined-outer-name
     def test_check_api_version(self, shell):
         """
         Test API version checker.
@@ -1526,7 +1215,6 @@ class TestSCMisc:
         for bigger in ["11", "10.6"]:
             assert not spacecmd.misc.check_api_version(shell, bigger)
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_system_id_no_duplicates(self, shell):
         """
         Test getting system ID without duplicates (normal run).
@@ -1541,7 +1229,6 @@ class TestSCMisc:
         assert spacecmd.misc.get_system_id(shell, "100100") == 100100
         assert spacecmd.misc.get_system_id(shell, "100200") == 100200
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_system_id_handle_duplicates(self, shell):
         """
         Test getting system ID with duplicates.
@@ -1549,27 +1236,22 @@ class TestSCMisc:
         :param shell:
         :return:
         """
-        shell.all_systems = {100100: "douchebox", 100200: "sloppy", 100300: "douchebox"}
+        shell.all_systems = {100100: "douchebox", 100200: "sloppy",
+                             100300: "douchebox"}
 
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.logging", logger) as lgr:
             assert spacecmd.misc.get_system_id(shell, "douchebox") == 0
 
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [
-                (("Duplicate system profile names found!",), {}),
-                (("Please reference systems by ID or resolve the",), {}),
-                (("underlying issue with 'system_delete' or 'system_rename'",), {}),
-                (("",), {}),
-                (("douchebox = 100100, 100300",), {}),
-            ],
-        )
+        assert_args_expect(logger.warning.call_args_list,
+                           [(('Duplicate system profile names found!',), {}),
+                            (('Please reference systems by ID or resolve the',), {}),
+                            (("underlying issue with 'system_delete' or 'system_rename'",), {}),
+                            (('',), {}),
+                            (('douchebox = 100100, 100300',), {})])
 
         assert logger.warning.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_get_package_name(self, shell):
         """
         Get package name.
@@ -1582,7 +1264,6 @@ class TestSCMisc:
         assert spacecmd.misc.get_package_name(shell, 43) is None
         assert shell.generate_package_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_system_cache_not_expired(self, shell):
         """
         Test generating system cache before expiration point.
@@ -1597,7 +1278,6 @@ class TestSCMisc:
         shell.SYSTEM_CACHE_TTL = 8000
         sleeper = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.sleep", sleeper) as slp:
             spacecmd.misc.generate_system_cache(shell)
 
@@ -1606,7 +1286,6 @@ class TestSCMisc:
         assert not sleeper.called
         assert shell.system_cache_expire == tst
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_system_cache_not_expired_forced(self, shell):
         """
         Test generating system cache before expiration point, forced.
@@ -1619,16 +1298,13 @@ class TestSCMisc:
         shell.options.quiet = False
         shell.all_systems = {}
         shell.SYSTEM_CACHE_TTL = 8000
-        shell.client.system.listSystems = MagicMock(
-            return_value=[
-                {"id": 100100, "name": "douchebox"},
-                {"id": 100101, "name": "useless"},
-                {"id": 100102, "name": "slowlaris"},
-            ]
-        )
+        shell.client.system.listSystems = MagicMock(return_value=[
+            {"id": 100100, "name": "douchebox"},
+            {"id": 100101, "name": "useless"},
+            {"id": 100102, "name": "slowlaris"},
+        ])
         sleeper = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.sleep", sleeper) as slp:
             spacecmd.misc.generate_system_cache(shell, force=True)
 
@@ -1640,7 +1316,6 @@ class TestSCMisc:
         assert shell.replace_line_buffer.call_count == 2
         assert shell.save_system_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_generate_system_cache_expired(self, shell):
         """
         Test generating system cache after expiration point.
@@ -1653,16 +1328,13 @@ class TestSCMisc:
         shell.options.quiet = False
         shell.all_systems = {}
         shell.SYSTEM_CACHE_TTL = 8000
-        shell.client.system.listSystems = MagicMock(
-            return_value=[
-                {"id": 100100, "name": "douchebox"},
-                {"id": 100101, "name": "useless"},
-                {"id": 100102, "name": "slowlaris"},
-            ]
-        )
+        shell.client.system.listSystems = MagicMock(return_value=[
+            {"id": 100100, "name": "douchebox"},
+            {"id": 100101, "name": "useless"},
+            {"id": 100102, "name": "slowlaris"},
+        ])
         sleeper = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.misc.sleep", sleeper) as slp:
             spacecmd.misc.generate_system_cache(shell, force=False)
 

--- a/spacecmd/tests/test_org.py
+++ b/spacecmd/tests/test_org.py
@@ -4,8 +4,6 @@ Test suite for "org" plugin
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.org
 
@@ -15,7 +13,6 @@ class TestSCOrg:
     Test suite for package module.
     """
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_create_interactive_password_mistmatch(self, shell):
         """
         Test do_org_create interactive, password mistmatch.
@@ -26,32 +23,19 @@ class TestSCOrg:
 
         shell.user_confirm = MagicMock(return_value=False)
         shell.client.org.create = MagicMock()
-        prompt_user = MagicMock(
-            side_effect=[
-                "Stark Industries",
-                "ironman",
-                "Dr.",
-                "Tony",
-                "Stark",
-                "t.stark@si.biz",
-            ]
-        )
-        mgetpass = MagicMock(
-            side_effect=["123", "3456", "donotmatch", "dontmatch", "foo", "foo"]
-        )
+        prompt_user = MagicMock(side_effect=[
+            "Stark Industries", "ironman", "Dr.", "Tony", "Stark", "t.stark@si.biz",
+        ])
+        mgetpass = MagicMock(side_effect=[
+            "123", "3456", "donotmatch", "dontmatch", "foo", "foo"
+        ])
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.prompt_user",
-            prompt_user
-            # pylint: disable-next=unused-variable
-        ) as pmu, patch("spacecmd.org.getpass", mgetpass) as gtps, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.prompt_user", prompt_user) as pmu, \
+            patch("spacecmd.org.getpass", mgetpass) as gtps, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_create(shell, "")
 
         assert not mprint.called
@@ -61,12 +45,12 @@ class TestSCOrg:
         assert logger.warning.called
 
         expectations = [
-            (("Organization Name:",), {"noblank": True}),
-            (("Username:",), {"noblank": True}),
-            (("Prefix (Dr., Mr., Miss, Mrs., Ms.):",), {"noblank": True}),
-            (("First Name:",), {"noblank": True}),
-            (("Last Name:",), {"noblank": True}),
-            (("Email:",), {"noblank": True}),
+            (('Organization Name:',), {"noblank": True}),
+            (('Username:',), {"noblank": True}),
+            (('Prefix (Dr., Mr., Miss, Mrs., Ms.):',), {"noblank": True}),
+            (('First Name:',), {"noblank": True}),
+            (('Last Name:',), {"noblank": True}),
+            (('Email:',), {"noblank": True})
         ]
 
         for call in prompt_user.call_args_list:
@@ -77,15 +61,10 @@ class TestSCOrg:
             expectations.pop(0)
         assert not expectations
 
-        assert_list_args_expect(
-            logger.warning.call_args_list,
-            [
-                "Password must be at least 5 characters",
-                "Passwords don't match",
-            ],
-        )
+        assert_list_args_expect(logger.warning.call_args_list,
+                                ["Password must be at least 5 characters",
+                                 "Passwords don't match", ])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_delete_noargs(self, shell):
         """
         Test do_org_delete without arguments.
@@ -103,7 +82,6 @@ class TestSCOrg:
         assert not shell.client.org.delete.called
         assert shell.help_org_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_delete_no_org_found(self, shell):
         """
         Test do_org_delete org not found (None).
@@ -117,12 +95,8 @@ class TestSCOrg:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_delete(shell, "ACME-Enterprises")
 
         assert not shell.client.org.delete.called
@@ -131,18 +105,17 @@ class TestSCOrg:
         assert logger.warning.called
         assert mprint.called
 
-        assert_expect(
-            mprint.call_args_list, "Organisation 'ACME-Enterprises' was not found"
-        )
-        expectations = [("No organisation found for the name %s", "ACME-Enterprises")]
+        assert_expect(mprint.call_args_list,
+                      "Organisation 'ACME-Enterprises' was not found")
+        expectations = [
+            ('No organisation found for the name %s', 'ACME-Enterprises')
+        ]
         for call in logger.warning.call_args_list:
-            # pylint: disable-next=unused-variable
             args, kw = call
             assert args == next(iter(expectations))
             expectations.pop(0)
         assert not expectations
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_delete_no_confirm(self, shell):
         """
         Test do_org_delete org not confirmed
@@ -157,12 +130,8 @@ class TestSCOrg:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_delete(shell, "ACME-Enterprises")
 
         assert not shell.client.org.delete.called
@@ -172,7 +141,6 @@ class TestSCOrg:
         assert shell.get_org_id.called
         assert shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_delete_confirm(self, shell):
         """
         Test do_org_delete org confirmed
@@ -187,12 +155,8 @@ class TestSCOrg:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_delete(shell, "ACME-Enterprises")
 
         assert not shell.help_org_delete.called
@@ -202,7 +166,6 @@ class TestSCOrg:
         assert shell.user_confirm.called
         assert shell.client.org.delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_rename_noargs(self, shell):
         """
         Test do_org_rename without arguments.
@@ -220,7 +183,6 @@ class TestSCOrg:
         assert not shell.client.org.updateName.called
         assert shell.help_org_rename.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_rename_no_org_found(self, shell):
         """
         Test do_org_rename org not found (None).
@@ -234,12 +196,8 @@ class TestSCOrg:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_rename(shell, "ACME-Enterprises Big-Stuff")
 
         assert not shell.client.org.updateName.called
@@ -248,18 +206,17 @@ class TestSCOrg:
         assert logger.warning.called
         assert mprint.called
 
-        assert_expect(
-            mprint.call_args_list, "Organisation 'ACME-Enterprises' was not found"
-        )
-        expectations = [("No organisation found for the name %s", "ACME-Enterprises")]
+        assert_expect(mprint.call_args_list,
+                      "Organisation 'ACME-Enterprises' was not found")
+        expectations = [
+            ('No organisation found for the name %s', 'ACME-Enterprises')
+        ]
         for call in logger.warning.call_args_list:
-            # pylint: disable-next=unused-variable
             args, kw = call
             assert args == next(iter(expectations))
             expectations.pop(0)
         assert not expectations
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_rename(self, shell):
         """
         Test do_org_rename org
@@ -273,12 +230,8 @@ class TestSCOrg:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_rename(shell, "ACME-Enterprises Big-Stuff")
 
         assert not shell.help_org_delete.called
@@ -287,7 +240,6 @@ class TestSCOrg:
         assert shell.get_org_id.called
         assert shell.client.org.updateName.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_addtrust_noarg(self, shell):
         """
         Test do_org_addtrust without arguments
@@ -301,19 +253,14 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_addtrust(shell, "")
 
         assert not shell.get_org_id.called
         assert not shell.client.org.trusts.addTrust.called
         assert shell.help_org_addtrust.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_addtrust_no_src_org(self, shell):
         """
         Test do_org_addtrust, source org not found
@@ -327,12 +274,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_addtrust(shell, "trust me")
 
         assert not shell.client.org.trusts.addTrust.called
@@ -341,20 +284,11 @@ class TestSCOrg:
         assert mprint.called
         assert logger.warning.called
         assert_expect(mprint.call_args_list, "Organisation 'trust' was not found")
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [
-                (
-                    (
-                        "No organisation found for the name %s",
-                        "trust",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.warning.call_args_list,
+                           [
+                               (('No organisation found for the name %s', 'trust',), {})
+                           ])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_addtrust_no_dst_org(self, shell):
         """
         Test do_org_addtrust, destination org not found
@@ -368,12 +302,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_addtrust(shell, "trust someone")
 
         assert not shell.client.org.trusts.addTrust.called
@@ -381,23 +311,12 @@ class TestSCOrg:
         assert shell.get_org_id.called
         assert mprint.called
         assert logger.warning.called
-        assert_expect(
-            mprint.call_args_list, "Organisation 'someone' to trust for, was not found"
-        )
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [
-                (
-                    (
-                        "No trust organisation found for the name %s",
-                        "someone",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_expect(mprint.call_args_list, "Organisation 'someone' to trust for, was not found")
+        assert_args_expect(logger.warning.call_args_list,
+                           [
+                               (('No trust organisation found for the name %s', 'someone',), {})
+                           ])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_removetrust_noarg(self, shell):
         """
         Test for do_org_removetrust without arguments.
@@ -411,12 +330,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_removetrust(shell, "")
 
         assert not shell.client.org.trusts.removeTrust.called
@@ -425,7 +340,6 @@ class TestSCOrg:
         assert not mprint.called
         assert shell.help_org_removetrust.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_removetrust_no_src(self, shell):
         """
         Test for do_org_removetrust source org not found.
@@ -439,12 +353,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_removetrust(shell, "trust bad-guys")
 
         assert not shell.client.org.trusts.removeTrust.called
@@ -454,12 +364,9 @@ class TestSCOrg:
         assert mprint.called
 
         assert_expect(mprint.call_args_list, "Organisation 'trust' was not found")
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [(("No organisation found for the name %s", "trust"), {})],
-        )
+        assert_args_expect(logger.warning.call_args_list,
+                           [(('No organisation found for the name %s', 'trust'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_removetrust_no_dst(self, shell):
         """
         Test for do_org_removetrust destination org not found.
@@ -473,12 +380,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_removetrust(shell, "trust bad-guys")
 
         assert not shell.client.org.trusts.removeTrust.called
@@ -487,15 +390,10 @@ class TestSCOrg:
         assert logger.warning.called
         assert mprint.called
 
-        assert_expect(
-            mprint.call_args_list, "Organisation 'bad-guys' to trust for, was not found"
-        )
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [(("No trust organisation found for the name %s", "bad-guys"), {})],
-        )
+        assert_expect(mprint.call_args_list, "Organisation 'bad-guys' to trust for, was not found")
+        assert_args_expect(logger.warning.call_args_list,
+                           [(('No trust organisation found for the name %s', 'bad-guys'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_trustdetails_noarg(self, shell):
         """
         Test for do_org_trustdetails no arguments.
@@ -511,12 +409,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_trustdetails(shell, "")
 
         assert not shell.get_org_id.called
@@ -525,7 +419,6 @@ class TestSCOrg:
         assert not shell.client.org.trusts.listChannelsProvided.called
         assert shell.help_org_trustdetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_trustdetails_no_org_found(self, shell):
         """
         Test for do_org_trustdetails no org found.
@@ -541,12 +434,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_trustdetails(shell, "notfound")
 
         assert not shell.client.org.trusts.getDetails.called
@@ -557,15 +446,12 @@ class TestSCOrg:
         assert mprint.called
         assert logger.warning.called
 
-        assert_expect(
-            mprint.call_args_list, "Trusted organisation 'notfound' was not found"
-        )
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [(("No trusted organisation found for the name %s", "notfound"), {})],
-        )
+        assert_expect(mprint.call_args_list,
+                      "Trusted organisation 'notfound' was not found")
+        assert_args_expect(logger.warning.call_args_list,
+                           [(('No trusted organisation found for the name %s',
+                              'notfound'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_trustdetails(self, shell):
         """
         Test do_or_trustdetails
@@ -575,35 +461,25 @@ class TestSCOrg:
         """
         shell.help_org_trustdetails = MagicMock()
         shell.get_org_id = MagicMock(return_value=1)
-        shell.client.org.trusts.getDetails = MagicMock(
-            return_value={
-                "trusted_since": "Mi 29. Mai 15:02:26 CEST 2019",
-                "systems_transferred_from": 3,
-                "systems_transferred_to": 8,
-            }
-        )
-        shell.client.org.trusts.listChannelsConsumed = MagicMock(
-            return_value=[
-                {"name": "base_channel"},
-                {"name": "special_channel"},
-            ]
-        )
-        shell.client.org.trusts.listChannelsProvided = MagicMock(
-            return_value=[
-                {"name": "base_channel"},
-                {"name": "suse_channel"},
-                {"name": "rh_channel"},
-            ]
-        )
+        shell.client.org.trusts.getDetails = MagicMock(return_value={
+            "trusted_since": "Mi 29. Mai 15:02:26 CEST 2019",
+            "systems_transferred_from": 3,
+            "systems_transferred_to": 8
+        })
+        shell.client.org.trusts.listChannelsConsumed = MagicMock(return_value=[
+            {"name": "base_channel"},
+            {"name": "special_channel"},
+        ])
+        shell.client.org.trusts.listChannelsProvided = MagicMock(return_value=[
+            {"name": "base_channel"},
+            {"name": "suse_channel"},
+            {"name": "rh_channel"},
+        ])
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_trustdetails(shell, "myorg")
 
         assert not shell.help_org_trustdetails.called
@@ -615,23 +491,17 @@ class TestSCOrg:
         assert mprint.called
 
         exp = [
-            "Trusted Organization:   myorg",
-            "Trusted Since:          Mi 29. Mai 15:02:26 CEST 2019",
-            "Systems Transferred From:  3",
-            "Systems Transferred To:    8",
-            "",
-            "Channels Consumed",
-            "-----------------",
-            "base_channel\nspecial_channel",
-            "",
-            "Channels Provided",
-            "-----------------",
-            "base_channel\nrh_channel\nsuse_channel",
+           'Trusted Organization:   myorg',
+           'Trusted Since:          Mi 29. Mai 15:02:26 CEST 2019',
+           'Systems Transferred From:  3', 'Systems Transferred To:    8', '',
+           'Channels Consumed', '-----------------',
+           'base_channel\nspecial_channel', '',
+           'Channels Provided', '-----------------',
+            'base_channel\nrh_channel\nsuse_channel'
         ]
 
         assert_list_args_expect(mprint.call_args_list, exp)
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_list_noret(self, shell):
         """
         Test do_org_list no data return.
@@ -639,22 +509,19 @@ class TestSCOrg:
         :param shell:
         :return:
         """
-        shell.client.org.listOrgs = MagicMock(
-            return_value=[
-                {"name": "suse"},
-                {"name": "rh"},
-                {"name": "other"},
-            ]
-        )
+        shell.client.org.listOrgs = MagicMock(return_value=[
+            {"name": "suse"},
+            {"name": "rh"},
+            {"name": "other"},
+        ])
         mprint = MagicMock()
         with patch("spacecmd.org.print", mprint):
             out = spacecmd.org.do_org_list(shell, "", doreturn=False)
 
         assert out is None
         assert mprint.called
-        assert_expect(mprint.call_args_list, "other\nrh\nsuse")
+        assert_expect(mprint.call_args_list, 'other\nrh\nsuse')
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_list_data_ret(self, shell):
         """
         Test do_org_list with data return.
@@ -662,13 +529,11 @@ class TestSCOrg:
         :param shell:
         :return:
         """
-        shell.client.org.listOrgs = MagicMock(
-            return_value=[
-                {"name": "suse"},
-                {"name": "rh"},
-                {"name": "other"},
-            ]
-        )
+        shell.client.org.listOrgs = MagicMock(return_value=[
+            {"name": "suse"},
+            {"name": "rh"},
+            {"name": "other"},
+        ])
         mprint = MagicMock()
         with patch("spacecmd.org.print", mprint):
             out = spacecmd.org.do_org_list(shell, "", doreturn=True)
@@ -677,7 +542,6 @@ class TestSCOrg:
         assert out == ["suse", "rh", "other"]
         assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_listtrusts_noargs(self, shell):
         """
         Test do_org_listtrusts without arguments.
@@ -691,19 +555,14 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_listtrusts(shell, "")
 
         assert not shell.get_org_id.called
         assert not shell.client.org.trusts.listTrusts.called
         assert shell.help_org_listtrusts.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_listtrusts_no_org(self, shell):
         """
         Test do_org_listtrusts org not found.
@@ -717,12 +576,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_listtrusts(shell, "notfound")
 
         assert not shell.client.org.trusts.listTrusts.called
@@ -732,12 +587,9 @@ class TestSCOrg:
         assert logger.warning.called
 
         assert_expect(mprint.call_args_list, "Organisation 'notfound' was not found")
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [(("No organisation found for the name %s", "notfound"), {})],
-        )
+        assert_args_expect(logger.warning.call_args_list,
+                           [(('No organisation found for the name %s', 'notfound'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_listtrusts_no_trusts(self, shell):
         """
         Test do_org_listtrusts trust orgs were not found.
@@ -751,12 +603,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_listtrusts(shell, "notfound")
 
         assert not shell.help_org_listtrusts.called
@@ -766,11 +614,8 @@ class TestSCOrg:
         assert logger.warning.called
 
         assert_expect(mprint.call_args_list, "No trust organisation has been found")
-        assert_expect(
-            logger.warning.call_args_list, "No trust organisation has been found"
-        )
+        assert_expect(logger.warning.call_args_list, "No trust organisation has been found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_listtrusts(self, shell):
         """
         Test do_org_listtrusts output.
@@ -780,23 +625,17 @@ class TestSCOrg:
         """
         shell.help_org_listtrusts = MagicMock()
         shell.get_org_id = MagicMock(return_value=1)
-        shell.client.org.trusts.listTrusts = MagicMock(
-            return_value=[
-                {"orgName": "suse", "trustEnabled": True},
-                {"orgName": "west", "trustEnabled": True},
-                {"orgName": "acme", "trustEnabled": True},
-                {"orgName": "ubuntu", "trustEnabled": False},
-            ]
-        )
+        shell.client.org.trusts.listTrusts = MagicMock(return_value=[
+            {"orgName": "suse", "trustEnabled": True},
+            {"orgName": "west", "trustEnabled": True},
+            {"orgName": "acme", "trustEnabled": True},
+            {"orgName": "ubuntu", "trustEnabled": False},
+        ])
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_listtrusts(shell, "notfound")
 
         assert not logger.warning.called
@@ -807,7 +646,6 @@ class TestSCOrg:
 
         assert_list_args_expect(mprint.call_args_list, ["acme", "suse", "west"])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_listusers_noargs(self, shell):
         """
         Test do_org_listusers without arguments.
@@ -820,12 +658,8 @@ class TestSCOrg:
         shell.get_org_id = MagicMock()
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_listusers(shell, "")
 
         assert not shell.client.org.listUsers.called
@@ -834,7 +668,6 @@ class TestSCOrg:
         assert not logger.warning.called
         assert shell.help_org_listusers.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_listusers_no_org(self, shell):
         """
         Test do_org_listusers where org was not found.
@@ -847,12 +680,8 @@ class TestSCOrg:
         shell.get_org_id = MagicMock(return_value=None)
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_listusers(shell, "foo")
 
         assert not shell.client.org.listUsers.called
@@ -861,12 +690,9 @@ class TestSCOrg:
         assert mprint.called
         assert logger.warning.called
         assert_expect(mprint.call_args_list, "Organisation 'foo' was not found")
-        assert_args_expect(
-            logger.warning.call_args_list,
-            [(("No organisation found for the name %s", "foo"), {})],
-        )
+        assert_args_expect(logger.warning.call_args_list,
+                           [(('No organisation found for the name %s', 'foo'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_listusers(self, shell):
         """
         Test do_org_listusers output
@@ -875,18 +701,15 @@ class TestSCOrg:
         :return:
         """
         shell.help_org_listusers = MagicMock()
-        shell.client.org.listUsers = MagicMock(
-            return_value=[{"login": "olafur"}, {"login": "gunnuhver"}]
-        )
+        shell.client.org.listUsers = MagicMock(return_value=[
+            {"login": "olafur"},
+            {"login": "gunnuhver"}
+        ])
         shell.get_org_id = MagicMock(return_value=1)
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_listusers(shell, "suse")
 
         assert not shell.help_org_listusers.called
@@ -894,9 +717,8 @@ class TestSCOrg:
         assert shell.client.org.listUsers.called
         assert shell.get_org_id.called
         assert mprint.called
-        assert_expect(mprint.call_args_list, "gunnuhver\nolafur")
+        assert_expect(mprint.call_args_list, 'gunnuhver\nolafur')
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_details_noarg(self, shell):
         """
         Test do_org_details without arguments.
@@ -909,12 +731,8 @@ class TestSCOrg:
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_details(shell, "")
 
         assert not logger.warning.called
@@ -922,7 +740,6 @@ class TestSCOrg:
         assert not shell.client.org.getDetails.called
         assert shell.help_org_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_org_details(self, shell):
         """
         Test do_org_details output.
@@ -931,27 +748,17 @@ class TestSCOrg:
         :return:
         """
         shell.help_org_details = MagicMock()
-        shell.client.org.getDetails = MagicMock(
-            return_value={
-                "name": "Test Organisation",
-                "active_users": 42,
-                "systems": 5,
-                "trusts": 1,
-                "system_groups": 6,
-                "activation_keys": 2,
-                "kickstart_profiles": 7,
-                "configuration_channels": 1,
-            }
-        )
+        shell.client.org.getDetails = MagicMock(return_value={
+            "name": "Test Organisation", "active_users": 42,
+            "systems": 5, "trusts": 1, "system_groups": 6,
+            "activation_keys": 2, "kickstart_profiles": 7,
+            "configuration_channels": 1
+        })
 
         logger = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.org.print", mprint) as prn, patch(
-            "spacecmd.org.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.org.print", mprint) as prn, \
+            patch("spacecmd.org.logging", logger) as lgr:
             spacecmd.org.do_org_details(shell, "testorg")
 
         assert not logger.warning.called
@@ -960,13 +767,13 @@ class TestSCOrg:
         assert shell.client.org.getDetails.called
 
         exp = [
-            "Name:                   Test Organisation",
-            "Active Users:           42",
-            "Systems:                5",
-            "Trusts:                 1",
-            "System Groups:          6",
-            "Activation Keys:        2",
-            "Kickstart Profiles:     7",
-            "Configuration Channels: 1",
+            'Name:                   Test Organisation',
+            'Active Users:           42',
+            'Systems:                5',
+            'Trusts:                 1',
+            'System Groups:          6',
+            'Activation Keys:        2',
+            'Kickstart Profiles:     7',
+            'Configuration Channels: 1',
         ]
         assert_list_args_expect(mprint.call_args_list, exp)

--- a/spacecmd/tests/test_package.py
+++ b/spacecmd/tests/test_package.py
@@ -4,8 +4,6 @@ Test suite for spacecmd.package module.
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect
 import spacecmd.package
 
@@ -14,8 +12,6 @@ class TestSCPackage:
     """
     Test suite for package module.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_package_details_noargs(self, shell):
         """
         Test do_package_details with no arguments call.
@@ -29,7 +25,6 @@ class TestSCPackage:
         shell.client.packages.listProvidingChannels = MagicMock()
         shell.client.system.listSystemsWithPackage = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.package.do_package_details(shell, "")
 
@@ -39,7 +34,6 @@ class TestSCPackage:
         assert not shell.client.system.listSystemsWithPackage.called
         assert shell.help_package_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_details_package(self, shell):
         """
         Test do_package_details with an argument of the package name.
@@ -48,114 +42,77 @@ class TestSCPackage:
         :return:
         """
         shell.help_package_details = MagicMock()
-        shell.do_package_search = MagicMock(
-            side_effect=[
-                ["emacs", "emacs-x11"],
-            ]
-        )
-        shell.get_package_id = MagicMock(
-            return_value=["emacs", "emacs-1"]  # IDs are bogus here
-        )
-        shell.client.packages.listProvidingChannels = MagicMock(
-            side_effect=[
-                [
-                    {"label": "base-channel"},
-                    {"label": "emacs-channel"},
-                ],
-                [
-                    {"label": "base-channel"},
-                    {"label": "emacs-channel"},
-                    {"label": "x11-stuff-channel"},
-                ],
-                [],
-                [],
-                [],
-            ]
-        )
-        shell.client.system.listSystemsWithPackage = MagicMock(
-            return_value=["system-a", "system-b", "system-c"]
-        )
-        shell.client.packages.getDetails = MagicMock(
-            side_effect=[
+        shell.do_package_search = MagicMock(side_effect=[
+            ["emacs", "emacs-x11"],
+        ])
+        shell.get_package_id = MagicMock(return_value=[
+            "emacs", "emacs-1"  # IDs are bogus here
+        ])
+        shell.client.packages.listProvidingChannels = MagicMock(side_effect=[
+            [
                 {
-                    "name": "emacs",
-                    "version": "24.5",
-                    "release": "42",
-                    "epoch": "1",
-                    "arch_label": "x86",
-                    "file": "emacs.rpm",
-                    "path": "/tmp",
-                    "size": "2000",
-                    "checksum_type": "md5",
-                    "checksum": "aaa0919fe05c15583b688fed115d1ab8",
-                    "description": "Better editor than Vim",
+                    "label": "base-channel"
                 },
                 {
-                    "name": "emacs-x11",
-                    "version": "24.5.7",
-                    "release": "42.1",
-                    "epoch": "2",
-                    "arch_label": "x86",
-                    "file": "emacs-x11.rpm",
-                    "path": "/tmp",
-                    "size": "22000",
-                    "checksum_type": "md5",
-                    "checksum": "9d188ed99c1114eba7a8e499798da47c",
-                    "description": "Better editor than Vim, using X11",
+                    "label": "emacs-channel"
+                },
+            ],
+            [
+                {
+                    "label": "base-channel"
                 },
                 {
-                    "name": "emacs-data",
-                    "version": "24.5.7",
-                    "release": "42.1",
-                    "epoch": "2",
-                    "arch_label": "x86",
-                    "file": "emacs-x11.rpm",
-                    "path": "/tmp",
-                    "size": "22000",
-                    "checksum_type": "md5",
-                    "checksum": "9d188ed99c1114eba7a8e499798da47c",
-                    "description": "Better editor than Vim, using X11",
+                    "label": "emacs-channel"
                 },
                 {
-                    "name": "emacs-melpa",
-                    "version": "24.5.7",
-                    "release": "42.1",
-                    "epoch": "2",
-                    "arch_label": "x86",
-                    "file": "emacs-x11.rpm",
-                    "path": "/tmp",
-                    "size": "22000",
-                    "checksum_type": "md5",
-                    "checksum": "9d188ed99c1114eba7a8e499798da47c",
-                    "description": "Better editor than Vim, using X11",
+                    "label": "x11-stuff-channel"
                 },
-                {
-                    "name": "emacs-el",
-                    "version": "24.5.7",
-                    "release": "42.1",
-                    "epoch": "2",
-                    "arch_label": "x86",
-                    "file": "emacs-x11.rpm",
-                    "path": "/tmp",
-                    "size": "22000",
-                    "checksum_type": "md5",
-                    "checksum": "9d188ed99c1114eba7a8e499798da47c",
-                    "description": "Better editor than Vim, using X11",
-                },
-            ]
-        )
+            ],
+            [], [], []
+        ])
+        shell.client.system.listSystemsWithPackage = MagicMock(return_value=[
+            "system-a", "system-b", "system-c"
+        ])
+        shell.client.packages.getDetails = MagicMock(side_effect=[
+            {
+                "name": "emacs", "version": "24.5", "release": "42", "epoch": "1",
+                "arch_label": "x86", "file": "emacs.rpm", "path": "/tmp", "size": "2000",
+                "checksum_type": "md5", "checksum": "aaa0919fe05c15583b688fed115d1ab8",
+                "description": "Better editor than Vim"
+            },
+            {
+                "name": "emacs-x11", "version": "24.5.7", "release": "42.1", "epoch": "2",
+                "arch_label": "x86", "file": "emacs-x11.rpm", "path": "/tmp", "size": "22000",
+                "checksum_type": "md5", "checksum": "9d188ed99c1114eba7a8e499798da47c",
+                "description": "Better editor than Vim, using X11"
+            },
+            {
+                "name": "emacs-data", "version": "24.5.7", "release": "42.1", "epoch": "2",
+                "arch_label": "x86", "file": "emacs-x11.rpm", "path": "/tmp", "size": "22000",
+                "checksum_type": "md5", "checksum": "9d188ed99c1114eba7a8e499798da47c",
+                "description": "Better editor than Vim, using X11"
+            },
+            {
+                "name": "emacs-melpa", "version": "24.5.7", "release": "42.1", "epoch": "2",
+                "arch_label": "x86", "file": "emacs-x11.rpm", "path": "/tmp", "size": "22000",
+                "checksum_type": "md5", "checksum": "9d188ed99c1114eba7a8e499798da47c",
+                "description": "Better editor than Vim, using X11"
+            },
+            {
+                "name": "emacs-el", "version": "24.5.7", "release": "42.1", "epoch": "2",
+                "arch_label": "x86", "file": "emacs-x11.rpm", "path": "/tmp", "size": "22000",
+                "checksum_type": "md5", "checksum": "9d188ed99c1114eba7a8e499798da47c",
+                "description": "Better editor than Vim, using X11"
+            },
+        ])
 
         shell.SEPARATOR = "###"
 
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_details(shell, "emacs")
 
         assert not shell.help_package_details.called
@@ -166,102 +123,101 @@ class TestSCPackage:
         assert shell.client.system.listSystemsWithPackage.called
 
         exp = [
-            "Name:      emacs",
-            "Version:   24.5",
-            "Release:   42",
-            "Epoch:     1",
-            "Arch:      x86",
-            "",
-            "File:      emacs.rpm",
-            "Path:      /tmp",
-            "Size:      2000",
-            "Retracted: No",
-            "MD5:       aaa0919fe05c15583b688fed115d1ab8",
-            "",
-            "Installed Systems: 3",
-            "",
-            "Description",
-            "-----------",
-            "Better editor than Vim",
-            "",
-            "Available From Channels",
-            "-----------------------",
-            "base-channel\nemacs-channel",
-            "",
-            "Name:      emacs-x11",
-            "Version:   24.5.7",
-            "Release:   42.1",
-            "Epoch:     2",
-            "Arch:      x86",
-            "",
-            "File:      emacs-x11.rpm",
-            "Path:      /tmp",
-            "Size:      22000",
-            "Retracted: No",
-            "MD5:       9d188ed99c1114eba7a8e499798da47c",
-            "",
-            "Installed Systems: 3",
-            "",
-            "Description",
-            "-----------",
-            "Better editor than Vim, using X11",
-            "",
-            "Available From Channels",
-            "-----------------------",
-            "base-channel\nemacs-channel\nx11-stuff-channel",
-            "",
-            "###",
-            "Name:      emacs-data",
-            "Version:   24.5.7",
-            "Release:   42.1",
-            "Epoch:     2",
-            "Arch:      x86",
-            "",
-            "File:      emacs-x11.rpm",
-            "Path:      /tmp",
-            "Size:      22000",
-            "Retracted: No",
-            "MD5:       9d188ed99c1114eba7a8e499798da47c",
-            "",
-            "Installed Systems: 3",
-            "",
-            "Description",
-            "-----------",
-            "Better editor than Vim, using X11",
-            "",
-            "Available From Channels",
-            "-----------------------",
-            "",
-            "",
-            "Name:      emacs-melpa",
-            "Version:   24.5.7",
-            "Release:   42.1",
-            "Epoch:     2",
-            "Arch:      x86",
-            "",
-            "File:      emacs-x11.rpm",
-            "Path:      /tmp",
-            "Size:      22000",
-            "Retracted: No",
-            "MD5:       9d188ed99c1114eba7a8e499798da47c",
-            "",
-            "Installed Systems: 3",
-            "",
-            "Description",
-            "-----------",
-            "Better editor than Vim, using X11",
-            "",
-            "Available From Channels",
-            "-----------------------",
-            "",
-            "",
+            'Name:      emacs',
+            'Version:   24.5',
+            'Release:   42',
+            'Epoch:     1',
+            'Arch:      x86',
+            '',
+            'File:      emacs.rpm',
+            'Path:      /tmp',
+            'Size:      2000',
+            'Retracted: No',
+            'MD5:       aaa0919fe05c15583b688fed115d1ab8',
+            '',
+            'Installed Systems: 3',
+            '',
+            'Description',
+            '-----------',
+            'Better editor than Vim',
+            '',
+            'Available From Channels',
+            '-----------------------',
+            'base-channel\nemacs-channel',
+            '',
+            'Name:      emacs-x11',
+            'Version:   24.5.7',
+            'Release:   42.1',
+            'Epoch:     2',
+            'Arch:      x86',
+            '',
+            'File:      emacs-x11.rpm',
+            'Path:      /tmp',
+            'Size:      22000',
+            'Retracted: No',
+            'MD5:       9d188ed99c1114eba7a8e499798da47c',
+            '',
+            'Installed Systems: 3',
+            '',
+            'Description',
+            '-----------',
+            'Better editor than Vim, using X11',
+            '',
+            'Available From Channels',
+            '-----------------------',
+            'base-channel\nemacs-channel\nx11-stuff-channel',
+            '',
+            '###',
+            'Name:      emacs-data',
+            'Version:   24.5.7',
+            'Release:   42.1',
+            'Epoch:     2',
+            'Arch:      x86',
+            '',
+            'File:      emacs-x11.rpm',
+            'Path:      /tmp',
+            'Size:      22000',
+            'Retracted: No',
+            'MD5:       9d188ed99c1114eba7a8e499798da47c',
+            '',
+            'Installed Systems: 3',
+            '',
+            'Description',
+            '-----------',
+            'Better editor than Vim, using X11',
+            '',
+            'Available From Channels',
+            '-----------------------',
+            '',
+            '',
+            'Name:      emacs-melpa',
+            'Version:   24.5.7',
+            'Release:   42.1',
+            'Epoch:     2',
+            'Arch:      x86',
+            '',
+            'File:      emacs-x11.rpm',
+            'Path:      /tmp',
+            'Size:      22000',
+            'Retracted: No',
+            'MD5:       9d188ed99c1114eba7a8e499798da47c',
+            '',
+            'Installed Systems: 3',
+            '',
+            'Description',
+            '-----------',
+            'Better editor than Vim, using X11',
+            '',
+            'Available From Channels',
+            '-----------------------',
+            '',
+            ''
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_details_multiple_packages(self, shell):
         """
         Test do_package_details with two arguments of package names.
@@ -270,67 +226,58 @@ class TestSCPackage:
         :return:
         """
         shell.help_package_details = MagicMock()
-        shell.do_package_search = MagicMock(side_effect=[["emacs-data", "emacs-x11"]])
-        shell.get_package_id = MagicMock(return_value=["id1"])  # IDs are bogus here
-        shell.client.packages.listProvidingChannels = MagicMock(
-            side_effect=[
-                [
-                    {"label": "base-channel"},
-                    {"label": "emacs-channel"},
-                ],
-                [
-                    {"label": "base-channel"},
-                    {"label": "emacs-channel"},
-                    {"label": "x11-stuff-channel"},
-                ],
-            ]
-        )
-        shell.client.system.listSystemsWithPackage = MagicMock(
-            return_value=["system-a", "system-b", "system-c"]
-        )
-        shell.client.packages.getDetails = MagicMock(
-            side_effect=[
+        shell.do_package_search = MagicMock(side_effect=[
+            ["emacs-data", "emacs-x11"]
+        ])
+        shell.get_package_id = MagicMock(return_value=[
+            "id1" # IDs are bogus here
+        ])
+        shell.client.packages.listProvidingChannels = MagicMock(side_effect=[
+            [
                 {
-                    "name": "emacs-data",
-                    "version": "24.5.7",
-                    "release": "42.1",
-                    "epoch": "2",
-                    "arch_label": "x86",
-                    "file": "emacs-x11.rpm",
-                    "path": "/tmp",
-                    "size": "22000",
-                    "checksum_type": "md5",
-                    "checksum": "9d188ed99c1114eba7a8e499798da47c",
-                    "description": "Better editor than Vim, using X11",
-                    "part_of_retracted_patch": True,
+                    "label": "base-channel"
                 },
                 {
-                    "name": "emacs-x11",
-                    "version": "24.5.7",
-                    "release": "42.1",
-                    "epoch": "2",
-                    "arch_label": "x86",
-                    "file": "emacs-x11.rpm",
-                    "path": "/tmp",
-                    "size": "22000",
-                    "checksum_type": "md5",
-                    "checksum": "9d188ed99c1114eba7a8e499798da47c",
-                    "description": "Better editor than Vim, using X11",
+                    "label": "emacs-channel"
+                },
+            ],
+            [
+                {
+                    "label": "base-channel"
+                },
+                {
+                    "label": "emacs-channel"
+                },
+                {
+                    "label": "x11-stuff-channel"
                 },
             ]
-        )
+        ])
+        shell.client.system.listSystemsWithPackage = MagicMock(return_value=[
+            "system-a", "system-b", "system-c"
+        ])
+        shell.client.packages.getDetails = MagicMock(side_effect=[
+            {
+                "name": "emacs-data", "version": "24.5.7", "release": "42.1", "epoch": "2",
+                "arch_label": "x86", "file": "emacs-x11.rpm", "path": "/tmp", "size": "22000",
+                "checksum_type": "md5", "checksum": "9d188ed99c1114eba7a8e499798da47c",
+                "description": "Better editor than Vim, using X11", "part_of_retracted_patch": True
+            },
+            {
+                "name": "emacs-x11", "version": "24.5.7", "release": "42.1", "epoch": "2",
+                "arch_label": "x86", "file": "emacs-x11.rpm", "path": "/tmp", "size": "22000",
+                "checksum_type": "md5", "checksum": "9d188ed99c1114eba7a8e499798da47c",
+                "description": "Better editor than Vim, using X11"
+            },
+        ])
 
         shell.SEPARATOR = "###"
 
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+                patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_details(shell, "emacs-data emacs-x11")
 
         assert not shell.help_package_details.called
@@ -341,58 +288,57 @@ class TestSCPackage:
         assert shell.client.system.listSystemsWithPackage.called
 
         exp = [
-            "Name:      emacs-data",
-            "Version:   24.5.7",
-            "Release:   42.1",
-            "Epoch:     2",
-            "Arch:      x86",
-            "",
-            "File:      emacs-x11.rpm",
-            "Path:      /tmp",
-            "Size:      22000",
-            "Retracted: Yes",
-            "MD5:       9d188ed99c1114eba7a8e499798da47c",
-            "",
-            "Installed Systems: 3",
-            "",
-            "Description",
-            "-----------",
-            "Better editor than Vim, using X11",
-            "",
-            "Available From Channels",
-            "-----------------------",
-            "base-channel\nemacs-channel",
-            "",
-            "###",
-            "Name:      emacs-x11",
-            "Version:   24.5.7",
-            "Release:   42.1",
-            "Epoch:     2",
-            "Arch:      x86",
-            "",
-            "File:      emacs-x11.rpm",
-            "Path:      /tmp",
-            "Size:      22000",
-            "Retracted: No",
-            "MD5:       9d188ed99c1114eba7a8e499798da47c",
-            "",
-            "Installed Systems: 3",
-            "",
-            "Description",
-            "-----------",
-            "Better editor than Vim, using X11",
-            "",
-            "Available From Channels",
-            "-----------------------",
-            "base-channel\nemacs-channel\nx11-stuff-channel",
-            "",
+            'Name:      emacs-data',
+            'Version:   24.5.7',
+            'Release:   42.1',
+            'Epoch:     2',
+            'Arch:      x86',
+            '',
+            'File:      emacs-x11.rpm',
+            'Path:      /tmp',
+            'Size:      22000',
+            'Retracted: Yes',
+            'MD5:       9d188ed99c1114eba7a8e499798da47c',
+            '',
+            'Installed Systems: 3',
+            '',
+            'Description',
+            '-----------',
+            'Better editor than Vim, using X11',
+            '',
+            'Available From Channels',
+            '-----------------------',
+            'base-channel\nemacs-channel',
+            '',
+            '###',
+            'Name:      emacs-x11',
+            'Version:   24.5.7',
+            'Release:   42.1',
+            'Epoch:     2',
+            'Arch:      x86',
+            '',
+            'File:      emacs-x11.rpm',
+            'Path:      /tmp',
+            'Size:      22000',
+            'Retracted: No',
+            'MD5:       9d188ed99c1114eba7a8e499798da47c',
+            '',
+            'Installed Systems: 3',
+            '',
+            'Description',
+            '-----------',
+            'Better editor than Vim, using X11',
+            '',
+            'Available From Channels',
+            '-----------------------',
+            'base-channel\nemacs-channel\nx11-stuff-channel',
+            ''
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_search_noargs(self, shell):
         """
         Test do_package_search without arguments.
@@ -403,12 +349,8 @@ class TestSCPackage:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             out = spacecmd.package.do_package_search(shell, "", doreturn=False)
 
         assert out is None
@@ -416,34 +358,21 @@ class TestSCPackage:
         assert not shell.client.packages.search.advanced.called
         assert shell.help_package_search.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_search(self, shell):
         """
         Test do_package_search with arguments of standard fields
         """
         shell.help_package_search = MagicMock()
-        shell.get_package_names = MagicMock(
-            return_value=[
-                "emacs-x11",
-                "emacs-melpa",
-                "emacs-nox",
-                "vim",
-                "pico",
-                "gedit",
-                "sed",
-            ]
-        )
+        shell.get_package_names = MagicMock(return_value=[
+            "emacs-x11", "emacs-melpa", "emacs-nox", "vim", "pico", "gedit", "sed"
+        ])
         shell.client.packages.search.advanced = MagicMock()
 
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             out = spacecmd.package.do_package_search(shell, "emacs*", doreturn=False)
 
         assert not shell.help_package_search.called
@@ -451,117 +380,62 @@ class TestSCPackage:
         assert not shell.client.packages.search.advanced.called
         assert out is None
         assert mprint.called
-        assert_expect(mprint.call_args_list, "emacs-melpa\nemacs-nox\nemacs-x11")
+        assert_expect(mprint.call_args_list, 'emacs-melpa\nemacs-nox\nemacs-x11')
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_search_multiple_packages(self, shell):
         """
         Test do_package_search with multiple arguments of standard fields
         """
         shell.help_package_search = MagicMock()
-        shell.get_package_names = MagicMock(
-            return_value=[
-                "emacs-x11",
-                "emacs-melpa",
-                "emacs-nox",
-                "vim",
-                "pico",
-                "gedit",
-                "sed",
-            ]
-        )
+        shell.get_package_names = MagicMock(return_value=[
+            "emacs-x11", "emacs-melpa", "emacs-nox", "vim", "pico", "gedit", "sed"
+        ])
         shell.client.packages.search.advanced = MagicMock()
 
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
-            out = spacecmd.package.do_package_search(
-                shell, "emacs-melpa emacs-x11", doreturn=False
-            )
+        with patch("spacecmd.package.print", mprint) as prn, \
+                patch("spacecmd.package.logging", logger) as lgr:
+            out = spacecmd.package.do_package_search(shell, "emacs-melpa emacs-x11", doreturn=False)
 
         assert not shell.help_package_search.called
         assert not logger.debug.called
         assert not shell.client.packages.search.advanced.called
         assert out is None
         assert mprint.called
-        assert_expect(mprint.call_args_list, "emacs-melpa\nemacs-x11")
+        assert_expect(mprint.call_args_list, 'emacs-melpa\nemacs-x11')
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_search_advanced(self, shell):
         """
         Test do_package_search with arguments of advanced fields.
         """
         shell.help_package_search = MagicMock()
-        shell.get_package_names = MagicMock(
-            return_value=[
-                "emacs-x11",
-                "emacs-melpa",
-                "emacs-nox",
-                "vim",
-                "pico",
-                "gedit",
-                "sed",
-            ]
-        )
-        shell.client.packages.search.advanced = MagicMock(
-            return_value=[
-                {
-                    "name": "emacs-x11",
-                    "version": "24.5",
-                    "release": "1",
-                    "epoch": "",
-                    "arch": "x86_64",
-                    "arch_label": "x86_64",
-                },
-                {
-                    "name": "emacs-melpa",
-                    "version": "16.7",
-                    "release": "2",
-                    "epoch": "",
-                    "arch": "noarch",
-                    "arch_label": "noarch",
-                },
-                {
-                    "name": "emacs-nox",
-                    "version": "24.5.2",
-                    "release": "3",
-                    "epoch": "",
-                    "arch": "x86_64",
-                    "arch_label": "x86_64",
-                },
-            ]
-        )
+        shell.get_package_names = MagicMock(return_value=[
+            "emacs-x11", "emacs-melpa", "emacs-nox", "vim", "pico", "gedit", "sed"
+        ])
+        shell.client.packages.search.advanced = MagicMock(return_value=[
+            {"name": "emacs-x11", "version": "24.5", "release": "1", "epoch": "", "arch": "x86_64", "arch_label": "x86_64"},
+            {"name": "emacs-melpa", "version": "16.7", "release": "2", "epoch": "", "arch": "noarch", "arch_label": "noarch"},
+            {"name": "emacs-nox", "version": "24.5.2", "release": "3", "epoch": "", "arch": "x86_64", "arch_label": "x86_64"},
+        ])
 
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+                patch("spacecmd.package.logging", logger) as lgr:
             out = spacecmd.package.do_package_search(
-                shell, "name:emacs*", doreturn=False
-            )
+                shell, "name:emacs*", doreturn=False)
 
         assert not shell.help_package_search.called
         assert logger.debug.called
         assert shell.client.packages.search.advanced.called
         assert out is None
         assert mprint.called
-        assert_expect(
-            mprint.call_args_list,
-            "emacs-melpa-16.7-2.noarch\nemacs-nox-24.5.2-3.x86_64\nemacs-x11-24.5-1.x86_64",
-        )
+        assert_expect(mprint.call_args_list,
+                      'emacs-melpa-16.7-2.noarch\nemacs-nox-24.5.2-3.x86_64\nemacs-x11-24.5-1.x86_64')
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_search_advanced_wrong_fields(self, shell):
         """
         Test do_package_search with arguments of advanced fields.
@@ -573,35 +447,22 @@ class TestSCPackage:
         logger = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+                patch("spacecmd.package.logging", logger) as lgr:
             out = spacecmd.package.do_package_search(
-                shell, "millenium:emacs*", doreturn=False
-            )
+                shell, "millenium:emacs*", doreturn=False)
 
         assert not logger.debug.called
         assert not shell.client.packages.search.advanced.called
         assert out is None
         assert shell.help_package_search.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_search_advanced_check_fields(self, shell):
         """
         Test do_package_search check advanced fields.
         """
-        for field in (
-            "name:",
-            "epoch:",
-            "version:",
-            "release:",
-            "arch:",
-            "description:",
-            "summary:",
-        ):
+        for field in('name:', 'epoch:', 'version:', 'release:',
+                     'arch:', 'description:', 'summary:'):
             shell.help_package_search = MagicMock()
             shell.get_package_names = MagicMock(return_value=[])
             shell.client.packages.search.advanced = MagicMock(return_value=[])
@@ -609,25 +470,16 @@ class TestSCPackage:
             logger = MagicMock()
             mprint = MagicMock()
 
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.package.print", mprint) as prn, patch(
-                "spacecmd.package.logging",
-                logger
-                # pylint: disable-next=unused-variable
-            ) as lgr:
+            with patch("spacecmd.package.print", mprint) as prn, \
+                    patch("spacecmd.package.logging", logger) as lgr:
                 out = spacecmd.package.do_package_search(
-                    shell,
-                    # pylint: disable-next=consider-using-f-string
-                    "{}emacs*".format(field),
-                    doreturn=True,
-                )
+                    shell, "{}emacs*".format(field), doreturn=True)
 
             assert not shell.help_package_search.called
             assert logger.debug.called
             assert shell.client.packages.search.advanced.called
             assert out is not None
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_remove_noarg(self, shell):
         """
         Test do_package_remove with no arguments passed.
@@ -642,12 +494,8 @@ class TestSCPackage:
         shell.user_configm = MagicMock(return_value=True)
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_remove(shell, "")
 
         assert not shell.get_package_names.called
@@ -657,7 +505,6 @@ class TestSCPackage:
         assert not shell.user_configm.called
         assert shell.help_package_remove.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_remove_no_pkg_found(self, shell):
         """
         Test do_package_remove with no valid packages (packages not found).
@@ -672,12 +519,8 @@ class TestSCPackage:
         shell.user_configm = MagicMock(return_value=True)
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_remove(shell, "i-do-not-exist")
 
         assert not shell.get_package_id.called
@@ -691,7 +534,6 @@ class TestSCPackage:
 
         assert_expect(mprint.call_args_list, "No packages found to remove")
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_remove_specific_pkg_aborted(self, shell):
         """
         Test do_package_remove with unconfirmed valid packages.
@@ -699,32 +541,16 @@ class TestSCPackage:
             :param shell:
         """
         shell.help_package_remove = MagicMock()
-        shell.get_package_names = MagicMock(
-            return_value=[
-                "vim",
-                "vim-plugins",
-                "vim-data",
-                "gvim",
-                "gvim-ext",
-                "pico",
-                "pico-data",
-                "emacs",
-                "emacs-nox",
-                "xemacs",
-            ]
-        )
+        shell.get_package_names = MagicMock(return_value=["vim", "vim-plugins", "vim-data", "gvim", "gvim-ext",
+                                                          "pico", "pico-data", "emacs", "emacs-nox", "xemacs"])
         shell.get_package_id = MagicMock()
         shell.client.packages.removePackage = MagicMock()
         shell.generate_package_cache = MagicMock()
         shell.user_confirm = MagicMock(return_value=False)
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_remove(shell, "vim* gvim pico")
 
         assert not shell.get_package_id.called
@@ -738,7 +564,6 @@ class TestSCPackage:
 
         assert mprint.call_args_list[-1][0][0] == "No packages has been removed"
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_remove_specific_pkg_accepted(self, shell):
         """
         Test do_package_remove with unconfirmed valid packages.
@@ -746,20 +571,8 @@ class TestSCPackage:
             :param shell:
         """
         shell.help_package_remove = MagicMock()
-        shell.get_package_names = MagicMock(
-            return_value=[
-                "vim",
-                "vim-plugins",
-                "vim-data",
-                "gvim",
-                "gvim-ext",
-                "pico",
-                "pico-data",
-                "emacs",
-                "emacs-nox",
-                "xemacs",
-            ]
-        )
+        shell.get_package_names = MagicMock(return_value=["vim", "vim-plugins", "vim-data", "gvim", "gvim-ext",
+                                                          "pico", "pico-data", "emacs", "emacs-nox", "xemacs"])
         shell.get_package_id = MagicMock(return_value=["bogus-id"])
         shell.client.packages.removePackage = MagicMock()
         shell.generate_package_cache = MagicMock()
@@ -767,17 +580,10 @@ class TestSCPackage:
         mprint = MagicMock()
         logger = MagicMock()
         mocks_order = MagicMock()
-        mocks_order.mprint, mocks_order.removePackage = (
-            mprint,
-            shell.client.packages.removePackage,
-        )
+        mocks_order.mprint, mocks_order.removePackage = mprint, shell.client.packages.removePackage
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_remove(shell, "vim* gvim pico")
 
         assert not shell.help_package_remove.called
@@ -790,151 +596,73 @@ class TestSCPackage:
         assert shell.generate_package_cache.called
         assert mprint.called
 
-        exp = ["Packages", "--------", "gvim\npico\nvim\nvim-data\nvim-plugins"]
+        exp = [
+            'Packages',
+            '--------',
+            'gvim\npico\nvim\nvim-data\nvim-plugins'
+        ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
         # mprint is called first and removePackage the last
-        assert mocks_order.mock_calls[0][0] == "mprint"
-        assert mocks_order.mock_calls[-1][0] == "removePackage"
+        assert mocks_order.mock_calls[0][0] == 'mprint'
+        assert mocks_order.mock_calls[-1][0] == 'removePackage'
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listorphans_noarg(self, shell):
         """
         Test do_package_listorphans without arguments.
 
             :param shell:
         """
-        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(
-            return_value=[
-                {
-                    "name": "vim",
-                    "version": "0.1",
-                    "release": "42",
-                    "epoch": "5",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-data",
-                    "version": "0.2",
-                    "release": "43",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-plugins",
-                    "version": "1.17",
-                    "release": "16",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-            ]
-        )
+        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(return_value=[
+            {"name": "vim", "version": "0.1", "release": "42", "epoch": "5", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-data", "version": "0.2", "release": "43", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-plugins", "version": "1.17", "release": "16", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.package.print", mprint) as prn:
             out = spacecmd.package.do_package_listorphans(shell, "", doreturn=False)
         assert out is None
         assert mprint.called
         assert shell.client.channel.software.listPackagesWithoutChannel.called
-        assert_expect(
-            mprint.call_args_list,
-            "vim-0.1-42:5.x86_64\nvim-data-0.2-43.x86_64\nvim-plugins-1.17-16.x86_64",
-        )
+        assert_expect(mprint.call_args_list, "vim-0.1-42:5.x86_64\nvim-data-0.2-43.x86_64\nvim-plugins-1.17-16.x86_64")
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listorphans_return(self, shell):
         """
         Test do_package_listorphans without arguments.
 
             :param shell:
         """
-        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(
-            return_value=[
-                {
-                    "name": "vim",
-                    "version": "0.1",
-                    "release": "42",
-                    "epoch": "5",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-data",
-                    "version": "0.2",
-                    "release": "43",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-plugins",
-                    "version": "1.17",
-                    "release": "16",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-            ]
-        )
+        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(return_value=[
+            {"name": "vim", "version": "0.1", "release": "42", "epoch": "5", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-data", "version": "0.2", "release": "43", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-plugins", "version": "1.17", "release": "16", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.package.print", mprint) as prn:
             out = spacecmd.package.do_package_listorphans(shell, "", doreturn=True)
         assert out is not None
         assert not mprint.called
         assert shell.client.channel.software.listPackagesWithoutChannel.called
-        assert out == [
-            "vim-0.1-42:5.x86_64",
-            "vim-data-0.2-43.x86_64",
-            "vim-plugins-1.17-16.x86_64",
-        ]
+        assert out == ['vim-0.1-42:5.x86_64', 'vim-data-0.2-43.x86_64', 'vim-plugins-1.17-16.x86_64']
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_removeorphans_noconfirm(self, shell):
         """
         Test do_package_removeorphans without confirmation.
 
             :param shell:
         """
-        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(
-            return_value=[
-                {
-                    "name": "vim",
-                    "version": "0.1",
-                    "release": "42",
-                    "epoch": "5",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-data",
-                    "version": "0.2",
-                    "release": "43",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-plugins",
-                    "version": "1.17",
-                    "release": "16",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-            ]
-        )
+        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(return_value=[
+            {"name": "vim", "version": "0.1", "release": "42", "epoch": "5", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-data", "version": "0.2", "release": "43", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-plugins", "version": "1.17", "release": "16", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+        ])
         shell.client.packages.removePackage = MagicMock()
         shell.user_confirm = MagicMock(return_value=False)
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.package.print", mprint) as prn:
             out = spacecmd.package.do_package_removeorphans(shell, "")
 
@@ -945,46 +673,21 @@ class TestSCPackage:
 
         assert mprint.call_args_list[-1][0][0] == "No packages were removed"
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_removeorphans_confirm(self, shell):
         """
         Test do_package_removeorphans with confirmation.
 
             :param shell:
         """
-        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(
-            return_value=[
-                {
-                    "name": "vim",
-                    "version": "0.1",
-                    "release": "42",
-                    "epoch": "5",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-data",
-                    "version": "0.2",
-                    "release": "43",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-                {
-                    "name": "vim-plugins",
-                    "version": "1.17",
-                    "release": "16",
-                    "epoch": "",
-                    "arch": "AMD64",
-                    "arch_label": "amd64",
-                },
-            ]
-        )
+        shell.client.channel.software.listPackagesWithoutChannel = MagicMock(return_value=[
+            {"name": "vim", "version": "0.1", "release": "42", "epoch": "5", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-data", "version": "0.2", "release": "43", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+            {"name": "vim-plugins", "version": "1.17", "release": "16", "epoch": "", "arch": "AMD64", "arch_label": "amd64"},
+        ])
         shell.client.packages.removePackage = MagicMock()
         shell.user_confirm = MagicMock(return_value=True)
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.package.print", mprint) as prn:
             out = spacecmd.package.do_package_removeorphans(shell, "")
 
@@ -994,9 +697,9 @@ class TestSCPackage:
         assert shell.client.channel.software.listPackagesWithoutChannel.called
 
         exp = [
-            "Packages",
-            "--------",
-            "vim-0.1-42:5.x86_64\nvim-data-0.2-43.x86_64\nvim-plugins-1.17-16.x86_64",
+            'Packages',
+            '--------',
+            'vim-0.1-42:5.x86_64\nvim-data-0.2-43.x86_64\nvim-plugins-1.17-16.x86_64'
         ]
 
         for call in mprint.call_args_list:
@@ -1004,7 +707,6 @@ class TestSCPackage:
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listinstallsystems_noarg(self, shell):
         """
         Test do_package_listinstallsystems without arguments.
@@ -1020,12 +722,8 @@ class TestSCPackage:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listinstalledsystems(shell, "")
 
         assert not shell.do_package_search.called
@@ -1035,7 +733,6 @@ class TestSCPackage:
         assert not logger.warning.called
         assert shell.help_package_listinstalledsystems.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listinstallsystems_package_not_found(self, shell):
         """
         Test do_package_listinstallsystems with not found package
@@ -1051,12 +748,8 @@ class TestSCPackage:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listinstalledsystems(shell, "darth-vader")
 
         assert not shell.get_package_id.called
@@ -1068,7 +761,6 @@ class TestSCPackage:
 
         assert_expect(logger.warning.call_args_list, "No packages found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listinstallsystems_few_packages(self, shell):
         """
         Test do_package_listinstallsystems with few packages.
@@ -1077,65 +769,55 @@ class TestSCPackage:
             :param shell:
         """
         shell.help_package_listinstalledsystems = MagicMock()
-        shell.do_package_search = MagicMock(
-            return_value=["emacs", "xemacs", "spacemacs"]
-        )
-        shell.get_package_id = MagicMock(
-            side_effect=[
-                ["emacs-id-1", "emacs-id-2", "emacs-id-3"],
-                ["xemacs-id-1", "xemacs-id-2", "xemacs-id-3"],
-                ["spacemacs-id-1", "spacemacs-id-2", "spacemacs-id-3"],
-            ]
-        )
-        shell.client.system.listSystemsWithPackage = MagicMock(
-            side_effect=[
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                    {"name": "bar.foo.com", "id": 1000010001},
-                    {"name": "fred.foo.com", "id": 1000010002},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                    {"name": "bar.foo.com", "id": 1000010001},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                    {"name": "bar.foo.com", "id": 1000010001},
-                    {"name": "fred.foo.com", "id": 1000010002},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                    {"name": "bar.foo.com", "id": 1000010001},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                    {"name": "bar.foo.com", "id": 1000010001},
-                    {"name": "fred.foo.com", "id": 1000010002},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                    {"name": "bar.foo.com", "id": 1000010001},
-                ],
-                [
-                    {"name": "web.foo.com", "id": 1000010000},
-                ],
-            ]
-        )
+        shell.do_package_search = MagicMock(return_value=["emacs", "xemacs", "spacemacs"])
+        shell.get_package_id = MagicMock(side_effect=[
+            ["emacs-id-1", "emacs-id-2", "emacs-id-3"],
+            ["xemacs-id-1", "xemacs-id-2", "xemacs-id-3"],
+            ["spacemacs-id-1", "spacemacs-id-2", "spacemacs-id-3"]
+        ])
+        shell.client.system.listSystemsWithPackage = MagicMock(side_effect=[
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+                {"name": "bar.foo.com", "id": 1000010001},
+                {"name": "fred.foo.com", "id": 1000010002},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+                {"name": "bar.foo.com", "id": 1000010001},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+                {"name": "bar.foo.com", "id": 1000010001},
+                {"name": "fred.foo.com", "id": 1000010002},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+                {"name": "bar.foo.com", "id": 1000010001},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+                {"name": "bar.foo.com", "id": 1000010001},
+                {"name": "fred.foo.com", "id": 1000010002},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+                {"name": "bar.foo.com", "id": 1000010001},
+            ],
+            [
+                {"name": "web.foo.com", "id": 1000010000},
+            ],
+        ])
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listinstalledsystems(shell, "darth-vader")
 
         assert not shell.help_package_listinstalledsystems.called
@@ -1146,20 +828,20 @@ class TestSCPackage:
         assert shell.do_package_search.called
 
         exp = [
-            "emacs",
-            "-----",
+            'emacs',
+            '-----',
+            'bar.foo.com : 1000010001\nbar.foo.com : 1000010001\nfred.foo.com : 1000010002\n'
+            'web.foo.com : 1000010000\nweb.foo.com : 1000010000\nweb.foo.com : 1000010000',
+            '----------',
+            'xemacs',
+            '------',
+            'bar.foo.com : 1000010001\nbar.foo.com : 1000010001\nfred.foo.com : 1000010002\n'
+            'web.foo.com : 1000010000\nweb.foo.com : 1000010000\nweb.foo.com : 1000010000',
+            '----------',
+            'spacemacs',
+            '---------',
             "bar.foo.com : 1000010001\nbar.foo.com : 1000010001\nfred.foo.com : 1000010002\n"
-            "web.foo.com : 1000010000\nweb.foo.com : 1000010000\nweb.foo.com : 1000010000",
-            "----------",
-            "xemacs",
-            "------",
-            "bar.foo.com : 1000010001\nbar.foo.com : 1000010001\nfred.foo.com : 1000010002\n"
-            "web.foo.com : 1000010000\nweb.foo.com : 1000010000\nweb.foo.com : 1000010000",
-            "----------",
-            "spacemacs",
-            "---------",
-            "bar.foo.com : 1000010001\nbar.foo.com : 1000010001\nfred.foo.com : 1000010002\n"
-            "web.foo.com : 1000010000\nweb.foo.com : 1000010000\nweb.foo.com : 1000010000",
+            "web.foo.com : 1000010000\nweb.foo.com : 1000010000\nweb.foo.com : 1000010000"
         ]
 
         for call in mprint.call_args_list:
@@ -1167,7 +849,6 @@ class TestSCPackage:
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listerrata_noargs(self, shell):
         """
         Test do_package_listerrata without args.
@@ -1181,12 +862,8 @@ class TestSCPackage:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listerrata(shell, "")
 
         assert not shell.do_package_search.called
@@ -1194,7 +871,6 @@ class TestSCPackage:
         assert not shell.get_package_id.called
         assert shell.help_package_listerrata.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listerrata_not_found_packages(self, shell):
         """
         Test do_package_listerrata with invalid package names.
@@ -1209,12 +885,8 @@ class TestSCPackage:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listerrata(shell, "iron-man")
 
         assert not shell.help_package_listerrata.called
@@ -1225,7 +897,6 @@ class TestSCPackage:
         assert shell.do_package_search.called
         assert_expect(logger.warning.call_args_list, "No packages found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listerrata_packages(self, shell):
         """
         Test do_package_listerrata with a package names.
@@ -1233,34 +904,32 @@ class TestSCPackage:
             :param shell:
             :param args:
         """
-        shell.do_package_search = MagicMock(
-            return_value=["emacs", "xemacs", "emacs-nox"]
-        )
-        shell.client.packages.listProvidingErrata = MagicMock(
-            side_effect=[
-                [
-                    {"advisory": "RHBA-2019:4231"},
-                    {"advisory": "CVE-2019:123-4"},
-                ],
-                [
-                    {"advisory": "RHBA-2019:4231"},
-                    {"advisory": "RHBA-2019:4232"},
-                    {"advisory": "RHBA-2019:4233"},
-                ],
-                [{"advisory": "CVE-2018:152-5"}],
+        shell.do_package_search = MagicMock(return_value=[
+            "emacs", "xemacs", "emacs-nox"
+        ])
+        shell.client.packages.listProvidingErrata = MagicMock(side_effect=[
+            [
+                {"advisory": "RHBA-2019:4231"},
+                {"advisory": "CVE-2019:123-4"},
+            ],
+            [
+                {"advisory": "RHBA-2019:4231"},
+                {"advisory": "RHBA-2019:4232"},
+                {"advisory": "RHBA-2019:4233"},
+            ],
+            [
+                {"advisory": "CVE-2018:152-5"}
             ]
-        )
-        shell.get_package_id = MagicMock(return_value=["bogus-package-id"])
+        ])
+        shell.get_package_id = MagicMock(return_value=[
+            "bogus-package-id"
+        ])
         shell.help_package_listerrata = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listerrata(shell, "emacs")
 
         assert not logger.warning.called
@@ -1271,22 +940,21 @@ class TestSCPackage:
         assert shell.do_package_search.called
 
         expectations = [
-            "emacs",
-            "-----",
-            "CVE-2019:123-4\nRHBA-2019:4231",
-            "----------",
-            "xemacs",
-            "------",
-            "RHBA-2019:4231\nRHBA-2019:4232\nRHBA-2019:4233",
-            "----------",
-            "emacs-nox",
-            "---------",
-            "CVE-2018:152-5",
+            'emacs',
+            '-----',
+            'CVE-2019:123-4\nRHBA-2019:4231',
+            '----------',
+            'xemacs',
+            '------',
+            'RHBA-2019:4231\nRHBA-2019:4232\nRHBA-2019:4233',
+            '----------',
+            'emacs-nox',
+            '---------',
+            'CVE-2018:152-5'
         ]
 
         assert_list_args_expect(mprint.call_args_list, expectations)
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listerrata_multiple_packages(self, shell):
         """
         Test do_package_listerrata with two package names.
@@ -1294,28 +962,28 @@ class TestSCPackage:
             :param shell:
             :param args:
         """
-        shell.do_package_search = MagicMock(return_value=["xemacs", "emacs-nox"])
-        shell.client.packages.listProvidingErrata = MagicMock(
-            side_effect=[
-                [
-                    {"advisory": "RHBA-2019:4231"},
-                    {"advisory": "RHBA-2019:4232"},
-                    {"advisory": "RHBA-2019:4233"},
-                ],
-                [{"advisory": "CVE-2018:152-5"}],
+        shell.do_package_search = MagicMock(return_value=[
+            "xemacs", "emacs-nox"
+        ])
+        shell.client.packages.listProvidingErrata = MagicMock(side_effect=[
+            [
+                {"advisory": "RHBA-2019:4231"},
+                {"advisory": "RHBA-2019:4232"},
+                {"advisory": "RHBA-2019:4233"},
+            ],
+            [
+                {"advisory": "CVE-2018:152-5"}
             ]
-        )
-        shell.get_package_id = MagicMock(return_value=["bogus-package-id"])
+        ])
+        shell.get_package_id = MagicMock(return_value=[
+            "bogus-package-id"
+        ])
         shell.help_package_listerrata = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+                patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listerrata(shell, "xemacs emacs-nox")
 
         assert not logger.warning.called
@@ -1326,18 +994,17 @@ class TestSCPackage:
         assert shell.do_package_search.called
 
         expectations = [
-            "xemacs",
-            "------",
-            "RHBA-2019:4231\nRHBA-2019:4232\nRHBA-2019:4233",
-            "----------",
-            "emacs-nox",
-            "---------",
-            "CVE-2018:152-5",
+            'xemacs',
+            '------',
+            'RHBA-2019:4231\nRHBA-2019:4232\nRHBA-2019:4233',
+            '----------',
+            'emacs-nox',
+            '---------',
+            'CVE-2018:152-5'
         ]
 
         assert_list_args_expect(mprint.call_args_list, expectations)
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listdependencies_noargs(self, shell):
         """
         Test do_packge_listdependencies without arguments.
@@ -1351,12 +1018,8 @@ class TestSCPackage:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listdependencies(shell, "")
 
         assert not shell.do_package_search.called
@@ -1366,7 +1029,6 @@ class TestSCPackage:
         assert not logger.warning.called
         assert shell.help_package_listdependencies.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listdependencies_no_packages_found(self, shell):
         """
         Test do_packge_listdependencies no packages found.
@@ -1380,12 +1042,8 @@ class TestSCPackage:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listdependencies(shell, "thor")
 
         assert not shell.get_package_id.called
@@ -1397,26 +1055,23 @@ class TestSCPackage:
 
         assert_expect(logger.warning.call_args_list, "No packages found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listdependencies_invalid_package(self, shell):
         """
         Test do_packge_listdependencies with invalid packages
             :param self:
             :param shell:
         """
-        shell.do_package_search = MagicMock(return_value=["vi", "vim", "gvim", "xvim"])
+        shell.do_package_search = MagicMock(return_value=[
+            "vi", "vim", "gvim", "xvim"
+        ])
         shell.help_package_listdependencies = MagicMock()
         shell.get_package_id = MagicMock(return_value=[None])
         shell.client.packages.list_dependencies = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listdependencies(shell, "bad-editor")
 
         assert not shell.client.packages.list_dependencies.called
@@ -1427,89 +1082,80 @@ class TestSCPackage:
         assert shell.get_package_id.called
 
         expectations = [
-            "vi is not a valid package",
-            "vim is not a valid package",
-            "gvim is not a valid package",
-            "xvim is not a valid package",
+            'vi is not a valid package',
+            'vim is not a valid package',
+            'gvim is not a valid package',
+            'xvim is not a valid package'
         ]
-        assert_list_args_expect(logger.warning.call_args_list, expectations)
+        assert_list_args_expect(logger.warning.call_args_list,
+                                expectations)
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listdependencies_packages(self, shell):
         """
         Test do_package_listdependencies with packages
             :param self:
             :param shell:
         """
-        shell.do_package_search = MagicMock(
-            return_value=[
-                "emacs",
-                "xemacs",
-                "vim",
-                "emacs-x11",  # One should fail here, obviously
-            ]
-        )
+        shell.do_package_search = MagicMock(return_value=[
+            "emacs", "xemacs", "vim", "emacs-x11"  # One should fail here, obviously
+        ])
         shell.help_package_listdependencies = MagicMock()
-        shell.get_package_id = MagicMock(side_effect=[["1"], ["2"], [None], ["3"]])
-        shell.client.packages.list_dependencies = MagicMock(
-            side_effect=[
-                [
-                    {
-                        "dependency": "libxml2.so.2",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "> 1.0",
-                    },
-                    {
-                        "dependency": "mimehandler(application/x-shellscript)",
-                        "dependency_type": "provides",
-                        "dependency_modifier": "",
-                    },
-                ],
-                [
-                    {
-                        "dependency": "libasound.so.2",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "",
-                    },
-                    {
-                        "dependency": "emacs_program",
-                        "dependency_type": "provides",
-                        "dependency_modifier": "= 24.3-19.2",
-                    },
-                ],
-                [
-                    {
-                        "dependency": "libc.so.6",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "",
-                    },
-                    {
-                        "dependency": "rpmlib (CompressedFileNames)",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "<= 3.0.4-1",
-                    },
-                    {
-                        "dependency": "rpmlib (PayloadFilesHavePrefix)",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "<= 4.0-1",
-                    },
-                    {
-                        "dependency": "rpmlib (PayloadIsLzma)",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "<= 4.4.6-1",
-                    },
-                ],
-            ]
-        )
+        shell.get_package_id = MagicMock(side_effect=[
+            ["1"], ["2"], [None], ["3"]
+        ])
+        shell.client.packages.list_dependencies = MagicMock(side_effect=[
+            [
+                {
+                    "dependency": "libxml2.so.2",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "> 1.0"
+                },
+                {
+                    "dependency": "mimehandler(application/x-shellscript)",
+                    "dependency_type": "provides",
+                    "dependency_modifier": ""
+                },
+            ],
+            [
+                {
+                    "dependency": "libasound.so.2",
+                    "dependency_type": "requires",
+                    "dependency_modifier": ""
+                },
+                {
+                    "dependency": "emacs_program",
+                    "dependency_type": "provides",
+                    "dependency_modifier": "= 24.3-19.2"
+                },
+            ],
+            [
+                {
+                    "dependency": "libc.so.6",
+                    "dependency_type": "requires",
+                    "dependency_modifier": ""
+                },
+                {
+                    "dependency": "rpmlib (CompressedFileNames)",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "<= 3.0.4-1"
+                },
+                {
+                    "dependency": "rpmlib (PayloadFilesHavePrefix)",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "<= 4.0-1"
+                },
+                {
+                    "dependency": "rpmlib (PayloadIsLzma)",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "<= 4.4.6-1"
+                },
+            ],
+        ])
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+            patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listdependencies(shell, "emacs")
 
         assert not shell.help_package_listdependencies.called
@@ -1535,94 +1181,88 @@ class TestSCPackage:
             "Dependency: rpmlib (CompressedFileNames) Type: requires Modifier: <= 3.0.4-1",
             "Dependency: rpmlib (PayloadFilesHavePrefix) Type: requires Modifier: <= 4.0-1",
             "Dependency: rpmlib (PayloadIsLzma) Type: requires Modifier: <= 4.4.6-1",
-            "----------",
-        ]
+            "----------"]
         assert_list_args_expect(mprint.call_args_list, expectations=expectations)
         assert_expect(logger.warning.call_args_list, "vim is not a valid package")
 
-    # pylint: disable-next=redefined-outer-name
     def test_package_listdependencies_multiple_packages(self, shell):
         """
         Test do_package_listdependencies with two packages
             :param self:
             :param shell:
         """
-        shell.do_package_search = MagicMock(
-            return_value=["emacs", "xemacs", "vim", "emacs-x11"]
-        )
+        shell.do_package_search = MagicMock(return_value=[
+            "emacs", "xemacs", "vim", "emacs-x11"
+        ])
         shell.help_package_listdependencies = MagicMock()
-        shell.get_package_id = MagicMock(side_effect=[["1"], ["2"], ["3"], ["4"]])
-        shell.client.packages.list_dependencies = MagicMock(
-            side_effect=[
-                [
-                    {
-                        "dependency": "libxml2.so.2",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "> 1.0",
-                    },
-                    {
-                        "dependency": "mimehandler(application/x-shellscript)",
-                        "dependency_type": "provides",
-                        "dependency_modifier": "",
-                    },
-                ],
-                [
-                    {
-                        "dependency": "libasound.so.2",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "",
-                    },
-                    {
-                        "dependency": "emacs_program",
-                        "dependency_type": "provides",
-                        "dependency_modifier": "= 24.3-19.2",
-                    },
-                ],
-                [
-                    {
-                        "dependency": "libacl.so.1",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "",
-                    },
-                    {
-                        "dependency": "libc.so.6",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "",
-                    },
-                ],
-                [
-                    {
-                        "dependency": "libc.so.6",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "",
-                    },
-                    {
-                        "dependency": "rpmlib (CompressedFileNames)",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "<= 3.0.4-1",
-                    },
-                    {
-                        "dependency": "rpmlib (PayloadFilesHavePrefix)",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "<= 4.0-1",
-                    },
-                    {
-                        "dependency": "rpmlib (PayloadIsLzma)",
-                        "dependency_type": "requires",
-                        "dependency_modifier": "<= 4.4.6-1",
-                    },
-                ],
-            ]
-        )
+        shell.get_package_id = MagicMock(side_effect=[
+            ["1"], ["2"], ["3"], ["4"]
+        ])
+        shell.client.packages.list_dependencies = MagicMock(side_effect=[
+            [
+                {
+                    "dependency": "libxml2.so.2",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "> 1.0"
+                },
+                {
+                    "dependency": "mimehandler(application/x-shellscript)",
+                    "dependency_type": "provides",
+                    "dependency_modifier": ""
+                },
+            ],
+            [
+                {
+                    "dependency": "libasound.so.2",
+                    "dependency_type": "requires",
+                    "dependency_modifier": ""
+                },
+                {
+                    "dependency": "emacs_program",
+                    "dependency_type": "provides",
+                    "dependency_modifier": "= 24.3-19.2"
+                },
+            ],
+            [
+                {
+                    "dependency": "libacl.so.1",
+                    "dependency_type": "requires",
+                    "dependency_modifier": ""
+                },
+                {
+                    "dependency": "libc.so.6",
+                    "dependency_type": "requires",
+                    "dependency_modifier": ""
+                },
+            ],
+            [
+                {
+                    "dependency": "libc.so.6",
+                    "dependency_type": "requires",
+                    "dependency_modifier": ""
+                },
+                {
+                    "dependency": "rpmlib (CompressedFileNames)",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "<= 3.0.4-1"
+                },
+                {
+                    "dependency": "rpmlib (PayloadFilesHavePrefix)",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "<= 4.0-1"
+                },
+                {
+                    "dependency": "rpmlib (PayloadIsLzma)",
+                    "dependency_type": "requires",
+                    "dependency_modifier": "<= 4.4.6-1"
+                },
+            ],
+        ])
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.package.print", mprint) as prn, patch(
-            "spacecmd.package.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.package.print", mprint) as prn, \
+                patch("spacecmd.package.logging", logger) as lgr:
             spacecmd.package.do_package_listdependencies(shell, "emacs vim")
 
         assert not shell.help_package_listdependencies.called
@@ -1653,6 +1293,5 @@ class TestSCPackage:
             "Dependency: rpmlib (CompressedFileNames) Type: requires Modifier: <= 3.0.4-1",
             "Dependency: rpmlib (PayloadFilesHavePrefix) Type: requires Modifier: <= 4.0-1",
             "Dependency: rpmlib (PayloadIsLzma) Type: requires Modifier: <= 4.4.6-1",
-            "----------",
-        ]
+            "----------"]
         assert_list_args_expect(mprint.call_args_list, expectations=expectations)

--- a/spacecmd/tests/test_proxy.py
+++ b/spacecmd/tests/test_proxy.py
@@ -5,8 +5,6 @@ Test suite for "proxy"
 from spacecmd import proxy
 
 from unittest.mock import mock_open, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell  # used by pytest
 import pytest
 
@@ -21,8 +19,8 @@ import pytest
         ("proxy.lab server.lab 1024 proxy@acme.org", True),
     ],
 )
-# pylint: disable-next=redefined-outer-name
 def test_proxy_container_config_invokes_help_when_needed(shell, args, calls_help):
+
     m_open = mock_open()
     with patch("spacecmd.proxy.read_file", return_value=""), patch(
         "spacecmd.proxy.open", m_open
@@ -45,11 +43,9 @@ def test_proxy_container_config_invokes_help_when_needed(shell, args, calls_help
     ],
 )
 def test_proxy_container_config_generate_cert_invokes_help_when_needed(
-    # pylint: disable-next=redefined-outer-name
-    shell,
-    args,
-    calls_help,
+    shell, args, calls_help
 ):
+
     m_open = mock_open()
     with patch("spacecmd.proxy.read_file", return_value=""), patch(
         "spacecmd.proxy.open", m_open

--- a/spacecmd/tests/test_repo.py
+++ b/spacecmd/tests/test_repo.py
@@ -4,8 +4,6 @@ Test suite for spacecmd.repo module
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.repo
 
@@ -15,7 +13,6 @@ class TestSCRepo:
     Test suite for "repo" module.
     """
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_list_noret(self, shell):
         """
         Test do_repo_list with no data return.
@@ -23,13 +20,9 @@ class TestSCRepo:
         :param shell:
         :return:
         """
-        shell.client.channel.software.listUserRepos = MagicMock(
-            return_value=[
-                {"label": "v-repo-one"},
-                {"label": "z-repo-two"},
-                {"label": "a-repo-three"},
-            ]
-        )
+        shell.client.channel.software.listUserRepos = MagicMock(return_value=[
+            {"label": "v-repo-one"}, {"label": "z-repo-two"}, {"label": "a-repo-three"}
+        ])
         mprint = MagicMock()
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_list(shell, "", doreturn=False)
@@ -38,9 +31,8 @@ class TestSCRepo:
         assert mprint.called
         assert out is None
 
-        assert_expect(mprint.call_args_list, "a-repo-three\nv-repo-one\nz-repo-two")
+        assert_expect(mprint.call_args_list, 'a-repo-three\nv-repo-one\nz-repo-two')
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_list_ret_data(self, shell):
         """
         Test do_repo_list with data return.
@@ -48,13 +40,9 @@ class TestSCRepo:
         :param shell:
         :return:
         """
-        shell.client.channel.software.listUserRepos = MagicMock(
-            return_value=[
-                {"label": "v-repo-one"},
-                {"label": "z-repo-two"},
-                {"label": "a-repo-three"},
-            ]
-        )
+        shell.client.channel.software.listUserRepos = MagicMock(return_value=[
+            {"label": "v-repo-one"}, {"label": "z-repo-two"}, {"label": "a-repo-three"}
+        ])
         mprint = MagicMock()
         with patch("spacecmd.repo.print", mprint):
             out = spacecmd.repo.do_repo_list(shell, "", doreturn=True)
@@ -65,7 +53,6 @@ class TestSCRepo:
         assert len(out) == 3
         assert out == ["v-repo-one", "z-repo-two", "a-repo-three"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_details_noarg(self, shell):
         """
         Test do_repo_details with no arguments passed.
@@ -83,7 +70,6 @@ class TestSCRepo:
         assert not shell.client.channel.software.getRepoDetails.called
         assert shell.help_repo_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_details_no_repos_found(self, shell):
         """
         Test do_repo_details no repos found.
@@ -103,11 +89,9 @@ class TestSCRepo:
         assert out is 1
         assert mprint.called
 
-        assert_expect(
-            mprint.call_args_list, "No repositories found for 'non-existing-repo' query"
-        )
+        assert_expect(mprint.call_args_list,
+                      "No repositories found for 'non-existing-repo' query")
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_details_repo_data(self, shell):
         """
         Test do_repo_details for repo data.
@@ -115,23 +99,17 @@ class TestSCRepo:
         :param shell:
         :return:
         """
-        shell.client.channel.software.getRepoDetails = MagicMock(
-            side_effect=[
-                {
-                    "label": "some-repository",
-                    "sourceUrl": "http://somehost/somerepo",
-                    "type": "yum",
-                },
-                {
-                    "label": "some-other-repository",
-                    "sourceUrl": "file:///tmp/someotherrepo",
-                    "type": "zypper",
-                    "sslCaDesc": "Ca Descr",
-                    "sslCertDesc": "Cert descr",
-                    "sslKeyDesc": "Key descr",
-                },
-            ]
-        )
+        shell.client.channel.software.getRepoDetails = MagicMock(side_effect=[
+            {
+                "label": "some-repository", "sourceUrl": "http://somehost/somerepo",
+                "type": "yum"
+            },
+            {
+                "label": "some-other-repository", "sourceUrl": "file:///tmp/someotherrepo",
+                "type": "zypper", "sslCaDesc": "Ca Descr", "sslCertDesc": "Cert descr",
+                "sslKeyDesc": "Key descr"
+            },
+        ])
         shell.do_repo_list = MagicMock(return_value=["some-repo", "some-other-repo"])
         shell.help_repo_details = MagicMock()
         mprint = MagicMock()
@@ -144,23 +122,22 @@ class TestSCRepo:
         assert mprint.called
 
         exp = [
-            "Repository Label:                  some-repository",
-            "Repository URL:                    http://somehost/somerepo",
-            "Repository Type:                   yum",
-            "Repository SSL Ca Certificate:     None",
-            "Repository SSL Client Certificate: None",
-            "Repository SSL Client Key:         None",
-            "----------",
-            "Repository Label:                  some-other-repository",
-            "Repository URL:                    file:///tmp/someotherrepo",
-            "Repository Type:                   zypper",
-            "Repository SSL Ca Certificate:     Ca Descr",
-            "Repository SSL Client Certificate: Cert descr",
-            "Repository SSL Client Key:         Key descr",
+            'Repository Label:                  some-repository',
+            'Repository URL:                    http://somehost/somerepo',
+            'Repository Type:                   yum',
+            'Repository SSL Ca Certificate:     None',
+            'Repository SSL Client Certificate: None',
+            'Repository SSL Client Key:         None',
+            '----------',
+            'Repository Label:                  some-other-repository',
+            'Repository URL:                    file:///tmp/someotherrepo',
+            'Repository Type:                   zypper',
+            'Repository SSL Ca Certificate:     Ca Descr',
+            'Repository SSL Client Certificate: Cert descr',
+            'Repository SSL Client Key:         Key descr'
         ]
         assert_list_args_expect(mprint.call_args_list, exp)
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_listfilters_noargs(self, shell):
         """
         Test do_repo_listfilters without arguments
@@ -180,7 +157,6 @@ class TestSCRepo:
         assert not shell.client.channel.software.listRepoFilters.called
         assert shell.help_repo_listfilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_listfilters_not_found(self, shell):
         """
         Test do_repo_listfilters no filters found.
@@ -202,7 +178,6 @@ class TestSCRepo:
 
         assert_expect(mprint.call_args_list, "No filters found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_listfilters_stdout(self, shell):
         """
         Test do_repo_listfilters stdout check
@@ -211,12 +186,10 @@ class TestSCRepo:
         :return:
         """
         shell.help_repo_listfilters = MagicMock()
-        shell.client.channel.software.listRepoFilters = MagicMock(
-            return_value=[
-                {"flag": "+", "filter": "stuff"},
-                {"flag": "-", "filter": "other"},
-            ]
-        )
+        shell.client.channel.software.listRepoFilters = MagicMock(return_value=[
+            {"flag": "+", "filter": "stuff"},
+            {"flag": "-", "filter": "other"},
+        ])
         mprint = MagicMock()
 
         with patch("spacecmd.repo.print", mprint):
@@ -227,9 +200,8 @@ class TestSCRepo:
         assert shell.client.channel.software.listRepoFilters.called
         assert mprint.called
 
-        assert_list_args_expect(mprint.call_args_list, ["+stuff", "-other"])
+        assert_list_args_expect(mprint.call_args_list, ['+stuff', '-other'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_addfilters_noargs(self, shell):
         """
         Test do_repo_addfilters no arguments.
@@ -249,7 +221,6 @@ class TestSCRepo:
         assert not shell.client.channel.software.addRepoFilter.called
         assert shell.help_repo_addfilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_addfilters_argcheck_repo_only(self, shell):
         """
         Test do_repo_addfilters check arguments: repo only
@@ -269,7 +240,6 @@ class TestSCRepo:
         assert not shell.client.channel.software.addRepoFilter.called
         assert shell.help_repo_addfilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_addfilters_argcheck_wrong_filter(self, shell):
         """
         Test do_repo_addfilters check arguments: wrong filter syntax
@@ -282,12 +252,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_addfilters(shell, "some-repo foo bar")
 
         assert out is 1
@@ -296,9 +262,8 @@ class TestSCRepo:
         assert not shell.client.channel.software.addRepoFilter.called
         assert logger.error.called
 
-        assert_expect(logger.error.call_args_list, "Each filter must start with + or -")
+        assert_expect(logger.error.call_args_list, 'Each filter must start with + or -')
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_addfilters_argcheck_add_filter(self, shell):
         """
         Test do_repo_addfilters add filter
@@ -311,12 +276,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_addfilters(shell, "some-repo +emacs")
 
         assert out is 0
@@ -325,7 +286,6 @@ class TestSCRepo:
         assert not logger.error.called
         assert shell.client.channel.software.addRepoFilter.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_removefilters_insufficient_args(self, shell):
         """
         Test do_repo_removefilters without sufficient arguments.
@@ -340,12 +300,8 @@ class TestSCRepo:
             mprint = MagicMock()
             logger = MagicMock()
 
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.repo.print", mprint) as prn, patch(
-                "spacecmd.repo.logging",
-                logger
-                # pylint: disable-next=unused-variable
-            ) as lgr:
+            with patch("spacecmd.repo.print", mprint) as prn, \
+                    patch("spacecmd.repo.logging", logger) as lgr:
                 out = spacecmd.repo.do_repo_removefilters(shell, arg)
 
             assert out is 1
@@ -354,7 +310,6 @@ class TestSCRepo:
             assert not logger.error.called
             assert shell.help_repo_removefilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_removefilters_wrong_syntax(self, shell):
         """
         Test do_repo_removefilters using wrong syntax.
@@ -367,12 +322,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_removefilters(shell, "repo foo bar")
 
         assert out is 1
@@ -381,9 +332,8 @@ class TestSCRepo:
         assert not shell.help_repo_removefilters.called
         assert logger.error.called
 
-        assert_expect(logger.error.call_args_list, "Each filter must start with + or -")
+        assert_expect(logger.error.call_args_list, 'Each filter must start with + or -')
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_removefilters_remove(self, shell):
         """
         Test do_repo_removefilters remove.
@@ -396,12 +346,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_removefilters(shell, "repo +emacs -vim")
 
         assert out is 0
@@ -411,15 +357,10 @@ class TestSCRepo:
         assert shell.client.channel.software.removeRepoFilter.called
         assert shell.client.channel.software.removeRepoFilter.call_count == 2
 
-        assert_args_expect(
-            shell.client.channel.software.removeRepoFilter.call_args_list,
-            [
-                ((shell.session, "repo", {"filter": "emacs", "flag": "+"}), {}),
-                ((shell.session, "repo", {"filter": "vim", "flag": "-"}), {}),
-            ],
-        )
+        assert_args_expect(shell.client.channel.software.removeRepoFilter.call_args_list,
+                           [((shell.session, 'repo', {'filter': 'emacs', 'flag': '+'}), {}),
+                            ((shell.session, 'repo', {'filter': 'vim', 'flag': '-'}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_setfilters_noargs(self, shell):
         """
         Test do_repo_setfilters no args.
@@ -433,12 +374,8 @@ class TestSCRepo:
             mprint = MagicMock()
             logger = MagicMock()
 
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.repo.print", mprint) as prn, patch(
-                "spacecmd.repo.logging",
-                logger
-                # pylint: disable-next=unused-variable
-            ) as lgr:
+            with patch("spacecmd.repo.print", mprint) as prn, \
+                    patch("spacecmd.repo.logging", logger) as lgr:
                 out = spacecmd.repo.do_repo_setfilters(shell, arg)
 
             assert out is 1
@@ -447,7 +384,6 @@ class TestSCRepo:
             assert not shell.client.channel.software.setRepoFilters.called
             assert shell.help_repo_setfilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_setfilters_wrong_filters_syntax(self, shell):
         """
         Test do_repo_setfilters with wrong filters syntax
@@ -460,12 +396,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_setfilters(shell, "repo foo bar")
 
         assert out is 1
@@ -476,7 +408,6 @@ class TestSCRepo:
 
         assert_expect(logger.error.call_args_list, "Each filter must start with + or -")
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_setfilters(self, shell):
         """
         Test do_repo_setfilters with wrong filters syntax
@@ -489,12 +420,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_setfilters(shell, "repo +emacs -vim")
 
         assert out is 0
@@ -504,24 +431,11 @@ class TestSCRepo:
         assert shell.client.channel.software.setRepoFilters.call_count == 1
         assert shell.client.channel.software.setRepoFilters.called
 
-        assert_args_expect(
-            shell.client.channel.software.setRepoFilters.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "repo",
-                        [
-                            {"filter": "emacs", "flag": "+"},
-                            {"filter": "vim", "flag": "-"},
-                        ],
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.channel.software.setRepoFilters.call_args_list,
+                           [((shell.session, 'repo',
+                              [{'filter': 'emacs', 'flag': '+'},
+                               {'filter': 'vim', 'flag': '-'}]), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_clearfilters_noargs(self, shell):
         """
         Test do_repo_clearfilters with no arguments.
@@ -534,12 +448,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_clearfilters(shell, "")
 
         assert out is 1
@@ -548,7 +458,6 @@ class TestSCRepo:
         assert not shell.client.channel.software.clearRepoFilters.called
         assert shell.help_repo_clearfilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_clearfilters_not_interactive(self, shell):
         """
         Test do_repo_clearfilters not interactive.
@@ -562,12 +471,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_clearfilters(shell, "repo --yes")
 
         assert out is 0
@@ -576,7 +481,6 @@ class TestSCRepo:
         assert not logger.error.called
         assert shell.client.channel.software.clearRepoFilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_clearfilters_interactive(self, shell):
         """
         Test do_repo_clearfilters interactive.
@@ -590,12 +494,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_clearfilters(shell, "repo")
 
         assert out is 0
@@ -604,7 +504,6 @@ class TestSCRepo:
         assert not logger.error.called
         assert shell.client.channel.software.clearRepoFilters.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_delete_noargs(self, shell):
         """
         Test do_repo_delete no arguments.
@@ -618,12 +517,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_delete(shell, "")
 
         assert out is 1
@@ -632,7 +527,6 @@ class TestSCRepo:
         assert not shell.client.channel.software.removeRepo.called
         assert shell.help_repo_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_rename_noargs(self, shell):
         """
         Test do_repo_rename no arguments.
@@ -646,12 +540,8 @@ class TestSCRepo:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_rename(shell, "")
 
         assert out is 1
@@ -660,7 +550,6 @@ class TestSCRepo:
         assert not shell.client.channel.software.getRepoDetails.called
         assert shell.help_repo_rename.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_updateurl_noargs(self, shell):
         """
         Test do_repo_updateurl no arguments.
@@ -668,7 +557,6 @@ class TestSCRepo:
         :param shell:
         :return:
         """
-        # pylint: disable-next=unused-variable
         for arg in ["", "repo", "http://foo", "http://bar"]:
             shell.help_repo_updateurl = MagicMock()
             shell.client.channel.software.updateRepUrl = MagicMock()
@@ -676,12 +564,8 @@ class TestSCRepo:
             mprint = MagicMock()
             logger = MagicMock()
 
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.repo.print", mprint) as prn, patch(
-                "spacecmd.repo.logging",
-                logger
-                # pylint: disable-next=unused-variable
-            ) as lgr:
+            with patch("spacecmd.repo.print", mprint) as prn, \
+                    patch("spacecmd.repo.logging", logger) as lgr:
                 out = spacecmd.repo.do_repo_updateurl(shell, "")
 
             assert out is 1
@@ -690,7 +574,6 @@ class TestSCRepo:
             assert not shell.client.channel.software.updateRepUrl.called
             assert shell.help_repo_updateurl.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_updatessl_interactive(self, shell):
         """
         Test do_repo_updatessl interactive.
@@ -705,12 +588,9 @@ class TestSCRepo:
         logger = MagicMock()
         prompter = MagicMock(side_effect=["name", "ca", "cert", "key"])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_updatessl(shell, "")
 
         assert out is 0
@@ -718,12 +598,9 @@ class TestSCRepo:
         assert not logger.error.called
         assert shell.client.channel.software.updateRepoSsl.called
 
-        assert_args_expect(
-            shell.client.channel.software.updateRepoSsl.call_args_list,
-            [((shell.session, "name", "ca", "cert", "key"), {})],
-        )
+        assert_args_expect(shell.client.channel.software.updateRepoSsl.call_args_list,
+                           [((shell.session, "name", "ca", "cert", "key"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_updatessl_non_interactive(self, shell):
         """
         Test do_repo_updatessl non-interactive.
@@ -738,27 +615,19 @@ class TestSCRepo:
         logger = MagicMock()
         prompter = MagicMock(return_value="")
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
-            out = spacecmd.repo.do_repo_updatessl(
-                shell, "--name name --ca ca --cert cert --key key"
-            )
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
+            out = spacecmd.repo.do_repo_updatessl(shell, "--name name --ca ca --cert cert --key key")
 
         assert out is 0
         assert not mprint.called
         assert not logger.error.called
         assert shell.client.channel.software.updateRepoSsl.called
 
-        assert_args_expect(
-            shell.client.channel.software.updateRepoSsl.call_args_list,
-            [((shell.session, "name", "ca", "cert", "key"), {})],
-        )
+        assert_args_expect(shell.client.channel.software.updateRepoSsl.call_args_list,
+                           [((shell.session, "name", "ca", "cert", "key"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_updatessl_missing_name(self, shell):
         """
         Test do_repo_updatessl non-interactive.
@@ -773,15 +642,10 @@ class TestSCRepo:
         logger = MagicMock()
         prompter = MagicMock(return_value="")
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
-            out = spacecmd.repo.do_repo_updatessl(
-                shell, "--ca ca --cert cert --key key"
-            )
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
+            out = spacecmd.repo.do_repo_updatessl(shell, "--ca ca --cert cert --key key")
 
         assert out is 1
         assert not mprint.called
@@ -790,7 +654,6 @@ class TestSCRepo:
 
         assert_expect(logger.error.call_args_list, "A name is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_create_interactive(self, shell):
         """
         Test do_repo_create interactive.
@@ -801,16 +664,12 @@ class TestSCRepo:
         shell.client.channel.software.createRepo = MagicMock()
         mprint = MagicMock()
         logger = MagicMock()
-        prompter = MagicMock(
-            side_effect=["name", "http://something", "type", "ca", "cert", "key"]
-        )
+        prompter = MagicMock(side_effect=["name", "http://something", "type",
+                                          "ca", "cert", "key"])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
             out = spacecmd.repo.do_repo_create(shell, "")
 
         assert out is 0
@@ -818,25 +677,9 @@ class TestSCRepo:
         assert shell.client.channel.software.createRepo.called
         assert not logger.error.called
 
-        assert_args_expect(
-            shell.client.channel.software.createRepo.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "name",
-                        "type",
-                        "http://something",
-                        "ca",
-                        "cert",
-                        "key",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.channel.software.createRepo.call_args_list,
+                           [((shell.session, 'name', 'type', 'http://something', 'ca', 'cert', 'key'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_create_non_interactive(self, shell):
         """
         Test do_repo_create non-interactive.
@@ -849,41 +692,20 @@ class TestSCRepo:
         logger = MagicMock()
         prompter = MagicMock(return_value="")
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
-            out = spacecmd.repo.do_repo_create(
-                shell,
-                "--n name --t type -u http://something "
-                "--ca ca --cert cert --key key",
-            )
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
+            out = spacecmd.repo.do_repo_create(shell,
+                                               "--n name --t type -u http://something "
+                                               "--ca ca --cert cert --key key")
 
         assert out is 0
         assert not mprint.called
         assert shell.client.channel.software.createRepo.called
         assert not logger.error.called
-        assert_args_expect(
-            shell.client.channel.software.createRepo.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "name",
-                        "type",
-                        "http://something",
-                        "ca",
-                        "cert",
-                        "key",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.channel.software.createRepo.call_args_list,
+                           [((shell.session, 'name', 'type', 'http://something', 'ca', 'cert', 'key'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_create_non_interactive_name_required(self, shell):
         """
         Test do_repo_create non-interactive, name is missing
@@ -896,15 +718,12 @@ class TestSCRepo:
         logger = MagicMock()
         prompter = MagicMock(return_value="")
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
-            out = spacecmd.repo.do_repo_create(
-                shell, "--t type -u http://something " "--ca ca --cert cert --key key"
-            )
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
+            out = spacecmd.repo.do_repo_create(shell,
+                                               "--t type -u http://something "
+                                               "--ca ca --cert cert --key key")
 
         assert out is 1
         assert not mprint.called
@@ -913,7 +732,6 @@ class TestSCRepo:
 
         assert_expect(logger.error.call_args_list, "A name is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_create_non_interactive_url_required(self, shell):
         """
         Test do_repo_create non-interactive, URL is missing
@@ -926,15 +744,12 @@ class TestSCRepo:
         logger = MagicMock()
         prompter = MagicMock(return_value="")
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
-            out = spacecmd.repo.do_repo_create(
-                shell, "-n name -t type " "--ca ca --cert cert --key key"
-            )
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
+            out = spacecmd.repo.do_repo_create(shell,
+                                               "-n name -t type "
+                                               "--ca ca --cert cert --key key")
 
         assert out is 1
         assert not mprint.called
@@ -943,7 +758,6 @@ class TestSCRepo:
 
         assert_expect(logger.error.call_args_list, "A URL is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_repo_create_non_interactive_type_required(self, shell):
         """
         Test do_repo_create non-interactive, type is missing
@@ -956,35 +770,17 @@ class TestSCRepo:
         logger = MagicMock()
         prompter = MagicMock(return_value="")
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.repo.print", mprint) as prn, patch(
-            "spacecmd.repo.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as prn, patch("spacecmd.repo.logging", logger) as lgr:
-            out = spacecmd.repo.do_repo_create(
-                shell, "-n name -u http://something " "--ca ca --cert cert --key key"
-            )
+        with patch("spacecmd.repo.print", mprint) as prn, \
+                patch("spacecmd.repo.prompt_user", prompter) as prn, \
+                patch("spacecmd.repo.logging", logger) as lgr:
+            out = spacecmd.repo.do_repo_create(shell,
+                                               "-n name -u http://something "
+                                               "--ca ca --cert cert --key key")
 
         assert out is 0
         assert not mprint.called
         assert not logger.error.called
         assert shell.client.channel.software.createRepo.called
 
-        assert_args_expect(
-            shell.client.channel.software.createRepo.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "name",
-                        "yum",
-                        "http://something",
-                        "ca",
-                        "cert",
-                        "key",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.channel.software.createRepo.call_args_list,
+                           [((shell.session, 'name', 'yum', 'http://something', 'ca', 'cert', 'key'), {})])

--- a/spacecmd/tests/test_report.py
+++ b/spacecmd/tests/test_report.py
@@ -3,11 +3,7 @@
 Tests for report.
 """
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 import pytest
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, exc2str
 import spacecmd.report
 
@@ -16,8 +12,6 @@ class TestSCReport:
     """
     Test suite for report.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_report_inactivesystems_noargs(self, shell):
         """
         Test do_report_inactivesystems with no arguments.
@@ -29,18 +23,15 @@ class TestSCReport:
         shell.client.system.listInactiveSystems = MagicMock(return_value=[])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_inactivesystems(shell, "")
 
         assert not mprint.called
         assert shell.client.system.listInactiveSystems.called
 
-        assert_expect(
-            shell.client.system.listInactiveSystems.call_args_list, shell.session
-        )
+        assert_expect(shell.client.system.listInactiveSystems.call_args_list,
+                      shell.session)
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_inactivesystems_systems(self, shell):
         """
         Test do_report_inactivesystems with no arguments, systems found.
@@ -48,37 +39,32 @@ class TestSCReport:
         :param shell:
         :return:
         """
-        shell.client.system.listInactiveSystems = MagicMock(
-            return_value=[
-                {"name": "system-1", "last_checkin": "2019.05.10", "id": 10001000},
-                {"name": "system-2", "last_checkin": "2019.05.11", "id": 10001001},
-                {"name": "system-3", "last_checkin": "2019.05.12", "id": 10001002},
-            ]
-        )
+        shell.client.system.listInactiveSystems = MagicMock(return_value=[
+            {"name": "system-1", "last_checkin": "2019.05.10", "id": 10001000},
+            {"name": "system-2", "last_checkin": "2019.05.11", "id": 10001001},
+            {"name": "system-3", "last_checkin": "2019.05.12", "id": 10001002},
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_inactivesystems(shell, "")
 
         assert mprint.called
         assert shell.client.system.listInactiveSystems.called
-        assert_expect(
-            shell.client.system.listInactiveSystems.call_args_list, shell.session
-        )
+        assert_expect(shell.client.system.listInactiveSystems.call_args_list,
+                      shell.session)
         exp = [
-            "System ID   System    Last Checkin",
-            "----------  --------  ------------",
-            "10001000  system-1  2019.05.10",
-            "10001001  system-2  2019.05.11",
-            "10001002  system-3  2019.05.12",
+            'System ID   System    Last Checkin',
+            '----------  --------  ------------',
+            '10001000  system-1  2019.05.10',
+            '10001001  system-2  2019.05.11',
+            '10001002  system-3  2019.05.12',
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_inactivesystems_wrong_args(self, shell):
         """
         Test do_report_inactivesystems with wrong days count, defaults to 7.
@@ -91,7 +77,6 @@ class TestSCReport:
             shell.client.system.listInactiveSystems = MagicMock(return_value=[])
             mprint = MagicMock()
 
-            # pylint: disable-next=unused-variable
             with patch("spacecmd.report.print", mprint) as prn:
                 spacecmd.report.do_report_inactivesystems(shell, m_arg)
 
@@ -103,7 +88,6 @@ class TestSCReport:
                 assert args == (shell.session, 7)
                 assert not kw
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_inactivesystems_args(self, shell):
         """
         Test do_report_inactivesystems with days count.
@@ -115,7 +99,6 @@ class TestSCReport:
         shell.client.system.listInactiveSystems = MagicMock(return_value=[])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_inactivesystems(shell, "3")
 
@@ -127,7 +110,6 @@ class TestSCReport:
             assert args == (shell.session, 3)
             assert not kw
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_outofdatesystems(self, shell):
         """
         Test do_report_outofdatesystems.
@@ -135,33 +117,29 @@ class TestSCReport:
         :param shell:
         :return:
         """
-        shell.client.system.listOutOfDateSystems = MagicMock(
-            return_value=[
-                {"name": "system-one", "outdated_pkg_count": 5},
-                {"name": "system-two", "outdated_pkg_count": 15},
-                {"name": "system-three", "outdated_pkg_count": 25},
-            ]
-        )
+        shell.client.system.listOutOfDateSystems = MagicMock(return_value=[
+            {"name": "system-one", "outdated_pkg_count": 5},
+            {"name": "system-two", "outdated_pkg_count": 15},
+            {"name": "system-three", "outdated_pkg_count": 25},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_outofdatesystems(shell, "")
 
         assert mprint.called
 
         exp = [
-            "System        Packages",
-            "------------  --------",
-            "system-one           5",
-            "system-three        25",
-            "system-two          15",
+            'System        Packages',
+            '------------  --------',
+            'system-one           5',
+            'system-three        25',
+            'system-two          15'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_ungroupedsystems(self, shell):
         """
         Test do_report_ungroupedsystems.
@@ -169,22 +147,18 @@ class TestSCReport:
         :param shell:
         :return:
         """
-        shell.client.system.listUngroupedSystems = MagicMock(
-            return_value=[
-                {"name": "system-one"},
-                {"name": "system-two"},
-                {"name": "system-three"},
-            ]
-        )
+        shell.client.system.listUngroupedSystems = MagicMock(return_value=[
+            {"name": "system-one"},
+            {"name": "system-two"},
+            {"name": "system-three"},
+        ])
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_ungroupedsystems(shell, "")
 
         assert mprint.called
-        assert_expect(mprint.call_args_list, "system-one\nsystem-three\nsystem-two")
+        assert_expect(mprint.call_args_list, 'system-one\nsystem-three\nsystem-two')
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_errata_noargs(self, shell):
         """
         Test do_report_errata with no arguments (request all errata).
@@ -195,19 +169,16 @@ class TestSCReport:
         shell.client.errata.listAffectedSystems = MagicMock()
         shell.expand_errata = MagicMock()
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_errata(shell, "")
 
         assert not shell.client.errata.listAffectedSystems.called
         assert mprint.called
 
-        assert_expect(
-            mprint.call_args_list,
-            "All errata requested - this may take " "a few minutes, please be patient!",
-        )
+        assert_expect(mprint.call_args_list,
+                      'All errata requested - this may take '
+                      'a few minutes, please be patient!')
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_errata_not_found(self, shell):
         """
         Test do_report_errata with not found errata.
@@ -219,19 +190,14 @@ class TestSCReport:
         shell.expand_errata = MagicMock(return_value=[])
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.report.print", mprint) as prn, patch(
-            "spacecmd.report.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.report.print", mprint) as prn, \
+            patch("spacecmd.report.logging", logger) as lgr:
             spacecmd.report.do_report_errata(shell, "whatever")
 
         assert not logger.debug.called
         assert mprint.called
         assert_expect(mprint.call_args_list, "No errata found for 'whatever'")
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_errata(self, shell):
         """
         Test do_report_errata on data.
@@ -239,22 +205,18 @@ class TestSCReport:
         :param shell:
         :return:
         """
-        shell.client.errata.listAffectedSystems = MagicMock(
-            side_effect=[
-                ["system-a"],
-                ["system-a", "system-b"],
-                ["system-a", "system-b", "system-c"],
-            ]
-        )
-        shell.expand_errata = MagicMock(return_value=["vim", "apache", "java"])
+        shell.client.errata.listAffectedSystems = MagicMock(side_effect=[
+            ["system-a"],
+            ["system-a", "system-b"],
+            ["system-a", "system-b", "system-c"],
+        ])
+        shell.expand_errata = MagicMock(return_value=[
+            "vim", "apache", "java"
+        ])
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.report.print", mprint) as prn, patch(
-            "spacecmd.report.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.report.print", mprint) as prn, \
+            patch("spacecmd.report.logging", logger) as lgr:
             spacecmd.report.do_report_errata(shell, "ERRATA")
 
         assert logger.debug.called
@@ -262,18 +224,17 @@ class TestSCReport:
         assert mprint.called
 
         exp = [
-            "Errata  # Systems",
-            "------  ---------",
-            "apache          2",
-            "java            3",
-            "vim             1",
+            'Errata  # Systems',
+            '------  ---------',
+            'apache          2',
+            'java            3',
+            'vim             1'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_ipaddresses_noargs(self, shell):
         """
         Test do_report_ipaddresses without args, no systems found.
@@ -288,7 +249,6 @@ class TestSCReport:
         shell.client.system.getNetwork = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_ipaddresses(shell, "")
 
@@ -298,7 +258,6 @@ class TestSCReport:
         assert not shell.client.system.getNetwork.called
         assert shell.get_system_names.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_ipaddresses_noargs_systems(self, shell):
         """
         Test do_report_ipaddresses without args, some systems found.
@@ -308,30 +267,24 @@ class TestSCReport:
         """
         shell.ssm = MagicMock()
         shell.expand_systems = MagicMock()
-        shell.get_system_names = MagicMock(
-            return_value=[
-                "system-a",
-                "system-b",
-            ]
-        )
-        shell.get_system_id = MagicMock(
-            side_effect=[
-                1000010000,
-                1000010001,
-            ]
-        )
-        shell.client.system.getNetwork = MagicMock(
-            side_effect=[
-                {
-                    "hostname": "moebel.de",
-                    "ip": "2011:0ab8:45b1:0000:0000:9f3e:a370:7336",
-                },
-                {"hostname": "schrott.de", "ip": "123.234.10.4"},
-            ]
-        )
+        shell.get_system_names = MagicMock(return_value=[
+            "system-a", "system-b",
+        ])
+        shell.get_system_id = MagicMock(side_effect=[
+            1000010000, 1000010001,
+        ])
+        shell.client.system.getNetwork = MagicMock(side_effect=[
+            {
+                "hostname": "moebel.de",
+                "ip": "2011:0ab8:45b1:0000:0000:9f3e:a370:7336"
+            },
+            {
+                "hostname": "schrott.de",
+                "ip": "123.234.10.4"
+            },
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_ipaddresses(shell, "")
 
@@ -342,17 +295,16 @@ class TestSCReport:
         assert shell.get_system_names.called
 
         exp = [
-            "System    Hostname    IP",
-            "------    --------    --",
-            "system-a  moebel.de   2011:0ab8:45b1:0000:0000:9f3e:a370:7336",
-            "system-b  schrott.de  123.234.10.4",
+            'System    Hostname    IP',
+            '------    --------    --',
+            'system-a  moebel.de   2011:0ab8:45b1:0000:0000:9f3e:a370:7336',
+            'system-b  schrott.de  123.234.10.4',
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_ipaddresses_ssm_systems(self, shell):
         """
         Test do_report_ipaddresses systems from the ssm
@@ -363,24 +315,21 @@ class TestSCReport:
         shell.ssm = {"system-a": {}, "system-b": {}}
         shell.expand_systems = MagicMock(return_value=[])
         shell.get_system_names = MagicMock(return_value=[])
-        shell.get_system_id = MagicMock(
-            side_effect=[
-                1000010000,
-                1000010001,
-            ]
-        )
-        shell.client.system.getNetwork = MagicMock(
-            side_effect=[
-                {
-                    "hostname": "moebel.de",
-                    "ip": "2011:0ab8:45b1:0000:0000:9f3e:a370:7336",
-                },
-                {"hostname": "schrott.de", "ip": "123.234.10.4"},
-            ]
-        )
+        shell.get_system_id = MagicMock(side_effect=[
+            1000010000, 1000010001,
+        ])
+        shell.client.system.getNetwork = MagicMock(side_effect=[
+            {
+                "hostname": "moebel.de",
+                "ip": "2011:0ab8:45b1:0000:0000:9f3e:a370:7336"
+            },
+            {
+                "hostname": "schrott.de",
+                "ip": "123.234.10.4"
+            },
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_ipaddresses(shell, "ssm")
 
@@ -390,17 +339,16 @@ class TestSCReport:
         assert shell.client.system.getNetwork.called
 
         exp = [
-            "System    Hostname    IP",
-            "------    --------    --",
-            "system-a  moebel.de   2011:0ab8:45b1:0000:0000:9f3e:a370:7336",
-            "system-b  schrott.de  123.234.10.4",
+            'System    Hostname    IP',
+            '------    --------    --',
+            'system-a  moebel.de   2011:0ab8:45b1:0000:0000:9f3e:a370:7336',
+            'system-b  schrott.de  123.234.10.4',
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_ipaddresses_search_systems(self, shell):
         """
         Test do_report_ipaddresses systems searched
@@ -411,24 +359,21 @@ class TestSCReport:
         shell.ssm = {}
         shell.expand_systems = MagicMock(return_value=["system-a", "system-b"])
         shell.get_system_names = MagicMock(return_value=[])
-        shell.get_system_id = MagicMock(
-            side_effect=[
-                1000010000,
-                1000010001,
-            ]
-        )
-        shell.client.system.getNetwork = MagicMock(
-            side_effect=[
-                {
-                    "hostname": "moebel.de",
-                    "ip": "2011:0ab8:45b1:0000:0000:9f3e:a370:7336",
-                },
-                {"hostname": "schrott.de", "ip": "123.234.10.4"},
-            ]
-        )
+        shell.get_system_id = MagicMock(side_effect=[
+            1000010000, 1000010001,
+        ])
+        shell.client.system.getNetwork = MagicMock(side_effect=[
+            {
+                "hostname": "moebel.de",
+                "ip": "2011:0ab8:45b1:0000:0000:9f3e:a370:7336"
+            },
+            {
+                "hostname": "schrott.de",
+                "ip": "123.234.10.4"
+            },
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_ipaddresses(shell, "search:system-*")
 
@@ -438,17 +383,16 @@ class TestSCReport:
         assert shell.client.system.getNetwork.called
 
         exp = [
-            "System    Hostname    IP",
-            "------    --------    --",
-            "system-a  moebel.de   2011:0ab8:45b1:0000:0000:9f3e:a370:7336",
-            "system-b  schrott.de  123.234.10.4",
+            'System    Hostname    IP',
+            '------    --------    --',
+            'system-a  moebel.de   2011:0ab8:45b1:0000:0000:9f3e:a370:7336',
+            'system-b  schrott.de  123.234.10.4',
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_kernels_noargs(self, shell):
         """
         Test do_report_kernels with no arguments.
@@ -463,7 +407,6 @@ class TestSCReport:
         shell.client.system.getRunningKernel = MagicMock()
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_kernels(shell, "")
 
@@ -473,7 +416,6 @@ class TestSCReport:
         assert not shell.client.system.getRunningKernel.called
         assert shell.get_system_names.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_kernels_noargs_kernels(self, shell):
         """
         Test do_report_kernels with no arguments, kernels found.
@@ -483,24 +425,18 @@ class TestSCReport:
         """
         shell.ssm = MagicMock()
         shell.expand_systems = MagicMock()
-        shell.get_system_names = MagicMock(
-            return_value=[
-                "system-a",
-                "system-b",
-            ]
-        )
-        shell.get_system_id = MagicMock(
-            side_effect=[
-                1000010000,
-                1000010001,
-            ]
-        )
-        shell.client.system.getRunningKernel = MagicMock(
-            side_effect=["4.4.0-109-generic", "4.1.0-286-generic"]
-        )
+        shell.get_system_names = MagicMock(return_value=[
+            "system-a", "system-b",
+        ])
+        shell.get_system_id = MagicMock(side_effect=[
+            1000010000, 1000010001,
+        ])
+        shell.client.system.getRunningKernel = MagicMock(side_effect=[
+            "4.4.0-109-generic",
+            "4.1.0-286-generic"
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_kernels(shell, "")
 
@@ -512,17 +448,16 @@ class TestSCReport:
         assert mprint.called
 
         exp = [
-            "System    Kernel",
-            "------    ------",
-            "system-a  4.4.0-109-generic",
-            "system-b  4.1.0-286-generic",
+            'System    Kernel',
+            '------    ------',
+            'system-a  4.4.0-109-generic',
+            'system-b  4.1.0-286-generic'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_kernels_ssm_kernels(self, shell):
         """
         Test do_report_kernels from system in the SSM.
@@ -533,18 +468,15 @@ class TestSCReport:
         shell.ssm = {"system-a": {}, "system-b": {}}
         shell.expand_systems = MagicMock()
         shell.get_system_names = MagicMock(return_value=[])
-        shell.get_system_id = MagicMock(
-            side_effect=[
-                1000010000,
-                1000010001,
-            ]
-        )
-        shell.client.system.getRunningKernel = MagicMock(
-            side_effect=["4.4.0-109-generic", "4.1.0-286-generic"]
-        )
+        shell.get_system_id = MagicMock(side_effect=[
+            1000010000, 1000010001,
+        ])
+        shell.client.system.getRunningKernel = MagicMock(side_effect=[
+            "4.4.0-109-generic",
+            "4.1.0-286-generic"
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_kernels(shell, "ssm")
 
@@ -555,17 +487,16 @@ class TestSCReport:
         assert mprint.called
 
         exp = [
-            "System    Kernel",
-            "------    ------",
-            "system-a  4.4.0-109-generic",
-            "system-b  4.1.0-286-generic",
+            'System    Kernel',
+            '------    ------',
+            'system-a  4.4.0-109-generic',
+            'system-b  4.1.0-286-generic'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_kernels_search_kernels(self, shell):
         """
         Test do_report_kernels from system by search
@@ -576,18 +507,15 @@ class TestSCReport:
         shell.ssm = MagicMock()
         shell.expand_systems = MagicMock(return_value=["system-a", "system-b"])
         shell.get_system_names = MagicMock(return_value=[])
-        shell.get_system_id = MagicMock(
-            side_effect=[
-                1000010000,
-                1000010001,
-            ]
-        )
-        shell.client.system.getRunningKernel = MagicMock(
-            side_effect=["4.4.0-109-generic", "4.1.0-286-generic"]
-        )
+        shell.get_system_id = MagicMock(side_effect=[
+            1000010000, 1000010001,
+        ])
+        shell.client.system.getRunningKernel = MagicMock(side_effect=[
+            "4.4.0-109-generic",
+            "4.1.0-286-generic"
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_kernels(shell, "search:system-*")
 
@@ -599,17 +527,16 @@ class TestSCReport:
         assert mprint.called
 
         exp = [
-            "System    Kernel",
-            "------    ------",
-            "system-a  4.4.0-109-generic",
-            "system-b  4.1.0-286-generic",
+            'System    Kernel',
+            '------    ------',
+            'system-a  4.4.0-109-generic',
+            'system-b  4.1.0-286-generic'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_duplicates_noapiver_10_11(self, shell):
         """
         Test do_report_duplicates, api version is not "10.11".
@@ -618,26 +545,23 @@ class TestSCReport:
         :return:
         """
         shell.check_api_version = MagicMock(return_value=False)
-        shell.get_system_names = MagicMock(
-            return_value=["system-a", "system-b", "system-a", "system-a"]
-        )
-        shell.client.system.searchByName = MagicMock(
-            side_effect=[
-                [
-                    {
-                        "id": 1000010000,
-                        "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
-                    },
-                ],
-            ]
-        )
+        shell.get_system_names = MagicMock(return_value=[
+            "system-a", "system-b", "system-a", "system-a"
+        ])
+        shell.client.system.searchByName = MagicMock(side_effect=[
+            [
+                {
+                    "id": 1000010000,
+                    "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
+                },
+            ],
+        ])
         shell.client.system.listDuplicatesByIp = MagicMock()
         shell.client.system.listDuplicatesByMac = MagicMock()
         shell.client.system.listDuplicatesByHostname = MagicMock()
         shell.SEPARATOR = "---"
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_duplicates(shell, "")
 
@@ -646,17 +570,16 @@ class TestSCReport:
         assert mprint.called
 
         exp = [
-            "system-a:",
-            "System ID   Last Checkin",
-            "----------  -----------------",
-            "1000010000  Di 21. Mai 16:18:46 CEST 2019",
+            'system-a:',
+            'System ID   Last Checkin',
+            '----------  -----------------',
+            '1000010000  Di 21. Mai 16:18:46 CEST 2019'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
         assert not exp
 
-    # pylint: disable-next=redefined-outer-name
     def test_report_duplicates_api_10_11(self, shell):
         """
         Test do_report_duplicates api version is "10.11".
@@ -665,74 +588,65 @@ class TestSCReport:
         :return:
         """
         shell.check_api_version = MagicMock(return_value=True)
-        shell.get_system_names = MagicMock(
-            return_value=["system-a", "system-b", "system-a", "system-a"]
-        )
-        shell.client.system.searchByName = MagicMock(
-            side_effect=[
-                [
+        shell.get_system_names = MagicMock(return_value=[
+            "system-a", "system-b", "system-a", "system-a"
+        ])
+        shell.client.system.searchByName = MagicMock(side_effect=[
+            [
+                {
+                    "id": 1000010000,
+                    "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
+                },
+            ],
+        ])
+        shell.client.system.listDuplicatesByIp = MagicMock(return_value=[
+            {
+                "ip": "10.4.1.12",
+                "systems": [
                     {
-                        "id": 1000010000,
+                        "systemId": 1000010000,
                         "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
                     },
+                    {
+                        "systemId": 1000010001,
+                        "last_checkin": "Di 21. Mai 14:23:16 CEST 2019",
+                    },
                 ],
-            ]
-        )
-        shell.client.system.listDuplicatesByIp = MagicMock(
-            return_value=[
-                {
-                    "ip": "10.4.1.12",
-                    "systems": [
-                        {
-                            "systemId": 1000010000,
-                            "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
-                        },
-                        {
-                            "systemId": 1000010001,
-                            "last_checkin": "Di 21. Mai 14:23:16 CEST 2019",
-                        },
-                    ],
-                },
-            ]
-        )
-        shell.client.system.listDuplicatesByMac = MagicMock(
-            return_value=[
-                {
-                    "mac": "68:f7:28:d0:d0:5b",
-                    "systems": [
-                        {
-                            "systemId": 1000010000,
-                            "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
-                        },
-                        {
-                            "systemId": 1000010001,
-                            "last_checkin": "Di 21. Mai 14:23:16 CEST 2019",
-                        },
-                    ],
-                },
-            ]
-        )
-        shell.client.system.listDuplicatesByHostname = MagicMock(
-            return_value=[
-                {
-                    "hostname": "dead-beef.de",
-                    "systems": [
-                        {
-                            "systemId": 1000010000,
-                            "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
-                        },
-                        {
-                            "systemId": 1000010001,
-                            "last_checkin": "Di 21. Mai 14:23:16 CEST 2019",
-                        },
-                    ],
-                },
-            ]
-        )
+            },
+        ])
+        shell.client.system.listDuplicatesByMac = MagicMock(return_value=[
+            {
+                "mac": "68:f7:28:d0:d0:5b",
+                "systems": [
+                    {
+                        "systemId": 1000010000,
+                        "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
+                    },
+                    {
+                        "systemId": 1000010001,
+                        "last_checkin": "Di 21. Mai 14:23:16 CEST 2019",
+                    },
+                ],
+            },
+        ])
+        shell.client.system.listDuplicatesByHostname = MagicMock(return_value=[
+            {
+                "hostname": "dead-beef.de",
+                "systems": [
+                    {
+                        "systemId": 1000010000,
+                        "last_checkin": "Di 21. Mai 16:18:46 CEST 2019",
+                    },
+                    {
+                        "systemId": 1000010001,
+                        "last_checkin": "Di 21. Mai 14:23:16 CEST 2019",
+                    },
+                ],
+            },
+        ])
         shell.SEPARATOR = "---"
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.report.print", mprint) as prn:
             spacecmd.report.do_report_duplicates(shell, "")
 
@@ -741,28 +655,28 @@ class TestSCReport:
         assert mprint.called
 
         exp = [
-            "system-a:",
-            "System ID   Last Checkin",
-            "----------  -----------------",
-            "1000010000  Di 21. Mai 16:18:46 CEST 2019",
-            "---",
-            "10.4.1.12:",
-            "System ID   Last Checkin",
-            "----------  -----------------",
-            "1000010000  Di 21. Mai 16:18:46 CEST 2019",
-            "1000010001  Di 21. Mai 14:23:16 CEST 2019",
-            "---",
-            "68:F7:28:D0:D0:5B:",
-            "System ID   Last Checkin",
-            "----------  -----------------",
-            "1000010000  Di 21. Mai 16:18:46 CEST 2019",
-            "1000010001  Di 21. Mai 14:23:16 CEST 2019",
-            "---",
-            "dead-beef.de:",
-            "System ID   Last Checkin",
-            "----------  -----------------",
-            "1000010000  Di 21. Mai 16:18:46 CEST 2019",
-            "1000010001  Di 21. Mai 14:23:16 CEST 2019",
+            'system-a:',
+            'System ID   Last Checkin',
+            '----------  -----------------',
+            '1000010000  Di 21. Mai 16:18:46 CEST 2019',
+            '---',
+            '10.4.1.12:',
+            'System ID   Last Checkin',
+            '----------  -----------------',
+            '1000010000  Di 21. Mai 16:18:46 CEST 2019',
+            '1000010001  Di 21. Mai 14:23:16 CEST 2019',
+            '---',
+            '68:F7:28:D0:D0:5B:',
+            'System ID   Last Checkin',
+            '----------  -----------------',
+            '1000010000  Di 21. Mai 16:18:46 CEST 2019',
+            '1000010001  Di 21. Mai 14:23:16 CEST 2019',
+            '---',
+            'dead-beef.de:',
+            'System ID   Last Checkin',
+            '----------  -----------------',
+            '1000010000  Di 21. Mai 16:18:46 CEST 2019',
+            '1000010001  Di 21. Mai 14:23:16 CEST 2019'
         ]
         for call in mprint.call_args_list:
             assert_expect([call], next(iter(exp)))

--- a/spacecmd/tests/test_scap.py
+++ b/spacecmd/tests/test_scap.py
@@ -4,11 +4,7 @@ Test suite for Scap commands at spacecmd.
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect
-
-# pylint: disable-next=unused-import
 import pytest
 import spacecmd.scap
 
@@ -18,7 +14,6 @@ class TestScap:
     Test suite for scap.
     """
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_listxccdfscans_noarg(self, shell):
         """
         Test calling scap listxccdfscans without arguments.
@@ -43,7 +38,6 @@ class TestScap:
         assert not shell.client.system.scap.listXccdfScans.called
         assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_listxccdfscans_ssm_arg(self, shell):
         """
         Test calling scap listxccdfscans with ssm argument.
@@ -70,7 +64,6 @@ class TestScap:
         assert not shell.client.system.scap.listXccdfScans.called
         assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_listxccdfscans_system_arg(self, shell):
         """
         Test calling scap listxccdfscans with a system name argument.
@@ -84,38 +77,16 @@ class TestScap:
         shell.ssm.keys = MagicMock(return_value=[])
         shell.expand_systems = MagicMock(return_value=["chair-1", "table-2"])
         shell.get_system_id = MagicMock(side_effect=["001", "002"])
-        shell.client.system.scap.listXccdfScans = MagicMock(
-            side_effect=[
-                [
-                    {
-                        "xid": 1,
-                        "profile": "001",
-                        "path": "/etc/first",
-                        "completed": "true",
-                    },
-                    {
-                        "xid": 2,
-                        "profile": "001",
-                        "path": "/etc/second",
-                        "completed": "false",
-                    },
-                ],
-                [
-                    {
-                        "xid": 3,
-                        "profile": "002",
-                        "path": "/opt/etc/third",
-                        "completed": "false",
-                    },
-                    {
-                        "xid": 4,
-                        "profile": "002",
-                        "path": "/opt/etc/fourth",
-                        "completed": "true",
-                    },
-                ],
-            ]
-        )
+        shell.client.system.scap.listXccdfScans = MagicMock(side_effect=[
+            [
+                {"xid": 1, "profile": "001", "path": "/etc/first", "completed": "true"},
+                {"xid": 2, "profile": "001", "path": "/etc/second", "completed": "false"},
+            ],
+            [
+                {"xid": 3, "profile": "002", "path": "/opt/etc/third", "completed": "false"},
+                {"xid": 4, "profile": "002", "path": "/opt/etc/fourth", "completed": "true"},
+            ],
+        ])
 
         mprint = MagicMock()
         with patch("spacecmd.scap.print", mprint):
@@ -129,19 +100,17 @@ class TestScap:
         assert mprint.called
 
         expectations = [
-            "System: chair-1",
-            "",
-            "XID: 1 Profile: 001 Path: (/etc/first) Completed: true",
-            "XID: 2 Profile: 001 Path: (/etc/second) Completed: false",
+            'System: chair-1', '',
+            'XID: 1 Profile: 001 Path: (/etc/first) Completed: true',
+            'XID: 2 Profile: 001 Path: (/etc/second) Completed: false',
             shell.SEPARATOR,
-            "System: table-2",
-            "",
-            "XID: 3 Profile: 002 Path: (/opt/etc/third) Completed: false",
-            "XID: 4 Profile: 002 Path: (/opt/etc/fourth) Completed: true",
+            'System: table-2',
+            '',
+            'XID: 3 Profile: 002 Path: (/opt/etc/third) Completed: false',
+            'XID: 4 Profile: 002 Path: (/opt/etc/fourth) Completed: true',
         ]
         assert_expect(mprint.call_args_list, *expectations)
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_getxccdfscanruleresults_noargs(self, shell):
         """
         Test getxccdfscanruleresults without args
@@ -159,7 +128,6 @@ class TestScap:
         assert not shell.client.system.scap.getXccdfScanRuleResults.called
         assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_getxccdfscanruleresults_xids_no_rules(self, shell):
         """
         Test getxccdfscanruleresults with XIDs but no rules
@@ -179,18 +147,11 @@ class TestScap:
         assert mprint.called
 
         expectations = [
-            "XID: 1",
-            "",
-            "---",
-            "XID: 2",
-            "",
-            "---",
-            "XID: 3",
-            "",
+            'XID: 1', '', '---', 'XID: 2',
+            '', '---', 'XID: 3', '',
         ]
         assert_expect(mprint.call_args_list, *expectations)
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_getxccdfscanruleresults_xids_with_rules(self, shell):
         """
         Test getxccdfscanruleresults with XIDs with rules
@@ -200,46 +161,20 @@ class TestScap:
         """
         shell.help_scap_getxccdfscanruleresults = MagicMock()
         shell.SEPARATOR = "---"
-        shell.client.system.scap.getXccdfScanRuleResults = MagicMock(
-            side_effect=[
-                [
-                    {
-                        "idref": "001A",
-                        "result": "result placeholder - 1",
-                        "idents": "idents placeholder - 1",
-                    },
-                    {
-                        "idref": "001B",
-                        "result": "result placeholder - 2",
-                        "idents": "idents placeholder - 2",
-                    },
-                ],
-                [
-                    {
-                        "idref": "002A",
-                        "result": "result placeholder - 1",
-                        "idents": "idents placeholder - 1",
-                    },
-                    {
-                        "idref": "002B",
-                        "result": "result placeholder - 2",
-                        "idents": "idents placeholder - 2",
-                    },
-                ],
-                [
-                    {
-                        "idref": "003A",
-                        "result": "result placeholder - 1",
-                        "idents": "idents placeholder - 1",
-                    },
-                    {
-                        "idref": "003B",
-                        "result": "result placeholder - 2",
-                        "idents": "idents placeholder - 2",
-                    },
-                ],
+        shell.client.system.scap.getXccdfScanRuleResults = MagicMock(side_effect=[
+            [
+                {"idref": "001A", "result": "result placeholder - 1", "idents": "idents placeholder - 1"},
+                {"idref": "001B", "result": "result placeholder - 2", "idents": "idents placeholder - 2"},
+            ],
+            [
+                {"idref": "002A", "result": "result placeholder - 1", "idents": "idents placeholder - 1"},
+                {"idref": "002B", "result": "result placeholder - 2", "idents": "idents placeholder - 2"},
+            ],
+            [
+                {"idref": "003A", "result": "result placeholder - 1", "idents": "idents placeholder - 1"},
+                {"idref": "003B", "result": "result placeholder - 2", "idents": "idents placeholder - 2"},
             ]
-        )
+        ])
         mprint = MagicMock()
         with patch("spacecmd.scap.print", mprint):
             spacecmd.scap.do_scap_getxccdfscanruleresults(shell, "1 2 3")
@@ -249,24 +184,18 @@ class TestScap:
         assert mprint.called
 
         expectations = [
-            "XID: 1",
-            "",
-            "IDref: 001A Result: result placeholder - 1 Idents: (idents placeholder - 1)",
-            "IDref: 001B Result: result placeholder - 2 Idents: (idents placeholder - 2)",
-            "---",
-            "XID: 2",
-            "",
-            "IDref: 002A Result: result placeholder - 1 Idents: (idents placeholder - 1)",
-            "IDref: 002B Result: result placeholder - 2 Idents: (idents placeholder - 2)",
-            "---",
-            "XID: 3",
-            "",
-            "IDref: 003A Result: result placeholder - 1 Idents: (idents placeholder - 1)",
-            "IDref: 003B Result: result placeholder - 2 Idents: (idents placeholder - 2)",
+            'XID: 1', '',
+            'IDref: 001A Result: result placeholder - 1 Idents: (idents placeholder - 1)',
+            'IDref: 001B Result: result placeholder - 2 Idents: (idents placeholder - 2)',
+            '---', 'XID: 2', '',
+            'IDref: 002A Result: result placeholder - 1 Idents: (idents placeholder - 1)',
+            'IDref: 002B Result: result placeholder - 2 Idents: (idents placeholder - 2)',
+            '---', 'XID: 3', '',
+            'IDref: 003A Result: result placeholder - 1 Idents: (idents placeholder - 1)',
+            'IDref: 003B Result: result placeholder - 2 Idents: (idents placeholder - 2)',
         ]
         assert_expect(mprint.call_args_list, *expectations)
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_getxccdfscandetails_no_args(self, shell):
         """
         Test getxccdfscandetails with no args.
@@ -286,7 +215,6 @@ class TestScap:
         assert not shell.client.system.scap.getXccdfScanDetails.called
         assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_getxccdfscandetails_xids(self, shell):
         """
         Test getxccdfscandetails with XID args.
@@ -296,40 +224,20 @@ class TestScap:
         """
         shell.help_scap_getxccdfscandetails = MagicMock()
         shell.SEPARATOR = "---"
-        shell.client.system.scap.getXccdfScanDetails = MagicMock(
-            side_effect=[
-                {
-                    "xid": 1,
-                    "sid": "0001",
-                    "action_id": "a1",
-                    "path": "p1",
-                    "oscap_parameters": "op1",
-                    "test_result": "tr1",
-                    "benchmark": "b1",
-                    "benchmark_version": "bv1",
-                    "profile": "p1",
-                    "profile_title": "pt1",
-                    "start_time": "st1",
-                    "end_time": "et1",
-                    "errors": "e1",
-                },
-                {
-                    "xid": 2,
-                    "sid": "0002",
-                    "action_id": "a2",
-                    "path": "p2",
-                    "oscap_parameters": "op2",
-                    "test_result": "tr2",
-                    "benchmark": "b2",
-                    "benchmark_version": "bv2",
-                    "profile": "p2",
-                    "profile_title": "pt2",
-                    "start_time": "st2",
-                    "end_time": "et2",
-                    "errors": "e2",
-                },
-            ]
-        )
+        shell.client.system.scap.getXccdfScanDetails = MagicMock(side_effect=[
+            {
+                "xid": 1, "sid": "0001", "action_id": "a1", "path": "p1",
+                "oscap_parameters": "op1", "test_result": "tr1", "benchmark": "b1",
+                "benchmark_version": "bv1", "profile": "p1", "profile_title": "pt1",
+                "start_time": "st1", "end_time": "et1", "errors": "e1",
+            },
+            {
+                "xid": 2, "sid": "0002", "action_id": "a2", "path": "p2",
+                "oscap_parameters": "op2", "test_result": "tr2", "benchmark": "b2",
+                "benchmark_version": "bv2", "profile": "p2", "profile_title": "pt2",
+                "start_time": "st2", "end_time": "et2", "errors": "e2",
+            },
+        ])
         mprint = MagicMock()
 
         with patch("spacecmd.scap.print", mprint):
@@ -339,7 +247,10 @@ class TestScap:
         assert shell.client.system.scap.getXccdfScanDetails.called
         assert mprint.called
 
-        expectations = [(shell.session, 1), (shell.session, 2)]
+        expectations = [
+            (shell.session, 1),
+            (shell.session, 2)
+        ]
         for call in shell.client.system.scap.getXccdfScanDetails.call_args_list:
             arg, kw = call
             assert kw == {}
@@ -347,67 +258,19 @@ class TestScap:
             expectations.pop(0)
 
         expectations = [
-            ("XID: 1",),
-            ("",),
-            (
-                "XID:",
-                1,
-                "SID:",
-                "0001",
-                "Action_ID:",
-                "a1",
-                "Path:",
-                "p1",
-                "OSCAP_Parameters:",
-                "op1",
-                "Test_Result:",
-                "tr1",
-                "Benchmark:",
-                "b1",
-                "Benchmark_Version:",
-                "bv1",
-                "Profile:",
-                "p1",
-                "Profile_Title:",
-                "pt1",
-                "Start_Time:",
-                "st1",
-                "End_Time:",
-                "et1",
-                "Errors:",
-                "e1",
-            ),
-            ("---",),
-            ("XID: 2",),
-            ("",),
-            (
-                "XID:",
-                2,
-                "SID:",
-                "0002",
-                "Action_ID:",
-                "a2",
-                "Path:",
-                "p2",
-                "OSCAP_Parameters:",
-                "op2",
-                "Test_Result:",
-                "tr2",
-                "Benchmark:",
-                "b2",
-                "Benchmark_Version:",
-                "bv2",
-                "Profile:",
-                "p2",
-                "Profile_Title:",
-                "pt2",
-                "Start_Time:",
-                "st2",
-                "End_Time:",
-                "et2",
-                "Errors:",
-                "e2",
-            ),
+            ('XID: 1',), ('',),
+            ('XID:', 1, 'SID:', '0001', 'Action_ID:', 'a1', 'Path:',
+             'p1', 'OSCAP_Parameters:', 'op1', 'Test_Result:', 'tr1',
+             'Benchmark:', 'b1', 'Benchmark_Version:', 'bv1',
+             'Profile:', 'p1', 'Profile_Title:', 'pt1', 'Start_Time:',
+             'st1', 'End_Time:', 'et1', 'Errors:', 'e1'),
+            ('---',),
+            ('XID: 2',), ('',),
+            ('XID:', 2, 'SID:', '0002', 'Action_ID:', 'a2', 'Path:',
+             'p2', 'OSCAP_Parameters:', 'op2', 'Test_Result:', 'tr2',
+             'Benchmark:', 'b2', 'Benchmark_Version:', 'bv2',
+             'Profile:', 'p2', 'Profile_Title:', 'pt2', 'Start_Time:',
+             'st2', 'End_Time:', 'et2', 'Errors:', 'e2'),
         ]
 
         for call in mprint.call_args_list:
@@ -416,7 +279,6 @@ class TestScap:
             assert arg == next(iter(expectations))
             expectations.pop(0)
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_schedulexccdfscan_no_args(self, shell):
         """
         Test for do_scap_schedulexccdfscan with no args.
@@ -442,7 +304,6 @@ class TestScap:
             assert not shell.client.system.scap.scheduleXccdfScan.called
             assert not mprint.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_schedulexccdfscan_ssm_arg(self, shell):
         """
         Test for do_scap_schedulexccdfscan with SSM arg
@@ -456,9 +317,7 @@ class TestScap:
         shell.get_system_id = MagicMock()
         shell.client.system.scap.scheduleXccdfScan = MagicMock()
 
-        spacecmd.scap.do_scap_schedulexccdfscan(
-            shell, "ssm /opt/xccdf.xml xccdf-option"
-        )
+        spacecmd.scap.do_scap_schedulexccdfscan(shell, "ssm /opt/xccdf.xml xccdf-option")
 
         assert not shell.help_scap_schedulexccdfscan.called
         assert shell.ssm.keys.called
@@ -466,7 +325,6 @@ class TestScap:
         assert not shell.get_system_id.called
         assert not shell.client.system.scap.scheduleXccdfScan.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_schedulexccdfscan_systems_arg(self, shell):
         """
         Test for do_scap_schedulexccdfscan with systems arg
@@ -480,9 +338,7 @@ class TestScap:
         shell.get_system_id = MagicMock()
         shell.client.system.scap.scheduleXccdfScan = MagicMock()
 
-        spacecmd.scap.do_scap_schedulexccdfscan(
-            shell, "/opt/xccdf.xml xccdf-option some.example.com"
-        )
+        spacecmd.scap.do_scap_schedulexccdfscan(shell, "/opt/xccdf.xml xccdf-option some.example.com")
 
         assert not shell.help_scap_schedulexccdfscan.called
         assert not shell.ssm.keys.called
@@ -492,7 +348,6 @@ class TestScap:
 
         assert_expect(shell.expand_systems.call_args_list, ["some.example.com"])
 
-    # pylint: disable-next=redefined-outer-name
     def test_scap_schedulexccdfscan_systems_arg_with_data(self, shell):
         """
         Test for do_scap_schedulexccdfscan with systems arg with data
@@ -506,9 +361,7 @@ class TestScap:
         shell.get_system_id = MagicMock(return_value="1000010000")
         shell.client.system.scap.scheduleXccdfScan = MagicMock()
 
-        spacecmd.scap.do_scap_schedulexccdfscan(
-            shell, "/opt/xccdf.xml xccdf-option some.example.com"
-        )
+        spacecmd.scap.do_scap_schedulexccdfscan(shell, "/opt/xccdf.xml xccdf-option some.example.com")
 
         assert not shell.help_scap_schedulexccdfscan.called
         assert not shell.ssm.keys.called
@@ -517,11 +370,5 @@ class TestScap:
         assert shell.client.system.scap.scheduleXccdfScan.called
 
         for call in shell.client.system.scap.scheduleXccdfScan.call_args_list:
-            # pylint: disable-next=unused-variable
             args, kw = call
-            assert args == (
-                shell.session,
-                "1000010000",
-                "/opt/xccdf.xml",
-                "--xccdf-option",
-            )
+            assert args == (shell.session, '1000010000', '/opt/xccdf.xml', '--xccdf-option')

--- a/spacecmd/tests/test_schedule.py
+++ b/spacecmd/tests/test_schedule.py
@@ -4,8 +4,6 @@ Test suite for spacecmd.schedule module.
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.schedule
 from xmlrpc import client as xmlrpclib
@@ -16,9 +14,8 @@ class TestSCSchedule:
     Test suite for "schedule" module.
     """
 
-    @patch("spacecmd.utils.input", create=True, new=MagicMock(return_value="y"))
-    @patch("spacecmd.utils.raw_input", create=True, new=MagicMock(return_value="y"))
-    # pylint: disable-next=redefined-outer-name
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
     def test_schedule_deletearchived_without_archived(self, shell):
         """
         Test do_schedule_deletearchived with no archived actions.
@@ -30,7 +27,6 @@ class TestSCSchedule:
         shell.help_schedule_deletearchived = MagicMock()
         shell.client.schedule.listAllArchivedActions = MagicMock(return_value=[])
         shell.client.schedule.deleteActions = MagicMock()
-        # pylint: disable-next=unused-variable
         logger = MagicMock()
 
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
@@ -38,9 +34,8 @@ class TestSCSchedule:
         assert shell.client.schedule.listAllArchivedActions.called
         assert not shell.client.schedule.deleteActions.called
 
-    @patch("spacecmd.utils.input", create=True, new=MagicMock(return_value="y"))
-    @patch("spacecmd.utils.raw_input", create=True, new=MagicMock(return_value="y"))
-    # pylint: disable-next=redefined-outer-name
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
     def test_schedule_deletearchived_with_archived(self, shell):
         """
         Test do_schedule_deletearchived with archived actions.
@@ -48,15 +43,12 @@ class TestSCSchedule:
         :param shell:
         :return:
         """
-        archived_dummy_actions = [{"id": 1}, {"id": 2}, {"id": 3}]
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
 
         shell.help_schedule_deletearchived = MagicMock()
         shell.client.schedule.listAllArchivedActions = MagicMock()
-        shell.client.schedule.listAllArchivedActions.side_effect = [
-            archived_dummy_actions
-        ] + [[]]
+        shell.client.schedule.listAllArchivedActions.side_effect = [archived_dummy_actions] + [[]]
         shell.client.schedule.deleteActions = MagicMock()
-        # pylint: disable-next=unused-variable
         logger = MagicMock()
 
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
@@ -64,9 +56,8 @@ class TestSCSchedule:
         assert shell.client.schedule.deleteActions.call_count == 1
         assert shell.client.schedule.deleteActions.call_args[0][1] == [1, 2, 3]
 
-    @patch("spacecmd.utils.input", create=True, new=MagicMock(return_value="n"))
-    @patch("spacecmd.utils.raw_input", create=True, new=MagicMock(return_value="n"))
-    # pylint: disable-next=redefined-outer-name
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='n'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='n'))
     def test_schedule_deletearchived_with_archived_but_user_answer_is_no(self, shell):
         """
         Test do_schedule_deletearchived with archived actions and the user answers with
@@ -75,24 +66,20 @@ class TestSCSchedule:
         :param shell:
         :return:
         """
-        archived_dummy_actions = [{"id": 1}, {"id": 2}, {"id": 3}]
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
 
         shell.help_schedule_deletearchived = MagicMock()
         shell.client.schedule.listAllArchivedActions = MagicMock()
-        shell.client.schedule.listAllArchivedActions.side_effect = [
-            archived_dummy_actions
-        ] + [[]]
+        shell.client.schedule.listAllArchivedActions.side_effect = [archived_dummy_actions] + [[]]
         shell.client.schedule.deleteActions = MagicMock()
-        # pylint: disable-next=unused-variable
         logger = MagicMock()
 
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
 
         assert shell.client.schedule.deleteActions.call_count == 0
 
-    @patch("spacecmd.utils.input", create=True, new=MagicMock(return_value=""))
-    @patch("spacecmd.utils.raw_input", create=True, new=MagicMock(return_value=""))
-    # pylint: disable-next=redefined-outer-name
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value=''))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value=''))
     def test_schedule_deletearchived_with_archived_but_no_user_answer(self, shell):
         """
         Test do_schedule_deletearchived with archived actions, but the user gives no answer.
@@ -101,22 +88,18 @@ class TestSCSchedule:
         :param shell:
         :return:
         """
-        archived_dummy_actions = [{"id": 1}, {"id": 2}, {"id": 3}]
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
 
         shell.help_schedule_deletearchived = MagicMock()
         shell.client.schedule.listAllArchivedActions = MagicMock()
-        shell.client.schedule.listAllArchivedActions.side_effect = [
-            archived_dummy_actions
-        ] + [[]]
+        shell.client.schedule.listAllArchivedActions.side_effect = [archived_dummy_actions] + [[]]
         shell.client.schedule.deleteActions = MagicMock()
-        # pylint: disable-next=unused-variable
         logger = MagicMock()
 
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
 
         assert shell.client.schedule.deleteActions.call_count == 0
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_cancel_noargs(self, shell):
         """
         Test do_schedule_cancel without arguments.
@@ -132,12 +115,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_cancel(shell, "")
 
         assert not shell.client.schedule.listInProgressActions.called
@@ -147,7 +126,6 @@ class TestSCSchedule:
         assert not logger.warning.called
         assert shell.help_schedule_cancel.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_cancel_globbing(self, shell):
         """
         Test do_schedule_cancel with globbing.
@@ -163,12 +141,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_cancel(shell, "*")
 
         assert not shell.client.schedule.listInProgressActions.called
@@ -179,9 +153,9 @@ class TestSCSchedule:
         assert shell.user_confirm.called
         assert logger.info.called
 
-        assert_expect(logger.info.call_args_list, "All pending actions left untouched")
+        assert_expect(logger.info.call_args_list,
+                      "All pending actions left untouched")
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_cancel_invalid_action_id(self, shell):
         """
         Test do_schedule_cancel with invalid action ids.
@@ -197,12 +171,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_cancel(shell, "1 two 3, and 4")
 
         assert not shell.help_schedule_cancel.called
@@ -213,26 +183,15 @@ class TestSCSchedule:
         assert logger.warning.called
         assert logger.info.called
 
-        assert_list_args_expect(
-            logger.warning.call_args_list,
-            [
-                '"two" is not a valid ID',
-                '"3," is not a valid ID',
-                '"and" is not a valid ID',
-            ],
-        )
-        assert_args_expect(
-            logger.info.call_args_list,
-            [
-                (("Canceled action: %i", 1), {}),
-                (("Canceled action: %i", 4), {}),
-                (("Failed action: %s", "two"), {}),
-                (("Failed action: %s", "3,"), {}),
-                (("Failed action: %s", "and"), {}),
-            ],
-        )
+        assert_list_args_expect(logger.warning.call_args_list,
+                                ['"two" is not a valid ID', '"3," is not a valid ID', '"and" is not a valid ID'])
+        assert_args_expect(logger.info.call_args_list,
+                           [(('Canceled action: %i', 1), {}),
+                            (('Canceled action: %i', 4), {}),
+                            (('Failed action: %s', 'two'), {}),
+                            (('Failed action: %s', '3,'), {}),
+                            (('Failed action: %s', 'and'), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_reschedule_noargs(self, shell):
         """
         Test do_schedule_reschedule without arguments.
@@ -248,12 +207,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_reschedule(shell, "")
 
         assert not shell.client.schedule.listInProgressActions.called
@@ -263,7 +218,6 @@ class TestSCSchedule:
         assert not logger.warning.called
         assert shell.help_schedule_reschedule.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_reschedule_globbing(self, shell):
         """
         Test do_schedule_reschedule with globbing.
@@ -279,12 +233,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_reschedule(shell, "*")
 
         assert not shell.client.schedule.rescheduleActions.called
@@ -294,7 +244,6 @@ class TestSCSchedule:
         assert shell.client.schedule.listFailedActions.called
         assert shell.user_confirm.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_reschedule_failed_actions(self, shell):
         """
         Test do_schedule_reschedule with failed actions.
@@ -304,20 +253,16 @@ class TestSCSchedule:
         """
 
         shell.help_schedule_reschedule = MagicMock()
-        shell.client.schedule.listFailedActions = MagicMock(
-            return_value=[{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
-        )
+        shell.client.schedule.listFailedActions = MagicMock(return_value=[
+            {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}
+        ])
         shell.client.schedule.rescheduleActions = MagicMock()
         shell.user_confirm = MagicMock(return_value=False)
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_reschedule(shell, "one 2 3, 5 and 4")
 
         assert not shell.help_schedule_reschedule.called
@@ -328,17 +273,12 @@ class TestSCSchedule:
         assert shell.client.schedule.listFailedActions.called
 
         assert_expect(mprint.call_args_list, "Rescheduled 2 action(s)")
-        assert_list_args_expect(
-            logger.warning.call_args_list,
-            [
-                '"one" is not a valid ID',
-                '"3," is not a valid ID',
-                '"5" is not a failed action',
-                '"and" is not a valid ID',
-            ],
-        )
+        assert_list_args_expect(logger.warning.call_args_list,
+                                ['"one" is not a valid ID',
+                                 '"3," is not a valid ID',
+                                 '"5" is not a failed action',
+                                 '"and" is not a valid ID'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_reschedule_missing_actions(self, shell):
         """
         Test do_schedule_reschedule with missing actions.
@@ -348,20 +288,16 @@ class TestSCSchedule:
         """
 
         shell.help_schedule_reschedule = MagicMock()
-        shell.client.schedule.listFailedActions = MagicMock(
-            return_value=[{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
-        )
+        shell.client.schedule.listFailedActions = MagicMock(return_value=[
+            {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}
+        ])
         shell.client.schedule.rescheduleActions = MagicMock()
         shell.user_confirm = MagicMock(return_value=False)
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_reschedule(shell, "one 5 and 6")
 
         assert not shell.client.schedule.rescheduleActions.called
@@ -370,18 +306,13 @@ class TestSCSchedule:
         assert not shell.user_confirm.called
         assert logger.warning.called
         assert shell.client.schedule.listFailedActions.called
-        assert_list_args_expect(
-            logger.warning.call_args_list,
-            [
-                '"one" is not a valid ID',
-                '"5" is not a failed action',
-                '"and" is not a valid ID',
-                '"6" is not a failed action',
-                "No failed actions to reschedule",
-            ],
-        )
+        assert_list_args_expect(logger.warning.call_args_list,
+                                ['"one" is not a valid ID',
+                                 '"5" is not a failed action',
+                                 '"and" is not a valid ID',
+                                 '"6" is not a failed action',
+                                 'No failed actions to reschedule'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_details_noargs(self, shell):
         """
         Test do_schedule_details without arguments.
@@ -399,12 +330,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_details(shell, "")
 
         assert not shell.client.schedule.listCompletedSystems.called
@@ -416,7 +343,6 @@ class TestSCSchedule:
         assert not logger.warning.called
         assert shell.help_schedule_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_details_invalid_action_id(self, shell):
         """
         Test do_schedule_details with invalid action ID.
@@ -434,12 +360,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_details(shell, "something")
 
         assert not shell.client.schedule.listCompletedSystems.called
@@ -451,9 +373,9 @@ class TestSCSchedule:
         assert logger.warning.called
         assert not shell.help_schedule_details.called
 
-        assert_expect(logger.warning.call_args_list, 'The ID "something" is invalid')
+        assert_expect(logger.warning.call_args_list,
+                      'The ID "something" is invalid')
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_details_missing_action_id(self, shell):
         """
         Test do_schedule_details with the missing action ID.
@@ -464,21 +386,17 @@ class TestSCSchedule:
         shell.client.schedule.listCompletedSystems = MagicMock(return_value=[])
         shell.client.schedule.listFailedSystems = MagicMock(return_value=[])
         shell.client.schedule.listInProgressSystems = MagicMock(return_value=[])
-        shell.client.schedule.listAllActions = MagicMock(
-            return_value=[{"id": 1}, {"id": 2}, {"id": 3}]
-        )
+        shell.client.schedule.listAllActions = MagicMock(return_value=[
+            {"id": 1}, {"id": 2}, {"id": 3}
+        ])
 
         shell.help_schedule_details = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_details(shell, "42")
 
         assert not mprint.called
@@ -491,9 +409,9 @@ class TestSCSchedule:
         assert shell.client.schedule.listAllActions.called
         assert logger.error.called
 
-        assert_expect(logger.error.call_args_list, 'No action found with the ID "42"')
+        assert_expect(logger.error.call_args_list,
+                      'No action found with the ID "42"')
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_details_report(self, shell):
         """
         Test do_schedule_details report layout
@@ -501,58 +419,34 @@ class TestSCSchedule:
         :param shell:
         :return:
         """
-        shell.client.schedule.listCompletedSystems = MagicMock(
-            return_value=[
-                {"server_name": "one"},
-                {"server_name": "two"},
-                {"server_name": "three"},
-            ]
-        )
-        shell.client.schedule.listFailedSystems = MagicMock(
-            return_value=[
-                {"server_name": "failed-machine"},
-            ]
-        )
-        shell.client.schedule.listInProgressSystems = MagicMock(
-            return_value=[
-                {"server_name": "four"},
-                {"server_name": "five"},
-            ]
-        )
-        shell.client.schedule.listAllActions = MagicMock(
-            return_value=[
-                {
-                    "id": 1,
-                    "name": "Reboot Coffee Machine",
-                    "scheduler": "qa-guy",
-                    "earliest": "2019-01-01",
-                },
-                {
-                    "id": 2,
-                    "name": "Upgrade Coffee Machine",
-                    "scheduler": "qa-guy",
-                    "earliest": "2019-01-01",
-                },
-                {
-                    "id": 3,
-                    "name": "Reinstall Coffee Machine Firmware",
-                    "scheduler": "qa-guy",
-                    "earliest": "2019-01-01",
-                },
-            ]
-        )
+        shell.client.schedule.listCompletedSystems = MagicMock(return_value=[
+            {"server_name": "one"},
+            {"server_name": "two"},
+            {"server_name": "three"},
+        ])
+        shell.client.schedule.listFailedSystems = MagicMock(return_value=[
+            {"server_name": "failed-machine"},
+        ])
+        shell.client.schedule.listInProgressSystems = MagicMock(return_value=[
+            {"server_name": "four"},
+            {"server_name": "five"},
+        ])
+        shell.client.schedule.listAllActions = MagicMock(return_value=[
+            {"id": 1, "name": "Reboot Coffee Machine",
+             "scheduler": "qa-guy", "earliest": "2019-01-01"},
+            {"id": 2, "name": "Upgrade Coffee Machine",
+             "scheduler": "qa-guy", "earliest": "2019-01-01"},
+            {"id": 3, "name": "Reinstall Coffee Machine Firmware",
+             "scheduler": "qa-guy", "earliest": "2019-01-01"},
+        ])
 
         shell.help_schedule_details = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_details(shell, "3")
 
         assert not logger.warning.called
@@ -565,36 +459,15 @@ class TestSCSchedule:
         assert shell.client.schedule.listAllActions.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "ID:        3",
-                "Action:    Reinstall Coffee Machine Firmware",
-                "User:      qa-guy",
-                "Date:      2019-01-01",
-                "",
-                "Completed:   3",
-                "Failed:      1",
-                "Pending:     2",
-                "",
-                "Completed Systems",
-                "-----------------",
-                "one",
-                "two",
-                "three",
-                "",
-                "Failed Systems",
-                "--------------",
-                "failed-machine",
-                "",
-                "Pending Systems",
-                "---------------",
-                "four",
-                "five",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['ID:        3', 'Action:    Reinstall Coffee Machine Firmware',
+                                 'User:      qa-guy', 'Date:      2019-01-01', '',
+                                 'Completed:   3', 'Failed:      1', 'Pending:     2', '',
+                                 'Completed Systems',
+                                 '-----------------', 'one', 'two', 'three', '',
+                                 'Failed Systems', '--------------', 'failed-machine', '',
+                                 'Pending Systems', '---------------', 'four', 'five'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_getoutput_noargs(self, shell):
         """
         Test do_schedule_getoutput without arguments.
@@ -609,12 +482,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_getoutput(shell, "")
 
         assert not shell.client.system.getScriptResults.called
@@ -623,7 +492,6 @@ class TestSCSchedule:
         assert not logger.warning.called
         assert shell.help_schedule_getoutput.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_getoutput_invalid_action_id(self, shell):
         """
         Test do_schedule_getoutput with an invalid action ID.
@@ -638,12 +506,8 @@ class TestSCSchedule:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_getoutput(shell, "fortytwo")
 
         assert not shell.client.system.getScriptResults.called
@@ -654,11 +518,9 @@ class TestSCSchedule:
 
         assert logger.error.called
 
-        assert_expect(
-            logger.error.call_args_list, '"fortytwo" is not a valid action ID'
-        )
+        assert_expect(logger.error.call_args_list,
+                      '"fortytwo" is not a valid action ID')
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_getoutput_no_script_results(self, shell):
         """
         Test do_schedule_getoutput with no script results (failed or None)
@@ -668,46 +530,28 @@ class TestSCSchedule:
         """
         shell.client.schedule.listCompletedSystems = MagicMock(
             return_value=[
-                {
-                    "server_name": "web.foo.com",
-                    "timestamp": "2019-01-01",
-                    "message": "Message from the web.foo.com",
-                },
-                {
-                    "server_name": "web1.foo.com",
-                    "timestamp": "2019-01-01",
-                    "message": "Message from the web1.foo.com as well",
-                },
-                {
-                    "server_name": "web2.foo.com",
-                    "timestamp": "2019-01-01",
-                    "message": "And some more message from web2.foo.com here",
-                },
+                {"server_name": "web.foo.com", "timestamp": "2019-01-01",
+                 "message": "Message from the web.foo.com"},
+                {"server_name": "web1.foo.com", "timestamp": "2019-01-01",
+                 "message": "Message from the web1.foo.com as well"},
+                {"server_name": "web2.foo.com", "timestamp": "2019-01-01",
+                 "message": "And some more message from web2.foo.com here"}
             ]
         )
         shell.client.schedule.listFailedSystems = MagicMock(
             return_value=[
-                {
-                    "server_name": "faulty.foo.com",
-                    "timestamp": "2019-01-01",
-                    "message": "Nothing good is happening on faulty.foo.com",
-                },
-            ]
-        )
+                {"server_name": "faulty.foo.com", "timestamp": "2019-01-01",
+                 "message": "Nothing good is happening on faulty.foo.com"},
+            ])
         shell.client.system.getScriptResults = MagicMock(
-            side_effect=xmlrpclib.Fault(faultCode=42, faultString="Happy NPE!")
-        )
+            side_effect=xmlrpclib.Fault(faultCode=42, faultString="Happy NPE!"))
         shell.help_schedule_getoutput = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_getoutput(shell, "42")
 
         assert not logger.warning.called
@@ -718,52 +562,22 @@ class TestSCSchedule:
         assert mprint.called
         assert logger.debug.called
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (
-                    (
-                        "Exception occurrect while get script results: %s",
-                        "<Fault 42: 'Happy NPE!'>",
-                    ),
-                    {},
-                )
-            ],
-        )
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "System:    web.foo.com",
-                "Completed: 2019-01-01",
-                "",
-                "Output",
-                "------",
-                "Message from the web.foo.com",
-                "----------",
-                "System:    web1.foo.com",
-                "Completed: 2019-01-01",
-                "",
-                "Output",
-                "------",
-                "Message from the web1.foo.com as well",
-                "----------",
-                "System:    web2.foo.com",
-                "Completed: 2019-01-01",
-                "",
-                "Output",
-                "------",
-                "And some more message from web2.foo.com here",
-                "----------",
-                "System:    faulty.foo.com",
-                "Completed: 2019-01-01",
-                "",
-                "Output",
-                "------",
-                "Nothing good is happening on faulty.foo.com",
-            ],
-        )
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Exception occurrect while get script results: %s',
+                              "<Fault 42: 'Happy NPE!'>"), {})])
+        assert_list_args_expect(mprint.call_args_list,
+                                ['System:    web.foo.com',
+                                 'Completed: 2019-01-01', '', 'Output', '------',
+                                 'Message from the web.foo.com', '----------', 'System:    web1.foo.com',
+                                 'Completed: 2019-01-01', '', 'Output', '------',
+                                 'Message from the web1.foo.com as well', '----------',
+                                 'System:    web2.foo.com',
+                                 'Completed: 2019-01-01', '', 'Output', '------',
+                                 'And some more message from web2.foo.com here',
+                                 '----------', 'System:    faulty.foo.com',
+                                 'Completed: 2019-01-01', '', 'Output', '------',
+                                 'Nothing good is happening on faulty.foo.com'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_getoutput_no_any_results(self, shell):
         """
         Test do_schedule_getoutput with no any results available
@@ -774,19 +588,14 @@ class TestSCSchedule:
         shell.client.schedule.listCompletedSystems = MagicMock(return_value=[])
         shell.client.schedule.listFailedSystems = MagicMock(return_value=[])
         shell.client.system.getScriptResults = MagicMock(
-            side_effect=xmlrpclib.Fault(faultCode=42, faultString="Happy NPE!")
-        )
+            side_effect=xmlrpclib.Fault(faultCode=42, faultString="Happy NPE!"))
         shell.help_schedule_getoutput = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_getoutput(shell, "42")
 
         assert not logger.warning.called
@@ -798,21 +607,12 @@ class TestSCSchedule:
         assert logger.debug.called
         assert logger.error.called
 
-        assert_args_expect(
-            logger.debug.call_args_list,
-            [
-                (
-                    (
-                        "Exception occurrect while get script results: %s",
-                        "<Fault 42: 'Happy NPE!'>",
-                    ),
-                    {},
-                )
-            ],
-        )
-        assert_args_expect(logger.error.call_args_list, [(("No systems found",), {})])
+        assert_args_expect(logger.debug.call_args_list,
+                           [(('Exception occurrect while get script results: %s',
+                              "<Fault 42: 'Happy NPE!'>"), {})])
+        assert_args_expect(logger.error.call_args_list,
+                           [(("No systems found",), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_schedule_getoutput_scripts(self, shell):
         """
         Test do_schedule_getoutput with scripts
@@ -823,42 +623,21 @@ class TestSCSchedule:
         shell.get_system_name = MagicMock(side_effect=["web.foo.com", "db.foo.com"])
         shell.client.schedule.listCompletedSystems = MagicMock(return_value=[])
         shell.client.schedule.listFailedSystems = MagicMock(return_value=[])
-        shell.client.system.getScriptResults = MagicMock(
-            return_value=[
-                {
-                    "serverId": 1000010000,
-                    "startDate": "2019-01-01",
-                    "stopDate": "2019-01-02",
-                    "returnCode": 42,
-                    "output": "Normal output",
-                },
-                {
-                    "startDate": "2019-02-01",
-                    "stopDate": "2019-02-02",
-                    "returnCode": 1,
-                    "output_enc64": True,
-                    "output": b"Tm93IHlvdSBzZWUgbWUh\n",
-                },
-                {
-                    "serverId": 1000010001,
-                    "startDate": "2019-01-11",
-                    "stopDate": "2019-01-22",
-                    "returnCode": 13,
-                    "output": None,
-                },
-            ]
-        )
+        shell.client.system.getScriptResults = MagicMock(return_value=[
+            {"serverId": 1000010000, "startDate": "2019-01-01", "stopDate": "2019-01-02", "returnCode": 42,
+             "output": "Normal output"},
+            {"startDate": "2019-02-01", "stopDate": "2019-02-02", "returnCode": 1,
+             "output_enc64": True, "output": b"Tm93IHlvdSBzZWUgbWUh\n"},
+            {"serverId": 1000010001, "startDate": "2019-01-11", "stopDate": "2019-01-22", "returnCode": 13,
+             "output": None}
+        ])
         shell.help_schedule_getoutput = MagicMock()
 
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.schedule.print", mprint) as prt, patch(
-            "spacecmd.schedule.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.schedule.print", mprint) as prt, \
+                patch("spacecmd.schedule.logging", logger) as lgr:
             spacecmd.schedule.do_schedule_getoutput(shell, "42")
 
         assert not logger.warning.called
@@ -870,34 +649,12 @@ class TestSCSchedule:
         assert mprint.called
         assert shell.client.system.getScriptResults.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "System:      web.foo.com",
-                "Start Time:  2019-01-01",
-                "Stop Time:   2019-01-02",
-                "Return Code: 42",
-                "",
-                "Output",
-                "------",
-                "Normal output",
-                "----------",
-                "System:      UNKNOWN",
-                "Start Time:  2019-02-01",
-                "Stop Time:   2019-02-02",
-                "Return Code: 1",
-                "",
-                "Output",
-                "------",
-                "Now you see me!",
-                "----------",
-                "System:      db.foo.com",
-                "Start Time:  2019-01-11",
-                "Stop Time:   2019-01-22",
-                "Return Code: 13",
-                "",
-                "Output",
-                "------",
-                "N/A",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list, ['System:      web.foo.com', 'Start Time:  2019-01-01',
+                                                        'Stop Time:   2019-01-02', 'Return Code: 42', '', 'Output',
+                                                        '------', 'Normal output', '----------', 'System:      UNKNOWN',
+                                                        'Start Time:  2019-02-01', 'Stop Time:   2019-02-02',
+                                                        'Return Code: 1', '',
+                                                        'Output', '------', 'Now you see me!', '----------',
+                                                        'System:      db.foo.com',
+                                                        'Start Time:  2019-01-11', 'Stop Time:   2019-01-22',
+                                                        'Return Code: 13', '', 'Output', '------', 'N/A'])

--- a/spacecmd/tests/test_shell.py
+++ b/spacecmd/tests/test_shell.py
@@ -15,7 +15,6 @@ class TestSCShell:
     """
     Test shell in spacecmd.
     """
-
     @patch("spacecmd.shell.atexit", MagicMock())
     def test_shell_history(self):
         """
@@ -24,60 +23,47 @@ class TestSCShell:
         assert SpacewalkShell.HISTORY_LENGTH == 1024
 
     @patch("spacecmd.shell.atexit", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims",
+           MagicMock(return_value=readline.get_completer_delims()))
     @patch("spacecmd.shell.sys.exit", MagicMock())
     def test_shell_delimeters(self):
         """
         Test shell delimieters are set without hyphens
         or colons during the tab completion.
         """
-        # pylint: disable-next=consider-using-f-string
         cfg_dir = "/tmp/shell/{}/conf".format(int(time.time()))
         m_logger = MagicMock()
 
         cpl_setter = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.shell.logging", m_logger) as lgr, patch(
-            "spacecmd.shell.readline.set_completer_delims", cpl_setter
-        ):
+        with patch("spacecmd.shell.logging", m_logger) as lgr, \
+            patch("spacecmd.shell.readline.set_completer_delims", cpl_setter):
             options = MagicMock()
             options.nohistory = True
             shell = SpacewalkShell(options, cfg_dir, None)
 
-            # pylint: disable-next=consider-using-f-string
             assert shell.history_file == "{}/history".format(cfg_dir)
             assert not m_logger.error.called
             assert cpl_setter.call_args[0][0] != readline.get_completer_delims()
-            assert cpl_setter.call_args[0][0] == " \t\n`~!@#$%^&*()=+[{]}\\|;'\",<>?"
+            assert cpl_setter.call_args[0][0] == ' \t\n`~!@#$%^&*()=+[{]}\\|;\'",<>?'
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims",
+           MagicMock(return_value=readline.get_completer_delims()))
     @patch("spacecmd.shell.sys.exit", MagicMock())
-    @patch(
-        "spacecmd.shell.os.path.isfile", MagicMock(side_effect=IOError("No such file"))
-    )
+    @patch("spacecmd.shell.os.path.isfile", MagicMock(side_effect=IOError("No such file")))
     def test_shell_no_history_file(self):
         """
         Test shell no history file should capture IOError and log it.
         """
-        # pylint: disable-next=consider-using-f-string
         cfg_dir = "/tmp/shell/{}/conf".format(int(time.time()))
         m_logger = MagicMock()
-        # pylint: disable-next=unused-variable
         cpl_setter = MagicMock()
         with patch("spacecmd.shell.logging", m_logger):
             options = MagicMock()
             options.nohistory = False
             shell = SpacewalkShell(options, cfg_dir, None)
 
-            # pylint: disable-next=consider-using-f-string
             assert shell.history_file == "{}/history".format(cfg_dir)
             assert not os.path.exists(shell.history_file)
             assert m_logger.error.call_args[0][0] == "Could not read history file"
@@ -86,10 +72,7 @@ class TestSCShell:
     @patch("spacecmd.shell.print", MagicMock())
     @patch("spacecmd.shell.sys.exit", MagicMock(side_effect=Exception("Exit attempt")))
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_precmd_exit_keywords(self):
         """
         Test 'precmd' method of the shell on exit keywords.
@@ -105,10 +88,7 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_precmd_common_keywords(self):
         """
         Test 'precmd' method of the shell on common keywords, e.g. login, logout, clear etc.
@@ -122,10 +102,7 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_precmd_empty_line(self):
         """
         Test 'precmd' method of the shell on empty line.
@@ -138,10 +115,7 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_precmd_session_login(self):
         """
         Test 'precmd' method of the shell on session login.
@@ -158,10 +132,7 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_precmd_help_keyword(self):
         """
         Test 'precmd' method of the shell on --help/-h arguments.
@@ -177,10 +148,7 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_precmd_one_char_cmd(self):
         """
         Test 'precmd' method one char.
@@ -196,14 +164,8 @@ class TestSCShell:
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.print", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_history_item",
-        MagicMock(return_value="repeated item"),
-    )
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_history_item", MagicMock(return_value="repeated item"))
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_precmd_history(self):
         """
         Test 'precmd' method getting history item.
@@ -218,10 +180,7 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_postcmd(self):
         """
         Test 'postcmd' method of the shell.
@@ -237,10 +196,7 @@ class TestSCShell:
 
     @patch("spacecmd.shell.atexit", MagicMock())
     @patch("spacecmd.shell.readline.set_completer_delims", MagicMock())
-    @patch(
-        "spacecmd.shell.readline.get_completer_delims",
-        MagicMock(return_value=readline.get_completer_delims()),
-    )
+    @patch("spacecmd.shell.readline.get_completer_delims", MagicMock(return_value=readline.get_completer_delims()))
     def test_shell_default(self):
         """
         Test 'default' method of the shell.

--- a/spacecmd/tests/test_snippet.py
+++ b/spacecmd/tests/test_snippet.py
@@ -2,14 +2,9 @@
 """
 Test suite for snippet source
 """
-# pylint: disable-next=unused-import
 from mock import MagicMock, patch, mock_open
 from spacecmd import snippet
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect
-
-# pylint: disable-next=unused-import
 import pytest
 
 
@@ -17,8 +12,6 @@ class TestSCSnippets:
     """
     Test for snippet API.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_list_noarg(self, shell):
         """
         Test snippet list noargs
@@ -35,11 +28,8 @@ class TestSCSnippets:
             out = snippet.do_snippet_list(shell, "")
 
         assert out is None
-        assert mprint.call_args_list[0][0] == (
-            "snippet - 1\nsnippet - 2\nsnippet - 3",
-        )  # Sorted
+        assert mprint.call_args_list[0][0] == ('snippet - 1\nsnippet - 2\nsnippet - 3',)  # Sorted
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_list_args(self, shell):
         """
         Test snippet list with the args
@@ -57,9 +47,8 @@ class TestSCSnippets:
             out = snippet.do_snippet_list(shell, "", doreturn=True)
 
         assert out is not None
-        assert out == ["snippet - 1", "snippet - 2", "snippet - 3"]  # Sorted
+        assert out == ['snippet - 1', 'snippet - 2', 'snippet - 3']  # Sorted
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_details_noarg(self, shell):
         """
         Test snippet details no args
@@ -74,41 +63,20 @@ class TestSCSnippets:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.snippet.print", mprint) as mpr, patch(
-            "spacecmd.snippet.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.snippet.print", mprint) as mpr, patch("spacecmd.snippet.logging", logger) as lgr:
             snippet.do_snippet_details(shell, "")
         assert not mprint.called
         assert not logger.warning.called
         assert shell.help_snippet_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_details_args(self, shell):
         """
         Test snippet details with the args
         """
         snippets = [
-            {
-                "name": "snippet3",
-                "contents": "three",
-                "fragment": "3rd fragment",
-                "file": "/tmp/3",
-            },
-            {
-                "name": "snippet1",
-                "contents": "one",
-                "fragment": "1st fragment",
-                "file": "/tmp/1",
-            },
-            {
-                "name": "snippet2",
-                "contents": "two",
-                "fragment": "2nd fragment",
-                "file": "/tmp/2",
-            },
+            {"name": "snippet3", "contents": "three", "fragment": "3rd fragment", "file": "/tmp/3"},
+            {"name": "snippet1", "contents": "one", "fragment": "1st fragment", "file": "/tmp/1"},
+            {"name": "snippet2", "contents": "two", "fragment": "2nd fragment", "file": "/tmp/2"},
         ]
         shell.client.kickstart.snippet.listCustom = MagicMock(return_value=snippets)
         shell.SEPARATOR = "---"
@@ -116,12 +84,7 @@ class TestSCSnippets:
 
         mprint = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.snippet.print", mprint) as mpr, patch(
-            "spacecmd.snippet.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.snippet.print", mprint) as mpr, patch("spacecmd.snippet.logging", logger) as lgr:
             snippet.do_snippet_details(shell, "snippet4 snippet5 snippet3 snippet1")
         assert not shell.help_snippet_details.called
         assert logger.warning.called
@@ -134,44 +97,21 @@ class TestSCSnippets:
         assert_expect(logger.warning.call_args_list, *calls)
 
         stdout_data = [
-            "Name:   snippet3",
-            "Macro:  3rd fragment",
-            "File:   /tmp/3",
-            "",
-            "three",
-            "---",
-            "Name:   snippet1",
-            "Macro:  1st fragment",
-            "File:   /tmp/1",
-            "",
-            "one",
+            'Name:   snippet3', 'Macro:  3rd fragment',
+            'File:   /tmp/3', '', 'three', '---',
+            'Name:   snippet1', 'Macro:  1st fragment',
+            'File:   /tmp/1', '', 'one',
         ]
         assert_expect(mprint.call_args_list, *stdout_data)
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_create_no_args(self, shell):
         """
         Test create snippet with no arguments and no name update.
         """
         snippets = [
-            {
-                "name": "snippet3",
-                "contents": "three",
-                "fragment": "3rd fragment",
-                "file": "/tmp/3",
-            },
-            {
-                "name": "snippet1",
-                "contents": "one",
-                "fragment": "1st fragment",
-                "file": "/tmp/1",
-            },
-            {
-                "name": "snippet2",
-                "contents": "two",
-                "fragment": "2nd fragment",
-                "file": "/tmp/2",
-            },
+            {"name": "snippet3", "contents": "three", "fragment": "3rd fragment", "file": "/tmp/3"},
+            {"name": "snippet1", "contents": "one", "fragment": "1st fragment", "file": "/tmp/1"},
+            {"name": "snippet2", "contents": "two", "fragment": "2nd fragment", "file": "/tmp/2"},
         ]
 
         prompt_user = MagicMock(side_effect=["custom-snippet", "/tmp/cs.snip"])
@@ -184,20 +124,11 @@ class TestSCSnippets:
         shell.client.kickstart.snippet.createOrUpdate = MagicMock()
         shell.user_confirm = MagicMock(return_value=True)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.snippet.logging", logger) as lgr, patch(
-            "spacecmd.snippet.prompt_user",
-            prompt_user
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.snippet.editor", editor) as edtr, patch(
-            "spacecmd.snippet.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch(
-            "spacecmd.snippet.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
+        with patch("spacecmd.snippet.logging", logger) as lgr, \
+             patch("spacecmd.snippet.prompt_user", prompt_user) as prmt, \
+             patch("spacecmd.snippet.editor", editor) as edtr, \
+             patch("spacecmd.snippet.read_file", read_file) as rfl, \
+             patch("spacecmd.snippet.print", mprint) as prn:
             snippet.do_snippet_create(shell, "")
 
         assert not logger.error.called
@@ -206,39 +137,16 @@ class TestSCSnippets:
         assert shell.client.kickstart.snippet.createOrUpdate.called
 
         assert_expect(prompt_user.call_args_list, "Name:", "File:")
-        assert_expect(
-            mprint.call_args_list,
-            "",
-            "Snippet: custom-snippet",
-            "Contents",
-            "--------",
-            "file content",
-        )
+        assert_expect(mprint.call_args_list, "", "Snippet: custom-snippet", "Contents", "--------", "file content")
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_create_name_arg(self, shell):
         """
         Test create snippet with only name argument
         """
         snippets = [
-            {
-                "name": "snippet3",
-                "contents": "three",
-                "fragment": "3rd fragment",
-                "file": "/tmp/3",
-            },
-            {
-                "name": "snippet1",
-                "contents": "one",
-                "fragment": "1st fragment",
-                "file": "/tmp/1",
-            },
-            {
-                "name": "snippet2",
-                "contents": "two",
-                "fragment": "2nd fragment",
-                "file": "/tmp/2",
-            },
+            {"name": "snippet3", "contents": "three", "fragment": "3rd fragment", "file": "/tmp/3"},
+            {"name": "snippet1", "contents": "one", "fragment": "1st fragment", "file": "/tmp/1"},
+            {"name": "snippet2", "contents": "two", "fragment": "2nd fragment", "file": "/tmp/2"},
         ]
 
         prompt_user = MagicMock(side_effect=["custom-snippet", "/tmp/cs.snip"])
@@ -251,20 +159,11 @@ class TestSCSnippets:
         shell.client.kickstart.snippet.createOrUpdate = MagicMock()
         shell.user_confirm = MagicMock(return_value=True)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.snippet.logging", logger) as lgr, patch(
-            "spacecmd.snippet.prompt_user",
-            prompt_user
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.snippet.editor", editor) as edtr, patch(
-            "spacecmd.snippet.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch(
-            "spacecmd.snippet.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
+        with patch("spacecmd.snippet.logging", logger) as lgr, \
+             patch("spacecmd.snippet.prompt_user", prompt_user) as prmt, \
+             patch("spacecmd.snippet.editor", editor) as edtr, \
+             patch("spacecmd.snippet.read_file", read_file) as rfl, \
+             patch("spacecmd.snippet.print", mprint) as prn:
             snippet.do_snippet_create(shell, "--name something")
 
         assert not shell.client.kickstart.snippet.listCustom.called
@@ -275,30 +174,14 @@ class TestSCSnippets:
         assert logger.error.called
         assert logger.error.call_args_list[0][0][0] == "A file is required"
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_create_file_arg(self, shell):
         """
         Test create snippet with only file argument
         """
         snippets = [
-            {
-                "name": "snippet3",
-                "contents": "three",
-                "fragment": "3rd fragment",
-                "file": "/tmp/3",
-            },
-            {
-                "name": "snippet1",
-                "contents": "one",
-                "fragment": "1st fragment",
-                "file": "/tmp/1",
-            },
-            {
-                "name": "snippet2",
-                "contents": "two",
-                "fragment": "2nd fragment",
-                "file": "/tmp/2",
-            },
+            {"name": "snippet3", "contents": "three", "fragment": "3rd fragment", "file": "/tmp/3"},
+            {"name": "snippet1", "contents": "one", "fragment": "1st fragment", "file": "/tmp/1"},
+            {"name": "snippet2", "contents": "two", "fragment": "2nd fragment", "file": "/tmp/2"},
         ]
 
         prompt_user = MagicMock(side_effect=["custom-snippet", "/tmp/cs.snip"])
@@ -311,20 +194,11 @@ class TestSCSnippets:
         shell.client.kickstart.snippet.createOrUpdate = MagicMock()
         shell.user_confirm = MagicMock(return_value=True)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.snippet.logging", logger) as lgr, patch(
-            "spacecmd.snippet.prompt_user",
-            prompt_user
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.snippet.editor", editor) as edtr, patch(
-            "spacecmd.snippet.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch(
-            "spacecmd.snippet.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
+        with patch("spacecmd.snippet.logging", logger) as lgr, \
+             patch("spacecmd.snippet.prompt_user", prompt_user) as prmt, \
+             patch("spacecmd.snippet.editor", editor) as edtr, \
+             patch("spacecmd.snippet.read_file", read_file) as rfl, \
+             patch("spacecmd.snippet.print", mprint) as prn:
             snippet.do_snippet_create(shell, "--file /path/to/somewhere.snip")
 
         assert not shell.client.kickstart.snippet.listCustom.called
@@ -333,34 +207,16 @@ class TestSCSnippets:
         assert not mprint.called
         assert not prompt_user.called
         assert logger.error.called
-        assert (
-            logger.error.call_args_list[0][0][0] == "A name is required for the snippet"
-        )
+        assert logger.error.call_args_list[0][0][0] == "A name is required for the snippet"
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_create_args(self, shell):
         """
         Test create snippet with arguments.
         """
         snippets = [
-            {
-                "name": "snippet3",
-                "contents": "three",
-                "fragment": "3rd fragment",
-                "file": "/tmp/3",
-            },
-            {
-                "name": "snippet1",
-                "contents": "one",
-                "fragment": "1st fragment",
-                "file": "/tmp/1",
-            },
-            {
-                "name": "snippet2",
-                "contents": "two",
-                "fragment": "2nd fragment",
-                "file": "/tmp/2",
-            },
+            {"name": "snippet3", "contents": "three", "fragment": "3rd fragment", "file": "/tmp/3"},
+            {"name": "snippet1", "contents": "one", "fragment": "1st fragment", "file": "/tmp/1"},
+            {"name": "snippet2", "contents": "two", "fragment": "2nd fragment", "file": "/tmp/2"},
         ]
 
         prompt_user = MagicMock(side_effect=["custom-snippet", "/tmp/cs.snip"])
@@ -373,23 +229,12 @@ class TestSCSnippets:
         shell.client.kickstart.snippet.createOrUpdate = MagicMock()
         shell.user_confirm = MagicMock(return_value=True)
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.snippet.logging", logger) as lgr, patch(
-            "spacecmd.snippet.prompt_user",
-            prompt_user
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.snippet.editor", editor) as edtr, patch(
-            "spacecmd.snippet.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch(
-            "spacecmd.snippet.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
-            snippet.do_snippet_create(
-                shell, "--name foobar --file /path/to/somewhere.snip"
-            )
+        with patch("spacecmd.snippet.logging", logger) as lgr, \
+             patch("spacecmd.snippet.prompt_user", prompt_user) as prmt, \
+             patch("spacecmd.snippet.editor", editor) as edtr, \
+             patch("spacecmd.snippet.read_file", read_file) as rfl, \
+             patch("spacecmd.snippet.print", mprint) as prn:
+            snippet.do_snippet_create(shell, "--name foobar --file /path/to/somewhere.snip")
 
         assert not logger.error.called
         assert not shell.client.kickstart.snippet.listCustom.called
@@ -397,39 +242,16 @@ class TestSCSnippets:
         assert shell.client.kickstart.snippet.createOrUpdate.called
         assert shell.user_confirm.called
         assert mprint.called
-        assert_expect(
-            mprint.call_args_list,
-            "",
-            "Snippet: foobar",
-            "Contents",
-            "--------",
-            "file content",
-        )
+        assert_expect(mprint.call_args_list, "", "Snippet: foobar", "Contents", "--------", "file content")
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_create_editor(self, shell):
         """
         Test create snippet using the editor.
         """
         snippets = [
-            {
-                "name": "snippet3",
-                "contents": "three",
-                "fragment": "3rd fragment",
-                "file": "/tmp/3",
-            },
-            {
-                "name": "snippet1",
-                "contents": "one",
-                "fragment": "1st fragment",
-                "file": "/tmp/1",
-            },
-            {
-                "name": "snippet2",
-                "contents": "two",
-                "fragment": "2nd fragment",
-                "file": "/tmp/2",
-            },
+            {"name": "snippet3", "contents": "three", "fragment": "3rd fragment", "file": "/tmp/3"},
+            {"name": "snippet1", "contents": "one", "fragment": "1st fragment", "file": "/tmp/1"},
+            {"name": "snippet2", "contents": "two", "fragment": "2nd fragment", "file": "/tmp/2"},
         ]
 
         prompt_user = MagicMock(side_effect=["custom-snippet", "/tmp/cs.snip"])
@@ -442,20 +264,11 @@ class TestSCSnippets:
         shell.client.kickstart.snippet.createOrUpdate = MagicMock()
         shell.user_confirm = MagicMock(side_effect=[False, True])
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.snippet.logging", logger) as lgr, patch(
-            "spacecmd.snippet.prompt_user",
-            prompt_user
-            # pylint: disable-next=unused-variable
-        ) as prmt, patch("spacecmd.snippet.editor", editor) as edtr, patch(
-            "spacecmd.snippet.read_file",
-            read_file
-            # pylint: disable-next=unused-variable
-        ) as rfl, patch(
-            "spacecmd.snippet.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prn:
+        with patch("spacecmd.snippet.logging", logger) as lgr, \
+             patch("spacecmd.snippet.prompt_user", prompt_user) as prmt, \
+             patch("spacecmd.snippet.editor", editor) as edtr, \
+             patch("spacecmd.snippet.read_file", read_file) as rfl, \
+             patch("spacecmd.snippet.print", mprint) as prn:
             snippet.do_snippet_create(shell, "")
 
         assert not logger.error.called
@@ -465,16 +278,8 @@ class TestSCSnippets:
         assert shell.user_confirm.called
         assert mprint.called
         assert editor.called
-        assert_expect(
-            mprint.call_args_list,
-            "",
-            "Snippet: custom-snippet",
-            "Contents",
-            "--------",
-            "editor content",
-        )
+        assert_expect(mprint.call_args_list, "", "Snippet: custom-snippet", "Contents", "--------", "editor content")
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_update_no_args(self, shell):
         """
         Test update snippet with no args
@@ -486,7 +291,6 @@ class TestSCSnippets:
         assert shell.help_snippet_update.called
         assert out is 1
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_update_args(self, shell):
         """
         Test update snippet with args
@@ -501,11 +305,8 @@ class TestSCSnippets:
         assert shell.do_snippet_create.called
         assert not shell.do_snippet_create.call_args_list[0][0][0]
         assert "update_name" in shell.do_snippet_create.call_args_list[0][1]
-        assert (
-            shell.do_snippet_create.call_args_list[0][1]["update_name"] == "custom_name"
-        )
+        assert shell.do_snippet_create.call_args_list[0][1]["update_name"] == "custom_name"
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_delete_no_args(self, shell):
         """
         Test delete snippet with no args
@@ -520,7 +321,6 @@ class TestSCSnippets:
         assert shell.help_snippet_delete.called
         assert out is 1
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_delete_args(self, shell):
         """
         Test delete snippet with args (snippet name)
@@ -534,16 +334,9 @@ class TestSCSnippets:
         assert shell.client.kickstart.snippet.delete.called
         assert not shell.help_snippet_delete.called
         assert out is 0
-        assert (
-            shell.client.kickstart.snippet.delete.call_args_list[0][0][0]
-            == shell.session
-        )
-        assert (
-            shell.client.kickstart.snippet.delete.call_args_list[0][0][1]
-            == "some-snippet"
-        )
+        assert shell.client.kickstart.snippet.delete.call_args_list[0][0][0] == shell.session
+        assert shell.client.kickstart.snippet.delete.call_args_list[0][0][1] == "some-snippet"
 
-    # pylint: disable-next=redefined-outer-name
     def test_snippet_delete_args_no_confirm(self, shell):
         """
         Test delete snippet with args (snippet name), unconfirmed.

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -5,14 +5,11 @@ Test software channel module.
 
 from mock import Mock, MagicMock, patch
 import spacecmd.softwarechannel
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect
 import pytest
 import rpm
 
 
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_list_doreturn_nolabels(shell):
     """
     Test do_softwarechannel_list no labels, return data.
@@ -31,8 +28,6 @@ def test_softwarechannel_list_doreturn_nolabels(shell):
     assert not shell.list_child_channels.called
     assert not shell.list_base_channels.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_list_noreturn_nolabels(shell):
     """
     Test do_softwarechannel_list no labels, no return data.
@@ -43,17 +38,13 @@ def test_softwarechannel_list_noreturn_nolabels(shell):
     shell.client.channel.listAllChannels = MagicMock(return_value=[])
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        out = spacecmd.softwarechannel.do_softwarechannel_list(
-            shell, "", doreturn=False
-        )
+        out = spacecmd.softwarechannel.do_softwarechannel_list(shell, "", doreturn=False)
     assert out is None
     assert not shell.help_softwarechannel_list.called
     assert not shell.client.channel.software.getDetails.called
     assert not shell.list_child_channels.called
     assert not shell.list_base_channels.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_list_noreturn_labels_std(shell):
     """
     Test do_softwarechannel_list with label, no return data, standard output.
@@ -61,20 +52,15 @@ def test_softwarechannel_list_noreturn_labels_std(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.listAllChannels = MagicMock(
-        return_value=[
-            {"label": "label-one"},
-            {"label": "label-last"},
-            {"label": "label-two"},
-            {"label": "label-three"},
-        ]
-    )
+    shell.client.channel.listAllChannels = MagicMock(return_value=[
+        {"label": "label-one"}, {"label": "label-last"},
+        {"label": "label-two"}, {"label": "label-three"},
+    ])
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(
-            shell, "", doreturn=False
-        )
+            shell, "", doreturn=False)
 
     assert out is None
     assert not shell.help_softwarechannel_list.called
@@ -82,12 +68,9 @@ def test_softwarechannel_list_noreturn_labels_std(shell):
     assert not shell.list_child_channels.called
     assert shell.client.channel.listAllChannels.called
 
-    assert_list_args_expect(
-        mprint.call_args_list, ["label-last", "label-one", "label-three", "label-two"]
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ["label-last", "label-one", "label-three", "label-two"])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_list_noreturn_labels_verbose(shell):
     """
     Test do_softwarechannel_list with label, no return data, verbose output.
@@ -95,24 +78,21 @@ def test_softwarechannel_list_noreturn_labels_verbose(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.listAllChannels = MagicMock(
-        return_value=[
-            {"label": "test_channel"},
-        ]
-    )
-    shell.client.channel.software.getDetails = MagicMock(
-        side_effect=[
-            {"summary": "Summary of test_channel"},
-            {"summary": "Summary of child_channel"},
-        ]
-    )
-    shell.list_child_channels = MagicMock(return_value=["child_channel"])
+    shell.client.channel.listAllChannels = MagicMock(return_value=[
+        {"label": "test_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "Summary of test_channel"},
+        {"summary": "Summary of child_channel"},
+    ])
+    shell.list_child_channels = MagicMock(return_value=[
+        "child_channel"
+    ])
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(
-            shell, "-v", doreturn=False
-        )
+            shell, "-v", doreturn=False)
 
     assert out is None
     assert not shell.help_softwarechannel_list.called
@@ -120,10 +100,9 @@ def test_softwarechannel_list_noreturn_labels_verbose(shell):
     assert shell.client.channel.software.getDetails.called
     assert shell.client.channel.listAllChannels.called
 
-    assert_expect(mprint.call_args_list, "test_channel : Summary of test_channel")
+    assert_expect(mprint.call_args_list,
+                    'test_channel : Summary of test_channel')
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_list_noreturn_labels_verbose_tree(shell):
     """
     Test do_softwarechannel_list with label, no return data, verbose output with tree.
@@ -131,26 +110,25 @@ def test_softwarechannel_list_noreturn_labels_verbose_tree(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.listAllChannels = MagicMock(
-        return_value=[
-            {"any_channel": "any_channel"},
-        ]
-    )
-    shell.client.channel.software.getDetails = MagicMock(
-        side_effect=[
-            {"summary": "Summary of test_channel"},
-            {"summary": "Summary of child_channel"},
-        ]
-    )
-    shell.list_child_channels = MagicMock(return_value=["child_channel"])
+    shell.client.channel.listAllChannels = MagicMock(return_value=[
+        {"any_channel": "any_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "Summary of test_channel"},
+        {"summary": "Summary of child_channel"},
+    ])
+    shell.list_child_channels = MagicMock(return_value=[
+        "child_channel"
+    ])
 
-    shell.list_base_channels = MagicMock(return_value=["base_channel"])
+    shell.list_base_channels = MagicMock(return_value=[
+        "base_channel"
+    ])
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_list(
-            shell, "-v -t", doreturn=False
-        )
+            shell, "-v -t", doreturn=False)
 
     assert out is None
     assert not shell.client.channel.listAllChannels.called
@@ -158,16 +136,10 @@ def test_softwarechannel_list_noreturn_labels_verbose_tree(shell):
     assert shell.list_child_channels.called
     assert shell.client.channel.software.getDetails.called
 
-    assert_list_args_expect(
-        mprint.call_args_list,
-        [
-            "base_channel : Summary of test_channel",
-            " |-child_channel : Summary of child_channel",
-        ],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ['base_channel : Summary of test_channel',
+                                ' |-child_channel : Summary of child_channel'])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_listmanageablechannels_noarg(shell):
     """
     Test do_softwarechannel_listmanageablechannels without arguments.
@@ -175,29 +147,22 @@ def test_softwarechannel_listmanageablechannels_noarg(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.listManageableChannels = MagicMock(
-        return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "a_channel"},
-        ]
-    )
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "a_channel"},
+    ])
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
-            shell, ""
-        )
+        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "")
 
     assert out is None
     assert not shell.client.channel.software.getDetails.called
     assert shell.client.channel.listManageableChannels.called
-    assert_list_args_expect(
-        mprint.call_args_list, ["a_channel", "x_channel", "z_channel"]
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ["a_channel", "x_channel", "z_channel"])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_listmanageablechannels_default_verbose(shell):
     """
     Test do_softwarechannel_listmanageablechannels with verbose arg (all).
@@ -205,44 +170,33 @@ def test_softwarechannel_listmanageablechannels_default_verbose(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.listManageableChannels = MagicMock(
-        return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "b_channel"},
-            {"label": "a_channel"},
-        ]
-    )
-    shell.client.channel.software.getDetails = MagicMock(
-        side_effect=[
-            {"summary": "A summary"},
-            {"summary": "B summary"},
-            {"summary": "X summary"},
-            {"summary": "Z summary"},
-        ]
-    )
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "b_channel"},
+        {"label": "a_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "A summary"},
+        {"summary": "B summary"},
+        {"summary": "X summary"},
+        {"summary": "Z summary"},
+    ])
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
-            shell, "--verbose"
-        )
+            shell, "--verbose")
 
     assert out is None
     assert shell.client.channel.software.getDetails.called
     assert shell.client.channel.listManageableChannels.called
-    assert_list_args_expect(
-        mprint.call_args_list,
-        [
-            "a_channel : A summary",
-            "b_channel : B summary",
-            "x_channel : X summary",
-            "z_channel : Z summary",
-        ],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ["a_channel : A summary",
+                                "b_channel : B summary",
+                                "x_channel : X summary",
+                                "z_channel : Z summary"])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_listmanageablechannels_data_sparse(shell):
     """
     Test do_softwarechannel_listmanageablechannels data out, short.
@@ -250,27 +204,21 @@ def test_softwarechannel_listmanageablechannels_data_sparse(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.listManageableChannels = MagicMock(
-        return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "a_channel"},
-        ]
-    )
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "a_channel"},
+    ])
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
-            shell, "", doreturn=True
-        )
+        out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(shell, "", doreturn=True)
 
     assert out is not None
     assert not shell.client.channel.software.getDetails.called
     assert shell.client.channel.listManageableChannels.called
     assert out == ["a_channel", "x_channel", "z_channel"]
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_listmanageablechannels_data_verbose(shell):
     """
     Test do_softwarechannel_listmanageablechannels with verbose arg (all).
@@ -278,36 +226,29 @@ def test_softwarechannel_listmanageablechannels_data_verbose(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.listManageableChannels = MagicMock(
-        return_value=[
-            {"label": "x_channel"},
-            {"label": "z_channel"},
-            {"label": "b_channel"},
-            {"label": "a_channel"},
-        ]
-    )
-    shell.client.channel.software.getDetails = MagicMock(
-        side_effect=[
-            {"summary": "A summary"},
-            {"summary": "B summary"},
-            {"summary": "X summary"},
-            {"summary": "Z summary"},
-        ]
-    )
+    shell.client.channel.listManageableChannels = MagicMock(return_value=[
+        {"label": "x_channel"},
+        {"label": "z_channel"},
+        {"label": "b_channel"},
+        {"label": "a_channel"},
+    ])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "A summary"},
+        {"summary": "B summary"},
+        {"summary": "X summary"},
+        {"summary": "Z summary"},
+    ])
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listmanageablechannels(
-            shell, "--verbose", doreturn=True
-        )
+            shell, "--verbose", doreturn=True)
 
     assert out is not None
     assert not shell.client.channel.software.getDetails.called
     assert shell.client.channel.listManageableChannels.called
     assert out == ["a_channel", "b_channel", "x_channel", "z_channel"]
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listchildchannels(shell):
     """
     Test do_softwarechannel_listchildchannels noargs.
@@ -315,26 +256,16 @@ def test_listchildchannels(shell):
     :param shell:
     :return:
     """
-    shell.list_child_channels = MagicMock(
-        return_value=[
-            "x_child_channel",
-            "z_child_channel",
-            "b_child_channel",
-            "a_child_channel",
-        ]
-    )
+    shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
+                                                        "b_child_channel", "a_child_channel",])
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "")
 
     assert not shell.client.channel.software.getDetails.called
-    assert_list_args_expect(
-        mprint.call_args_list,
-        ["a_child_channel\nb_child_channel\nx_child_channel\nz_child_channel"],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ['a_child_channel\nb_child_channel\nx_child_channel\nz_child_channel'])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listchildchannels_verbose(shell):
     """
     Test do_softwarechannel_listchildchannels verbose.
@@ -342,41 +273,25 @@ def test_listchildchannels_verbose(shell):
     :param shell:
     :return:
     """
-    shell.list_child_channels = MagicMock(
-        return_value=[
-            "x_child_channel",
-            "z_child_channel",
-            "b_child_channel",
-            "a_child_channel",
-        ]
-    )
-    shell.client.channel.software.getDetails = MagicMock(
-        side_effect=[
-            {"summary": "A summary"},
-            {"summary": "B summary"},
-            {"summary": "X summary"},
-            {"summary": "Z summary"},
-        ]
-    )
+    shell.list_child_channels = MagicMock(return_value=["x_child_channel", "z_child_channel",
+                                                        "b_child_channel", "a_child_channel",])
+    shell.client.channel.software.getDetails = MagicMock(side_effect=[
+        {"summary": "A summary"},
+        {"summary": "B summary"},
+        {"summary": "X summary"},
+        {"summary": "Z summary"},
+    ])
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        spacecmd.softwarechannel.do_softwarechannel_listchildchannels(
-            shell, "--verbose"
-        )
+        spacecmd.softwarechannel.do_softwarechannel_listchildchannels(shell, "--verbose")
 
     assert shell.client.channel.software.getDetails.called
-    assert_list_args_expect(
-        mprint.call_args_list,
-        [
-            "a_child_channel : A summary",
-            "b_child_channel : B summary",
-            "x_child_channel : X summary",
-            "z_child_channel : Z summary",
-        ],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ['a_child_channel : A summary',
+                                'b_child_channel : B summary',
+                                'x_child_channel : X summary',
+                                'z_child_channel : Z summary'])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listsystems_noargs(shell):
     """
     Test do_softwarechannel_listsystems no args.
@@ -393,8 +308,6 @@ def test_listsystems_noargs(shell):
     assert not shell.client.channel.software.listSubscribedSystems.called
     assert shell.help_softwarechannel_listsystems.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listsystems_noargs_channel_no_data(shell):
     """
     Test do_softwarechannel_listsystems one channel, no data.
@@ -402,31 +315,23 @@ def test_listsystems_noargs_channel_no_data(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.software.listSubscribedSystems = MagicMock(
-        return_value=[
-            {"name": "one.acme.lan"},
-            {"name": "two.acme.lan"},
-            {"name": "zetta.acme.lan"},
-            {"name": "third.zoo.lan"},
-        ]
-    )
+    shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
+        {"name": "one.acme.lan"},
+        {"name": "two.acme.lan"},
+        {"name": "zetta.acme.lan"},
+        {"name": "third.zoo.lan"},
+    ])
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        out = spacecmd.softwarechannel.do_softwarechannel_listsystems(
-            shell, "my_channel"
-        )
+        out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel")
 
     assert not shell.help_softwarechannel_listsystems.called
     assert out is None
     assert mprint.called
     assert shell.client.channel.software.listSubscribedSystems.called
-    assert_list_args_expect(
-        mprint.call_args_list,
-        ["one.acme.lan\nthird.zoo.lan\ntwo.acme.lan\nzetta.acme.lan"],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ['one.acme.lan\nthird.zoo.lan\ntwo.acme.lan\nzetta.acme.lan'])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listsystems_noargs_channel_data_return(shell):
     """
     Test do_softwarechannel_listsystems one channel, data return.
@@ -434,27 +339,21 @@ def test_listsystems_noargs_channel_data_return(shell):
     :param shell:
     :return:
     """
-    shell.client.channel.software.listSubscribedSystems = MagicMock(
-        return_value=[
-            {"name": "one.acme.lan"},
-            {"name": "two.acme.lan"},
-            {"name": "zetta.acme.lan"},
-            {"name": "third.zoo.lan"},
-        ]
-    )
+    shell.client.channel.software.listSubscribedSystems = MagicMock(return_value=[
+        {"name": "one.acme.lan"},
+        {"name": "two.acme.lan"},
+        {"name": "zetta.acme.lan"},
+        {"name": "third.zoo.lan"},
+    ])
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        out = spacecmd.softwarechannel.do_softwarechannel_listsystems(
-            shell, "my_channel", doreturn=True
-        )
+        out = spacecmd.softwarechannel.do_softwarechannel_listsystems(shell, "my_channel", doreturn=True)
 
     assert not shell.help_softwarechannel_listsystems.called
     assert not mprint.called
     assert out is not None
-    assert out == ["one.acme.lan", "third.zoo.lan", "two.acme.lan", "zetta.acme.lan"]
+    assert out == ['one.acme.lan', 'third.zoo.lan', 'two.acme.lan', 'zetta.acme.lan']
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listpackages_noargs_nodata(shell):
     """
     Test do_softwarechannel_listpackages no args. No data return.
@@ -470,8 +369,6 @@ def test_listpackages_noargs_nodata(shell):
     assert not shell.client.channel.software.listLatestPackages.called
     assert shell.help_softwarechannel_listpackages.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listpackages_too_much_args_nodata(shell):
     """
     Test do_softwarechannel_listpackages with too much much arguments.
@@ -482,15 +379,12 @@ def test_listpackages_too_much_args_nodata(shell):
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
-            shell, "one_channel other_channel somemore_channels"
-        )
+            shell, "one_channel other_channel somemore_channels")
 
     assert out is None
     assert not shell.client.channel.software.listLatestPackages.called
     assert shell.help_softwarechannel_listpackages.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listpackages_one_channel_no_data(shell):
     """
     Test do_softwarechannel_listpackages with one channel. No data return.
@@ -500,45 +394,24 @@ def test_listpackages_one_channel_no_data(shell):
     """
     shell.client.channel.software.listLatestPackages = MagicMock(
         return_value=[
-            {
-                "name": "emacs",
-                "version": "42.0",
-                "release": "9",
-                "epoch": "",
-                "arch": "x86_64",
-            },
-            {
-                "name": "emacs-nox",
-                "version": "42.0",
-                "release": "10",
-                "epoch": "",
-                "arch_label": "x86_64",
-            },
-            {
-                "name": "tiff",
-                "version": "1.0",
-                "release": "11",
-                "epoch": "3",
-                "arch": "amd64",
-            },
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
         ]
     )
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
-            shell, "one_channel"
-        )
+        out = spacecmd.softwarechannel.do_softwarechannel_listpackages(shell, "one_channel")
 
     assert out is None
     assert not shell.help_softwarechannel_listpackages.called
     assert shell.client.channel.software.listLatestPackages.called
-    assert_list_args_expect(
-        mprint.call_args_list,
-        ["emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64"],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listpackages_one_channel_with_data(shell):
     """
     Test do_softwarechannel_listpackages with one channel. With data return.
@@ -548,46 +421,25 @@ def test_listpackages_one_channel_with_data(shell):
     """
     shell.client.channel.software.listLatestPackages = MagicMock(
         return_value=[
-            {
-                "name": "emacs",
-                "version": "42.0",
-                "release": "9",
-                "epoch": "",
-                "arch": "x86_64",
-            },
-            {
-                "name": "emacs-nox",
-                "version": "42.0",
-                "release": "10",
-                "epoch": "",
-                "arch_label": "x86_64",
-            },
-            {
-                "name": "tiff",
-                "version": "1.0",
-                "release": "11",
-                "epoch": "3",
-                "arch": "amd64",
-            },
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
         ]
     )
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listpackages(
-            shell, "one_channel", doreturn=True
-        )
+            shell, "one_channel", doreturn=True)
 
     assert out is not None
     assert not shell.help_softwarechannel_listpackages.called
     assert shell.client.channel.software.listLatestPackages.called
-    assert out == [
-        "emacs-42.0-9.x86_64",
-        "emacs-nox-42.0-10.x86_64",
-        "tiff-1.0-11:3.x86_64",
-    ]
+    assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
+                    'tiff-1.0-11:3.x86_64']
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listallpackages_noargs_nodata(shell):
     """
     Test do_softwarechannel_listallpackages no args. No data return.
@@ -603,8 +455,6 @@ def test_listallpackages_noargs_nodata(shell):
     assert not shell.client.channel.software.listAllPackages.called
     assert shell.help_softwarechannel_listallpackages.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listallpackages_too_much_args_nodata(shell):
     """
     Test do_softwarechannel_listallpackages with too much much arguments.
@@ -615,15 +465,12 @@ def test_listallpackages_too_much_args_nodata(shell):
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
-            shell, "one_channel other_channel somemore_channels"
-        )
+            shell, "one_channel other_channel somemore_channels")
 
     assert out is None
     assert not shell.client.channel.software.listAllPackages.called
     assert shell.help_softwarechannel_listallpackages.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listallpackages_one_channel_no_data(shell):
     """
     Test do_softwarechannel_listallpackages with one channel. No data return.
@@ -633,45 +480,24 @@ def test_listallpackages_one_channel_no_data(shell):
     """
     shell.client.channel.software.listAllPackages = MagicMock(
         return_value=[
-            {
-                "name": "emacs",
-                "version": "42.0",
-                "release": "9",
-                "epoch": "",
-                "arch": "x86_64",
-            },
-            {
-                "name": "emacs-nox",
-                "version": "42.0",
-                "release": "10",
-                "epoch": "",
-                "arch_label": "x86_64",
-            },
-            {
-                "name": "tiff",
-                "version": "1.0",
-                "release": "11",
-                "epoch": "3",
-                "arch": "amd64",
-            },
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
         ]
     )
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
-            shell, "one_channel"
-        )
+        out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(shell, "one_channel")
 
     assert out is None
     assert not shell.help_softwarechannel_listallpackages.called
     assert shell.client.channel.software.listAllPackages.called
-    assert_list_args_expect(
-        mprint.call_args_list,
-        ["emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64"],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listallpackages_one_channel_with_data(shell):
     """
     Test do_softwarechannel_listallpackages with one channel. With data return.
@@ -681,48 +507,26 @@ def test_listallpackages_one_channel_with_data(shell):
     """
     shell.client.channel.software.listAllPackages = MagicMock(
         return_value=[
-            {
-                "name": "emacs",
-                "version": "42.0",
-                "release": "9",
-                "epoch": "",
-                "arch": "x86_64",
-            },
-            {
-                "name": "emacs-nox",
-                "version": "42.0",
-                "release": "10",
-                "epoch": "",
-                "arch_label": "x86_64",
-            },
-            {
-                "name": "tiff",
-                "version": "1.0",
-                "release": "11",
-                "epoch": "3",
-                "arch": "amd64",
-            },
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
         ]
     )
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listallpackages(
-            shell, "one_channel", doreturn=True
-        )
+            shell, "one_channel", doreturn=True)
 
     assert out is not None
     assert not shell.help_softwarechannel_listallpackages.called
     assert shell.client.channel.software.listAllPackages.called
-    assert out == [
-        "emacs-42.0-9.x86_64",
-        "emacs-nox-42.0-10.x86_64",
-        "tiff-1.0-11:3.x86_64",
-    ]
+    assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64',
+                    'tiff-1.0-11:3.x86_64']
 
-
-@pytest.mark.skipif(
-    not hasattr(rpm, "labelCompare"), reason="Full RPM bindings required"
-)
+@pytest.mark.skipif(not hasattr(rpm, "labelCompare"), reason="Full RPM bindings required")
 def test_filter_latest_packages():
     """
     Test filter_latest_packages function.
@@ -730,41 +534,16 @@ def test_filter_latest_packages():
     :return:
     """
     data = [
-        {
-            "name": "emacs",
-            "version": "42.0",
-            "release": "9",
-            "epoch": "",
-            "arch": "x86_64",
-        },
-        {
-            "name": "emacs",
-            "version": "42.0",
-            "release": "10",
-            "epoch": "",
-            "arch_label": "x86_64",
-        },
-        {
-            "name": "emacs",
-            "version": "42.0",
-            "release": "8",
-            "epoch": "",
-            "arch": "x86_64",
-        },
-        {
-            "name": "emacs",
-            "version": "42.1",
-            "release": "7",
-            "epoch": "",
-            "arch": "x86_64",
-        },
-        {
-            "name": "emacs",
-            "version": "41.9",
-            "release": "11",
-            "epoch": "",
-            "arch_label": "x86_64",
-        },
+        {"name": "emacs", "version": "42.0",
+            "release": "9", "epoch": "", "arch": "x86_64"},
+        {"name": "emacs", "version": "42.0",
+            "release": "10", "epoch": "", "arch_label": "x86_64"},
+        {"name": "emacs", "version": "42.0",
+            "release": "8", "epoch": "", "arch": "x86_64"},
+        {"name": "emacs", "version": "42.1",
+            "release": "7", "epoch": "", "arch": "x86_64"},
+        {"name": "emacs", "version": "41.9",
+            "release": "11", "epoch": "", "arch_label": "x86_64"},
     ]
     out = list(spacecmd.softwarechannel.filter_latest_packages(data))
     assert len(out) == 1
@@ -776,8 +555,6 @@ def test_filter_latest_packages():
     assert res["arch"] == "x86_64"
     assert res["epoch"] == ""
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listlatestpackages_noargs_nodata(shell):
     """
     Test do_softwarechannel_listlatestpackages without args. No data return.
@@ -792,8 +569,6 @@ def test_listlatestpackages_noargs_nodata(shell):
     assert not shell.client.channel.software.listAllPackages.called
     assert shell.help_softwarechannel_listlatestpackages.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listlatestpackages_wrongargs_nodata(shell):
     """
     Test do_softwarechannel_listlatestpackages with wrong amount of args. No data return.
@@ -803,15 +578,12 @@ def test_listlatestpackages_wrongargs_nodata(shell):
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
-            shell, "one two three"
-        )
+            shell, "one two three")
 
     assert out is None
     assert not shell.client.channel.software.listAllPackages.called
     assert shell.help_softwarechannel_listlatestpackages.called
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listlatestpackages_channel_packages(shell):
     """
     Test do_softwarechannel_listlatestpackages with channel supplied.
@@ -820,46 +592,26 @@ def test_listlatestpackages_channel_packages(shell):
     """
     shell.client.channel.software.listAllPackages = MagicMock(
         return_value=[
-            {
-                "name": "emacs",
-                "version": "42.0",
-                "release": "9",
-                "epoch": "",
-                "arch": "x86_64",
-            },
-            {
-                "name": "emacs-nox",
-                "version": "42.0",
-                "release": "10",
-                "epoch": "",
-                "arch_label": "x86_64",
-            },
-            {
-                "name": "tiff",
-                "version": "1.0",
-                "release": "11",
-                "epoch": "3",
-                "arch": "amd64",
-            },
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
         ]
     )
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
-            shell, "some_channel"
-        )
+            shell, "some_channel")
 
     assert out is None
     assert not shell.help_softwarechannel_listlatestpackages.called
     assert shell.client.channel.software.listAllPackages.called
 
-    assert_list_args_expect(
-        mprint.call_args_list,
-        ["emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64"],
-    )
+    assert_list_args_expect(mprint.call_args_list,
+                            ['emacs-42.0-9.x86_64\nemacs-nox-42.0-10.x86_64\ntiff-1.0-11:3.x86_64'])
 
-
-# pylint: disable-next=redefined-outer-name
 def test_listlatestpackages_channel_packages_as_data(shell):
     """
     Test do_softwarechannel_listlatestpackages with channel supplied. Return as data.
@@ -868,47 +620,25 @@ def test_listlatestpackages_channel_packages_as_data(shell):
     """
     shell.client.channel.software.listAllPackages = MagicMock(
         return_value=[
-            {
-                "name": "emacs",
-                "version": "42.0",
-                "release": "9",
-                "epoch": "",
-                "arch": "x86_64",
-            },
-            {
-                "name": "emacs-nox",
-                "version": "42.0",
-                "release": "10",
-                "epoch": "",
-                "arch_label": "x86_64",
-            },
-            {
-                "name": "tiff",
-                "version": "1.0",
-                "release": "11",
-                "epoch": "3",
-                "arch": "amd64",
-            },
+            {"name": "emacs", "version": "42.0",
+                "release": "9", "epoch": "", "arch": "x86_64"},
+            {"name": "emacs-nox", "version": "42.0",
+                "release": "10", "epoch": "", "arch_label": "x86_64"},
+            {"name": "tiff", "version": "1.0",
+                "release": "11", "epoch": "3", "arch": "amd64"},
         ]
     )
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
         out = spacecmd.softwarechannel.do_softwarechannel_listlatestpackages(
-            shell, "some_channel", doreturn=True
-        )
+            shell, "some_channel", doreturn=True)
 
     assert out is not None
     assert not shell.help_softwarechannel_listlatestpackages.called
     assert shell.client.channel.software.listAllPackages.called
 
-    assert out == [
-        "emacs-42.0-9.x86_64",
-        "emacs-nox-42.0-10.x86_64",
-        "tiff-1.0-11:3.x86_64",
-    ]
+    assert out == ['emacs-42.0-9.x86_64', 'emacs-nox-42.0-10.x86_64', 'tiff-1.0-11:3.x86_64']
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_diff(shell):
     """
     Test that do_softwarechannel_diff function prints correct output
@@ -922,7 +652,6 @@ def test_softwarechannel_diff(shell):
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        # pylint: disable-next=assignment-from-none
         out = spacecmd.softwarechannel.do_softwarechannel_diff(
             shell, "source_channel target_channel"
         )
@@ -939,8 +668,6 @@ def test_softwarechannel_diff(shell):
         ],
     )
 
-
-# pylint: disable-next=redefined-outer-name
 def test_softwarechannel_errata_diff(shell):
     """
     Test that do_softwarechannel_errata_diff function prints correct output
@@ -957,7 +684,6 @@ def test_softwarechannel_errata_diff(shell):
 
     mprint = MagicMock()
     with patch("spacecmd.softwarechannel.print", mprint):
-        # pylint: disable-next=assignment-from-none
         out = spacecmd.softwarechannel.do_softwarechannel_errata_diff(
             shell, "source_channel target_channel"
         )
@@ -973,3 +699,4 @@ def test_softwarechannel_errata_diff(shell):
             "+SUSE-12-2021-3660 Recommended update for NetworkManager",
         ],
     )
+

--- a/spacecmd/tests/test_ssm.py
+++ b/spacecmd/tests/test_ssm.py
@@ -3,12 +3,9 @@
 Test suite for the SSM module commands.
 """
 
-# pylint: disable-next=unused-import
 from mock import MagicMock, patch, mock_open
 from spacecmd import ssm
 from helpers import shell, assert_expect
-
-# pylint: disable-next=unused-import
 import pytest
 
 
@@ -16,8 +13,6 @@ class TestSCSSM:
     """
     Test for SSM module API.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_add_noarg(self, shell):
         """
         Test do_ssm_add no args.
@@ -32,19 +27,14 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_add(shell, "")
 
         assert not logger.warning.called
         assert not logger.debug.called
         assert shell.help_ssm_add.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_add_system_not_found(self, shell):
         """
         Test do_ssm_add a system that does not exists.
@@ -59,12 +49,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_add(shell, "example.com")
 
         assert logger.warning.called
@@ -73,7 +59,6 @@ class TestSCSSM:
 
         assert_expect(logger.warning.call_args_list, "No systems found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_add_system_already_in_list(self, shell):
         """
         Test do_ssm_add a system that already in the list.
@@ -90,12 +75,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_add(shell, "example.com")
 
         assert logger.warning.called
@@ -103,9 +84,7 @@ class TestSCSSM:
         assert not shell.help_ssm_add.called
         assert save_cache.called
 
-        assert_expect(
-            logger.warning.call_args_list, "example.com is already in the list"
-        )
+        assert_expect(logger.warning.call_args_list, "example.com is already in the list")
         assert_expect(logger.debug.call_args_list, "Systems Selected: 1")
 
         for call in save_cache.call_args_list:
@@ -113,7 +92,6 @@ class TestSCSSM:
             assert not kw
             assert args == (shell.ssm_cache_file, shell.ssm)
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_add_system_new(self, shell):
         """
         Test do_ssm_add a new system.
@@ -130,12 +108,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_add(shell, "new.com")
 
         assert not logger.warning.called
@@ -153,7 +127,6 @@ class TestSCSSM:
             assert not kw
             assert args == (shell.ssm_cache_file, shell.ssm)
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_intersect_noarg(self, shell):
         """
         Test do_ssm_intersect without arguments.
@@ -168,12 +141,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_intersect(shell, "")
 
         assert shell.help_ssm_intersect.called
@@ -181,7 +150,6 @@ class TestSCSSM:
         assert not logger.debug.called
         assert not save_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_intersect_no_systems_found(self, shell):
         """
         Test do_ssm_intersect when no given systems found.
@@ -196,12 +164,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_intersect(shell, "unknown")
 
         assert not shell.help_ssm_intersect.called
@@ -211,7 +175,6 @@ class TestSCSSM:
 
         assert_expect(logger.warning.call_args_list, "No systems found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_intersect(self, shell):
         """
         Test do_ssm_intersect when no given systems found.
@@ -229,12 +192,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_intersect(shell, "existing.com")
 
         assert not shell.help_ssm_intersect.called
@@ -247,14 +206,13 @@ class TestSCSSM:
             assert_expect([call], next(iter(exp)))
             exp.pop(0)
 
-        assert shell.ssm == {"existing.com": {"name": "keptalive"}}
+        assert shell.ssm == {'existing.com': {'name': 'keptalive'}}
 
         for call in save_cache.call_args_list:
             args, kw = call
             assert not kw
             assert args == (shell.ssm_cache_file, shell.ssm)
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_remove_noarg(self, shell):
         """
         Test do_ssm_remove without arguments.
@@ -269,12 +227,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_remove(shell, "")
 
         assert shell.help_ssm_remove.called
@@ -282,7 +236,6 @@ class TestSCSSM:
         assert not logger.debug.called
         assert not save_cache.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_remove_no_systems_found(self, shell):
         """
         Test do_ssm_remove without arguments.
@@ -297,12 +250,8 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_remove(shell, "unknown")
 
         assert not shell.help_ssm_remove.called
@@ -312,7 +261,6 @@ class TestSCSSM:
 
         assert_expect(logger.warning.call_args_list, "No systems found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_ssm_remove(self, shell):
         """
         Test do_ssm_remove without arguments.
@@ -327,19 +275,15 @@ class TestSCSSM:
 
         logger = MagicMock()
         save_cache = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-            "spacecmd.ssm.save_cache",
-            save_cache
-            # pylint: disable-next=unused-variable
-        ) as svc:
+        with patch("spacecmd.ssm.logging", logger) as lgr, \
+            patch("spacecmd.ssm.save_cache", save_cache) as svc:
             ssm.do_ssm_remove(shell, "unknown")
 
         assert not shell.help_ssm_remove.called
         assert not logger.warning.called
         assert logger.debug.called
         assert save_cache.called
-        assert shell.ssm == {"keepalive.io": {}}
+        assert shell.ssm == {'keepalive.io': {}}
 
         exp = ["Removed remove.me", "Systems Selected: 1"]
         for call in logger.debug.call_args_list:
@@ -364,12 +308,9 @@ class TestSCSSM:
             logger = MagicMock()
             mprint = MagicMock()
             save_cache = MagicMock()
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-                "spacecmd.ssm.save_cache",
-                save_cache
-                # pylint: disable-next=unused-variable
-            ) as svc, patch("spacecmd.ssm.print", mprint) as prn:
+            with patch("spacecmd.ssm.logging", logger) as lgr, \
+                patch("spacecmd.ssm.save_cache", save_cache) as svc, \
+                patch("spacecmd.ssm.print", mprint) as prn:
                 ssm.do_ssm_list(shell, args=args)
 
             assert len(shell.ssm) == 2
@@ -390,12 +331,9 @@ class TestSCSSM:
             logger = MagicMock()
             mprint = MagicMock()
             save_cache = MagicMock()
-            # pylint: disable-next=unused-variable
-            with patch("spacecmd.ssm.logging", logger) as lgr, patch(
-                "spacecmd.ssm.save_cache",
-                save_cache
-                # pylint: disable-next=unused-variable
-            ) as svc, patch("spacecmd.ssm.print", mprint) as prn:
+            with patch("spacecmd.ssm.logging", logger) as lgr, \
+                patch("spacecmd.ssm.save_cache", save_cache) as svc, \
+                patch("spacecmd.ssm.print", mprint) as prn:
                 ssm.do_ssm_clear(shell, args=args)
 
             assert not shell.ssm

--- a/spacecmd/tests/test_system.py
+++ b/spacecmd/tests/test_system.py
@@ -4,8 +4,6 @@ Test suite for spacecmd.system module.
 """
 from datetime import datetime
 from unittest.mock import MagicMock, patch, mock_open
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.system
 
@@ -15,10 +13,9 @@ class TestSystem:
     Test suite for "system" module.
     """
 
-    # pylint: disable-next=redefined-outer-name
     def test_help_system_listevents_new_version_api_deprecation(self, shell):
         """
-        test help_system_listevents to ensure the deprecation warning is shown for recent API version
+            test help_system_listevents to ensure the deprecation warning is shown for recent API version
         """
         shell.check_api_version = MagicMock(return_value=True)
 
@@ -28,18 +25,13 @@ class TestSystem:
             spacecmd.system.help_system_listevents(shell)
 
         assert m_logger.warning.called
-        assert_list_args_expect(
-            m_logger.warning.call_args_list,
-            [
-                "This method is deprecated and will be removed in a future API version. "
-                "Please use system_listeventhistory instead.\n"
-            ],
-        )
+        assert_list_args_expect(m_logger.warning.call_args_list,
+                                ['This method is deprecated and will be removed in a future API version. '
+                                 'Please use system_listeventhistory instead.\n'])
 
-    # pylint: disable-next=redefined-outer-name
     def test_help_system_listevents_old_version_api_no_deprecation(self, shell):
         """
-        test help_system_listevents to ensure the deprecation warning is shown for recent API version
+            test help_system_listevents to ensure the deprecation warning is shown for recent API version
         """
         shell.check_api_version = MagicMock(return_value=False)
 
@@ -50,10 +42,9 @@ class TestSystem:
 
         assert not m_logger.warning.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listevents_new_version_api_deprecation(self, shell):
         """
-        test do_system_listevents to ensure the deprecation warning is shown for recent API version
+            test do_system_listevents to ensure the deprecation warning is shown for recent API version
         """
         shell.check_api_version = MagicMock(return_value=True)
         shell.client.system.getEventHistory = MagicMock()
@@ -67,21 +58,16 @@ class TestSystem:
             spacecmd.system.do_system_listevents(shell, "123456789")
 
         assert m_logger.warning.called
-        assert_list_args_expect(
-            m_logger.warning.call_args_list,
-            [
-                "This method is deprecated and will be removed in a future API version. "
-                "Please use system_listeventhistory instead.\n"
-            ],
-        )
+        assert_list_args_expect(m_logger.warning.call_args_list,
+                                ['This method is deprecated and will be removed in a future API version. '
+                                 'Please use system_listeventhistory instead.\n'])
 
         assert shell.client.system.getEventHistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_noargs(self, shell):
         """
         Test do_system_listeventhistory without arguments
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -91,11 +77,10 @@ class TestSystem:
         assert shell.help_system_listeventhistory.called
         assert not shell.client.system.getEventHistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_old_version(self, shell):
         """
         Test do_system_listeventhistory with an old API version
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -108,19 +93,16 @@ class TestSystem:
             spacecmd.system.do_system_listeventhistory(shell, "")
 
         assert m_logger.warning.called
-        assert_list_args_expect(
-            m_logger.warning.call_args_list,
-            ["This version of the API doesn't support this method"],
-        )
+        assert_list_args_expect(m_logger.warning.call_args_list,
+                                ["This version of the API doesn't support this method"])
 
         assert not shell.help_system_listeventhistory.called
         assert not shell.client.system.getEventHistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_only_server(self, shell):
         """
         Test do_system_listeventhistory with only the server parameter
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -132,18 +114,15 @@ class TestSystem:
         spacecmd.system.do_system_listeventhistory(shell, "123456789")
 
         assert shell.client.system.getEventHistory.called
-        assert_args_expect(
-            shell.client.system.getEventHistory.call_args_list,
-            [((shell.session, 1000010000, datetime(1970, 1, 1)), {})],
-        )
+        assert_args_expect(shell.client.system.getEventHistory.call_args_list,
+                           [((shell.session, 1000010000, datetime(1970, 1, 1)), {})])
 
         assert not shell.help_system_listeventhistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_server_and_start_time(self, shell):
         """
         Test do_system_listeventhistory with server and start time
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -155,18 +134,15 @@ class TestSystem:
         spacecmd.system.do_system_listeventhistory(shell, "123456789 -s 20211020")
 
         assert shell.client.system.getEventHistory.called
-        assert_args_expect(
-            shell.client.system.getEventHistory.call_args_list,
-            [((shell.session, 1000010000, datetime(2021, 10, 20)), {})],
-        )
+        assert_args_expect(shell.client.system.getEventHistory.call_args_list,
+                           [((shell.session, 1000010000, datetime(2021, 10, 20)), {})])
 
         assert not shell.help_system_listeventhistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_server_and_start_time_and_limit(self, shell):
         """
         Test do_system_listeventhistory with server, start time and limit
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -178,21 +154,15 @@ class TestSystem:
         spacecmd.system.do_system_listeventhistory(shell, "123456789 -s 20211020 -l 10")
 
         assert shell.client.system.getEventHistory.called
-        assert_args_expect(
-            shell.client.system.getEventHistory.call_args_list,
-            [((shell.session, 1000010000, datetime(2021, 10, 20), 0, 10), {})],
-        )
+        assert_args_expect(shell.client.system.getEventHistory.call_args_list,
+                           [((shell.session, 1000010000, datetime(2021, 10, 20), 0, 10), {})])
 
         assert not shell.help_system_listeventhistory.called
 
-    def test_do_system_listeventhistory_server_and_start_time_and_limit_and_offset(
-        self,
-        # pylint: disable-next=redefined-outer-name
-        shell,
-    ):
+    def test_do_system_listeventhistory_server_and_start_time_and_limit_and_offset(self, shell):
         """
         Test do_system_listeventhistory with server, start time, limit and offset
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -201,23 +171,18 @@ class TestSystem:
         shell.expand_systems = MagicMock(return_value=["system-a"])
         shell.get_system_id = MagicMock(side_effect=[1000010000])
 
-        spacecmd.system.do_system_listeventhistory(
-            shell, "123456789 -s 20211020 -l 10 -o 5"
-        )
+        spacecmd.system.do_system_listeventhistory(shell, "123456789 -s 20211020 -l 10 -o 5")
 
         assert shell.client.system.getEventHistory.called
-        assert_args_expect(
-            shell.client.system.getEventHistory.call_args_list,
-            [((shell.session, 1000010000, datetime(2021, 10, 20), 5, 10), {})],
-        )
+        assert_args_expect(shell.client.system.getEventHistory.call_args_list,
+                           [((shell.session, 1000010000, datetime(2021, 10, 20), 5, 10), {})])
 
         assert not shell.help_system_listeventhistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_invalid_start_time(self, shell):
         """
         Test do_system_listeventhistory with an invalid start time parameter
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -232,18 +197,16 @@ class TestSystem:
             spacecmd.system.do_system_listeventhistory(shell, "123456789 -s qwe123")
 
         assert m_logger.error.called
-        assert_list_args_expect(
-            m_logger.error.call_args_list, ["Invalid time provided"]
-        )
+        assert_list_args_expect(m_logger.error.call_args_list,
+                                ['Invalid time provided'])
 
         assert not shell.client.system.getEventHistory.called
         assert not shell.help_system_listeventhistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_invalid_limit(self, shell):
         """
         Test do_system_listeventhistory with an invalid limit parameter
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -258,16 +221,16 @@ class TestSystem:
             spacecmd.system.do_system_listeventhistory(shell, "123456789 -l wrong")
 
         assert m_logger.error.called
-        assert_list_args_expect(m_logger.error.call_args_list, ["Invalid limit"])
+        assert_list_args_expect(m_logger.error.call_args_list,
+                                ['Invalid limit'])
 
         assert not shell.client.system.getEventHistory.called
         assert not shell.help_system_listeventhistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_invalid_offset(self, shell):
         """
         Test do_system_listeventhistory with an invalid offset parameter
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -279,24 +242,19 @@ class TestSystem:
         m_logger = MagicMock()
 
         with patch("spacecmd.system.logging", m_logger):
-            spacecmd.system.do_system_listeventhistory(
-                shell, "123456789 -l 10 -o wrong"
-            )
+            spacecmd.system.do_system_listeventhistory(shell, "123456789 -l 10 -o wrong")
 
         assert m_logger.error.called
-        assert_list_args_expect(m_logger.error.call_args_list, ["Invalid offset"])
+        assert_list_args_expect(m_logger.error.call_args_list,
+                                ['Invalid offset'])
 
         assert not shell.client.system.getEventHistory.called
         assert not shell.help_system_listeventhistory.called
 
-    def test_do_system_listeventhistory_offset_ignore_when_limit_not_provided(
-        self,
-        # pylint: disable-next=redefined-outer-name
-        shell,
-    ):
+    def test_do_system_listeventhistory_offset_ignore_when_limit_not_provided(self, shell):
         """
         Test do_system_listeventhistory to make sure the offset is ignored if the limit is not specified as well
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
         shell.client.system.getEventHistory = MagicMock()
@@ -308,38 +266,24 @@ class TestSystem:
         spacecmd.system.do_system_listeventhistory(shell, "123456789 -o 10")
 
         assert shell.client.system.getEventHistory.called
-        assert_args_expect(
-            shell.client.system.getEventHistory.call_args_list,
-            [((shell.session, 1000010000, datetime(1970, 1, 1)), {})],
-        )
+        assert_args_expect(shell.client.system.getEventHistory.call_args_list,
+                           [((shell.session, 1000010000, datetime(1970, 1, 1)), {})])
 
         assert not shell.help_system_listeventhistory.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_listeventhistory_output(self, shell):
         """
         Test do_system_listeventhistory output format
-        """
+         """
 
         shell.help_system_listeventhistory = MagicMock()
-        shell.client.system.getEventHistory = MagicMock(
-            return_value=[
-                {
-                    "id": 3,
-                    "history_type": "Apply states",
-                    "status": "Completed",
-                    "summary": "Apply states [certs, channels] scheduled by (system)",
-                    "completed": "20211015T16:56:27",
-                },
-                {
-                    "id": 1,
-                    "history_type": "History Event",
-                    "status": "(n/a)",
-                    "summary": "added system entitlement",
-                    "completed": "20211015T16:56:14",
-                },
-            ]
-        )
+        shell.client.system.getEventHistory = MagicMock(return_value=[{
+            "id": 3, "history_type": "Apply states", "status": "Completed",
+            "summary": "Apply states [certs, channels] scheduled by (system)", "completed": "20211015T16:56:27",
+        }, {
+            "id": 1, "history_type": "History Event", "status": "(n/a)",
+            "summary": "added system entitlement", "completed": "20211015T16:56:14",
+        }])
         shell.session = MagicMock()
 
         shell.expand_systems = MagicMock(return_value=["system-a"])
@@ -354,18 +298,18 @@ class TestSystem:
         assert not shell.help_system_listeventhistory.called
 
         expected = [
-            "",
-            "Id:           3",
-            "History type: Apply states",
-            "Status:       Completed",
-            "Summary:      Apply states [certs, channels] scheduled by (system)",
-            "Completed:    20211015T16:56:27",
-            "",
-            "Id:           1",
-            "History type: History Event",
-            "Status:       (n/a)",
-            "Summary:      added system entitlement",
-            "Completed:    20211015T16:56:14",
+            '',
+            'Id:           3',
+            'History type: Apply states',
+            'Status:       Completed',
+            'Summary:      Apply states [certs, channels] scheduled by (system)',
+            'Completed:    20211015T16:56:27',
+            '',
+            'Id:           1',
+            'History type: History Event',
+            'Status:       (n/a)',
+            'Summary:      added system entitlement',
+            'Completed:    20211015T16:56:14'
         ]
 
         for call in m_print.call_args_list:
@@ -373,7 +317,6 @@ class TestSystem:
             expected.pop(0)
         assert not expected
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_event_details_noargs(self, shell):
         """
         Test do_system_event_details with no arguments.
@@ -387,7 +330,6 @@ class TestSystem:
         assert shell.help_system_eventdetails.called
         assert not shell.client.system.getEventDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_event_details_noevent(self, shell):
         """
         Test do_system_event_details with no event
@@ -402,16 +344,15 @@ class TestSystem:
             spacecmd.system.do_system_eventdetails(shell, "123456789")
 
         assert m_logger.warning.called
-        assert_list_args_expect(m_logger.warning.call_args_list, ["No event specified"])
+        assert_list_args_expect(m_logger.warning.call_args_list, ['No event specified'])
 
         assert not shell.help_system_eventdetails.called
         assert not shell.client.system.getEventDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_event_details_old_version(self, shell):
         """
         Test do_system_event_details when using an old version of the API
-        """
+         """
 
         shell.help_system_eventdetails = MagicMock()
         shell.client.system.getEventDetails = MagicMock()
@@ -423,15 +364,12 @@ class TestSystem:
             spacecmd.system.do_system_eventdetails(shell, "123456789")
 
         assert m_logger.warning.called
-        assert_list_args_expect(
-            m_logger.warning.call_args_list,
-            ["This version of the API doesn't support this method"],
-        )
+        assert_list_args_expect(m_logger.warning.call_args_list,
+                                ["This version of the API doesn't support this method"])
 
         assert not shell.help_system_eventdetails.called
         assert not shell.client.system.getEventDetails.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_event_details_history_output(self, shell):
         """
         Test do_system_event_details output format with an event of type history
@@ -440,22 +378,15 @@ class TestSystem:
         shell.help_system_eventdetails = MagicMock()
         shell.expand_systems = MagicMock(return_value=["system-a"])
         shell.get_system_id = MagicMock(side_effect=[1000010000])
-        shell.client.system.getEventDetails = MagicMock(
-            return_value={
-                "id": 1,
-                "history_type": "History Event",
-                "status": "(n/a)",
-                "summary": "added system entitlement",
-                "completed": "20211005T09:47:49",
-            }
-        )
+        shell.client.system.getEventDetails = MagicMock(return_value={
+            "id": 1, "history_type": "History Event", "status": "(n/a)",
+            "summary": "added system entitlement", "completed": "20211005T09:47:49"
+        })
 
         m_logger = MagicMock()
         m_print = MagicMock()
 
-        with patch("spacecmd.system.logging", m_logger), patch(
-            "spacecmd.system.print", m_print
-        ):
+        with patch("spacecmd.system.logging", m_logger), patch("spacecmd.system.print", m_print):
             spacecmd.system.do_system_eventdetails(shell, "123456 1")
 
         assert not shell.help_system_eventdetails.called
@@ -464,16 +395,16 @@ class TestSystem:
         assert shell.client.system.getEventDetails.called
 
         expected = [
-            "",
-            "Id:              1",
-            "",
-            "History type:    History Event",
-            "Status:          (n/a)",
-            "Summary:         added system entitlement",
-            "",
-            "Created:         None",
-            "Picked up:       None",
-            "Completed:       20211005T09:47:49",
+            '',
+            'Id:              1',
+            '',
+            'History type:    History Event',
+            'Status:          (n/a)',
+            'Summary:         added system entitlement',
+            '',
+            'Created:         None',
+            'Picked up:       None',
+            'Completed:       20211005T09:47:49'
         ]
 
         for call in m_print.call_args_list:
@@ -481,7 +412,6 @@ class TestSystem:
             expected.pop(0)
         assert not expected
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_event_details_action_output(self, shell):
         """
         Test do_system_event_details output format with an event of type action
@@ -490,22 +420,16 @@ class TestSystem:
         shell.help_system_eventdetails = MagicMock()
         shell.expand_systems = MagicMock(return_value=["system-a"])
         shell.get_system_id = MagicMock(side_effect=[1000010000])
-        shell.client.system.getEventDetails = MagicMock(
-            return_value={
-                "id": 1,
-                "history_type": "Apply states",
-                "status": "Completed",
-                "summary": "Apply states [certs] scheduled by (system)",
-                "created": "20211005T09:47:53",
-                "picked_up": "20211005T09:48:03",
-                "completed": "20211005T09:48:18",
-                "earliest_action": "20211005T09:47:53",
-                "result_msg": "Successfully applied state(s): [certs]",
-                "result_code": 0,
-                "additional_info": [
-                    {
-                        "result": 0,
-                        "detail": """----------
+        shell.client.system.getEventDetails = MagicMock(return_value={
+            "id": 1, "history_type": "Apply states", "status": "Completed",
+            "summary": "Apply states [certs] scheduled by (system)",
+            "created": "20211005T09:47:53", "picked_up": "20211005T09:48:03",
+            "completed": "20211005T09:48:18", "earliest_action": "20211005T09:47:53",
+            "result_msg": "Successfully applied state(s): [certs]",
+            "result_code": 0,
+            "additional_info": [{
+                "result": 0,
+                "detail": """----------
           ID: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
     Function: file.managed
         Name: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
@@ -515,18 +439,14 @@ class TestSystem:
     Duration: 33.988
          SLS: certs
      Changed: diff: New file
-              mode: '0644'""",
-                    }
-                ],
-            }
-        )
+              mode: '0644'"""
+            }]
+        })
 
         m_logger = MagicMock()
         m_print = MagicMock()
 
-        with patch("spacecmd.system.logging", m_logger), patch(
-            "spacecmd.system.print", m_print
-        ):
+        with patch("spacecmd.system.logging", m_logger), patch("spacecmd.system.print", m_print):
             spacecmd.system.do_system_eventdetails(shell, "123456 1")
 
         assert not shell.help_system_eventdetails.called
@@ -535,23 +455,23 @@ class TestSystem:
         assert shell.client.system.getEventDetails.called
 
         expected = [
-            "",
-            "Id:              1",
-            "",
-            "History type:    Apply states",
-            "Status:          Completed",
-            "Summary:         Apply states [certs] scheduled by (system)",
-            "",
-            "Created:         20211005T09:47:53",
-            "Picked up:       20211005T09:48:03",
-            "Completed:       20211005T09:48:18",
-            "",
-            "Earliest action: 20211005T09:47:53",
-            "Result message:  Successfully applied state(s): [certs]",
-            "Result code:     0",
-            "",
-            "Additional info:",
-            "    Result:          0",
+            '',
+            'Id:              1',
+            '',
+            'History type:    Apply states',
+            'Status:          Completed',
+            'Summary:         Apply states [certs] scheduled by (system)',
+            '',
+            'Created:         20211005T09:47:53',
+            'Picked up:       20211005T09:48:03',
+            'Completed:       20211005T09:48:18',
+            '',
+            'Earliest action: 20211005T09:47:53',
+            'Result message:  Successfully applied state(s): [certs]',
+            'Result code:     0',
+            '',
+            'Additional info:',
+            '    Result:          0',
             """    Detail:          ----------
           ID: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
     Function: file.managed
@@ -563,6 +483,7 @@ class TestSystem:
          SLS: certs
      Changed: diff: New file
               mode: '0644'""",
+
         ]
 
         for call in m_print.call_args_list:
@@ -570,7 +491,6 @@ class TestSystem:
             expected.pop(0)
         assert not expected
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_bootstrap(self, shell):
         """
         Test do_system_bootstrap
@@ -580,31 +500,13 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        spacecmd.system.do_system_bootstrap(
-            shell, "-H uyuni.example.com -u admin -P secret"
-        )
+        spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -P secret")
 
         assert shell.client.system.bootstrap.called
         assert not shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrap.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "secret",
-                        "",
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrap.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'secret', '', False), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_bootstrap_with_activation_key(self, shell):
         """
         Test do_system_bootstrap
@@ -614,31 +516,13 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        spacecmd.system.do_system_bootstrap(
-            shell, "-H uyuni.example.com -u admin -P secret -a 1-akey"
-        )
+        spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -P secret -a 1-akey")
 
         assert shell.client.system.bootstrap.called
         assert not shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrap.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "secret",
-                        "1-akey",
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrap.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'secret', '1-akey', False), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_bootstrap_with_reactivation(self, shell):
         """
         Test do_system_bootstrap
@@ -648,32 +532,13 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        spacecmd.system.do_system_bootstrap(
-            shell, "-H uyuni.example.com -u admin -P secret -r 1-re-key"
-        )
+        spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -P secret -r 1-re-key")
 
         assert shell.client.system.bootstrap.called
         assert not shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrap.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "secret",
-                        "",
-                        "1-re-key",
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrap.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'secret', '', '1-re-key', False), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_bootstrap_saltssh(self, shell):
         """
         Test do_system_bootstrap
@@ -683,31 +548,14 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        spacecmd.system.do_system_bootstrap(
-            shell, "-H uyuni.example.com -u admin -P secret -a 1-sshkey --saltssh"
-        )
+        spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -P secret -a 1-sshkey --saltssh")
 
         assert shell.client.system.bootstrap.called
         assert not shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrap.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "secret",
-                        "1-sshkey",
-                        True,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrap.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'secret', '1-sshkey', True), {})])
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_do_system_bootstrap_proxy(self, shell):
         """
         Test do_system_bootstrap
@@ -717,32 +565,14 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        spacecmd.system.do_system_bootstrap(
-            shell, "-H uyuni.example.com -u admin -P secret --proxyid 1000010042"
-        )
+        spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -P secret --proxyid 1000010042")
 
         assert shell.client.system.bootstrap.called
         assert not shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrap.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "secret",
-                        "",
-                        1000010042,
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrap.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'secret', '', 1000010042, False), {})])
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_do_system_bootstrap_all(self, shell):
         """
         Test do_system_bootstrap
@@ -752,34 +582,14 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        spacecmd.system.do_system_bootstrap(
-            shell,
-            "-H uyuni.example.com -u admin -P secret -a 1-sshkey -r 1-re-key --proxyid 1000010042 --saltssh",
-        )
+        spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -P secret -a 1-sshkey -r 1-re-key --proxyid 1000010042 --saltssh")
 
         assert shell.client.system.bootstrap.called
         assert not shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrap.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "secret",
-                        "1-sshkey",
-                        "1-re-key",
-                        1000010042,
-                        True,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrap.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'secret', '1-sshkey', '1-re-key', 1000010042, True), {})])
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_do_system_bootstrap_sshprivkey(self, shell):
         """
         Test do_system_bootstrap
@@ -789,38 +599,15 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        with patch(
-            "spacecmd.system.open",
-            new_callable=mock_open,
-            read_data="private_ssh_key"
-            # pylint: disable-next=unused-variable
-        ) as opn:
-            spacecmd.system.do_system_bootstrap(
-                shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key"
-            )
+        with patch("spacecmd.system.open", new_callable=mock_open, read_data="private_ssh_key") as opn:
+            spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key")
 
         assert not shell.client.system.bootstrap.called
         assert shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "private_ssh_key",
-                        "",
-                        "",
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'private_ssh_key', '', '', False), {})])
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_do_system_bootstrap_sshprivkey_password(self, shell):
         """
         Test do_system_bootstrap
@@ -830,39 +617,14 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        with patch(
-            "spacecmd.system.open",
-            new_callable=mock_open,
-            read_data="private_ssh_key"
-            # pylint: disable-next=unused-variable
-        ) as opn:
-            spacecmd.system.do_system_bootstrap(
-                shell,
-                "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -S key_secret",
-            )
+        with patch("spacecmd.system.open", new_callable=mock_open, read_data="private_ssh_key") as opn:
+            spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -S key_secret")
 
         assert not shell.client.system.bootstrap.called
         assert shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "private_ssh_key",
-                        "key_secret",
-                        "",
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'private_ssh_key', 'key_secret', '', False), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_bootstrap_sshprivkey_activationkey(self, shell):
         """
         Test do_system_bootstrap
@@ -872,38 +634,14 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        with patch(
-            "spacecmd.system.open",
-            new_callable=mock_open,
-            read_data="private_ssh_key"
-            # pylint: disable-next=unused-variable
-        ) as opn:
-            spacecmd.system.do_system_bootstrap(
-                shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -a 1-akey"
-            )
+        with patch("spacecmd.system.open", new_callable=mock_open, read_data="private_ssh_key") as opn:
+            spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -a 1-akey")
 
         assert not shell.client.system.bootstrap.called
         assert shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "private_ssh_key",
-                        "",
-                        "1-akey",
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'private_ssh_key', '', '1-akey', False), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_do_system_bootstrap_sshprivkey_reactivationkey(self, shell):
         """
         Test do_system_bootstrap
@@ -913,39 +651,15 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        with patch(
-            "spacecmd.system.open",
-            new_callable=mock_open,
-            read_data="private_ssh_key"
-            # pylint: disable-next=unused-variable
-        ) as opn:
-            spacecmd.system.do_system_bootstrap(
-                shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -r 1-re-key"
-            )
+        with patch("spacecmd.system.open", new_callable=mock_open, read_data="private_ssh_key") as opn:
+            spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -r 1-re-key")
 
         assert not shell.client.system.bootstrap.called
         assert shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "private_ssh_key",
-                        "",
-                        "",
-                        "1-re-key",
-                        False,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'private_ssh_key', '', '', '1-re-key', False), {})])
 
-    # pylint: disable-next=redefined-outer-name
+
     def test_do_system_bootstrap_sshprivkey_all(self, shell):
         """
         Test do_system_bootstrap
@@ -955,36 +669,10 @@ class TestSystem:
         shell.client.system.bootstrap = MagicMock()
         shell.client.system.bootstrapWithPrivateSshKey = MagicMock()
 
-        with patch(
-            "spacecmd.system.open",
-            new_callable=mock_open,
-            read_data="private_ssh_key"
-            # pylint: disable-next=unused-variable
-        ) as opn:
-            spacecmd.system.do_system_bootstrap(
-                shell,
-                "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -S key_secret -a 1-akey -r 1-re-key --proxyid 1000010042 --saltssh",
-            )
+        with patch("spacecmd.system.open", new_callable=mock_open, read_data="private_ssh_key") as opn:
+            spacecmd.system.do_system_bootstrap(shell, "-H uyuni.example.com -u admin -k /tmp/ssh_priv_key -S key_secret -a 1-akey -r 1-re-key --proxyid 1000010042 --saltssh")
 
         assert not shell.client.system.bootstrap.called
         assert shell.client.system.bootstrapWithPrivateSshKey.called
-        assert_args_expect(
-            shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "uyuni.example.com",
-                        22,
-                        "admin",
-                        "private_ssh_key",
-                        "key_secret",
-                        "1-akey",
-                        "1-re-key",
-                        1000010042,
-                        True,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.system.bootstrapWithPrivateSshKey.call_args_list,
+                           [((shell.session, 'uyuni.example.com', 22, 'admin', 'private_ssh_key', 'key_secret', '1-akey', '1-re-key', 1000010042, True), {})])

--- a/spacecmd/tests/test_user.py
+++ b/spacecmd/tests/test_user.py
@@ -4,8 +4,6 @@ Test case for spacecmd.user module
 """
 
 from unittest.mock import MagicMock, patch
-
-# pylint: disable-next=unused-import
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.user
 from xmlrpc import client as xmlrpclib
@@ -15,8 +13,6 @@ class TestSCUser:
     """
     Test suite for "user" module.
     """
-
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_interactive(self, shell):
         """
         Test do_user_create interactive mode.
@@ -28,38 +24,19 @@ class TestSCUser:
         shell.user_confirm = MagicMock(return_value=1)
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
-        prompter = MagicMock(
-            side_effect=["lksw", "Luke", "Skywalker", "l.skywalker@suse.com"]
-        )
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
+        prompter = MagicMock(side_effect=["lksw", "Luke", "Skywalker",
+                                          "l.skywalker@suse.com"])
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
             spacecmd.user.do_user_create(shell, "")
 
         assert shell.client.user.create.called
         assert not logger.warning.called
-        assert_args_expect(
-            shell.client.user.create.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "lksw",
-                        "1234567890",
-                        "Luke",
-                        "Skywalker",
-                        "l.skywalker@suse.com",
-                        1,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.user.create.call_args_list,
+                           [((shell.session, 'lksw', '1234567890', 'Luke',
+                              'Skywalker', 'l.skywalker@suse.com', 1), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_args(self, shell):
         """
         Test do_user_create parameters/arguments mode.
@@ -72,39 +49,19 @@ class TestSCUser:
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
         prompter = MagicMock(side_effect=Exception("Should not happen"))
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
-            spacecmd.user.do_user_create(
-                shell,
-                "-u lksw -f Luke -l Skywalker " "-e l.skywalker@suse.com -p 1234567890",
-            )
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
+            spacecmd.user.do_user_create(shell, "-u lksw -f Luke -l Skywalker "
+                                                "-e l.skywalker@suse.com -p 1234567890")
 
         assert shell.client.user.create.called
         assert not logger.error.called
         assert not logger.warning.called
-        assert_args_expect(
-            shell.client.user.create.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "lksw",
-                        "1234567890",
-                        "Luke",
-                        "Skywalker",
-                        "l.skywalker@suse.com",
-                        0,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(shell.client.user.create.call_args_list,
+                           [((shell.session, 'lksw', '1234567890', 'Luke',
+                              'Skywalker', 'l.skywalker@suse.com', 0), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_no_username(self, shell):
         """
         Test do_user_create, missing user name
@@ -117,22 +74,17 @@ class TestSCUser:
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
         prompter = MagicMock(side_effect=Exception("Should not happen"))
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
-            spacecmd.user.do_user_create(
-                shell, "-f Luke -l Skywalker " "-e l.skywalker@suse.com -p 1234567890"
-            )
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
+            spacecmd.user.do_user_create(shell, "-f Luke -l Skywalker "
+                                                "-e l.skywalker@suse.com -p 1234567890")
 
         assert not shell.client.user.create.called
         assert not logger.warning.called
         assert logger.error.called
         assert_expect(logger.error.call_args_list, "A username is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_no_first_name(self, shell):
         """
         Test do_user_create, missing first name
@@ -145,22 +97,17 @@ class TestSCUser:
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
         prompter = MagicMock(side_effect=Exception("Should not happen"))
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
-            spacecmd.user.do_user_create(
-                shell, "-u lksw -l Skywalker " "-e l.skywalker@suse.com -p 1234567890"
-            )
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
+            spacecmd.user.do_user_create(shell, "-u lksw -l Skywalker "
+                                                "-e l.skywalker@suse.com -p 1234567890")
 
         assert not shell.client.user.create.called
         assert not logger.warning.called
         assert logger.error.called
         assert_expect(logger.error.call_args_list, "A first name is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_no_last_name(self, shell):
         """
         Test do_user_create, missing last name
@@ -173,22 +120,17 @@ class TestSCUser:
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
         prompter = MagicMock(side_effect=Exception("Should not happen"))
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
-            spacecmd.user.do_user_create(
-                shell, "-u lksw -f Luke " "-e l.skywalker@suse.com -p 1234567890"
-            )
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
+            spacecmd.user.do_user_create(shell, "-u lksw -f Luke "
+                                                "-e l.skywalker@suse.com -p 1234567890")
 
         assert not shell.client.user.create.called
         assert not logger.warning.called
         assert logger.error.called
         assert_expect(logger.error.call_args_list, "A last name is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_no_email(self, shell):
         """
         Test do_user_create, missing email removeress
@@ -201,22 +143,17 @@ class TestSCUser:
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
         prompter = MagicMock(side_effect=Exception("Should not happen"))
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
-            spacecmd.user.do_user_create(
-                shell, "-u lksw -f Luke -l Skywalker " "-p 1234567890"
-            )
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
+            spacecmd.user.do_user_create(shell, "-u lksw -f Luke -l Skywalker "
+                                                "-p 1234567890")
 
         assert not shell.client.user.create.called
         assert not logger.warning.called
         assert logger.error.called
         assert_expect(logger.error.call_args_list, "An email address is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_no_auth(self, shell):
         """
         Test do_user_create, missing authentication
@@ -229,22 +166,17 @@ class TestSCUser:
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
         prompter = MagicMock(side_effect=Exception("Should not happen"))
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
-            spacecmd.user.do_user_create(
-                shell, "-u lksw -f Luke -l Skywalker " "-e l.skywalker@suse.com"
-            )
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
+            spacecmd.user.do_user_create(shell, "-u lksw -f Luke -l Skywalker "
+                                                "-e l.skywalker@suse.com")
 
         assert not shell.client.user.create.called
         assert not logger.warning.called
         assert logger.error.called
         assert_expect(logger.error.call_args_list, "A password is required")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_create_no_password_with_pam(self, shell):
         """
         Test do_user_create, password should be ignored if user opted for PAM
@@ -257,43 +189,21 @@ class TestSCUser:
         logger = MagicMock()
         getps = MagicMock(return_value="1234567890")
         prompter = MagicMock(side_effect=Exception("Should not happen"))
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.logging", logger) as lgr, patch(
-            "spacecmd.user.prompt_user",
-            prompter
-            # pylint: disable-next=unused-variable
-        ) as pmt, patch("spacecmd.user.getpass", getps) as gpw:
-            spacecmd.user.do_user_create(
-                shell,
-                "-u lksw -f Luke -l Skywalker --pam "
-                "-e l.skywalker@suse.com -p 123123123",
-            )
+        with patch("spacecmd.user.logging", logger) as lgr, \
+                patch("spacecmd.user.prompt_user", prompter) as pmt, \
+                patch("spacecmd.user.getpass", getps) as gpw:
+            spacecmd.user.do_user_create(shell, "-u lksw -f Luke -l Skywalker --pam "
+                                                "-e l.skywalker@suse.com -p 123123123")
 
         assert not logger.error.called
         assert shell.client.user.create.called
         assert logger.warning.called
-        assert_expect(
-            logger.warning.call_args_list, "Note: password was ignored due to PAM mode"
-        )
-        assert_args_expect(
-            shell.client.user.create.call_args_list,
-            [
-                (
-                    (
-                        shell.session,
-                        "lksw",
-                        "",
-                        "Luke",
-                        "Skywalker",
-                        "l.skywalker@suse.com",
-                        1,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_expect(logger.warning.call_args_list,
+                      "Note: password was ignored due to PAM mode")
+        assert_args_expect(shell.client.user.create.call_args_list,
+                           [((shell.session, 'lksw', '', 'Luke',
+                              'Skywalker', 'l.skywalker@suse.com', 1), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_delete_noargs(self, shell):
         """
         Test do_user_delete, no arguments
@@ -310,7 +220,6 @@ class TestSCUser:
         assert not shell.user_confirm.called
         assert shell.help_user_delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_delete_non_interactive(self, shell):
         """
         Test do_user_delete, non-interactive mode.
@@ -329,7 +238,6 @@ class TestSCUser:
         assert not shell.user_confirm.called
         assert shell.client.user.delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_delete_interactive(self, shell):
         """
         Test do_user_delete, interactive mode.
@@ -348,7 +256,6 @@ class TestSCUser:
         assert shell.user_confirm.called
         assert shell.client.user.delete.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_disable_noargs(self, shell):
         """
         Test do_user_disable, no arguments
@@ -363,7 +270,6 @@ class TestSCUser:
         assert not shell.client.user.disable.called
         assert shell.help_user_disable.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_disable_too_much_arguments(self, shell):
         """
         Test do_user_disable, too much arguments
@@ -378,7 +284,6 @@ class TestSCUser:
         assert not shell.client.user.disable.called
         assert shell.help_user_disable.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_disable(self, shell):
         """
         Test do_user_disable, username
@@ -393,7 +298,6 @@ class TestSCUser:
         assert not shell.help_user_disable.called
         assert shell.client.user.disable.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_enable_noargs(self, shell):
         """
         Test do_user_enable, no arguments
@@ -408,7 +312,6 @@ class TestSCUser:
         assert not shell.client.user.enable.called
         assert shell.help_user_enable.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_enable_too_much_arguments(self, shell):
         """
         Test do_user_enable, too much arguments
@@ -423,7 +326,6 @@ class TestSCUser:
         assert not shell.client.user.enable.called
         assert shell.help_user_enable.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_enable(self, shell):
         """
         Test do_user_enable, username
@@ -438,7 +340,6 @@ class TestSCUser:
         assert not shell.help_user_enable.called
         assert shell.client.user.enable.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_list_no_data_no_users(self, shell):
         """
         Test do_user_list, no data return, no users.
@@ -449,14 +350,12 @@ class TestSCUser:
         shell.client.user.listUsers = MagicMock(return_value=[])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.user.print", mprint) as prt:
             out = spacecmd.user.do_user_list(shell, "")
 
         assert not mprint.called
         assert out is None
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_list_get_data_no_users(self, shell):
         """
         Test do_user_list, data return, no users.
@@ -467,14 +366,12 @@ class TestSCUser:
         shell.client.user.listUsers = MagicMock(return_value=[])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.user.print", mprint) as prt:
             out = spacecmd.user.do_user_list(shell, "", doreturn=True)
 
         assert not mprint.called
         assert out == []
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_list_no_data_with_users(self, shell):
         """
         Test do_user_list, no data return, users found.
@@ -482,15 +379,12 @@ class TestSCUser:
         :param shell:
         :return:
         """
-        shell.client.user.listUsers = MagicMock(
-            return_value=[
-                {"login": "pointyhaired"},
-                {"login": "someone-else"},
-            ]
-        )
+        shell.client.user.listUsers = MagicMock(return_value=[
+            {"login": "pointyhaired"},
+            {"login": "someone-else"},
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.user.print", mprint) as prt:
             out = spacecmd.user.do_user_list(shell, "")
 
@@ -498,7 +392,6 @@ class TestSCUser:
         assert out is None
         assert_expect(mprint.call_args_list, "pointyhaired\nsomeone-else")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_list_get_data_with_users(self, shell):
         """
         Test do_user_list, data return, users found.
@@ -506,22 +399,18 @@ class TestSCUser:
         :param shell:
         :return:
         """
-        shell.client.user.listUsers = MagicMock(
-            return_value=[
-                {"login": "pointyhaired"},
-                {"login": "someone-else"},
-            ]
-        )
+        shell.client.user.listUsers = MagicMock(return_value=[
+            {"login": "pointyhaired"},
+            {"login": "someone-else"},
+        ])
         mprint = MagicMock()
 
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.user.print", mprint) as prt:
             out = spacecmd.user.do_user_list(shell, "", doreturn=True)
 
         assert not mprint.called
         assert out == ["pointyhaired", "someone-else"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_listavailableroles_no_data_no_roles(self, shell):
         """
         test do_user_listavailableroles, no data return, no roles found.
@@ -533,20 +422,16 @@ class TestSCUser:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.print", mprint) as prt, patch(
-            "spacecmd.user.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.user.print", mprint) as prt, \
+                patch("spacecmd.user.logging", logger) as lgr:
             out = spacecmd.user.do_user_listavailableroles(shell, "")
         assert out is None
         assert not mprint.called
         assert logger.error.called
 
-        assert_expect(logger.error.call_args_list, "No roles has been found")
+        assert_expect(logger.error.call_args_list,
+                      "No roles has been found")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_listavailableroles_no_data_with_roles(self, shell):
         """
         test do_user_listavailableroles, no data return, roles found.
@@ -554,26 +439,20 @@ class TestSCUser:
         :param shell:
         :return:
         """
-        shell.client.user.listAssignableRoles = MagicMock(
-            return_value=["bofh", "coffee"]
-        )
+        shell.client.user.listAssignableRoles = MagicMock(return_value=["bofh", "coffee"])
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.print", mprint) as prt, patch(
-            "spacecmd.user.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.user.print", mprint) as prt, \
+                patch("spacecmd.user.logging", logger) as lgr:
             out = spacecmd.user.do_user_listavailableroles(shell, "")
         assert out is None
         assert not logger.error.called
         assert mprint.called
 
-        assert_expect(mprint.call_args_list, "bofh\ncoffee")
+        assert_expect(mprint.call_args_list,
+                      "bofh\ncoffee")
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_listavailableroles_with_data_no_roles(self, shell):
         """
         test do_user_listavailableroles, no data return, no roles found.
@@ -585,19 +464,14 @@ class TestSCUser:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.print", mprint) as prt, patch(
-            "spacecmd.user.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.user.print", mprint) as prt, \
+                patch("spacecmd.user.logging", logger) as lgr:
             out = spacecmd.user.do_user_listavailableroles(shell, "", doreturn=True)
         assert out is not None
         assert not mprint.called
         assert not logger.error.called
         assert out == []
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_listavailableroles_with_data_with_roles(self, shell):
         """
         test do_user_listavailableroles, no data return, roles found.
@@ -605,25 +479,18 @@ class TestSCUser:
         :param shell:
         :return:
         """
-        shell.client.user.listAssignableRoles = MagicMock(
-            return_value=["bofh", "coffee"]
-        )
+        shell.client.user.listAssignableRoles = MagicMock(return_value=["bofh", "coffee"])
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.print", mprint) as prt, patch(
-            "spacecmd.user.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.user.print", mprint) as prt, \
+                patch("spacecmd.user.logging", logger) as lgr:
             out = spacecmd.user.do_user_listavailableroles(shell, "", doreturn=True)
         assert out is not None
         assert not logger.error.called
         assert not mprint.called
         assert out == ["bofh", "coffee"]
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_addrole_noargs(self, shell):
         """
         Test do_user_addrole, no arguments
@@ -638,7 +505,6 @@ class TestSCUser:
         assert not shell.client.user.addRole.called
         assert shell.help_user_addrole.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_addrole(self, shell):
         """
         Test do_user_addrole, with correct arguments of user and role
@@ -652,12 +518,9 @@ class TestSCUser:
 
         assert not shell.help_user_addrole.called
         assert shell.client.user.addRole.called
-        assert_args_expect(
-            shell.client.user.addRole.call_args_list,
-            [((shell.session, "bofh", "coffee"), {})],
-        )
+        assert_args_expect(shell.client.user.addRole.call_args_list,
+                           [((shell.session, "bofh", "coffee"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_removerole_noargs(self, shell):
         """
         Test do_user_removerole, no arguments
@@ -672,7 +535,6 @@ class TestSCUser:
         assert not shell.client.user.removeRole.called
         assert shell.help_user_removerole.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_removerole(self, shell):
         """
         Test do_user_removerole, with correct arguments of user and role
@@ -686,12 +548,9 @@ class TestSCUser:
 
         assert not shell.help_user_removerole.called
         assert shell.client.user.removeRole.called
-        assert_args_expect(
-            shell.client.user.removeRole.call_args_list,
-            [((shell.session, "bofh", "coffee"), {})],
-        )
+        assert_args_expect(shell.client.user.removeRole.call_args_list,
+                           [((shell.session, "bofh", "coffee"), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_addgroup_noargs(self, shell):
         """
         Test do_user_addgroup, no arguments
@@ -706,7 +565,6 @@ class TestSCUser:
         assert not shell.client.user.addAssignedSystemGroups.called
         assert shell.help_user_addgroup.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_addgroup(self, shell):
         """
         Test do_user_addgroup, with correct arguments of user and groups
@@ -720,12 +578,9 @@ class TestSCUser:
 
         assert not shell.help_user_addgroup.called
         assert shell.client.user.addAssignedSystemGroups.called
-        assert_args_expect(
-            shell.client.user.addAssignedSystemGroups.call_args_list,
-            [((shell.session, "bofh", ["coffee", "teamaker"], False), {})],
-        )
+        assert_args_expect(shell.client.user.addAssignedSystemGroups.call_args_list,
+                           [((shell.session, "bofh", ["coffee", "teamaker"], False), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_adddefaultgroup_noargs(self, shell):
         """
         Test do_user_adddefaultgroup, no arguments
@@ -740,7 +595,6 @@ class TestSCUser:
         assert not shell.client.user.addDefaultSystemGroups.called
         assert shell.help_user_adddefaultgroup.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_adddefaultgroup(self, shell):
         """
         Test do_user_adddefaultgroup, with correct arguments of user and groups
@@ -754,12 +608,9 @@ class TestSCUser:
 
         assert not shell.help_user_adddefaultgroup.called
         assert shell.client.user.addDefaultSystemGroups.called
-        assert_args_expect(
-            shell.client.user.addDefaultSystemGroups.call_args_list,
-            [((shell.session, "bofh", ["coffee", "teamaker"]), {})],
-        )
+        assert_args_expect(shell.client.user.addDefaultSystemGroups.call_args_list,
+                           [((shell.session, "bofh", ["coffee", "teamaker"]), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_removegroup_noargs(self, shell):
         """
         Test do_user_removegroup, no arguments
@@ -774,7 +625,6 @@ class TestSCUser:
         assert not shell.client.user.removeAssignedSystemGroups.called
         assert shell.help_user_removegroup.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_removegroup(self, shell):
         """
         Test do_user_removegroup, with correct arguments of user and groups
@@ -788,12 +638,9 @@ class TestSCUser:
 
         assert not shell.help_user_removegroup.called
         assert shell.client.user.removeAssignedSystemGroups.called
-        assert_args_expect(
-            shell.client.user.removeAssignedSystemGroups.call_args_list,
-            [((shell.session, "bofh", ["coffee", "teamaker"], True), {})],
-        )
+        assert_args_expect(shell.client.user.removeAssignedSystemGroups.call_args_list,
+                           [((shell.session, "bofh", ["coffee", "teamaker"], True), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_removedefaultgroup_noargs(self, shell):
         """
         Test do_user_removedefaultgroup, no arguments
@@ -808,7 +655,6 @@ class TestSCUser:
         assert not shell.client.user.removeDefaultSystemGroups.called
         assert shell.help_user_removedefaultgroup.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_removedefaultgroup(self, shell):
         """
         Test do_user_removedefaultgroup, with correct arguments of user and groups
@@ -822,12 +668,9 @@ class TestSCUser:
 
         assert not shell.help_user_removedefaultgroup.called
         assert shell.client.user.removeDefaultSystemGroups.called
-        assert_args_expect(
-            shell.client.user.removeDefaultSystemGroups.call_args_list,
-            [((shell.session, "bofh", ["coffee", "teamaker"]), {})],
-        )
+        assert_args_expect(shell.client.user.removeDefaultSystemGroups.call_args_list,
+                           [((shell.session, "bofh", ["coffee", "teamaker"]), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setfirstname_noargs(self, shell):
         """
         Test do_user_setfirstname without arguments.
@@ -844,7 +687,6 @@ class TestSCUser:
         assert not shell.client.user.setDetails.called
         assert shell.help_user_setfirstname.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setfirstname(self, shell):
         """
         Test do_user_setfirstname with data.
@@ -861,12 +703,9 @@ class TestSCUser:
         assert not shell.help_user_setfirstname.called
         assert shell.client.user.setDetails.called
 
-        assert_args_expect(
-            shell.client.user.setDetails.call_args_list,
-            [((shell.session, "bofh", {"first_name": "Operator"}), {})],
-        )
+        assert_args_expect(shell.client.user.setDetails.call_args_list,
+                           [((shell.session, "bofh", {"first_name": "Operator"}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setlastname_noargs(self, shell):
         """
         Test do_user_setlastname without arguments.
@@ -883,7 +722,6 @@ class TestSCUser:
         assert not shell.client.user.setDetails.called
         assert shell.help_user_setlastname.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setlastname(self, shell):
         """
         Test do_user_setlastname with data.
@@ -900,12 +738,9 @@ class TestSCUser:
         assert not shell.help_user_setlastname.called
         assert shell.client.user.setDetails.called
 
-        assert_args_expect(
-            shell.client.user.setDetails.call_args_list,
-            [((shell.session, "bofh", {"last_name": "Hell"}), {})],
-        )
+        assert_args_expect(shell.client.user.setDetails.call_args_list,
+                           [((shell.session, "bofh", {"last_name": "Hell"}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setemail_noargs(self, shell):
         """
         Test do_user_setemail without arguments.
@@ -922,7 +757,6 @@ class TestSCUser:
         assert not shell.client.user.setDetails.called
         assert shell.help_user_setemail.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setemail(self, shell):
         """
         Test do_user_setemail with data.
@@ -939,12 +773,9 @@ class TestSCUser:
         assert not shell.help_user_setemail.called
         assert shell.client.user.setDetails.called
 
-        assert_args_expect(
-            shell.client.user.setDetails.call_args_list,
-            [((shell.session, "bofh", {"email": "b@op.com"}), {})],
-        )
+        assert_args_expect(shell.client.user.setDetails.call_args_list,
+                           [((shell.session, "bofh", {"email": "b@op.com"}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setprefix_noargs(self, shell):
         """
         Test do_user_setprefix without arguments.
@@ -961,7 +792,6 @@ class TestSCUser:
         assert not shell.client.user.setDetails.called
         assert shell.help_user_setprefix.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setprefix_empty(self, shell):
         """
         Test do_user_setprefix with empty prefix.
@@ -978,12 +808,9 @@ class TestSCUser:
         assert not shell.help_user_setprefix.called
         assert shell.client.user.setDetails.called
 
-        assert_args_expect(
-            shell.client.user.setDetails.call_args_list,
-            [((shell.session, "bofh", {"prefix": " "}), {})],
-        )
+        assert_args_expect(shell.client.user.setDetails.call_args_list,
+                           [((shell.session, "bofh", {"prefix": " "}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setprefix_pref(self, shell):
         """
         Test do_user_setprefix with any prefix.
@@ -1000,12 +827,9 @@ class TestSCUser:
         assert not shell.help_user_setprefix.called
         assert shell.client.user.setDetails.called
 
-        assert_args_expect(
-            shell.client.user.setDetails.call_args_list,
-            [((shell.session, "bofh", {"prefix": "Bst"}), {})],
-        )
+        assert_args_expect(shell.client.user.setDetails.call_args_list,
+                           [((shell.session, "bofh", {"prefix": "Bst"}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setpassword_noargs(self, shell):
         """
         Test do_user_setpassword without arguments.
@@ -1022,7 +846,6 @@ class TestSCUser:
         assert not shell.client.user.setDetails.called
         assert shell.help_user_setpassword.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_setpassword(self, shell):
         """
         Test do_user_setpassword with data.
@@ -1039,12 +862,9 @@ class TestSCUser:
         assert not shell.help_user_setpassword.called
         assert shell.client.user.setDetails.called
 
-        assert_args_expect(
-            shell.client.user.setDetails.call_args_list,
-            [((shell.session, "someuser", {"password": "toto"}), {})],
-        )
+        assert_args_expect(shell.client.user.setDetails.call_args_list,
+                           [((shell.session, "someuser", {"password": "toto"}), {})])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_details_noargs(self, shell):
         """
         Test do_user_details without arguments.
@@ -1061,12 +881,8 @@ class TestSCUser:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.print", mprint) as prt, patch(
-            "spacecmd.user.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.user.print", mprint) as prt, \
+                patch("spacecmd.user.logging", logger) as lgr:
             spacecmd.user.do_user_details(shell, "")
 
         assert not shell.client.user.getDetails.called
@@ -1078,7 +894,6 @@ class TestSCUser:
         assert not logger.warning.called
         assert shell.help_user_details.called
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_details_invalid_users(self, shell):
         """
         Test do_user_details with invalid/not-found users.
@@ -1087,11 +902,8 @@ class TestSCUser:
         :return:
         """
         shell.help_user_details = MagicMock()
-        shell.client.user.getDetails = MagicMock(
-            side_effect=xmlrpclib.Fault(
-                faultCode=42, faultString="User caused disks spinning backwards"
-            )
-        )
+        shell.client.user.getDetails = MagicMock(side_effect=xmlrpclib.Fault(
+            faultCode=42, faultString="User caused disks spinning backwards"))
         shell.client.user.listRoles = MagicMock()
         shell.client.user.listAssignedSystemGroups = MagicMock()
         shell.client.user.listDefaultSystemGroups = MagicMock()
@@ -1099,12 +911,8 @@ class TestSCUser:
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.print", mprint) as prt, patch(
-            "spacecmd.user.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.user.print", mprint) as prt, \
+                patch("spacecmd.user.logging", logger) as lgr:
             spacecmd.user.do_user_details(shell, "hairypointed othermissing")
 
         assert not shell.client.user.listRoles.called
@@ -1117,21 +925,15 @@ class TestSCUser:
         assert logger.debug.called
         assert shell.client.user.getDetails.called
 
-        assert_list_args_expect(
-            logger.warning.call_args_list,
-            ["hairypointed is not a valid user", "othermissing is not a valid user"],
-        )
-        assert_list_args_expect(
-            logger.debug.call_args_list,
-            [
-                "Error '42' while getting data about user "
-                "'hairypointed': User caused disks spinning backwards",
-                "Error '42' while getting data about user "
-                "'othermissing': User caused disks spinning backwards",
-            ],
-        )
+        assert_list_args_expect(logger.warning.call_args_list,
+                                ["hairypointed is not a valid user",
+                                 "othermissing is not a valid user"])
+        assert_list_args_expect(logger.debug.call_args_list,
+                                ["Error '42' while getting data about user "
+                                 "'hairypointed': User caused disks spinning backwards",
+                                 "Error '42' while getting data about user "
+                                 "'othermissing': User caused disks spinning backwards"])
 
-    # pylint: disable-next=redefined-outer-name
     def test_user_details_get_data(self, shell):
         """
         Test do_user_details with found users to check the data
@@ -1140,51 +942,28 @@ class TestSCUser:
         :return:
         """
         shell.help_user_details = MagicMock()
-        shell.client.user.getDetails = MagicMock(
-            side_effect=[
-                {
-                    "first_name": "John",
-                    "last_name": "Smith",
-                    "email": "j.smith@company.com",
-                    "last_login_date": "1999.01.02",
-                    "created_date": "1999.01.01",
-                    "enabled": False,
-                },
-                {
-                    "first_name": "Bofh",
-                    "last_name": "Operator",
-                    "email": "bofh@company.com",
-                    "last_login_date": "2019.01.01",
-                    "created_date": "1980.01.01",
-                    "enabled": True,
-                },
-            ]
-        )
-        shell.client.user.listRoles = MagicMock(
-            side_effect=[
-                ["printer", "spectator"],
-                ["coffee", "bofh"],
-            ]
-        )
-        shell.client.user.listAssignedSystemGroups = MagicMock(
-            side_effect=[
-                [{"name": "beer"}, {"name": "schinken"}, {"name": "swimming pool"}],
-                [{"name": "butterfly catchers"}, {"name": "chessplayers"}],
-            ]
-        )
-        shell.client.user.listDefaultSystemGroups = MagicMock(
-            side_effect=[[{"name": "something"}], []]
-        )
+        shell.client.user.getDetails = MagicMock(side_effect=[
+            {"first_name": "John", "last_name": "Smith", "email": "j.smith@company.com",
+             "last_login_date": "1999.01.02", "created_date": "1999.01.01", "enabled": False},
+            {"first_name": "Bofh", "last_name": "Operator", "email": "bofh@company.com",
+             "last_login_date": "2019.01.01", "created_date": "1980.01.01", "enabled": True},
+        ])
+        shell.client.user.listRoles = MagicMock(side_effect=[
+            ["printer", "spectator"], ["coffee", "bofh"],
+        ])
+        shell.client.user.listAssignedSystemGroups = MagicMock(side_effect=[
+            [{"name": "beer"}, {"name": "schinken"}, {"name": "swimming pool"}],
+            [{"name": "butterfly catchers"}, {"name": "chessplayers"}],
+        ])
+        shell.client.user.listDefaultSystemGroups = MagicMock(side_effect=[
+            [{"name": "something"}], []
+        ])
         shell.client.org.getDetails = MagicMock(return_value={"name": "company.com"})
         mprint = MagicMock()
         logger = MagicMock()
 
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.user.print", mprint) as prt, patch(
-            "spacecmd.user.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.user.print", mprint) as prt, \
+                patch("spacecmd.user.logging", logger) as lgr:
             spacecmd.user.do_user_details(shell, "hairypointed bofh")
 
         assert not shell.help_user_details.called
@@ -1197,45 +976,14 @@ class TestSCUser:
         assert shell.client.user.getDetails.called
         assert mprint.called
 
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Username:      hairypointed",
-                "First Name:    John",
-                "Last Name:     Smith",
-                "Email Address: j.smith@company.com",
-                "Organisation:  company.com",
-                "Last Login:    1999.01.02",
-                "Created:       1999.01.01",
-                "Enabled:       False",
-                "",
-                "Roles",
-                "-----",
-                "printer\nspectator",
-                "",
-                "Assigned Groups",
-                "---------------",
-                "beer\nschinken\nswimming pool",
-                "",
-                "Default Groups",
-                "--------------",
-                "something",
-                "----------",
-                "Username:      bofh",
-                "First Name:    Bofh",
-                "Last Name:     Operator",
-                "Email Address: bofh@company.com",
-                "Organisation:  company.com",
-                "Last Login:    2019.01.01",
-                "Created:       1980.01.01",
-                "Enabled:       True",
-                "",
-                "Roles",
-                "-----",
-                "bofh\ncoffee",
-                "",
-                "Assigned Groups",
-                "---------------",
-                "butterfly catchers\nchessplayers",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Username:      hairypointed', 'First Name:    John', 'Last Name:     Smith',
+                                 'Email Address: j.smith@company.com', 'Organisation:  company.com',
+                                 'Last Login:    1999.01.02', 'Created:       1999.01.01', 'Enabled:       False',
+                                 '', 'Roles', '-----', 'printer\nspectator', '', 'Assigned Groups', '---------------',
+                                 'beer\nschinken\nswimming pool', '', 'Default Groups', '--------------', 'something',
+                                 '----------', 'Username:      bofh', 'First Name:    Bofh', 'Last Name:     Operator',
+                                 'Email Address: bofh@company.com', 'Organisation:  company.com',
+                                 'Last Login:    2019.01.01', 'Created:       1980.01.01', 'Enabled:       True',
+                                 '', 'Roles', '-----', 'bofh\ncoffee', '', 'Assigned Groups', '---------------',
+                                 'butterfly catchers\nchessplayers'])

--- a/spacecmd/tests/test_utils.py
+++ b/spacecmd/tests/test_utils.py
@@ -4,18 +4,8 @@ Test spacecmd.utils
 """
 from unittest.mock import MagicMock, patch, mock_open
 import pytest
-
-# pylint: disable-next=unused-import
-from helpers import (
-    shell,
-    assert_expect,
-    assert_list_args_expect,
-    assert_args_expect,
-    exc2str,
-)
+from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect, exc2str
 import spacecmd.utils
-
-# pylint: disable-next=unused-import
 from xmlrpc import client as xmlrpclib
 import os
 import tempfile
@@ -32,16 +22,13 @@ class TestSCUtilsCacheIntegration:
     This creates and saves cache, loads it and expires it into
     a temporary directory.
     """
-
     def setup_method(self):
         """
         Setup test
 
         :return:
         """
-        self.data = {
-            "key": hashlib.sha256(str(time.time()).encode("utf-8")).hexdigest()
-        }
+        self.data = {"key": hashlib.sha256(str(time.time()).encode("utf-8")).hexdigest()}
         self.temp = tempfile.mkdtemp()
         self.expiration = datetime.datetime(2019, 1, 1, 10, 30, 45)
         self.cachefile = os.path.join(self.temp, "spacecmd.cache")
@@ -63,9 +50,7 @@ class TestSCUtilsCacheIntegration:
 
         :return:
         """
-        spacecmd.utils.save_cache(
-            cachefile=self.cachefile, data=self.data, expire=self.expiration
-        )
+        spacecmd.utils.save_cache(cachefile=self.cachefile, data=self.data, expire=self.expiration)
         assert os.path.exists(self.cachefile)
         out = pickle.load(open(self.cachefile, "rb"))
 
@@ -74,10 +59,7 @@ class TestSCUtilsCacheIntegration:
         assert out["expire"] == self.expiration
         assert self.data["key"] == out["key"]
 
-    @patch(
-        "spacecmd.utils.open",
-        MagicMock(side_effect=IOError("Wrong polarity on neutron flow")),
-    )
+    @patch("spacecmd.utils.open", MagicMock(side_effect=IOError("Wrong polarity on neutron flow")))
     def test_save_cache_io_error(self):
         """
         Handle saving cache when IOError happens.
@@ -85,24 +67,12 @@ class TestSCUtilsCacheIntegration:
         :return:
         """
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.utils.logging", logger) as lgr:
-            spacecmd.utils.save_cache(
-                cachefile=self.cachefile, data=self.data, expire=self.expiration
-            )
+            spacecmd.utils.save_cache(cachefile=self.cachefile,
+                                      data=self.data, expire=self.expiration)
         assert logger.error.called
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Couldn't write to %s",
-                        self.cachefile,
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(("Couldn't write to %s", self.cachefile,), {})])
 
     def test_load_cache(self):
         """
@@ -110,9 +80,7 @@ class TestSCUtilsCacheIntegration:
 
         :return:
         """
-        spacecmd.utils.save_cache(
-            cachefile=self.cachefile, data=self.data, expire=self.expiration
-        )
+        spacecmd.utils.save_cache(cachefile=self.cachefile, data=self.data, expire=self.expiration)
 
         assert os.path.exists(self.cachefile)
 
@@ -135,7 +103,6 @@ class TestSCUtilsCacheIntegration:
         out, expiration = spacecmd.utils.load_cache(self.cachefile)
 
         assert out == {}
-        # pylint: disable-next=bad-chained-comparison
         assert expiration != self.expiration is not None
         assert not os.path.exists(self.cachefile)
 
@@ -152,15 +119,11 @@ class TestSCUtils:
         """
 
         arg_parser = spacecmd.utils.get_argument_parser()
-        args, opts = spacecmd.utils.parse_command_arguments(
-            "one two three", argument_parser=arg_parser, glob=True
-        )
+        args, opts = spacecmd.utils.parse_command_arguments("one two three", argument_parser=arg_parser, glob=True)
         assert args == ["one", "two", "three"] == opts.leftovers
 
         arg_parser.add_argument("-a", "--arg")
-        args, opts = spacecmd.utils.parse_command_arguments(
-            "--arg idea", argument_parser=arg_parser, glob=True
-        )
+        args, opts = spacecmd.utils.parse_command_arguments("--arg idea", argument_parser=arg_parser, glob=True)
 
         assert opts.leftovers == []
         assert opts.arg == "idea"
@@ -172,21 +135,14 @@ class TestSCUtils:
         """
 
         arg_parser = spacecmd.utils.get_argument_parser()
-        # pylint: disable-next=unused-variable
-        args, opts = spacecmd.utils.parse_command_arguments(
-            "arg", argument_parser=arg_parser, glob=True
-        )
+        args, opts = spacecmd.utils.parse_command_arguments("arg", argument_parser=arg_parser, glob=True)
         assert not spacecmd.utils.is_interactive(opts)
 
         arg_parser.add_argument("-a", "--arg")
-        args, opts = spacecmd.utils.parse_command_arguments(
-            "--arg idea", argument_parser=arg_parser, glob=True
-        )
+        args, opts = spacecmd.utils.parse_command_arguments("--arg idea", argument_parser=arg_parser, glob=True)
         assert not spacecmd.utils.is_interactive(opts)
 
-        args, opts = spacecmd.utils.parse_command_arguments(
-            "", argument_parser=arg_parser, glob=True
-        )
+        args, opts = spacecmd.utils.parse_command_arguments("", argument_parser=arg_parser, glob=True)
         assert spacecmd.utils.is_interactive(opts)
 
     def test_filter_results(self):
@@ -195,49 +151,18 @@ class TestSCUtils:
 
         :return:
         """
-        out = spacecmd.utils.filter_results(
-            [
-                "space",
-                "spacecmd",
-                "cmdspace",
-                "somespacecmd",
-                "somecmd",
-                "cmdsome",
-                "piglet",
-            ],
-            ["space*", "pig"],
-            search=True,
-        )
-        assert out == ["space", "spacecmd", "cmdspace", "somespacecmd", "piglet"]
+        out = spacecmd.utils.filter_results(["space", "spacecmd", "cmdspace", "somespacecmd",
+                                             "somecmd", "cmdsome", "piglet"],
+                                            ["space*", "pig"], search=True)
+        assert out == ['space', 'spacecmd', 'cmdspace', 'somespacecmd', 'piglet']
 
-        out = spacecmd.utils.filter_results(
-            [
-                "space",
-                "spacecmd",
-                "cmdspace",
-                "somespacecmd",
-                "somecmd",
-                "cmdsome",
-                "piglet",
-            ],
-            ["space*", "pig"],
-            search=False,
-        )
-        assert out == ["space"]
+        out = spacecmd.utils.filter_results(["space", "spacecmd", "cmdspace", "somespacecmd",
+                                             "somecmd", "cmdsome", "piglet"],
+                                            ["space*", "pig"], search=False)
+        assert out == ['space']
 
-    @patch(
-        "spacecmd.utils.mkstemp",
-        MagicMock(
-            return_value=(
-                1,
-                "test",
-            )
-        ),
-    )
-    @patch(
-        "spacecmd.utils.os.fdopen",
-        MagicMock(side_effect=IOError("Electromagnetic energy loss")),
-    )
+    @patch("spacecmd.utils.mkstemp", MagicMock(return_value=(1, "test",)))
+    @patch("spacecmd.utils.os.fdopen", MagicMock(side_effect=IOError("Electromagnetic energy loss")))
     def test_editor_ioerror_handle(self):
         """
         Test to handle IOError by an external editor when the temporary file cannot be written.
@@ -246,27 +171,15 @@ class TestSCUtils:
         """
         spawner = MagicMock()
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.utils.os.spawnlp", spawner) as spw, patch(
-            "spacecmd.utils.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.utils.os.spawnlp", spawner) as spw, \
+            patch("spacecmd.utils.logging", logger) as lgr:
             spacecmd.utils.editor("clock speed adjustments")
 
         assert logger.warning.called
         assert logger.error.called
         assert not spawner.called
 
-    @patch(
-        "spacecmd.utils.mkstemp",
-        MagicMock(
-            return_value=(
-                1,
-                "test",
-            )
-        ),
-    )
+    @patch("spacecmd.utils.mkstemp", MagicMock(return_value=(1, "test",)))
     @patch("spacecmd.utils.os.fdopen", MagicMock(return_value=MagicMock()))
     @patch("spacecmd.utils.os.environ", {})
     def test_editor_editor_failed(self):
@@ -277,38 +190,22 @@ class TestSCUtils:
         """
         spawner = MagicMock(return_value=42)
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.utils.os.spawnlp", spawner) as spw, patch(
-            "spacecmd.utils.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr:
+        with patch("spacecmd.utils.os.spawnlp", spawner) as spw, \
+            patch("spacecmd.utils.logging", logger) as lgr:
             spacecmd.utils.editor("clock speed adjustments")
 
         assert not logger.warning.called
         assert logger.error.called
         assert spawner.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (('Editor "%s" exited with code %i', "vim", 42), {}),
-                (('Editor "%s" exited with code %i', "vi", 42), {}),
-                (('Editor "%s" exited with code %i', "emacs", 42), {}),
-                (('Editor "%s" exited with code %i', "nano", 42), {}),
-                (("No editors found",), {}),
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Editor "%s" exited with code %i', "vim", 42), {}),
+                            (('Editor "%s" exited with code %i', "vi", 42), {}),
+                            (('Editor "%s" exited with code %i', "emacs", 42), {}),
+                            (('Editor "%s" exited with code %i', "nano", 42), {}),
+                            (('No editors found',), {})])
 
-    @patch(
-        "spacecmd.utils.mkstemp",
-        MagicMock(
-            return_value=(
-                1,
-                "test",
-            )
-        ),
-    )
+    @patch("spacecmd.utils.mkstemp", MagicMock(return_value=(1, "test",)))
     @patch("spacecmd.utils.os.fdopen", MagicMock(return_value=MagicMock()))
     @patch("spacecmd.utils.os.environ", {})
     @patch("spacecmd.utils.os.path.isfile", MagicMock(return_value=True))
@@ -321,25 +218,18 @@ class TestSCUtils:
         spawner = MagicMock(return_value=0)
         logger = MagicMock()
         remover = MagicMock()
-        # pylint: disable-next=unused-variable
-        with patch("spacecmd.utils.os.spawnlp", spawner) as spw, patch(
-            "spacecmd.utils.logging",
-            logger
-            # pylint: disable-next=unused-variable
-        ) as lgr, patch("spacecmd.utils.os.remove", remover) as rmr, patch(
-            "spacecmd.utils.open", new_callable=mock_open, read_data="contents data"
-        ):
+        with patch("spacecmd.utils.os.spawnlp", spawner) as spw, \
+            patch("spacecmd.utils.logging", logger) as lgr, \
+            patch("spacecmd.utils.os.remove", remover) as rmr, \
+            patch("spacecmd.utils.open", new_callable=mock_open, read_data="contents data"):
             out = spacecmd.utils.editor("clock speed adjustments", delete=True)
 
         assert not logger.error.called
         assert remover.called
-        assert out == ("contents data", "")
+        assert out == ('contents data', '')
 
     @patch("spacecmd.utils.input", MagicMock(return_value="single line data"))
-    @patch(
-        "spacecmd.utils.sys.stdin.read",
-        MagicMock(return_value="data\nand\nother\ndata"),
-    )
+    @patch("spacecmd.utils.sys.stdin.read", MagicMock(return_value="data\nand\nother\ndata"))
     def test_prompt_user_single_line(self):
         """
         Test prompt user, single line.
@@ -348,10 +238,7 @@ class TestSCUtils:
         assert spacecmd.utils.prompt_user("") == "single line data"
 
     @patch("spacecmd.utils.input", MagicMock(return_value=""))
-    @patch(
-        "spacecmd.utils.sys.stdin.read",
-        MagicMock(return_value="data\nand\nother\ndata"),
-    )
+    @patch("spacecmd.utils.sys.stdin.read", MagicMock(return_value="data\nand\nother\ndata"))
     def test_prompt_user_single_line_blank(self):
         """
         Test prompt user, single blank line.
@@ -360,18 +247,13 @@ class TestSCUtils:
         assert spacecmd.utils.prompt_user("") == ""
 
     @patch("spacecmd.utils.input", MagicMock(return_value="single line data"))
-    @patch(
-        "spacecmd.utils.sys.stdin.read",
-        MagicMock(return_value="data\nand\nother\ndata"),
-    )
+    @patch("spacecmd.utils.sys.stdin.read", MagicMock(return_value="data\nand\nother\ndata"))
     def test_prompt_user_multi_line_blank(self):
         """
         Test prompt user, multiline, blank.
         :return:
         """
-        assert (
-            spacecmd.utils.prompt_user("", multiline=True) == "data\nand\nother\ndata"
-        )
+        assert spacecmd.utils.prompt_user("", multiline=True) == "data\nand\nother\ndata"
 
     def test_time_input_default(self):
         """
@@ -382,7 +264,6 @@ class TestSCUtils:
 
         dt = MagicMock()
         dt.now = MagicMock(return_value=datetime.datetime(2019, 5, 1, 10, 45))
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.utils.datetime", dt) as dtm:
             out = spacecmd.utils.parse_time_input()
 
@@ -443,16 +324,9 @@ class TestSCUtils:
 
         :return:
         """
-        out = spacecmd.utils.build_package_names(
-            {
-                "name": "emacs",
-                "version": "42",
-                "release": "13",
-                "epoch": "1",
-                "arch": "x86_64",
-                "arch_label": "amd",
-            }
-        )
+        out = spacecmd.utils.build_package_names({"name": "emacs", "version": "42",
+                                                  "release": "13", "epoch": "1",
+                                                  "arch": "x86_64", "arch_label": "amd"})
         assert out == "emacs-42-13:1.x86_64"
 
     def test_build_package_names_no_epoch(self):
@@ -461,15 +335,9 @@ class TestSCUtils:
 
         :return:
         """
-        out = spacecmd.utils.build_package_names(
-            {
-                "name": "emacs",
-                "version": "42",
-                "release": "13",
-                "arch": "x86_64",
-                "arch_label": "amd",
-            }
-        )
+        out = spacecmd.utils.build_package_names({"name": "emacs", "version": "42",
+                                                  "release": "13",
+                                                  "arch": "x86_64", "arch_label": "amd"})
         assert out == "emacs-42-13.x86_64"
 
     def test_build_package_names_empty_epoch(self):
@@ -478,16 +346,9 @@ class TestSCUtils:
 
         :return:
         """
-        out = spacecmd.utils.build_package_names(
-            {
-                "name": "emacs",
-                "version": "42",
-                "release": "13",
-                "epoch": "",
-                "arch": "x86_64",
-                "arch_label": "amd",
-            }
-        )
+        out = spacecmd.utils.build_package_names({"name": "emacs", "version": "42",
+                                                  "release": "13", "epoch": "",
+                                                  "arch": "x86_64", "arch_label": "amd"})
         assert out == "emacs-42-13.x86_64"
 
     def test_build_package_names_amd64_uc(self):
@@ -496,16 +357,9 @@ class TestSCUtils:
 
         :return:
         """
-        out = spacecmd.utils.build_package_names(
-            {
-                "name": "emacs",
-                "version": "42",
-                "release": "13",
-                "epoch": "2",
-                "arch": "AMD64",
-                "arch_label": "amd",
-            }
-        )
+        out = spacecmd.utils.build_package_names({"name": "emacs", "version": "42",
+                                                  "release": "13", "epoch": "2",
+                                                  "arch": "AMD64", "arch_label": "amd"})
         assert out == "emacs-42-13:2.x86_64"
 
     def test_build_package_names_amd64_lc(self):
@@ -514,16 +368,9 @@ class TestSCUtils:
 
         :return:
         """
-        out = spacecmd.utils.build_package_names(
-            {
-                "name": "emacs",
-                "version": "42",
-                "release": "13",
-                "epoch": "2",
-                "arch": "amd64",
-                "arch_label": "amd",
-            }
-        )
+        out = spacecmd.utils.build_package_names({"name": "emacs", "version": "42",
+                                                  "release": "13", "epoch": "2",
+                                                  "arch": "amd64", "arch_label": "amd"})
         assert out == "emacs-42-13:2.x86_64"
 
     def test_print_errata_summary_no_date_key(self):
@@ -532,20 +379,14 @@ class TestSCUtils:
 
         :return:
         """
-        erratum = {
-            "issue_date": "2019.01.15",
-            "advisory_name": "CVE-12345-678",
-            "advisory_synopsis": "Sometimes synopsis has a long text here. " * 5,
-        }
+        erratum = {"issue_date": "2019.01.15", "advisory_name": "CVE-12345-678",
+                   "advisory_synopsis": "Sometimes synopsis has a long text here. " * 5}
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.utils.print", mprint) as prt:
             spacecmd.utils.print_errata_summary(erratum=erratum)
 
-        assert_expect(
-            mprint.call_args_list,
-            "CVE-12345-678   Sometimes synopsis has a long text here.                      2019.01.15",
-        )
+        assert_expect(mprint.call_args_list,
+                      'CVE-12345-678   Sometimes synopsis has a long text here.                      2019.01.15')
 
     def test_print_errata_summary_no_date_no_issue_date_key(self):
         """
@@ -553,19 +394,14 @@ class TestSCUtils:
 
         :return:
         """
-        erratum = {
-            "advisory_name": "CVE-12345-678",
-            "advisory_synopsis": "Sometimes synopsis has a long text here. " * 5,
-        }
+        erratum = {"advisory_name": "CVE-12345-678",
+                   "advisory_synopsis": "Sometimes synopsis has a long text here. " * 5}
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.utils.print", mprint) as prt:
             spacecmd.utils.print_errata_summary(erratum=erratum)
 
-        assert_expect(
-            mprint.call_args_list,
-            "CVE-12345-678   Sometimes synopsis has a long text here.                           N/A",
-        )
+        assert_expect(mprint.call_args_list,
+                      'CVE-12345-678   Sometimes synopsis has a long text here.                           N/A')
 
     def test_print_errata_list_no_errata(self):
         """
@@ -575,7 +411,6 @@ class TestSCUtils:
         """
         errata = []
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.utils.print", mprint) as prt:
             spacecmd.utils.print_errata_list(errata=errata)
 
@@ -587,51 +422,30 @@ class TestSCUtils:
 
         :return:
         """
-        errata = [
-            {
-                "advisory_type": "security",
-                "advisory_name": "CVE-123-4567",
-                "advisory_synopsis": "text here " * 10,
-                "date": "2019.01.15",
-            },
-            {
-                "advisory_type": "bug fix",
-                "advisory_name": "CVE-123-4567",
-                "advisory_synopsis": "text here " * 10,
-                "date": "2019.01.15",
-            },
-            {
-                "advisory_type": "product enhancement",
-                "advisory_name": "CVE-123-4567",
-                "advisory_synopsis": "text here " * 10,
-                "date": "2019.01.15",
-            },
-        ]
+        errata = [{"advisory_type": "security",
+                   "advisory_name": "CVE-123-4567", "advisory_synopsis": "text here " * 10,
+                   "date": "2019.01.15"},
+                  {"advisory_type": "bug fix",
+                   "advisory_name": "CVE-123-4567", "advisory_synopsis": "text here " * 10,
+                   "date": "2019.01.15"},
+                  {"advisory_type": "product enhancement",
+                   "advisory_name": "CVE-123-4567", "advisory_synopsis": "text here " * 10,
+                   "date": "2019.01.15"}]
         mprint = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.utils.print", mprint) as prt:
             spacecmd.utils.print_errata_list(errata=errata)
 
         assert mprint.called
-        assert_list_args_expect(
-            mprint.call_args_list,
-            [
-                "Security Errata",
-                "---------------",
-                "CVE-123-4567    text here text here text here text here "
-                "text here             2019.01.15",
-                "",
-                "Bug Fix Errata",
-                "--------------",
-                "CVE-123-4567    text here text here text here text here "
-                "text here             2019.01.15",
-                "",
-                "Enhancement Errata",
-                "------------------",
-                "CVE-123-4567    text here text here text here text here "
-                "text here             2019.01.15",
-            ],
-        )
+        assert_list_args_expect(mprint.call_args_list,
+                                ['Security Errata',
+                                 '---------------',
+                                 'CVE-123-4567    text here text here text here text here '
+                                 'text here             2019.01.15', '', 'Bug Fix Errata', '--------------',
+                                 'CVE-123-4567    text here text here text here text here '
+                                 'text here             2019.01.15', '', 'Enhancement Errata', '------------------',
+                                 'CVE-123-4567    text here text here text here text here '
+                                 'text here             2019.01.15']
+                                )
 
     def test_max_length(self):
         """
@@ -642,7 +456,7 @@ class TestSCUtils:
         items = [
             "The POP server is out of Coke",
             "User to computer ratio is too low",
-            "This is an undocumented feature",
+            "This is an undocumented feature"
         ]
         assert spacecmd.utils.max_length(items=items) == 33
 
@@ -653,15 +467,10 @@ class TestSCUtils:
 
         :return:
         """
-        # pylint: disable-next=use-implicit-booleaness-not-comparison
         assert spacecmd.utils.list_locales() == []
 
     @patch("spacecmd.utils.os.path.isdir", MagicMock(return_value=True))
-    @patch(
-        "spacecmd.utils.os.listdir",
-        MagicMock(side_effect=[["Europe"], ["Berlin", "London"]]),
-    )
-    # pylint: disable-next=function-redefined
+    @patch("spacecmd.utils.os.listdir", MagicMock(side_effect=[["Europe"], ["Berlin", "London"]]))
     def test_list_locales_no_data(self):
         """
         Test locale list when no data (no directory found).
@@ -669,11 +478,10 @@ class TestSCUtils:
         :return:
         """
         logger = MagicMock()
-        # pylint: disable-next=unused-variable
         with patch("spacecmd.utils.logging", logger) as lgr:
             out = spacecmd.utils.list_locales()
 
-        assert out == ["Europe/Berlin", "Europe/London"]
+        assert out == ['Europe/Berlin', 'Europe/London']
 
     def test_parse_str(self):
         """
@@ -683,9 +491,7 @@ class TestSCUtils:
         """
         assert spacecmd.utils.parse_str("1234567", int) == 1234567
         assert spacecmd.utils.parse_str("1234567") == 1234567
-        # pylint: disable-next=singleton-comparison
         assert spacecmd.utils.parse_str("True") == True
-        # pylint: disable-next=singleton-comparison
         assert spacecmd.utils.parse_str("False") == False
         assert spacecmd.utils.parse_str("ABC1234567") == "ABC1234567"
         assert spacecmd.utils.parse_str('{"foo": "bar"}') == {"foo": "bar"}
@@ -709,33 +515,22 @@ class TestSCUtils:
 
         :return:
         """
-        assert (
-            spacecmd.utils.parse_api_args('{"channelLabel": "foo-i386-5"}')[0][
-                "channelLabel"
-            ]
-            == "foo-i386-5"
-        )
+        assert spacecmd.utils.parse_api_args('{"channelLabel": "foo-i386-5"}')[0]["channelLabel"] == "foo-i386-5"
 
-        i, s, d = spacecmd.utils.parse_api_args(
-            '1234567,abcXYZ012,{"channelLabel": "foo-i386-5"}'
-        )
+        i, s, d = spacecmd.utils.parse_api_args('1234567,abcXYZ012,{"channelLabel": "foo-i386-5"}')
         assert i == 1234567
         assert s == "abcXYZ012"
         assert d["channelLabel"] == "foo-i386-5"
 
-        i, s, d = spacecmd.utils.parse_api_args(
-            '[1234567,"abcXYZ012",{"channelLabel": "foo-i386-5"}]'
-        )
+        i, s, d = spacecmd.utils.parse_api_args('[1234567,"abcXYZ012",{"channelLabel": "foo-i386-5"}]')
         assert i == 1234567
         assert s == "abcXYZ012"
         assert d["channelLabel"] == "foo-i386-5"
 
-        i, b, s, b2 = spacecmd.utils.parse_api_args("1234,True,abc1234,False")
+        i, b, s, b2 = spacecmd.utils.parse_api_args('1234,True,abc1234,False')
         assert i == 1234
-        # pylint: disable-next=singleton-comparison
         assert b == True
         assert s == "abc1234"
-        # pylint: disable-next=singleton-comparison
         assert b2 == False
 
     def test_json_dump_to_file(self):
@@ -747,16 +542,9 @@ class TestSCUtils:
         filename = "/tmp/something"
         logger = MagicMock()
         mprint = MagicMock()
-        with patch(
-            "spacecmd.utils.open",
-            new_callable=mock_open,
-            read_data="contents data"
-            # pylint: disable-next=unused-variable
-        ) as opn, patch("spacecmd.utils.logging", logger) as lgr, patch(
-            "spacecmd.utils.print",
-            mprint
-            # pylint: disable-next=unused-variable
-        ) as prt:
+        with patch("spacecmd.utils.open", new_callable=mock_open, read_data="contents data") as opn, \
+                patch("spacecmd.utils.logging", logger) as lgr, \
+            patch("spacecmd.utils.print", mprint) as prt:
             out = spacecmd.utils.json_dump_to_file(None, filename=filename)
 
         assert out
@@ -771,29 +559,16 @@ class TestSCUtils:
         """
         filename = "/tmp/something"
         logger = MagicMock()
-        with patch(
-            "spacecmd.utils.open",
-            MagicMock(side_effect=IOError("write-only file system")),
-            # pylint: disable-next=unused-variable
-        ) as opn, patch("spacecmd.utils.logging", logger) as lgr:
+        with patch("spacecmd.utils.open", MagicMock(side_effect=IOError("write-only file system"))) as opn, \
+            patch("spacecmd.utils.logging", logger) as lgr:
             out = spacecmd.utils.json_dump_to_file(None, filename=filename)
 
         assert not out
         assert logger.error.called
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Could not open file %s for writing: %s",
-                        "/tmp/something",
-                        "write-only file system",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not open file %s for writing: %s',
+                              '/tmp/something', 'write-only file system'), {})])
 
     def test_json_read_from_file(self):
         """
@@ -803,12 +578,8 @@ class TestSCUtils:
         """
         filename = "/tmp/something"
         logger = MagicMock()
-        with patch(
-            "spacecmd.utils.open",
-            new_callable=mock_open,
-            read_data='{"foo": "bar", "int": 123}',
-            # pylint: disable-next=unused-variable
-        ) as opn, patch("spacecmd.utils.logging", logger) as lgr:
+        with patch("spacecmd.utils.open", new_callable=mock_open, read_data='{"foo": "bar", "int": 123}') as opn, \
+            patch("spacecmd.utils.logging", logger) as lgr:
             out = spacecmd.utils.json_read_from_file(filename=filename)
 
         assert not logger.error.called
@@ -824,34 +595,17 @@ class TestSCUtils:
         """
         filename = "/tmp/something"
         logger = MagicMock()
-        with patch(
-            "spacecmd.utils.open",
-            MagicMock(side_effect=IOError("Hard drive is sleeping")),
-            # pylint: disable-next=unused-variable
-        ) as opn, patch("spacecmd.utils.logging", logger) as lgr:
+        with patch("spacecmd.utils.open", MagicMock(side_effect=IOError("Hard drive is sleeping"))) as opn, \
+            patch("spacecmd.utils.logging", logger) as lgr:
             out = spacecmd.utils.json_read_from_file(filename=filename)
 
         assert logger.error.called
         assert out is None
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Could not open file %s for reading: %s",
-                        "/tmp/something",
-                        "Hard drive is sleeping",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not open file %s for reading: %s', '/tmp/something', 'Hard drive is sleeping'), {})])
 
-    @patch(
-        "spacecmd.utils.json.loads",
-        MagicMock(side_effect=ValueError("Curly brackets replaced by dashes")),
-    )
+    @patch("spacecmd.utils.json.loads", MagicMock(side_effect=ValueError("Curly brackets replaced by dashes")))
     def test_json_read_from_file_valueerror(self):
         """
         Test JSON read from file ValueError handling.
@@ -860,30 +614,16 @@ class TestSCUtils:
         """
         filename = "/tmp/something"
         logger = MagicMock()
-        with patch(
-            "spacecmd.utils.open",
-            new_callable=mock_open,
-            read_data='{"foo": "bar", "int": 123}',
-            # pylint: disable-next=unused-variable
-        ) as opn, patch("spacecmd.utils.logging", logger) as lgr:
+        with patch("spacecmd.utils.open", new_callable=mock_open, read_data='{"foo": "bar", "int": 123}') as opn, \
+            patch("spacecmd.utils.logging", logger) as lgr:
             out = spacecmd.utils.json_read_from_file(filename=filename)
 
         assert logger.error.called
         assert out is None
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Could not parse JSON data from %s: %s",
-                        "/tmp/something",
-                        "Curly brackets replaced by dashes",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Could not parse JSON data from %s: %s',
+                              '/tmp/something', 'Curly brackets replaced by dashes'), {})])
 
     def test_json_read_from_file_general_exception(self):
         """
@@ -893,29 +633,16 @@ class TestSCUtils:
         """
         filename = "/tmp/something"
         logger = MagicMock()
-        with patch(
-            "spacecmd.utils.open",
-            MagicMock(side_effect=Exception("Admin went for lunch")),
-            # pylint: disable-next=unused-variable
-        ) as opn, patch("spacecmd.utils.logging", logger) as lgr:
+        with patch("spacecmd.utils.open", MagicMock(side_effect=Exception("Admin went for lunch"))) as opn, \
+            patch("spacecmd.utils.logging", logger) as lgr:
             out = spacecmd.utils.json_read_from_file(filename=filename)
 
         assert logger.error.called
         assert out is None
 
-        assert_args_expect(
-            logger.error.call_args_list,
-            [
-                (
-                    (
-                        "Error processing file %s: %s",
-                        "/tmp/something",
-                        "Admin went for lunch",
-                    ),
-                    {},
-                )
-            ],
-        )
+        assert_args_expect(logger.error.call_args_list,
+                           [(('Error processing file %s: %s',
+                              '/tmp/something', 'Admin went for lunch'), {})])
 
     def test_get_string_diff_dicts(self):
         """
@@ -924,9 +651,8 @@ class TestSCUtils:
 
         :return:
         """
-        rpl_a, rpl_b = spacecmd.utils.get_string_diff_dicts(
-            "rhel6-x86_64-dev-application1", "rhel6-x86_64-qas-application1"
-        )
+        rpl_a, rpl_b = spacecmd.utils.get_string_diff_dicts("rhel6-x86_64-dev-application1",
+                                                            "rhel6-x86_64-qas-application1")
         assert r"(^|-)dev(-|$)" in rpl_a
         assert rpl_a[r"(^|-)dev(-|$)"] == r"\1DIFF(dev|qas)\2"
         assert r"(^|-)qas(-|$)" in rpl_b
@@ -940,10 +666,7 @@ class TestSCUtils:
         """
         line = "Cellular megabot interference"
         repldict = {"mega": "tele", "bot": "phone"}
-        assert (
-            spacecmd.utils.replace(line, replacedict=repldict)
-            == "Cellular telephone interference"
-        )
+        assert spacecmd.utils.replace(line, replacedict=repldict) == "Cellular telephone interference"
 
     def test_get_normalised_text_no_modifier(self):
         """
@@ -957,16 +680,10 @@ class TestSCUtils:
 3-sle15-x86_64-dev
 4-sle15-x86_64-prd
 5-sle15-x86_64-prd
-""".strip().split(
-            "\n"
-        )
-        assert spacecmd.utils.get_normalized_text(text) == [
-            "1-sle15-x86_64-dev",
-            "2-sle15-x86_64-prd",
-            "3-sle15-x86_64-dev",
-            "4-sle15-x86_64-prd",
-            "5-sle15-x86_64-prd",
-        ]
+""".strip().split("\n")
+        assert spacecmd.utils.get_normalized_text(text) == ['1-sle15-x86_64-dev', '2-sle15-x86_64-prd',
+                                                            '3-sle15-x86_64-dev', '4-sle15-x86_64-prd',
+                                                            '5-sle15-x86_64-prd']
 
     def test_get_normalised_text(self):
         """
@@ -980,16 +697,12 @@ class TestSCUtils:
 3-sle15-x86_64-dev
 4-sle15-x86_64-prd
 5-sle15-x86_64-prd
-""".strip().split(
-            "\n"
-        )
-        assert spacecmd.utils.get_normalized_text(text, replacedict={"dev": "prd"}) == [
-            "1-sle15-x86_64-prd",
-            "2-sle15-x86_64-prd",
-            "3-sle15-x86_64-prd",
-            "4-sle15-x86_64-prd",
-            "5-sle15-x86_64-prd",
-        ]
+""".strip().split("\n")
+        assert spacecmd.utils.get_normalized_text(text, replacedict={"dev": "prd"}) == ['1-sle15-x86_64-prd',
+                                                                                        '2-sle15-x86_64-prd',
+                                                                                        '3-sle15-x86_64-prd',
+                                                                                        '4-sle15-x86_64-prd',
+                                                                                        '5-sle15-x86_64-prd']
 
     def test_file_is_binary(self):
         """


### PR DESCRIPTION
## What does this PR change?

This PR reverts linting and formatting, which turns out to be incompatible with py2.7. This is because we still support running the `spacecmd` code on py2.7.