### PR TITLE
QE: Remove the CNAME for the containerized proxy

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1445,12 +1445,12 @@ When(/^I generate the configuration "([^"]*)" of Containerized Proxy on the serv
     end
 
     command = "spacecmd -u admin -p admin proxy_container_config -- -o #{file_path} -p 8022 " \
-              "#{get_target('proxy').full_hostname.sub('pxy', 'pod-pxy')} #{get_target('server').full_hostname} 2048 galaxy-noise@suse.de " \
+              "#{get_target('proxy').full_hostname} #{get_target('server').full_hostname} 2048 galaxy-noise@suse.de " \
               '/tmp/ca.crt /tmp/proxy.crt /tmp/proxy.key'
   else
     # Doc: https://www.uyuni-project.org/uyuni-docs/en/uyuni/reference/spacecmd/proxy_container.html
     command = 'echo spacewalk > cert_pass && spacecmd -u admin -p admin proxy_container_config_generate_cert' \
-              " -- -o #{file_path} -p 8022 #{get_target('proxy').full_hostname.sub('pxy', 'pod-pxy')} #{get_target('server').full_hostname}" \
+              " -- -o #{file_path} -p 8022 #{get_target('proxy').full_hostname} #{get_target('server').full_hostname}" \
               ' 2048 galaxy-noise@suse.de --ca-pass cert_pass' \
               ' && rm cert_pass'
   end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -367,8 +367,6 @@ def get_system_name(host)
         word =~ /example.sle15sp4terminal-/
       end
     system_name = 'sle15sp4terminal.example.org' if system_name.nil?
-  when 'containerized_proxy'
-    system_name = get_target('proxy').full_hostname.sub('pxy', 'pod-pxy')
   else
     begin
       node = get_target(host)


### PR DESCRIPTION
## What does this PR change?

This will remove the adaptation for the containerized proxy in the test suite. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): partially fixes https://github.com/SUSE/spacewalk/issues/23362
Ports(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!