### PR TITLE
Wait for retail network and for build host entitlement

### DIFF
--- a/testsuite/features/build_validation/retail/proxy_branch_network.feature
+++ b/testsuite/features/build_validation/retail/proxy_branch_network.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @proxy
@@ -190,6 +190,8 @@ Feature: Prepare the branch server for PXE booting
     And I enable repositories before installing branch server
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
+    # Network takes time to stabilize
+    And I wait for "5" seconds
 
   Scenario: Let the server know about the new IP and FQDN of the proxy
     When I follow "Details" in the content area

--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle12sp5_buildhost
@@ -51,8 +51,8 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
 
   Scenario: Check the built SLES 12 SP5 OS image
     Given I am on the Systems overview page of this "sle12sp5_buildhost"
-    Then I should see a "[OS Image Build Host]" text
-    When I wait until the image build "suse_os_image_12" is completed
+    When I wait until I see "[OS Image Build Host]" text
+    And I wait until the image build "suse_os_image_12" is completed
     And I wait until the image inspection for "sle12sp5_terminal" is completed
     And I wait until no Salt job is running on "sle12sp5_buildhost"
     And I am on the image store of the Kiwi image for organization "1"

--- a/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp4_buildhost
@@ -50,8 +50,8 @@ Feature: Prepare buildhost and build OS image for SLES 15 SP4
 
   Scenario: Check the built SLES 15 SP4 OS image
     Given I am on the Systems overview page of this "sle15sp4_buildhost"
-    Then I should see a "[OS Image Build Host]" text
-    When I wait until the image build "suse_os_image_15" is completed
+    When I wait until I see "[OS Image Build Host]" text
+    And I wait until the image build "suse_os_image_15" is completed
     And I wait until the image inspection for "sle15sp4_terminal" is completed
     And I am on the image store of the Kiwi image for organization "1"
     Then I should see the name of the image for "sle15sp4_terminal"


### PR DESCRIPTION
## What does this PR change?

* wait for the retail network to stabilize after network formula
* wait for the OS build host entitlement to appear

For the first one we found no other solution than a fixed wait :disappointed: .


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/23668


## Changelogs

- [x] No changelog needed
