### PR TITLE
QE: Adapt BV test suite for 5.0

### DIFF
--- a/testsuite/features/build_validation/add_non_MU_repositories/centos7_minion_add_iso.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/centos7_minion_add_iso.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @centos7_minion
@@ -24,7 +24,7 @@ Feature: Add the CentOS 7 distribution custom repositories
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "centos-7-iso" as "label"
-    And I enter "http://127.0.0.1/centos-7-iso" as "url"
+    And I enter "file:///srv/www/htdocs/pub/centos-7-iso" as "url"
     And I uncheck "metadataSigned"
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text

--- a/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @rocky8_minion
@@ -39,7 +39,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "rocky-8-iso-appstream" as "label"
-    And I enter "http://127.0.0.1/rocky-8-iso/AppStream" as "url"
+    And I enter "file:///srv/www/htdocs/pub/rocky-8-iso/AppStream" as "url"
     And I uncheck "metadataSigned"
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
@@ -48,7 +48,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "rocky-8-iso-baseos" as "label"
-    And I enter "http://127.0.0.1/rocky-8-iso/BaseOS" as "url"
+    And I enter "file:///srv/www/htdocs/pub/rocky-8-iso/BaseOS" as "url"
     And I uncheck "metadataSigned"
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text

--- a/testsuite/features/build_validation/init_clients/ubuntu2204_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2204_minion.feature
@@ -22,7 +22,7 @@ Feature: Bootstrap a Ubuntu 22.04 Salt minion
     And I enter "22" as "port"
     And I enter "linux" as "password"
     And I select "1-ubuntu2204_minion_key" from "activationKeys"
-    And I select the hostname of "proxy" from "proxies"
+    And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "ubuntu2204_minion"

--- a/testsuite/features/build_validation/init_clients/ubuntu2204_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2204_ssh_minion.feature
@@ -21,7 +21,7 @@ Feature: Bootstrap a Ubuntu 22.04 Salt SSH minion
     And I enter "linux" as "password"
     And I enter "22" as "port"
     And I select "1-ubuntu2204_ssh_minion_key" from "activationKeys"
-    And I select the hostname of "proxy" from "proxies"
+    And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -23,7 +23,7 @@ end
 When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server, validating its checksum$/) do |name, url|
   # When using a mirror it is automatically mounted at /mirror
   if $mirror
-    iso_path = url.sub(/^https?:\/\/[^\/]+/, '/mirror')
+    iso_path = $is_container_provider ? url.sub(/^https?:\/\/[^\/]+/, '/srv/mirror') : url.sub(/^https?:\/\/[^\/]+/, '/mirror')
   else
     iso_path = "/tmp/#{name}.iso"
     get_target('server').run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 1500)
@@ -35,10 +35,19 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server, validating its
 
   raise 'SHA256 checksum validation failed' unless validate_checksum_with_file(original_iso_name, iso_path, checksum_path)
 
-  mount_point = "/srv/www/htdocs/#{name}"
-  get_target('server').run("mkdir -p #{mount_point}")
-  get_target('server').run("grep #{iso_path} /etc/fstab || echo '#{iso_path}  #{mount_point}  iso9660  loop,ro,_netdev  0 0' >> /etc/fstab")
-  get_target('server').run("umount #{iso_path}; mount #{iso_path}")
+  if $is_container_provider
+    mount_point = '/srv/www/distributions'
+    get_target('server').run("mkdir -p #{mount_point}")
+    # this needs to be run outside the container
+    get_target('server').run_local("mgradm distro copy #{iso_path} #{name}", verbose: true)
+    get_target('server').run("ln -s #{mount_point}/#{name} /srv/www/htdocs/pub/")
+  else
+    mount_point = "/srv/www/htdocs/pub/#{name}"
+    cmd = "mkdir -p #{mount_point} && " \
+          "grep #{iso_path} /etc/fstab || echo '#{iso_path}  #{mount_point}  iso9660  loop,ro,_netdev  0 0' >> /etc/fstab && " \
+          "umount #{iso_path}; mount #{iso_path}"
+    get_target('server').run(cmd, verbose: true)
+  end
 end
 
 Then(/^the hostname for "([^"]*)" should be correct$/) do |host|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -174,7 +174,7 @@ When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
 end
 
 When(/^I select the parent channel for the "([^"]*)" from "([^"]*)"$/) do |client, from|
-  product_key = $is_container_provider ? 'Fake' : product
+  product_key = $is_container_provider && !$build_validation ? 'Fake' : product
   select(BASE_CHANNEL_BY_CLIENT[product_key][client], from: from, exact: false)
 end
 

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2023-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'net/http'
@@ -68,9 +68,10 @@ def get_checksum_path(dir, original_file_name, file_url)
   checksum_file_names = %W[CHECKSUM SHA256SUMS sha256sum.txt #{original_file_name}.CHECKSUM #{original_file_name}.sha256]
 
   server = get_target('server')
+  cmd = "ls -1 #{dir}"
   # when using a mirror, the checksum file should be present and in the same directory of the file
   if $mirror
-    output, _code = server.run("ls -1 #{dir}")
+    output, _code = $is_container_provider ? server.run_local(cmd) : server.run(cmd)
     files = output.split("\n")
     checksum_file = files.find { |file| checksum_file_names.include?(file) }
 
@@ -107,7 +108,8 @@ end
 # The original file name is used to retrieve the correct checksum entry
 def validate_checksum_with_file(original_file_name, file_path, checksum_path)
   # search the checksum file for what should be the only non-comment line containing the original file name
-  checksum_line, _code = get_target('server').run("grep -v '^#' #{checksum_path} | grep '#{original_file_name}'")
+  cmd = "grep -v '^#' #{checksum_path} | grep '#{original_file_name}'"
+  checksum_line, _code = $is_container_provider ? get_target('server').run_local(cmd) : get_target('server').run(cmd)
   raise "SHA256 checksum entry for #{original_file_name} not found in #{checksum_path}" unless checksum_line
 
   # this relies on the fact that SHA256 hashes have a fixed length of 64 hexadecimal characters to extract the checksum
@@ -122,6 +124,7 @@ end
 # Computes the SHA256 checksum of the file at the given path and returns a boolean representing whether it
 # matches the expected checksum or not
 def validate_checksum(file_path, expected_checksum)
-  file_checksum, _code = get_target('server').run("sha256sum -b #{file_path} | awk '{print $1}'")
+  cmd = "sha256sum -b #{file_path} | awk '{print $1}'"
+  file_checksum, _code = $is_container_provider ? get_target('server').run_local(cmd) : get_target('server').run(cmd)
   file_checksum.strip == expected_checksum
 end


### PR DESCRIPTION
## What does this PR change?

This fixes some of the current issues found in the 5.0 BV, like

- Add MU repos: wrong parent channel selection
- Add non MU repos: adapt our image mounting steps for the container, e.g. use `mgradm distro copy`, because we cannot mount anything inside the server container
- fix the proxy selection step for Ubuntu 22.04

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # https://github.com/SUSE/spacewalk/pull/23719

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!