### PR TITLE
QE: Adapt smoke test template for SLE Micro 5.x

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -162,7 +162,6 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled by admin" is completed
-    And I reboot the "<client>" if it is a SLE Micro
 
 @skip_for_sle_micro_ssh_minion
   Scenario: Enable Prometheus Node exporter formula on the <client>
@@ -198,6 +197,7 @@ Feature: Smoke tests for <client>
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
+    And I reboot the "<client>" if it is a SLE Micro
 
 @skip_for_sle_micro_ssh_minion
 @sle_micro_minion


### PR DESCRIPTION
## What does this PR change?

This PR
- removes one unnecessary reboot in a scenario that gets skipped for SLE Micro
- adds a necessary reboot after applying high state

for the SLE Micro Minions in the smoke test template.


![image](https://github.com/uyuni-project/uyuni/assets/12104291/4d5bc1bc-4296-4eab-93ed-97c9a6e9a3b7)
![image](https://github.com/uyuni-project/uyuni/assets/12104291/5e8f7b87-7129-4421-91c5-6a0e26e8c1de)
with follow up issues 
```bash
[2024-03-06T18:42:50.974Z] Failing Scenarios:
[2024-03-06T18:42:50.974Z] cucumber features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:121 # Scenario: Deploy the configuration file to slemicro55_minion
[2024-03-06T18:42:50.974Z] cucumber features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:205 # Scenario: Enable and start Prometheus Node Exporter service
[2024-03-06T18:42:50.974Z] cucumber features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:210 # Scenario: Visit Node monitoring endpoint on the slemicro55_minion
[2024-03-06T18:42:50.974Z] cucumber features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:223 # Scenario: The data from slemicro55_minion appear on Grafana dashboard
```
After a reboot, the failed scenarios were successful again:
```bash
(...)
  @skip_for_sle_micro_ssh_minion @sle_micro_minion
  Scenario: Enable and start Prometheus Node Exporter service                          # features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:205
      This scenario ran at: 2024-03-07 11:08:28 +0100
Initializing a twopence node for 'slemicro55_minion'.
Node: suma-bv-50-min-slemicro55.mgr.suse.de, OS Version: 5.5, Family: sle-micro
systemctl start prometheus-node_exporter.service returned status code = 0.
Output:
''
    And I start the "prometheus-node_exporter.service" service on "slemicro55_minion"  # features/step_definitions/command_steps.rb:724
systemctl enable prometheus-node_exporter.service returned status code = 0.
Output:
'Created symlink /etc/systemd/system/multi-user.target.wants/prometheus-node_exporter.service → /usr/lib/systemd/system/prometheus-node_exporter.service.
'
    And I enable the "prometheus-node_exporter.service" service on "slemicro55_minion" # features/step_definitions/command_steps.rb:724
      This scenario took: 3 seconds

  @skip_for_sle_micro_ssh_minion
  Scenario: Visit Node monitoring endpoint on the slemicro55_minion             # features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:210
      This scenario ran at: 2024-03-07 11:08:31 +0100
    When I wait until "node" exporter service is active on "slemicro55_minion"  # features/step_definitions/command_steps.rb:311
    And I visit "Prometheus node exporter" endpoint of this "slemicro55_minion" # features/step_definitions/navigation_steps.rb:1034
      This scenario took: 0 seconds

  @skip_for_sle_micro
  Scenario: Visit Apache and Postgres monitoring endpoint on the slemicro55_minion  # features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:215
      This scenario ran at: 2024-03-07 11:08:31 +0100
    When I wait until "apache" exporter service is active on "slemicro55_minion"    # features/step_definitions/command_steps.rb:311
    And I visit "Prometheus apache exporter" endpoint of this "slemicro55_minion"   # features/step_definitions/navigation_steps.rb:1034
    And I wait until "postgres" exporter service is active on "slemicro55_minion"   # features/step_definitions/command_steps.rb:311
    And I visit "Prometheus postgres exporter" endpoint of this "slemicro55_minion" # features/step_definitions/navigation_steps.rb:1034
      This scenario took: 0 seconds

  @skip_for_sle_micro_ssh_minion @monitoring_server
  Scenario: The data from slemicro55_minion appear on Grafana dashboard # features/build_validation/smoke_tests/slemicro55_minion_smoke_tests.feature:223
      This scenario ran at: 2024-03-07 11:08:31 +0100
Initializing a twopence node for 'monitoring_server'.
Node: suma-bv-50-monitoring, OS Version: 15-SP4, Family: sles
    When I visit the grafana dashboards of this "monitoring_server"     # features/step_definitions/navigation_steps.rb:1191
    And I wait until I do not see "Loading Grafana" text                # features/step_definitions/navigation_steps.rb:43
    And I wait until I see "General" text                               # features/step_definitions/navigation_steps.rb:39
    And I check radio button "View as list", if not checked             # features/step_definitions/common_steps.rb:224
    When I follow "Client Systems"                                      # features/step_definitions/navigation_steps.rb:282
    Then I should see "slemicro55_minion" hostname                      # features/step_definitions/navigation_steps.rb:602
    When I enter "slemicro55_minion" hostname on grafana's host field   # features/step_definitions/navigation_steps.rb:1144
    And I wait until I do not see "No data" text                        # features/step_definitions/navigation_steps.rb:43
      This scenario took: 17 seconds

5 scenarios (1 skipped, 4 passed)
17 steps (4 skipped, 13 passed)
0m32.843s
```

See https://github.com/SUSE/spacewalk/issues/23705#issuecomment-1981444309

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23705#issuecomment-1981444309
Ports(s): # https://github.com/SUSE/spacewalk/pull/23891

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!