### PR TITLE
skip deploying the CA into the salt dir on proxies

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -603,13 +603,15 @@ def deployCAUyuni(certData):
                 f.write(ca["content"])
             os.chmod(os.path.join(CA_TRUST_DIR, PKI_ROOT_CA_NAME), int("0644", 8))
 
-            if os.path.exists(os.path.join(SALT_CA_DIR, ROOT_CA_NAME)):
-                os.remove(os.path.join(SALT_CA_DIR, ROOT_CA_NAME))
-            with open(
-                os.path.join(SALT_CA_DIR, ROOT_CA_NAME), "w", encoding="utf-8"
-            ) as f:
-                f.write(ca["content"])
-            os.chmod(os.path.join(SALT_CA_DIR, ROOT_CA_NAME), int("0644", 8))
+            # SALT_CA_DIR exists only on the server, ignore on proxies
+            if os.path.exists(SALT_CA_DIR):
+                if os.path.exists(os.path.join(SALT_CA_DIR, ROOT_CA_NAME)):
+                    os.remove(os.path.join(SALT_CA_DIR, ROOT_CA_NAME))
+                with open(
+                    os.path.join(SALT_CA_DIR, ROOT_CA_NAME), "w", encoding="utf-8"
+                ) as f:
+                    f.write(ca["content"])
+                os.chmod(os.path.join(SALT_CA_DIR, ROOT_CA_NAME), int("0644", 8))
             break
     # in case a systemd timer try to do the same
     time.sleep(3)

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mcalmer.Manager-4.3-MU-4.3.11-fix-ca-deploy-on-proxy
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mcalmer.Manager-4.3-MU-4.3.11-fix-ca-deploy-on-proxy
@@ -1,0 +1,1 @@
+- skip deploying the CA into the salt dir on proxies (bsc#1219850)


### PR DESCRIPTION
## What does this PR change?

Fix regression introduced with the last bugfix (https://github.com/uyuni-project/uyuni/pull/8268).
On a proxy, the salt filesystem directory does not exists. No need to copy the CA to that place.
This prevent a "No such file or directory" error


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/23684

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
