### PR TITLE
Fix reboot needed detection

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -7,6 +7,9 @@ mgr_keep_system_up2date_updatestack:
     - onlyif: 'zypper patch-check --updatestack-only; r=$?; test $r -eq 100 || test $r -eq 101'
     - require:
       - sls: channels
+
+{% set patch_need_reboot = salt['cmd.retcode']('zypper -x list-patches | grep \'restart="true"\' > /dev/null', python_shell=True) %}
+
 {% else %}
 
 mgr_keep_system_up2date_updatestack:
@@ -44,6 +47,8 @@ mgr_keep_system_up2date_pkgs:
 mgr_reboot_if_needed:
   cmd.run:
     - name: shutdown -r +5
+    - require:
+      - pkg: mgr_keep_system_up2date_pkgs
 {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 8 %}
     - onlyif: 'dnf -q needs-restarting -r; [ $? -eq 1 ]'
 {%- elif grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 7 %}
@@ -55,6 +60,6 @@ mgr_reboot_if_needed:
     - onlyif:
       - test -e /boot/do_purge_kernels
 {%- else %}
-    - onlyif: 'zypper ps -s; [ $? -eq 102 ]'
+    - onlyif: 'zypper ps -s; [ $? -eq 102 ] || [ {{ patch_need_reboot }} -eq 0 ]'
 {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -2,7 +2,7 @@ include:
   - channels
 
 {%- if grains['os_family'] == 'Suse' %}
-keep_system_up2date_updatestack:
+mgr_keep_system_up2date_updatestack:
   pkg.uptodate:
     - onlyif: 'zypper patch-check --updatestack-only; r=$?; test $r -eq 100 || test $r -eq 101'
     - require:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-fix-reboot-detection
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-fix-reboot-detection
@@ -1,0 +1,1 @@
+- fix reboot needed detection for SUSE systems


### PR DESCRIPTION
## What does this PR change?

pkg.update calls `zypper update` which only look at package data and ignore flags set for the patch.
As we want to perform a full update, we can simply check if any patch require a reboot and use this as second opinion.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/23630

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
