### PR TITLE
Configuration files: give the confirmation page time to appear

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -1,9 +1,9 @@
-# Copyright (c) 2020-2023 SUSE LLC.
+# Copyright (c) 2020-2024 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @<client>
 Feature: Smoke tests for <client>
-  In order to test <client>
+  In order to manage <client>
   As an authorized user
   I want to :
   - View the details of the system
@@ -119,7 +119,7 @@ Feature: Smoke tests for <client>
     And I reboot the "<client>" if it is a SLE Micro
 
   Scenario: Deploy the configuration file to <client>
-    And I follow the left menu "Configuration > Channels"
+    When I follow the left menu "Configuration > Channels"
     And I wait until I see "Centrally Managed Configuration Channel" text
     And I follow "Mixed Channel"
     And I wait until I see "Channel Properties" text
@@ -129,6 +129,7 @@ Feature: Smoke tests for <client>
     And I click on the filter button
     And I check the "<client>" client
     And I click on "Confirm & Deploy to Selected Systems"
+    And I wait until I see "Revision 1" text
     Then I should see a "/etc/s-mgr/config" link
     When I click on "Deploy Files to Selected Systems"
     Then I should see a "1 revision-deploy is being scheduled." text


### PR DESCRIPTION
## What does this PR change?

Configuration files: give the confirmation page time to appear


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/23659
 

## Changelogs

- [x] No changelog needed
