### PR TITLE
fix memory size extraction in virtual instances

### DIFF
--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.scc.SCCCachingFactory;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 import com.redhat.rhn.domain.server.CPU;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 
 import com.suse.scc.SCCSystemId;
@@ -97,12 +98,16 @@ public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegis
             cpu.flatMap(c -> ofNullable(c.getNrsocket())).ifPresent(c -> hwInfo.setSockets(c.intValue()));
             hwInfo.setArch(srv.getServerArch().getLabel().split("-")[0]);
             if (srv.isVirtualGuest()) {
-                hwInfo.setHypervisor(srv.getVirtualInstance().getType().getHypervisor().orElse(""));
-                hwInfo.setCloudProvider(srv.getVirtualInstance().getType().getCloudProvider().orElse(""));
-                ofNullable(srv.getVirtualInstance().getUuid())
+                VirtualInstance virtualInstance = srv.getVirtualInstance();
+
+                hwInfo.setHypervisor(virtualInstance.getType().getHypervisor().orElse(""));
+                hwInfo.setCloudProvider(virtualInstance.getType().getCloudProvider().orElse(""));
+                ofNullable(virtualInstance.getUuid())
                         .ifPresent(u -> hwInfo.setUuid(u.replaceAll("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})",
                                 "$1-$2-$3-$4-$5")));
-                hwInfo.setMemTotal(srv.getVirtualInstance().getTotalMemory().intValue());
+
+                ofNullable(virtualInstance.getTotalMemory())
+                        .ifPresent(totalMemory -> hwInfo.setMemTotal(totalMemory.intValue()));
             }
             else {
                 hwInfo.setMemTotal((int) srv.getRam());

--- a/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationSystemDataAcquisitorTest.java
+++ b/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationSystemDataAcquisitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 SUSE LLC
+ * Copyright (c) 2023--2024 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,16 +15,49 @@
 
 package com.suse.scc.test.registration;
 
+import static java.util.Optional.ofNullable;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
+import com.redhat.rhn.domain.product.SUSEProduct;
+import com.redhat.rhn.domain.product.SUSEProductSet;
+import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
+import com.redhat.rhn.domain.server.CPU;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerArch;
+import com.redhat.rhn.domain.server.ServerInfo;
+import com.redhat.rhn.domain.server.VirtualInstance;
+import com.redhat.rhn.domain.server.VirtualInstanceType;
 
+import com.suse.scc.SCCSystemId;
+import com.suse.scc.model.SCCHwInfoJson;
+import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.registration.SCCSystemRegistrationContext;
 import com.suse.scc.registration.SCCSystemRegistrationSystemDataAcquisitor;
 
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.jmock.junit5.JUnit5Mockery;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@ExtendWith(JUnit5Mockery.class)
 public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSystemRegistrationTest {
+
+    @RegisterExtension
+    protected final JUnit5Mockery context = new JUnit5Mockery();
 
     /**
      * Tests when no systems are provided.
@@ -34,19 +67,20 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
     public void testSuccessSCCSystemRegistrationSystemDataAcquisitorWhenNoSystemsProvided() throws Exception {
         // setup
         this.setupSystems(0, 0);
-        final SCCSystemRegistrationContext context = new SCCSystemRegistrationContext(null, getTestSystems(), null);
+        final SCCSystemRegistrationContext sccSystemRegistrationContext =
+                new SCCSystemRegistrationContext(null, getTestSystems(), null);
 
         // pre-conditions
-        assertEquals(0, context.getItems().size());
-        assertEquals(0, context.getPendingRegistrationSystems().size());
-        assertEquals(0, context.getItemsBySccSystemId().size());
+        assertEquals(0, sccSystemRegistrationContext.getItems().size());
+        assertEquals(0, sccSystemRegistrationContext.getPendingRegistrationSystems().size());
+        assertEquals(0, sccSystemRegistrationContext.getItemsBySccSystemId().size());
 
         // execution
-        new SCCSystemRegistrationSystemDataAcquisitor().handle(context);
+        new SCCSystemRegistrationSystemDataAcquisitor().handle(sccSystemRegistrationContext);
 
         // assertions
-        assertEquals(0, context.getPendingRegistrationSystems().size());
-        assertEquals(0, context.getItemsBySccSystemId().size());
+        assertEquals(0, sccSystemRegistrationContext.getPendingRegistrationSystems().size());
+        assertEquals(0, sccSystemRegistrationContext.getItemsBySccSystemId().size());
     }
 
     /**
@@ -59,23 +93,354 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
     public void testSuccessSCCSystemRegistrationSystemDataAcquisitor() throws Exception {
         // setup
         this.setupSystems(15, 5);
-        final SCCSystemRegistrationContext context = new SCCSystemRegistrationContext(null, getTestSystems(), null);
+        final SCCSystemRegistrationContext sccSystemRegistrationContext =
+                new SCCSystemRegistrationContext(null, getTestSystems(), null);
 
         // pre-conditions
-        assertEquals(20, context.getItems().size());
-        assertEquals(20, context.getItems().stream().filter(SCCRegCacheItem::isSccRegistrationRequired).count());
-        assertEquals(0, context.getPendingRegistrationSystems().size());
-        assertEquals(0, context.getItemsBySccSystemId().size());
-        assertEquals(0, context.getPaygSystems().size());
+        assertEquals(20, sccSystemRegistrationContext.getItems().size());
+        assertEquals(20,
+                sccSystemRegistrationContext.getItems().stream()
+                        .filter(SCCRegCacheItem::isSccRegistrationRequired)
+                        .count()
+        );
+        assertEquals(0, sccSystemRegistrationContext.getPendingRegistrationSystems().size());
+        assertEquals(0, sccSystemRegistrationContext.getItemsBySccSystemId().size());
+        assertEquals(0, sccSystemRegistrationContext.getPaygSystems().size());
 
         // execution
-        new SCCSystemRegistrationSystemDataAcquisitor().handle(context);
+        new SCCSystemRegistrationSystemDataAcquisitor().handle(sccSystemRegistrationContext);
 
         // assertions
-        assertEquals(20, context.getItems().stream().filter(SCCRegCacheItem::isSccRegistrationRequired).count());
-        assertEquals(15, context.getPendingRegistrationSystems().size());
-        assertEquals(context.getPendingRegistrationSystems().keySet(), context.getItemsBySccSystemId().keySet());
-        assertEquals(5, context.getPaygSystems().size());
+        assertEquals(20,
+                sccSystemRegistrationContext.getItems().stream()
+                        .filter(SCCRegCacheItem::isSccRegistrationRequired)
+                        .count()
+        );
+        assertEquals(15, sccSystemRegistrationContext.getPendingRegistrationSystems().size());
+        assertEquals(
+                sccSystemRegistrationContext.getPendingRegistrationSystems().keySet(),
+                sccSystemRegistrationContext.getItemsBySccSystemId().keySet()
+        );
+        assertEquals(5, sccSystemRegistrationContext.getPaygSystems().size());
     }
 
+
+    /**
+     * Tests the scenario where getPayload processes physical server instance with minimal data provided with no
+     * installed products but login and password information available.
+     * @throws Exception if the test setup fails
+     */
+    @Test
+    public void testGetPayloadWhenPhysicalServerAndProducts() throws Exception {
+        final Date testBeginTimestamp = new Date();
+
+        // SCC setup
+        this.setupSystems(1, 0);
+
+        //
+        final String expectedHostname = "physicalServeHostname";
+        final long expectedCpus = 4L;
+        final long expectedSockets = 2L;
+        final long expectedRam = 8765;
+
+        SUSEProduct baseProduct =
+                SUSEProductTestUtils.createTestSUSEProduct(ChannelFamilyFactoryTest.createTestChannelFamily());
+        SUSEProduct addonProduct =
+                SUSEProductTestUtils.createTestSUSEProduct(ChannelFamilyFactoryTest.createTestChannelFamily());
+        Long[] targetAddonProducts = new Long[] {addonProduct.getId()};
+        final SUSEProductSet suseProductSetMock = new SUSEProductSet(baseProduct.getId(), List.of(targetAddonProducts));
+
+        SCCRegCacheItemMock sccRegCacheItemMock = new SCCRegCacheItemMockBuilder(false, true)
+                .suseProductSet(suseProductSetMock)
+                .hostname(expectedHostname)
+                .serverArchLabel("server0-arch-mock")
+                .cpus(expectedCpus)
+                .sockets(expectedSockets)
+                .ram(expectedRam)
+                .build();
+
+        // Execute
+        new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
+
+        // Assertions
+        Map<SCCSystemId, SCCRegisterSystemJson> pendingRegistrationSystems =
+                sccRegCacheItemMock.getPendingRegistrationSystems();
+        assertEquals(1, pendingRegistrationSystems.size());
+        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystems.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
+        assertEquals(2, sccRegisterSystemJson.getProducts().size());
+        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+
+        assertNotNull(sccRegisterSystemJson.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertEquals(expectedCpus, hwInfo.getCpus());
+        assertEquals(expectedSockets, hwInfo.getSockets());
+        assertEquals("server0", hwInfo.getArch());
+        assertNull(hwInfo.getUuid());
+        assertEquals(expectedRam, hwInfo.getMemTotal());
+        assertNull(hwInfo.getHypervisor());
+        assertNull(hwInfo.getCloudProvider());
+    }
+
+    /**
+     * Tests the scenario where getPayload processes virtual server instance with minimal data provided with no
+     * installed products but login and password information available.
+     * @throws Exception if the test setup fails
+     */
+    @Test
+    public void testGetPayloadWhenVirtualServerHasMinimalData() throws Exception {
+        final Date testBeginTimestamp = new Date();
+
+        //
+        final String expectedHostname = "virtualServerHostname";
+        final long expectedCpus = 0;
+        final long expectedSockets = 0;
+
+        // SCC setup
+        this.setupSystems(1, 0);
+
+        // Mock setup
+        SCCRegCacheItemMock sccRegCacheItemMock = new SCCRegCacheItemMockBuilder(true, false)
+                .hostname(expectedHostname)
+                .serverArchLabel("server1-arch-mock")
+                .cpus(expectedCpus)
+                .sockets(expectedSockets)
+                .build();
+
+        // Execute
+        new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
+
+        // Assertions
+        Map<SCCSystemId, SCCRegisterSystemJson> pendingRegistrationSystems =
+                sccRegCacheItemMock.getPendingRegistrationSystems();
+        assertEquals(1, pendingRegistrationSystems.size());
+        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystems.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
+        assertEquals(0, sccRegisterSystemJson.getProducts().size());
+        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+
+        assertNotNull(sccRegisterSystemJson.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertEquals(expectedCpus, hwInfo.getCpus());
+        assertEquals(expectedSockets, hwInfo.getSockets());
+        assertEquals("server1", hwInfo.getArch());
+        assertNull(hwInfo.getUuid());
+        assertEquals(0, hwInfo.getMemTotal());
+        assertTrue(hwInfo.getHypervisor().isEmpty());
+        assertTrue(hwInfo.getCloudProvider().isEmpty());
+    }
+
+    /**
+     * Tests the scenario where getPayload processes a virtual server instance with full data provided;
+     * both with no installed products but login and password information available.
+     * @throws Exception if the test setup fails
+     */
+    @Test
+    public void testGetPayloadWhenVirtualServerHasFullData() throws Exception {
+        final Date testBeginTimestamp = new Date();
+
+        // SCC setup
+        this.setupSystems(1, 0);
+
+        final String expectedCloudProvider = "Amazon";
+        final String expectedHypervisor = "KVM";
+        final String expectedHostname = "virtualServerHostname";
+        final String expectedUuid = "018d9d33-f73c-79f6-a21c-05722fd4ff22";
+        long expectedTotalMemory = 2048L;
+
+        SCCRegCacheItemMock sccRegCacheItemMock = new SCCRegCacheItemMockBuilder(true, false)
+                .cloudProvider(expectedCloudProvider)
+                .hypervisor(expectedHypervisor)
+                .hostname(expectedHostname)
+                .uuid(expectedUuid)
+                .serverArchLabel("server2-arch-mock")
+                .totalMemory(expectedTotalMemory)
+                .build();
+
+        // Execute
+        new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
+
+        // Assertions
+        Map<SCCSystemId, SCCRegisterSystemJson> pendingRegistrationSystems =
+                sccRegCacheItemMock.getPendingRegistrationSystems();
+        assertEquals(1, pendingRegistrationSystems.size());
+        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystems.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
+        assertEquals(0, sccRegisterSystemJson.getProducts().size());
+        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+
+        assertNotNull(sccRegisterSystemJson.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertEquals(0L, hwInfo.getCpus());
+        assertEquals(0L, hwInfo.getSockets());
+        assertEquals("server2", hwInfo.getArch());
+        assertEquals(expectedUuid, hwInfo.getUuid());
+        assertEquals(expectedTotalMemory, hwInfo.getMemTotal());
+        assertEquals(expectedHypervisor, hwInfo.getHypervisor());
+        assertEquals(expectedCloudProvider, hwInfo.getCloudProvider());
+    }
+
+    class SCCRegCacheItemMockBuilder {
+        private final boolean isVirtualGuest;
+        private final boolean hasCpuInfo;
+
+        private SUSEProductSet suseProductSet;
+        private Long cpus;
+        private Long sockets;
+        private String serverArchLabel;
+        private String hypervisor;
+        private String cloudProvider;
+        private String hostname;
+        private String uuid;
+        private Long totalMemory;
+        private Long ram;
+
+        SCCRegCacheItemMockBuilder(boolean isVirtualGuestIn, boolean hasCpuInfoIn) {
+            isVirtualGuest = isVirtualGuestIn;
+            hasCpuInfo = hasCpuInfoIn;
+        }
+
+        public SCCRegCacheItemMockBuilder suseProductSet(SUSEProductSet suseProductSetIn) {
+            suseProductSet = suseProductSetIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder cpus(Long cpusIn) {
+            cpus = cpusIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder sockets(Long socketsIn) {
+            sockets = socketsIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder serverArchLabel(String serverArchLabelIn) {
+            serverArchLabel = serverArchLabelIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder hypervisor(String hypervisorIn) {
+            hypervisor = hypervisorIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder cloudProvider(String cloudProviderIn) {
+            cloudProvider = cloudProviderIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder hostname(String hostnameIn) {
+            hostname = hostnameIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder uuid(String uuidIn) {
+            uuid = uuidIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder totalMemory(Long totalMemoryIn) {
+            totalMemory = totalMemoryIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMockBuilder ram(Long ramIn) {
+            ram = ramIn;
+            return this;
+        }
+
+        public SCCRegCacheItemMock build() {
+            return new SCCRegCacheItemMock(this);
+        }
+    }
+
+    class SCCRegCacheItemMock {
+        public static final String SCC_LOGIN = "sccLogin";
+        public static final String SCC_PWD = "sccPasswd";
+
+        // Maps we need to spy on
+        private final Map<SCCSystemId, SCCRegisterSystemJson> pendingRegistrationSystems = new HashMap<>();
+
+        private final SCCSystemRegistrationContext contextMock;
+
+        SCCRegCacheItemMock(SCCRegCacheItemMockBuilder builder) {
+            // So you can mock more than just interfaces
+            context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+
+            this.contextMock = context.mock(SCCSystemRegistrationContext.class);
+
+            final CPU cpuMock = context.mock(CPU.class);
+            final SCCRegCacheItem cacheItemMock = context.mock(SCCRegCacheItem.class);
+            final Server serverMock = context.mock(Server.class);
+            final ServerArch serverArchMock = context.mock(ServerArch.class);
+            final ServerInfo serverInfoMock = context.mock(ServerInfo.class);
+            final VirtualInstance virtualInstanceMock = context.mock(VirtualInstance.class);
+            final VirtualInstanceType virtualInstanceTypeMock = context.mock(VirtualInstanceType.class);
+
+            final Map<SCCSystemId, SCCRegCacheItem> itemsBySccSystemId = new HashMap<>();
+
+            // Mock expectations
+            context.checking(new Expectations() {{
+                // Base expectations to get into getPayload method
+                allowing(contextMock).getItems(); will(returnValue(Arrays.asList(cacheItemMock)));
+                allowing(cacheItemMock).getOptServer(); will(returnValue(Optional.of(serverMock)));
+                allowing(serverMock).isForeign(); will(returnValue(false));
+                allowing(serverMock).isPayg(); will(returnValue(false));
+                allowing(contextMock).getItemsBySccSystemId(); will(returnValue(itemsBySccSystemId));
+                allowing(contextMock).getPendingRegistrationSystems(); will(returnValue(pendingRegistrationSystems));
+
+                //  Installed products
+                allowing(serverMock).getInstalledProductSet(); will(returnValue(ofNullable(builder.suseProductSet)));
+
+                // CPU information
+                if(builder.hasCpuInfo) {
+                    allowing(serverMock).getCpu(); will(returnValue(cpuMock));
+                }
+                allowing(cpuMock).getNrCPU(); will(returnValue(builder.cpus));
+                allowing(cpuMock).getNrsocket(); will(returnValue(builder.sockets));
+
+                // Arch label setup
+                allowing(serverArchMock).getLabel();
+                will(returnValue(builder.serverArchLabel));
+                allowing(serverMock).getServerArch(); will(returnValue(serverArchMock));
+
+                // Set as virtual guest
+                allowing(serverMock).isVirtualGuest(); will(returnValue(builder.isVirtualGuest));
+                allowing(serverMock).getVirtualInstance(); will(returnValue(virtualInstanceMock));
+                allowing(virtualInstanceMock).getType(); will(returnValue(virtualInstanceTypeMock));
+                allowing(virtualInstanceTypeMock).getHypervisor(); will(returnValue(ofNullable(builder.hypervisor)));
+                allowing(virtualInstanceTypeMock).getCloudProvider();
+                will(returnValue(ofNullable(builder.cloudProvider)));
+                allowing(virtualInstanceMock).getUuid(); will(returnValue(builder.uuid));
+                allowing(virtualInstanceMock).getTotalMemory(); will(returnValue(builder.totalMemory));
+                allowing(serverMock).getRam(); will(returnValue(builder.ram));
+
+                // SCC login and password setup
+                allowing(cacheItemMock).getOptSccLogin(); will(returnValue(Optional.of(SCC_LOGIN)));
+                allowing(cacheItemMock).getOptSccPasswd(); will(returnValue(Optional.of(SCC_PWD)));
+
+                // Additional data required for SCCRegisterSystemJson
+                allowing(serverMock).getHostname(); will(returnValue(builder.hostname));
+                allowing(serverMock).getServerInfo(); will(returnValue(serverInfoMock));
+                allowing(serverInfoMock).getCheckin(); will(returnValue(new Date()));
+
+            }});
+
+        }
+
+        public Map<SCCSystemId, SCCRegisterSystemJson> getPendingRegistrationSystems() {
+            return pendingRegistrationSystems;
+        }
+
+        public SCCSystemRegistrationContext getContextMock() {
+            return contextMock;
+        }
+    }
 }

--- a/java/spacewalk-java.changes.rjpmestre.fix-memory-size-extraction-virtual-instances
+++ b/java/spacewalk-java.changes.rjpmestre.fix-memory-size-extraction-virtual-instances
@@ -1,0 +1,1 @@
+- fix memory size extraction in virtual instances (bsc#1219634)


### PR DESCRIPTION
## What does this PR change?

This PR fixes the memory size extraction in virtual instances (while registering in scc).
The problem was the initial assumption that this value would not be nullable.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23649

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
