### PR TITLE
Fix typo in 'Deploy Files' page

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -15139,7 +15139,7 @@ but are not subscribed to _@@PRODUCT_NAME@@Config_.</context>
         </context-group>
       </trans-unit>
       <trans-unit id="deployconfirm.jsp.h2" xml:space="preserve">
-        <source>Deploy Configuration Files: Comfirm Fields and Systems for Deployment</source>
+        <source>Deploy Configuration Files: Confirm Fields and Systems for Deployment</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/configuration/channel/DeployConfirm.do</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/manager/profile/ProfileManager.java
+++ b/java/code/src/com/redhat/rhn/manager/profile/ProfileManager.java
@@ -550,7 +550,7 @@ public class ProfileManager extends BaseManager {
     }
 
     /**
-     * Prepares the list of packages to be synced for comfirmation.
+     * Prepares the list of packages to be synced for confirmation.
      * @param sid Server involved in sync.
      * @param prid Profile we're syncing with.
      * @param orgid Org id
@@ -584,7 +584,7 @@ public class ProfileManager extends BaseManager {
     }
 
     /**
-     * Prepares the list of packages to be synced for comfirmation.
+     * Prepares the list of packages to be synced for confirmation.
      * @param sid Server involved in sync.
      * @param sid1 Profile we're syncing with.
      * @param orgid Org id

--- a/java/scripts/spelling/ignored_en.txt
+++ b/java/scripts/spelling/ignored_en.txt
@@ -136,7 +136,6 @@ checkboxes
 checkin
 Checksum
 chroot
-Comfirm
 commandline
 CommitErrataPackageChanges
 CompletedActions

--- a/java/spacewalk-java.changes.pinvernizzi.frontend-typo-fix
+++ b/java/spacewalk-java.changes.pinvernizzi.frontend-typo-fix
@@ -1,0 +1,1 @@
+- Fix a typo in 'Deploy Files' page


### PR DESCRIPTION
## What does this PR change?

Fix a typo appearing in the "Deploy Files" page when trying to deploy configuration files.

Co**m**firm -> Confirm

![image](https://github.com/uyuni-project/uyuni/assets/61153476/2cf2e17b-778d-477b-b7c1-abc1437e1881)

## GUI diff

After: Same with  "Confirm" in the displayed  text

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage

- No tests: minor change in UI

- [x] **DONE**

## Links

Port(s):  Manager 4.3 https://github.com/SUSE/spacewalk/pull/23660

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
