### PR TITLE
QE: If any, add Avahi hosts into the containerized proxy configuration

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy_container.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_container.feature
@@ -43,6 +43,9 @@ Feature: Setup containerized proxy
     When I generate the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy on the server
     And I copy the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy from the server to the proxy
 
+  Scenario: Set-up the containerized proxy service to support Avahi
+    When I add avahi hosts in containerized proxy configuration
+
   Scenario: Run a containerized proxy
     When I run "mgrpxy install podman /tmp/proxy_container_config.tar.gz" on "proxy"
 

--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -43,6 +43,9 @@ Feature: Setup containerized proxy
     When I generate the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy on the server
     And I copy the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy from the server to the proxy
 
+  Scenario: Set-up the containerized proxy service to support Avahi
+    When I add avahi hosts in containerized proxy configuration
+
   Scenario: Run a containerized proxy
     When I run "mgrpxy install podman /tmp/proxy_container_config.tar.gz" on "proxy"
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1465,8 +1465,6 @@ When(/^I copy the configuration "([^"]*)" of containerized proxy from the server
   get_target('proxy').inject(file_path, file_path)
 end
 
-# TODO: Refactor this step to use the new mgrpxy command
-#       For now, this step is not used to onboard our containerized proxy
 When(/^I add avahi hosts in containerized proxy configuration$/) do
   if get_target('server').full_hostname.include? 'tf.local'
     hosts_list = ''
@@ -1474,8 +1472,7 @@ When(/^I add avahi hosts in containerized proxy configuration$/) do
       hosts_list += "--add-host=#{node.full_hostname}:#{node.public_ip} "
     end
     hosts_list = escape_regex(hosts_list)
-    regex = "s/^#?EXTRA_POD_ARGS=.*$/EXTRA_POD_ARGS=#{hosts_list}/g;"
-    get_target('proxy').run("sed -i.bak -Ee '#{regex}' /etc/sysconfig/uyuni-proxy-systemd-services")
+    get_target('proxy').run("echo 'export UYUNI_PODMAN_ARGS=\"#{hosts_list}\"' >> ~/.bashrc && source ~/.bashrc", runs_in_container: false)
     log "Avahi hosts added: #{hosts_list}"
     log 'The Development team has not been working to support avahi in containerized proxy, yet. This is best effort.'
   else


### PR DESCRIPTION
## What does this PR change?

This PR refactors the step definition to include the Avahi hosts into the Uyuni Podman args.
Before, it was made through the configuration of a systemd service, but that has been changed with the new Proxy version, now we pass it through an environment variable `UYUNI_PODMAN_ARGS`.
Although, we can also pass it through the configuration file like:
```
podman:
  args:
    - --add-host=...
    - --add-host=...
```
And we also have the possibility to pass it using an argument, `mgrpxy install podman` has a `--podman-arg` argument.
If any, add Avahi hosts into the containerized proxy configuration

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Related to https://github.com/SUSE/spacewalk/issues/23517

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
