### PR TITLE
QE: sumaform cleanup and reboot  after bootstrap for SLE Micro 5.X minions

### DIFF
--- a/testsuite/features/build_validation/init_clients/slemicro51_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro51_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro51_minion
 Feature: Bootstrap a SLE Micro 5.1 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro 5.1 minion
+    When I perform a full salt minion cleanup on "slemicro51_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -22,8 +25,10 @@ Feature: Bootstrap a SLE Micro 5.1 Salt minion
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 
-  Scenario: Reboot the SLE Micro 5.1 minion and wait until reboot is completed
-    When I reboot the "slemicro51_minion" minion through the web UI
+  # Following the bootstrapping process, automatic booting is disabled.
+  # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
+  Scenario: Reboot the SLE Micro 5.1 minion through SSH
+    When I reboot the "slemicro51_minion" minion through SSH
 
   Scenario: Check the new bootstrapped SLE Micro 5.1 minion in System Overview page
     When I wait until onboarding is completed for "slemicro51_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro51_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro51_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro51_ssh_minion
 Feature: Bootstrap a SLE Micro 5.1 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro SSH 5.1 minion
+    When I perform a full salt minion cleanup on "slemicro51_ssh_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro52_minion
 Feature: Bootstrap a SLE Micro 5.2 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro 5.2 minion
+    When I perform a full salt minion cleanup on "slemicro52_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -22,8 +25,10 @@ Feature: Bootstrap a SLE Micro 5.2 Salt minion
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 
-  Scenario: Reboot the SLE Micro 5.2 minion and wait until reboot is completed
-    When I reboot the "slemicro52_minion" minion through the web UI
+  # Following the bootstrapping process, automatic booting is disabled.
+  # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
+  Scenario: Reboot the SLE Micro 5.2 minion through SSH
+    When I reboot the "slemicro52_minion" minion through SSH
 
   Scenario: Check the new bootstrapped SLE Micro 5.2 minion in System Overview page
     When I wait until onboarding is completed for "slemicro52_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro52_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro52_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro52_ssh_minion
 Feature: Bootstrap a SLE Micro 5.2 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro SSH 5.2 SSH minion
+    When I perform a full salt minion cleanup on "slemicro52_ssh_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro53_minion
 Feature: Bootstrap a SLE Micro 5.3 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro 5.3 minion
+    When I perform a full salt minion cleanup on "slemicro53_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -22,8 +25,10 @@ Feature: Bootstrap a SLE Micro 5.3 Salt minion
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 
-  Scenario: Reboot the SLE Micro 5.3 minion and wait until reboot is completed
-    When I reboot the "slemicro53_minion" minion through the web UI
+  # Following the bootstrapping process, automatic booting is disabled.
+  # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
+  Scenario: Reboot the SLE Micro 5.3 minion through SSH
+    When I reboot the "slemicro53_minion" minion through SSH
 
   Scenario: Check the new bootstrapped SLE Micro 5.3 minion in System Overview page
     When I wait until onboarding is completed for "slemicro53_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro53_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro53_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro53_ssh_minion
 Feature: Bootstrap a SLE Micro 5.3 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro SSH 5.3 SSH minion
+    When I perform a full salt minion cleanup on "slemicro53_ssh_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/build_validation/init_clients/slemicro54_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro54_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro54_minion
 Feature: Bootstrap a SLE Micro 5.4 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro 5.4 minion
+    When I perform a full salt minion cleanup on "slemicro54_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -22,8 +25,10 @@ Feature: Bootstrap a SLE Micro 5.4 Salt minion
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 
-  Scenario: Reboot the SLE Micro 5.4 minion and wait until reboot is completed
-    When I reboot the "slemicro54_minion" minion through the web UI
+  # Following the bootstrapping process, automatic booting is disabled.
+  # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
+  Scenario: Reboot the SLE Micro 5.4 minion through SSH
+    When I reboot the "slemicro54_minion" minion through SSH
 
   Scenario: Check the new bootstrapped SLE Micro 5.4 minion in System Overview page
     When I wait until onboarding is completed for "slemicro54_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro54_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro54_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -7,6 +7,9 @@
 @slemicro54_ssh_minion
 Feature: Bootstrap a SLE Micro 5.4 Salt SSH minion
 
+  Scenario: Clean up sumaform leftovers on a SLE Micro SSH 5.4 SSH minion
+    When I perform a full salt minion cleanup on "slemicro54_ssh_minion"
+  
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/build_validation/init_clients/slemicro55_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro55_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro55_minion
 Feature: Bootstrap a SLE Micro 5.5 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro 5.5 minion
+    When I perform a full salt minion cleanup on "slemicro55_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -22,8 +25,10 @@ Feature: Bootstrap a SLE Micro 5.5 Salt minion
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 
-  Scenario: Reboot the SLE Micro 5.5 minion and wait until reboot is completed
-    When I reboot the "slemicro55_minion" minion through the web UI
+  # Following the bootstrapping process, automatic booting is disabled.
+  # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
+  Scenario: Reboot the SLE Micro 5.5 minion through SSH
+    When I reboot the "slemicro55_minion" minion through SSH
 
   Scenario: Check the new bootstrapped SLE Micro 5.5 minion in System Overview page
     When I wait until onboarding is completed for "slemicro55_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro55_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro55_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Beware: After altering the system e.g. package installation/removal, the system
@@ -6,6 +6,9 @@
 
 @slemicro55_ssh_minion
 Feature: Bootstrap a SLE Micro 5.5 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a SLE Micro SSH 5.5 SSH minion
+    When I perform a full salt minion cleanup on "slemicro55_ssh_minion"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -838,7 +838,7 @@ When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]
   os_family = node.os_family
   cmd = ''
   case os_family
-  when /^opensuse/, /^sles/
+  when /^opensuse/, /^sles/, /^suse/
     mand_repos = ''
     repos.split.map do |repo|
       mand_repos = "#{mand_repos} #{repo}"
@@ -1511,6 +1511,11 @@ When(/^I reboot the server through SSH$/) do
     end
     sleep 1
   end
+end
+
+When(/^I reboot the "([^"]*)" minion through SSH$/) do |host|
+  node = get_target(host)
+  node.run('reboot')
 end
 
 When(/^I reboot the "([^"]*)" minion through the web UI$/) do |host|

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 SUSE LLC
+# Copyright 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ### This file contains all step definitions concerning Salt and bootstrapping
@@ -503,7 +503,9 @@ end
 When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   node = get_target(host)
   if use_salt_bundle
-    if rh_host?(host)
+    if slemicro_host?(host)
+      node.run('transactional-update --continue -n pkg rm venv-salt-minion', check_errors: false)
+    elsif rh_host?(host)
       node.run('yum -y remove --setopt=clean_requirements_on_remove=1 venv-salt-minion', check_errors: false)
     elsif deb_host?(host)
       node.run('apt-get --assume-yes remove venv-salt-minion && apt-get --assume-yes purge venv-salt-minion && apt-get --assume-yes autoremove', check_errors: false)
@@ -512,7 +514,9 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
     end
     node.run('rm -Rf /root/salt /var/cache/venv-salt-minion /run/venv-salt-minion /var/venv-salt-minion.log /etc/venv-salt-minion /var/tmp/.root*', check_errors: false)
   else
-    if rh_host?(host)
+    if slemicro_host?(host)
+      node.run('transactional-update --continue -n pkg rm salt salt-minion', check_errors: false)
+    elsif rh_host?(host)
       node.run('yum -y remove --setopt=clean_requirements_on_remove=1 salt salt-minion', check_errors: false)
     elsif deb_host?(host)
       node.run('apt-get --assume-yes remove salt-common salt-minion && apt-get --assume-yes purge salt-common salt-minion && apt-get --assume-yes autoremove', check_errors: false)


### PR DESCRIPTION
## What does this PR change?

To fix the issue described at [Salt execution error being displayed when trying to bootstrap an SLE Micro minion through the UI](https://bugzilla.suse.com/show_bug.cgi?id=121814), following the bootstrapping process, automatic booting is disabled.
This change was implemented due to intermittent automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.

We'll need to reboot the SLE Micro 5.X minions via SSH in order to complete the bootstrap procedure.

Includes also Sumaform cleanup and closes https://github.com/SUSE/spacewalk/issues/23224

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber Scenarios using a new step definition were added to substitute previous scenarios.

- [x] **DONE**

## Links

Port(s): Manager 4.3 https://github.com/SUSE/spacewalk/pull/23688

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
