### PR TITLE
Remove disabled repos from salt to avoid issues on traditional to salt migration

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -1,9 +1,3 @@
-{% if repos_disabled is not defined or repos_disabled.get('skip', false) == false %}
-# disable all spacewalk:* repos
-{% set repos_disabled = {'match_str': 'spacewalk:', 'matching': true} %}
-{%- include 'channels/disablelocalrepos.sls' %}
-{% endif %}
-
 include:
   - util.syncstates
 
@@ -38,10 +32,6 @@ remove_traditional_stack_all:
 {%- elif grains['os_family'] == 'Debian' %}
       - apt-transport-spacewalk
 {%- endif %}
-{%- if repos_disabled.count > 0 %}
-    - require:
-      - mgrcompat: disable_repo*
-{%- endif %}
 
 remove_traditional_stack:
   pkg.removed:
@@ -51,10 +41,6 @@ remove_traditional_stack:
       - mgr-cfg
 {%- if grains['os_family'] == 'Suse' %}
       - suseRegisterInfo
-{%- endif %}
-{%- if repos_disabled.count > 0 %}
-    - require:
-      - mgrcompat: disable_repo*
 {%- endif %}
     - unless: rpm -q spacewalk-proxy-common || rpm -q spacewalk-common
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vanda.vb-rm-disabled-repos-from-trad-migration-sls
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vanda.vb-rm-disabled-repos-from-trad-migration-sls
@@ -1,0 +1,1 @@
+- Avoid issues on reactivating traditional clients as salt managed


### PR DESCRIPTION
## What does this PR change?
Removes the mention to `disabled repos` on the traditional client to salt migration

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation being taken care of on the context of https://github.com/SUSE/spacewalk/issues/22391

- [ ] **DONE**

## Test coverage
- Cucumber tests being added on the context of https://github.com/SUSE/spacewalk/issues/22391

- [ ] **DONE**

## Links

Ports:
- 4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
