### PR TITLE
Revert "Bump actions/labeler from 4 to 5"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts uyuni-project/uyuni#8348

Apparently, we need changes for our `labeler.yml` file. According to https://github.com/actions/labeler/tree/main?tab=readme-ov-file#usage, I was a bit quick on reading the first point.