### PR TITLE
CI: clean up old packages when publishing new packages

### DIFF
--- a/susemanager-utils/testing/automation/publish-rpms.sh
+++ b/susemanager-utils/testing/automation/publish-rpms.sh
@@ -39,6 +39,8 @@ if [ -z "${obs_project}" ] || \
 fi
 
 repo_dir=$repo_dir/$obs_project/$obs_repo/$obs_arch
+echo "Clean up packages older than 30 days, to do some cleanup"
+find $repo_dir -mtime +30 | xargs rm
 
 osc -A $obs_api getbinaries $obs_project $obs_repo $obs_arch -d $repo_dir
 


### PR DESCRIPTION
## What does this PR change?

If we do not clean up old packages, disc gets eventually full. The simplest thing is to clean up old packages every time we call publish_rpms.sh . This way, the clean up does not happen in the middle of a build and it happens before recreating the metadata.



## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
