### PR TITLE
Fix incorrectly scoped styles

### DIFF
--- a/web/html/src/components/input/Radio.module.css
+++ b/web/html/src/components/input/Radio.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
     .radio label {
         font-weight: normal;

--- a/web/html/src/components/picker/recurring-event-picker.module.css
+++ b/web/html/src/components/picker/recurring-event-picker.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
   .center {
     display: flex;

--- a/web/html/src/manager/admin/config/monitoring-admin.module.css
+++ b/web/html/src/manager/admin/config/monitoring-admin.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
     .gap_right {
         margin-right: 10px

--- a/web/html/src/manager/content-management/shared/components/panels/build/build-version.module.css
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build-version.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
   .version_collapse_line {
     padding-top: .3em;

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.module.css
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
   .wrapper {
     position: relative;

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.module.css
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
     .search_icon_container {
         color: rgba(167, 169, 172, 0.6);

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.module.css
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
     .attached {
         padding: 2px 2px 2px 0px;

--- a/web/html/src/manager/login/susemanager/login.module.less
+++ b/web/html/src/manager/login/susemanager/login.module.less
@@ -1,6 +1,6 @@
 @import "../../../branding/css/susemanager/variables.less";
 
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
   .background {
     display: flex;

--- a/web/html/src/manager/virtualization/guests/console/guests-console.module.css
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.module.css
@@ -1,4 +1,4 @@
-:global(.old-theme)
+:global(.old-theme),
 :global(.new-theme) {
   .navbar_pf_console {
     top: 0px;

--- a/web/spacewalk-web.changes.eth.comma-power
+++ b/web/spacewalk-web.changes.eth.comma-power
@@ -1,0 +1,1 @@
+- Fix incorrectly scoped web UI styles


### PR DESCRIPTION
## What does this PR change?

I fat fingered the last rebase in the style scoping PR, this PR makes the selectors for the old and new theme separate as they should be.  

Note to self, this issue might also be present in the stashed branch with the Sass update.

## GUI diff

Fixes login page and other affected pages where styles are broken.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: CSS

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
