### PR TITLE
QE: Remove old cloud tests in BV

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -69,14 +69,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
     And I wait until all synchronized channels for "sles15-sp2" have finished
 
-@cloud
-@sle15sp2_minion
-  Scenario: Add SUSE Linux Enterprise Server 15 SP2 Public Cloud channels
-    When I add "sle-module-public-cloud15-sp2-pool-x86_64" channel
-    And I wait until the channel "sle-module-public-cloud15-sp2-pool-x86_64" has been synced
-    And I add "sle-module-public-cloud15-sp2-updates-x86_64" channel
-    And I wait until the channel "sle-module-public-cloud15-sp2-updates-x86_64" has been synced
-
 @uyuni
 @sle15sp2_minion
   Scenario: Add SUSE Linux Enterprise Server 15 SP2 Uyuni Client tools
@@ -105,14 +97,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Server 15 SP3 x86_64" product has been added
     And I wait until all synchronized channels for "sles15-sp3" have finished
-
-@cloud
-@sle15sp3_minion
-  Scenario: Add SUSE Linux Enterprise Server 15 SP3 Public Cloud channels
-    When I add "sle-module-public-cloud15-sp3-pool-x86_64" channel
-    And I wait until the channel "sle-module-public-cloud15-sp3-pool-x86_64" has been synced
-    And I add "sle-module-public-cloud15-sp3-updates-x86_64" channel
-    And I wait until the channel "sle-module-public-cloud15-sp3-updates-x86_64" has been synced
 
 @uyuni
 @sle15sp3_minion


### PR DESCRIPTION
## What does this PR change?

This will remove the old cloud tests for SLES 15 SP2 and SP3 and align the code with what we already have in 4.3. See https://github.com/SUSE/spacewalk/pull/23592.
`contsants.rb` do not need to be adjusted, the entries are not present there.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # not needed. The change is already present in 4.3

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!