### PR TITLE
Make mgr_events engine non-blocking on reading events

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -5,7 +5,7 @@ LISTEN/NOTIFY mechanism to alert SUSE Manager of newly available events.
 
 mgr_events.py tries to keep the I/O low in high load scenarios. Therefore
 events are INSERTed with the separate thread with no blocking the event bus
-amd COMMITted every `commit_interval`.
+and COMMITted every `commit_interval`.
 
 .. versionadded:: 2018.3.0
 

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -1,22 +1,11 @@
-# -*- coding: utf-8 -*-
 """
 mgr_events.py is a SaltStack engine that writes selected events to SUSE
 Manager's PostgreSQL database. Additionally, it sends notifications via the
 LISTEN/NOTIFY mechanism to alert SUSE Manager of newly available events.
 
 mgr_events.py tries to keep the I/O low in high load scenarios. Therefore
-events are INSERTed once they come in, but not necessarily COMMITted
-immediately.
-
-The algorithm is an implementation of token bucket:
- - a COMMIT costs one token
- - initially, commit_burst tokens are available
- - every commit_interval seconds, one new token is generated
-   (up to commit_burst)
- - when an event arrives and there are tokens available it is COMMITted
-   immediately
- - when an event arrives but no tokens are available, the event is INSERTed but
-   not COMMITted yet. COMMIT will happen as soon as a token is available
+events are INSERTed with the separate thread with no blocking the event bus
+amd COMMITted every `commit_interval`.
 
 .. versionadded:: 2018.3.0
 
@@ -58,10 +47,12 @@ default for host is 'localhost'.
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import json
 import logging
-import time
-import fnmatch
 import hashlib
+import re
+import threading
+import time
 
 try:
     import psycopg2
@@ -71,10 +62,8 @@ except ImportError:
     HAS_PSYCOPG2 = False
 
 # Import salt libs
-import salt.version
 import salt.ext.tornado
 import salt.utils.event
-import json
 
 log = logging.getLogger(__name__)
 
@@ -96,11 +85,30 @@ class Responder:
         self.config.setdefault("postgres_db", {})
         self.config["postgres_db"].setdefault("host", "localhost")
         self.config["postgres_db"].setdefault("notify_channel", "suseSaltEvent")
-        self.counters = [0 for i in range(config["events"]["thread_pool_size"] + 1)]
-        self.tokens = config["commit_burst"]
+        self._commit_interval = config["commit_interval"]
+        self._commit_burst = config["commit_burst"]
+        self._thread_pool_size = config["events"]["thread_pool_size"]
+        self.counter = 0
+        self.counters = [0] * (self._thread_pool_size + 1)
+        # Pass salt job returns: salt/job/*/ret/*
+        self.re_job_ret = re.compile(r"salt\/job\/\d+\/ret\/.*")
+        # Pass all additional significant events
+        self.re_additional = [
+            re.compile(r"salt\/minion\/([^\/]+)\/start"),
+            re.compile(r"salt\/beacon\/.*"),
+            re.compile(
+                r"salt\/engines\/libvirt_events\/([^\/]+)\/(domain|pool|network)\/lifecycle"
+            ),
+            re.compile(r"salt\/engines\/libvirt_events\/([^\/]+)\/pool\/refresh"),
+            re.compile(r"salt\/batch\/([^\/]+)\/start"),
+            re.compile(r"suse\/manager\/(image_deployed|image_synced|pxe_update)"),
+            re.compile(r"suse\/systemid\/generate"),
+        ]
+        self._queue = []
         self.event_bus = event_bus
         self._connect_to_database()
-        self.event_bus.io_loop.call_later(config["commit_interval"], self.add_token)
+        self._queue_thread = threading.Thread(target=self.queue_thread)
+        self._queue_thread.start()
 
     def _connect_to_database(self):
         db_config = self.config.get("postgres_db")
@@ -125,34 +133,27 @@ class Responder:
                 time.sleep(5)
         self.cursor = self.connection.cursor()
 
+    def match_additiona_events(self, tag):
+        for p in self.re_additional:
+            if p.match(tag):
+                return True
+        return False
+
     def _insert(self, tag, data):
-        self.db_keepalive()
         if (
-            any(
-                [
-                    fnmatch.fnmatch(tag, "salt/minion/*/start"),
-                    fnmatch.fnmatch(tag, "salt/job/*/ret/*"),
-                    fnmatch.fnmatch(tag, "salt/beacon/*"),
-                    fnmatch.fnmatch(
-                        tag, "salt/engines/libvirt_events/*/domain/lifecycle"
-                    ),
-                    fnmatch.fnmatch(
-                        tag, "salt/engines/libvirt_events/*/pool/lifecycle"
-                    ),
-                    fnmatch.fnmatch(
-                        tag, "salt/engines/libvirt_events/*/network/lifecycle"
-                    ),
-                    fnmatch.fnmatch(tag, "salt/engines/libvirt_events/*/pool/refresh"),
-                    fnmatch.fnmatch(tag, "salt/batch/*/start"),
-                    fnmatch.fnmatch(tag, "suse/manager/image_deployed"),
-                    fnmatch.fnmatch(tag, "suse/manager/image_synced"),
-                    fnmatch.fnmatch(tag, "suse/manager/pxe_update"),
-                    fnmatch.fnmatch(tag, "suse/systemid/generate"),
-                ]
+            # Pass all salt/job/*/ret/* events
+            self.re_job_ret.match(tag)
+            and not (
+                # Except mine updates
+                data.get("fun") == "mine.update"
+                or (
+                    # And presence test.ping returns
+                    data.get("fun") == "test.ping"
+                    and data.get("metadata", {}).get("batch-mode")
+                )
             )
-            and not self._is_salt_mine_event(tag, data)
-            and not self._is_presence_ping(tag, data)
-        ):
+        ) or self.match_additiona_events(tag):
+            # Pass all significant events also
             queue = 0
             if "id" in data:
                 hash_sum = hashlib.md5(
@@ -167,8 +168,8 @@ class Responder:
                     "INSERT INTO suseSaltEvent (minion_id, data, queue) VALUES (%s, %s, %s);",
                     (data.get("id"), json.dumps({"tag": tag, "data": data}), queue),
                 )
+                self.counter += 1
                 self.counters[queue] += 1
-                self.attempt_commit()
             # pylint: disable-next=broad-exception-caught
             except Exception as err:
                 log.error("%s: %s", __name__, err)
@@ -184,59 +185,49 @@ class Responder:
             log.debug("%s: Discarding event -> %s", __name__, tag)
 
     def trace_log(self):
-        log.trace("%s: queues sizes -> %s", __name__, self.counters)
-        log.trace("%s: tokens -> %s", __name__, self.tokens)
+        if self.counter or self._queue:
+            log.trace("%s: queues sizes [%d] -> %s", __name__, len(self._queue), self.counters)
 
-    def _is_salt_mine_event(self, tag, data):
-        return fnmatch.fnmatch(tag, "salt/job/*/ret/*") and self._is_salt_mine_update(
-            data
-        )
-
-    def _is_salt_mine_update(self, data):
-        return data.get("fun") == "mine.update"
-
-    def _is_presence_ping(self, tag, data):
-        return (
-            fnmatch.fnmatch(tag, "salt/job/*/ret/*")
-            and self._is_test_ping(data)
-            and self._is_batch_mode(data)
-        )
-
-    def _is_test_ping(self, data):
-        return data.get("fun") == "test.ping"
-
-    def _is_batch_mode(self, data):
-        return data.get("metadata", {}).get("batch-mode")
+    def push_events_from_queue(self):
+        while self._queue and (
+            self.counter < self._commit_burst or self._commit_burst == 0
+        ):
+            tag, data = self._queue.pop(0)
+            self._insert(tag, data)
 
     @salt.ext.tornado.gen.coroutine
     def add_event_to_queue(self, raw):
-        # FIXME: Drop once we only use Salt >= 3004
-        if salt.version.SaltStackVersion(*salt.version.__version_info__).major < 3004:
-            tag, data = self.event_bus.unpack(raw, self.event_bus.serial)
-        else:
+        try:
             tag, data = self.event_bus.unpack(raw)
-        self._insert(tag, data)
+        # pylint: disable-next=broad-exception-caught
+        except Exception as e:
+            log.warning("Unable to unpack the event data: %s", e)
+        self._queue.append((tag, data))
 
     def db_keepalive(self):
         if self.connection.closed:
             log.error("%s: Diconnected from database. Trying to reconnect...", __name__)
             self._connect_to_database()
 
-    @salt.ext.tornado.gen.coroutine
-    def add_token(self):
-        self.tokens = min(self.tokens + 1, self.config["commit_burst"])
-        self.attempt_commit()
-        self.trace_log()
-        self.event_bus.io_loop.call_later(
-            self.config["commit_interval"], self.add_token
-        )
+    def queue_thread(self):
+        while True:
+            try:
+                self.db_keepalive()
+                self.push_events_from_queue()
+                self.trace_log()
+                self.attempt_commit()
+            # pylint: disable-next=broad-exception-caught
+            except Exception:
+                log.error(
+                    "Exception while processing the events queue: %s", exc_info=True
+                )
+            time.sleep(self._commit_interval)
 
     def attempt_commit(self):
         """
         Committing to the database.
         """
-        self.db_keepalive()
-        if self.tokens > 0 and sum(self.counters) > 0:
+        if self.counter > 0:
             log.debug("%s: commit", __name__)
             self.cursor.execute(
                 # pylint: disable-next=consider-using-f-string
@@ -246,10 +237,8 @@ class Responder:
                 )
             )
             self.connection.commit()
-            self.counters = [
-                0 for i in range(0, self.config["events"]["thread_pool_size"] + 1)
-            ]
-            self.tokens -= 1
+            self.counter = 0
+            self.counters = [0] * (self._thread_pool_size + 1)
 
 
 def start(**config):

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -152,7 +152,7 @@ class Responder:
                     and data.get("metadata", {}).get("batch-mode")
                 )
             )
-        ) or self.match_additiona_events(tag):
+        ) or self.match_additional_events(tag):
             # Pass all significant events also
             queue = 0
             if "id" in data:

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -122,14 +122,14 @@ class Responder:
             conn_string = "dbname='{dbname}' user='{user}' host='{host}' password='{password}'".format(
                 **db_config
             )
-        log.debug("%s: connecting to database", __name__)
+        log.debug("connecting to database")
         while True:
             try:
                 self.connection = psycopg2.connect(conn_string)
                 break
             except psycopg2.OperationalError as err:
-                log.error("%s: %s", __name__, err)
-                log.error("%s: Retrying in 5 seconds.", __name__)
+                log.error("DB Error: %s", err)
+                log.error("Retrying in 5 seconds.")
                 time.sleep(5)
         self.cursor = self.connection.cursor()
 
@@ -162,7 +162,7 @@ class Responder:
                 queue = (
                     int(hash_sum, 16) % self.config["events"]["thread_pool_size"] + 1
                 )
-            log.debug("%s: Adding event to queue %d -> %s", __name__, queue, tag)
+            log.debug("Adding event to queue %d -> %s", queue, tag)
             try:
                 self.cursor.execute(
                     "INSERT INTO suseSaltEvent (minion_id, data, queue) VALUES (%s, %s, %s);",
@@ -172,21 +172,21 @@ class Responder:
                 self.counters[queue] += 1
             # pylint: disable-next=broad-exception-caught
             except Exception as err:
-                log.error("%s: %s", __name__, err)
+                log.error("Error while inserting data to the table: %s", err)
                 try:
                     self.connection.commit()
                 # pylint: disable-next=broad-exception-caught
                 except Exception as err2:
-                    log.error("%s: Error commiting: %s", __name__, err2)
+                    log.error("Error commiting: %s", err2)
                     self.connection.close()
             finally:
-                log.debug("%s: %s", __name__, self.cursor.query)
+                log.debug("Cursor query: %s", self.cursor.query)
         else:
-            log.debug("%s: Discarding event -> %s", __name__, tag)
+            log.debug("Discarding event -> %s", tag)
 
     def trace_log(self):
         if self.counter or self._queue:
-            log.trace("%s: queues sizes [%d] -> %s", __name__, len(self._queue), self.counters)
+            log.trace("queues sizes [%d] -> %s", len(self._queue), self.counters)
 
     def push_events_from_queue(self):
         while self._queue and (
@@ -206,7 +206,7 @@ class Responder:
 
     def db_keepalive(self):
         if self.connection.closed:
-            log.error("%s: Diconnected from database. Trying to reconnect...", __name__)
+            log.error("Diconnected from database. Trying to reconnect...")
             self._connect_to_database()
 
     def queue_thread(self):
@@ -228,7 +228,7 @@ class Responder:
         Committing to the database.
         """
         if self.counter > 0:
-            log.debug("%s: commit", __name__)
+            log.debug("DB: commit")
             self.cursor.execute(
                 # pylint: disable-next=consider-using-f-string
                 "NOTIFY {}, '{}';".format(

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -133,7 +133,7 @@ class Responder:
                 time.sleep(5)
         self.cursor = self.connection.cursor()
 
-    def match_additiona_events(self, tag):
+    def match_additional_events(self, tag):
         for p in self.re_additional:
             if p.match(tag):
                 return True

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.improve-mgr_events-engine
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.improve-mgr_events-engine
@@ -1,0 +1,1 @@
+- Make mgr_events salt engine non-blocking on reading events


### PR DESCRIPTION
## What does this PR change?

While investigating root causes of high memory utilisation by salt EventPublisher was found that memory consumption is growing when the subscribers are not reading the events from the stream fast enough.

One of the subscirbers is `mgr_events` salt engine, it's made `async` and in most cases not causing blocking, but in case of having large amount of events in the publisher this module could cause additional delays on performing `COMMIT` to the DB.

This change is intended to move DB operations to the distinct thread to make it non-blocking for all the cases.

## GUI diff

No difference.


## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered, high workload tests not really possible to perform in CI

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/23526

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
