### PR TITLE
fix virtual systems listing filters

### DIFF
--- a/java/code/src/com/redhat/rhn/common/ExceptionMessage.java
+++ b/java/code/src/com/redhat/rhn/common/ExceptionMessage.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.common;
+
+/**
+ * Exception message constants.
+ */
+public class ExceptionMessage {
+    public static final String NOT_INSTANTIABLE = "Not instantiable";
+
+    private ExceptionMessage() {
+        throw new UnsupportedOperationException(NOT_INSTANTIABLE);
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -1160,9 +1160,9 @@ public class SystemManager extends BaseManager {
                             "S.channel_labels, " +
                             "S.status_type, " +
                             "VI.host_system_id, " +
-                            "(SELECT S.name FROM rhnServer S WHERE S.id = VI.host_system_id) as host_server_name, " +
                             "VI.virtual_system_id, " +
                             "VI.uuid, " +
+                            "COALESCE(RS.name, '(none)') AS host_server_name, " +
                             "COALESCE(VII.name, '(none)') AS server_name, " +
                             "COALESCE(VIS.name, '(unknown)') AS STATE_NAME, " +
                             "COALESCE(VIS.label, 'unknown') AS STATE_LABEL, " +
@@ -1175,7 +1175,8 @@ public class SystemManager extends BaseManager {
                 .from("rhnVirtualInstance VI " +
                         "    LEFT OUTER JOIN rhnVirtualInstanceInfo VII ON VI.id = VII.instance_id " +
                         "    LEFT OUTER JOIN rhnVirtualInstanceState VIS ON VII.state = VIS.id " +
-                        "    LEFT OUTER JOIN suseSystemOverview S ON S.id = VI.virtual_system_id")
+                        "    LEFT OUTER JOIN suseSystemOverview S ON S.id = VI.virtual_system_id" +
+                        "    LEFT OUTER JOIN rhnServer RS ON RS.id = VI.host_system_id")
                 .where("EXISTS ( " +
                         "   SELECT 1 " +
                         "   FROM rhnUserServerPerms USP " +

--- a/java/code/src/com/suse/manager/webui/controllers/test/SystemsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/SystemsControllerTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.controllers.test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.VirtualInstance;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.testing.ServerTestUtils;
+import com.redhat.rhn.testing.SparkTestUtils;
+
+import com.suse.manager.reactor.messaging.test.SaltTestUtils;
+import com.suse.manager.webui.controllers.SystemsController;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.test.TestSaltApi;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import spark.ModelAndView;
+import spark.Request;
+
+public class SystemsControllerTest extends BaseControllerTestCase {
+
+    private static final Gson GSON = new GsonBuilder().create();
+    private static final Map<String, List<String>> SERVER_NAMES_BY_HOST_SERVER_NAME_NAME_MAP = Map.of(
+            "hostA", Arrays.asList("hostA_VmA", "hostA_VmB", "hostA_VmC"),
+            "hostB", Arrays.asList("hostB_VmA", "hostB_VmB")
+    );
+    private static final String BASE_URI = "http://localhost:8080/rhn/manager/systems/list/virtual";
+    private static final String KEY_HOST_SERVER_NAME = "host_server_name";
+    private static final String KEY_SERVER_NAME = "server_name";
+    private static final String PROPERTY_HOST_SERVER_NAME = "hostServerName";
+    private static final String PROPERTY_SERVER_NAME = "name";
+
+    //
+    private VirtManager virtManager;
+    private Map<String, Server> serversByHostServerName;
+    private SystemsController systemsController;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+
+        virtManager = mock(VirtManager.class);
+        context().checking(new Expectations() {
+            {
+                allowing(virtManager).getCapabilities("testminion.local");
+                will(returnValue(
+                        SaltTestUtils.getSaltResponse(
+                                "/com/suse/manager/webui/controllers/virtualization/test/virt.guest.allcaps.json", null,
+                                new TypeToken<Map<String, JsonElement>>() {
+                                })
+                ));
+                allowing(virtManager).updateLibvirtEngine(with(any(MinionServer.class)));
+            }
+        });
+
+        SaltApi saltApi = new TestSaltApi();
+        systemsController = new SystemsController(saltApi);
+        MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
+        ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
+        SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+                new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+                new SystemEntitler(new TestSaltApi(), virtManager, monitoringManager, serverGroupManager)
+        );
+
+        serversByHostServerName = new HashMap<>();
+        for (Map.Entry<String, List<String>> e : SERVER_NAMES_BY_HOST_SERVER_NAME_NAME_MAP.entrySet()) {
+
+            // Set up the host
+            String hostName = e.getKey();
+            Server host = ServerTestUtils.createVirtHostWithGuests(user, e.getValue().size(), true,
+                    systemEntitlementManager);
+            host.setName(hostName);
+            serversByHostServerName.put(hostName, host);
+
+            // Set up the host's vms
+            Iterator<String> vmNamesIterator = e.getValue().iterator();
+            Iterator<VirtualInstance> guestIterator = host.getGuests().iterator();
+            while (guestIterator.hasNext() && vmNamesIterator.hasNext()) {
+                VirtualInstance guest = guestIterator.next();
+                String vmName = vmNamesIterator.next();
+                guest.setName(vmName);
+            }
+
+        }
+
+        // Assert all vms are created
+        for (Server host : serversByHostServerName.values()) {
+            int expectedVmsSize = SERVER_NAMES_BY_HOST_SERVER_NAME_NAME_MAP.get(host.getName()).size();
+            int actualVmsSize = SystemManager.virtualGuestsForHostList(user, host.getId(), null).size();
+            assertEquals(expectedVmsSize, actualVmsSize,
+                    "Expected to find " + expectedVmsSize + " guests for host " + host.getName() +
+                            " but got " + actualVmsSize);
+        }
+    }
+
+    /**
+     * Test that all virtual systems are returned when no filter is provided
+     */
+    @Test
+    public void testVirtualSystemsReturnAllSystemsWhenNoFilter() {
+        Request request = SparkTestUtils.createMockRequest(BASE_URI);
+        Object virtualSystemsObject = systemsController.virtualSystems(request, response, user);
+        assertNotNull(virtualSystemsObject);
+        Map<String, Object> virtualSystemsAsMap = new Gson().fromJson(virtualSystemsObject.toString(), Map.class);
+        assertEquals(5, ((Collection) virtualSystemsAsMap.get("items")).size());
+    }
+
+    /**
+     * Test that all virtual systems are returned when blank params are provided
+     */
+    @Test
+    public void testVirtualSystemsReturnAllSystemsWhenBlankParams() {
+        List<Map<String, Object>> items = getVirtualSystemsItems(StringUtils.EMPTY, StringUtils.EMPTY);
+        assertEquals(5, items.size());
+    }
+
+    /**
+     * Test that virtual systems are returned when filtered exact host or vm names
+     */
+    @Test
+    public void testVirtualSystemsReturnAllHostVMsWhenFilterByExactName() {
+        SERVER_NAMES_BY_HOST_SERVER_NAME_NAME_MAP.entrySet().forEach(e -> {
+            String hostName = e.getKey();
+            List<String> hostVmNames = e.getValue();
+
+            List<Map<String, Object>> hostFilteredItems = getVirtualSystemsItems(KEY_HOST_SERVER_NAME, hostName);
+            assertEquals(hostVmNames.size(), hostFilteredItems.size(),
+                    "Expected host  " + hostName + " to return " + hostVmNames.size() +
+                            " but got " + hostFilteredItems.size());
+            assertTrue(hostFilteredItems.stream().allMatch(
+                            obj -> obj.get(PROPERTY_HOST_SERVER_NAME).equals(hostName)),
+                    "Querying for " + hostName + " should return only \"+hostName+\"'s vms"
+            );
+
+            hostVmNames.forEach(vmName -> {
+                List<Map<String, Object>> vmFilteredItems = getVirtualSystemsItems(KEY_SERVER_NAME, vmName);
+                assertEquals(1, vmFilteredItems.size());
+                assertEquals(vmName, vmFilteredItems.get(0).get(PROPERTY_SERVER_NAME));
+            });
+        });
+    }
+
+    /**
+     * Test virtual systems are returned when filtered by common/partial name
+     */
+    @Test
+    public void testVirtualSystemsReturnAllWhenFilterByPartialName() {
+        List<Map<String, Object>> items = getVirtualSystemsItems(KEY_HOST_SERVER_NAME, "host");
+        assertEquals(5, items.size());
+        assertTrue(items.stream().allMatch(obj -> obj.get(PROPERTY_HOST_SERVER_NAME).toString().contains("host")));
+
+        assertEquals(2, getVirtualSystemsItems(KEY_SERVER_NAME, "VmA").size());
+        assertEquals(2, getVirtualSystemsItems(KEY_SERVER_NAME, "VmB").size());
+        assertEquals(1, getVirtualSystemsItems(KEY_SERVER_NAME, "VmC").size());
+        assertEquals(5, getVirtualSystemsItems(KEY_SERVER_NAME, "Vm").size());
+    }
+
+    /**
+     * Test no virtual systems are returned when filtered by a non-existent host name
+     */
+    @Test
+    public void testVirtualSystemsReturnsNoneWhenNameMatches() {
+        assertEquals(0, getVirtualSystemsItems(KEY_HOST_SERVER_NAME, "hostY").size());
+        assertEquals(0, getVirtualSystemsItems(KEY_SERVER_NAME, "VmY").size());
+    }
+
+
+    /**
+     * Sets up the query parameters and executes @link{SystemsController#virtualSystems}
+     *
+     * @param queryColumn the name of the column to filter by
+     * @param query       the value to filter by
+     * @return filtered virtual systems
+     */
+    private List<Map<String, Object>> getVirtualSystemsItems(String queryColumn, String query) {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("qc", queryColumn);
+        queryParams.put("q", query);
+        Request request = SparkTestUtils.createMockRequestWithParams(BASE_URI, queryParams);
+
+        //
+        Object virtualSystemsObject = systemsController.virtualSystems(request, response, user);
+
+        //
+        assertNotNull(virtualSystemsObject);
+        Map<String, Object> virtualSystemsAsMap = GSON.fromJson(virtualSystemsObject.toString(), Map.class);
+
+        return (List<Map<String, Object>>) virtualSystemsAsMap.get("items");
+    }
+
+    @Test
+    public void testVirtualListPageQueryParamsConversion() {
+        final String paramQC = "dummy_param_qc";
+        final String paramQ = "dummy_param_q";
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("qc", paramQC);
+        queryParams.put("q", paramQ);
+        Request request = SparkTestUtils.createMockRequestWithParams(BASE_URI, queryParams);
+        ModelAndView virtualSystemsModelAndView = systemsController.virtualListPage(request, response, user);
+
+        assertNotNull(virtualSystemsModelAndView);
+        assertNotNull(virtualSystemsModelAndView.getModel());
+
+        HashMap model = (HashMap) virtualSystemsModelAndView.getModel();
+        assertAll(
+                () -> assertTrue(model.containsKey("queryColumn")),
+                () -> assertEquals(String.format("'%s'", paramQC), model.get("queryColumn"))
+        );
+        assertAll(
+                () -> assertTrue(model.containsKey("query")),
+                () -> assertEquals(String.format("'%s'", paramQ), model.get("query"))
+        );
+    }
+
+
+}

--- a/java/code/src/com/suse/manager/webui/templates/systems/virtual-list.jade
+++ b/java/code/src/com/suse/manager/webui/templates/systems/virtual-list.jade
@@ -12,7 +12,9 @@ script(type='text/javascript').
             module.renderer(
                 'systems-virtual-list', '#{docsLocale}',
                 {
-                    isAdmin: #{is_admin}
+                    isAdmin: #{is_admin},
+                    queryColumn: #{queryColumn},
+                    query: !{query}
                 }
             )
         });

--- a/java/code/src/com/suse/utils/Predicates.java
+++ b/java/code/src/com/suse/utils/Predicates.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.utils;
+
+import static com.redhat.rhn.common.ExceptionMessage.NOT_INSTANTIABLE;
+import static java.util.Objects.isNull;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import spark.utils.StringUtils;
+
+/**
+ * A collection of utility methods for evaluating object presence and absence.
+ */
+public final class Predicates {
+
+    /**
+     * Determines whether an object is considered to be absent, as per {@link #isProvided(Object)}.
+     *
+     * @param value the object to be evaluated
+     * @return true if the object does not contain meaningful content
+     */
+    public static boolean isAbsent(Object value) {
+        return !(isProvided(value));
+    }
+
+    /**
+     * Determines whether the value obtained from the given supplier is considered to be absent, as per
+     * {@link #isAbsent(Object)}.
+     *
+     * @param supplier the supplier from which to obtain the value
+     * @return true if the value obtained from the supplier is absent based on the predicate, otherwise false
+     */
+    public static boolean isAbsent(Supplier<?> supplier) {
+        return Optional.ofNullable(supplier).map(Supplier::get).map(Predicates::isAbsent).orElse(true);
+    }
+
+    /**
+     * Determines whether the value obtained from the given supplier is considered to be provided, as per
+     * {@link #isAbsent(Object)}.
+     *
+     * @param supplier the supplier from which to obtain the value
+     * @return true if the value obtained from the supplier is provided based on the predicate, otherwise false
+     */
+    public static boolean isProvided(Supplier<?> supplier) {
+        return Optional.ofNullable(supplier).map(Supplier::get).map(Predicates::isProvided).orElse(false);
+    }
+
+    /**
+     * Determines if an object is whether or not considered to be provided.
+     * An object is considered provided if it is non-null and contains meaningful data.
+     * Exceptions to this rule include:
+     * a) If the object is assignable from CharSequence, it is considered provided if it contains any non-space
+     * character.
+     * b) If the object is assignable from Collection or an array, it is considered provided if its contents contain
+     * any non-null object.
+     *
+     * <pre>
+     * Predicates.isProvided(null)         = false
+     * Predicates.isProvided(new Object()) = true
+     * Predicates.isProvided("")           = false
+     * Predicates.isProvided(" ")          = false
+     * Predicates.isProvided(new String()) = false
+     * Predicates.isProvided("suse")       = true
+     * </pre>
+     *
+     * @param value the object to be evaluated
+     * @return true if the object contains meaningful content
+     */
+    public static boolean isProvided(Object value) {
+        if (isNull(value)) {
+            return false;
+        }
+
+        if (CharSequence.class.isAssignableFrom(value.getClass())) {
+            return !StringUtils.isBlank((CharSequence) value);
+        }
+
+        if (Optional.class.isAssignableFrom(value.getClass())) {
+            return ((Optional<?>) value).isPresent();
+        }
+
+        if (Collection.class.isAssignableFrom(value.getClass())) {
+            Collection<?> collection = (Collection<?>) value;
+            return !collection.isEmpty() && !allAbsent(collection.toArray());
+        }
+
+        if (Object[].class.isAssignableFrom(value.getClass())) {
+            Object[] objArray = (Object[]) value;
+            return objArray.length > 0 && !allAbsent(objArray);
+        }
+
+        return true;
+    }
+
+    /**
+     * Determines whether ALL provided objects are considered to be provided, as per {@link #isProvided(Object)}.
+     *
+     * @param args the varargs to be evaluated
+     * @return true if all provided objects are considered provided, otherwise false
+     */
+    public static boolean allProvided(Object... args) {
+        return Arrays.stream(args).allMatch(Predicates::isProvided);
+    }
+
+    /**
+     * Determines whether ALL provided objects are considered to be absent, as per {@link #isAbsent(Object)}.
+     *
+     * @param collection the collection to be evaluated
+     * @return true if none of the elements in the collection are considered provided, otherwise false
+     */
+    public static boolean noneProvided(Collection<?> collection) {
+        if ((collection == null) || collection.isEmpty()) {
+            return true;
+        }
+        return !isProvided(collection);
+    }
+
+    /**
+     * Determines whether ANY provided objects are considered to be provided, as per {@link #isProvided(Object)}.
+     *
+     * @param collection the collection to be evaluated
+     * @return true if any of the elements in the collection are considered provided, otherwise false
+     */
+    public static boolean anyProvided(Collection<?> collection) {
+        return !(noneProvided(collection));
+    }
+
+    /**
+     * Determines whether ALL provided objects are considered to be absent, as per {@link #isAbsent(Object)}.
+     *
+     * @param args the varargs to be evaluated
+     * @return true if all provided objects are considered absent, otherwise false
+     */
+    public static boolean allAbsent(Object... args) {
+        return Arrays.stream(args).allMatch(Predicates::isAbsent);
+    }
+
+    private Predicates() {
+        throw new UnsupportedOperationException(NOT_INSTANTIABLE);
+    }
+
+
+}

--- a/java/code/src/com/suse/utils/test/PredicatesTest.java
+++ b/java/code/src/com/suse/utils/test/PredicatesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.utils.test;
+
+import static java.util.Objects.nonNull;
+import static org.junit.Assert.assertEquals;
+
+import com.suse.utils.Predicates;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class PredicatesTest {
+
+    private static Stream<Arguments> expressionPredicates() {
+        return Stream.of(
+                Arguments.of(null, true, false, true, false, true, false),
+                Arguments.of(null, true, false, true, false, true, false),
+                Arguments.of(new Object(), false, true, false, true, true, false),
+                Arguments.of(new String(), true, false, true, false, true, false),
+                Arguments.of("", true, false, true, false, true, false),
+                Arguments.of(" ", true, false, true, false, true, false),
+                Arguments.of("null", false, true, false, true, false, true),
+                Arguments.of(new String[0], true, false, true, false, true, false),
+                Arguments.of(new String[]{}, true, false, true, false, true, false),
+                Arguments.of(new String[]{"1"}, false, true, false, true, false, true),
+                Arguments.of(new String[]{"1", null}, false, true, false, true, false, true),
+                Arguments.of(new String[]{"1", null, "2"}, false, true, false, true, false, true),
+                Arguments.of(new String[]{"1", "2", "3"}, false, true, false, true, false, true),
+                Arguments.of(new String[]{null, null, "", " "}, true, false, true, false, true, false),
+                Arguments.of(Arrays.asList(), true, false, true, false, true, false),
+                Arguments.of(Arrays.asList(null, null), true, false, true, false, true, false),
+                Arguments.of(Arrays.asList(null, new String()), true, false, true, false, true, false),
+                Arguments.of(Arrays.asList(null, new String(), "not null"), false, true, false, true, false, true),
+                Arguments.of(new ArrayList<>(), true, false, true, false, true, false),
+                Arguments.of(new HashSet<>(), true, false, true, false, true, false),
+                Arguments.of(new HashSet<>(Arrays.asList(1, 2, 3)), false, true, false, true, false, true),
+                Arguments.of(Optional.of(1), false, true, false, true, false, true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("expressionPredicates")
+    public void testPredicates(
+            Object value,
+            boolean expectedIsAbsent,
+            boolean expectedIsProvided,
+            boolean expectedAllAbsent,
+            boolean expectedAllProvided,
+            boolean expectedNoneProvided,
+            boolean expectedAnyProvided
+    ) {
+        assertEquals(expectedIsAbsent, Predicates.isAbsent(value));
+        assertEquals(expectedIsProvided, Predicates.isProvided(value));
+        assertEquals(expectedAllAbsent, Predicates.allAbsent(value));
+        assertEquals(expectedAllProvided, Predicates.allProvided(value));
+        if (nonNull(value) && Collection.class.isAssignableFrom(value.getClass())) {
+            assertEquals(expectedNoneProvided, Predicates.noneProvided((Collection<?>) value));
+            assertEquals(expectedAnyProvided, Predicates.anyProvided((Collection<?>) value));
+        }
+    }
+
+}

--- a/java/spacewalk-java.changes.rjpmestre.fix-virtual-systems-filters
+++ b/java/spacewalk-java.changes.rjpmestre.fix-virtual-systems-filters
@@ -1,0 +1,1 @@
+- fix virtual systems filters (bsc#1208572)

--- a/web/html/src/manager/systems/list-filter.tsx
+++ b/web/html/src/manager/systems/list-filter.tsx
@@ -52,6 +52,15 @@ const allListOptions = [
   { value: "group_count", label: t("Groups") },
 ];
 
+const virtualSystemsListOptions = [
+  { value: "host_server_name", label: t("Virtual Host") },
+  { value: "server_name", label: t("Virtual System") },
+];
+
 export const SystemsListFilter = (props) => {
   return <TableFilter filterOptions={allListOptions} name="criteria" {...props} />;
+};
+
+export const VirtualSystemsListFilter = (props) => {
+  return <TableFilter filterOptions={virtualSystemsListOptions} name="criteria" {...props} />;
 };

--- a/web/html/src/manager/systems/virtual-list.renderer.tsx
+++ b/web/html/src/manager/systems/virtual-list.renderer.tsx
@@ -8,13 +8,15 @@ import { VirtualSystems } from "./virtual-list";
 
 type RendererProps = {
   isAdmin: boolean;
+  queryColumn?: string;
+  query?: string;
 };
 
-export const renderer = (id: string, docsLocale: string, { isAdmin }: RendererProps) =>
+export const renderer = (id: string, docsLocale: string, { isAdmin, queryColumn, query }: RendererProps) =>
   SpaRenderer.renderNavigationReact(
     <>
       <MessagesContainer />
-      <VirtualSystems docsLocale={docsLocale} isAdmin={isAdmin} />
+      <VirtualSystems docsLocale={docsLocale} isAdmin={isAdmin} queryColumn={queryColumn} query={query} />
     </>,
     document.getElementById(id)
   );

--- a/web/html/src/manager/systems/virtual-list.tsx
+++ b/web/html/src/manager/systems/virtual-list.tsx
@@ -3,17 +3,20 @@ import * as React from "react";
 import { IconTag } from "components/icontag";
 import * as Systems from "components/systems";
 import { Column } from "components/table/Column";
-import { SearchField } from "components/table/SearchField";
 import { Table } from "components/table/Table";
 
 import { Utils } from "utils/functions";
 import Network from "utils/network";
+
+import { VirtualSystemsListFilter } from "./list-filter";
 
 // See java/code/src/com/suse/manager/webui/templates/systems/virtual-list.jade
 type Props = {
   /** Locale of the help links */
   docsLocale: string;
   isAdmin: boolean;
+  queryColumn?: string;
+  query?: string;
 };
 
 export function VirtualSystems(props: Props) {
@@ -26,13 +29,6 @@ export function VirtualSystems(props: Props) {
     Network.post("/rhn/manager/api/sets/system_list", data).catch(Network.showResponseErrorToastr);
 
     setSelectedSystems(items);
-  };
-
-  const searchData = (datum, criteria) => {
-    if (criteria) {
-      return datum.name.toLocaleLowerCase().includes(criteria.toLocaleLowerCase());
-    }
-    return true;
   };
 
   return (
@@ -52,11 +48,13 @@ export function VirtualSystems(props: Props) {
       <Table
         data="/rhn/manager/api/systems/list/virtual"
         identifier={(item) => item.virtualSystemId || item.uuid}
-        initialSortColumnKey="hostServerName"
+        initialSortColumnKey="host_server_name"
         selectable={(item) => item.hasOwnProperty("virtualSystemId")}
         selectedItems={selectedSystems}
         onSelect={handleSelectedSystems}
-        searchField={<SearchField filter={searchData} placeholder={t("Filter by name")} />}
+        searchField={<VirtualSystemsListFilter />}
+        defaultSearchField={props.queryColumn || "host_server_name"}
+        initialSearch={props.query}
         emptyText={t("No Virtual Systems.")}
       >
         <Column

--- a/web/spacewalk-web.changes.rjpmestre.fix-virtual-systems-filters
+++ b/web/spacewalk-web.changes.rjpmestre.fix-virtual-systems-filters
@@ -1,0 +1,1 @@
+- fix virtual systems filters (bsc#1208572)


### PR DESCRIPTION
## What does this PR change?

This PR fixes virtual system listing and enhances its filtering system. It adds a new dropdown input field. This will allow users to select either "Virtual Host" or "Virtual System" as the target for their query.

## GUI diff

Before:

![image](https://github.com/uyuni-project/uyuni/assets/124290023/31b00500-eecf-4f7e-b0c0-ef9993d838b6)

After:

![image](https://github.com/uyuni-project/uyuni/assets/124290023/6c80ea1c-0132-4ed7-8fba-b0cf856ea2cc)

- [ ] **DONE**

## Documentation
- No documentation needed: There is a GUI difference but the granularity its not high enough to cover these filters.

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/21192

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
