### PR TITLE
QE: Fix Grafana dashboard scenario in BV tests

### DIFF
--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -85,6 +85,18 @@ Feature: Bootstrap the monitoring server
     When I wait until "grafana-server" service is active on "monitoring_server"
     And I visit "Grafana" endpoint of this "monitoring_server"
 
+@susemanager
+  Scenario: Test Grafana dashboards of monitoring server
+    When I visit the grafana dashboards of this "monitoring_server"
+    And I wait until I do not see "Loading Grafana" text
+    And I check radio button "View as list", if not checked
+    # These are the 4 dashboards created by default when enabling the Grafana formula
+    Then I should see a "Apache2" text
+    And I should see a "PostgreSQL database insights" text
+    And I should see a "SUSE Manager Client Systems" text
+    And I should see a "SUSE Manager Server" text
+
+@uyuni
   Scenario: Test Grafana dashboards of monitoring server
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text


### PR DESCRIPTION
## What does this PR change?

This fixes the Grafana dashboard tests in our BV. Since we have a 5.0 BV now, we this product differentiation.


### Before
```bash
(...)
  Scenario: Test Grafana dashboards of monitoring server            # features/build_validation/init_clients/monitoring_server.feature:88
      This scenario ran at: 2024-02-08 10:52:07 +0100
    When I visit the grafana dashboards of this "monitoring_server" # features/step_definitions/navigation_steps.rb:1191
    And I wait until I do not see "Loading Grafana" text            # features/step_definitions/navigation_steps.rb:43
    And I check radio button "View as list", if not checked         # features/step_definitions/common_steps.rb:215
    # These are the 4 dashboards created by default when enabling the Grafana formula
    Then I should see a "Apache2" text                              # features/step_definitions/navigation_steps.rb:589
    And I should see a "PostgreSQL database insights" text          # features/step_definitions/navigation_steps.rb:589
    And I should see a "Uyuni Client Systems" text                  # features/step_definitions/navigation_steps.rb:589
      Text 'Uyuni Client Systems' not found (ScriptError)
      ./features/step_definitions/navigation_steps.rb:590:in `/^I should see a "([^"]*)" text$/'
      features/build_validation/init_clients/monitoring_server.feature:95:in `I should see a "Uyuni Client Systems" text'
    And I should see a "Uyuni Server" text                          # features/step_definitions/navigation_steps.rb:589
/root/spacewalk/testsuite/features/support/env.rb:142: warning: constant ::TimeoutError is deprecated
=> /var/log/rhn/rhn_web_ui.log

=> /var/log/rhn/rhn_web_api.log
[2024-02-08 09:49:56,788] INFO  - REQUESTED FROM: 10.145.209.80 CALL: states.summary(sid=1000010000) CALLER: (admin) TIME: 0.041 seconds
[2024-02-08 09:49:56,861] INFO  - REQUESTED FROM: 10.145.209.80 CALL: states.applyall(test=false, ids=[1000010000], earliest="2024-02-08T09:49:56.730Z", actionChain=null) CALLER: (admin) TIME: 0.031 seconds
[2024-02-08 09:50:44,056] INFO  - REQUESTED FROM: 10.145.209.83 CALL: auth.login(duration=600, password=******, username=admin) CALLER: (none) TIME: 0.032 seconds
[2024-02-08 09:50:44,082] INFO  - REQUESTED FROM: 10.145.209.83 CALL: system.listSystemGroupsForSystemsWithEntitlement(entitlement=monitoring_entitled, loggedInUser=admin) CALLER: (admin) TIME: 0.021 seconds
[2024-02-08 09:50:44,086] INFO  - REQUESTED FROM: 10.145.209.83 CALL: system.monitoring.listEndpoints(sids=[], loggedInUser=admin) CALLER: (admin) TIME: 0.001 seconds
[2024-02-08 09:50:44,089] INFO  - REQUESTED FROM: 10.145.209.83 CALL: system.getNetworkForSystems(sids=[], loggedInUser=admin) CALLER: (admin) TIME: 0.001 seconds
[2024-02-08 09:51:08,995] INFO  - REQUESTED FROM: 10.145.209.80 CALL: auth.login(password=******, username=admin) CALLER: (none) TIME: 0.029 seconds
[2024-02-08 09:51:09,002] INFO  - REQUESTED FROM: 10.145.209.80 CALL: system.searchByName(regexp=suma-bv-50-monitoring.mgr.suse.de, loggedInUser=admin) CALLER: (admin) TIME: 0.002 seconds
[2024-02-08 09:51:09,010] INFO  - REQUESTED FROM: 10.145.209.80 CALL: auth.logout(sessionKey=******) CALLER: (admin) TIME: 0.003 seconds
[2024-02-08 09:51:09,727] INFO  - REQUESTED FROM: 10.145.209.80 CALL: formulas.list.SERVER.1000010000() CALLER: (admin) TIME: 0.021 seconds
[2024-02-08 09:51:10,390] INFO  - REQUESTED FROM: 10.145.209.80 CALL: formulas.select(id="1000010000", type="SERVER", selected=["grafana","prometheus"]) CALLER: (admin) TIME: 0.486 seconds
[2024-02-08 09:51:10,423] INFO  - REQUESTED FROM: 10.145.209.80 CALL: formulas.list.SERVER.1000010000() CALLER: (admin) TIME: 0.025 seconds
[2024-02-08 09:51:10,799] INFO  - REQUESTED FROM: 10.145.209.80 CALL: formulas.form.SERVER.1000010000.0() CALLER: (admin) TIME: 0.013 seconds
[2024-02-08 09:51:11,588] INFO  - REQUESTED FROM: 10.145.209.80 CALL: maintenance.upcoming-windows(actionType="states.apply", systemIds=[1000010000]) CALLER: (admin) TIME: 0.001 seconds
[2024-02-08 09:51:11,623] INFO  - REQUESTED FROM: 10.145.209.80 CALL: states.summary(sid=1000010000) CALLER: (admin) TIME: 0.032 seconds
[2024-02-08 09:51:11,717] INFO  - REQUESTED FROM: 10.145.209.80 CALL: states.applyall(test=false, ids=[1000010000], earliest="2024-02-08T09:51:11.580Z", actionChain=null) CALLER: (admin) TIME: 0.035 seconds
[2024-02-08 09:51:11,803] INFO  - REQUESTED FROM: 10.145.209.80 CALL: formulas.save(formula_name="grafana", id="1000010000", type="SERVER", content=******) CALLER: (admin) TIME: 0.478 seconds
[2024-02-08 09:51:44,109] INFO  - REQUESTED FROM: 10.145.209.83 CALL: system.listSystemGroupsForSystemsWithEntitlement(entitlement=monitoring_entitled, loggedInUser=admin) CALLER: (admin) TIME: 0.003 seconds
[2024-02-08 09:51:44,114] INFO  - REQUESTED FROM: 10.145.209.83 CALL: system.monitoring.listEndpoints(sids=[], loggedInUser=admin) CALLER: (admin) TIME: 0.001 seconds
[2024-02-08 09:51:44,116] INFO  - REQUESTED FROM: 10.145.209.83 CALL: system.getNetworkForSystems(sids=[], loggedInUser=admin) CALLER: (admin) TIME: 0.0 seconds

      This scenario took: 21 seconds

Failing Scenarios:
cucumber features/build_validation/init_clients/monitoring_server.feature:88 # Scenario: Test Grafana dashboards of monitoring server

4 scenarios (1 failed, 3 passed)
41 steps (1 failed, 1 skipped, 39 passed)
3m11.656s
```

### After
```bash
(...)
  @susemanager
  Scenario: Test Grafana dashboards of monitoring server            # features/build_validation/init_clients/monitoring_server.feature:89
      This scenario ran at: 2024-02-08 11:36:25 +0100
Initializing a twopence node for 'monitoring_server'.
Node: suma-bv-50-monitoring, OS Version: 15-SP4, Family: sles
    When I visit the grafana dashboards of this "monitoring_server" # features/step_definitions/navigation_steps.rb:1191
    And I wait until I do not see "Loading Grafana" text            # features/step_definitions/navigation_steps.rb:43
    And I check radio button "View as list", if not checked         # features/step_definitions/common_steps.rb:215
    # These are the 4 dashboards created by default when enabling the Grafana formula
    Then I should see a "Apache2" text                              # features/step_definitions/navigation_steps.rb:589
    And I should see a "PostgreSQL database insights" text          # features/step_definitions/navigation_steps.rb:589
    And I should see a "SUSE Manager Client Systems" text           # features/step_definitions/navigation_steps.rb:589
    And I should see a "SUSE Manager Server" text                   # features/step_definitions/navigation_steps.rb:589
      This scenario took: 12 seconds

  @uyuni
  Scenario: Test Grafana dashboards of monitoring server            # features/build_validation/init_clients/monitoring_server.feature:100
      This scenario ran at: 2024-02-08 11:36:37 +0100
    When I visit the grafana dashboards of this "monitoring_server" # features/step_definitions/navigation_steps.rb:1191
    And I wait until I do not see "Loading Grafana" text            # features/step_definitions/navigation_steps.rb:43
    And I check radio button "View as list", if not checked         # features/step_definitions/common_steps.rb:215
    # These are the 4 dashboards created by default when enabling the Grafana formula
    Then I should see a "Apache2" text                              # features/step_definitions/navigation_steps.rb:589
    And I should see a "PostgreSQL database insights" text          # features/step_definitions/navigation_steps.rb:589
    And I should see a "Uyuni Client Systems" text                  # features/step_definitions/navigation_steps.rb:589
    And I should see a "Uyuni Server" text                          # features/step_definitions/navigation_steps.rb:589
      This scenario took: 0 seconds

3 scenarios (1 skipped, 2 passed)
15 steps (7 skipped, 8 passed)
0m24.774s
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # https://github.com/SUSE/spacewalk/pull/23655, https://github.com/SUSE/spacewalk/pull/23656

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!](<## What does this PR change?