### PR TITLE
Tftp container: Use localhost and http by default

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.fix_logging_error
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.fix_logging_error
@@ -1,0 +1,1 @@
+- Remove 'file=sys.stderr' kwarg from logging as it does not know it

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -80,7 +80,7 @@ with open(config_path + "httpd.yaml") as httpdSource:
         container_version = subprocess.run(["rpm", "-q", "--queryformat", "%{version}", "spacewalk-proxy-common"],
                 stdout=subprocess.PIPE, universal_newlines=True).stdout
         if not container_version.startswith(major_version):
-            logging.critical("Proxy container image version (%s) doesn't match server major version (%s)", container_version, major_version, file=sys.stderr)
+            logging.critical("Proxy container image version (%s) doesn't match server major version (%s)", container_version, major_version)
             sys.exit(1)
     
     # store the systemid content

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.tftp_use_localhost_and_http
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.tftp_use_localhost_and_http
@@ -1,0 +1,1 @@
+- Connect to localhost instead of FQDN from tftp wrapper (bsc#1221138)

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) 2022 SUSE LLC
+# SPDX-FileCopyrightText: 2024 SUSE LLC
+#
+# SPDX-License-Identifier: MIT
 
 import argparse
 import logging
@@ -12,8 +14,10 @@ from fbtftp.base_handler import ResponseData
 from fbtftp.base_handler import StringResponseData
 from fbtftp.base_server import BaseServer
 
+
 def stats(s):
     pass
+
 
 class FileResponseData(ResponseData):
     def __init__(self, path):
@@ -29,6 +33,7 @@ class FileResponseData(ResponseData):
     def close(self):
         self._reader.close()
 
+
 class HttpResponseData(ResponseData):
     def __init__(self, url, capath):
         # request file by url and store it
@@ -37,35 +42,45 @@ class HttpResponseData(ResponseData):
             raise FileNotFoundError()
         self._request.raise_for_status()
         self._stream = self._request.iter_content(chunk_size=1024)
-        self._content = b''
-        self._size = int(self._request.headers['content-length'])
+        self._content = b""
+        self._size = int(self._request.headers["content-length"])
+
     def read(self, requested):
         data = self._content
         read = len(self._content)
         while read < requested:
-           if self._stream is None:
-              break
-           try:
-              d = next(self._stream)
-              data += d
-              read += len(d)
-           except StopIteration:
-              break
+            if self._stream is None:
+                break
+            try:
+                d = next(self._stream)
+                data += d
+                read += len(d)
+            except StopIteration:
+                break
         if read > requested:
-           self._content = data[requested:]
-           data = data[:requested]
+            self._content = data[requested:]
+            data = data[:requested]
         else:
-           self._content = b''
+            self._content = b""
         return data
+
     def size(self):
         return self._size
+
     def close(self):
         self._request.close()
 
+
 class HttpResponseDataFiltered(HttpResponseData):
+    """
+    Filter reponse entries based on supplied fqdn option
+
+    Saltboot entries have MASTER= option, we want only those mathing our proxy
+    """
+
     def __init__(self, url, capath, fqdn):
         # request file by url and store it
-        self._fqdn = fqdn
+        self._proxyFqdn = fqdn
         self._request = requests.get(url, stream=True, verify=capath)
         if self._request.status_code == 404:
             raise FileNotFoundError()
@@ -82,62 +97,75 @@ class HttpResponseDataFiltered(HttpResponseData):
 
 class HttpResponseDataFilteredPXE(HttpResponseDataFiltered):
     def contentFilter(self):
-        new_content = ''
+        new_content = ""
         have_entry = False
-        entry = ''
+        entry = ""
         in_entry = False
-        for line in self._content.decode('utf-8').splitlines():
+        for line in self._content.decode("utf-8").splitlines():
             if in_entry:
-                 if line.startswith(' ') or line.startswith('\t'):
-                     entry += line + '\n'
-                 else:
+                if line.startswith(" ") or line.startswith("\t"):
+                    entry += line + "\n"
+                else:
                     in_entry = False
                     # detect Saltboot entries
-                    if " MASTER=" + self._fqdn in entry and "MINION_ID_PREFIX" in entry:
+                    if (
+                        " MASTER=" + self._proxyFqdn in entry
+                        and "MINION_ID_PREFIX" in entry
+                    ):
                         have_entry = True
                         new_content += entry
-                    entry = ''
+                    entry = ""
             if not in_entry:
-                if line.startswith('LABEL'):
-                    entry = line + '\n'
+                if line.startswith("LABEL"):
+                    entry = line + "\n"
                     in_entry = True
                 else:
-                    if not line.startswith('ONTIMEOUT'): #ONTIMEOUT points to deleted entry
-                        new_content += line + '\n'
+                    if not line.startswith(
+                        "ONTIMEOUT"
+                    ):  # ONTIMEOUT points to deleted entry
+                        new_content += line + "\n"
         if not have_entry:
-            return # there are no specific Saltboot entries, keep the content unchanged
-        self._content = new_content.encode('utf-8')
+            return  # there are no specific Saltboot entries, keep the content unchanged
+        self._content = new_content.encode("utf-8")
+
 
 class HttpResponseDataFilteredGrub(HttpResponseDataFiltered):
     def contentFilter(self):
-        new_content = ''
+        new_content = ""
         have_entry = False
-        entry = ''
+        entry = ""
         in_entry = False
-        for line in self._content.decode('utf-8').splitlines():
+        for line in self._content.decode("utf-8").splitlines():
             if in_entry:
-                 entry += line + '\n'
-                 if line.rstrip().endswith('}'):
+                entry += line + "\n"
+                if line.rstrip().endswith("}"):
                     in_entry = False
                     # detect Saltboot entries
-                    if " MASTER=" + self._fqdn in entry and "MINION_ID_PREFIX" in entry:
+                    if (
+                        " MASTER=" + self._proxyFqdn in entry
+                        and "MINION_ID_PREFIX" in entry
+                    ):
                         have_entry = True
                         new_content += entry
-                    entry = ''
+                    entry = ""
             if not in_entry:
-                if line.startswith('menuentry'):
-                    entry = line + '\n'
+                if line.startswith("menuentry"):
+                    entry = line + "\n"
                     in_entry = True
                 else:
-                    new_content += line + '\n'
+                    new_content += line + "\n"
         if not have_entry:
-            return # there are no specific Saltboot entries, keep the content unchanged
-        self._content = new_content.encode('utf-8')
+            return  # there are no specific Saltboot entries, keep the content unchanged
+        self._content = new_content.encode("utf-8")
+
 
 class TFTPHandler(BaseHandler):
-    def __init__(self, server_addr, peer, path, options, root, httpHost, capath):
+    def __init__(
+        self, server_addr, peer, path, options, root, httpHost, proxyFqdn, capath
+    ):
         self._root = root
         self._httpHost = httpHost
+        self._proxyFqdn = proxyFqdn
         self._capath = capath
         super().__init__(server_addr, peer, path, options, stats)
 
@@ -145,67 +173,116 @@ class TFTPHandler(BaseHandler):
         capath = self._capath
         target = self._httpHost
         path = self._path
-        if self._path[0] == '/':
+        if self._path[0] == "/":
             path = self._path[1:]
 
         # accept only mac based config and defaults file
         if path.startswith("pxelinux.cfg/01-"):
             # request specific system configuration
             logging.debug(f"Got request for {path}, forwarding to HTTP")
-            return HttpResponseData(f"https://{target}/tftp/{path}", capath)
+            return HttpResponseData(f"{target}/tftp/{path}", capath)
         elif path.startswith("pxelinux.cfg/default"):
             # server local default
             logging.debug(f"Got request for {path}, filtering HTTP")
-            return HttpResponseDataFilteredPXE(f"https://{target}/tftp/{path}", capath, target)
+            return HttpResponseDataFilteredPXE(
+                f"{target}/tftp/{path}", capath, self._proxyFqdn
+            )
         elif path.startswith("pxelinux.cfg/"):
             # ignore other pxelinux.cfg files
             logging.debug(f"Got request for {path}, ignoring")
             raise FileNotFoundError()
         elif path.startswith("grub/") and path.endswith("_menu_items.cfg"):
             logging.debug(f"Got request for {path}, filtering HTTP")
-            return HttpResponseDataFilteredGrub(f"https://{target}/tftp/{path}", capath, target)
+            return HttpResponseDataFilteredGrub(
+                f"{target}/tftp/{path}", capath, self._proxyFqdn
+            )
         # The rest get from http
         logging.debug(f"Got request for {path}, forwarding to HTTP")
-        return HttpResponseData(f"https://{target}/tftp/{path}", capath)
+        return HttpResponseData(f"{target}/tftp/{path}", capath)
+
 
 class TFTPServer(BaseServer):
-    def __init__(self, address, port, retries, timeout, root, httpHost, capath):
+    def __init__(
+        self, address, port, retries, timeout, root, httpHost, proxyFqdn, capath
+    ):
         self._root = root
-        self._httpHost = httpHost
+        if capath is None or httpHost == "localhost":
+            self._httpHost = f"http://{httpHost}"
+            logging.info("SSL not used for inproxy communication")
+        else:
+            self._httpHost = f"https://{httpHost}"
+            logging.info("HTTPS used for inproxy communication")
+
+        self._proxyFqdn = proxyFqdn
         self._capath = capath
         super().__init__(address, port, retries, timeout, None)
 
     def get_handler(self, server_addr, peer, path, options):
         return TFTPHandler(
-            server_addr, peer, path, options, self._root, self._httpHost, self._capath
+            server_addr,
+            peer,
+            path,
+            options,
+            self._root,
+            self._httpHost,
+            self._proxyFqdn,
+            self._capath,
         )
+
 
 def get_arguments():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ip", type=str, default="0.0.0.0", help="IP address to bind to")
+    parser.add_argument(
+        "--ip", type=str, default="0.0.0.0", help="IP address to bind to"
+    )
     parser.add_argument("--port", type=int, default=69, help="port to bind to")
     parser.add_argument(
         "--retries", type=int, default=5, help="Number of per-packet retries"
     )
     parser.add_argument(
-        "--timeout", type=int, default=2, help="Timeout for packet retransmission in seconds"
+        "--timeout",
+        type=int,
+        default=2,
+        help="Timeout for packet retransmission in seconds",
     )
     parser.add_argument(
-        "--root", type=str, default="/srv/tftpboot", help="Root of the static filesystem"
+        "--root",
+        type=str,
+        default="/srv/tftpboot",
+        help="Root of the static filesystem",
     )
     parser.add_argument(
-        "--httpHost", type=str, default="localhost", help="Hostname where to forward HTTP requests"
+        "--httpHost",
+        type=str,
+        default="localhost",
+        help="Hostname where to forward HTTP requests",
     )
     parser.add_argument(
-        "--logLevel", choices=['error', 'warning', 'info', 'debug'], default="debug", help="Logging level for the server"
+        "--proxyFqdn",
+        type=str,
+        help="Hostname of the proxy for retail filtering",
+        default="localhost",
     )
     parser.add_argument(
-        "--configFile", type=str, default="/etc/uyuni/config.yaml", help="Path to configuration file"
+        "--logLevel",
+        choices=["error", "warning", "info", "debug"],
+        default="info",
+        help="Logging level for the server",
     )
     parser.add_argument(
-        "--caPath", type=str, default="/usr/share/uyuni/ca.crt", help="Path to CA certificate"
+        "--configFile",
+        type=str,
+        default="/etc/uyuni/config.yaml",
+        help="Path to configuration file",
+    )
+    parser.add_argument(
+        "--caPath",
+        type=str,
+        default="/usr/share/uyuni/ca.crt",
+        help="Path to CA certificate",
     )
     return parser.parse_args()
+
 
 def main():
     args = get_arguments()
@@ -214,12 +291,19 @@ def main():
     try:
         with open(args.configFile) as source:
             config = yaml.safe_load(source)
-            args.httpHost = config['proxy_fqdn']
+            args.proxyFqdn = config.get("proxy_fqdn", "localhost")
+            log_level = logging.INFO if config.get("log_level", 1) == 1 else logging.DEBUG
+            logging.getLogger().setLevel(log_level)
 
     except IOError as err:
         logging.warning(f"Configuration file reading error {err}, ignoring")
     except KeyError as err:
         logging.warning(f"Invalid configuration file passed, missing {err}")
+
+    logging.info("Starting TFTP proxy:")
+    logging.info(f"httpHost: {args.httpHost}")
+    logging.info(f"proxyFqdn: {args.proxyFqdn}")
+    logging.info(f"CA path: {args.caPath}")
 
     server = TFTPServer(
         args.ip,
@@ -228,12 +312,14 @@ def main():
         args.timeout,
         args.root,
         args.httpHost,
-        args.caPath
+        args.proxyFqdn,
+        args.caPath,
     )
     try:
         server.run()
     except KeyboardInterrupt:
         server.close()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What does this PR change?

To prevent hairpin problems and also because we are by default running in pod with other containers, we want to connect to the localhost instead of FQDN.
With localhost we use http.

PR includes black linting of the file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23966

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
