### PR TITLE
QE: remove unused step definitions

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -298,40 +298,6 @@ When(/^I wait until "([^"]*)" exporter service is active on "([^"]*)"$/) do |ser
   node.run_until_ok(cmd)
 end
 
-When(/^I enable product "([^"]*)"$/) do |prd|
-  list_output, _code = get_target('server').run('mgr-sync list products', check_errors: false, buffer_size: 1_000_000)
-  executed = false
-  linenum = 0
-  list_output.each_line do |line|
-    next unless /^ *\[ \]/ =~ line
-
-    linenum += 1
-    next unless line.include? prd
-
-    executed = true
-    $command_output, _code = get_target('server').run("echo '#{linenum}' | mgr-sync add product", check_errors: false, buffer_size: 1_000_000)
-    break
-  end
-  raise $command_output.to_s unless executed
-end
-
-When(/^I enable product "([^"]*)" without recommended$/) do |prd|
-  list_output, _code = get_target('server').run('mgr-sync list products', check_errors: false, buffer_size: 1_000_000)
-  executed = false
-  linenum = 0
-  list_output.each_line do |line|
-    next unless /^ *\[ \]/ =~ line
-
-    linenum += 1
-    next unless line.include? prd
-
-    executed = true
-    $command_output, _code = get_target('server').run("echo '#{linenum}' | mgr-sync add product --no-recommends", check_errors: false, buffer_size: 1_000_000)
-    break
-  end
-  raise $command_output.to_s unless executed
-end
-
 When(/^I execute mgr-sync "([^"]*)" with user "([^"]*)" and password "([^"]*)"$/) do |arg1, u, p|
   get_target('server').run("echo -e \'mgrsync.user = \"#{u}\"\nmgrsync.password = \"#{p}\"\n\' > ~/.mgr-sync")
   $command_output, _code = get_target('server').run("echo -e '#{u}\n#{p}\n' | mgr-sync #{arg1}", check_errors: false, buffer_size: 1_000_000)


### PR DESCRIPTION
## What does this PR change?

Remove some step definitions which are no longer used in any of the feature files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber step definitions were deleted

- [x] **DONE**

## Links

Port(s): # Manager 4.3 https://github.com/SUSE/spacewalk/pull/23661

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"