### PR TITLE
Coco attestation java

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -90,7 +90,9 @@ import com.redhat.rhn.domain.task.Task;
 
 import com.suse.cloud.domain.PaygDimensionComputation;
 import com.suse.cloud.domain.PaygDimensionResult;
+import com.suse.manager.model.attestation.CoCoAttestationResult;
 import com.suse.manager.model.attestation.CoCoEnvironmentTypeConverter;
+import com.suse.manager.model.attestation.CoCoResultTypeConverter;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
@@ -189,7 +191,9 @@ public class AnnotationRegistry {
         VHMCredentials.class,
         ServerCoCoAttestationConfig.class,
         ServerCoCoAttestationReport.class,
-        CoCoEnvironmentTypeConverter.class
+        CoCoEnvironmentTypeConverter.class,
+        CoCoAttestationResult.class,
+        CoCoResultTypeConverter.class
     );
 
     /**

--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -92,6 +92,7 @@ import com.suse.cloud.domain.PaygDimensionComputation;
 import com.suse.cloud.domain.PaygDimensionResult;
 import com.suse.manager.model.attestation.CoCoEnvironmentTypeConverter;
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 
@@ -187,6 +188,7 @@ public class AnnotationRegistry {
         SCCCredentials.class,
         VHMCredentials.class,
         ServerCoCoAttestationConfig.class,
+        ServerCoCoAttestationReport.class,
         CoCoEnvironmentTypeConverter.class
     );
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -90,6 +90,8 @@ import com.redhat.rhn.domain.task.Task;
 
 import com.suse.cloud.domain.PaygDimensionComputation;
 import com.suse.cloud.domain.PaygDimensionResult;
+import com.suse.manager.model.attestation.CoCoEnvironmentTypeConverter;
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 
@@ -183,7 +185,9 @@ public class AnnotationRegistry {
         ReportDBCredentials.class,
         RHUICredentials.class,
         SCCCredentials.class,
-        VHMCredentials.class
+        VHMCredentials.class,
+        ServerCoCoAttestationConfig.class,
+        CoCoEnvironmentTypeConverter.class
     );
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/Action.java
+++ b/java/code/src/com/redhat/rhn/domain/action/Action.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.webui.websocket.WebSocketActionIdProvider;
 
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +52,7 @@ public class Action extends BaseDomainHelper implements Serializable, WebSocketA
     private ActionType actionType;
 
     private Set<ServerAction> serverActions;
+    private Set<ServerCoCoAttestationReport> cocoAttestationReports;
     private User schedulerUser;
     private Org org;
 
@@ -209,6 +211,33 @@ public class Action extends BaseDomainHelper implements Serializable, WebSocketA
     @Override
     public void setModified(Date modifiedIn) {
         this.modified = modifiedIn;
+    }
+
+    /**
+     * Getter for CocoAttestationReports
+     * @return return the attestation reports
+     */
+    public Set<ServerCoCoAttestationReport> getCocoAttestationReports() {
+        return cocoAttestationReports;
+    }
+
+    /**
+     * Setter for CocoAttestationReports
+     * @param cocoAttestationReportsIn the reports
+     */
+    public void setCocoAttestationReports(Set<ServerCoCoAttestationReport> cocoAttestationReportsIn) {
+        cocoAttestationReports = cocoAttestationReportsIn;
+    }
+
+    /**
+     * Add CocoAttestationReport to Action
+     * @param cocoAttestationReportIn the report to add
+     */
+    public void addCocoAttestationReport(ServerCoCoAttestationReport cocoAttestationReportIn) {
+        if (cocoAttestationReports == null) {
+            cocoAttestationReports = new HashSet<>();
+        }
+        cocoAttestationReports.add(cocoAttestationReportIn);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -508,6 +508,9 @@ public class ActionFactory extends HibernateFactory {
         else if (typeIn.equals(TYPE_PLAYBOOK)) {
             retval = new PlaybookAction();
         }
+        else if (typeIn.equals(TYPE_COCO_ATTESTATION)) {
+            retval = new CoCoAttestationAction();
+        }
         else {
             retval = new Action();
         }
@@ -1427,5 +1430,11 @@ public class ActionFactory extends HibernateFactory {
      */
     public static final ActionType TYPE_VIRTUALIZATION_GUEST_MIGRATE =
             lookupActionTypeByLabel("virt.guest_migrate");
+
+    /**
+     * The constant representing "Confidential Compute Attestation" [ID:523]
+     */
+    public static final ActionType TYPE_COCO_ATTESTATION =
+            lookupActionTypeByLabel("coco.attestation");
 }
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -38,6 +38,10 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             <one-to-many
                 class="com.redhat.rhn.domain.action.server.ServerAction" />
         </set>
+        <set name="cocoAttestationReports" outer-join="false" cascade="all" lazy="true" inverse="true">
+            <key column="action_id"/>
+            <one-to-many class="com.suse.manager.model.attestation.ServerCoCoAttestationReport"/>
+        </set>
         <many-to-one
             name="org"
             class="com.redhat.rhn.domain.org.Org"

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -539,6 +539,11 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 <property name="target"/>
             </join>
         </subclass>
+        <!-- CoCoAttestation Action -->
+        <subclass
+            name="com.redhat.rhn.domain.action.CoCoAttestationAction"
+            discriminator-value="523" lazy="true">
+        </subclass>
 
     </class>
     <query name="Action.findByIdandOrgId">

--- a/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.action;
+
+
+/**
+ * CoCoAttestationAction - Class representing TYPE_COCO_ATTESTATION
+ */
+public class CoCoAttestationAction extends Action {
+
+}

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -41,6 +41,7 @@ import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.utils.Opt;
 
@@ -123,6 +124,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     private Set<ConfigChannel> localChannels = new HashSet<>();
     private Location serverLocation;
     private ServerCoCoAttestationConfig cocoAttestationConfig;
+    private Set<ServerCoCoAttestationReport> cocoAttestationReports;
     private Set<VirtualInstance> guests = new HashSet<>();
     private VirtualInstance virtualInstance;
     private PushClient pushClient;
@@ -1325,6 +1327,26 @@ public class Server extends BaseDomainHelper implements Identifiable {
         cocoAttestationConfig = cocoAttestationConfigIn;
     }
 
+    /**
+     * @return Returns the Attestation Reports assosiated with the server
+     */
+    public Set<ServerCoCoAttestationReport> getCocoAttestationReports() {
+        return cocoAttestationReports;
+    }
+
+    /**
+     * @param cocoAttestationReportsIn the attestation reports to set
+     */
+    public void setCocoAttestationReports(Set<ServerCoCoAttestationReport> cocoAttestationReportsIn) {
+        cocoAttestationReports = cocoAttestationReportsIn;
+    }
+
+    /**
+     * @param cocoAttestationReportIn the attestation report to add
+     */
+    public void addCocoAttestationReports(ServerCoCoAttestationReport cocoAttestationReportIn) {
+        cocoAttestationReports.add(cocoAttestationReportIn);
+    }
     private void initializeRam() {
         if (ram == null) {
             ram = new Ram();

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -40,6 +40,7 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.manager.system.SystemManager;
 
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.utils.Opt;
 
@@ -121,6 +122,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     private List<ConfigChannel> configChannels = new ArrayList<>();
     private Set<ConfigChannel> localChannels = new HashSet<>();
     private Location serverLocation;
+    private ServerCoCoAttestationConfig cocoAttestationConfig;
     private Set<VirtualInstance> guests = new HashSet<>();
     private VirtualInstance virtualInstance;
     private PushClient pushClient;
@@ -1300,6 +1302,27 @@ public class Server extends BaseDomainHelper implements Identifiable {
      */
     public void setLocation(Location locationIn) {
         serverLocation = locationIn;
+    }
+
+    /**
+     * @return Returns the cocoAttestationConfiguration assosiated with the server
+     */
+    protected ServerCoCoAttestationConfig getCocoAttestationConfig() {
+        return cocoAttestationConfig;
+    }
+
+    /**
+     * @return Returns the cocoAttestationConfiguration assosiated with the server if available
+     */
+    public Optional<ServerCoCoAttestationConfig> getOptCocoAttestationConfig() {
+        return Optional.ofNullable(cocoAttestationConfig);
+    }
+
+    /**
+     * @param cocoAttestationConfigIn cocoAttestationConfiguration for this server
+     */
+    public void setCocoAttestationConfig(ServerCoCoAttestationConfig cocoAttestationConfigIn) {
+        cocoAttestationConfig = cocoAttestationConfigIn;
     }
 
     private void initializeRam() {

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -160,6 +160,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <one-to-one name="location" class="com.redhat.rhn.domain.server.Location"
             property-ref="server" cascade="all" lazy="proxy" />
 
+        <one-to-one name="cocoAttestationConfig" class="com.suse.manager.model.attestation.ServerCoCoAttestationConfig"
+                    cascade="all" lazy="proxy"/>
+
         <one-to-one name="virtualInstance"
                     class="com.redhat.rhn.domain.server.VirtualInstance"
                     property-ref="guestSystem"

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -161,7 +161,11 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             property-ref="server" cascade="all" lazy="proxy" />
 
         <one-to-one name="cocoAttestationConfig" class="com.suse.manager.model.attestation.ServerCoCoAttestationConfig"
-                    cascade="all" lazy="proxy"/>
+                    property-ref="server" cascade="all" lazy="proxy"/>
+        <set name="cocoAttestationReports" inverse="true" cascade="all">
+            <key column="server_id"/>
+            <one-to-many class="com.suse.manager.model.attestation.ServerCoCoAttestationReport"/>
+        </set>
 
         <one-to-one name="virtualInstance"
                     class="com.redhat.rhn.domain.server.VirtualInstance"

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/CoCoAttestationConfigSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/CoCoAttestationConfigSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.suse.manager.api.ApiResponseSerializer;
+import com.suse.manager.api.SerializationBuilder;
+import com.suse.manager.api.SerializedApiResponse;
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
+
+/**
+ * CoCoAttestationConfigSerializer will serialize an {@link ServerCoCoAttestationConfig} object to XMLRPC
+ * syntax.
+ *
+ * @apidoc.doc
+ *
+ * #struct_begin("coco_attestation_config")
+ *   #prop_desc("boolean", "enabled", "true if Confidential Compute Attestation is enabled for this system")
+ *   #prop_desc("string", "environment_type", "the configured environment type")
+ *   #prop_desc("int", "system_id", "the ID of the system")
+ * #struct_end()
+ */
+public class CoCoAttestationConfigSerializer extends ApiResponseSerializer<ServerCoCoAttestationConfig> {
+
+    @Override
+    public Class<ServerCoCoAttestationConfig> getSupportedClass() {
+        return ServerCoCoAttestationConfig.class;
+    }
+
+    @Override
+    public SerializedApiResponse serialize(ServerCoCoAttestationConfig src) {
+        return new SerializationBuilder()
+                .add("enabled", src.isEnabled())
+                .add("environment_type", src.getEnvironmentType().name())
+                .add("system_id", src.getServer().getId())
+                .build();
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -160,6 +160,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(SystemEventDtoSerializer.class);
         SERIALIZER_CLASSES.add(SystemEventDetailsDtoSerializer.class);
         SERIALIZER_CLASSES.add(PaygSshDataSerializer.class);
+        SERIALIZER_CLASSES.add(CoCoAttestationConfigSerializer.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -36,6 +36,7 @@ import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionType;
+import com.redhat.rhn.domain.action.CoCoAttestationAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesActionDetails;
 import com.redhat.rhn.domain.action.salt.ApplyStatesActionResult;
 import com.redhat.rhn.domain.action.salt.StateResult;
@@ -116,6 +117,7 @@ import com.redhat.rhn.frontend.dto.SystemOverview;
 import com.redhat.rhn.frontend.dto.VirtualSystemOverview;
 import com.redhat.rhn.frontend.events.SsmDeleteServersEvent;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidActionTypeException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
@@ -189,6 +191,10 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.cloud.CloudPaygManager;
 import com.suse.manager.api.ApiIgnore;
 import com.suse.manager.api.ReadOnly;
+import com.suse.manager.attestation.AttestationDisabledException;
+import com.suse.manager.attestation.AttestationManager;
+import com.suse.manager.model.attestation.CoCoEnvironmentType;
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.virtualization.VirtualizationActionHelper;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestSetterActionJson;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestsBaseActionJson;
@@ -5156,6 +5162,96 @@ public class SystemHandler extends BaseHandler {
         return scheduleScriptRun(loggedInUser, label, systemIds, username, groupname,
                 timeout,
                 script, earliestOccurrence);
+    }
+
+    /**
+     * Schedule Confidential Compute Attestation Action
+     * @param loggedInUser the logged in user
+     * @param sid ID of the server to run the attestation for
+     * @param earliestOccurrence Earliest the script can run
+     * @return ID of the new script action
+     *
+     * @apidoc.doc Schedule Confidential Compute Attestation Action
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("int", "sid",
+     * "ID of the server to run the script on.")
+     * @apidoc.param #param_desc("$date", "earliestOccurrence",
+     * "Earliest the script can run.")
+     * @apidoc.returntype #param_desc("int", "id", "ID of the script run action created. Can be used to fetch
+     * results with system.getScriptResults")
+     */
+    public Integer scheduleCoCoAttestation(User loggedInUser, Integer sid, Date earliestOccurrence) {
+        MinionServer minionServer = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser)
+                .asMinionServer().orElseThrow(NoSuchSystemException::new);
+        try {
+            AttestationManager mgr = new AttestationManager();
+            CoCoAttestationAction action = mgr.scheduleAttestationAction(loggedInUser, minionServer,
+                    earliestOccurrence);
+            return action.getId().intValue();
+        }
+        catch (LookupException e) {
+            throw new EntityNotExistsFaultException(e);
+        }
+        catch (AttestationDisabledException e) {
+            throw new UnsupportedOperationException(e);
+        }
+        catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
+            throw new TaskomaticApiException(e.getMessage());
+        }
+    }
+
+    /**
+     * Return the Confidential Compute Attestation configuration for the given system id
+     * @param loggedInUser the user
+     * @param sid the system id
+     * @return returns {@link com.suse.manager.model.attestation.ServerCoCoAttestationConfig} values
+     *
+     * @apidoc.doc Return the Confidential Compute Attestation configuration for the given system id
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("int", "sid", "ID of the server to get the config for.")
+     * @apidoc.returntype $CoCoAttestationConfigSerializer
+     */
+    @ReadOnly
+    public ServerCoCoAttestationConfig getCoCoAttestationConfig(User loggedInUser, Integer sid) {
+        MinionServer minionServer = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser).asMinionServer()
+                .orElseThrow(NoSuchSystemException::new);
+        return minionServer.getOptCocoAttestationConfig()
+                .orElse(new ServerCoCoAttestationConfig());
+    }
+
+    /**
+     * Configure Confidential Compute Attestation for the given system
+     * @param loggedInUser the user
+     * @param sid the ID of the system
+     * @param enabled set the endabled state for Confidential Compute Attestation
+     * @param environmentType set the environment type of the system
+     * @return Returns 1 if successful, exception otherwise.
+     *
+     * @apidoc.doc Configure Confidential Compute Attestation for the given system
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("int", "sid", "ID of the server to get the config for.")
+     * @apidoc.param #param_desc("boolean", "enabled", "set the endabled state for Confidential Compute Attestation")
+     * @apidoc.param #param_desc("string", "environmentType", "set the environment type of the system:")
+     *   #options()
+     *     #item("NONE")
+     *     #item("KVM_AMD_EPYC_MILAN")
+     *     #item("KVM_AMD_EPYC_GENOA")
+     *   #options_end()
+     * @apidoc.returntype #return_int_success()
+     */
+    public Integer setCoCoAttestationConfig(User loggedInUser, Integer sid, Boolean enabled, String environmentType) {
+        MinionServer minionServer = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser).asMinionServer()
+                .orElseThrow(NoSuchSystemException::new);
+        AttestationManager mgr = new AttestationManager();
+        minionServer.getOptCocoAttestationConfig()
+                .ifPresentOrElse(
+                        c -> {
+                            c.setEnabled(enabled);
+                            c.setEnvironmentType(CoCoEnvironmentType.valueOf(environmentType));
+                        },
+                        () -> mgr.createConfig(loggedInUser, minionServer,
+                                CoCoEnvironmentType.valueOf(environmentType), enabled));
+        return 1;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -2458,7 +2458,6 @@ public class ActionManager extends BaseManager {
      * @return Returns a list of scheduled action ids
      *
      */
-
     public static List<Long> changeProxy(User loggedInUser, List<Long> sysids, Long proxyId)
         throws TaskomaticApiException {
         List<Long> visible = MinionServerFactory.lookupVisibleToUser(loggedInUser)

--- a/java/code/src/com/suse/manager/attestation/AttestationDisabledException.java
+++ b/java/code/src/com/suse/manager/attestation/AttestationDisabledException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.attestation;
+
+/**
+ * AttestationDisabledException
+ */
+public class AttestationDisabledException extends RuntimeException {
+
+    /**
+     * Constructor
+     */
+    public AttestationDisabledException() {
+        super();
+    }
+}

--- a/java/code/src/com/suse/manager/attestation/AttestationManager.java
+++ b/java/code/src/com/suse/manager/attestation/AttestationManager.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.attestation;
+
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.CoCoAttestationAction;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
+import com.suse.manager.model.attestation.AttestationFactory;
+import com.suse.manager.model.attestation.CoCoEnvironmentType;
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Attestation Manager
+ */
+public class AttestationManager {
+    private static final Logger LOG = LogManager.getLogger(AttestationManager.class);
+    private final AttestationFactory factory;
+    private final TaskomaticApi taskomaticApi;
+
+    /**
+     * Constructor
+     */
+    public AttestationManager() {
+        this(new AttestationFactory(), new TaskomaticApi());
+    }
+
+    /**
+     * Constructor
+     * @param factoryIn the attestation factory
+     * @param taskomaticApiIn the taskomatic api
+     */
+    public AttestationManager(AttestationFactory factoryIn, TaskomaticApi taskomaticApiIn) {
+        factory = factoryIn;
+        taskomaticApi = taskomaticApiIn;
+    }
+
+    /**
+     * Create an Attestation Action for a given minion.
+     * @param userIn the user
+     * @param minionIn the minion
+     * @param earliest the earliest execution date
+     * @return returns a {@link CoCoAttestationAction}
+     */
+    public CoCoAttestationAction scheduleAttestationAction(User userIn, MinionServer minionIn, Date earliest)
+            throws TaskomaticApiException {
+        ensureSystemAccessible(userIn, minionIn);
+        ensureSystemConfigured(minionIn);
+        CoCoAttestationAction action = (CoCoAttestationAction) ActionFactory.createAction(
+                ActionFactory.TYPE_COCO_ATTESTATION, earliest);
+        action.setSchedulerUser(userIn);
+        action.setOrg(userIn.getOrg());
+        action.setName("Confidential Compute Attestation");
+        ActionFactory.save(action);
+
+        //Initialize the report
+        ServerCoCoAttestationReport initReport = initializeReport(userIn, minionIn);
+        initReport.setAction(action);
+        if (initReport.getEnvironmentType().isNonceRequired()) {
+            SecureRandom rand = new SecureRandom();
+            byte[] bytes = new byte[64];
+            rand.nextBytes(bytes);
+            initReport.setInData(Map.of("nonce", Base64.getEncoder().encodeToString(bytes)));
+        }
+
+        MinionPillarManager.INSTANCE.generatePillar(minionIn, false, MinionPillarManager.PillarSubset.GENERAL);
+        ActionManager.scheduleForExecution(action, Set.of(minionIn.getId()));
+        action = (CoCoAttestationAction) ActionFactory.save(action);
+        taskomaticApi.scheduleActionExecution(action);
+        return action;
+    }
+
+    /**
+     * Create a Attestation configuration for a given server
+     * @param userIn the user
+     * @param serverIn the server
+     * @param typeIn the environment type
+     * @param enabledIn should the config been enabled
+     * @return returns the configuration
+     */
+    public ServerCoCoAttestationConfig createConfig(User userIn, Server serverIn, CoCoEnvironmentType typeIn,
+                                                    boolean enabledIn) {
+        ensureSystemAccessible(userIn, serverIn);
+        return factory.createConfigForServer(serverIn, typeIn, enabledIn);
+    }
+
+    /**
+     * Initialize a new Attestation Report with defaults from the Server Configuration
+     * @param userIn the user
+     * @param serverIn the server
+     * @return returns the initialized report
+     */
+    public ServerCoCoAttestationReport initializeReport(User userIn, Server serverIn) {
+        ensureSystemAccessible(userIn, serverIn);
+        return factory.createReportForServer(serverIn);
+    }
+
+    /**
+     * Initialze the Attestation Results for a given report
+     * @param userIn the user
+     * @param reportIn the report
+     */
+    public void initializeResults(User userIn, ServerCoCoAttestationReport reportIn) {
+        Server server = reportIn.getServer();
+        ensureSystemAccessible(userIn, server);
+        factory.initResultsForReport(reportIn);
+    }
+
+    /**
+     * @param userIn the user
+     * @param serverIn the server
+     * @param actionIn the action
+     * @return returns the attestation report for this server and action if available
+     */
+    public Optional<ServerCoCoAttestationReport> lookupReportByServerAndAction(
+            User userIn, Server serverIn, Action actionIn) {
+        ensureSystemAccessible(userIn, serverIn);
+        return factory.lookupReportByServerAndAction(serverIn, actionIn);
+    }
+
+    private void ensureSystemAccessible(User userIn, Server serverIn) {
+        if (serverIn == null) {
+            LOG.error("Server not found");
+            throw new LookupException("Server not found");
+        }
+        else if (!SystemManager.isAvailableToUser(userIn, serverIn.getId())) {
+            String msg = String.format("User '%s' can't access system '%s'", userIn, serverIn.getName());
+            LOG.error(msg);
+            throw new PermissionException(msg);
+        }
+    }
+
+    private void ensureSystemConfigured(Server serverIn) {
+        if (serverIn == null) {
+            LOG.error("Server not found");
+            throw new LookupException("Server not found");
+        }
+        ServerCoCoAttestationConfig cnf = serverIn.getOptCocoAttestationConfig()
+                .orElseThrow(() -> {
+                    LOG.error("Configuration not initialized");
+                    return new LookupException("Configuration not found");
+                });
+        if (!cnf.isEnabled()) {
+            LOG.error("Attestation disabled");
+            throw new AttestationDisabledException();
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
+++ b/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.attestation.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.CoCoAttestationAction;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Pillar;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.attestation.AttestationManager;
+import com.suse.manager.model.attestation.AttestationFactory;
+import com.suse.manager.model.attestation.CoCoAttestationResult;
+import com.suse.manager.model.attestation.CoCoEnvironmentType;
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
+import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
+
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
+
+    private User user2;
+    private Server server;
+    private AttestationManager mgr;
+    private static TaskomaticApi taskomaticApi;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        context.setThreadingPolicy(new Synchroniser());
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        user2 = UserTestUtils.createUser("user2", user.getOrg().getId());
+        server = ServerFactoryTest.createTestServer(user, true);
+        mgr = new AttestationManager(new AttestationFactory(), getTaskomaticApi());
+    }
+
+    @Test
+    public void testCreateAttestationConfiguration() {
+        assertThrows(PermissionException.class,
+                () -> mgr.createConfig(user2, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true));
+
+        ServerCoCoAttestationConfig cnf = mgr.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
+        assertNotNull(cnf);
+    }
+
+    @Test
+    public void testInitializeAttestationReport() {
+        assertThrows(PermissionException.class, () -> mgr.initializeReport(user2, server));
+        assertThrows(LookupException.class, () -> mgr.initializeReport(user, server));
+
+        mgr.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
+        ServerCoCoAttestationReport report = mgr.initializeReport(user, server);
+        assertNotNull(report);
+    }
+
+    @Test
+    public void testInitializeAttestationResults() {
+        mgr.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
+        ServerCoCoAttestationReport report = mgr.initializeReport(user, server);
+        assertThrows(PermissionException.class, () -> mgr.initializeResults(user2, report));
+
+        ServerCoCoAttestationReport brokenReport = new ServerCoCoAttestationReport();
+        assertThrows(LookupException.class, () -> mgr.initializeResults(user, brokenReport));
+
+        mgr.initializeResults(user, report);
+        List<CoCoAttestationResult> results = report.getResults();
+        assertTrue(results.size() > 0);
+    }
+
+    @Test
+    public void testCreateAttestationAction() throws TaskomaticApiException {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        mgr.createConfig(user, minion, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
+        Date now = new Date();
+        CoCoAttestationAction action = mgr.scheduleAttestationAction(user, minion, now);
+        assertNotNull(action);
+
+        AttestationFactory f = new AttestationFactory();
+        Optional<ServerCoCoAttestationReport> latestReport = f.lookupLatestReportByServer(minion);
+        Map<String, Object> inData = latestReport.orElse(new ServerCoCoAttestationReport()).getInData();
+        assertNotNull(inData);
+        String nonceReport = (String) inData.getOrDefault("nonce", "not in report");
+        Pillar pillar = minion.getPillarByCategory(MinionGeneralPillarGenerator.CATEGORY).orElse(new Pillar());
+        Map<String, Object> attestationData = (Map<String, Object>) pillar.getPillar()
+                .getOrDefault("attestation_data", new HashMap<>());
+        String noncePillar = (String) attestationData.getOrDefault("nonce", "not in pillar");
+        assertEquals(nonceReport, noncePillar);
+        assertEquals("KVM_AMD_EPYC_GENOA",
+                attestationData.getOrDefault("environment_type", "environment_type not found"));
+    }
+
+     private TaskomaticApi getTaskomaticApi() throws TaskomaticApiException {
+        if (taskomaticApi == null) {
+            taskomaticApi = context.mock(TaskomaticApi.class);
+            context.checking(new Expectations() {
+                {
+                    allowing(taskomaticApi).scheduleActionExecution(with(any(Action.class)));
+                }
+            });
+        }
+
+        return taskomaticApi;
+    }
+}

--- a/java/code/src/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/code/src/com/suse/manager/model/attestation/AttestationFactory.java
@@ -45,6 +45,14 @@ public class AttestationFactory extends HibernateFactory {
     }
 
     /**
+     * Save a {@link CoCoAttestationResult} object
+     * @param result object to save
+     */
+    public void save(CoCoAttestationResult result) {
+        saveObject(result);
+    }
+
+    /**
      * @param serverId the server id
      * @return returns the optional attestation config for the selected system
      */
@@ -96,6 +104,18 @@ public class AttestationFactory extends HibernateFactory {
     }
 
     /**
+     * @param resultId the result id
+     * @return returns the optional attestation result for the given id
+     */
+    public Optional<CoCoAttestationResult> lookupResultById(long resultId) {
+        return getSession()
+                .createQuery("FROM CoCoAttestationResult WHERE id = :id",
+                        CoCoAttestationResult.class)
+                .setParameter("id", resultId)
+                .uniqueResultOptional();
+    }
+
+    /**
      * Create a Confidential Compute Attestation Config for a given Server ID
      * @param serverIn the server
      * @param typeIn the environment type
@@ -134,6 +154,23 @@ public class AttestationFactory extends HibernateFactory {
         }
         else {
             throw new LookupException("CoCoAttestation Config not found or disabled");
+        }
+    }
+
+    /**
+     * Initialize expected results for a given report.
+     * @param report the report
+     */
+    public void initResultsForReport(ServerCoCoAttestationReport report) {
+        CoCoEnvironmentType envType = report.getEnvironmentType();
+        for (CoCoResultType t : envType.getSupportedResultTypes()) {
+            CoCoAttestationResult result = new CoCoAttestationResult();
+            result.setResultType(t);
+            result.setReport(report);
+            result.setStatus(CoCoAttestationStatus.PENDING);
+            result.setDescription(t.getTypeDescription());
+            save(result);
+            report.addResults(result);
         }
     }
 

--- a/java/code/src/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/code/src/com/suse/manager/model/attestation/AttestationFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AttestationFactory extends HibernateFactory {
+
+    private static final Logger LOG = LogManager.getLogger(AttestationFactory.class);
+
+    /**
+     * Save a {@link ServerCoCoAttestationConfig} object
+     * @param cnf object to save
+     */
+    public void save(ServerCoCoAttestationConfig cnf) {
+        saveObject(cnf);
+    }
+
+    /**
+     * @param serverId the server id
+     * @return returns the optional attestation config for the selected system
+     */
+    public Optional<ServerCoCoAttestationConfig> lookupConfigByServerId(long serverId) {
+        return getSession()
+                .createQuery("FROM ServerCoCoAttestationConfig WHERE server_id = :serverId",
+                        ServerCoCoAttestationConfig.class)
+                .setParameter("serverId", serverId)
+                .uniqueResultOptional();
+    }
+    /**
+     * Create a Confidential Compute Attestation Config for a given Server ID
+     * @param serverIn the server
+     * @param typeIn the environment type
+     * @param enabledIn enabled status
+     * @return returns the Confidential Compute Attestation Config
+     */
+    public ServerCoCoAttestationConfig createConfigForServer(Server serverIn, CoCoEnvironmentType typeIn,
+                                                             boolean enabledIn) {
+        ServerCoCoAttestationConfig cnf = new ServerCoCoAttestationConfig();
+        cnf.setServer(serverIn);
+        cnf.setEnvironmentType(typeIn);
+        cnf.setEnabled(enabledIn);
+        save(cnf);
+        serverIn.setCocoAttestationConfig(cnf);
+        return cnf;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+}

--- a/java/code/src/com/suse/manager/model/attestation/CoCoAttestationResult.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoAttestationResult.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Optional;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+@Entity
+@Table(name = "suseCoCoAttestationResult")
+public class CoCoAttestationResult {
+    private Long id;
+    private ServerCoCoAttestationReport report;
+    private CoCoResultType resultType;
+    private CoCoAttestationStatus status;
+    private String description;
+    private String details;
+
+    /**
+     * @return return the ID
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cocoatt_result_seq")
+    @SequenceGenerator(name = "cocoatt_result_seq", sequenceName = "suse_cocoatt_res_id_seq",
+            allocationSize = 1)
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @return return the server
+     */
+    @ManyToOne
+    @JoinColumn(name = "report_id")
+    public ServerCoCoAttestationReport getReport() {
+        return report;
+    }
+
+    /**
+     * @return return the selected environment type
+     */
+    @Column(name = "result_type")
+    @Convert(converter = CoCoResultTypeConverter.class)
+    public CoCoResultType getResultType() {
+        return resultType;
+    }
+
+    /**
+     * @return returns the status
+     */
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    public CoCoAttestationStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * @return returns the description
+     */
+    @Column(name = "description")
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @return return the details if available
+     */
+    @Column(name = "details")
+    protected String getDetails() {
+        return details;
+    }
+
+    /**
+     * @return return the details if available
+     */
+    @Transient
+    public Optional<String> getDetailsOpt() {
+        return Optional.ofNullable(details);
+    }
+
+    /**
+     * @param idIn set the id
+     */
+    public void setId(Long idIn) {
+        id = idIn;
+    }
+
+    /**
+     * @param reportIn the report to set
+     */
+    public void setReport(ServerCoCoAttestationReport reportIn) {
+        report = reportIn;
+    }
+
+    /**
+     * @param resultTypeIn set the result type
+     */
+    public void setResultType(CoCoResultType resultTypeIn) {
+        resultType = resultTypeIn;
+    }
+
+    /**
+     * @param statusIn the status to set
+     */
+    public void setStatus(CoCoAttestationStatus statusIn) {
+        status = statusIn;
+    }
+
+    /**
+     * @param descriptionIn the description to set
+     */
+    public void setDescription(String descriptionIn) {
+        description = descriptionIn;
+    }
+
+    /**
+     * @param detailsIn the output data to set
+     */
+    public void setDetails(String detailsIn) {
+        details = detailsIn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CoCoAttestationResult that = (CoCoAttestationResult) o;
+        return new EqualsBuilder()
+                .append(description, that.description)
+                .append(status, that.status)
+                .append(resultType, that.resultType)
+                .append(report, that.report)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(report)
+                .append(resultType)
+                .append(description)
+                .append(status)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ServerCoCoAttestationReport{" +
+                "report_id=" + report.getId() +
+                ", resultType=" + resultType +
+                ", status=" + status +
+                ", descrption=" + description +
+                '}';
+    }
+}

--- a/java/code/src/com/suse/manager/model/attestation/CoCoAttestationStatus.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoAttestationStatus.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+public enum CoCoAttestationStatus {
+    PENDING,
+    SUCCEEDED,
+    FAILED;
+}

--- a/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentType.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentType.java
@@ -15,21 +15,32 @@
 package com.suse.manager.model.attestation;
 
 import java.util.Arrays;
+import java.util.List;
 
 public enum CoCoEnvironmentType {
-    NONE(0),
-    KVM_AMD_EPYC_MILAN(1),
-    KVM_AMD_EPYC_GENOA(2),
-    AZURE(3);
+    NONE(0, List.of()),
+    KVM_AMD_EPYC_MILAN(1, List.of(CoCoResultType.SEV_SNP, CoCoResultType.SECURE_BOOT)),
+    KVM_AMD_EPYC_GENOA(2, List.of(CoCoResultType.SEV_SNP, CoCoResultType.SECURE_BOOT)),
+    AZURE(3, List.of(CoCoResultType.AZURE_SEV_SNP, CoCoResultType.AZURE_SECURE_BOOT,
+                    CoCoResultType.AZURE_DISK_ENCRYPTED));
 
     private final long value;
+    private final List<CoCoResultType> supportedResultTypes;
 
-    CoCoEnvironmentType(long valueIn) {
+    CoCoEnvironmentType(long valueIn, List<CoCoResultType> supportedResultTypesIn) {
         value = valueIn;
+        supportedResultTypes = supportedResultTypesIn;
     }
 
     public long getValue() {
         return value;
+    }
+
+    /**
+     * @return returns the list of supported {@link CoCoResultType} for this environment
+     */
+    public List<CoCoResultType> getSupportedResultTypes() {
+        return supportedResultTypes;
     }
 
     /**
@@ -41,5 +52,12 @@ public enum CoCoEnvironmentType {
                      .filter(e -> e.getValue() == valueIn)
                      .findFirst()
                      .orElseThrow(() -> new IllegalArgumentException("Invalid CoCoEnvironmentType value " + valueIn));
+    }
+
+    /**
+     * @return returns if a nonce value is required
+     */
+    public boolean isNonceRequired() {
+        return List.of(KVM_AMD_EPYC_MILAN, KVM_AMD_EPYC_GENOA).contains(this);
     }
 }

--- a/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentType.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import java.util.Arrays;
+
+public enum CoCoEnvironmentType {
+    NONE(0),
+    KVM_AMD_EPYC_MILAN(1),
+    KVM_AMD_EPYC_GENOA(2),
+    AZURE(3);
+
+    private final long value;
+
+    CoCoEnvironmentType(long valueIn) {
+        value = valueIn;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    /**
+     * @param valueIn the value
+     * @return returns the enum type for the given value
+     */
+    public static CoCoEnvironmentType fromValue(long valueIn) {
+        return Arrays.stream(CoCoEnvironmentType.values())
+                     .filter(e -> e.getValue() == valueIn)
+                     .findFirst()
+                     .orElseThrow(() -> new IllegalArgumentException("Invalid CoCoEnvironmentType value " + valueIn));
+    }
+}

--- a/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentTypeConverter.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentTypeConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter(autoApply = true)
+public class CoCoEnvironmentTypeConverter implements AttributeConverter<CoCoEnvironmentType, Long> {
+
+    @Override
+    public Long convertToDatabaseColumn(CoCoEnvironmentType typeIn) {
+        return null == typeIn ? null : typeIn.getValue();
+    }
+
+    @Override
+    public CoCoEnvironmentType convertToEntityAttribute(Long valueIn) {
+        return CoCoEnvironmentType.fromValue(valueIn);
+    }
+
+}

--- a/java/code/src/com/suse/manager/model/attestation/CoCoResultType.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoResultType.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import java.util.Arrays;
+
+public enum CoCoResultType {
+    NONE(0, "Result Type not found"),
+    SEV_SNP(1, "AMD Secure Encrypted Virtualization-Secure Nested Paging (SEV-SNP)"),
+    SECURE_BOOT(2, "Secure Boot enabled"),
+    AZURE_SEV_SNP(3, "AMD Secure Encrypted Virtualization-Secure Nested Paging (SEV-SNP) Azure attestation"),
+    AZURE_SECURE_BOOT(4, "Secure Boot Azure attestation"),
+    AZURE_DISK_ENCRYPTED(5, "Disks encrypted Azure attestation");
+
+    private final int value;
+    private final String description;
+
+    CoCoResultType(int valueIn, String descriptionIn) {
+        value = valueIn;
+        description = descriptionIn;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * @return returns a description for the result type
+     */
+    public String getTypeDescription() {
+        return description;
+    }
+
+    /**
+     * @param valueIn the value
+     * @return returns the enum type for the given value
+     */
+    public static CoCoResultType fromValue(int valueIn) {
+        return Arrays.stream(CoCoResultType.values())
+                     .filter(e -> e.getValue() == valueIn)
+                     .findFirst()
+                     .orElseThrow(() -> new IllegalArgumentException("Invalid CoCoResultType value " + valueIn));
+    }
+}

--- a/java/code/src/com/suse/manager/model/attestation/CoCoResultTypeConverter.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoResultTypeConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter(autoApply = true)
+public class CoCoResultTypeConverter implements AttributeConverter<CoCoResultType, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(CoCoResultType typeIn) {
+        return null == typeIn ? null : typeIn.getValue();
+    }
+
+    @Override
+    public CoCoResultType convertToEntityAttribute(Integer valueIn) {
+        return CoCoResultType.fromValue(valueIn);
+    }
+
+}

--- a/java/code/src/com/suse/manager/model/attestation/ServerCoCoAttestationConfig.java
+++ b/java/code/src/com/suse/manager/model/attestation/ServerCoCoAttestationConfig.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import com.redhat.rhn.domain.server.Server;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "suseServerCoCoAttestationConfig")
+public class ServerCoCoAttestationConfig {
+    private Long id;
+    private Server server;
+    private boolean enabled;
+    private CoCoEnvironmentType environmentType;
+
+    /**
+     * Constructor
+     */
+    public ServerCoCoAttestationConfig() {
+        enabled = false;
+        environmentType = CoCoEnvironmentType.NONE;
+    }
+
+    /**
+     * @return return the ID
+     */
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "suse_srvcocoatt_cnf_seq")
+    @SequenceGenerator(name = "suse_srvcocoatt_cnf_seq", sequenceName = "suse_srvcocoatt_cnf_id_seq",
+            allocationSize = 1)
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @return return the server
+     */
+    @ManyToOne
+    @JoinColumn(name = "server_id")
+    public Server getServer() {
+        return server;
+    }
+
+    /**
+     * @return return if enabled
+     */
+    @Column(name = "enabled")
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * @return return the selected environment type
+     */
+    @Column(name = "env_type")
+    @Convert(converter = CoCoEnvironmentTypeConverter.class)
+    public CoCoEnvironmentType getEnvironmentType() {
+        return environmentType;
+    }
+
+    /**
+     * Use setServer() instead
+     * @param idIn set the id
+     */
+    protected void setId(Long idIn) {
+        id = idIn;
+    }
+
+    /**
+     * @param serverIn the server object
+     */
+    public void setServer(Server serverIn) {
+        server = serverIn;
+    }
+
+    /**
+     * @param enabledIn set is enabled
+     */
+    public void setEnabled(boolean enabledIn) {
+        enabled = enabledIn;
+    }
+
+    /**
+     * @param environmentTypeIn set the environment type
+     */
+    public void setEnvironmentType(CoCoEnvironmentType environmentTypeIn) {
+        environmentType = environmentTypeIn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ServerCoCoAttestationConfig that = (ServerCoCoAttestationConfig) o;
+        return new EqualsBuilder()
+                .append(enabled, that.enabled)
+                .append(environmentType, that.environmentType)
+                .append(server, that.server)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(server)
+                .append(enabled)
+                .append(environmentType)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ServerCoCoAttestationConfig{" +
+                "server=" + server +
+                ", enabled=" + enabled +
+                ", environmentType=" + environmentType +
+                '}';
+    }
+}

--- a/java/code/src/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/code/src/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.annotations.Type;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -31,11 +33,13 @@ import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -50,6 +54,7 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
     private CoCoAttestationStatus status;
     private Map<String, Object> inData = new TreeMap<>();
     private Map<String, Object> outData = new TreeMap<>();
+    private List<CoCoAttestationResult> results = new ArrayList<>();
 
     /**
      * @return return the ID
@@ -103,6 +108,11 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
         return outData;
     }
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "report")
+    public List<CoCoAttestationResult> getResults() {
+        return results;
+    }
+
     /**
      * @param idIn set the id
      */
@@ -151,6 +161,20 @@ public class ServerCoCoAttestationReport extends BaseDomainHelper implements Ser
      */
     public void setOutData(Map<String, Object> outDataIn) {
         outData = outDataIn;
+    }
+
+    /**
+     * @param resultsIn the results to set
+     */
+    public void setResults(List<CoCoAttestationResult> resultsIn) {
+        results = resultsIn;
+    }
+
+    /**
+     * @param resultIn the results to add
+     */
+    public void addResults(CoCoAttestationResult resultIn) {
+        results.add(resultIn);
     }
 
     @Override

--- a/java/code/src/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
+++ b/java/code/src/com/suse/manager/model/attestation/ServerCoCoAttestationReport.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation;
+
+import com.redhat.rhn.domain.BaseDomainHelper;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.server.Server;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.Type;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "suseServerCoCoAttestationReport")
+public class ServerCoCoAttestationReport extends BaseDomainHelper implements Serializable {
+    private static final long serialVersionUID = 8161461482693316376L;
+    private Long id;
+    private Server server;
+    private Action action;
+    private CoCoEnvironmentType environmentType;
+    private CoCoAttestationStatus status;
+    private Map<String, Object> inData = new TreeMap<>();
+    private Map<String, Object> outData = new TreeMap<>();
+
+    /**
+     * @return return the ID
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "server_cocoatt_report_seq")
+    @SequenceGenerator(name = "server_cocoatt_report_seq", sequenceName = "suse_srvcocoatt_rep_id_seq",
+            allocationSize = 1)
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @return return the server
+     */
+    @ManyToOne
+    @JoinColumn(name = "server_id")
+    public Server getServer() {
+        return server;
+    }
+
+    @ManyToOne
+    public Action getAction() {
+        return action;
+    }
+
+    /**
+     * @return return the selected environment type
+     */
+    @Column(name = "env_type")
+    @Convert(converter = CoCoEnvironmentTypeConverter.class)
+    public CoCoEnvironmentType getEnvironmentType() {
+        return environmentType;
+    }
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    public CoCoAttestationStatus getStatus() {
+        return status;
+    }
+
+    @Type(type = "json")
+    @Column(columnDefinition = "jsonb", name = "in_data")
+    public Map<String, Object> getInData() {
+        return inData;
+    }
+
+    @Type(type = "json")
+    @Column(columnDefinition = "jsonb", name = "out_data")
+    public Map<String, Object> getOutData() {
+        return outData;
+    }
+
+    /**
+     * @param idIn set the id
+     */
+    public void setId(Long idIn) {
+        id = idIn;
+    }
+
+    /*
+     * Better set the ID directly (?)
+     * But this method is required for Hibernate
+     */
+    protected void setServer(Server serverIn) {
+        server = serverIn;
+    }
+
+    /**
+     * @param actionIn the action id
+     */
+    public void setAction(Action actionIn) {
+        action = actionIn;
+    }
+
+    /**
+     * @param environmentTypeIn set the environment type
+     */
+    public void setEnvironmentType(CoCoEnvironmentType environmentTypeIn) {
+        environmentType = environmentTypeIn;
+    }
+
+    /**
+     * @param statusIn the status to set
+     */
+    public void setStatus(CoCoAttestationStatus statusIn) {
+        status = statusIn;
+    }
+
+    /**
+     * @param inDataIn the input data to set
+     */
+    public void setInData(Map<String, Object> inDataIn) {
+        inData = inDataIn;
+    }
+
+    /**
+     * @param outDataIn the output data to set
+     */
+    public void setOutData(Map<String, Object> outDataIn) {
+        outData = outDataIn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ServerCoCoAttestationReport that = (ServerCoCoAttestationReport) o;
+        return new EqualsBuilder()
+                .append(outData, that.outData)
+                .append(inData, that.inData)
+                .append(status, that.status)
+                .append(environmentType, that.environmentType)
+                .append(action, that.action)
+                .append(server, that.server)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(server)
+                .append(action)
+                .append(environmentType)
+                .append(outData)
+                .append(inData)
+                .append(status)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ServerCoCoAttestationReport{" +
+                "server=" + server +
+                ", action=" + action +
+                ", environmentType=" + environmentType +
+                ", status=" + status +
+                '}';
+    }
+}

--- a/java/code/src/com/suse/manager/model/attestation/test/AttestationFactoryTest.java
+++ b/java/code/src/com/suse/manager/model/attestation/test/AttestationFactoryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.model.attestation.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.test.ActionFactoryTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.model.attestation.AttestationFactory;
+import com.suse.manager.model.attestation.CoCoAttestationResult;
+import com.suse.manager.model.attestation.CoCoAttestationStatus;
+import com.suse.manager.model.attestation.CoCoEnvironmentType;
+import com.suse.manager.model.attestation.CoCoResultType;
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class AttestationFactoryTest extends BaseTestCaseWithUser {
+
+    private Server server;
+    private AttestationFactory attestationFactory;
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        server = ServerFactoryTest.createTestServer(user);
+        attestationFactory = new AttestationFactory();
+    }
+
+    @Test
+    public void testCreateAttestationConfiguration() {
+        ServerCoCoAttestationConfig cnf = attestationFactory.createConfigForServer(server,
+                CoCoEnvironmentType.KVM_AMD_EPYC_MILAN, true);
+        HibernateFactory.getSession().flush();
+        assertEquals(server, cnf.getServer());
+        assertEquals(CoCoEnvironmentType.KVM_AMD_EPYC_MILAN, cnf.getEnvironmentType());
+        assertTrue(cnf.isEnabled(), "Config is not enabled");
+    }
+
+    @Test
+    public void testAttestationConfigurationLookup() {
+        ServerCoCoAttestationConfig cnf = attestationFactory.createConfigForServer(server,
+                CoCoEnvironmentType.KVM_AMD_EPYC_MILAN, true);
+        HibernateFactory.getSession().flush();
+        Server srv = ServerFactory.lookupByIdAndOrg(server.getId(), user.getOrg());
+        Optional<ServerCoCoAttestationConfig> cocoAttCnf = srv.getOptCocoAttestationConfig();
+        assertNotNull(cocoAttCnf);
+        if (cocoAttCnf.isPresent()) {
+            assertEquals(cnf.getId(), cocoAttCnf.get().getId());
+            assertEquals(cnf.getEnvironmentType(), cocoAttCnf.get().getEnvironmentType());
+            assertEquals(cnf.isEnabled(), cocoAttCnf.get().isEnabled());
+            assertEquals(CoCoEnvironmentType.KVM_AMD_EPYC_MILAN, cocoAttCnf.get().getEnvironmentType());
+            assertTrue(cocoAttCnf.get().isEnabled());
+        }
+        else {
+            fail("config not initialzed");
+        }
+
+        Optional<ServerCoCoAttestationConfig> optConfig = attestationFactory.lookupConfigByServerId(srv.getId());
+        if (optConfig.isPresent()) {
+            assertEquals(cnf, optConfig.get());
+        }
+        else {
+            fail("Configuration not initialized");
+        }
+    }
+
+    @Test
+    public void testCreateAttestationReport() throws Exception {
+        ServerCoCoAttestationConfig cnf = attestationFactory.createConfigForServer(server,
+                CoCoEnvironmentType.KVM_AMD_EPYC_MILAN, true);
+        ServerCoCoAttestationReport report = attestationFactory.createReportForServer(server);
+        HibernateFactory.getSession().flush();
+        assertNotNull(report);
+        assertEquals(CoCoAttestationStatus.PENDING, report.getStatus());
+        assertEquals(cnf.getEnvironmentType(), report.getEnvironmentType());
+        assertNull(report.getAction());
+
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_COCO_ATTESTATION);
+        report.setAction(action);
+        action.addCocoAttestationReport(report);
+
+        Long actionId = action.getId();
+        TestUtils.flushAndEvict(action);
+
+        Action a1 = ActionFactory.lookupByUserAndId(user, actionId);
+        assertNotNull(a1);
+        Set<ServerCoCoAttestationReport> reports = a1.getCocoAttestationReports();
+        assertNotNull(reports);
+        assertNotEmpty(reports);
+        reports.forEach(r -> assertEquals(report, r));
+    }
+
+    @Test
+    public void testInitAttestationResults() {
+        attestationFactory.createConfigForServer(server, CoCoEnvironmentType.KVM_AMD_EPYC_MILAN, true);
+        ServerCoCoAttestationReport report = attestationFactory.createReportForServer(server);
+        Long reportId = report.getId();
+        attestationFactory.initResultsForReport(report);
+        TestUtils.flushAndEvict(report);
+
+        Optional<ServerCoCoAttestationReport> optReport = attestationFactory.lookupReportById(reportId);
+        List<CoCoAttestationResult> results = optReport.orElseThrow().getResults();
+        assertNotEmpty(results);
+        List<CoCoResultType> rTypeList = results.stream()
+                .map(CoCoAttestationResult::getResultType)
+                .collect(Collectors.toList());
+        assertContains(rTypeList, CoCoResultType.SEV_SNP);
+        assertContains(rTypeList, CoCoResultType.SECURE_BOOT);
+        assertNotContains(rTypeList, CoCoResultType.AZURE_SEV_SNP);
+
+        assertTrue(results.stream()
+                .filter(r -> r.getResultType().equals(CoCoResultType.SEV_SNP))
+                .anyMatch(r -> r.getDescription().equals(CoCoResultType.SEV_SNP.getTypeDescription())));
+    }
+}

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -84,6 +84,9 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.attestation.AttestationManager;
+import com.suse.manager.model.attestation.CoCoAttestationStatus;
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.reactor.hardware.CpuArchUtil;
 import com.suse.manager.reactor.hardware.HardwareMapper;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
@@ -100,6 +103,7 @@ import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.YamlHelper;
+import com.suse.manager.webui.utils.salt.custom.CoCoAttestationRequestData;
 import com.suse.manager.webui.utils.salt.custom.DistUpgradeDryRunSlsResult;
 import com.suse.manager.webui.utils.salt.custom.DistUpgradeOldSlsResult;
 import com.suse.manager.webui.utils.salt.custom.DistUpgradeSlsResult;
@@ -705,11 +709,15 @@ public class SaltUtils {
             // Intentionally don't get only the comment since the changes value could be interesting
             serverAction.setResultMsg(getJsonResultWithPrettyPrint(jsonResult));
         }
+        else if (action.getActionType().equals(ActionFactory.TYPE_COCO_ATTESTATION)) {
+            handleCocoAttestationResult(action, serverAction, jsonResult);
+        }
         else {
            serverAction.setResultMsg(getJsonResultWithPrettyPrint(jsonResult));
         }
         LOG.debug("Finished update server action for action {}", action.getId());
     }
+
 
     private void handleStateApplyData(ServerAction serverAction, JsonElement jsonResult, long retcode,
             boolean success) {
@@ -1707,6 +1715,53 @@ public class SaltUtils {
         return packageToKey(entry.getKey(), entry.getValue());
     }
 
+    private void handleCocoAttestationResult(Action action, ServerAction serverAction, JsonElement jsonResult) {
+        AttestationManager mgr = new AttestationManager();
+
+        Optional<ServerCoCoAttestationReport> optReport = mgr.lookupReportByServerAndAction(action.getSchedulerUser(),
+                serverAction.getServer(), action);
+        if (optReport.isEmpty()) {
+            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setResultMsg("Failed to find a report entry");
+            return;
+        }
+        ServerCoCoAttestationReport report = optReport.get();
+
+        try {
+            CoCoAttestationRequestData requestData = Json.GSON.fromJson(jsonResult, CoCoAttestationRequestData.class);
+            report.setOutData(requestData.asMap());
+            mgr.initializeResults(action.getSchedulerUser(), report);
+        }
+        catch (JsonSyntaxException e) {
+            String msg = "Failed to parse the attestation result:\n";
+            msg += Optional.ofNullable(jsonResult)
+                    .map(JsonElement::toString)
+                    .orElse("Got no result");
+            LOG.error(msg);
+            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setResultMsg(msg);
+            return;
+        }
+        if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+            String msg = "Error while request attestation data from target system:\n";
+            if (jsonResult == null) {
+                msg += "Got no result from system";
+            }
+            else {
+                msg += getJsonResultWithPrettyPrint(jsonResult);
+            }
+            serverAction.setResultMsg(msg);
+            if (report.getResults().isEmpty()) {
+                // results are not initialized yet. So we need to set the report status
+                // directly to failed.
+                report.setStatus(CoCoAttestationStatus.FAILED);
+            }
+        }
+        else {
+            serverAction.setResultMsg("Successfully collected attestation data");
+        }
+    }
+
     /**
      * Update the hardware profile for a minion in the database from incoming
      * event data.
@@ -2020,6 +2075,7 @@ public class SaltUtils {
             LOG.debug("{} reboot actions set to completed", actionsChanged);
         }
     }
+
 
     private static boolean shouldCleanupAction(Date bootTime, ServerAction sa) {
         Action action = sa.getParentAction();

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -697,14 +697,10 @@ public class SaltUtils {
         else if (action.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS)) {
             handleSubscribeChannels(serverAction, jsonResult, action);
         }
-        else if (action instanceof BaseVirtualizationGuestAction) {
-            // Tell VirtNotifications that we got a change, passing actionId
-            VirtNotifications.spreadActionUpdate(action);
-            // Dump the whole message since the failure could be anywhere in the chain
-            serverAction.setResultMsg(getJsonResultWithPrettyPrint(jsonResult));
-        }
-        else if (action instanceof BaseVirtualizationPoolAction || action instanceof BaseVirtualizationNetworkAction) {
-            // Tell VirtNotifications that we got a pool action change, passing action
+        else if (action instanceof BaseVirtualizationGuestAction ||
+                action instanceof BaseVirtualizationPoolAction ||
+                action instanceof BaseVirtualizationNetworkAction) {
+            // Tell VirtNotifications that we got an action change, passing action
             VirtNotifications.spreadActionUpdate(action);
             // Intentionally don't get only the comment since the changes value could be interesting
             serverAction.setResultMsg(getJsonResultWithPrettyPrint(jsonResult));

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -241,6 +241,7 @@ public class SaltServerActionService {
     private static final String SYSTEM_REBOOT = "system.reboot";
     private static final String KICKSTART_INITIATE = "bootloader.autoinstall";
     private static final String ANSIBLE_RUNPLAYBOOK = "ansible.runplaybook";
+    private static final String COCOATTEST_REQUESTDATA = "cocoattest.requestdata";
 
     /** SLS pillar parameter name for the list of update stack patch names. */
     public static final String PARAM_UPDATE_STACK_PATCHES = "param_update_stack_patches";
@@ -466,6 +467,9 @@ public class SaltServerActionService {
         }
         else if (ActionFactory.TYPE_PLAYBOOK.equals(actionType)) {
             return singletonMap(executePlaybookActionCall((PlaybookAction) actionIn), minions);
+        }
+        else if (ActionFactory.TYPE_COCO_ATTESTATION.equals(actionType)) {
+            return cocoAttestationAction(minions);
         }
         else {
             if (LOG.isDebugEnabled()) {
@@ -2310,6 +2314,13 @@ public class SaltServerActionService {
         pillarData.put("flush_cache", details.isFlushCache());
         return State.apply(singletonList(ANSIBLE_RUNPLAYBOOK), Optional.of(pillarData), Optional.of(true),
                 Optional.of(details.isTestMode()));
+    }
+
+    private Map<LocalCall<?>, List<MinionSummary>> cocoAttestationAction(List<MinionSummary> minionSummaries) {
+        return Map.of(
+                State.apply(Collections.singletonList(COCOATTEST_REQUESTDATA), Optional.empty()),
+                minionSummaries
+        );
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -94,9 +94,9 @@ public class MinionGeneralPillarGenerator extends MinionPillarGeneratorBase {
         Map<String, Object> beaconConfig = new HashMap<>();
         // this add the configuration for the beacon that tell us when the
         // minion packages are modified locally
-        if (minion.getOsFamily().toLowerCase().equals("suse") ||
-                minion.getOsFamily().toLowerCase().equals("redhat") ||
-                minion.getOsFamily().toLowerCase().equals("debian")) {
+        if (minion.getOsFamily().equalsIgnoreCase("suse") ||
+                minion.getOsFamily().equalsIgnoreCase("redhat") ||
+                minion.getOsFamily().equalsIgnoreCase("debian")) {
             beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
             beaconConfig.put("reboot_info", REBOOT_INFO_BEACON_PROPS);
         }

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/CoCoAttestationRequestData.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/CoCoAttestationRequestData.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.utils.salt.custom;
+
+import com.suse.salt.netapi.results.CmdResult;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Confidential Compute Attestation Result Data from cocoattest.requestdata
+ */
+public class CoCoAttestationRequestData {
+
+    @SerializedName("cmd_|-mgr_snpguest_report_|-cat /tmp/cocoattest/report.bin | base64_|-run")
+    private StateApplyResult<CmdResult> snpguestResult;
+
+    @SerializedName("cmd_|-mgr_secureboot_enabled_|-mokutil --sb-state_|-run")
+    private StateApplyResult<CmdResult> securebootResult;
+
+    /**
+     * Gets the attestation report
+     * @return the attestation report if available
+     */
+    public Optional<StateApplyResult<CmdResult>> getSnpguestReport() {
+        return Optional.ofNullable(snpguestResult);
+    }
+
+    /**
+     * Gets the info if the system has secure boot
+     * @return returns if the system has secure boot
+     */
+    public Optional<StateApplyResult<CmdResult>> getSecureBoot() {
+        return Optional.ofNullable(securebootResult);
+    }
+
+    /**
+     * Gets all info returned as Map for inserting into the report entry
+     * @return returns data as Map.
+     */
+    public Map<String, Object> asMap() {
+        Map<String, Object> out = new HashMap<>();
+        getSnpguestReport()
+                .map(StateApplyResult::getChanges)
+                .ifPresent(c -> {
+                    if (c.getRetcode() == 0) {
+                        out.put("mgr_snpguest_report", c.getStdout());
+                    }
+                });
+
+        getSecureBoot()
+                .map(StateApplyResult::getChanges)
+                .ifPresent(c -> {
+                    if (!c.getStdout().isEmpty()) {
+                        out.put("mgr_secureboot_enabled", c.getStdout());
+                    }
+                    else {
+                        out.put("mgr_secureboot_enabled", c.getStderr());
+                    }
+                });
+        return out;
+    }
+}

--- a/schema/spacewalk/postgres/triggers/suseCoCoAttestationResult.sql
+++ b/schema/spacewalk/postgres/triggers/suseCoCoAttestationResult.sql
@@ -1,15 +1,15 @@
 CREATE OR REPLACE FUNCTION suse_cocoatt_res_up_trig_fun() RETURNS TRIGGER AS
 $$
 BEGIN
-	IF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'pending' AND report_id = NEW.report_id) THEN
+	IF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'PENDING' AND report_id = NEW.report_id) THEN
 		return new;
-	ELSIF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'failed' AND report_id = NEW.report_id) THEN
+	ELSIF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'FAILED' AND report_id = NEW.report_id) THEN
 		UPDATE suseServerCoCoAttestationReport
-		SET status = 'failed'
+		SET status = 'FAILED'
 		WHERE id = NEW.report_id;
 	ELSE
 		UPDATE suseServerCoCoAttestationReport
-		SET status = 'succeeded'
+		SET status = 'SUCCEEDED'
 		WHERE id = NEW.report_id;
 	END IF;
 	return new;

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.5-to-susemanager-schema-5.0.6/013-suseCoCoAttestationResult-trigger.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.5-to-susemanager-schema-5.0.6/013-suseCoCoAttestationResult-trigger.sql
@@ -1,15 +1,15 @@
 CREATE OR REPLACE FUNCTION suse_cocoatt_res_up_trig_fun() RETURNS TRIGGER AS
 $$
 BEGIN
-	IF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'pending' AND report_id = NEW.report_id) THEN
+	IF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'PENDING' AND report_id = NEW.report_id) THEN
 		return new;
-	ELSIF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'failed' AND report_id = NEW.report_id) THEN
+	ELSIF EXISTS(SELECT FROM suseCoCoAttestationResult WHERE status = 'FAILED' AND report_id = NEW.report_id) THEN
 		UPDATE suseServerCoCoAttestationReport
-		SET status = 'failed'
+		SET status = 'FAILED'
 		WHERE id = NEW.report_id;
 	ELSE
 		UPDATE suseServerCoCoAttestationReport
-		SET status = 'succeeded'
+		SET status = 'SUCCEEDED'
 		WHERE id = NEW.report_id;
 	END IF;
 	return new;

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
@@ -1,0 +1,53 @@
+include:
+  - channels
+
+mgr_create_attestdir:
+  file.directory:
+    - name: /tmp/cocoattest
+    - dir_mode: 700
+
+{% if salt['pillar.get']('attestation_data:environment_type', 'NONE') in ['KVM_AMD_EPYC_MILAN', 'KVM_AMD_EPYC_GENOA'] %}
+
+mgr_inst_snpguest:
+  pkg.latest:
+    - pkgs:
+      - snpguest
+      - mokutil
+    - require:
+      - sls: channels
+
+mgr_write_request_data:
+  cmd.run:
+    - name: echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | base64 -d > /tmp/cocoattest/request-data.txt
+    - onlyif: test -x /usr/bin/base64
+    - require:
+      - file: mgr_create_attestdir
+
+mgr_create_snpguest_report:
+  cmd.run:
+    - name: snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
+    - require:
+      - cmd: mgr_write_request_data
+      - file: mgr_create_attestdir
+
+mgr_snpguest_report:
+  cmd.run:
+    - name: cat /tmp/cocoattest/report.bin | base64
+    - require:
+      - cmd: mgr_create_snpguest_report
+      - file: mgr_create_attestdir
+
+mgr_secureboot_enabled:
+  cmd.run:
+    - name: mokutil --sb-state
+    - success_retcodes:
+      - 255
+      - 0
+
+{% endif %}
+
+mgr_cleanup_attest:
+  file.absent:
+    - name: /tmp/cocoattest
+    - require:
+      - file: mgr_create_attestdir


### PR DESCRIPTION
## What does this PR change?

Implement java backend for Confidential Compute Attestation.
- create and update configuration
- schedule a attestation action
- handling the report and result objects
- implement the state to gather the data from the system
- parse the result and insert it into the database
- API for get/set the configuration and schedule the action

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Part of the big doc task

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23551

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
