### PR TITLE
reposync: import GPG keys to RPM DB individually (bsc#1217003)

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -64,6 +64,7 @@ import xml.etree.ElementTree as etree
 
 from functools import cmp_to_key
 from salt.utils.versions import LooseVersion
+from shlex import quote as sh_quote
 from uyuni.common import checksum, fileutils
 from spacewalk.common import rhnLog
 from spacewalk.satellite_tools.repo_plugins import ContentPackage, CACHE_DIR
@@ -146,22 +147,47 @@ class ZyppoSync:
         This method does update the Zypper RPM database with new keys coming from the Spacewalk GPG keyring
 
         """
+
+        def _log_command(args):
+            log(3, " ".join([sh_quote(x) for x in args]))
+
         spacewalk_gpg_keys = {}
         zypper_gpg_keys = {}
-        with tempfile.NamedTemporaryFile() as f:
+
+        with tempfile.TemporaryDirectory() as temp_dir:
             # Collect GPG keys from the Spacewalk GPG keyring
             # The '--export-options export-clean' is needed avoid exporting key signatures
             # which are not needed and can cause issues when importing into the RPMDB
-            os.system(
-                # pylint: disable-next=consider-using-f-string
-                "gpg -q --batch --no-options --no-default-keyring --no-permission-warning --keyring {} --export --export-options export-clean -a > {}".format(
-                    SPACEWALK_GPG_KEYRING, f.name
-                )
-            )
+            all_keys_file = os.path.join(temp_dir, "_all_keys.gpg")
+            args = [
+                "gpg",
+                "-q",
+                "--batch",
+                "--no-options",
+                "--no-default-keyring",
+                "--no-permission-warning",
+                "--keyring",
+                SPACEWALK_GPG_KEYRING,
+                "--export",
+                "--export-options",
+                "export-clean",
+                "--with-colons",
+                "-a",
+                "--output",
+                all_keys_file,
+            ]
+            _log_command(args)
+            # pylint: disable-next=subprocess-run-check
+            process = subprocess.run(args)
+            args = [
+                "gpg",
+                "--verbose",
+                "--with-colons",
+                all_keys_file,
+            ]
+            _log_command(args)
             process = subprocess.Popen(
-                ["gpg", "--verbose", "--with-colons", f.name],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
+                args, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
             )
             for line in process.stdout.readlines():
                 line_l = line.decode().split(":")
@@ -176,16 +202,21 @@ class ZyppoSync:
             )
 
             # Collect GPG keys from reposync Zypper RPM database
-            process = subprocess.Popen(
-                ["rpm", "-q", "gpg-pubkey", "--dbpath", REPOSYNC_ZYPPER_RPMDB_PATH],
-                stdout=subprocess.PIPE,
-            )
+            args = ["rpm", "-q", "gpg-pubkey", "--dbpath", REPOSYNC_ZYPPER_RPMDB_PATH]
+            _log_command(args)
+            process = subprocess.Popen(args, stdout=subprocess.PIPE)
             for line in process.stdout.readlines():
                 match = RPM_PUBKEY_VERSION_RELEASE_RE.match(line.decode())
                 if match:
                     zypper_gpg_keys[match.groups()[0]] = match.groups()[1]
             # pylint: disable-next=consider-using-f-string
-            log(3, "zypper keyIds:    {}".format([k for k in sorted(zypper_gpg_keys)]))
+            log(3, "zypper keyIds:    {}".format(sorted(zypper_gpg_keys.keys())))
+
+            keys_to_load = list(
+                set(spacewalk_gpg_keys).difference(set(zypper_gpg_keys))
+            )
+            # pylint: disable-next=consider-using-f-string
+            log(3, "diff keyIds:      {}".format(keys_to_load))
 
             # Compare GPG keys and remove keys from reposync that are going to be imported with a newer release.
             # pylint: disable-next=consider-using-dict-items
@@ -197,62 +228,82 @@ class ZyppoSync:
                 ):
                     # This GPG key has a newer release on the Spacewalk GPG keyring that on the reposync Zypper RPM database.
                     # We delete this key from the RPM database to allow importing the newer version.
-                    os.system(
+                    args = [
+                        "rpm",
+                        "--dbpath",
+                        REPOSYNC_ZYPPER_RPMDB_PATH,
+                        "-e",
                         # pylint: disable-next=consider-using-f-string
-                        "rpm --dbpath {} -e gpg-pubkey-{}-{}".format(
-                            REPOSYNC_ZYPPER_RPMDB_PATH, key, zypper_gpg_keys[key]
-                        )
-                    )
+                        "gpg-pubkey-{}-{}".format(key, zypper_gpg_keys[key]),
+                    ]
+                    _log_command(args)
+                    # pylint: disable-next=subprocess-run-check
+                    subprocess.run(args)
                     log(
                         3,
                         # pylint: disable-next=consider-using-f-string
-                        "new version available for gpg-pubkey-{}-{}".format(
+                        "New version available for gpg-pubkey-{}-{}".format(
                             key, zypper_gpg_keys[key]
                         ),
                     )
+                    keys_to_load.append(key)
+
+            # pylint: disable-next=consider-using-f-string
+            log(3, "to load keyIds:   {}".format(keys_to_load))
 
             # Finally, once we deleted the existing old key releases from the Zypper RPM database
-            # we proceed to import all keys from the Spacewalk GPG keyring. This will allow new GPG
+            # we proceed to import all missing keys from the Spacewalk GPG keyring. This will allow new GPG
             # keys release are upgraded in the Zypper keyring since rpmkeys does not handle the upgrade
             # properly
-            log(
-                3,
+            for key_id in keys_to_load:
                 # pylint: disable-next=consider-using-f-string
-                "rpmkeys -vv --dbpath {} --import {}".format(
-                    REPOSYNC_ZYPPER_RPMDB_PATH, f.name
-                ),
-            )
-            process = subprocess.Popen(
-                [
+                key_file = os.path.join(temp_dir, "{}.gpg".format(key_id))
+                args = [
+                    "gpg",
+                    "-q",
+                    "--batch",
+                    "--no-options",
+                    "--no-default-keyring",
+                    "--no-permission-warning",
+                    "--keyring",
+                    SPACEWALK_GPG_KEYRING,
+                    "--export",
+                    "--export-options",
+                    "export-clean",
+                    "--with-colons",
+                    "-a",
+                    "--output",
+                    key_file,
+                    key_id,
+                ]
+                _log_command(args)
+                # pylint: disable-next=subprocess-run-check
+                subprocess.run(args)
+                args = [
                     "rpmkeys",
                     "-vv",
                     "--dbpath",
                     REPOSYNC_ZYPPER_RPMDB_PATH,
                     "--import",
-                    f.name,
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            )
-            try:
-                # pylint: disable-next=unused-variable
-                outs, errs = process.communicate(timeout=15)
-                if process.returncode is None or process.returncode > 0:
-                    log(
-                        0,
-                        # pylint: disable-next=consider-using-f-string
-                        "Failed to import keys into rpm database ({}): {}".format(
-                            process.returncode, outs.decode("utf-8")
-                        ),
-                    )
-                else:
-                    # pylint: disable-next=consider-using-f-string
-                    log(3, "CMD out: {}".format(outs.decode("utf-8")))
-            except subprocess.TimeoutExpired:
-                process.kill()
-                log(0, "Timeout exceeded while importing keys to rpm database")
-            keycont = f.read()
-            rhnLog.log_clean(5, keycont.decode("utf-8"))
+                    key_file,
+                ]
+                _log_command(args)
+                process = subprocess.Popen(
+                    args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+                )
+                try:
+                    outs, _ = process.communicate(timeout=15)
+                    if process.returncode is None or process.returncode > 0:
+                        log(
+                            0,
+                            # pylint: disable-next=consider-using-f-string
+                            "Failed to import key {} into rpm database, rpmkeys returned ({}): {}".format(
+                                key_id, process.returncode, outs.decode("utf-8")
+                            ),
+                        )
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    log(0, "Timeout exceeded while importing keys to rpm database")
 
 
 # pylint: disable-next=missing-class-docstring

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -177,8 +177,7 @@ class ZyppoSync:
                 all_keys_file,
             ]
             _log_command(args)
-            # pylint: disable-next=subprocess-run-check
-            process = subprocess.run(args)
+            process = subprocess.run(args, check=False)
             args = [
                 "gpg",
                 "--verbose",
@@ -237,8 +236,7 @@ class ZyppoSync:
                         "gpg-pubkey-{}-{}".format(key, zypper_gpg_keys[key]),
                     ]
                     _log_command(args)
-                    # pylint: disable-next=subprocess-run-check
-                    subprocess.run(args)
+                    subprocess.run(args, check=False)
                     log(
                         3,
                         # pylint: disable-next=consider-using-f-string
@@ -277,8 +275,7 @@ class ZyppoSync:
                     key_id,
                 ]
                 _log_command(args)
-                # pylint: disable-next=subprocess-run-check
-                subprocess.run(args)
+                subprocess.run(args, check=False)
                 args = [
                     "rpmkeys",
                     "-vv",

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-reposync-gpgkeys-refactor
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-reposync-gpgkeys-refactor
@@ -1,0 +1,1 @@
+- reposync: import GPG keys to RPM DB individually (bsc#1217003)


### PR DESCRIPTION
## What does this PR change?

This PR refactors the code around GPG keys importing from Spacewalk keyring to the RPM DB that is used by Zypper during `spacewalk-repo-sync` execution:

- GPG keys are processed individually, instead of all in the same file.
- Continue processing keys even if there are errors in some of them. 
- Enhance related import logging.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **already covered at accepteance tests. No unit tests for GPG keys import**

- [x] **DONE**

## Links

Issue(s):
- https://github.com/SUSE/spacewalk/issues/23150
- https://github.com/uyuni-project/uyuni/issues/8176 (?)

Ports(s): https://github.com/SUSE/spacewalk/pull/23629

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
