### PR TITLE
Replace Uyuni configuration formula with an API call

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.frontend.xmlrpc.activationkey.ActivationKeyHandler;
+import com.redhat.rhn.frontend.xmlrpc.admin.configuration.AdminConfigurationHandler;
 import com.redhat.rhn.frontend.xmlrpc.admin.monitoring.AdminMonitoringHandler;
 import com.redhat.rhn.frontend.xmlrpc.ansible.AnsibleHandler;
 import com.redhat.rhn.frontend.xmlrpc.api.ApiHandler;
@@ -149,18 +150,29 @@ public class HandlerFactory {
         SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
                 systemManager, serverGroupManager, GlobalInstanceHolder.PAYG_MANAGER);
 
+        OrgHandler orgHandler = new OrgHandler(migrationManager);
+        ServerGroupHandler serverGroupHandler = new ServerGroupHandler(xmlRpcSystemHelper, serverGroupManager);
+        UserHandler userHandler = new UserHandler(serverGroupManager);
+        ActivationKeyHandler activationKeyHandler = new ActivationKeyHandler(serverGroupManager);
+        ChannelHandler channelHandler = new ChannelHandler();
+        ChannelSoftwareHandler channelSoftwareHandler = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        AdminConfigurationHandler adminConfigurationHandler = new AdminConfigurationHandler(
+                                  orgHandler, serverGroupHandler, userHandler, activationKeyHandler,
+                                  systemHandler, channelHandler, channelSoftwareHandler, saltApi);
+
         factory.addHandler("actionchain", new ActionChainHandler());
-        factory.addHandler("activationkey", new ActivationKeyHandler(serverGroupManager));
+        factory.addHandler("activationkey", activationKeyHandler);
+        factory.addHandler("admin.configuration", adminConfigurationHandler);
         factory.addHandler("admin.monitoring", new AdminMonitoringHandler());
         factory.addHandler("admin.payg", new AdminPaygHandler(taskomaticApi));
         factory.addHandler("ansible", new AnsibleHandler(new AnsibleManager(GlobalInstanceHolder.SALT_API)));
         factory.addHandler("api", new ApiHandler(factory));
         factory.addHandler("audit", new CVEAuditHandler());
         factory.addHandler("auth", new AuthHandler());
-        factory.addHandler("channel", new ChannelHandler());
+        factory.addHandler("channel", channelHandler);
         factory.addHandler("channel.access", new ChannelAccessHandler());
         factory.addHandler("channel.org", new ChannelOrgHandler());
-        factory.addHandler("channel.software", new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper));
+        factory.addHandler("channel.software", channelSoftwareHandler);
         factory.addHandler("configchannel", new ConfigChannelHandler());
         factory.addHandler("contentmanagement", new ContentManagementHandler());
         factory.addHandler("distchannel", new DistChannelHandler());
@@ -180,7 +192,7 @@ public class HandlerFactory {
         factory.addHandler("kickstart.snippet", new SnippetHandler());
         factory.addHandler("kickstart.tree", new KickstartTreeHandler());
         factory.addHandler("maintenance", new MaintenanceHandler());
-        factory.addHandler("org", new OrgHandler(migrationManager));
+        factory.addHandler("org", orgHandler);
         factory.addHandler("org.trusts", new OrgTrustHandler());
         factory.addHandler("packages", new PackagesHandler());
         factory.addHandler("packages.provider", new PackagesProviderHandler());
@@ -207,10 +219,10 @@ public class HandlerFactory {
         factory.addHandler("system.scap", new SystemScapHandler());
         factory.addHandler("system.search", new SystemSearchHandler());
         factory.addHandler("virtualhostmanager", new VirtualHostManagerHandler());
-        factory.addHandler("systemgroup", new ServerGroupHandler(xmlRpcSystemHelper, serverGroupManager));
+        factory.addHandler("systemgroup", serverGroupHandler);
         factory.addHandler("taskomatic", new TaskomaticHandler());
         factory.addHandler("taskomatic.org", new TaskomaticOrgHandler());
-        factory.addHandler("user", new UserHandler(serverGroupManager));
+        factory.addHandler("user", userHandler);
         factory.addHandler("user.external", new UserExternalHandler());
         return factory;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/AdminConfigurationHandler.java
@@ -1,0 +1,525 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.admin.configuration;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.token.ActivationKey;
+import com.redhat.rhn.domain.token.TokenPackage;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.ChannelTreeNode;
+import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.LookupServerGroupException;
+import com.redhat.rhn.frontend.xmlrpc.UserLoginException;
+import com.redhat.rhn.frontend.xmlrpc.ValidationException;
+import com.redhat.rhn.frontend.xmlrpc.activationkey.ActivationKeyHandler;
+import com.redhat.rhn.frontend.xmlrpc.channel.ChannelHandler;
+import com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler;
+import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
+import com.redhat.rhn.frontend.xmlrpc.system.SystemHandler;
+import com.redhat.rhn.frontend.xmlrpc.systemgroup.ServerGroupHandler;
+import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
+import com.redhat.rhn.frontend.xmlrpc.user.XmlRpcUserHelper;
+import com.redhat.rhn.manager.user.UserManager;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.security.auth.login.LoginException;
+
+/**
+ * AdminConfigurationHandler
+ * @apidoc.namespace admin.configuration
+ * @apidoc.doc Provides methods to configure the #product() server.
+ */
+public class AdminConfigurationHandler extends BaseHandler {
+    private static final Logger LOG = LogManager.getLogger(AdminConfigurationHandler.class);
+    private final OrgHandler orgHandler;
+    private final ServerGroupHandler serverGroupHandler;
+    private final UserHandler userHandler;
+    private final ActivationKeyHandler activationKeyHandler;
+    private final SystemHandler systemHandler;
+    private final ChannelHandler channelHandler;
+    private final ChannelSoftwareHandler channelSoftwareHandler;
+    private final SaltApi saltApi;
+
+    /**
+     * @param orgHandlerIn OrgHandler
+     * @param serverGroupHandlerIn ServerGroupHandler
+     * @param userHandlerIn UserHandler
+     * @param activationKeyHandlerIn ActivationKeyHandler
+     * @param systemHandlerIn SystemHandler
+     * @param channelHandlerIn ChannelHandler
+     * @param channelSoftwareHandlerIn ChannelSoftwareHandler
+     * @param saltApiIn SaltApi
+     */
+    public AdminConfigurationHandler(OrgHandler orgHandlerIn,
+                        ServerGroupHandler serverGroupHandlerIn,
+                        UserHandler userHandlerIn,
+                        ActivationKeyHandler activationKeyHandlerIn,
+                        SystemHandler systemHandlerIn,
+                        ChannelHandler channelHandlerIn,
+                        ChannelSoftwareHandler channelSoftwareHandlerIn,
+                        SaltApi saltApiIn) {
+         orgHandler = orgHandlerIn;
+         serverGroupHandler = serverGroupHandlerIn;
+         userHandler = userHandlerIn;
+         activationKeyHandler = activationKeyHandlerIn;
+         systemHandler = systemHandlerIn;
+         channelHandler = channelHandlerIn;
+         channelSoftwareHandler = channelSoftwareHandlerIn;
+         saltApi = saltApiIn;
+    }
+
+
+
+    private Long createOrUpdateOrg(User loggedInUser, String orgName, String adminLogin,
+            String adminPassword, String firstName, String lastName,
+            String email) {
+
+        Org org = OrgFactory.lookupByName(orgName);
+        if (org == null) {
+            LOG.debug("Org {} not found", orgName);
+            Long orgId = orgHandler.create(loggedInUser, orgName, adminLogin, adminPassword,
+                 "Mr.", firstName, lastName, email, false).getId();
+            LOG.debug("Organization {}, id: {} created, admin: {}", orgName, orgId, adminLogin);
+            return orgId;
+        }
+        LOG.debug("Org {} found", orgName);
+        return org.getId();
+    }
+
+    private User updateAdminUser(String adminLogin,
+            String adminPassword, String firstName, String lastName,
+            String email) {
+        try {
+            User user = UserManager.loginReadOnlyUser(adminLogin, adminPassword);
+
+            if (!firstName.equals(user.getFirstNames()) ||
+                !lastName.equals(user.getLastName()) || !email.equals(user.getEmail())) {
+                Map<String, String> details = new HashMap<>();
+                details.put("password", adminPassword);
+                details.put("first_name", firstName);
+                details.put("last_name", lastName);
+                details.put("email", email);
+                userHandler.setDetails(user, adminLogin, details);
+                LOG.debug("User {} details updated: {} {}, {}", adminLogin, firstName, lastName, email);
+            }
+            return user;
+        }
+        catch (LoginException e) {
+            // Convert to fault exception
+            throw new UserLoginException(e.getMessage());
+        }
+    }
+
+    private void createOrUpdateGroup(User loggedInUser, String name, String description,
+                                     String target, String targetType) {
+        try {
+            ServerGroup currentGroup = serverGroupHandler.getDetails(loggedInUser, name);
+            LOG.debug("Group {} already exists", currentGroup.getName());
+        }
+        catch (LookupServerGroupException e) {
+            serverGroupHandler.create(loggedInUser, name, description);
+            LOG.debug("Group {} created", name);
+        }
+        if (target == null || targetType == null || target.isEmpty() || targetType.isEmpty()) {
+            // do not call salt to get system list
+            return;
+        }
+
+        List<Long> currentSystems = serverGroupHandler.listSystemsMinimal(loggedInUser, name).stream()
+                .map(system -> system.getId())
+                .collect(Collectors.toList());
+
+        Map<String, Long> minionIdMap = systemHandler.getMinionIdMap(loggedInUser);
+        LOG.debug("Minion map {}", minionIdMap);
+        List<String> minions = saltApi.selectMinions(target, targetType);
+        LOG.debug("Selected minions {}", minions);
+        List<Long> selectedMinionIds = minions.stream()
+                .map(minionIdMap::get)
+                .filter(id -> id != null)
+                .collect(Collectors.toList());
+
+        List<Long> toAdd = new ArrayList<>();
+        for (Long id: selectedMinionIds) {
+            if (!currentSystems.contains(id)) {
+                toAdd.add(id);
+            }
+        }
+        LOG.debug("System IDs to add: {}", toAdd);
+        if (!toAdd.isEmpty()) {
+            serverGroupHandler.addOrRemoveSystems(loggedInUser, name, toAdd, true);
+        }
+
+        List<Long> toRemove = new ArrayList<>();
+        for (Long id: currentSystems) {
+            if (!selectedMinionIds.contains(id)) {
+                toRemove.add(id);
+            }
+        }
+        LOG.debug("System IDs to remove: {}", toRemove);
+        if (!toRemove.isEmpty()) {
+            serverGroupHandler.addOrRemoveSystems(loggedInUser, name, toRemove, false);
+        }
+    }
+
+    private void createOrUpdateUser(User loggedInUser, String name, String password, String email,
+                                    String firstName, String lastName, List<String> roles,
+                                    List<String> systemGroups, List<String> manageableChannels,
+                                    List<String> subscribableChannels) {
+        try {
+            Map<String, Object> existing = userHandler.getDetails(loggedInUser, name);
+
+            LOG.debug("User {} found", name);
+            if (!password.equals(existing.get("password")) || !firstName.equals(existing.get("first_name")) ||
+                !lastName.equals(existing.get("last_name")) || !email.equals(existing.get("email"))) {
+                Map<String, String> details = new HashMap<>();
+                details.put("password", password);
+                details.put("first_name", firstName);
+                details.put("last_name", lastName);
+                details.put("email", email);
+                userHandler.setDetails(loggedInUser, name, details);
+            }
+        }
+        catch (Exception e) {
+            userHandler.create(loggedInUser, name, password, firstName, lastName, email, 0);
+            LOG.debug("User {} created", name);
+        }
+
+        List<Object> existingRoles = Arrays.asList(userHandler.listRoles(loggedInUser, name));
+        LOG.debug("existing roles: {}", existingRoles);
+        LOG.debug("requested roles: {}", roles);
+        for (Object role: existingRoles) {
+            if (!roles.contains(role)) {
+                LOG.debug("Removing role {}", role);
+                userHandler.removeRole(loggedInUser, name, (String)role);
+            }
+        }
+        for (String role: roles) {
+            if (!existingRoles.contains(role)) {
+                LOG.debug("Adding role {}", role);
+                userHandler.addRole(loggedInUser, name, role);
+            }
+        }
+
+        User target = XmlRpcUserHelper.getInstance().lookupTargetUser(loggedInUser, name);
+        List<String> existingGroups = ServerGroupFactory.listAdministeredServerGroups(target).stream()
+                 .map(group -> group.getName())
+                 .collect(Collectors.toList());
+        LOG.debug("existing groups: {}", existingGroups);
+        LOG.debug("requested groups: {}", systemGroups);
+        List<String> toAdd = new ArrayList<>();
+        for (String group: systemGroups) {
+            if (!existingGroups.contains(group)) {
+                toAdd.add(group);
+            }
+        }
+        LOG.debug("groups to add: {}", toAdd);
+        if (!toAdd.isEmpty()) {
+            userHandler.addAssignedSystemGroups(loggedInUser, name, toAdd, false);
+        }
+
+        List<String> toRemove = new ArrayList<>();
+        for (String group: existingGroups) {
+            if (!systemGroups.contains(group)) {
+                toRemove.add(group);
+            }
+        }
+        LOG.debug("groups to remove: {}", toRemove);
+        if (!toRemove.isEmpty()) {
+            userHandler.removeAssignedSystemGroups(loggedInUser, name, toRemove, false);
+        }
+
+        List<String> existingManageableChannels = Arrays.stream(channelHandler.listManageableChannels(target))
+                 .map(c -> ((ChannelTreeNode)c).getChannelLabel())
+                 .collect(Collectors.toList());
+
+        LOG.debug("existing manageable channels: {}", existingManageableChannels);
+        LOG.debug("requested manageable channels: {}", manageableChannels);
+
+        for (String channel: existingManageableChannels) {
+            if (!manageableChannels.contains(channel)) {
+                LOG.debug("Removing manageable channel {}", channel);
+                channelSoftwareHandler.setUserManageable(loggedInUser, channel, name, false);
+            }
+        }
+        for (String channel: manageableChannels) {
+            if (!existingManageableChannels.contains(channel)) {
+                LOG.debug("Adding manageable channel {}", channel);
+                channelSoftwareHandler.setUserManageable(loggedInUser, channel, name, true);
+            }
+        }
+
+        List<String> existingSubscribableChannels = Arrays.stream(channelHandler.listMyChannels(target))
+                 .map(c -> ((ChannelTreeNode)c).getChannelLabel())
+                 .collect(Collectors.toList());
+
+        LOG.debug("existing subscribable channels: {}", existingSubscribableChannels);
+        LOG.debug("requested subscribable channels: {}", subscribableChannels);
+
+        for (String channel: existingSubscribableChannels) {
+            if (!subscribableChannels.contains(channel)) {
+                LOG.debug("Removing subscribable channel {}", channel);
+                channelSoftwareHandler.setUserSubscribable(loggedInUser, channel, name, false);
+            }
+        }
+        for (String channel: subscribableChannels) {
+            if (!existingSubscribableChannels.contains(channel)) {
+                LOG.debug("Adding subscribable channel {}", channel);
+                channelSoftwareHandler.setUserSubscribable(loggedInUser, channel, name, true);
+            }
+        }
+    }
+
+    private void createOrUpdateActivationKey(User loggedInUser, Long orgId, String name, String description,
+                                             String baseChannel, List<String> childChannels, List<Map<String,
+                                             String>> packages, List<String> serverGroups, Integer usageLimit,
+                                             List<String> systemTypes, String contactMethod,
+                                             Boolean configureAfterRegistration, List<String> configurationChannels) {
+
+        String key = String.format("%d-%s", orgId, name);
+        try {
+            ActivationKey details = activationKeyHandler.getDetails(loggedInUser, key);
+            LOG.debug("Activation Key found: {} {}", name, details.getNote());
+
+            if (!description.equals(details.getNote()) ||
+                !baseChannel.equals(details.getBaseChannel().getLabel()) ||
+                usageLimit != details.getUsageLimit().intValue() ||
+                !contactMethod.equals(details.getContactMethod().getName())) {
+
+                LOG.debug("Updating Activation Key details: {}", name);
+                Map<String, Object> newDetails = new HashMap<>();
+                newDetails.put("description", description);
+                newDetails.put("base_channel_label", baseChannel);
+                newDetails.put("usage_limit", usageLimit);
+                newDetails.put("contact_method", contactMethod);
+                activationKeyHandler.setDetails(loggedInUser, key, newDetails);
+            }
+        }
+        catch (Exception e) {
+            LOG.debug("Activation Key not found");
+            activationKeyHandler.create(loggedInUser, name, description,
+                baseChannel, usageLimit, systemTypes, configureAfterRegistration);
+            LOG.debug("Activation Key created");
+        }
+
+        ActivationKey details = activationKeyHandler.getDetails(loggedInUser, key);
+        LOG.debug("base channel: {}", details.getBaseChannel().getLabel());
+        LOG.debug("requested child channels: {}", childChannels);
+        List<String> channelsToAdd = new ArrayList<>(childChannels);
+        List<String> channelsToRemove = new ArrayList<>();
+        for (Channel c : details.getChannels()) {
+            if (!c.isBaseChannel()) {
+                 if (!childChannels.contains(c.getLabel())) {
+                     channelsToRemove.add(c.getLabel());
+                 }
+                 else {
+                     channelsToAdd.remove(c.getLabel());
+                 }
+            }
+        }
+        LOG.debug("channels to remove: {}", channelsToRemove);
+        LOG.debug("channels to add: {}", channelsToAdd);
+        activationKeyHandler.removeChildChannels(loggedInUser, key, channelsToRemove);
+        activationKeyHandler.addChildChannels(loggedInUser, key, channelsToAdd);
+
+
+        LOG.debug("requested packages: {}", packages);
+        List<Map<String, String>> packagesToAdd = new ArrayList<>(packages);
+        List<Map<String, String>> packagesToRemove = new ArrayList<>();
+        for (TokenPackage pkg : details.getPackages()) {
+            Map<String, String> pkgMap = new HashMap<>();
+            pkgMap.put("name", pkg.getPackageName().getName());
+
+            if (pkg.getPackageArch() != null) {
+                pkgMap.put("arch", pkg.getPackageArch().getLabel());
+            }
+            if (!packages.contains(pkgMap)) {
+                packagesToRemove.add(pkgMap);
+            }
+            else {
+                packagesToAdd.remove(pkgMap);
+            }
+        }
+        LOG.debug("packages to remove: {}", packagesToRemove);
+        LOG.debug("packages to add: {}", packagesToAdd);
+        activationKeyHandler.removePackages(loggedInUser, key, packagesToRemove);
+        activationKeyHandler.addPackages(loggedInUser, key, packagesToAdd);
+
+
+        LOG.debug("requested server groups: {}", serverGroups);
+        List<String> serverGroupsToAdd = new ArrayList<>(serverGroups);
+        List<Integer> serverGroupsToRemove = new ArrayList<>();
+        for (ServerGroup group : details.getServerGroups()) {
+            if (!serverGroups.contains(group.getName())) {
+                serverGroupsToRemove.add(group.getId().intValue());
+            }
+            else {
+                serverGroupsToAdd.remove(group.getName());
+            }
+        }
+
+        LOG.debug("server groups to remove: {}", serverGroupsToRemove);
+        LOG.debug("server groups to add: {}", serverGroupsToAdd);
+        activationKeyHandler.removeServerGroups(loggedInUser, key, serverGroupsToRemove);
+        activationKeyHandler.addServerGroups(loggedInUser, key,
+                 serverGroupsToAdd.stream()
+                 .map(groupName -> serverGroupHandler.getDetails(loggedInUser, groupName).getId().intValue())
+                 .collect(Collectors.toList()));
+        LOG.debug("Configuration channels: {}", configurationChannels);
+        activationKeyHandler.setConfigChannels(loggedInUser, Arrays.asList(key), configurationChannels);
+    }
+
+    /**
+     * Configure the server.
+     * @param loggedInUser the current user
+     * @param content the Uyuni configuration formula data
+     * @return 1 on success
+     *
+     * @apidoc.doc Configure server.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("map", "content", "the Uyuni configuration formula data")
+     * @apidoc.returntype #return_int_success()
+     */
+    public int configure(User loggedInUser, Map<String, Object> content) {
+        ensureSatAdmin(loggedInUser);
+
+        Map<String, Object> uyuniData = (Map<String, Object>)content.get("uyuni");
+        List<Map<String, Object>> orgList = (List<Map<String, Object>>)
+                uyuniData.getOrDefault("orgs", Collections.emptyList());
+        if (orgList == null) {
+            throw new ValidationException("Invalid org list");
+        }
+
+        for (Map<String, Object> orgData : orgList) {
+            String orgName = (String)orgData.get("org_id");
+            String adminLogin = (String)orgData.get("org_admin_user");
+            String adminPassword = (String)orgData.get("org_admin_password");
+            String firstName = (String)orgData.get("first_name");
+            String lastName = (String)orgData.get("last_name");
+            String email = (String)orgData.get("email");
+            List<Map<String, Object>> groupList = (List<Map<String, Object>>)
+                    orgData.getOrDefault("system_groups", Collections.emptyList());
+            List<Map<String, Object>> userList = (List<Map<String, Object>>)
+                    orgData.getOrDefault("users", Collections.emptyList());
+            List<Map<String, Object>> activationKeyList = (List<Map<String, Object>>)
+                    orgData.getOrDefault("activation_keys", Collections.emptyList());
+
+            if (orgName == null || adminLogin == null || adminPassword == null ||
+                firstName == null || lastName == null || email == null) {
+                throw new ValidationException("Invalid org data");
+            }
+            if (groupList == null) {
+                throw new ValidationException("Invalid group list");
+            }
+            if (userList == null) {
+                throw new ValidationException("Invalid user list");
+            }
+            if (activationKeyList == null) {
+                throw new ValidationException("Invalid activation key list");
+            }
+
+            Long orgId = createOrUpdateOrg(loggedInUser, orgName, adminLogin, adminPassword,
+                                           firstName, lastName, email);
+            User orgAdmin = updateAdminUser(adminLogin, adminPassword, firstName, lastName, email);
+
+            for (Map<String, Object> groupData : groupList) {
+                String groupName = (String)groupData.get("name");
+                String groupDescription = (String)groupData.get("description");
+                String groupTarget = (String)groupData.get("target");
+                String groupTargetType = (String)groupData.getOrDefault("target_type", "glob");
+                if (groupName == null || groupDescription == null) {
+                    throw new ValidationException("Invalid group data");
+                }
+                createOrUpdateGroup(orgAdmin, groupName, groupDescription, groupTarget, groupTargetType);
+            }
+            for (Map<String, Object> userData : userList) {
+                String userName = (String) userData.get("name");
+                String userPassword = (String) userData.get("password");
+                String userEmail = (String) userData.get("email");
+                String userFirstName = (String) userData.get("first_name");
+                String userLastName = (String) userData.get("last_name");
+                List<String> userRoles = (List<String>) userData.getOrDefault("roles", Collections.emptyList());
+                List<String> userSystemGroups = (List<String>)
+                        userData.getOrDefault("system_groups", Collections.emptyList());
+                List<String> manageableChannels = (List<String>)
+                        userData.getOrDefault("manageable_channels", Collections.emptyList());
+                List<String> subscribableChannels = (List<String>)
+                        userData.getOrDefault("subscribable_channels", Collections.emptyList());
+
+                if (userName == null || userPassword == null || userEmail == null ||
+                    userFirstName == null || userLastName == null ||
+                    userRoles == null || userSystemGroups == null ||
+                    manageableChannels == null || subscribableChannels == null) {
+                    throw new ValidationException("Invalid user data");
+                }
+
+                createOrUpdateUser(orgAdmin, userName, userPassword, userEmail, userFirstName, userLastName,
+                                   userRoles, userSystemGroups, manageableChannels, subscribableChannels);
+            }
+
+            for (Map<String, Object> activationKeyData : activationKeyList) {
+                String activationKeyName = (String) activationKeyData.get("name");
+                String activationKeyDescription = (String) activationKeyData.get("description");
+                String baseChannel = (String) activationKeyData.get("base_channel");
+                List<String> childChannels = (List<String>)
+                        activationKeyData.getOrDefault("child_channels", Collections.emptyList());
+                List<Map<String, String>> packages = (List<Map<String, String>>)
+                        activationKeyData.getOrDefault("packages", Collections.emptyList());
+                List<String> serverGroups = (List<String>)
+                        activationKeyData.getOrDefault("server_groups", Collections.emptyList());
+                Integer usageLimit = (Integer) activationKeyData.get("usage_limit");
+                List<Map<String, String>> systemTypes = (List<Map<String, String>>)
+                        activationKeyData.getOrDefault("system_types", Collections.emptyList());
+                List<String> systemTypesList = systemTypes.stream()
+                        .map(entry -> entry.get("type"))
+                        .collect(Collectors.toList());
+                String contactMethod = (String) activationKeyData.get("contact_method");
+                Boolean configureAfterRegistration = (Boolean) activationKeyData.get("configure_after_registration");
+                List<String> configurationChannels = (List<String>)
+                        activationKeyData.getOrDefault("configuration_channels", Collections.emptyList());
+
+                if (activationKeyName == null || activationKeyDescription == null || baseChannel == null ||
+                    childChannels == null || packages == null || serverGroups == null || usageLimit == null ||
+                    systemTypes == null || systemTypesList == null || contactMethod == null ||
+                    configureAfterRegistration == null || configurationChannels == null) {
+                    throw new ValidationException("Invalid activation key data");
+                }
+
+                createOrUpdateActivationKey(orgAdmin, orgId, activationKeyName, activationKeyDescription,
+                                            baseChannel, childChannels, packages, serverGroups, usageLimit,
+                                            systemTypesList, contactMethod, configureAfterRegistration,
+                                            configurationChannels);
+            }
+
+        }
+        return 1;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/AdminConfigurationHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/AdminConfigurationHandlerTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.admin.configuration.test;
+
+import static com.redhat.rhn.domain.product.test.SUSEProductTestUtils.createTestSUSEProduct;
+import static com.redhat.rhn.domain.product.test.SUSEProductTestUtils.createTestSUSEProductChannel;
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelFamily;
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelProduct;
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestVendorBaseChannel;
+import static com.redhat.rhn.testing.ErrataTestUtils.createTestVendorChildChannel;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFamily;
+import com.redhat.rhn.domain.channel.ChannelProduct;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.config.ConfigChannel;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.product.SUSEProduct;
+import com.redhat.rhn.domain.server.ManagedServerGroup;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.frontend.xmlrpc.activationkey.ActivationKeyHandler;
+import com.redhat.rhn.frontend.xmlrpc.admin.configuration.AdminConfigurationHandler;
+import com.redhat.rhn.frontend.xmlrpc.channel.ChannelHandler;
+import com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler;
+import com.redhat.rhn.frontend.xmlrpc.configchannel.ConfigChannelHandler;
+import com.redhat.rhn.frontend.xmlrpc.org.OrgHandler;
+import com.redhat.rhn.frontend.xmlrpc.system.SystemHandler;
+import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
+import com.redhat.rhn.frontend.xmlrpc.systemgroup.ServerGroupHandler;
+import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
+import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.org.MigrationManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.testing.TestUtils;
+
+
+import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
+import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class AdminConfigurationHandlerTest extends BaseHandlerTestCase {
+
+    private static final Logger LOG = LogManager.getLogger(AdminConfigurationHandlerTest.class);
+    private TaskomaticApi taskomaticApi = new TaskomaticApi();
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
+    private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
+    private RegularMinionBootstrapper regularMinionBootstrapper =
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+    private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
+            regularMinionBootstrapper,
+            sshMinionBootstrapper
+    );
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
+    );
+    private SystemManager systemManager =
+            new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
+
+    private SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper,
+                systemEntitlementManager, systemManager, serverGroupManager, GlobalInstanceHolder.PAYG_MANAGER);
+    private MigrationManager migrationManager = new MigrationManager(serverGroupManager);
+    private OrgHandler orgHandler = new OrgHandler(migrationManager);
+    private ServerGroupHandler serverGroupHandler = new ServerGroupHandler(xmlRpcSystemHelper, serverGroupManager);
+    private UserHandler userHandler = new UserHandler(serverGroupManager);
+    private ActivationKeyHandler activationKeyHandler = new ActivationKeyHandler(serverGroupManager);
+    private ChannelHandler channelHandler = new ChannelHandler();
+    private ChannelSoftwareHandler channelSoftwareHandler =
+            new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+    private AdminConfigurationHandler adminConfigurationHandler;
+    private SaltApi testSaltApi;
+
+    @RegisterExtension
+    protected final Mockery context = new JUnit5Mockery() {{
+        setThreadingPolicy(new Synchroniser());
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+    }};
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        testSaltApi = context.mock(SaltApi.class);
+        adminConfigurationHandler = new AdminConfigurationHandler(
+                                  orgHandler, serverGroupHandler, userHandler, activationKeyHandler,
+                                  systemHandler, channelHandler, channelSoftwareHandler, testSaltApi);
+    }
+
+    @Test
+    public void testAdminConfigurationHandler() throws Exception {
+
+        ChannelFamily channelFamily = createTestChannelFamily();
+        SUSEProduct product = createTestSUSEProduct(channelFamily);
+        ChannelProduct channelProduct1 = createTestChannelProduct();
+        // Create channels
+        Channel baseChannel = createTestVendorBaseChannel(channelFamily, channelProduct1);
+        baseChannel.setUpdateTag("SLE-SERVER");
+        createTestSUSEProductChannel(baseChannel, product, true);
+
+        Channel childChannel1 = createTestVendorChildChannel(baseChannel, channelProduct1);
+        Channel childChannel2 = createTestVendorChildChannel(baseChannel, channelProduct1);
+
+        createTestSUSEProductChannel(childChannel1, product, true);
+        createTestSUSEProductChannel(childChannel2, product, true);
+
+
+
+        String config = TestUtils.readAll(TestUtils.findTestData("config1.yaml"));
+        config = config.replace("BASE_CHANNEL", baseChannel.getLabel());
+        config = config.replace("CHILD_CHANNEL", childChannel1.getLabel());
+
+        config = config.replace("MANAGEABLE_CHANNEL", "");
+        config = config.replace("SUBSCRIBABLE_CHANNEL", "");
+        config = config.replace("CONFIGURATION_CHANNEL", "");
+
+        Map<String, Object> configYaml = new Yaml().load(config);
+
+        int nOrgsBefore = OrgFactory.lookupAllOrgs().size();
+        int nUsersBefore = UserFactory.getInstance().findAllUsers(Optional.empty()).size();
+
+        context.checking(new Expectations() {
+            {
+                allowing(testSaltApi).selectMinions(with("*httpd*"), with("glob"));
+                will(returnValue(Arrays.asList("httpd_server_1")));
+            }
+        });
+
+
+        // call the API for the first time
+        adminConfigurationHandler.configure(satAdmin, configYaml);
+
+        int nOrgs = OrgFactory.lookupAllOrgs().size();
+        assertEquals(nOrgs, nOrgsBefore + 2);
+
+        Org org1 = OrgFactory.lookupByName("my_org1");
+        Org org2 = OrgFactory.lookupByName("my_org2");
+
+        int nUsers = UserFactory.getInstance().findAllUsers(Optional.empty()).size();
+        assertEquals(nUsers, nUsersBefore + 4); // 2 orgs, 1 admin and 1 user each -> 4 users.
+
+        int nUsers1 = UserFactory.getInstance().findAllUsers(Optional.of(org1)).size();
+        int nUsers2 = UserFactory.getInstance().findAllUsers(Optional.of(org2)).size();
+        assertEquals(nUsers1, 2);
+        assertEquals(nUsers2, 2);
+
+
+        int nGroups1 = ServerGroupFactory.listManagedGroups(org1).size();
+        int nGroups2 = ServerGroupFactory.listManagedGroups(org2).size();
+
+        assertEquals(nGroups1, 1);
+        assertEquals(nGroups2, 1);
+
+        User admin1 = UserFactory.getInstance().findAllOrgAdmins(org1).get(0);
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(admin1);
+        minion.setMinionId("httpd_server_1");
+
+        ConfigChannelHandler cch = new ConfigChannelHandler();
+        ConfigChannel configChannel = cch.create(admin1, TestUtils.randomString(),
+                TestUtils.randomString(), TestUtils.randomString());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(admin1);
+        HibernateFactory.getSession().flush();
+
+        // the MinionServerFactoryTest.createTestMinionServer call above creates also a new group, update the number
+        nGroups1 = ServerGroupFactory.listManagedGroups(org1).size();
+
+        // call the API again
+        config = TestUtils.readAll(TestUtils.findTestData("config1.yaml"));
+        config = config.replace("BASE_CHANNEL", baseChannel.getLabel());
+        config = config.replace("CHILD_CHANNEL", childChannel1.getLabel());
+
+        config = config.replace("MANAGEABLE_CHANNEL", channel.getLabel());
+        config = config.replace("SUBSCRIBABLE_CHANNEL", channel.getLabel());
+
+        config = config.replace("CONFIGURATION_CHANNEL", configChannel.getLabel());
+        LOG.error("{}", config);
+        configYaml = new Yaml().load(config);
+        adminConfigurationHandler.configure(satAdmin, configYaml);
+
+        assertEquals(nOrgs, OrgFactory.lookupAllOrgs().size());
+
+        assertEquals(nUsers, UserFactory.getInstance().findAllUsers(Optional.empty()).size());
+
+        assertEquals(nUsers1, UserFactory.getInstance().findAllUsers(Optional.of(org1)).size());
+        assertEquals(nUsers2, UserFactory.getInstance().findAllUsers(Optional.of(org2)).size());
+
+        assertEquals(nGroups1, ServerGroupFactory.listManagedGroups(org1).size());
+        assertEquals(nGroups2, ServerGroupFactory.listManagedGroups(org2).size());
+
+        ManagedServerGroup group1 = ServerGroupFactory.lookupByNameAndOrg("httpd_servers", org1);
+        List<Server> servers1 = ServerGroupFactory.listServers(group1);
+        assertEquals(1, servers1.size());
+        assertEquals(minion.getName(), servers1.get(0).getName());
+
+        ManagedServerGroup group2 = ServerGroupFactory.lookupByNameAndOrg("httpd_servers", org2);
+        List<Server> servers2 = ServerGroupFactory.listServers(group2);
+        assertEquals(0, servers2.size());
+
+        // call the API again
+        config = TestUtils.readAll(TestUtils.findTestData("config1.yaml"));
+        config = config.replace("BASE_CHANNEL", baseChannel.getLabel());
+        config = config.replace("CHILD_CHANNEL", childChannel1.getLabel());
+
+        config = config.replace("MANAGEABLE_CHANNEL", "");
+        config = config.replace("SUBSCRIBABLE_CHANNEL", "");
+        config = config.replace("CONFIGURATION_CHANNEL", "");
+        LOG.error("{}", config);
+        configYaml = new Yaml().load(config);
+        adminConfigurationHandler.configure(satAdmin, configYaml);
+    }
+
+    @Test
+    public void testMinimal() throws Exception {
+        String config = TestUtils.readAll(TestUtils.findTestData("minimal.yaml"));
+        Map<String, Object> configYaml = new Yaml().load(config);
+
+
+        adminConfigurationHandler.configure(satAdmin, configYaml);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/config1.yaml
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/config1.yaml
@@ -1,0 +1,65 @@
+uyuni:
+  xmlrpc:
+    user: admin
+    password: admin
+  orgs:
+    - org_id: my_org1
+      org_admin_user: org_form_user
+      org_admin_password: org_form_user
+      first_name: admin org
+      last_name: admin org
+      email: admin_org@org.com
+      system_groups:
+        - name: httpd_servers
+          description: httpd_servers
+          target: "*httpd*"
+      users:
+        - name: user_form_1
+          password: user_form_1
+          email: user_form_1@teest.como
+          first_name: first
+          last_name: last
+          roles: ['config_admin']
+          system_groups: ['httpd_servers']
+          manageable_channels : [MANAGEABLE_CHANNEL]
+          subscribable_channels : [SUBSCRIBABLE_CHANNEL]
+      activation_keys:
+        - name: my_key
+          description: My Activation Key created via formula
+          base_channel: BASE_CHANNEL
+          child_channels: [CHILD_CHANNEL]
+          configuration_channels: [CONFIGURATION_CHANNEL]
+          packages:
+            - name: vim
+            - name: emacs
+              arch: x86_64
+          server_groups: ['httpd_servers']
+          usage_limit: 10
+          # HACK do to limitation on the form framework we had to have a list of objects, instead of a list o string.
+          # This was needed to allow the usage of select instead of free text.
+          system_types:
+            - type: 'virtualization_host'
+            - type: 'container_build_host'
+          contact_method: 'ssh-push'
+          universal_default: false
+          configure_after_registration: true
+    - org_id: my_org2
+      org_admin_user: my_org_user
+      org_admin_password: my_org_user
+      first_name: first_name
+      last_name: last_name__
+      email: my_org_user@org.com
+      system_groups:
+        - name: httpd_servers
+          description: httpd_servers
+          target: "*httpd*"
+      users:
+        - name: user2
+          password: user2
+          email: user1@teest.como
+          first_name: first
+          last_name: last
+          roles: []
+          system_groups: ['httpd_servers']
+          manageable_channels : []
+          subscribable_channels : []

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/minimal.yaml
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/minimal.yaml
@@ -1,0 +1,8 @@
+uyuni:
+  orgs:
+    - org_id: my_org_minimal
+      org_admin_user: org_form_user
+      org_admin_password: org_form_user
+      first_name: admin org
+      last_name: admin org
+      email: admin_org@org.com

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -497,4 +497,12 @@ public interface SaltApi {
      */
      String checkSSLCert(String rootCA, SSLCertPair serverCertKey, List<String> intermediateCAs)
              throws IllegalArgumentException;
+
+    /**
+     * Call 'mgrutil.select_minions'
+     * @param target return the minions matching the target
+     * @param targetType type of target
+     * @return list of matching minions
+     */
+     List<String> selectMinions(String target, String targetType);
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1499,4 +1499,11 @@ public class SaltService implements SystemQuery, SaltApi {
         }
         return result.get("cert");
     }
+
+    @Override
+    public List<String> selectMinions(String target, String targetType)
+            throws IllegalStateException {
+        RunnerCall<List<String>> call = MgrUtilRunner.selectMinions(target, targetType);
+        return callSync(call).orElseThrow(() -> new IllegalStateException("Can't get minion list"));
+    }
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -262,4 +262,17 @@ public class MgrUtilRunner {
         args.put("intermediate_cas", intermediateCAs);
         return new RunnerCall<>("mgrutil.check_ssl_cert", Optional.of(args), new TypeToken<>() { });
     }
+
+    /**
+     * Call 'mgrutil.select_minions'
+     * @param target return the minions matching the target
+     * @param targetType type of target
+     * @return list of matching minions
+     */
+    public static RunnerCall<List<String>> selectMinions(String target, String targetType) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("target", target);
+        args.put("target_type", targetType);
+        return new RunnerCall<>("mgrutil.select_minions", Optional.of(args), new TypeToken<List<String>>() { });
+    }
 }

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -304,4 +304,10 @@ public class TestSaltApi implements SaltApi {
                                          List<String> intermediateCAs) throws IllegalArgumentException {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public List<String> selectMinions(String target, String targetType) {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/java/spacewalk-java.changes.nadvornik.uyuni_config
+++ b/java/spacewalk-java.changes.nadvornik.uyuni_config
@@ -1,0 +1,1 @@
+- Replace Uyuni configuration formula with an API call

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import salt.utils
 import tempfile
+from salt.utils.minions import CkMinions
 
 import certs.mgr_ssl_cert_setup
 
@@ -194,3 +195,9 @@ def check_ssl_cert(root_ca, server_crt, server_key, intermediate_cas):
         return {"cert": cert}
     except certs.mgr_ssl_cert_setup.CertCheckError as err:
         return {"error": str(err)}
+
+
+def select_minions(target, target_type):
+    # pylint: disable-next=undefined-variable
+    minions = CkMinions(__opts__)
+    return minions.check_minions(expr=target, tgt_type=target_type).get("minions", [])

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.uyuni_config
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.uyuni_config
@@ -1,0 +1,1 @@
+- Replace Uyuni configuration formula with an API call


### PR DESCRIPTION
## What does this PR change?

This PR implements API call equivalent to Uyuni configuration formula.

All the logic is handled in java,  except for salt minion id matching, which is implemented
via salt runner call.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- TBD

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/22499

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
