### PR TITLE
Match only beginning of path in Python workflow

### DIFF
--- a/.github/workflows/python-checkstyle.yml
+++ b/.github/workflows/python-checkstyle.yml
@@ -29,7 +29,7 @@ jobs:
     
     - id: filter-files
       run: |
-        echo added_modified_renamed="$( echo '${{ steps.files.outputs.added_modified_renamed }}' | tr ' ' '\n' | grep -E 'python|spacewalk|susemanager' | tr '\n' ' ')" >> $GITHUB_ENV
+        echo added_modified_renamed="$( echo '${{ steps.files.outputs.added_modified_renamed }}' | tr ' ' '\n' | grep -E '^(python|spacewalk|susemanager)/' | tr '\n' ' ')" >> $GITHUB_ENV
 
     - name: Run black on files
       run: |


### PR DESCRIPTION
## What does this PR change?

Previously, the Python workflow matched any paths that contained the strings `python`, `spacewalk`, or `susemanager`. The intention was to match only paths that begin with the string, which is now fixed in the regular expression.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **a workflow change**


- [ ] **DONE**

## Test coverage
- No tests: **a workflow change**

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
