### PR TITLE
Don't add architecture in the path for the init image on IBS

### DIFF
--- a/containers/init-image/init-image.changes.cbosdonnat.image-arch
+++ b/containers/init-image/init-image.changes.cbosdonnat.image-arch
@@ -1,0 +1,1 @@
+- Do not add the architecture to the image path for SUSE Manager

--- a/rel-eng/container_push.sh
+++ b/rel-eng/container_push.sh
@@ -38,17 +38,24 @@ if [ -f "${SRPM_PKG_DIR}/Dockerfile" ]; then
   if [ "${OSCAPI}" == "https://api.suse.de" ]; then
     # SUSE Manager settings
     VERSION=$(echo ${PRODUCT_VERSION} | sed 's/^\([0-9]\+\.[0-9]\+\).*$/\1/')
-    sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}\/%ARCH%/g" -i ${SRPM_PKG_DIR}/Dockerfile
+    ARCH=
+    # OBS cannot find the dependencies with a placeholder or %_arch from the project config.
+    # The best solution is to only use the architecture in the path of the images to release,
+    # not intermediary ones.
+    if [ "${NAME}" != "init" ]; then
+        ARCH="\/%ARCH%"
+    fi
+    sed "/^#\!BuildTag:/s/uyuni/suse\/manager\/${VERSION}${ARCH}/g" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "s/^\(LABEL org.opensuse.reference=\)\"\([^:]\+:\)\([^%]\+\)%RELEASE%\"/\1\"\2${PRODUCT_VERSION}.%RELEASE%\"/" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "/^# labelprefix=/s/org\.opensuse\.uyuni/com.suse.manager/" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "s/^ARG VENDOR=.*$/ARG VENDOR=\"SUSE LLC\"/" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "s/^ARG PRODUCT=.*$/ARG PRODUCT=\"SUSE Manager\"/" -i ${SRPM_PKG_DIR}/Dockerfile
-    sed "s/^LABEL org\.opensuse\.reference=\"\${REFERENCE_PREFIX}/LABEL org.opensuse.reference=\"\${REFERENCE_PREFIX}\/%ARCH%/" -i ${SRPM_PKG_DIR}/Dockerfile
+    sed "s/^LABEL org\.opensuse\.reference=\"\${REFERENCE_PREFIX}/LABEL org.opensuse.reference=\"\${REFERENCE_PREFIX}${ARCH}/" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "/^# labelprefix=.*$/aLABEL com.suse.eula=\"${EULA}\"" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "/^# labelprefix=.*$/aLABEL com.suse.release-stage=\"${RELEASE_STAGE}\"" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "/^# labelprefix=.*$/aLABEL com.suse.lifecycle-url=\"https://www.suse.com/lifecycle/\"" -i ${SRPM_PKG_DIR}/Dockerfile
     sed "/^# labelprefix=.*$/aLABEL com.suse.supportlevel=\"l3\"" -i ${SRPM_PKG_DIR}/Dockerfile
-    NAME="suse\/manager\/${VERSION}\/%ARCH%\/${NAME}"
+    NAME="suse\/manager\/${VERSION}${ARCH}\/${NAME}"
   else
     NAME="uyuni\/${NAME}"
   fi


### PR DESCRIPTION
## What does this PR change?

Since OBS doesn't interpret the placeholder in the FROM image, nor the %_arch variable from the spec file, we only use the architecture in the path of the images to release.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
