### PR TITLE
Fix recurring event picker

### DIFF
--- a/web/html/src/components/picker/recurring-event-picker.tsx
+++ b/web/html/src/components/picker/recurring-event-picker.tsx
@@ -55,7 +55,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
     { id: Number(7), text: t("Saturday") },
   ];
 
-  monthDays = Array.from(Array(28).keys()).map((id) => ({ id: Number(id + 1), text: (id + 1).toString() }));
+  monthDays = Array.from(Array(31).keys()).map((id) => ({ id: Number(id + 1), text: (id + 1).toString() }));
 
   constructor(props: RecurringEventPickerProps) {
     super(props);
@@ -442,7 +442,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
                     id="monthly-day-picker"
                     name="date_monthly"
                     selectedId={this.state.monthDay.id}
-                    options={this.monthDays}
+                    options={this.monthDays.filter((day) => day.id < 29)}
                     onSelect={this.onSelectMonthDay}
                     onFocus={this.onFocusMonthDay}
                   />


### PR DESCRIPTION
## What does this PR change?

Fix to recurring actions edit page not loading if a custom quartz string with a day greater than 28 is used.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8399

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
