### PR TITLE
Fix OES 23.4 internal name

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -59,7 +59,7 @@
     {
         "id" : -42,
         "name" : "Open Enterprise Server",
-        "identifier" : "Open_Enterprise_Server",
+        "identifier" : "OES",
         "former_identifier" : "",
         "version" : "23.4",
         "release_type" : null,

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -373,11 +373,23 @@
   },
   {
     "label" : "SMP",
-    "name" : "SUSE Manager Proxy"
+    "name" : "SUSE Manager Proxy x86_64"
+  },
+  {
+    "label" : "SMP-ARM64",
+    "name" : "SUSE Manager Proxy ARM64"
   },
   {
     "label" : "SMRBS",
-    "name" : "SUSE Manager for Retail Branch Server"
+    "name" : "SUSE Manager for Retail Branch Server x86_64"
+  },
+  {
+    "label" : "SMRBS-ARM64",
+    "name" : "SUSE Manager for Retail Branch Server ARM64"
+  },
+  {
+    "label" : "SMS-ARM64",
+    "name" : "SUSE Manager Server ARM64"
   },
   {
     "label" : "SMS-PPC",
@@ -385,7 +397,7 @@
   },
   {
     "label" : "SMS-X86",
-    "name" : "SUSE Manager Server X86-64"
+    "name" : "SUSE Manager Server X86_64"
   },
   {
     "label" : "SMS-Z",

--- a/susemanager-sync-data/susemanager-sync-data.changes.mackdk.fix-oes-internal-name
+++ b/susemanager-sync-data/susemanager-sync-data.changes.mackdk.fix-oes-internal-name
@@ -1,0 +1,1 @@
+- Fix OES 23.4 internal name (bsc#1218837)


### PR DESCRIPTION
## What does this PR change?

This PR fixes the identifier for OES 23.4 due to the change of internal name from Open_Enterprise_Server to OES.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: change in configuration files

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23444
Port(s): https://github.com/SUSE/spacewalk/pull/23582

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
