### PR TITLE
Testsuite: remove /etc/motd contents from the server

### DIFF
--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -43,7 +43,7 @@ end
 
 def initialize_server(host, node)
   # Remove /etc/motd, or any output from node.run will contain the content of /etc/motd
-  node.run("rm -f /etc/motd && touch /etc/motd")
+  node.run('rm -f /etc/motd && touch /etc/motd')
   _out, code = node.run('which mgrctl', check_errors: false)
   node.init_has_mgrctl if code.zero?
 

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -42,6 +42,8 @@ def process_private_and_public_ip(host, node)
 end
 
 def initialize_server(host, node)
+  # Remove /etc/motd, or any output from node.run will contain the content of /etc/motd
+  node.run("rm -f /etc/motd && touch /etc/motd")
   _out, code = node.run('which mgrctl', check_errors: false)
   node.init_has_mgrctl if code.zero?
 


### PR DESCRIPTION
## What does this PR change?

Otherwise, twopence gets the output of /etc/motd on every node.run

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
- No tests
- [ ] **DONE**

## Links

N/A

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
