### PR TITLE
Wait for first event on Retail terminal

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @proxy
@@ -19,11 +19,14 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sle12sp5_terminal", refreshing the page
     And I follow this "sle12sp5_terminal" link
-    And I wait until event "Apply states [saltboot] scheduled" is completed
+    And I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "added system entitlement" completed during last minute, refreshing the page
+    And I wait until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLES12-SP5-Pool" is checked, refreshing the page
-    And I wait until event "Package List Refresh scheduled" is completed
+    And I wait until event "Package List Refresh" is completed
     Then "sle12sp5_terminal" should have been reformatted
 
   Scenario: Check connection from SLES 12 SP5 retail terminal to branch server

--- a/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @proxy
@@ -19,11 +19,14 @@ Feature: PXE boot a SLES 15 SP4 retail terminal
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "sle15sp4_terminal", refreshing the page
     And I follow this "sle15sp4_terminal" link
-    And I wait until event "Apply states [saltboot] scheduled" is completed
+    And I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "added system entitlement" completed during last minute, refreshing the page
+    And I wait until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLE-Product-SLES15-SP4-Pool" is checked, refreshing the page
-    And I wait until event "Package List Refresh scheduled" is completed
+    And I wait until event "Package List Refresh" is completed
     Then "sle15sp4_terminal" should have been reformatted
 
   Scenario: Check connection from SLES 15 SP4 retail terminal to branch server

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # Idempotency note:
@@ -196,8 +196,10 @@ Feature: PXE boot a Retail terminal
     Given I am on the Systems page
     When I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
-    # Workaround: Increase timeout temporarily get rid of timeout issues
-    And I wait at most 350 seconds until event "Apply states [saltboot]" is completed
+    And I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "added system entitlement" completed during last minute, refreshing the page
+    And I wait until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLE-Product-SLES15-SP4-Pool for x86_64" is checked, refreshing the page


### PR DESCRIPTION
## What does this PR change?

Wait for the first event on Retail terminal. This because there is one more full minute needed after it to reformat the terminal, apply and verify the image, and we don't want it to eat the timeout.


## Links

Port(s):
 * 4.3:
    * https://github.com/SUSE/spacewalk/pull/23670
    * https://github.com/SUSE/spacewalk/pull/23674
    * https://github.com/SUSE/spacewalk/pull/23675
    * https://github.com/SUSE/spacewalk/pull/23676

## Changelogs

- [x] No changelog needed
