### PR TITLE
Fix lists of channels to sync - Uyuni

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -634,21 +634,23 @@ PKGARCH_BY_CLIENT = {
   'sle15sp5s390_ssh_minion' => 's390x'
 }.freeze
 
+# Explanations:
+# - beta channels were removed because they are not selected and not currently synced, add them again when we will use them
+# - SLED channels for SUMA tools were removed as we are not currently synchronizing them
+# - 'default' is required for auto-installation tests.
+# - '# CHECKED' means that we verified that the list of channels matches the results in /var/log/rhn/reposync,
+#   and that we took the occasion to evaluate a reasonable timeout for them
 CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
-  # WARNING:
-  # - beta channels were removed because they are not selected and not currently synced, add them again when we will use them
-  # - sled channels for SUMA tools were removed as we are not currently synchronizing them
-  # - 'default' is required for auto-installation tests.
   'SUSE Manager' => {
     'default' => # CHECKED
       %w[
-        sle-module-desktop-applications15-sp4-updates-x86_64
-        sle-module-desktop-applications15-sp4-pool-x86_64
         sle-product-sles15-sp4-pool-x86_64
         sle-product-sles15-sp4-updates-x86_64
         sle15-sp4-installer-updates-x86_64
         sle-module-basesystem15-sp4-updates-x86_64
         sle-module-basesystem15-sp4-pool-x86_64
+        sle-module-desktop-applications15-sp4-updates-x86_64
+        sle-module-desktop-applications15-sp4-pool-x86_64
         sle-module-server-applications15-sp4-pool-x86_64
         sle-module-server-applications15-sp4-updates-x86_64
         sle-manager-tools15-pool-x86_64-sp4
@@ -780,13 +782,13 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
       ],
     'sles15-sp4' => # CHECKED
       %w[
-        sle-module-desktop-applications15-sp4-updates-x86_64
-        sle-module-desktop-applications15-sp4-pool-x86_64
         sle-product-sles15-sp4-pool-x86_64
         sle-product-sles15-sp4-updates-x86_64
         sle15-sp4-installer-updates-x86_64
         sle-module-basesystem15-sp4-updates-x86_64
         sle-module-basesystem15-sp4-pool-x86_64
+        sle-module-desktop-applications15-sp4-updates-x86_64
+        sle-module-desktop-applications15-sp4-pool-x86_64
         sle-module-server-applications15-sp4-pool-x86_64
         sle-module-server-applications15-sp4-updates-x86_64
         sle-product-sles15-sp4-ltss-updates-x86_64
@@ -979,43 +981,46 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-module-containers15-sp4-updates-x86_64
         sles15-sp4-uyuni-client-x86_64
       ],
-    'almalinux8' =>
+    'almalinux8' => # CHECKED
       %w[
-        almalinux8-appstream-x86_64
-        almalinux8-extras-x86_64
         almalinux8-x86_64
-        almalinux8-uyuni-client-x86_64
+        almalinux8-x86_64-appstream
+        almalinux8-x86_64-extras
+        almalinux8-uyuni-client-devel-x86_64
       ],
-    'almalinux9' =>
+    'almalinux9' => # CHECKED
       %w[
-        almalinux9-appstream-x86_64
-        almalinux9-extras-x86_64
         almalinux9-x86_64
-        almalinux9-uyuni-client-x86_64
+        almalinux9-x86_64-appstream
+        almalinux9-x86_64-extras
+        almalinux9-uyuni-client-devel-x86_64
       ],
-    'debian-10' =>
+    'centos7' => # CHECKED
       %w[
-        debian-10-main-security-amd64
-        debian-10-main-updates-amd64
-        debian-10-pool-amd64
-        devel-debian-10-client-tools
-        debian-10-amd64-uyuni-client
+        centos7-x86_64
+        centos7-x86_64-extras
+        centos7-uyuni-client-devel-x86_64
       ],
-    'debian-11' =>
+    'debian-10' => # CHECKED
       %w[
-        debian-11-main-security-amd64
-        debian-11-main-updates-amd64
-        debian-11-pool-amd64
-        devel-debian-11-client-tools
-        debian-11-amd64-uyuni-client
+        debian-10-pool-amd64-uyuni
+        debian-10-amd64-main-updates-uyuni
+        debian-10-amd64-main-security-uyuni
+        debian-10-amd64-uyuni-client-devel
       ],
-    'debian-12' =>
+    'debian-11' => # CHECKED
       %w[
-        debian-12-main-security-amd64
-        debian-12-main-updates-amd64
-        debian-12-pool-amd64
-        devel-debian-12-client-tools
-        debian-12-amd64-uyuni-client
+        debian-11-pool-amd64-uyuni
+        debian-11-amd64-main-updates-uyuni
+        debian-11-amd64-main-security-uyuni
+        debian-11-amd64-uyuni-client-devel
+      ],
+    'debian-12' => # CHECKED
+      %w[
+        debian-12-pool-amd64-uyuni
+        debian-12-amd64-main-updates-uyuni
+        debian-12-amd64-main-security-uyuni
+        debian-12-amd64-uyuni-client-devel
       ],
     'sll-9' =>
       %w[
@@ -1027,33 +1032,34 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
       %w[
         el9-pool-x86_64
       ],
-    'rockylinux-8' =>
+    'rockylinux-8' => # CHECKED
       %w[
+        rockylinux-8-x86_64
         rockylinux-8-appstream-x86_64
         rockylinux-8-extras-x86_64
-        rockylinux-8-x86_64
-        rockylinux8-uyuni-client-x86_64
+        rockylinux8-uyuni-client-devel-x86_64
       ],
-    'rockylinux-9' =>
+    'rockylinux-9' => # CHECKED
       %w[
+        rockylinux-9-x86_64
         rockylinux-9-appstream-x86_64
         rockylinux-9-extras-x86_64
-        rockylinux-9-x86_64
-        rockylinux9-uyuni-client-x86_64
+        rockylinux9-uyuni-client-devel-x86_64
       ],
-    'oraclelinux9' =>
+    'oraclelinux9' => # CHECKED
       %w[
-        oraclelinux9-appstream-x86_64
         oraclelinux9-x86_64
-        oraclelinux9-uyuni-client-x86_64
+        oraclelinux9-appstream-x86_64
+        oraclelinux9-uyuni-client-devel-x86_64
       ],
-    'sles12-sp5' =>
+    'sles12-sp5' => # CHECKED
       %w[
         sles12-sp5-installer-updates-x86_64
         sles12-sp5-pool-x86_64
         sles12-sp5-updates-x86_64
+        sles12-sp5-uyuni-client-devel-x86_64
       ],
-    'sles15-sp1' =>
+    'sles15-sp1' => # CHECKED
       %w[
         sle-product-sles15-sp1-ltss-updates-x86_64
         sle-product-sles15-sp1-pool-x86_64
@@ -1063,8 +1069,9 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-module-basesystem15-sp1-pool-x86_64
         sle-module-basesystem15-sp1-updates-x86_64
         sle15-sp1-installer-updates-x86_64
+        sles15-sp1-devel-uyuni-client-x86_64
       ],
-    'sles15-sp2' =>
+    'sles15-sp2' => # CHECKED
       %w[
         sle-product-sles15-sp2-ltss-updates-x86_64
         sle-product-sles15-sp2-pool-x86_64
@@ -1078,52 +1085,60 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-module-basesystem15-sp2-pool-x86_64
         sle-module-basesystem15-sp2-updates-x86_64
         sle15-sp2-installer-updates-x86_64
+        sles15-sp2-devel-uyuni-client-x86_64
       ],
-    'sles15-sp3' =>
+    'sles15-sp3' => # CHECKED
       %w[
         sle-product-sles15-sp3-ltss-updates-x86_64
         sle-product-sles15-sp3-pool-x86_64
-        sle-module-basesystem15-sp3-pool-x86_64
-        sle-module-server-applications15-sp3-pool-x86_64
         sle-product-sles15-sp3-updates-x86_64
+        sle-module-basesystem15-sp3-pool-x86_64
         sle-module-basesystem15-sp3-updates-x86_64
-        sle-module-server-applications15-sp3-updates-x86_64
-        sle15-sp3-installer-updates-x86_64
         sle-module-desktop-applications15-sp3-pool-x86_64
         sle-module-desktop-applications15-sp3-updates-x86_64
         sle-module-devtools15-sp3-pool-x86_64
         sle-module-devtools15-sp3-updates-x86_64
+        sle-module-server-applications15-sp3-pool-x86_64
+        sle-module-server-applications15-sp3-updates-x86_64
+        sle15-sp3-installer-updates-x86_64
+        sles15-sp3-devel-uyuni-client-x86_64
       ],
-    'sles15-sp4' =>
+    'sles15-sp4' => # CHECKED
       %w[
         sle-product-sles15-sp4-pool-x86_64
         sle-product-sles15-sp4-updates-x86_64
-        sle15-sp4-installer-updates-x86_64
-        sle-module-basesystem15-sp4-updates-x86_64
         sle-module-basesystem15-sp4-pool-x86_64
-        sle-module-server-applications15-sp4-updates-x86_64
-        sle-module-server-applications15-sp4-pool-x86_64
-        sle-module-desktop-applications15-sp4-updates-x86_64
+        sle-module-basesystem15-sp4-updates-x86_64
         sle-module-desktop-applications15-sp4-pool-x86_64
-        sle-product-sles15-sp4-ltss-updates-x86_64
+        sle-module-desktop-applications15-sp4-updates-x86_64
         sle-module-devtools15-sp4-pool-x86_64
         sle-module-devtools15-sp4-updates-x86_64
         sle-module-containers15-sp4-pool-x86_64
         sle-module-containers15-sp4-updates-x86_64
-        sles15-sp4-uyuni-client-x86_64
+        sle-module-public-cloud15-sp4-pool-x86_64
+        sle-module-public-cloud15-sp4-updates-x86_64
+        sle-module-server-applications15-sp4-pool-x86_64
+        sle-module-server-applications15-sp4-updates-x86_64
+        sle15-sp4-installer-updates-x86_64
+        sles15-sp4-devel-uyuni-client-x86_64
       ],
-    'sles15-sp5' =>
+    'sles15-sp5' => # CHECKED
       %w[
+        sle-product-sles15-sp5-pool-x86_64
+        sle-product-sles15-sp5-updates-x86_64
         sle-module-basesystem15-sp5-pool-x86_64
         sle-module-basesystem15-sp5-updates-x86_64
         sle-module-desktop-applications15-sp5-pool-x86_64
         sle-module-desktop-applications15-sp5-updates-x86_64
         sle-module-devtools15-sp5-pool-x86_64
         sle-module-devtools15-sp5-updates-x86_64
+        sle-module-public-cloud15-sp5-pool-x86_64
+        sle-module-public-cloud15-sp5-updates-x86_64
+        sle-module-python3-15-sp5-pool-x86_64
+        sle-module-python3-15-sp5-updates-x86_64
         sle-module-server-applications15-sp5-pool-x86_64
         sle-module-server-applications15-sp5-updates-x86_64
-        sle-product-sles15-sp5-pool-x86_64
-        sle-product-sles15-sp5-updates-x86_64
+        sles15-sp5-devel-uyuni-client-x86_64
       ],
     'slesforsap15-sp5' =>
       %w[
@@ -1164,67 +1179,91 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         res-cb-8-updates-x86_64
         sll8-uyuni-client-x86_64
       ],
-    'leap15.5-x86_64' =>
+    'leap15.5-x86_64' => # CHECKED
       %w[
         opensuse_leap15_5-x86_64
+        opensuse_leap15_5-x86_64-backports-updates
         opensuse_leap15_5-x86_64-non-oss
         opensuse_leap15_5-x86_64-non-oss-updates
         opensuse_leap15_5-x86_64-updates
-        opensuse_leap15_5-x86_64-backports-updates
         opensuse_leap15_5-x86_64-sle-updates
         opensuse_leap15_5-uyuni-client-x86_64
         opensuse_leap15_5-uyuni-client-devel-x86_64
         uyuni-proxy-devel-leap-x86_64
       ],
-    'leap15.4-aarch64' =>
+    'leap15.4-aarch64' => # CHECKED
       %w[
-        opensuse-backports-15.4-updates-aarch64
-        opensuse-leap-15.4-pool-aarch64
-        opensuse-leap-15.4-updates-aarch64
+        opensuse_leap15_4-aarch64
+        opensuse_leap15_4-aarch64-backports-updates
+        opensuse_leap15_4-aarch64-non-oss
+        opensuse_leap15_4-aarch64-non-oss-updates
+        opensuse_leap15_4-aarch64-sle-updates
+        opensuse_leap15_4-aarch64-updates
+        opensuse_leap15_4-uyuni-client-devel-aarch64
       ],
-    'leap15.5-aarch64' =>
+    'leap15.5-aarch64' => # CHECKED
       %w[
-        opensuse-backports-15.5-updates-aarch64
-        opensuse-leap-15.5-pool-aarch64
-        opensuse-leap-15.5-updates-aarch64
-        opensuse-sle-15.5-updates-aarch64
+        opensuse_leap15_5-aarch64
+        opensuse_leap15_5-aarch64-backports-updates
+        opensuse_leap15_5-aarch64-non-oss
+        opensuse_leap15_5-aarch64-non-oss-updates
+        opensuse_leap15_5-aarch64-sle-updates
+        opensuse_leap15_5-aarch64-updates
+        opensuse_leap15_5-uyuni-client-devel-aarch64
       ],
-    'suse-microos-5.1' =>
+    'suse-microos-5.1' => # CHECKED
       %w[
         suse-microos-5.1-pool-x86_64
         suse-microos-5.1-updates-x86_64
+        suse-microos-5.1-devel-uyuni-client-x86_64
       ],
-    'suse-microos-5.2' =>
+    'suse-microos-5.2' => # CHECKED
       %w[
         suse-microos-5.2-pool-x86_64
         suse-microos-5.2-updates-x86_64
+        suse-microos-5.2-devel-uyuni-client-x86_64
       ],
-    'sle-micro-5.3' =>
+    'sle-micro-5.3' => # CHECKED
       %w[
         sle-micro-5.3-pool-x86_64
         sle-micro-5.3-updates-x86_64
+        sle-micro-5.3-devel-uyuni-client-x86_64
       ],
-    'sle-micro-5.4' =>
+    'sle-micro-5.4' => # CHECKED
       %w[
         sle-micro-5.4-pool-x86_64
         sle-micro-5.4-updates-x86_64
+        sle-micro-5.4-devel-uyuni-client-x86_64
       ],
-    'sle-micro-5.5' =>
+    'sle-micro-5.5' => # CHECKED
       %w[
         sle-micro-5.5-pool-x86_64
         sle-micro-5.5-updates-x86_64
+        sle-micro-5.5-devel-uyuni-client-x86_64
       ],
-    'ubuntu-2004' =>
+    'ubuntu-2004' => # CHECKED
       %w[
-        ubuntu-2004-amd64-main-amd64
-        ubuntu-2004-amd64-main-security-amd64
-        ubuntu-2004-amd64-main-updates-amd64
+        ubuntu-20.04-pool-amd64-uyuni
+        ubuntu-2004-amd64-main-uyuni
+        ubuntu-2004-amd64-main-security-uyuni
+        ubuntu-2004-amd64-main-updates-uyuni
+        ubuntu-2004-amd64-universe-uyuni
+        ubuntu-2004-amd64-universe-backports-uyuni
+        ubuntu-2004-amd64-universe-security-uyuni
+        ubuntu-2004-amd64-universe-updates-uyuni
+        ubuntu-2004-amd64-uyuni-client-devel
       ],
-    'ubuntu-2204' =>
+    'ubuntu-2204' => # CHECKED
       %w[
-        ubuntu-2204-amd64-main-amd64
-        ubuntu-2204-amd64-main-security-amd64
-        ubuntu-2204-amd64-main-updates-amd64
+        ubuntu-22.04-pool-amd64-uyuni
+        ubuntu-2204-amd64-main-security-uyuni
+        ubuntu-2204-amd64-main-updates-uyuni
+        ubuntu-2204-amd64-main-uyuni
+        ubuntu-2204-amd64-universe-backports-uyuni
+        ubuntu-2204-amd64-universe-security-uyuni
+        ubuntu-2204-amd64-universe-updates-uyuni
+        ubuntu-2204-amd64-universe-uyuni
+        ubuntu-2204-amd64-uyuni-client-devel
       ],
     'fake' =>
       %w[
@@ -1252,22 +1291,45 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
   }
 }.freeze
 
+# The timeouts are determining experimentally, by looking at the files in /var/log/rhn/reposync on the server
+# Formula: (end date - startup date) * 2, rounded to upper 60 seconds
 TIMEOUT_BY_CHANNEL_NAME = {
   'almalinux8-appstream-x86_64' => 480,
-  'almalinux8-x86_64' => 120,
+  'almalinux8-uyuni-client-devel-x86_64' => 60,
+  'almalinux8-x86_64' => 420,
+  'almalinux8-x86_64-appstream' => 1740,
+  'almalinux8-x86_64-extras' => 60,
   'almalinux9-appstream-x86_64' => 480,
+  'almalinux9-uyuni-client-devel-x86_64' => 60,
   'almalinux9-x86_64' => 120,
+  'almalinux9-x86_64-appstream' => 720,
+  'almalinux9-x86_64-extras' => 60,
+  'centos7-uyuni-client-devel-x86_64' => 60,
+  'centos7-x86_64' => 960,
+  'centos7-x86_64-extras' => 120,
+  'debian-10-amd64-main-security-uyuni' => 780,
+  'debian-10-amd64-main-updates-uyuni' => 60,
+  'debian-10-amd64-uyuni-client-devel' => 60,
   'debian-10-main-security-amd64' => 540,
   'debian-10-main-updates-amd64' => 60,
   'debian-10-pool-amd64' => 19_860,
+  'debian-10-pool-amd64-uyuni' => 21_060,
   'debian-10-suse-manager-tools-amd64' => 60,
+  'debian-11-amd64-main-security-uyuni' => 240,
+  'debian-11-amd64-main-updates-uyuni' => 60,
+  'debian-11-amd64-uyuni-client-devel' => 60,
   'debian-11-main-security-amd64' => 240,
   'debian-11-main-updates-amd64' => 60,
   'debian-11-pool-amd64' => 22_920,
+  'debian-11-pool-amd64-uyuni' => 23_580,
   'debian-11-suse-manager-tools-amd64' => 60,
+  'debian-12-amd64-main-security-uyuni' => 240,
+  'debian-12-amd64-main-updates-uyuni' => 120,
+  'debian-12-amd64-uyuni-client-devel' => 60,
   'debian-12-main-security-amd64' => 240,
   'debian-12-main-updates-amd64' => 120,
   'debian-12-pool-amd64' => 27_960,
+  'debian-12-pool-amd64-uyuni' => 28_260,
   'debian-12-suse-manager-tools-amd64' => 60,
   'el9-manager-tools-pool-x86_64' => 60,
   'el9-manager-tools-pool-x86_64-alma' => 60,
@@ -1278,14 +1340,42 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'el9-manager-tools-updates-x86_64-ol9' => 60,
   'el9-manager-tools-updates-x86_64-rocky' => 60,
   'el9-pool-x86_64' => 60,
+  'opensuse_leap15_4-aarch64' => 8940,
+  'opensuse_leap15_4-aarch64-backports-updates' => 540,
+  'opensuse_leap15_4-aarch64-non-oss' => 60,
+  'opensuse_leap15_4-aarch64-non-oss-updates' => 60,
+  'opensuse_leap15_4-aarch64-sle-updates' => 7740,
+  'opensuse_leap15_4-aarch64-updates' => 180,
+  'opensuse_leap15_4-uyuni-client-devel-aarch64' => 60,
+  'opensuse_leap15_5-aarch64' => 10_020,
+  'opensuse_leap15_5-aarch64-backports-updates' => 420,
+  'opensuse_leap15_5-aarch64-non-oss' => 60,
+  'opensuse_leap15_5-aarch64-non-oss-updates' => 60,
+  'opensuse_leap15_5-aarch64-sle-updates' => 4140,
+  'opensuse_leap15_5-aarch64-updates' => 60,
+  'opensuse_leap15_5-uyuni-client-devel-aarch64' => 60,
   'opensuse_leap15_5-uyuni-client-devel-x86_64' => 60,
+  'opensuse_leap15_5-uyuni-client-x86_64' => 60,
+  'opensuse_leap15_5-x86_64' => 10_380,
+  'opensuse_leap15_5-x86_64-backports-updates' => 360,
+  'opensuse_leap15_5-x86_64-non-oss' => 60,
+  'opensuse_leap15_5-x86_64-non-oss-updates' => 120,
+  'opensuse_leap15_5-x86_64-sle-updates' => 5400,
+  'opensuse_leap15_5-x86_64-updates' => 60,
   'oraclelinux9-appstream-x86_64' => 2100,
+  'oraclelinux9-uyuni-client-devel-x86_64' => 60,
   'oraclelinux9-x86_64' => 840,
   'res7-suse-manager-tools-x86_64' => 300,
   'res7-x86_64' => 21_000,
   'rhel-x86_64-server-7' => 60,
+  'rockylinux8-uyuni-client-devel-x86_64' => 60,
+  'rockylinux8-x86_64' => 600,
+  'rockylinux8-x86_64-appstream' => 1260,
+  'rockylinux8-x86_64-extras' => 420,
   'rockylinux-9-appstream-x86_64' => 480,
+  'rockylinux9-uyuni-client-devel-x86_64' => 60,
   'rockylinux-9-x86_64' => 120,
+  'rockylinux9-x86_64-extras' => 120,
   'sle15-sp1-installer-updates-x86_64' => 60,
   'sle15-sp2-installer-updates-x86_64' => 60,
   'sle15-sp3-installer-updates-x86_64' => 60,
@@ -1314,10 +1404,13 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-manager-tools-for-micro5-updates-x86_64-5.3' => 60,
   'sle-manager-tools-for-micro5-updates-x86_64-5.4' => 60,
   'sle-manager-tools-for-micro5-updates-x86_64-5.5' => 60,
+  'sle-micro-5.3-devel-uyuni-client-x86_64' => 60,
   'sle-micro-5.3-pool-x86_64' => 120,
   'sle-micro-5.3-updates-x86_64' => 240,
+  'sle-micro-5.4-devel-uyuni-client-x86_64' => 60,
   'sle-micro-5.4-pool-x86_64' => 60,
   'sle-micro-5.4-updates-x86_64' => 60,
+  'sle-micro-5.5-devel-uyuni-client-x86_64' => 60,
   'sle-micro-5.5-pool-x86_64' => 120,
   'sle-micro-5.5-updates-x86_64' => 120,
   'sle-module-basesystem15-sp1-pool-x86_64' => 180,
@@ -1350,6 +1443,10 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-devtools15-sp4-updates-x86_64' => 600,
   'sle-module-devtools15-sp5-pool-x86_64' => 120,
   'sle-module-devtools15-sp5-updates-x86_64' => 300,
+  'sle-module-public-cloud15-sp4-pool-x86_64' => 840,
+  'sle-module-public-cloud15-sp4-updates-x86_64' => 600,
+  'sle-module-public-cloud15-sp5-pool-x86_64' => 600,
+  'sle-module-public-cloud15-sp5-updates-x86_64' => 420,
   'sle-module-python3-15-sp5-pool-x86_64' => 60,
   'sle-module-python3-15-sp5-updates-x86_64' => 60,
   'sle-module-server-applications15-sp1-pool-x86_64' => 60,
@@ -1383,20 +1480,46 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sles12-sp5-installer-updates-x86_64' => 60,
   'sles12-sp5-pool-x86_64' => 180,
   'sles12-sp5-updates-x86_64' => 2280,
+  'sles12-sp5-uyuni-client-devel-x86_64' => 120,
+  'sles15-sp1-devel-uyuni-client-x86_64' => 60,
+  'sles15-sp2-devel-uyuni-client-x86_64' => 60,
+  'sles15-sp3-devel-uyuni-client-x86_64' => 60,
+  'sles15-sp4-devel-uyuni-client-x86_64' => 60,
+  'sles15-sp5-devel-uyuni-client-x86_64' => 60,
   'sll-9-updates-x86_64' => 720,
   'sll-as-9-updates-x86_64' => 1620,
   'sll-cb-9-updates-x86_64' => 2640,
+  'suse-microos-5.1-devel-uyuni-client-x86_64' => 60,
   'suse-microos-5.1-pool-x86_64' => 60,
   'suse-microos-5.1-updates-x86_64' => 300,
+  'suse-microos-5.2-devel-uyuni-client-x86_64' => 60,
   'suse-microos-5.2-pool-x86_64' => 60,
   'suse-microos-5.2-updates-x86_64' => 60,
   'ubuntu-2004-amd64-main-amd64' => 480,
   'ubuntu-2004-amd64-main-security-amd64' => 3480,
+  'ubuntu-2004-amd64-main-security-uyuni' => 4200,
   'ubuntu-2004-amd64-main-updates-amd64' => 660,
+  'ubuntu-2004-amd64-main-updates-uyuni' => 600,
+  'ubuntu-2004-amd64-main-uyuni' => 660,
+  'ubuntu-2004-amd64-universe-backports-uyuni' => 60,
+  'ubuntu-2004-amd64-universe-security-uyuni' => 900,
+  'ubuntu-2004-amd64-universe-updates-uyuni' => 240,
+  'ubuntu-2004-amd64-universe-uyuni' => 19_560,
+  'ubuntu-2004-amd64-uyuni-client-devel' => 60,
+  'ubuntu-20.04-pool-amd64-uyuni' => 60,
   'ubuntu-20.04-suse-manager-tools-amd64' => 60,
   'ubuntu-2204-amd64-main-amd64' => 780,
   'ubuntu-2204-amd64-main-security-amd64' => 2760,
+  'ubuntu-2204-amd64-main-security-uyuni' => 2040,
   'ubuntu-2204-amd64-main-updates-amd64' => 180,
+  'ubuntu-2204-amd64-main-updates-uyuni' => 300,
+  'ubuntu-2204-amd64-main-uyuni' => 780,
+  'ubuntu-2204-amd64-universe-backports-uyuni' => 60,
+  'ubuntu-2204-amd64-universe-security-uyuni' => 1020,
+  'ubuntu-2204-amd64-universe-updates-uyuni' => 240,
+  'ubuntu-2204-amd64-universe-uyuni' => 24_000,
+  'ubuntu-2204-amd64-uyuni-client-devel' => 60,
+  'ubuntu-22.04-pool-amd64-uyuni' => 60,
   'ubuntu-22.04-suse-manager-tools-amd64' => 60,
   'uyuni-proxy-devel-leap-x86_64' => 60
 }.freeze


### PR DESCRIPTION
## What does this PR change?

This PR fixes constants `CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION` and `TIMEOUT_BY_CHANNEL_NAME` based on experimental data from a test suite run on the uyuni BV test suite.

Note: in `srv_sync_all-products` we must use these arrays in all cases, not only for SLES. @szachovy will take care of that, see SUSE/spacewalk#23395.


## Links

Issue(s): SUSE/spacewalk#23572
Port(s):
 * 4.3: SUSE/spacewalk#23772


## Changelogs

- [x] No changelog needed
