### PR TITLE
add debian 12 bootstrap data

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1920,8 +1920,15 @@ DATA = {
         "PDID": [-32, 2410],
         "BETAPDID": [2411],
         "PKGLIST": PKGLISTDEBIAN11,
-        "DEST": "/srv/www/htdocs/pub/repositories/debian/11/bootstrap/",
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/debian/11/bootstrap/",
         "TYPE": "deb",
+    },
+    'debian12-amd64' : {
+        'PDID' : [-43, 2677],
+        'BETAPDID' : [2676],
+        'PKGLIST' : PKGLISTDEBIAN12,
+        'DEST' : DOCUMENT_ROOT + '/pub/repositories/debian/12/bootstrap/',
+        'TYPE' : 'deb'
     },
     "debian9-amd64-uyuni": {
         "BASECHANNEL": "debian-9-pool-amd64-uyuni",

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1923,12 +1923,12 @@ DATA = {
         "DEST": DOCUMENT_ROOT + "/pub/repositories/debian/11/bootstrap/",
         "TYPE": "deb",
     },
-    'debian12-amd64' : {
-        'PDID' : [-43, 2677],
-        'BETAPDID' : [2676],
-        'PKGLIST' : PKGLISTDEBIAN12,
-        'DEST' : DOCUMENT_ROOT + '/pub/repositories/debian/12/bootstrap/',
-        'TYPE' : 'deb'
+    "debian12-amd64": {
+        "PDID": [-43, 2677],
+        "BETAPDID": [2676],
+        "PKGLIST": PKGLISTDEBIAN12,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/debian/12/bootstrap/",
+        "TYPE": "deb",
     },
     "debian9-amd64-uyuni": {
         "BASECHANNEL": "debian-9-pool-amd64-uyuni",

--- a/susemanager/susemanager.changes.mc.add-debian12-bootstrap-data
+++ b/susemanager/susemanager.changes.mc.add-debian12-bootstrap-data
@@ -1,0 +1,1 @@
+- add debian 12 bootstrap data


### PR DESCRIPTION
## What does this PR change?

Add missing Debian 12 bootstrap data for SUSE Manager

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/22665 (partial forward port)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
