### PR TITLE
CI: skip first user creation for container

### DIFF
--- a/testsuite/features/core/srv_first_settings.feature
+++ b/testsuite/features/core/srv_first_settings.feature
@@ -19,9 +19,13 @@ Feature: Very first settings
   As the admin user
   I want to create the organisation, the first users and set the HTTP proxy
 
+  Scenario: Cleanup Salt files
+    When I run "rm -Rf /srv/salt/*" on "server"
+
+
+@skip_if_container_server
   Scenario: Create admin user and first organization
     Given I access the host the first time
-    And I run "rm -Rf /srv/salt/*" on "server"
     When I go to the home page
     And I enter "SUSE Test" as "orgName"
     And I enter "admin" as "login"


### PR DESCRIPTION
## What does this PR change?

Since mgradm install now enforces the first user creation, this step needs to be skipped in the CI.

Related to https://github.com/uyuni-project/uyuni-tools/pull/192

## Test coverage

- Cucumber tests were changed

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23337

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
