### PR TITLE
CLM: Improve Attach/Detach Filter UI

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -244,6 +244,7 @@ public class ResponseMappers {
                     );
                     return contentFilterResponse;
                 })
+                .sorted(Comparator.comparing(FilterResponse::getName))
                 .collect(Collectors.toList());
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/FilterResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/FilterResponse.java
@@ -80,6 +80,10 @@ public class FilterResponse {
         this.name = nameIn;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public void setProjects(List<ImmutablePair<String, String>> projectsIn) {
          this.projects = projectsIn;
     }

--- a/java/spacewalk-java.changes.welder.sort-clm-filters
+++ b/java/spacewalk-java.changes.welder.sort-clm-filters
@@ -1,0 +1,1 @@
+- Sort CLM project filters by filter name

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.tsx
@@ -38,6 +38,14 @@ const FiltersProjectSelection = (props: FiltersProps) => {
 
   return (
     <React.Fragment>
+      <LinkButton
+        id={`create-new-filter-link`}
+        icon="fa-plus"
+        className="btn btn-default js-spa"
+        text={t("Create New Filter")}
+        href={`/rhn/manager/contentmanagement/filters?openFilterId=-1&projectLabel=${props.projectId}`}
+      />
+
       {allFilters &&
         allFilters.length > 0 &&
         allFilters.map((filter) => (
@@ -59,13 +67,6 @@ const FiltersProjectSelection = (props: FiltersProps) => {
             </label>
           </div>
         ))}
-      <LinkButton
-        id={`create-new-filter-link`}
-        icon="fa-plus"
-        className="btn-link js-spa"
-        text={t("Create New Filter")}
-        href={`/rhn/manager/contentmanagement/filters?openFilterId=-1&projectLabel=${props.projectId}`}
-      />
     </React.Fragment>
   );
 };

--- a/web/spacewalk-web.changes.welder.improve-create-new-filter-ui
+++ b/web/spacewalk-web.changes.welder.improve-create-new-filter-ui
@@ -1,0 +1,1 @@
+- Improve CLM Create New Filter button


### PR DESCRIPTION
## What does this PR change?

- It sorts project filters by filter name
- It moves the `Create New Filter` button to the top so it can be visible when the modal opens even if there is a big number of filter
- It adds border to the `Create New Filter` button so it can be with the filters and in the same pattern as the other buttons in the modal.

## GUI diff

Before:
![image](https://github.com/uyuni-project/uyuni/assets/17532261/f63ba481-ba36-4eb4-9eb8-e2f44ed5bb60)

After:
![image](https://github.com/uyuni-project/uyuni/assets/17532261/97880bbd-559a-4c5d-a839-7f922e0ddf84)

- [x] **DONE**

## Documentation
- No documentation needed: small UI improvements

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/17896

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
