### PR TITLE
QE: add systems errata API testing feature

### DIFF
--- a/testsuite/features/secondary/srv_errata_api.feature
+++ b/testsuite/features/secondary/srv_errata_api.feature
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@scope_api
+Feature: Systems errata API
+
+  @ssh_minion
+  Scenario: Check the relevant errata for a system
+    When I retrieve the relevant errata for ssh_minion
+
+  @ssh_minion
+  @rhlike_minion
+  @deblike_minion
+  Scenario: Check the relevant errata for multiple systems
+    When I retrieve the relevant errata for ssh_minion, rhlike_minion, deblike_minion

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -75,6 +75,18 @@ When(/^I wait for the OpenSCAP audit to finish$/) do
   end
 end
 
+When(/^I retrieve the relevant errata for (.+)$/) do |raw_hosts|
+  hosts = raw_hosts.split(',').map(&:strip)
+  sids = []
+
+  hosts.each do |host|
+    node = get_target(host)
+    sids << get_system_id(node)
+  end
+  # system.getErrata is an overloaded API method accepting either a single sid or a list of them
+  sids.size == 1  ? $api_test.system.get_system_errata(sids[0]) : $api_test.system.get_systems_errata(sids)
+end
+
 ## user namespace
 
 When(/^I call user\.list_users\(\)$/) do

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -84,7 +84,7 @@ When(/^I retrieve the relevant errata for (.+)$/) do |raw_hosts|
     sids << get_system_id(node)
   end
   # system.getErrata is an overloaded API method accepting either a single sid or a list of them
-  sids.size == 1  ? $api_test.system.get_system_errata(sids[0]) : $api_test.system.get_systems_errata(sids)
+  sids.size == 1 ? $api_test.system.get_system_errata(sids[0]) : $api_test.system.get_systems_errata(sids)
 end
 
 ## user namespace

--- a/testsuite/features/support/http_client.rb
+++ b/testsuite/features/support/http_client.rb
@@ -3,6 +3,11 @@
 
 require 'faraday'
 
+# When we pass a list of values in the query string of an HTTP request, the defaul encoder will only update the key for that param
+# As an example: sids=1000010027&sids=1000010010&sids=1000010012 maps to params={"sids"=>"1000010012"}
+# With FlatParamEncoder, it maps to params={"sids"=>["1000010027", "1000010010", "1000010012"]}
+Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
+
 # Wrapper class for HTTP client library (Faraday)
 class HttpClient
   ##
@@ -38,7 +43,12 @@ class HttpClient
       unless params.nil?
         params.each do |key, value|
           url += '&' unless url[-1] == '?'
-          url += "#{key}=#{value}"
+          url +=
+            if value.is_a?(Array)
+              value.map { |v| "#{key}=#{v}" }.join('&')
+            else
+              "#{key}=#{value}"
+            end
         end
       end
     end

--- a/testsuite/features/support/namespaces/system.rb
+++ b/testsuite/features/support/namespaces/system.rb
@@ -184,6 +184,24 @@ class NamespaceSystem
   def set_variables(server, variables)
     @test.call('system.setVariables', sessionKey: @test.token, sid: server, netboot: true, variables: variables)
   end
+
+  ##
+  # Returns a list of all errata that are relevant to the system with the given SID
+  #
+  # Args:
+  #   id: The ID of the system
+  def get_system_errata(system_id)
+    @test.call('system.getRelevantErrata', sessionKey: @test.token, sid: system_id)
+  end
+
+  ##
+  # Returns a list of all errata that are relevant to the systems with the given SIDs
+  #
+  # Args:
+  #   system_ids: The IDs of the systems
+  def get_systems_errata(system_ids)
+    @test.call('system.getRelevantErrata', sessionKey: @test.token, sids: system_ids)
+  end
 end
 
 # System Configuration namespace

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -38,6 +38,7 @@
 - features/secondary/srv_reportdb.feature
 - features/secondary/srv_dist_channel_mapping.feature
 - features/secondary/srv_task_status_engine.feature
+- features/secondary/srv_errata_api.feature
 
 - features/secondary/proxy_retail_pxeboot_and_mass_import.feature
 - features/secondary/allcli_overview_systems_details.feature


### PR DESCRIPTION
## What does this PR change?

Closes https://github.com/SUSE/spacewalk/issues/23534

Adds namespaces and testsuite support for  the system.getRelevantErrata API calls/endpoints and features to test them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests and files were added and edited

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23534
Port(s): Manager 4.3 https://github.com/SUSE/spacewalk/pull/23773

- [x] **DONE**

## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
