### PR TITLE
QE: Fix variables for GitHub and container runtime

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy_container.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_container.feature
@@ -7,7 +7,7 @@
 #
 # Bootstrap the proxy as a Pod
 
-@skip_if_not_container_server
+@containerized_server
 @scope_containerized_proxy
 @proxy
 Feature: Setup containerized proxy

--- a/testsuite/features/build_validation/init_clients/proxy_traditional.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_traditional.feature
@@ -4,7 +4,7 @@
 # The scenarios in this feature are skipped if there is no proxy
 # ($proxy is nil)
 
-@skip_if_container_server
+@skip_if_containerized_server
 @proxy
 Feature: Setup SUSE Manager proxy
   In order to use a proxy with the SUSE manager server

--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -5,7 +5,7 @@
 #       due to the fact that the mgr-bootstrap command is not available in the proxy
 #       container. Reported Bug: https://bugzilla.suse.com/show_bug.cgi?id=1220864
 
-@skip_if_container_server
+@skip_if_containerized_server
 @skip_if_github_validation
 @proxy
 @sle12sp5_buildhost

--- a/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
@@ -5,7 +5,7 @@
 #       due to the fact that the mgr-bootstrap command is not available in the proxy
 #       container. Reported Bug: https://bugzilla.suse.com/show_bug.cgi?id=1220864
 
-@skip_if_container_server
+@skip_if_containerized_server
 @skip_if_github_validation
 @proxy
 @sle15sp4_buildhost

--- a/testsuite/features/core/srv_first_settings.feature
+++ b/testsuite/features/core/srv_first_settings.feature
@@ -23,7 +23,7 @@ Feature: Very first settings
     When I run "rm -Rf /srv/salt/*" on "server"
 
 
-@skip_if_container_server
+@skip_if_containerized_server
   Scenario: Create admin user and first organization
     Given I access the host the first time
     When I go to the home page

--- a/testsuite/features/init_clients/proxy_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_branch_network.feature
@@ -7,7 +7,7 @@
 # TODO: RBS tests needs a refactor to don't use salt formulas.
 #       Card: https://github.com/SUSE/spacewalk/issues/23616
 
-@skip_if_container_server
+@skip_if_containerized_server
 @skip_if_github_validation
 @sle_minion
 @scope_proxy
@@ -26,7 +26,7 @@ Feature: Setup Uyuni for Retail branch network
 
 @proxy
 @private_net
-@skip_if_container_server
+@skip_if_containerized_server
   Scenario: Install or update branch network formulas on the server
     When I manually install the "branch-network" formula on the server
     And I manually install the "dhcpd" formula on the server
@@ -35,7 +35,7 @@ Feature: Setup Uyuni for Retail branch network
 @proxy
 @private_net
 @susemanager
-@skip_if_container_server
+@skip_if_containerized_server
   Scenario: Install the Retail pattern on the SUSE Manager server
     When I refresh the metadata for "server"
     When I install pattern "suma_retail" on this "server"
@@ -45,7 +45,7 @@ Feature: Setup Uyuni for Retail branch network
 @proxy
 @private_net
 @uyuni
-@skip_if_container_server
+@skip_if_containerized_server
   Scenario: Install the Retail pattern on the Uyuni server
     When I refresh the metadata for "server"
     When I install pattern "uyuni_retail" on this "server"

--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -7,7 +7,7 @@
 #
 # Bootstrap the proxy as a Pod
 
-@skip_if_not_container_server
+@containerized_server
 @scope_containerized_proxy
 @proxy
 Feature: Setup containerized proxy

--- a/testsuite/features/init_clients/proxy_traditional.feature
+++ b/testsuite/features/init_clients/proxy_traditional.feature
@@ -6,7 +6,7 @@
 #
 # Alternative: Bootstrap the proxy as Salt minion from GUI
 
-@skip_if_container_server
+@skip_if_containerized_server
 @scope_proxy
 @proxy
 Feature: Setup Uyuni proxy

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -62,7 +62,7 @@ Feature: Manage a group of systems
     And I should see "sle_minion" as link
 
    #container already has locale formula installed
-   @skip_if_container_server 
+   @skip_if_containerized_server 
    Scenario: Install the locale formula package on the server
      When I manually install the "locale" formula on the server
 
@@ -106,7 +106,7 @@ Feature: Manage a group of systems
 
   # Red Hat-like minion is intentionally not removed from group
 
-  @skip_if_container_server 
+  @skip_if_containerized_server 
   Scenario: Cleanup: uninstall formula from the server
     When I manually uninstall the "locale" formula from the server
 

--- a/testsuite/features/secondary/min_baremetal_discovery.feature
+++ b/testsuite/features/secondary/min_baremetal_discovery.feature
@@ -5,7 +5,7 @@
 #       due to the fact that the mgr-bootstrap command is not available in the proxy
 #       container. Reported Bug: https://bugzilla.suse.com/show_bug.cgi?id=1220864
 
-@skip_if_container_server
+@skip_if_containerized_server
 @skip_if_github_validation
 @sle_minion
 Feature: Bare metal discovery

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -9,7 +9,7 @@
 #       due to the fact that the mgr-bootstrap command is not available in the proxy
 #       container. Reported Bug: https://bugzilla.suse.com/show_bug.cgi?id=1220864
 
-@skip_if_container_server
+@skip_if_containerized_server
 @skip_if_github_validation
 @sle_minion
 @scope_onboarding

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -12,7 +12,7 @@ Feature: Use salt formulas
       Given I am authorized for the "Admin" section
 
    #container already has locale formula installed
-   @skip_if_container_server 
+   @skip_if_containerized_server 
    Scenario: Install the locale formula package on the server
      When I manually install the "locale" formula on the server
 
@@ -167,7 +167,7 @@ Feature: Use salt formulas
      And the keymap on "sle_minion" should be "us"
      And the language on "sle_minion" should be "en_US.UTF-8"
 
-  @skip_if_container_server
+  @skip_if_containerized_server
   Scenario: Cleanup: uninstall formula package from the server
      When I manually uninstall the "locale" formula from the server
 

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -9,7 +9,7 @@
 #       due to the fact that the mgr-bootstrap command is not available in the proxy
 #       container. Reported Bug: https://bugzilla.suse.com/show_bug.cgi?id=1220864
 
-@skip_if_container_server
+@skip_if_containerized_server
 @skip_if_github_validation
 @scope_salt_ssh
 @ssh_minion

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -8,7 +8,7 @@
 #       The proxy container does not support Salt formulas, so the test is failing.
 
 @skip_if_github_validation
-@skip_if_container_server
+@skip_if_containerized_server
 @proxy
 @private_net
 @pxeboot_minion

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -16,7 +16,7 @@
 #       as it does not support Salt formulas.
 #       Additionally, we have this bug that impedes to use mgr-bootstrap command https://bugzilla.suse.com/show_bug.cgi?id=1220864
 
-@skip_if_container_server
+@skip_if_containerized_server
 @skip_if_github_validation
 @buildhost
 @proxy

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -21,7 +21,7 @@
 # it could let the monitoring feature disabled for the Debian-like minion
 
 @skip_if_github_validation
-@skip_if_container_server
+@skip_if_containerized_server
 @scope_monitoring
 Feature: Disable and re-enable monitoring of the server
 

--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -8,7 +8,7 @@
 
 @skip_if_github_validation
 @skip_if_cloud
-@skip_if_container_server
+@skip_if_containerized_server
 Feature: Reconfigure the server's hostname
   As admin user
   In order to change the server's hostname

--- a/testsuite/features/secondary/srv_restart.feature
+++ b/testsuite/features/secondary/srv_restart.feature
@@ -9,7 +9,7 @@
 # All features following this one if the server fails to restart.
 
 @skip_if_github_validation
-@skip_if_container_server
+@skip_if_containerized_server
 Feature: Restart the spacewalk services via UI
 
   Scenario: Restart the SUSE Manager through the WebUI Admin option

--- a/testsuite/features/secondary/srv_user_configuration_salt_states.feature
+++ b/testsuite/features/secondary/srv_user_configuration_salt_states.feature
@@ -6,7 +6,7 @@
 @scope_salt
 Feature: Create organizations, users, groups, and activation keys using Salt states
 
-@skip_if_container_server
+@skip_if_containerized_server
   Scenario: Apply configuration salt state to server
     When I manually install the "uyuni-config" formula on the server
 
@@ -70,7 +70,7 @@ Feature: Create organizations, users, groups, and activation keys using Salt sta
   Scenario: Cleanup: apply configuration teardown salt state to server
     When I apply "teardown_users_configuration" local salt state on "server"
 
-@skip_if_container_server
+@skip_if_containerized_server
   Scenario: Cleanup: uninstall the uyuni-config formula from the server
     And I manually uninstall the "uyuni-config" formula from the server
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -23,7 +23,7 @@ end
 When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server, validating its checksum$/) do |name, url|
   # When using a mirror it is automatically mounted at /mirror
   if $mirror
-    iso_path = $is_container_provider ? url.sub(/^https?:\/\/[^\/]+/, '/srv/mirror') : url.sub(/^https?:\/\/[^\/]+/, '/mirror')
+    iso_path = $is_containerized_server ? url.sub(/^https?:\/\/[^\/]+/, '/srv/mirror') : url.sub(/^https?:\/\/[^\/]+/, '/mirror')
   else
     iso_path = "/tmp/#{name}.iso"
     get_target('server').run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 1500)
@@ -35,7 +35,7 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server, validating its
 
   raise 'SHA256 checksum validation failed' unless validate_checksum_with_file(original_iso_name, iso_path, checksum_path)
 
-  if $is_container_provider
+  if $is_containerized_server
     mount_point = '/srv/www/distributions'
     get_target('server').run("mkdir -p #{mount_point}")
     # this needs to be run outside the container

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -174,7 +174,7 @@ When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
 end
 
 When(/^I select the parent channel for the "([^"]*)" from "([^"]*)"$/) do |client, from|
-  product_key = $is_container_provider && !$build_validation ? 'Fake' : product
+  product_key = $is_gh_validation && !$build_validation ? 'Fake' : product
   select(BASE_CHANNEL_BY_CLIENT[product_key][client], from: from, exact: false)
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -224,7 +224,7 @@ end
 
 def extract_logs_from_node(node)
   os_family = node.os_family
-  node.run('zypper --non-interactive install tar') if os_family =~ /^opensuse/ && !$is_container_provider
+  node.run('zypper --non-interactive install tar') if os_family =~ /^opensuse/ && !$is_gh_validation
   node.run('journalctl > /var/log/messages', check_errors: false)
   node.run('venv-salt-call --local grains.items | tee -a /var/log/salt_grains', verbose: true, check_errors: false) unless $host_by_node[node] == 'server'
   node.run("tar cfvJP /tmp/#{node.full_hostname}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]]")
@@ -447,7 +447,7 @@ end
 
 # This function initializes the API client
 def new_api_client
-  ssl_verify = !$is_container_provider
+  ssl_verify = !$is_gh_validation
   if $debug_mode || product == 'SUSE Manager'
     ApiTestXmlrpc.new(get_target('server', refresh: true).full_hostname)
   else

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -577,8 +577,8 @@ Before('@skip_if_containerized_server') do
   skip_this_scenario if $is_containerized_server
 end
 
-# skip tests if the server does not run in a container
-Before('@skip_if_not_container_server') do
+# do test only if we have a containerized server
+Before('@containerized_server') do
   skip_this_scenario unless $is_containerized_server
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -573,7 +573,7 @@ Before('@skip_if_github_validation') do
 end
 
 # skip tests if the server runs in a container
-Before('@skip_if_container_server') do
+Before('@skip_if_containerized_server') do
   skip_this_scenario if $is_containerized_server
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -53,8 +53,8 @@ STARTTIME = Time.new.to_i
 Capybara.default_max_wait_time = ENV['CAPYBARA_TIMEOUT'] ? ENV['CAPYBARA_TIMEOUT'].to_i : 10
 DEFAULT_TIMEOUT = ENV['DEFAULT_TIMEOUT'] ? ENV['DEFAULT_TIMEOUT'].to_i : 250
 $is_cloud_provider = ENV['PROVIDER'].include? 'aws'
-$is_container_provider = ENV['PROVIDER'].include? 'podman'
-$is_container_server = %w[k3s podman].include? ENV.fetch('CONTAINER_RUNTIME', '')
+$is_gh_validation = ENV['PROVIDER'].include? 'podman'
+$is_containerized_server = %w[k3s podman].include? ENV.fetch('CONTAINER_RUNTIME', '')
 $is_using_build_image = ENV.fetch('IS_USING_BUILD_IMAGE', false)
 $is_using_scc_repositories = (ENV.fetch('IS_USING_SCC_REPOSITORIES', 'False') != 'False')
 $catch_timeout_message = (ENV.fetch('CATCH_TIMEOUT_MESSAGE', 'False') == 'True')
@@ -567,19 +567,19 @@ Before('@skip_if_cloud') do
   skip_this_scenario if $is_cloud_provider
 end
 
-# skip tests if executed in containers for the githug validation
+# skip tests if executed in containers for the GitHub validation
 Before('@skip_if_github_validation') do
-  skip_this_scenario if $is_container_provider
+  skip_this_scenario if $is_gh_validation
 end
 
 # skip tests if the server runs in a container
 Before('@skip_if_container_server') do
-  skip_this_scenario if $is_container_server
+  skip_this_scenario if $is_containerized_server
 end
 
 # skip tests if the server does not run in a container
 Before('@skip_if_not_container_server') do
-  skip_this_scenario unless $is_container_server
+  skip_this_scenario unless $is_containerized_server
 end
 
 # have more infos about the errors

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -71,7 +71,7 @@ def get_checksum_path(dir, original_file_name, file_url)
   cmd = "ls -1 #{dir}"
   # when using a mirror, the checksum file should be present and in the same directory of the file
   if $mirror
-    output, _code = $is_container_provider ? server.run_local(cmd) : server.run(cmd)
+    output, _code = $is_containerized_server ? server.run_local(cmd) : server.run(cmd)
     files = output.split("\n")
     checksum_file = files.find { |file| checksum_file_names.include?(file) }
 
@@ -109,7 +109,7 @@ end
 def validate_checksum_with_file(original_file_name, file_path, checksum_path)
   # search the checksum file for what should be the only non-comment line containing the original file name
   cmd = "grep -v '^#' #{checksum_path} | grep '#{original_file_name}'"
-  checksum_line, _code = $is_container_provider ? get_target('server').run_local(cmd) : get_target('server').run(cmd)
+  checksum_line, _code = $is_containerized_server ? get_target('server').run_local(cmd) : get_target('server').run(cmd)
   raise "SHA256 checksum entry for #{original_file_name} not found in #{checksum_path}" unless checksum_line
 
   # this relies on the fact that SHA256 hashes have a fixed length of 64 hexadecimal characters to extract the checksum
@@ -125,6 +125,6 @@ end
 # matches the expected checksum or not
 def validate_checksum(file_path, expected_checksum)
   cmd = "sha256sum -b #{file_path} | awk '{print $1}'"
-  file_checksum, _code = $is_container_provider ? get_target('server').run_local(cmd) : get_target('server').run(cmd)
+  file_checksum, _code = $is_containerized_server ? get_target('server').run_local(cmd) : get_target('server').run(cmd)
   file_checksum.strip == expected_checksum
 end


### PR DESCRIPTION
## What does this PR change?

This PR
- renames the 2 variables used for the GitHub validation and the container runtime
- uses the correct one in the ISO mounting steps that failed in the 5.0 BV because of that before

See https://github.com/SUSE/spacewalk/issues/23705


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # No port needed 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
