### PR TITLE
Add org/createFirst to unauthenticated HTTP API paths

### DIFF
--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -125,7 +125,8 @@ public class HttpApiRegistry {
     public static Set<String> getUnautenticatedRoutes() {
         return Set.of(
             "/rhn/manager/api/api/getVersion",
-            "/rhn/manager/api/api/systemVersion"
+            "/rhn/manager/api/api/systemVersion",
+            "/rhn/manager/api/org/createFirst"
         );
     }
 

--- a/java/spacewalk-java.changes.cbosdonnat.api-auth-fix
+++ b/java/spacewalk-java.changes.cbosdonnat.api-auth-fix
@@ -1,0 +1,1 @@
+- Add org/createFirst to unauthenticated HTTP API paths


### PR DESCRIPTION
## What does this PR change?

Since there is no user, this API method has to be unauthenticated or it can't be called.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
