### PR TITLE
Master uyuni configfiles sync

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -85,6 +85,25 @@ RUN systemctl enable prometheus-node_exporter; \
     systemctl enable uyuni-setup; \
     systemctl enable timezone_alignment;
 
+# Provide tool to synchronize package and configuration files to persistent volumes
+COPY uyuni-configfiles-sync /usr/bin
+RUN chmod -R 755 /usr/bin/uyuni-configfiles-sync
+
+# We inject uyuni-configfiles-sync to be executed at Spacewalk target start
+COPY uyuni-configfiles-sync.service /usr/lib/systemd/system/
+RUN sed -i 's/Description=Spacewalk/Description=Spacewalk\nRequires=uyuni-configfiles-sync.service/g' /usr/lib/systemd/system/spacewalk.target
+
+# Initialize environments to sync configuration and package files to persistent volumes
+RUN uyuni-configfiles-sync init /etc/apache2/
+RUN uyuni-configfiles-sync init /etc/cobbler/
+RUN uyuni-configfiles-sync init /etc/postfix/
+RUN uyuni-configfiles-sync init /etc/rhn/
+RUN uyuni-configfiles-sync init /etc/salt/
+RUN uyuni-configfiles-sync init /etc/sysconfig/
+RUN uyuni-configfiles-sync init /etc/tomcat/
+RUN uyuni-configfiles-sync init /srv/tftpboot/
+RUN uyuni-configfiles-sync init /srv/www/
+
 # LABELs
 ARG PRODUCT=Uyuni
 ARG VENDOR="Uyuni project"

--- a/containers/server-image/server-image.changes.meaksh.master-uyuni-configfiles-sync
+++ b/containers/server-image/server-image.changes.meaksh.master-uyuni-configfiles-sync
@@ -1,0 +1,1 @@
+- Add uyuni-configfiles-sync to synchronize configuration and package files

--- a/containers/server-image/uyuni-configfiles-sync
+++ b/containers/server-image/uyuni-configfiles-sync
@@ -1,0 +1,201 @@
+#!/bin/bash
+
+DEFAULTS_STORAGE="/etc/uyuni-configfiles-sync/"
+SYSCONFIG_FILE="/etc/sysconfig/uyuni-configfiles-sync"
+
+help() {
+	printf "Uyuni config files defaults synchronization tool
+
+Usage:
+  uyuni-configfiles-sync [command]
+
+Available Commands:
+  init	Add persistent volume to track package and config files.
+  list	List initializated persistent volumes environments.
+  sync	Synchronize files to persistent volumes and run RPM scripts.
+"
+}
+
+
+# FIXME: TBD: Add also non packaged files on the persistent volumes
+# there are files that are generated during %post scripts that we may want to persist
+init() {
+	pv=$(echo "$1/" | tr -s /)
+	if [ ! -f $DEFAULTS_STORAGE/.buildhash ]; then
+		echo $RANDOM | sha256sum | head -c 64 > $DEFAULTS_STORAGE/.buildhash
+	fi
+	echo -n "Initializing environment for persistent volume $pv ... "
+	TARGET="$DEFAULTS_STORAGE/`echo $pv | sed 's/\//-/g'`"
+	mkdir -p $TARGET
+	echo "$pv" > $TARGET/.pv
+	# Calculate the packages that are owning the files under this path
+	PKGNAMES=$(LANG=C rpm -q -qf `find $pv` | egrep -v "^file .+ is not owned by any package" | sort -u)
+	# Sync the package files (non-configuration and configuration files) to our storage
+	# FIXME: Include also non packaged files
+	for pkg in $PKGNAMES; do
+		for cfgfile in $(rpm -ql $pkg | grep "^$pv"); do
+			echo ${cfgfile#"$pv"} | rsync -a --files-from=- --exclude={'*'} $pv $TARGET
+		done
+	done
+	echo "done!"
+}
+
+sync_file() {
+	SOURCE_FILE=$1
+	TARGET_FILE=$2
+	# Synchronize package and config files
+	if echo $LIST_CONFIG_NO_REPLACE | egrep -q "( |^)$i( |$)"; then
+		# Configuration (no replace) files
+		echo "    - $TARGET_FILE - Contains modifications made by the user. Not replacing and saving new file content as rpmnew file"
+		rsync -a $SOURCE_FILE $TARGET_FILE.rpmnew;
+	else
+		# Config (replace) and rest of package files
+		echo "    - $TARGET_FILE - Contains modifications made by the user. Replacing and saving old file content as rpmsave file"
+		rsync -ab --suffix ".rpmsave" $SOURCE_FILE $TARGET_FILE;
+	fi
+}
+
+sync() {
+	# We skip the sync if already triggered on this container
+	if [ ! -f $DEFAULTS_STORAGE/.buildhash ]; then
+		echo "Missing /etc/uyuni-configfiles-sync/.buildhash file. You probably need to run 'init' command first. Skipping."
+		exit
+	elif [ -f $SYSCONFIG_FILE ] && [ "$(cat $DEFAULTS_STORAGE/.buildhash)" = "$(cat $SYSCONFIG_FILE)" ]; then
+		echo "Skipping 'sync' as it was already executed on this container"
+		exit
+	fi
+	echo "Synchronizing defaults for all initializated environments"
+	echo
+	for PV_DIR in $(ls $DEFAULTS_STORAGE | grep -v "^\.buildhash$"); do
+		SOURCES=$(echo "$DEFAULTS_STORAGE/$PV_DIR/" | tr -s /)
+		PV=$(cat $SOURCES/.pv)
+		PKGNAMES=$(LANG=C rpm -q -qf `find $PV` | egrep -v "^file .+ is not owned by any package" | sort -u)
+		echo "- Processing pv: $PV"
+		echo -n "  * Getting information for files to synchronize ... "
+		LIST_CONFIG_NO_REPLACE=""
+		LIST_CONFIG_REPLACE=""
+		LIST_ALL_FILES_FULL_PATH=$(rpm -ql $PKGNAMES | grep "^$PV")
+		LIST_ALL_FILES_REL_PATH="${LIST_ALL_FILES_FULL_PATH//$PV/}"
+		# For each config file, we check the noreplace flag
+		for cfgfile in $(rpm -q --configfiles $PKGNAMES | grep "^$PV"); do
+			FILEFLAG=$(rpm -q --qf '[%{filenames}: %{fileflags}\n]' $PKGNAMES | egrep "^$cfgfile: .+" | cut -d":" -f2)
+			if [ "$((FILEFLAG & 16))" = "16" ]; then
+				LIST_CONFIG_NO_REPLACE="$LIST_CONFIG_NO_REPLACE ${cfgfile#"$PV"}"
+			else
+				LIST_CONFIG_REPLACE="$LIST_CONFIG_REPLACE ${cfgfile#"$PV"}"
+			fi
+		done
+		echo "done!"
+
+		echo -n "  * Syncing non configuration files ... "
+		RSYNC_ARGS=""
+		# We exclude configuration files as they are going to be processed later
+		# Exclude args, if apply, must has formatted as: {'file1','file2'}
+		LIST_FILES_TO_EXCLUDE="'$(echo $LIST_CONFIG_REPLACE $LIST_CONFIG_NO_REPLACE | sed "s/ /','/g")'"
+		if [ ! "$LIST_FILES_TO_EXCLUDE" = "''" ]; then
+			RSYNC_ARGS="--exclude={$LIST_FILES_TO_EXCLUDE}"
+		fi
+		# Synchronize package files from source excluding (configuration files)
+		CMD="rsync -ab $RSYNC_ARGS --exclude=".pv" --suffix ".rpmsave" $SOURCES $PV"
+		eval $CMD
+		echo "done!"
+
+		echo "  * Syncing configuration files ..."
+		for i in $(echo $LIST_CONFIG_NO_REPLACE $LIST_CONFIG_REPLACE); do
+			SOURCE_FILE=$(echo $SOURCES/$i | tr -s /)
+			TARGET_FILE=$(echo $PV/$i | tr -s /)
+			# Some files listed in the package may be removed, we don't want to recreate them, so we skip.
+			if [ ! -f $SOURCE_FILE ]; then
+				echo "    - WARNING: $TARGET_FILE is listed as beloging to a package but it was not existing at the time the persistent volume was initializated. Skipping."
+				continue
+			fi
+			# Check possible changes to sync. Excluding changes on creation/modification times
+			# We need to parse output:
+			#   - no output or line starting with "." -> nothing to sync
+			#   - else -> changes to sync
+			CHECK_CHANGES=$(rsync --dry-run -a --itemize-changes --size-only $SOURCE_FILE $TARGET_FILE)
+			if [ -z "$CHECK_CHANGES" ] || echo $CHECK_CHANGES | grep -q "^\."; then
+				# No changes are needed for this file
+				echo "    - $TARGET_FILE - No changes needed"
+			else
+				# Changes are needed for this file.
+				# Now we need to determine if changes are coming from a package upgrade
+				# or local changes made by user in order to determine the sync strategy.
+				if [ -f $TARGET_FILE ]; then
+					# Target file does exist in persistent volume
+					# We check stored checksum to know if changes are from coming by the user or from a package upgrade
+					# NOTE: stored checksum file may not exist yet, when "sync" has been never executed yet (first start)
+					if [ -f $PV/.defaults_checksums ]; then
+						CHECKSUM=$(grep "  $SOURCE_FILE$" $PV/.defaults_checksums | awk '{print $1}')
+					else
+						CHECKSUM=""
+					fi
+					if [ ! -z "$CHECKSUM" ] && [ "$CHECKSUM" = "$(sha256sum $SOURCE_FILE | awk '{print $1}')" ]; then
+						# Checksum are equal between new defaults and cached defaults
+						# this mean changes are made by the user
+						sync_file $SOURCE_FILE $TARGET_FILE
+					elif [ ! -z "$CHECKSUM" ] && [ ! "$CHECKSUM" = "$(sha256sum $SOURCE_FILE | awk '{print $1}')" ]; then
+						# Checksum are different between new defaults and cached defaults checksums
+						# Meaning changes in file due an upgrade or local user changes
+						if [ "$CHECKSUM" = "$(sha256sum $TARGET_FILE | awk '{print $1}')" ]; then
+							# Checksum is equal between cached defaults and target file
+							# Meaning no local changes and changes are due an upgrade
+							echo "    - $TARGET_FILE - No local modifications but new changes coming from a package upgrade, replacing file"
+							rsync -a $SOURCE_FILE $TARGET_FILE;
+						else
+							# Local changes made by the user.
+							sync_file $SOURCE_FILE $TARGET_FILE
+						fi
+					else
+						# First sync - no checksums stored yet. Syncing
+						sync_file $SOURCE_FILE $TARGET_FILE
+					fi
+				else
+					# File does not exist - we synchronize it
+					echo "    - $TARGET_FILE - Does not exist, we synchronize it"
+					rsync -a $SOURCE_FILE $TARGET_FILE;
+				fi
+			fi
+		done
+
+		# Regenerate checksum cache for defaults
+		rm $PV/.defaults_checksums &> /dev/null || :
+		for i in $(echo $LIST_ALL_FILES_REL_PATH); do
+			SOURCE_FILE=$(echo $SOURCES/$i | tr -s /)
+			if [ -f "$SOURCE_FILE" ]; then
+				sha256sum $SOURCE_FILE >> $PV/.defaults_checksums
+			fi;
+		done;
+		echo "  * Completed"
+		echo
+	done
+
+	# We lock the sync so it cannot run until next upgrade of the container image
+	cp $DEFAULTS_STORAGE/.buildhash $SYSCONFIG_FILE
+}
+
+list() {
+	echo "List of initialized persistent volumes"
+	echo "--------------------------------------"
+	echo
+	for pv in $(ls $DEFAULTS_STORAGE | grep -v "^\.buildhash$");
+	do
+		SOURCES=$(echo "$DEFAULTS_STORAGE/$pv" | tr -s /)
+		PV=$(cat $SOURCES/.pv)
+		echo "$PV - `find $SOURCES -type f | grep -v ".pv$" | wc -l` configuration and package files - $SOURCES/"
+	done
+}
+
+if [ "$1" == "init" ] && [ -n "$2" ];
+then
+	PV=$2;
+	init $PV;
+elif [ "$1" == "sync" ];
+then
+	sync;
+elif [ "$1" == "list" ];
+then
+	list;
+else
+	help;
+fi;

--- a/containers/server-image/uyuni-configfiles-sync
+++ b/containers/server-image/uyuni-configfiles-sync
@@ -17,8 +17,6 @@ Available Commands:
 }
 
 
-# FIXME: TBD: Add also non packaged files on the persistent volumes
-# there are files that are generated during %post scripts that we may want to persist
 init() {
 	pv=$(echo "$1/" | tr -s /)
 	if [ ! -f $DEFAULTS_STORAGE/.buildhash ]; then
@@ -31,7 +29,6 @@ init() {
 	# Calculate the packages that are owning the files under this path
 	PKGNAMES=$(LANG=C rpm -q -qf `find $pv` | egrep -v "^file .+ is not owned by any package" | sort -u)
 	# Sync the package files (non-configuration and configuration files) to our storage
-	# FIXME: Include also non packaged files
 	for pkg in $PKGNAMES; do
 		for cfgfile in $(rpm -ql $pkg | grep "^$pv"); do
 			echo ${cfgfile#"$pv"} | rsync -a --files-from=- --exclude={'*'} $pv $TARGET
@@ -66,10 +63,12 @@ sync() {
 	fi
 	echo "Synchronizing defaults for all initializated environments"
 	echo
+	PACKAGES=""
 	for PV_DIR in $(ls $DEFAULTS_STORAGE | grep -v "^\.buildhash$"); do
 		SOURCES=$(echo "$DEFAULTS_STORAGE/$PV_DIR/" | tr -s /)
 		PV=$(cat $SOURCES/.pv)
 		PKGNAMES=$(LANG=C rpm -q -qf `find $PV` | egrep -v "^file .+ is not owned by any package" | sort -u)
+		PACKAGES=$(echo -e "$PACKAGES\n$PKGNAMES")
 		echo "- Processing pv: $PV"
 		echo -n "  * Getting information for files to synchronize ... "
 		LIST_CONFIG_NO_REPLACE=""
@@ -170,8 +169,41 @@ sync() {
 		echo
 	done
 
+	# Run RPM scriptslets simulating a package upgrade
+	echo "- Running scriptlets for packages:"
+        PACKAGES=$(echo "$PACKAGES" | sort -u)
+	run_scripts "$PACKAGES"
+	echo "  * Completed"
+
 	# We lock the sync so it cannot run until next upgrade of the container image
 	cp $DEFAULTS_STORAGE/.buildhash $SYSCONFIG_FILE
+}
+
+run_scripts() {
+	PACKAGE_NAMES=$1
+	for PKG in $PACKAGE_NAMES; do
+		echo "  * Running scripts for $PKG ..."
+		PREIN_SCRIPT=$(rpm -q --qf "%{PREIN}" $PKG)
+		if [ ! "$PREIN_SCRIPT" = "(none)" ]; then
+			echo "$PREIN_SCRIPT" | sh -s -- 2
+		fi
+		POSTIN_SCRIPT=$(rpm -q --qf "%{POSTIN}" $PKG)
+		if [ ! "$POSTIN_SCRIPT" = "(none)" ]; then
+			echo "$POSTIN_SCRIPT" | sh -s -- 2
+		fi
+#		PREUN_SCRIPT=$(rpm -q --qf "%{PREUN}" $PKG)
+#		if [ ! "$PREUN_SCRIPT" = "(none)" ]; then
+#			echo "$PREUN_SCRIPT" | sh -s -- 1
+#		fi
+#		POSTUN_SCRIPT=$(rpm -q --qf "%{POSTUN}" $PKG)
+#		if [ ! "$POSTUN_SCRIPT" = "(none)" ]; then
+#			echo "$POSTUN_SCRIPT" | sh -s -- 1
+#		fi
+		POSTTRANS_SCRIPT=$(rpm -q --qf "%{POSTTRANS}" $PKG)
+		if [ ! "$POSTTRANS_SCRIPT" = "(none)" ]; then
+			echo "$POSTTRANS_SCRIPT" | sh -s -- 2
+		fi
+	done
 }
 
 list() {

--- a/containers/server-image/uyuni-configfiles-sync.service
+++ b/containers/server-image/uyuni-configfiles-sync.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Uyuni configuration files sync to persistent volumes
+Before=uyuni-check-database.service tomcat.service apache2.service rhn-search.service taskomatic.service postgresql.service postfix.service
+
+[Service]
+ExecStart=/usr/bin/uyuni-configfiles-sync sync
+Type=oneshot
+RemainAfterExit=yes


### PR DESCRIPTION
## What does this PR change?

This PR introduces `uyuni-configfiles-sync` tool for the Uyuni containerized server.

This tool aims to solve the problematic of synchronizing configuration and packages files to persistent folders after the initial setup, as changes in package managed files are expected for example during an upgrade to a newer server image.

This tool will run at container build time to prepare the environments needed for the different persistent volumes (creating a backup of those paths that will be hidden later after mounting the volumes at container creation). Then, the tool will also run during container startup to ensure the persistent folders files are synchronized after the volumes are mounted.

Replicating what RPM does during a package upgrade, if there are local changes on a file that is changing on the upgraded version, this tool would create "rpmsave" and "rpmnew" files accordingly to the "noreplace" flag of the particular configuration file, and will produce corresponding logging message so the user is aware of this.

The tool takes care also to run RPM upgrade scriptlets in order to get the necessary modifications of files in the persistent volumes after an upgrade.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22412

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
