### PR TITLE
Merge minion with foreign proxy

### DIFF
--- a/java/spacewalk-java.changes.cbosdonnat.proxy-register-fix
+++ b/java/spacewalk-java.changes.cbosdonnat.proxy-register-fix
@@ -1,0 +1,1 @@
+- Merge minion with foreign system for container proxy


### PR DESCRIPTION
## What does this PR change?

When first generating the container proxy configuration and then bootstrapping the host, two systems are showing up the list. This merges the two into a minion.

The downside is that the systemid file added to the configuration is no longer valid as is contains the OS and OS release which are set with the registration.

## Documentation
- No documentation needed: May be we need to document that the configuration needs to be generated again, unless we find a way to overcome this issue.

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23800

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
