### PR TITLE
QE: Remove Build Validation folder from PR tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,8 +59,14 @@ branding/ @uyuni-project/frontend
 
 # QE
 testsuite/ @uyuni-project/qe
-.github/Maintenance_Update.md @uyuni-project/qe
+.github/scripts/test_covering_pr.js @uyuni-project/qe
 .github/workflows/rubocop.yml @uyuni-project/qe
+.github/workflows/acceptance_tests_common.yml @uyuni-project/qe
+.github/workflows/acceptance_tests_feedback.yml @uyuni-project/qe
+.github/workflows/acceptance_tests_secondary_parallel.yml @uyuni-project/qe
+.github/workflows/acceptance_tests_secondary.yml @uyuni-project/qe
+.github/workflows/build_containers.yml@uyuni-project/qe
+.github/workflows/test-covering-pr.yml @uyuni-project/qe
 .rubocop.yml @uyuni-project/qe
 
 # mgr-libmod

--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -28,6 +28,7 @@ jobs:
               - 'web/html/src/**'
               - 'testsuite/**'
               - '!.github/workflows/**'
+              - '!testsuite/features/build_validation/**'
   test-uyuni:
     runs-on: ubuntu-22.04
     needs: paths-filter

--- a/.github/workflows/acceptance_tests_feedback.yml
+++ b/.github/workflows/acceptance_tests_feedback.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/acceptance_tests_feedback.yml'
       - '.github/workflows/acceptance_tests_common.yml'
       - '!java/*.changes*'
+      - '!testsuite/features/build_validation/**'
 jobs:
   comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR change?

- Exclude BV folder from GitHub PR test suite tests. Since we do not test any BV tests with the GitHub Actions PR tests, it makes no sense to wait for the regular test suite code to be tested when BV only code is modified.
- Add missing QE owned files to CODEOWNERS 

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- No tests are needed, only configuration is added.

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!