### PR TITLE
QE: Don't reboot after bootstrapping the Proxy Host, as we don't use yet a transactional-server image

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy_container.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_container.feature
@@ -29,7 +29,9 @@ Feature: Setup containerized proxy
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 
-  # workaround for bsc#1218146
+# workaround for bsc#1218146
+# Once we start using Leap Micro #23811 in Uyuni Proxy, we need to remove this Cucumber tag
+@susemanager
   Scenario: Reboot the proxy host
     When I reboot the "proxy" minion through SSH
     And I wait until port "22" is listening on "proxy" host

--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -29,7 +29,9 @@ Feature: Setup containerized proxy
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 
-  # workaround for bsc#1218146
+# workaround for bsc#1218146
+# Once we start using Leap Micro #23811 in Uyuni Proxy, we need to remove this Cucumber tag
+@susemanager
   Scenario: Reboot the proxy host
     When I reboot the "proxy" minion through SSH
     And I wait until port "22" is listening on "proxy" host


### PR DESCRIPTION
## What does this PR change?

We included a reboot after bootstrapping the Proxy Host, as we considered we were operating under a transactional-server image (SLE or Leap Micro), but in fact, in our test environment we still deploying a SLES/Leap system. Therefore, we don't need to reboot just after the bootstrap.

Note: We will keep the scenario commented, as very soon, we will make a change in our infra and start using a SLE/Leap Micro image for the Proxy Host

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were disabled

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
