### PR TITLE
Ignore retry suffix when getting recurring action id from schedule name

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/recurringactions/RecurringActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/recurringactions/RecurringActionFactory.java
@@ -273,7 +273,8 @@ public class RecurringActionFactory extends HibernateFactory {
      * @return optional of matching recurring action
      */
     public static Optional<RecurringAction> lookupByJobName(String scheduleName) {
-        long id = Long.parseLong(scheduleName.replace(RecurringAction.RECURRING_ACTION_PREFIX, ""));
+        String scheduleNameIgnoringRetry = scheduleName.split("-retry\\d+$")[0];
+        long id = Long.parseLong(scheduleNameIgnoringRetry.replace(RecurringAction.RECURRING_ACTION_PREFIX, ""));
         return lookupById(id);
     }
 

--- a/java/spacewalk-java.changes.welder.fix-recurring-action-id-from-schedule
+++ b/java/spacewalk-java.changes.welder.fix-recurring-action-id-from-schedule
@@ -1,0 +1,1 @@
+- Ignore retry suffix when getting recurring action id from schedule name


### PR DESCRIPTION
## What does this PR change?

When a quartz trigger is retried due to thread unavailability in Taskomatic, it is renamed with a `retry` suffix being added to its name. As the code obtains the action id based on the schedule name it needs to ignore the `retry` suffix when it is present.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8400
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
