### PR TITLE
No symlinks in saltfs

### DIFF
--- a/python/linting/lint.sh
+++ b/python/linting/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/env -S bash -euo pipefail
+#!/usr/bin/env -S bash -euo pipefail
 
 # Check pre-requisites
 if ! command -v git &>/dev/null ; then

--- a/spacewalk/admin/spacewalk-admin.changes.mc.no-symlinks-in-saltfs
+++ b/spacewalk/admin/spacewalk-admin.changes.mc.no-symlinks-in-saltfs
@@ -1,0 +1,1 @@
+- copy CA certificate to Salt filesystem during startup (bsc#1219577)

--- a/spacewalk/admin/uyuni-update-config
+++ b/spacewalk/admin/uyuni-update-config
@@ -46,10 +46,27 @@ def importSumaGPGKeyring():
 
     if result.returncode:
         sys.stdout.write("Failed to import SUSE Manager Build Keys\n")
-    sys.stdout.write("{}\n".format(result.stdout))
+    if result.stdout:
+        sys.stdout.write("{}\n".format(result.stdout))
     sys.stdout.flush()
+
+def copyCA():
+    result = subprocess.run(
+            ["cp",
+             "/etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT",
+             "/usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT"],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            encoding='utf-8')
+
+    if result.returncode:
+        sys.stdout.write("Failed to copy the CA certificate to the Salt Filesystem\n")
+    if result.stdout:
+        sys.stdout.write("{}\n".format(result.stdout))
+    sys.stdout.flush()
+
 
 initSccLogin()
 importSumaGPGKeyring()
+copyCA()
 
 sys.exit(0)

--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -589,21 +589,25 @@ def deployCAUyuni(certData):
         if ca["root"]:
             if os.path.exists(os.path.join(ROOT_CA_HTTP_DIR, ROOT_CA_NAME)):
                 os.remove(os.path.join(ROOT_CA_HTTP_DIR, ROOT_CA_NAME))
-            # pylint: disable-next=unspecified-encoding
-            with open(os.path.join(ROOT_CA_HTTP_DIR, ROOT_CA_NAME), "w") as f:
+            with open(
+                os.path.join(ROOT_CA_HTTP_DIR, ROOT_CA_NAME), "w", encoding="utf-8"
+            ) as f:
                 f.write(ca["content"])
             os.chmod(os.path.join(ROOT_CA_HTTP_DIR, ROOT_CA_NAME), int("0644", 8))
 
             if os.path.exists(os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME)):
                 os.remove(os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME))
-            # pylint: disable-next=unspecified-encoding
-            with open(os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME), "w") as f:
+            with open(
+                os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME), "w", encoding="utf-8"
+            ) as f:
                 f.write(ca["content"])
             os.chmod(os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME), int("0644", 8))
 
             if os.path.exists(os.path.join(SALT_CA_DIR, ROOT_CA_NAME)):
                 os.remove(os.path.join(SALT_CA_DIR, ROOT_CA_NAME))
-            with open(os.path.join(SALT_CA_DIR, ROOT_CA_NAME), "w") as f:
+            with open(
+                os.path.join(SALT_CA_DIR, ROOT_CA_NAME), "w", encoding="utf-8"
+            ) as f:
                 f.write(ca["content"])
             os.chmod(os.path.join(SALT_CA_DIR, ROOT_CA_NAME), int("0644", 8))
             break

--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -53,6 +53,7 @@ if not os.path.exists(CA_TRUST_DIR):
     # Red Hat
     CA_TRUST_DIR = os.path.join(PKI_DIR, "ca-trust", "source", "anchors")
 
+SALT_CA_DIR = "/usr/share/susemanager/salt/certs/"
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -599,6 +600,12 @@ def deployCAUyuni(certData):
             with open(os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME), "w") as f:
                 f.write(ca["content"])
             os.chmod(os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME), int("0644", 8))
+
+            if os.path.exists(os.path.join(SALT_CA_DIR, ROOT_CA_NAME)):
+                os.remove(os.path.join(SALT_CA_DIR, ROOT_CA_NAME))
+            with open(os.path.join(SALT_CA_DIR, ROOT_CA_NAME), "w") as f:
+                f.write(ca["content"])
+            os.chmod(os.path.join(SALT_CA_DIR, ROOT_CA_NAME), int("0644", 8))
             break
     # in case a systemd timer try to do the same
     time.sleep(3)

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.Manager-4.3.11-no-symlinks-in-saltfs
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.Manager-4.3.11-no-symlinks-in-saltfs
@@ -1,0 +1,1 @@
+- deploy the CA certificate also into the salt filesystem (bsc#1219577)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3.11-no-symlinks-in-saltfs
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3.11-no-symlinks-in-saltfs
@@ -1,0 +1,2 @@
+- change certs/RHN-ORG-TRUSTED-SSL-CERT from symlink into a real file
+  (bsc#1219577)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -127,10 +127,25 @@ py.test%{?rhel:-3}
 # been replaced by "mgrcompat.module_run" calls.
 ! grep --include "*.sls" -r "module\.run" %{buildroot}/usr/share/susemanager/salt || exit 1
 
+%pre
+# change /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT
+# from symlink into a real file
+if [ -L /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT ]; then
+  rm -f /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT
+  if [ -f /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT ]; then
+    cp /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT \
+       /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT
+  elif [ -f /etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT ]; then
+    cp /etc/pki/ca-trust/source/anchors/RHN-ORG-TRUSTED-SSL-CERT \
+       /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT
+  fi
+fi
+
 %post
-# HACK! Create broken link when it will be replaces with the real file
-ln -sf %{wwwpubroot}/pub/RHN-ORG-TRUSTED-SSL-CERT \
-   /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT 2>&1 ||:
+# this will be filled with content when a certificate gets deployed
+if [ ! -e /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT ]; then
+  touch /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT
+fi
 
 %posttrans
 # Run JMX exporter as Java Agent (bsc#1184617)


### PR DESCRIPTION
## What does this PR change?

Salt does not allow symlinks in the salt filesystem which point to the outside.
This means we need to change how we provide the CA certificate.
In the past we had a symlink. Now we need to put a copy to it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/23633

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
