### PR TITLE
CI: fix test names

### DIFF
--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '0 */12 * * *'
 jobs:
-  test-uyuni:
+  acceptance-tests-secondary:
     uses: ./.github/workflows/acceptance_tests_common.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '0 */12 * * *'
 jobs:
-  test-uyuni:
+  acceptance-tests-secondary-parrallel:
     uses: ./.github/workflows/acceptance_tests_common.yml
     strategy:
       fail-fast: false


### PR DESCRIPTION
We need to differentiate secondary and secondary parallel to be able to set them as required.

Let's choose "acceptance tests" like name, that is more descriptive than just test-uyuni
