### PR TITLE
Update license 2024 regex

### DIFF
--- a/java/buildconf/LICENSE.txt
+++ b/java/buildconf/LICENSE.txt
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \(c\) (20([012]\d|20)--)?20(1\d|2[01234]) (Red Hat, Inc.|SUSE LLC)$
+^ \* Copyright \(c\) (20([0123]\d|20)--)?20(1\d|2[01234]) (Red Hat, Inc.|SUSE LLC)$
 ^ \*$
 ^ \* This software is licensed to you under the GNU General Public License,$
 ^ \* version 2 \(GPLv2\). There is NO WARRANTY for this software, express or$

--- a/java/buildconf/LICENSE.txt
+++ b/java/buildconf/LICENSE.txt
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \(c\) (20([012]\d|20)--)?20(1\d|2[0123]) (Red Hat, Inc.|SUSE LLC)$
+^ \* Copyright \(c\) (20([012]\d|20)--)?20(1\d|2[01234]) (Red Hat, Inc.|SUSE LLC)$
 ^ \*$
 ^ \* This software is licensed to you under the GNU General Public License,$
 ^ \* version 2 \(GPLv2\). There is NO WARRANTY for this software, express or$

--- a/java/spacewalk-java.changes.rjpmestre.license-copyright-year-update
+++ b/java/spacewalk-java.changes.rjpmestre.license-copyright-year-update
@@ -1,0 +1,1 @@
+- Update license to include the year 2024


### PR DESCRIPTION
## What does this PR change?

This PR updates the regex license so it allows to use year 2024.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
