### PR TITLE
Bump the WebUI version to 5.0.0 Beta1

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -58,7 +58,7 @@ web.config_delim_start = {|
 web.config_delim_end = |}
 
 # the version of SUSE Manager to show at the WebUI
-web.version = 5.0.0 Alpha1
+web.version = 5.0.0 Beta1
 
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them

--- a/web/spacewalk-web.changes.deneb-alpha.webversion_bump
+++ b/web/spacewalk-web.changes.deneb-alpha.webversion_bump
@@ -1,0 +1,1 @@
+- Bump the WebUI version to 5.0.0 Beta1


### PR DESCRIPTION
## What does this PR change?

* **Bump the WebUI version to 5.0.0 Beta1**
* schema  and reportdb  migration paths are  ok. no need  to  create  the empty migration  paths

## GUI diff

Before: 5.0.0 Alpha1

After: 5.0.0 Beta1

- [x] **DONE**

## Documentation
- No documentation needed: **Bump the WebUI version to 5.0.0 Beta1**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23495

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
