### PR TITLE
Update GitHub labeler action from v4 to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,109 +1,208 @@
-#Dev Labels
+# Development labels
 java:
-- java/*
-- java/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/*
+    - java/**/*
+
 ui:
-- web/*
-- web/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - web/*
+    - web/**/*
+
 webapp:
-- java/code/webapp/*
-- java/code/webapp/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/webapp/*
+    - java/code/webapp/**/*
+
 cobbler:
-- java/code/src/org/cobbler/*
-- java/code/src/org/cobbler/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/org/cobbler/*
+    - java/code/src/org/cobbler/**/*
+
 documentation:
-- documentation/*
-- documentation/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - documentation/*
+    - documentation/**/*
+
 proxy:
-- proxy/*
-- proxy/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - proxy/*
+    - proxy/**/*
+
 API:
-- java/code/src/com/redhat/rhn/frontend/*
-- java/code/src/com/redhat/rhn/frontend/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/redhat/rhn/frontend/*
+    - java/code/src/com/redhat/rhn/frontend/**/*
+
 Virtualization management:
-- java/code/src/com/suse/manager/virtualization/*
-- java/code/src/com/suse/manager/virtualization/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/virtualization/*
+    - java/code/src/com/suse/manager/virtualization/**/*
+
 monitoring:
-- java/code/src/com/suse/manager/webui/services/impl/test/monitoring/*
-- java/code/src/com/suse/manager/webui/services/impl/test/monitoring/**/*
-- java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/*
-- java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/webui/services/impl/test/monitoring/*
+    - java/code/src/com/suse/manager/webui/services/impl/test/monitoring/**/*
+    - java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/*
+    - java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/**/*
+
 python3:
-- java/**/*.py
-- backend/**/*.py
-- client/**/*.py
-- susemanager/**/*.py
-- spacecmd/*
-- spacecmd/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/**/*.py
+    - backend/**/*.py
+    - client/**/*.py
+    - susemanager/**/*.py
+    - spacecmd/*
+    - spacecmd/**/*
+
 database:
-- schema/spacewalk/*
-- schema/spacewalk/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - schema/spacewalk/*
+    - schema/spacewalk/**/*
+
 content-management:
-- java/code/src/com/suse/manager/webui/controllers/contentmanagement/*
-- java/code/src/com/suse/manager/webui/controllers/contentmanagement/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/webui/controllers/contentmanagement/*
+    - java/code/src/com/suse/manager/webui/controllers/contentmanagement/**/*
+
 spark-router:
-- java/code/src/com/suse/manager/webui/Router.java
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/webui/Router.java
+
 webui-templates:
-- java/code/src/com/suse/manager/webui/templates/*
-- java/code/src/com/suse/manager/webui/templates/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/webui/templates/*
+    - java/code/src/com/suse/manager/webui/templates/**/*
+
 webui-controllers:
-- java/code/src/com/suse/manager/webui/controller/*
-- java/code/src/com/suse/manager/webui/controller/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/webui/controller/*
+    - java/code/src/com/suse/manager/webui/controller/**/*
+
 salt-actions-implementations:
-- java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+
 salt-events-listener:
-- java/code/src/com/suse/manager/reactor/SaltReactor.java
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/suse/manager/reactor/SaltReactor.java
+
 data-model:
-- java/code/src/com/redhat/rhn/domain/*
-- java/code/src/com/redhat/rhn/domain/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/redhat/rhn/domain/*
+    - java/code/src/com/redhat/rhn/domain/**/*
+
 old-ui:
-- java/code/src/com/redhat/rhn/frontend/*
-- java/code/src/com/redhat/rhn/frontend/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/redhat/rhn/frontend/*
+    - java/code/src/com/redhat/rhn/frontend/**/*
+
 xmlrpc:
-- java/code/src/com/redhat/rhn/frontend/xmlrpc/*
-- java/code/src/com/redhat/rhn/frontend/xmlrpc/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - java/code/src/com/redhat/rhn/frontend/xmlrpc/*
+    - java/code/src/com/redhat/rhn/frontend/xmlrpc/**/*
 
-#QE Labels
+# QE labels
 testing:
-- testsuite/*
-- testsuite/**/*
-test-framework:
-- testsuite/features/support/*
-- testsuite/features/step_definitions/*
-core-features:
-- testsuite/features/core/*
-- testsuite/features/core/**/*
-build-validation-features:
-- testsuite/features/build_validation/*
-- testsuite/features/build_validation/**/*
-secondary-features:
-- testsuite/features/secondary/*
-- testsuite/features/secondary/**/*
-ci-pipelines:
-- testsuite/**/*.yml
+- changed-files:
+  - any-glob-to-any-file:
+    - testsuite/*
+    - testsuite/**/*
 
-#Unit tests
-backend_unittests_pgsql:
-- backend/*
-- backend/**/*
-javascript_lint:
-- web/*
-- web/**/*
-java_lint_checkstyle:
-- java/*
-- java/**/*
-java_pgsql_tests:
-- java/*
-- java/**/*
+test-framework:
+- changed-files:
+  - any-glob-to-any-file:
+    - testsuite/features/support/*
+    - testsuite/features/step_definitions/*
+
+core-features:
+- changed-files:
+  - any-glob-to-any-file:
+    - testsuite/features/core/*
+    - testsuite/features/core/**/*
+
+build-validation-features:
+- changed-files:
+  - any-glob-to-any-file:
+    - testsuite/features/build_validation/*
+    - testsuite/features/build_validation/**/*
+
+secondary-features:
+- changed-files:
+  - any-glob-to-any-file:
+    - testsuite/features/secondary/*
+    - testsuite/features/secondary/**/*
+
+ci-pipelines:
+- changed-files:
+  - any-glob-to-any-file:
+    - testsuite/**/*.yml
+
 ruby_rubocop:
-- testsuite/*
-- testsuite/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - testsuite/*
+    - testsuite/**/*
+
+# Unit test labels
+backend_unittests_pgsql:
+- changed-files:
+  - any-glob-to-any-file:
+    - backend/*
+    - backend/**/*
+
+javascript_lint:
+- changed-files:
+  - any-glob-to-any-file:
+    - web/*
+    - web/**/*
+
+java_lint_checkstyle:
+- changed-files:
+  - any-glob-to-any-file:
+    - java/*
+    - java/**/*
+
+java_pgsql_tests:
+- changed-files:
+  - any-glob-to-any-file:
+    - java/*
+    - java/**/*
+
 schema_migration_test_oracle:
-- schema/spacewalk/*
-- schema/spacewalk/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - schema/spacewalk/*
+    - schema/spacewalk/**/*
+
 schema_migration_test_pgsql:
-- schema/spacewalk/*
-- schema/spacewalk/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - schema/spacewalk/*
+    - schema/spacewalk/**/*
+
 susemanager_unittests:
-- susemanager/*
-- susemanager/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - susemanager/*
+    - susemanager/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request
+- pull_request_target
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   triage:
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -3,7 +3,7 @@
 
 Feature: Sanity checks
   In order to use the product
-  I want to be sure to use a sane environment
+  I want to be sure to use a sane environment test
 
   Scenario: The server is healthy
     Then "server" should have a FQDN

--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 # Skip if container because action chains fail on containers
-# This needs to be fixed
+# This needs to be fixed test
 
 @ssh_minion
 @sle_minion

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -18,7 +18,7 @@ require_relative 'code_coverage'
 require_relative 'twopence_env'
 require_relative 'commonlib'
 
-## code coverage analysis
+## code coverage analysis test
 # SimpleCov.start
 
 server = ENV.fetch('SERVER', nil)


### PR DESCRIPTION
## What does this PR change?

This PR
-  bumps the version of our labeler to v5 and adapts the `labeler.yml` file to the new configuration file structure. See https://github.com/actions/labeler#breaking-changes-in-v5
- `pull_request_target` is temporarily change to `pull_request`, and will be reverted once all checks have passed. See https://github.com/actions/labeler#notes-regarding-pull_request_target-event
-  tmp change in one of our Ruby files to check the labeler

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!