### PR TITLE
Feat: Provide Python path matching in GH flow 

### DIFF
--- a/.github/workflows/python-checkstyle.yml
+++ b/.github/workflows/python-checkstyle.yml
@@ -26,11 +26,15 @@ jobs:
       uses: Ana06/get-changed-files@v2.2.0
       with:
         filter: '*.py'
+    
+    - id: filter-files
+      run: |
+        echo added_modified_renamed="$( echo '${{ steps.files.outputs.added_modified_renamed }}' | tr ' ' '\n' | grep -E 'python|spacewalk|susemanager' | tr '\n' ' ')" >> $GITHUB_ENV
 
     - name: Run black on files
       run: |
-        black --check --diff -t py36 ${{ steps.files.outputs.added_modified_renamed }}
+        black --check --diff -t py36 $added_modified_renamed
 
     - name: Run pylint on files
       run: |
-        pylint --rcfile=/root/.pylintrc ${{ steps.files.outputs.added_modified_renamed }}
+        pylint --rcfile=/root/.pylintrc $added_modified_renamed


### PR DESCRIPTION
## What does this PR change?

As per https://github.com/uyuni-project/uyuni/pull/8100, we linted files only in 4 directories: `python`, `spacewalk`, `susemanager` and `susemanager-utils`. This PR modifies the workflow such that it only runs checks on files in those directories. 

Tested before squashing commits into one.

## GUI diff

No difference.

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
