### PR TITLE
Testsuite: replace wget by curl

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -26,7 +26,7 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server, validating its
     iso_path = $is_container_provider ? url.sub(/^https?:\/\/[^\/]+/, '/srv/mirror') : url.sub(/^https?:\/\/[^\/]+/, '/mirror')
   else
     iso_path = "/tmp/#{name}.iso"
-    get_target('server').run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 1500)
+    get_target('server').run("curl --insecure -o #{iso_path} #{url}", timeout: 1500)
   end
 
   iso_dir = File.dirname(iso_path)

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1047,7 +1047,7 @@ When(/^I visit "([^"]*)" endpoint of this "([^"]*)"$/) do |service, host|
     end
   # debian based systems don't come with curl installed
   if (os_family.include? 'debian') || (os_family.include? 'ubuntu')
-    node.run_until_ok("wget --no-check-certificate -qO- #{protocol}://#{system_name}:#{port}#{path} | grep -i '#{text}'")
+    node.run_until_ok("curl --insecure -s #{protocol}://#{system_name}:#{port}#{path} | grep -i '#{text}'")
   else
     node.run_until_ok("curl -s -k #{protocol}://#{system_name}:#{port}#{path} | grep -i '#{text}'")
   end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -416,7 +416,7 @@ def update_controller_ca
 
   puts `certutil -d sql:/root/.pki/nssdb -t TC -n "susemanager" -D;
   rm /etc/pki/trust/anchors/*;
-  wget http://#{server_ip}/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/#{server_name}.cert &&
+  curl http://#{server_ip}/pub/RHN-ORG-TRUSTED-SSL-CERT -o /etc/pki/trust/anchors/#{server_name}.cert &&
   update-ca-certificates &&
   certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /etc/pki/trust/anchors/#{server_name}.cert`
 end

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -95,7 +95,7 @@ def get_checksum_path(dir, original_file_name, file_url)
       next unless response.is_a?(Net::HTTPSuccess)
 
       checksum_url = base_url + name
-      _output, code = server.run("cd #{dir} && wget --no-check-certificate #{checksum_url}", timeout: 10)
+      _output, code = server.run("cd #{dir} && curl --insecure #{checksum_url}-o #{name}", timeout: 10)
       return "#{dir}/#{name}" if code.zero?
     end
 


### PR DESCRIPTION
## What does this PR change?

wget is not in leap micro or sle micro

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
