### PR TITLE
QE: Fix Rocky 9 and Ubuntu channel label for SUMA in the BV

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -213,13 +213,11 @@ PACKAGE_BY_CLIENT = {
   'salt_migration_minion' => 'bison'
 }.freeze
 
-# The values can be found under Software -> Channel List -> Create Channel
-# Then have a look at Parent Channel and find the desired name
-
 # Names of our base/parent channels
 # The keys are the Twopence targets
 # The values can be found in the webUI under Software -> Manage -> Channels -> Create Channel
-# Then have a look at the the Parent Channel selections
+# The required product has to be synced before
+# Then take a look at the Parent Channel selections
 BASE_CHANNEL_BY_CLIENT = {
   'SUSE Manager' => {
     'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool for x86_64',
@@ -270,8 +268,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'rhel9_ssh_minion' => 'EL9-Pool for x86_64',
     'rocky8_minion' => 'RHEL8-Pool for x86_64',
     'rocky8_ssh_minion' => 'RHEL8-Pool for x86_64',
-    'rocky9_minion' => 'rockylinux9 for x86_64',
-    'rocky9_ssh_minion' => 'rockylinux9 for x86_64',
+    'rocky9_minion' => 'rockylinux-9 for x86_64',
+    'rocky9_ssh_minion' => 'rockylinux-9 for x86_64',
     'ubuntu2004_minion' => 'ubuntu-2004-amd64-main for amd64',
     'ubuntu2004_ssh_minion' => 'ubuntu-2004-amd64-main for amd64',
     'ubuntu2204_minion' => 'ubuntu-2204-amd64-main for amd64',
@@ -367,10 +365,10 @@ BASE_CHANNEL_BY_CLIENT = {
 
 # Used for creating activation keys
 # The keys are the values of BASE_CHANNEL_BY_CLIENT
-# The values can be found under Admin -> Setup Wizard -> Products for SUMA
+# SUMA: The values can be found under Admin -> Setup Wizard -> Products
 # Select the desired product and have a look at its product channels
-# The required product has to be synced before.
-# For Uyuni, you have to use `spacewalk-common-channels -l` to get the proper values
+# The required product has to be synced before
+# Uyuni: You have to use `spacewalk-common-channels -l` to get the proper values
 LABEL_BY_BASE_CHANNEL = {
   'SUSE Manager' => {
     'SLE-Product-SUSE-Manager-Proxy-4.3-Pool for x86_64' => 'sle-product-suse-manager-proxy-4.3-pool-x86_64',
@@ -393,7 +391,7 @@ LABEL_BY_BASE_CHANNEL = {
     'EL9-Pool for x86_64' => 'no-appstream-liberty-9-result-el9-pool-x86_64',
     'oraclelinux9 for x86_64' => 'no-appstream-oracle-9-result-oraclelinux9-x86_64',
     'RHEL8-Pool for x86_64' => 'no-appstream-8-result-rhel8-pool-x86_64',
-    'rockylinux9 for x86_64' => 'no-appstream-9-result-rockylinux9-x86_64',
+    'rockylinux-9 for x86_64' => 'no-appstream-9-result-rockylinux-9-x86_64',
     'ubuntu-2004-amd64-main for amd64' => 'ubuntu-2004-amd64-main-amd64',
     'ubuntu-2204-amd64-main for amd64' => 'ubuntu-2204-amd64-main-amd64',
     'debian-10-pool for amd64' => 'debian-10-pool-amd64',
@@ -424,7 +422,7 @@ LABEL_BY_BASE_CHANNEL = {
     'EL9-Pool for x86_64' => 'no-appstream-liberty-9-result-el9-pool-x86_64',
     'Oracle Linux 9 (x86_64)' => 'no-appstream-oracle-9-result-oraclelinux9-x86_64',
     'Rocky Linux 8 (x86_64)' => 'no-appstream-8-result-rockylinux8-x86_64',
-    'Rocky Linux 9 (x86_64)' => 'no-appstream-9-result-rockylinux9-x86_64',
+    'Rocky Linux 9 (x86_64)' => 'no-appstream-9-result-rockylinux-9-x86_64',
     'Ubuntu 20.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2004-pool-amd64-uyuni',
     'Ubuntu 22.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2204-pool-amd64-uyuni',
     'Debian 10 (buster) pool for amd64 for Uyuni' => 'debian-10-pool-amd64-uyuni',
@@ -461,9 +459,9 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'EL9-Pool for x86_64' => 'SUSE-LibertyLinux9-x86_64',
     'oraclelinux9 for x86_64' => 'oracle-9-x86_64',
     'RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
-    'rockylinux9 for x86_64' => 'rockylinux9-x86_64',
-    'ubuntu-2004-amd64-main for amd64' => 'ubuntu-2004-amd64',
-    'ubuntu-2204-amd64-main for amd64' => 'ubuntu-2204-amd64',
+    'rockylinux-9 for x86_64' => 'rockylinux-9-x86_64',
+    'ubuntu-2004-amd64-main for amd64' => 'ubuntu-20.04-amd64',
+    'ubuntu-2204-amd64-main for amd64' => 'ubuntu-22.04-amd64',
     'debian-10-pool for amd64' => 'debian10-amd64',
     'debian-11-pool for amd64' => 'debian11-amd64',
     'debian-12-pool for amd64' => 'debian12-amd64',
@@ -504,10 +502,10 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
 }.freeze
 
 # Used for creating bootstrap repositories
-# The values can be found under Admin -> Setup Wizard -> Products for SUMA
+# SUMA: The values can be found under Admin -> Setup Wizard -> Products
 # Select the desired product and have a look at its product channels
-# The required product has to be synced before.
-# For Uyuni, you have to use `spacewalk-common-channels -l` with the appended architecture
+# The required product has to be synced before
+# Uyuni: You have to use `spacewalk-common-channels -l` with the appended architecture
 # e.g. almalinux9 -> almalinux9-x86_64
 PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
   'SUSE Manager' => {
@@ -530,7 +528,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'EL9-Pool for x86_64' => 'el9-pool-x86_64',
     'oraclelinux9 for x86_64' => nil,
     'RHEL8-Pool for x86_64' => nil,
-    'rockylinux9 for x86_64' => nil,
+    'rockylinux-9 for x86_64' => nil,
     'ubuntu-2004-amd64-main for amd64' => nil,
     'ubuntu-2204-amd64-main for amd64' => nil,
     'debian-10-pool for amd64' => 'debian-10-pool-amd64',
@@ -718,8 +716,8 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
       ],
     'rockylinux9' => # CHECKED
       %w[
-        rockylinux9-x86_64
-        rockylinux9-appstream-x86_64
+        rockylinux-9-x86_64
+        rockylinux-9-appstream-x86_64
       ],
     'oraclelinux9' => # CHECKED
       %w[
@@ -930,14 +928,14 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         ubuntu-2004-amd64-main-amd64
         ubuntu-2004-amd64-main-security-amd64
         ubuntu-2004-amd64-main-updates-amd64
-        ubuntu-2004-suse-manager-tools-amd64
+        ubuntu-20.04-suse-manager-tools-amd64
       ],
     'ubuntu-2204' => # CHECKED
       %w[
         ubuntu-2204-amd64-main-amd64
         ubuntu-2204-amd64-main-updates-amd64
         ubuntu-2204-amd64-main-security-amd64
-        ubuntu-2204-suse-manager-tools-amd64
+        ubuntu-22.04-suse-manager-tools-amd64
       ],
     'suma-proxy-43' => # CHECKED
       %w[
@@ -1523,7 +1521,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'ubuntu-2004-amd64-universe-uyuni' => 19_560,
   'ubuntu-2004-amd64-uyuni-client-devel' => 60,
   'ubuntu-2004-pool-amd64-uyuni' => 60,
-  'ubuntu-2004-suse-manager-tools-amd64' => 60,
+  'ubuntu-20.04-suse-manager-tools-amd64' => 60,
   'ubuntu-2204-amd64-main-amd64' => 780,
   'ubuntu-2204-amd64-main-security-amd64' => 2760,
   'ubuntu-2204-amd64-main-security-uyuni' => 2040,
@@ -1536,7 +1534,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'ubuntu-2204-amd64-universe-uyuni' => 24_000,
   'ubuntu-2204-amd64-uyuni-client-devel' => 60,
   'ubuntu-2204-pool-amd64-uyuni' => 60,
-  'ubuntu-2204-suse-manager-tools-amd64' => 60,
+  'ubuntu-22.04-suse-manager-tools-amd64' => 60,
   'uyuni-proxy-devel-leap-x86_64' => 60
 }.freeze
 


### PR DESCRIPTION
## What does this PR change?

Apparently the labels for Rocky 9 and Ubuntu 22.04 and 20.04 have changed, according to https://github.com/SUSE/spacewalk/issues/23705#issuecomment-1981078586. This only touches the labels for SUMA, **not** Uyuni.
These regressions were introduced with
- https://github.com/uyuni-project/uyuni/pull/8367 
- https://github.com/SUSE/spacewalk/pull/23788

```bash
uyuni-server:/tmp # mgr-create-bootstrap-repo
1. RES7-x86_64
2. RHEL8-x86_64
3. SLE-12-SP5-x86_64
4. SLE-15-SP1-x86_64
5. SLE-15-SP2-x86_64
6. SLE-15-SP3-x86_64
7. SLE-15-SP4-x86_64
8. SLE-15-SP5-s390x
9. SLE-15-SP5-x86_64
10. SLE-ES8-x86_64
11. SLE-MICRO-5.1-x86_64
12. SLE-MICRO-5.2-x86_64
13. SLE-MICRO-5.3-x86_64
14. SLE-MICRO-5.4-x86_64
15. SLE-MICRO-5.5-x86_64
16. SUSE-LibertyLinux9-x86_64
17. almalinux-9-x86_64
18. debian11-amd64
19. debian12-amd64
20. openSUSE-Leap-15.4-aarch64
21. openSUSE-Leap-15.5-aarch64
22. oracle-9-x86_64
23. rockylinux-9-x86_64
24. ubuntu-20.04-amd64
25. ubuntu-22.04-amd64
Enter a number of a product label: ^C
Process has been interrupted.
```


- Rocky 9
  ![image](https://github.com/SUSE/spacewalk/assets/12104291/e3ce4a5c-d78e-48d3-a76d-802f752ca7ae)
```bash
uyuni-server:/tmp # mgr-create-bootstrap-repo --create rockylinux-9-x86_64 --with-custom-channels --flush
FLUSH: move destdir '/srv/www/htdocs/pub/repositories/rockylinux/9/bootstrap' to old

Creating bootstrap repo for rockylinux-9-x86_64
copy 'venv-salt-minion-3006.0-1.33.1.x86_64'
Directory walk started
Directory walk done - 1 packages
Temporary output repo path: /srv/www/htdocs/pub/repositories/rockylinux/9/bootstrap.tmp/.repodata/
Preparing sqlite DBs
Pool started (with 5 workers)
Pool finished
```
  ![image](https://github.com/uyuni-project/uyuni/assets/12104291/a172e502-cf57-48d4-9b9d-e28433e48409)
  ![image](https://github.com/uyuni-project/uyuni/assets/12104291/d4745f3d-9ef4-4922-bed9-b19c8783502a)
- Ubuntu 20.04
  ![image](https://github.com/SUSE/spacewalk/assets/12104291/7942ba80-4eb0-4865-bf2a-8dc0a6ff9275)
  ![image](https://github.com/uyuni-project/uyuni/assets/12104291/a95e8ad3-bb33-4d52-b985-1c25bdd511f4)
```bash
uyuni-server:/tmp # mgr-create-bootstrap-repo --create ubuntu-2004-amd64 --with-custom-channels --flush
'ubuntu-2004-amd64' not found

uyuni-server:/tmp # mgr-create-bootstrap-repo --create ubuntu-20.04-amd64 --with-custom-channels --flush
FLUSH: move destdir '/srv/www/htdocs/pub/repositories/ubuntu/20/4/bootstrap' to old

Creating bootstrap repo for ubuntu-20.04-amd64
copy 'dctrl-tools-2.24-3.amd64-deb'
copy 'libnorm1-1.5.8+dfsg2-2build1.amd64-deb'
copy 'libpgm-5.2-0-5.2.122~dfsg-3ubuntu1.amd64-deb'
copy 'libzmq5-4.3.2-2ubuntu1.amd64-deb'
copy 'python3-crypto-2.6.1-13ubuntu2.amd64-deb'
copy 'python3-dateutil-2.7.3-3ubuntu1.all-deb'
copy 'python3-distro-1.4.0-1.all-deb'
copy 'python3-jinja2-2.10.1-2ubuntu0.2.all-deb'
copy 'python3-markupsafe-1.1.0-1build2.amd64-deb'
copy 'python3-msgpack-0.6.2-1.amd64-deb'
copy 'python3-psutil-5.5.1-1ubuntu4.amd64-deb'
copy 'python3-pycryptodome-3.6.1-2build4.amd64-deb'
copy 'python3-zmq-18.1.1-3.amd64-deb'
copy 'python3-gnupg-0.4.5-2.all-deb'
copy 'python3-looseversion-1.0.2-2.all-deb'
copy 'python3-jmespath-0.9.4-2ubuntu1.all-deb'
copy 'salt-common-3006.0+ds-1+2.119.2.all-deb'
copy 'salt-minion-3006.0+ds-1+2.119.2.all-deb'
copy 'gnupg-2.2.19-3ubuntu2.2.all-deb'
copy 'venv-salt-minion-3006.0-2.49.3.amd64-deb'
Exporting indices...
```
- Ubuntu 22.04
  ![image](https://github.com/SUSE/spacewalk/assets/12104291/318958dc-c2e3-4c4c-9333-d242dc004a1a)
  ![image](https://github.com/uyuni-project/uyuni/assets/12104291/35528bdd-4b0e-471b-bdb8-a311e3c52387)
```bash
uyuni-server:/tmp # mgr-create-bootstrap-repo --create ubuntu-2204-amd64 --with-custom-channels --flush
'ubuntu-2204-amd64' not found

uyuni-server:/tmp # mgr-create-bootstrap-repo --create ubuntu-22.04-amd64 --with-custom-channels --flush
FLUSH: move destdir '/srv/www/htdocs/pub/repositories/ubuntu/22/4/bootstrap' to old

Creating bootstrap repo for ubuntu-22.04-amd64
copy 'venv-salt-minion-3006.0-2.40.3.amd64-deb'
Exporting indices...
```


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # 
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
