### PR TITLE
More reposync timeout fixes

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -98,9 +98,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added
-    When I use spacewalk-common-channel to add channel "sles15-sp4-uyuni-client" with arch "x86_64"
+    When I use spacewalk-common-channel to add channel "sles15-sp4-devel-uyuni-client" with arch "x86_64"
     And I wait until all synchronized channels for "sles15-sp4" have finished
-    # TODO: Refactor the scenarios in order to don't require a full synchronization of SLES 15 SP4 product in Uyuni
+    # TODO: Refactor the scenarios in order to not require a full synchronization of SLES 15 SP4 product in Uyuni
     # When I kill running spacewalk-repo-sync for "sles15-sp4"
 
 @uyuni

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -936,14 +936,6 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         ubuntu-2204-amd64-main-security-amd64
         ubuntu-22.04-suse-manager-tools-amd64
       ],
-    'fake' => # CHECKED
-      %w[
-        fake-rpm-suse-channel
-        fake-child-channel-i586
-        fake-child-channel-suse-like
-        fake-base-channel-debian-like
-        fake-base-channel-rh-like
-      ],
     'suma-proxy-43' => # CHECKED
       %w[
         sle-product-suse-manager-proxy-4.3-pool-x86_64
@@ -1264,17 +1256,6 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         ubuntu-2204-amd64-universe-uyuni
         ubuntu-2204-amd64-uyuni-client-devel
       ],
-    'fake' =>
-      %w[
-        fake-base-channel-suse-like
-        fake-child-channel-suse-like
-        fake-base-channel-i586
-        fake-child-channel-i586
-        test-base-channel-x86_64
-        test-child-channel-x86_64
-        fake-base-channel-debian-like
-        fake-base-channel-rh-like
-      ],
     'uyuni-proxy' => # CHECKED
       %w[
         opensuse_leap15_5-x86_64
@@ -1344,6 +1325,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'fake-child-channel-i586' => 60,
   'fake-child-channel-suse-like' => 60,
   'fake-rpm-suse-channel' => 60,
+  'fake-rpm-terminal-channel' => 60,
   'opensuse_leap15_4-aarch64' => 8940,
   'opensuse_leap15_4-aarch64-backports-updates' => 540,
   'opensuse_leap15_4-aarch64-non-oss' => 60,
@@ -1509,6 +1491,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'suse-microos-5.2-devel-uyuni-client-x86_64' => 60,
   'suse-microos-5.2-pool-x86_64' => 60,
   'suse-microos-5.2-updates-x86_64' => 60,
+  'test-child-channel-x86_64' => 60,
   'ubuntu-2004-amd64-main-amd64' => 480,
   'ubuntu-2004-amd64-main-security-amd64' => 3480,
   'ubuntu-2004-amd64-main-security-uyuni' => 4200,


### PR DESCRIPTION
## What does this PR change?

Still more fixes after reposync refactoring in October:

* fix wrong channel name for client tools in Uyuni
* we don't reposync a "fake" product, only individual channels
* add 2 more missing timeouts


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/23780


## Changelogs

- [x] No changelog needed
