### PR TITLE
Allow comments on same line as code in constants.rb

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -32,6 +32,10 @@ Style/IfUnlessModifier:
     - 'features/step_definitions/vm_steps.rb'
     - 'features/support/http_client.rb'
 
+Style/InlineComment:
+  Exclude:
+    - 'features/support/constants.rb'
+
 # Offense count: 7
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: respond_to_missing?


### PR DESCRIPTION
## What does this PR change?

Do not choke on
```
features/support/constants.rb:670:18: C: Style/InlineComment: Avoid trailing inline comments.
    'default' => # CHECKED
                 ^^^^^^^^^
```


## Links

Port(s):
 * 4.3:


## Changelogs

- [x] No changelog needed
