### PR TITLE
Liberty 7 product has base channel name "RHEL x86_64 Server 7"

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -255,8 +255,8 @@ BASE_CHANNEL_BY_CLIENT = {
                                 'slemicro55_ssh_minion' => 'SLE-Micro-5.5-Pool for x86_64',
                                 'alma9_minion' => 'almalinux9 for x86_64',
                                 'alma9_ssh_minion' => 'almalinux9 for x86_64',
-                                'centos7_minion' => 'SUSE Liberty Linux 7 x86_64',
-                                'centos7_ssh_minion' => 'SUSE Liberty Linux 7 x86_64',
+                                'centos7_minion' => 'RHEL x86_64 Server 7',
+                                'centos7_ssh_minion' => 'RHEL x86_64 Server 7',
                                 'liberty9_minion' => 'EL9-Pool for x86_64',
                                 'liberty9_ssh_minion' => 'EL9-Pool for x86_64',
                                 'oracle9_minion' => 'oraclelinux9 for x86_64',
@@ -383,7 +383,7 @@ LABEL_BY_BASE_CHANNEL = {
                               'SLE-Micro-5.5-Pool for x86_64' => 'sle-micro-5.5-pool-x86_64',
                               'almalinux9 for x86_64' => 'no-appstream-alma-9-result-almalinux9-x86_64',
                               'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
-                              'SUSE Liberty Linux 7 x86_64' => 'rhel-x86_64-server-7',
+                              'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                               'EL9-Pool for x86_64' => 'no-appstream-liberty-9-result-el9-pool-x86_64',
                               'oraclelinux9 for x86_64' => 'no-appstream-oracle-9-result-oraclelinux9-x86_64',
                               'RHEL8-Pool for x86_64' => 'no-appstream-8-result-rhel8-pool-x86_64',
@@ -396,7 +396,7 @@ LABEL_BY_BASE_CHANNEL = {
                               'openSUSE-Leap-15.4-Pool for aarch64' => 'opensuse-leap-15.4-pool-aarch64',
                               'openSUSE-Leap-15.5-Pool for aarch64' => 'opensuse-leap-15.5-pool-aarch64'
                             },
-                          'Uyuni' =>
+  'Uyuni' =>
                           {
                             'openSUSE Leap 15.4 (x86_64)' => 'opensuse_leap15_4-x86_64',
                             'openSUSE Leap 15.5 (x86_64)' => 'opensuse_leap15_5-x86_64',
@@ -449,7 +449,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
                                               'SLE-Micro-5.5-Pool for x86_64' => 'SLE-MICRO-5.5-x86_64',
                                               'almalinux9 for x86_64' => 'almalinux-9-x86_64',
                                               'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
-                                              'SUSE Liberty Linux 7 x86_64' => 'res7-x86_64',
+                                              'RHEL x86_64 Server 7' => 'res7-x86_64',
                                               'EL9-Pool for x86_64' => 'SUSE-LibertyLinux9-x86_64',
                                               'oraclelinux9 for x86_64' => 'oracle-9-x86_64',
                                               'RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
@@ -462,7 +462,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
                                               'openSUSE-Leap-15.4-Pool for aarch64' => 'openSUSE-Leap-15.4-aarch64',
                                               'openSUSE-Leap-15.5-Pool for aarch64' => 'openSUSE-Leap-15.5-aarch64'
                                             },
-                                          'Uyuni' =>
+  'Uyuni' =>
                                           {
                                             'openSUSE Leap 15.4 (x86_64)' => 'openSUSE-Leap-15.4-x86_64-uyuni',
                                             'openSUSE Leap 15.5 (x86_64)' => 'openSUSE-Leap-15.5-x86_64-uyuni',
@@ -517,7 +517,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
                                                       'SLE-Micro-5.5-Pool for x86_64' => 'sle-micro-5.5-pool-x86_64',
                                                       'almalinux9 for x86_64' => nil,
                                                       'Fake-Base-Channel-SUSE-like' => nil,
-                                                      'SUSE Liberty Linux 7 x86_64' => 'rhel-x86_64-server-7',
+                                                      'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
                                                       'EL9-Pool for x86_64' => 'el9-pool-x86_64',
                                                       'oraclelinux9 for x86_64' => nil,
                                                       'RHEL8-Pool for x86_64' => nil,
@@ -530,7 +530,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
                                                       'openSUSE-Leap-15.4-Pool for aarch64' => nil,
                                                       'openSUSE-Leap-15.5-Pool for aarch64' => nil
                                                     },
-                                                  'Uyuni' =>
+  'Uyuni' =>
                                                   {
                                                     'openSUSE Leap 15.4 (x86_64)' => nil,
                                                     'openSUSE Leap 15.5 (x86_64)' => nil,


### PR DESCRIPTION
## What does this PR change?

Liberty 7 product has base channel name "RHEL x86_64 Server 7"

Piggyback: indentation a bit calmer...


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/23597


## Changelogs

- [x] No changelog needed
