### PR TITLE
port to new supportconfig plugin resource file

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes.mcalmer.update-supportplugin-functions
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes.mcalmer.update-supportplugin-functions
@@ -1,0 +1,1 @@
+- port to new supportconfig resource file

--- a/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.spec
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.spec
@@ -25,6 +25,7 @@ License:        GPL-2.0-only
 Group:          Documentation/SuSE
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
+BuildRequires:  supportutils
 Requires:       supportconfig-plugin-resource
 Requires:       supportconfig-plugin-tag
 Supplements:    packageand(salt-minion:supportutils)
@@ -47,7 +48,15 @@ rm -rf $RPM_BUILD_ROOT
 install -d $RPM_BUILD_ROOT/usr/lib/supportconfig/plugins
 install -d $RPM_BUILD_ROOT/usr/share/man/man8
 install -d $RPM_BUILD_ROOT/sbin
-install -m 0544 susemanagerclient $RPM_BUILD_ROOT/usr/lib/supportconfig/plugins
+
+# if the new style rc file is available install the new version, otherwise the old one
+# Only SLE15 and newer support the new style rc file.
+# SLE12 and older only the old variant
+if [ -e /usr/lib/supportconfig/resources/supportconfig.rc ]; then
+    install -m 0544 susemanagerclient $RPM_BUILD_ROOT/usr/lib/supportconfig/plugins/susemanagerclient
+else
+    install -m 0544 susemanagerclient-scplugin $RPM_BUILD_ROOT/usr/lib/supportconfig/plugins/susemanagerclient
+fi
 install -m 0644 susemanagerclient-plugin.8.gz $RPM_BUILD_ROOT/usr/share/man/man8/susemanagerclient-plugin.8.gz
 
 %files

--- a/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
@@ -5,34 +5,21 @@
 #              about a SUSE Manager Client
 # License:     GPLv2
 # Author:      Michael Calmer <mc@suse.de>
-# Modified:    2020 November 09
+# Modified:    2024 February 03
 #############################################################
 
-SVER=4.2.0
-RCFILE="/usr/lib/supportconfig/resources/scplugin.rc"
+SVER=5.0.0
+RCFILE="/usr/lib/supportconfig/resources/supportconfig.rc"
+OF='plugin-susemanager-client.txt'
 
 [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 
-validate_rpm_if_installed() {
-    THISRPM=$1
-    echo "#==[ Validating RPM ]=================================#"
-    if rpm -q $THISRPM >/dev/null 2>&1; then
-        echo "# rpm -V $THISRPM"
+log_write $OF
+log_entry $OF note "Supportconfig Plugin for SUSE Manager Client, v${SVER}"
+addHeaderFile $OF
 
-        if rpm -V $THISRPM; then
-            echo "Status: Passed"
-        else
-            echo "Status: WARNING"
-        fi
-    else
-        echo "package $THISRPM is not installed"
-        echo "Status: Skipped"
-    fi
-    echo
-}
 
 #############################################################
-section_header "Supportconfig Plugin for SUSE Manager Client, v${SVER}"
 RPMLIST="
 spacewalk-client-tools
 spacewalk-check
@@ -47,16 +34,16 @@ uyuni-proxy-systemd-services
 "
 
 for THISRPM in $RPMLIST; do
-    validate_rpm_if_installed $THISRPM
+    rpm_verify $OF $THISRPM
 done
 
-plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib"
-plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib64"
-plugin_command "/bin/ls -l --time-style=long-iso /etc/ssl/certs/"
+log_cmd $OF "/bin/ls -l --time-style=long-iso /usr/local/lib"
+log_cmd $OF "/bin/ls -l --time-style=long-iso /usr/local/lib64"
+log_cmd $OF "/bin/ls -l --time-style=long-iso /etc/ssl/certs/"
 
-section_header "SUSE Manager Client Config Files"
+log_entry $OF note "SUSE Manager Client Config Files"
 
-pconf_files \
+conf_files $OF \
     /etc/sysconfig/rhn/up2date \
     /etc/sysconfig/rhn/osad.conf \
     /etc/sysconfig/rhn/rhncfg-client.conf \
@@ -72,47 +59,39 @@ pconf_files \
     /etc/sysconfig/uyuni-proxy-systemd-services
 
 
-section_header "SUSE Manager Client Capabilities"
+log_entry $OF note "SUSE Manager Client Log Files"
 
-find /etc/sysconfig/rhn/clientCaps.d/
+log_files $OF 1000 /var/log/salt/minion
 
-section_header "SUSE Manager Client allowed Actions"
+log_cmd $OF "zypper --no-refresh ls"
+log_cmd $OF "zypper --no-refresh lr -u"
+log_cmd $OF "salt-minion --versions-report"
 
-find /etc/sysconfig/rhn/allowed-actions/
+log_cmd $OF "cp /var/log/zypper.log $LOG"
 
-section_header "SUSE Manager Client Log Files"
-
-plog_files 1000 /var/log/up2date
-plog_files 100 /var/log/osad
-plog_files 1000 /var/log/salt/minion
-
-plugin_command "zypper --no-refresh ls"
-plugin_command "zypper --no-refresh lr -u"
-plugin_command "salt-minion --versions-report"
-
-plugin_command "cp /var/log/zypper.log $LOG"
-
-section_header "Crypto Policy"
+log_entry $OF note "Crypto Policy"
 
 if [ -f /etc/crypto-policies/config ]; then
-        plugin_command "cat /etc/crypto-policies/config"
+        log_cmd $OF "cat /etc/crypto-policies/config"
 elif [ $(cat /proc/sys/crypto/fips_enabled) -ne 0 ]; then
-        plugin_message "FIPS"
+        log_write $OF "FIPS"
 else
-        plugin_command "grep -v '#' /usr/share/crypto-policies/default-config"
+        log_cmd $OF "grep -v '#' /usr/share/crypto-policies/default-config"
 fi
 
-section_header "Proxy Containers Configuration Files"
+log_entry $OF note "Cloud / PAYG"
+log_cmd $OF "test -e /usr/bin/instance-flavor-check && /usr/bin/instance-flavor-check"
+rpm_verify $OF "python-instance-billing-flavor-check"
 
-plugin_command "ls -l /etc/uyuni/proxy/"
+####################################################################
+#### The instance where a proxy is running, is just a managed client
+####################################################################
 
-section_header "Proxy Containers Systems Status"
+log_entry $OF note "Proxy Containers Configuration Files"
 
-systemd_status() {
-    if systemctl list-unit-files $1 >/dev/null; then
-        plugin_command "systemctl status $1"
-    fi
-}
+log_cmd $OF "ls -l /etc/uyuni/proxy/"
+
+log_entry $OF note "Proxy Containers Systems Status"
 
 SERVICES="
     uyuni-proxy-pod
@@ -124,7 +103,7 @@ SERVICES="
 "
 
 for SERVICE in $SERVICES; do
-    systemd_status "$SERVICE.service"
+    check_service $OF $SERVICE
 done
 
 CONTAINERS="
@@ -136,19 +115,16 @@ CONTAINERS="
 "
 
 if which podman >/dev/null 2>&1; then
-    section_header "Proxy Containers Inspects"
+    log_entry $OF note "Proxy Containers Inspects"
 
     for CONTAINER in $CONTAINERS; do
-        plugin_command "podman inspect $CONTAINER"
+        log_cmd $OF "podman inspect $CONTAINER"
     done
 
-    section_header "Proxy Containers Logs"
+    log_entry $OF note "Proxy Containers Logs"
 
     for CONTAINER in $CONTAINERS; do
-        plugin_command "podman logs $CONTAINER"
+        log_cmd $OF "podman logs $CONTAINER"
     done
 fi
 
-section_header "Cloud / PAYG"
-plugin_command "test -e /usr/bin/instance-flavor-check && /usr/bin/instance-flavor-check"
-validate_rpm_if_installed "python-instance-billing-flavor-check"

--- a/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient-scplugin
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient-scplugin
@@ -1,0 +1,154 @@
+#!/bin/bash
+#############################################################
+# Name:        Supportconfig Plugin for SUSE Manager Client
+# Description: Gathers important troubleshooting information
+#              about a SUSE Manager Client
+# License:     GPLv2
+# Author:      Michael Calmer <mc@suse.de>
+# Modified:    2024 February 03
+#############################################################
+
+SVER=5.0.0
+RCFILE="/usr/lib/supportconfig/resources/scplugin.rc"
+
+[ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
+
+validate_rpm_if_installed() {
+    THISRPM=$1
+    echo "#==[ Validating RPM ]=================================#"
+    if rpm -q $THISRPM >/dev/null 2>&1; then
+        echo "# rpm -V $THISRPM"
+
+        if rpm -V $THISRPM; then
+            echo "Status: Passed"
+        else
+            echo "Status: WARNING"
+        fi
+    else
+        echo "package $THISRPM is not installed"
+        echo "Status: Skipped"
+    fi
+    echo
+}
+
+#############################################################
+section_header "Supportconfig Plugin for SUSE Manager Client, v${SVER}"
+RPMLIST="
+spacewalk-client-tools
+spacewalk-check
+spacewalk-client-setup
+rhnlib
+osad
+zypp-plugin-spacewalk
+salt-minion
+salt
+podman
+uyuni-proxy-systemd-services
+"
+
+for THISRPM in $RPMLIST; do
+    validate_rpm_if_installed $THISRPM
+done
+
+plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib"
+plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib64"
+plugin_command "/bin/ls -l --time-style=long-iso /etc/ssl/certs/"
+
+section_header "SUSE Manager Client Config Files"
+
+pconf_files \
+    /etc/sysconfig/rhn/up2date \
+    /etc/sysconfig/rhn/osad.conf \
+    /etc/sysconfig/rhn/rhncfg-client.conf \
+    /etc/sysconfig/rhn/rhncfg-manager.conf \
+    /etc/sysconfig/rhn/image.cfg \
+    /etc/sysconfig/rhn/rhnpushrc \
+    /etc/sysconfig/rhn/rhnsd \
+    /etc/sysconfig/rhn/systemid \
+    /etc/salt/minion \
+    /etc/salt/minion.d/susemanager.conf \
+    /etc/salt/minion.d/_schedule.conf \
+    /etc/uyuni/proxy/config.yaml \
+    /etc/sysconfig/uyuni-proxy-systemd-services
+
+
+section_header "SUSE Manager Client Capabilities"
+
+find /etc/sysconfig/rhn/clientCaps.d/
+
+section_header "SUSE Manager Client allowed Actions"
+
+find /etc/sysconfig/rhn/allowed-actions/
+
+section_header "SUSE Manager Client Log Files"
+
+plog_files 1000 /var/log/up2date
+plog_files 100 /var/log/osad
+plog_files 1000 /var/log/salt/minion
+
+plugin_command "zypper --no-refresh ls"
+plugin_command "zypper --no-refresh lr -u"
+plugin_command "salt-minion --versions-report"
+
+plugin_command "cp /var/log/zypper.log $LOG"
+
+section_header "Crypto Policy"
+
+if [ -f /etc/crypto-policies/config ]; then
+        plugin_command "cat /etc/crypto-policies/config"
+elif [ $(cat /proc/sys/crypto/fips_enabled) -ne 0 ]; then
+        plugin_message "FIPS"
+else
+        plugin_command "grep -v '#' /usr/share/crypto-policies/default-config"
+fi
+
+section_header "Proxy Containers Configuration Files"
+
+plugin_command "ls -l /etc/uyuni/proxy/"
+
+section_header "Proxy Containers Systems Status"
+
+systemd_status() {
+    if systemctl list-unit-files $1 >/dev/null; then
+        plugin_command "systemctl status $1"
+    fi
+}
+
+SERVICES="
+    uyuni-proxy-pod
+    uyuni-proxy-httpd
+    uyuni-proxy-salt-broker
+    uyuni-proxy-squid
+    uyuni-proxy-ssh
+    uyuni-proxy-tftpd
+"
+
+for SERVICE in $SERVICES; do
+    systemd_status "$SERVICE.service"
+done
+
+CONTAINERS="
+    uyuni-proxy-httpd
+    uyuni-proxy-ssh
+    uyuni-proxy-squid
+    uyuni-proxy-tftpd
+    uyuni-proxy-salt-broker
+"
+
+if which podman >/dev/null 2>&1; then
+    section_header "Proxy Containers Inspects"
+
+    for CONTAINER in $CONTAINERS; do
+        plugin_command "podman inspect $CONTAINER"
+    done
+
+    section_header "Proxy Containers Logs"
+
+    for CONTAINER in $CONTAINERS; do
+        plugin_command "podman logs $CONTAINER"
+    done
+fi
+
+section_header "Cloud / PAYG"
+plugin_command "test -e /usr/bin/instance-flavor-check && /usr/bin/instance-flavor-check"
+validate_rpm_if_installed "python-instance-billing-flavor-check"

--- a/susemanager-utils/supportutils-plugin-susemanager-proxy/supportutils-plugin-susemanager-proxy.changes.mcalmer.update-supportplugin-functions
+++ b/susemanager-utils/supportutils-plugin-susemanager-proxy/supportutils-plugin-susemanager-proxy.changes.mcalmer.update-supportplugin-functions
@@ -1,0 +1,1 @@
+- port to new supportconfig resource file

--- a/susemanager-utils/supportutils-plugin-susemanager-proxy/susemanagerproxy
+++ b/susemanager-utils/supportutils-plugin-susemanager-proxy/susemanagerproxy
@@ -5,39 +5,25 @@
 #              about SUSE Manager Proxy
 # License:     GPLv2
 # Author:      Michael Calmer <mc@suse.de>
-# Modified:    2020 November 09
+# Modified:    2024 February 03
 #############################################################
 
-SVER=4.2.0
-RCFILE="/usr/lib/supportconfig/resources/scplugin.rc"
+SVER=5.0.0
+RCFILE="/usr/lib/supportconfig/resources/supportconfig.rc"
+OF='plugin-susemanager-proxy.txt'
 LOG_LINES=500  # 0 means include the entire file
 
 [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 
-plugin_command "grep web.version /usr/share/rhn/config-defaults/rhn_web.conf"
+log_write $OF
+log_entry $OF note "Supportconfig Plugin for SUSE Manager Proxy, v${SVER}"
+addHeaderFile $OF
 
-plugin_command "hostname --fqdn"
+log_cmd $OF "grep web.version /usr/share/rhn/config-defaults/rhn_web.conf"
 
-validate_rpm_if_installed() {
-        THISRPM=$1
-        echo "#==[ Validating RPM ]=================================#"
-        if rpm -q $THISRPM >/dev/null 2>&1; then
-                echo "# rpm -V $THISRPM"
-
-                if rpm -V $THISRPM; then
-                        echo "Status: Passed"
-                else
-                        echo "Status: WARNING"
-                fi
-        else
-                echo "package $THISRPM is not installed"
-                echo "Status: Skipped"
-        fi
-        echo
-}
+log_cmd $OF "hostname --fqdn"
 
 #############################################################
-section_header "Supportconfig Plugin for SUSE Manager Proxy, v${SVER}"
 RPMLIST="
 spacewalk-backend
 spacewalk-backend-libs
@@ -57,45 +43,45 @@ SUSE-Manager-Proxy-release
 "
 
 for THISRPM in $RPMLIST; do
-        validate_rpm_if_installed $THISRPM
+        rpm_verify $OF $THISRPM
 done
 
-find_and_plog_files () {
+find_and_log_files () {
         [ -d "$1" ] || return 0
         FILES=$(find "$@" ! -name \*.gz ! -name \*.bz2 ! -name \*.xz)
         if [ -n "$FILES" ]; then
-                plog_files $LOG_LINES $FILES
+                log_files $OF $LOG_LINES $FILES
         fi
 }
 
-section_header "SUSE Manager Proxy Config Files"
+log_entry $OF note "SUSE Manager Proxy Config Files"
 
-pconf_files \
+conf_files $OF \
     /etc/rhn/rhn.conf \
     /etc/squid/squid.conf
 
-section_header "SUSE Manager Proxy Log Files"
+log_entry $OF note "SUSE Manager Proxy Log Files"
 
-find_and_plog_files /var/log/rhn -type f
-find_and_plog_files /var/log/squid -type f
-find_and_plog_files /var/log/apache2 -type f
-find_and_plog_files /var/log/salt -type f
+find_and_log_files /var/log/rhn -type f
+find_and_log_files /var/log/squid -type f
+find_and_log_files /var/log/apache2 -type f
+find_and_log_files /var/log/salt -type f
 
-section_header "SSL Configuration"
+log_entry $OF note "SSL Configuration"
 
-pconf_files $(spacewalk-cfg-get documentroot)/pub/RHN-ORG-TRUSTED-SSL-CERT \
+conf_files $OF $(spacewalk-cfg-get documentroot)/pub/RHN-ORG-TRUSTED-SSL-CERT \
             /etc/apache2/ssl.crt/server.crt
 
-section_header "Crypto Policy"
+log_entry $OF note "Crypto Policy"
 
 if [ -f /etc/crypto-policies/config ]; then
-        plugin_command "cat /etc/crypto-policies/config"
+        log_cmd $OF "cat /etc/crypto-policies/config"
 elif [ $(cat /proc/sys/crypto/fips_enabled) -ne 0 ]; then
-        plugin_message "FIPS"
+        log_write $OF "FIPS"
 else
-        plugin_command "grep -v '#' /usr/share/crypto-policies/default-config"
+        log_cmd $OF "grep -v '#' /usr/share/crypto-policies/default-config"
 fi
 
-plugin_command "zypper --no-refresh ls"
-plugin_command "zypper --no-refresh lr -u"
+log_cmd $OF "zypper --no-refresh ls"
+log_cmd $OF "zypper --no-refresh lr -u"
 

--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.mcalmer.update-supportplugin-functions
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.mcalmer.update-supportplugin-functions
@@ -1,0 +1,1 @@
+- port to new supportconfig resource file

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager
@@ -6,19 +6,22 @@
 # License:     GPLv2
 # Author:      Stefan Bogner <sbogner@suse.com>
 #              Michael Calmer <mc@suse.com>
-# Modified:    2020 November 09
+# Modified:    2024 February 03
 #############################################################
 
-SVER=4.2.0
-RCFILE="/usr/lib/supportconfig/resources/scplugin.rc"
+SVER=5.0.0
+RCFILE="/usr/lib/supportconfig/resources/supportconfig.rc"
+OF='plugin-susemanager.txt'
 
 [ -s $RCFILE ] && . $RCFILE || { echo "ERROR: Initializing resource file: $RCFILE"; exit 1; }
 
-section_header "Supportconfig Plugin for SUSE Manager, v${SVER}"
+log_write $OF
+log_entry $OF note "Supportconfig Plugin for SUSE Manager, v${SVER}"
+addHeaderFile $OF
 
-plugin_command "grep web.version /usr/share/rhn/config-defaults/rhn_web.conf"
+log_cmd $OF "grep web.version /usr/share/rhn/config-defaults/rhn_web.conf"
 
-plugin_command "hostname --fqdn"
+log_cmd $OF "hostname --fqdn"
 
 RPMLIST="
 susemanager-tools
@@ -29,7 +32,7 @@ sle-module-suse-manager-server-release
 salt-minion
 salt
 "
-DAEMONLIST="susemanager tomcat osa-dispatcher postgresql"
+DAEMONLIST="tomcat taskomatic postgresql rhn-search cobblerd apache2 salt-api salt-master"
 
 if ! rpm -q susemanager &>/dev/null; then
   echo "ERROR: SUSE Manager package(s) not installed"
@@ -39,69 +42,75 @@ fi
 
 for THISRPM in $RPMLIST
 do
-   validate_rpm $THISRPM
+   rpm_verify $OF $THISRPM
 done
 
 for i in $DAEMONLIST
 do
-    plugin_command "systemctl status $i"
+    log_cmd $OF "systemctl status $i"
 done
 
-plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib"
-plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib64"
+log_cmd $OF "/bin/ls -l --time-style=long-iso /usr/local/lib"
+log_cmd $OF "/bin/ls -l --time-style=long-iso /usr/local/lib64"
 
-plugin_command "find /usr/share/susemanager/www/tomcat/webapps/rhn/WEB-INF/lib/ | xargs file | grep broken"
-plugin_command "find /usr/share/spacewalk/taskomatic/ | xargs file | grep broken"
-plugin_command "find /usr/share/rhn/search/lib/ | xargs file | grep broken"
+log_cmd $OF "find /usr/share/susemanager/www/tomcat/webapps/rhn/WEB-INF/lib/ | xargs file | grep broken"
+log_cmd $OF "find /usr/share/spacewalk/taskomatic/ | xargs file | grep broken"
+log_cmd $OF "find /usr/share/rhn/search/lib/ | xargs file | grep broken"
 
-section_header "SSL Configuration"
+log_entry $OF note "SSL Configuration"
 
-pconf_files $(spacewalk-cfg-get documentroot)/pub/RHN-ORG-TRUSTED-SSL-CERT \
-            /etc/apache2/ssl.crt/server.crt
-plugin_command "/bin/ls -l --time-style=long-iso /etc/ssl/certs/"
+conf_files $OF $(spacewalk-cfg-get documentroot)/pub/RHN-ORG-TRUSTED-SSL-CERT \
+            /etc/pki/tls/certs/spacewalk.crt
+log_cmd $OF "/bin/ls -l --time-style=long-iso /etc/ssl/certs/"
 
-plugin_command "/bin/ls -l --time-style=long-iso $(spacewalk-cfg-get documentroot)/pub/ | grep -i trusted"
+log_cmd $OF "/bin/ls -l --time-style=long-iso $(spacewalk-cfg-get documentroot)/pub/ | grep -i trusted"
 
-section_header "Crypto Policy"
+log_entry $OF note "Crypto Policy"
 
 if [ -f /etc/crypto-policies/config ]; then
-	plugin_command "cat /etc/crypto-policies/config"
+	log_cmd $OF "cat /etc/crypto-policies/config"
 elif [ $(cat /proc/sys/crypto/fips_enabled) -ne 0 ]; then
-	plugin_message "FIPS"
+	log_write $OF "FIPS"
 else
-	plugin_command "grep -v '#' /usr/share/crypto-policies/default-config"
+	log_cmd $OF "grep -v '#' /usr/share/crypto-policies/default-config"
 fi
 
 
-plugin_command "psql --version"
-plugin_command "cat /var/lib/pgsql/data/PG_VERSION"
-plugin_command "zypper --no-refresh ls"
-plugin_command "zypper --no-refresh lr -u"
-plugin_command "/usr/lib/susemanager/bin/susemanager-connection-check"
-plugin_command "salt-master --versions-report"
+log_cmd $OF "psql --version"
+log_cmd $OF "cat /var/lib/pgsql/data/PG_VERSION"
+log_cmd $OF "zypper --no-refresh ls"
+log_cmd $OF "zypper --no-refresh lr -u"
+log_cmd $OF "/usr/lib/susemanager/bin/susemanager-connection-check"
+log_cmd $OF "salt-master --versions-report"
 
-plugin_command "echo \"select username scc_org from susecredentials sc where sc.type = 'scc';\" | spacewalk-sql --select-mode-direct -"
+log_cmd $OF "spacewalk-sql --select-mode-direct - <<< \"select username scc_org from susecredentials sc where sc.type = 'scc';\""
 
-plugin_command "echo \"Number of elements in table susesaltevent. If the next number is too high, please verify the large scale tuning guide property 'java.salt_event_thread_pool_size'.\""
-plugin_command "echo \"select count(*) from susesaltevent;\" | spacewalk-sql --select-mode-direct -"
-plugin_command "grep \"Client bootstrap script\" /srv/www/htdocs/pub/bootstrap/*.sh"
+log_write $OF "# Number of elements in table susesaltevent. If the next number is too high, please verify the large scale tuning guide property 'java.salt_event_thread_pool_size'."
+log_cmd $OF "spacewalk-sql --select-mode-direct - <<< \"select count(*) from susesaltevent;\""
+log_cmd $OF "grep \"Client bootstrap script\" /srv/www/htdocs/pub/bootstrap/*.sh"
 
-section_header "Cloud / PAYG"
-plugin_command "/usr/bin/instance-flavor-check"
-if [ -e /usr/bin/instance-flavor-check -a $(/usr/bin/instance-flavor-check) == "PAYG" ]; then
-        validate_rpm "python-instance-billing-flavor-check"
-        validate_rpm "billing-data-service"
-        validate_rpm "csp-billing-adapter-service"
-        validate_rpm "python3-csp-billing-adapter"
-        validate_rpm "python3-csp-billing-adapter-local"
-        validate_rpm "python3-csp-billing-adapter-amazon"
-        validate_rpm "suma-amazon-adapter-config-llc"
-        validate_rpm "suma-amazon-adapter-config-ltd"
-        validate_rpm "python3-csp-billing-adapter-azure"
-        validate_rpm "suma-azure-adapter-config-llc"
-        validate_rpm "suma-azure-adapter-config-ltd"
+log_entry $OF note "Cloud / PAYG"
+if [ -x /usr/bin/instance-flavor-check ]; then
+        log_cmd $OF "/usr/bin/instance-flavor-check"
+        if [ $(/usr/bin/instance-flavor-check) == "PAYG" ]; then
+                validate_rpm "python-instance-billing-flavor-check"
+                validate_rpm "billing-data-service"
+                validate_rpm "csp-billing-adapter-service"
+                validate_rpm "python3-csp-billing-adapter"
+                validate_rpm "python3-csp-billing-adapter-local"
+                validate_rpm "python3-csp-billing-adapter-amazon"
+                validate_rpm "suma-amazon-adapter-config-llc"
+                validate_rpm "suma-amazon-adapter-config-ltd"
+                validate_rpm "python3-csp-billing-adapter-azure"
+                validate_rpm "suma-azure-adapter-config-llc"
+                validate_rpm "suma-azure-adapter-config-ltd"
+        else
+                log_write $OF "Not a PAYG Instance"
+        fi
+else
+        log_write $OF "Not a Cloud Instance"
 fi
 
-plugin_command "/sbin/supportconfig-sumalog $LOG"
-plugin_command "cp /var/log/zypper.log $LOG"
+log_cmd $OF "/sbin/supportconfig-sumalog $LOG"
+log_cmd $OF "cp /var/log/zypper.log $LOG"
 


### PR DESCRIPTION
## What does this PR change?

With ALP only the new style supportconfig plugin resource file will be supported.
Time to migrate it.
It is available since SLE15 GA.
We can already use it when running Server and Proxy on SLE15.

Just for clients we need both versions as SLE12 and older support only the old style format

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): Not (yet) ported. Not need as 4.3 server and proxy will stay on SLE15 and client will switch to this version as soon as 5.0 gets released. Depends on when we want to start supporting SLE-Micro 6.0

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
