### PR TITLE
Fix issue in "spacewalk-repo-sync" when RPM packages contains files with size greater than 4GB (bsc#1219151)

### DIFF
--- a/python/spacewalk/server/importlib/headerSource.py
+++ b/python/spacewalk/server/importlib/headerSource.py
@@ -289,6 +289,9 @@ class rpmBinaryPackage(Package, rpmPackage):
                 # pylint: disable-next=use-implicit-booleaness-not-len
                 elif not len(v) and k in ("device", "flags"):
                     hash[k] = 0
+                # file size information is empty string when not available
+                elif not len(v) and k in ('file_size', 'file_size_long'):
+                    hash[k] = None
                 else:
                     hash[k] = v[i]
 
@@ -428,6 +431,7 @@ class rpmFile(File, ChangeLog):
         "groupname": "filegroupname",
         "rdev": "filerdevs",
         "file_size": "filesizes",
+        "file_size_long": "longfilesizes",
         "mtime": "filemtimes",
         "filedigest": "filemd5s",  # FILEMD5S is a pre-rpm4.6 name for FILEDIGESTS
         # we have to use it for compatibility reason
@@ -448,6 +452,9 @@ class rpmFile(File, ChangeLog):
         if isinstance(self["filedigest"], str):
             self["checksum"] = self["filedigest"]
             del self["filedigest"]
+        # Files with size higher than 4GB provides value as "file_size_long"
+        if self["file_size"] is None:
+            self["file_size"] = self["file_size_long"]
 
 
 class rpmProvides(Dependency):

--- a/python/spacewalk/server/importlib/headerSource.py
+++ b/python/spacewalk/server/importlib/headerSource.py
@@ -290,7 +290,7 @@ class rpmBinaryPackage(Package, rpmPackage):
                 elif not len(v) and k in ("device", "flags"):
                     hash[k] = 0
                 # file size information is empty string when not available
-                elif not len(v) and k in ("file_size", "file_size_long"):
+                elif not v and k in ("file_size", "file_size_long"):
                     hash[k] = None
                 else:
                     hash[k] = v[i]

--- a/python/spacewalk/server/importlib/headerSource.py
+++ b/python/spacewalk/server/importlib/headerSource.py
@@ -290,7 +290,7 @@ class rpmBinaryPackage(Package, rpmPackage):
                 elif not len(v) and k in ("device", "flags"):
                     hash[k] = 0
                 # file size information is empty string when not available
-                elif not len(v) and k in ('file_size', 'file_size_long'):
+                elif not len(v) and k in ("file_size", "file_size_long"):
                     hash[k] = None
                 else:
                     hash[k] = v[i]

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.Manager-4.3-bsc1219151
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.Manager-4.3-bsc1219151
@@ -1,0 +1,1 @@
+- Fix issue in "spacewalk-repo-sync" when RPM packages contains files with size greater than 4GB (bsc#1219151)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue that happens in "spacewalk-repo-sync" when trying to synchronize an RPM package that contains files with sizes higher than 4GB:

```console
2024/01/31 14:41:35 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '-c', 'res-as-8-debug-updates-x86_64', '--include', 'firefox-debuginfo']
2024/01/31 14:41:35 +02:00 Sync of channel started.
2024/01/31 14:41:41 +02:00 Repo URL: https://updates.suse.com/SUSE/Updates/RES-AS/8/debug/update/?<token>
2024/01/31 14:41:41 +02:00     Packages in repo:             23167
2024/01/31 14:41:41 +02:00     Packages passed filter rules:     1
2024/01/31 14:41:41 +02:00     Packages already synced:          0
2024/01/31 14:41:41 +02:00     Packages to sync:                 1
2024/01/31 14:41:41 +02:00     New packages to download:         1
2024/01/31 14:41:41 +02:00   Downloading packages:
2024/01/31 14:41:43 +02:00     1/1 : firefox-debuginfo-115.6.0-1.el8_9.x86_64.rpm
2024/01/31 14:41:44 +02:00 Importing packages started.
2024/01/31 14:41:44 +02:00
2024/01/31 14:41:44 +02:00   Importing packages to DB:
2024/01/31 14:41:47 +02:00 list index out of range
2024/01/31 14:41:47 +02:00   Package batch #1 of 1 completed...
2024/01/31 14:41:47 +02:00 Importing packages finished.
```

In this case, we need to check a different header attribute: (LONGFILESIZES) instead of (FILESIZES).

As example:

```console
# rpm -qp --qf "[%-50{FILENAMES} %10{FILESIZES} %10{LONGFILESIZES} %{FILEMD5S}\n]" ~/firefox-debuginfo-115.6.0-1.el8_9.x86_64.rpm
...
/usr/lib/debug/usr/lib64/firefox/libmozwayland.so-115.6.0-1.el8_9.x86_64.debug     (none)      42336 40e74fa54154cf4a8b33bc93b97ccb4b7dc654e70c63542ef43253d6df83f7f7
/usr/lib/debug/usr/lib64/firefox/libxul.so-115.6.0-1.el8_9.x86_64.debug     (none) 4468796784 72f9e36a875d716b1cbc59301bd2208805c15f738b349cd0cc85141136a960aa
/usr/lib/debug/usr/lib64/firefox/pingsender-115.6.0-1.el8_9.x86_64.debug     (none)   10645336 d92c4cb77c3601253800d9be25715981e4ae9220c61bec861591724d4319cd5c
/usr/lib/debug/usr/lib64/firefox/plugin-container-115.6.0-1.el8_9.x86_64.debug     (none)   10411632 aa48eaf5c18c90fe5a29ece018e8145397575b8b620bbc93eb73f239fc24cf19
/usr/lib/debug/usr/lib64/firefox/vaapitest-115.6.0-1.el8_9.x86_64.debug     (none)     114304 77619d5cac5ff142462a7e8c6ca9135b72f66fc9c29d2a00eb6d94e06cb62a10
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **we have no backend tests yet around rpmFile, headerSource**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23419
Port(s): https://github.com/SUSE/spacewalk/pull/23605

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
