### PR TITLE
QE: fix system.setVariables API call

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -559,7 +559,7 @@ When(/^I create and modify the kickstart system "([^"]*)" with kickstart label "
   $api_test.system.create_system_record_with_sid(sid, kslabel)
   # this works only with a 2 column table where the key is in the left column
   variables = values.rows_hash
-  $api_test.system.set_variables(system_id, variables)
+  $api_test.system.set_variables(sid, variables)
 end
 
 When(/^I create a kickstart tree via the API$/) do


### PR DESCRIPTION
## What does this PR change?

Pass the correct value  to a function executing an API call.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- A Cucumber step definition was edited

- [x] **DONE**

## Links

Port(s):  Manager 4.3 https://github.com/SUSE/spacewalk/pull/23576

- [x] **DONE**

## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"