### PR TITLE
Commit salt event removal in case of process failure (bsc#1218931)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/PGEventStream.java
+++ b/java/code/src/com/suse/manager/reactor/PGEventStream.java
@@ -232,6 +232,11 @@ public class PGEventStream extends AbstractEventStream implements PGNotification
             List<Long> ids = uncommittedEvents.stream().map(SaltEvent::getId).collect(toList());
             List<Long> deletedIds = SaltEventFactory.deleteSaltEvents(ids);
             LOG.error("Events {} were lost", deletedIds);
+            // In case of error processing the event the transation is rollback in the PGeventListener
+            // Then this method is called. We need a commit in here to make sure we clean the DB events
+            // before we call the extra exception listener. This is needed to deal with cases where
+            // the extra listener fails with exception, which will cause the transaction helper to rollback
+            HibernateFactory.commitTransaction();
         }
 
         if (exception instanceof PGEventListenerException) {

--- a/java/spacewalk-java.changes.rmateus.m43-pgeventlistener-error-handling
+++ b/java/spacewalk-java.changes.rmateus.m43-pgeventlistener-error-handling
@@ -1,0 +1,1 @@
+- Commit salt event removal in case of process failure (bsc#1218931)


### PR DESCRIPTION
## What does this PR change?

Port of: https://github.com/SUSE/spacewalk/pull/23645

When we are processing an event action, like RegisterMinionEventMessageAction, an exception can happen (minion not exist, for example). The action execution on the PGEventListener, when an exception happens, will look for an exception handler for this particular action. In the case of minion registration action, it has a custom exception handler, which sends some notifications.

The PGEventStream calls the process event and passes an exception handler, that deals with event removal from the database, and calls the custom exception handler for the error.

The problem happens when the custom exception handler also throws an exception, forcing the rollback of the event removal from database. This happened on the "TransactionHelper" -> "handlingTransaction".

The side effect of this is that the failling event is never cleaned from the rhnsaltevent table and blocks all the other events present in there.

The workflow:

PGEventStream -> notification -> TransactionHelper.handlingTransaction --> in here with the "PGEventStream->handleExceptions" [1]
An exception happens in the "processEvents" because of some error in the Message Action.
"TransactionHelper.handlingTransaction" will rollback and call the "PGEventStream->handleExceptions" inside a new "handlingTransaction" [2]
It will remove the events from the database, but doesn't commit
Calls the action custom exception listeners. It fails with an exception
The "handlingTransaction" resolves with an exception and rollback the transaction, and reverting the delete of the already processed events (and failed one) [3]
[1] https://github.com/SUSE/spacewalk/blob/Manager-4.3/java/code/src/com/suse/manager/reactor/PGEventStream.java#L196-L199

[2] https://github.com/SUSE/spacewalk/blob/Manager-4.3/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java#L54-L57

[3] https://github.com/SUSE/spacewalk/blob/Manager-4.3/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java#L50-L52

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
