### PR TITLE
QE: Skip first user creation in BV for container

### DIFF
--- a/testsuite/features/build_validation/core/srv_first_settings.feature
+++ b/testsuite/features/build_validation/core/srv_first_settings.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Very first settings
@@ -6,9 +6,12 @@ Feature: Very first settings
   As the admin user
   I want to create the organisation, the first users and set the HTTP proxy
 
+  Scenario: Cleanup Salt files
+    When I run "rm -Rf /srv/salt/*" on "server"
+
+@skip_if_containerized_server
   Scenario: Create admin user and first organization
     Given I access the host the first time
-    And I run "rm -Rf /srv/salt/*" on "server"
     When I go to the home page
     And I enter "SUSE Test" as "orgName"
     And I enter "admin" as "login"

--- a/testsuite/features/core/srv_first_settings.feature
+++ b/testsuite/features/core/srv_first_settings.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in:
@@ -21,7 +21,6 @@ Feature: Very first settings
 
   Scenario: Cleanup Salt files
     When I run "rm -Rf /srv/salt/*" on "server"
-
 
 @skip_if_containerized_server
   Scenario: Create admin user and first organization


### PR DESCRIPTION
## What does this PR change?

> Since mgradm install now enforces the first user creation, this step needs to be skipped in the CI.

Same as https://github.com/uyuni-project/uyuni/pull/8402 but for BV. 

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # not needed

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!