### PR TITLE
QE: Fix Uyuni Proxy channel selection

### DIFF
--- a/testsuite/features/init_clients/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/init_clients/proxy_register_as_minion_with_gui.feature
@@ -78,7 +78,7 @@ Feature: Setup Uyuni proxy
     And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
-    And I check "Uyuni Proxy Stable for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/init_clients/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/init_clients/proxy_register_as_minion_with_script.feature
@@ -88,7 +88,7 @@ Feature: Setup Uyuni proxy
     And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
-    And I check "Uyuni Proxy Stable for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -144,7 +144,7 @@ Feature: Update activation keys
     And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
-    And I check "Uyuni Proxy Stable for openSUSE Leap 15.5 (x86_64)"
+    And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1142,7 +1142,7 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         opensuse_leap15_5-x86_64-sle-updates
         opensuse_leap15_5-uyuni-client-x86_64
         opensuse_leap15_5-uyuni-client-devel-x86_64
-        uyuni-proxy-stable-leap-155-x86_64
+        uyuni-proxy-devel-leap-x86_64
       ],
     'leap15.4-aarch64' =>
       %w[
@@ -1363,7 +1363,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'ubuntu-2204-amd64-main-security-amd64' => 2760,
   'ubuntu-2204-amd64-main-updates-amd64' => 180,
   'ubuntu-22.04-suse-manager-tools-amd64' => 60,
-  'uyuni-proxy-stable-leap-155-x86_64' => 60
+  'uyuni-proxy-devel-leap-x86_64' => 60
 }.freeze
 
 EMPTY_CHANNELS = %w[sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64].freeze


### PR DESCRIPTION
## What does this PR change?

We want to test the devel packages in our CI, not the released stable ones.

Reverts https://github.com/uyuni-project/uyuni/pull/8304 Regression initially introduced with https://github.com/uyuni-project/uyuni/pull/8281.
The changes from https://github.com/uyuni-project/uyuni/pull/8326 are not needed anymore.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
