### PR TITLE
add bootstrap repository definition for SLE15 SP6

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1456,6 +1456,26 @@ DATA = {
         "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/opensuse/15/5/bootstrap/",
     },
+    "openSUSE-Leap-15.6-x86_64": {
+        "PDID": [2734, 1712],
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/opensuse/15/6/bootstrap/",
+    },
+    "openSUSE-Leap-15.6-aarch64": {
+        "PDID": [2731, 1709],
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/opensuse/15/6/bootstrap/",
+    },
+    "openSUSE-Leap-15.6-x86_64-uyuni": {
+        "BASECHANNEL": "opensuse_leap15_6-x86_64",
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/opensuse/15/6/bootstrap/",
+    },
+    "openSUSE-Leap-15.6-aarch64-uyuni": {
+        "BASECHANNEL": "opensuse_leap15_6-aarch64",
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/opensuse/15/6/bootstrap/",
+    },
     "openSUSE-Leap-Micro-5.3-x86_64-uyuni": {
         "BASECHANNEL": "opensuse_micro5_3-x86_64",
         "PKGLIST": PKGLISTMICRO_BUNDLE_ONLY,

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1240,6 +1240,30 @@ DATA = {
         "PKGLIST": ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/5/bootstrap/",
     },
+    "SLE-15-SP6-aarch64": {
+        "PDID": [2615, 1709],
+        "BETAPDID": [1925],
+        "PKGLIST": ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/6/bootstrap/",
+    },
+    "SLE-15-SP6-ppc64le": {
+        "PDID": [2616, 1710],
+        "BETAPDID": [1926],
+        "PKGLIST": ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_PPC,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/6/bootstrap/",
+    },
+    "SLE-15-SP6-s390x": {
+        "PDID": [2617, 1711],
+        "BETAPDID": [1927],
+        "PKGLIST": ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_Z,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/6/bootstrap/",
+    },
+    "SLE-15-SP6-x86_64": {
+        "PDID": [2618, 1712],
+        "BETAPDID": [1928],
+        "PKGLIST": ONLYSLE15 + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/6/bootstrap/",
+    },
     # When adding new SLE15 Service packs, keep in mind the first PDID is for the BaseSystem product (not the base product)!
     "SUMA-43-PROXY-x86_64": {
         "PDID": [2299, 2384],

--- a/susemanager/susemanager.changes.mcalmer.bootstrap-repos-2024
+++ b/susemanager/susemanager.changes.mcalmer.bootstrap-repos-2024
@@ -1,2 +1,2 @@
 - add bootstrap repository definition for openSUSE Leap 15.6
-- add bootstrap repository definition for SLE15 SP6
+- add bootstrap repository definition for SUSE Linux Enterprise 15 SP6

--- a/susemanager/susemanager.changes.mcalmer.bootstrap-repos-2024
+++ b/susemanager/susemanager.changes.mcalmer.bootstrap-repos-2024
@@ -1,1 +1,2 @@
+- add bootstrap repository definition for openSUSE Leap 15.6
 - add bootstrap repository definition for SLE15 SP6

--- a/susemanager/susemanager.changes.mcalmer.bootstrap-repos-2024
+++ b/susemanager/susemanager.changes.mcalmer.bootstrap-repos-2024
@@ -1,0 +1,1 @@
+- add bootstrap repository definition for SLE15 SP6

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1256,6 +1256,78 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_leap15_6]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap 15.6 (%(arch)s)
+gpgkey_url = file:///usr/lib/rpm/gnupg/keys/gpg-pubkey-29b700a4-62b07e22.asc
+gpgkey_id = 29B700A4
+gpgkey_fingerprint = AD48 5664 E901 B867 051A B15F 35A2 F86E 29B7 00A4
+repo_url = http://download.opensuse.org/distribution/leap/15.6/repo/oss/
+dist_map_release = 15.6
+
+[opensuse_leap15_6-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE 15.6 non oss (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_6-%(arch)s
+repo_url = http://download.opensuse.org/distribution/leap/15.6/repo/non-oss/
+
+[opensuse_leap15_6-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.6 Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_6-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.6/oss/
+
+[opensuse_leap15_6-non-oss-updates]
+label    = %(base_channel)s-non-oss-updates
+name     = openSUSE Leap 15.6 non oss Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_6-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.6/non-oss/
+
+[opensuse_leap15_6-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.6 (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_6-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.6/sle/
+
+[opensuse_leap15_6-backports-updates]
+label    = %(base_channel)s-backports-updates
+name     = Update repository of openSUSE Leap 15.6 Backports (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_6-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.6/backports/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_6-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_6-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_6-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_6-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
 [opensuse_micro5_3]
 checksum = sha256
 archs    = x86_64, aarch64

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1786,6 +1786,46 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
+[sles15-sp6-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP6 %(arch)s
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles15-sp6-pool-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sp6-devel-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP6 %(arch)s (Development)
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles15-sp6-pool-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sap-sp6-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP6 SAP %(arch)s
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles_sap15-sp6-pool-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+
+[sles15-sap-sp6-devel-uyuni-client]
+name     = Uyuni Client Tools for SLES15 SP6 SAP %(arch)s (Development)
+archs    =  x86_64, s390x, aarch64, ppc64le
+base_channels = sle-product-sles_sap15-sp6-pool-%(arch)s
+checksum = sha256
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+
 [suse-microos-5.1-uyuni-client]
 name     = Uyuni Client Tools for SUSE MicroOS 5.1 %(arch)s
 archs    =  x86_64, s390x, aarch64

--- a/utils/spacewalk-utils.changes.mcalmer.bootstrap-repos-2024
+++ b/utils/spacewalk-utils.changes.mcalmer.bootstrap-repos-2024
@@ -1,2 +1,2 @@
 - add openSUSE Leap 15.6 and its client tools
-- add uyuni client tools for SLES 15 SP6
+- add Uyuni client tools for SUSE Linux Enterprise 15 SP6

--- a/utils/spacewalk-utils.changes.mcalmer.bootstrap-repos-2024
+++ b/utils/spacewalk-utils.changes.mcalmer.bootstrap-repos-2024
@@ -1,1 +1,2 @@
+- add openSUSE Leap 15.6 and its client tools
 - add uyuni client tools for SLES 15 SP6

--- a/utils/spacewalk-utils.changes.mcalmer.bootstrap-repos-2024
+++ b/utils/spacewalk-utils.changes.mcalmer.bootstrap-repos-2024
@@ -1,0 +1,1 @@
+- add uyuni client tools for SLES 15 SP6


### PR DESCRIPTION
## What does this PR change?

- added SLE15 SP6  to bootstrap data
- added Uyuni Client Tools Channels to spacewalk-common-channels.ini
- add also openSUSE Leap 15.6 and its uyuni client tools

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23476
Port(s): https://github.com/SUSE/spacewalk/pull/23814

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
