### PR TITLE
QE: Fix proxy Uyuni client tools

### DIFF
--- a/testsuite/features/init_clients/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/init_clients/proxy_register_as_minion_with_gui.feature
@@ -78,7 +78,7 @@ Feature: Setup Uyuni proxy
     And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
-    And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Proxy Stable for openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/init_clients/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/init_clients/proxy_register_as_minion_with_script.feature
@@ -88,7 +88,7 @@ Feature: Setup Uyuni proxy
     And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
-    And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Proxy Stable for openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -144,7 +144,7 @@ Feature: Update activation keys
     And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
-    And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Proxy Stable for openSUSE Leap 15.5 (x86_64)"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 


### PR DESCRIPTION
## What does this PR change?

The name changed:
![image](https://github.com/uyuni-project/uyuni/assets/12104291/a2648269-8af5-426c-ad92-21edbc8750d0)

Uyuni/Uyuni Podman server CI:
![image](https://github.com/uyuni-project/uyuni/assets/12104291/9828ea30-1a41-4b3d-856d-3fed2df39c4e)


We have more similar occurrences for this in `secondary`, but I would wait until they really show up as failure:

```cucumber
# These tests do not test if recommended channesl are shown correctly due to the fact that we kill the reposync
# for openSUSE Leap. With this caveat, no child channels are selected when selection openSUSE as parent.
@uyuni
  Scenario: Play with recommended and required child channels selection for a single system
    Given I am on the Systems overview page of this "sle_minion"
    When I follow "Software" in the content area
    And I follow "Software Channels" in the content area
    And I wait for child channels to appear
    And I check radio button "(none, disable service)"
    And I wait for child channels to appear
    And I check radio button "openSUSE Leap 15.5 (x86_64)"
    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" "unselected" and "disabled"
    Then I should see the child channel "openSUSE 15.5 non oss (x86_64)" "selected"
    When I select the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)"
    Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" "selected"
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!](<## What does this PR change?