### PR TITLE
Backport 23680 from Manager-4.3: Remove automatic reboot from transactional systems bootstrap

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -318,10 +318,4 @@ transactional_update_set_reboot_method_systemd:
     - unless:
       - grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
 
-{# Use transactional reboot support -> server will be rebooted according to REBOOT_METHOD #}
-reboot_transactional_server:
-  mgrcompat.module_run:
-    - name: transactional_update.reboot
-    - require:
-      - {{ salt_minion_name }}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.welder.bsc1218146
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.welder.bsc1218146
@@ -1,0 +1,1 @@
+- Remove automatic reboot from transactional systems bootstrap (bsc#1218146)


### PR DESCRIPTION
## What does this PR change?

Backport 23680 from Manager-4.3: Remove automatic reboot from transactional systems bootstrap

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23248 
Port(s): https://github.com/SUSE/spacewalk/pull/23680

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
