### PR TITLE
QE: On CI, if a channel is not synchronized in the expected time, raise an error

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -420,7 +420,11 @@ When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
       sleep checking_rate
     end
   rescue StandardError => e
-    log e.message # It might be that the MU repository is wrong, but we want to continue in any case
+    log e.message
+    unless $build_validation
+      # It might be that the MU repository is wrong, but we want to continue in any case
+      raise ScriptError, "This channel was not fully synced: #{channel}"
+    end
   end
 end
 
@@ -453,7 +457,11 @@ When(/^I wait until all synchronized channels for "([^"]*)" have finished$/) do 
       sleep checking_rate
     end
   rescue StandardError => e
-    log e.message # It might be that the MU repository is wrong, but we want to continue in any case
+    log e.message
+    unless $build_validation
+      # It might be that the MU repository is wrong, but we want to continue in any case
+      raise ScriptError, "These channels were not fully synced:\n #{channels_to_wait}"
+    end
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

On CI, if a channel is not synchronized in the expected time, raise an error, so we identify on time the root cause, instead of having it hidden and cascaded in other test cases.
But in BV, let's keep the behavior untouched and let's keep running the pipeline.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
