### PR TITLE
QE: Adapt Uyuni/5.0 BV for the containerized proxy

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -211,7 +211,7 @@ namespace :jenkins do
   task :generate_rake_files_init_clients, [:instances] do |_t, args|
     minions = args[:instances]
     minions.each do |minion|
-      next if minion.include?('proxy') || minion.include?('monitoring')
+      next if minion.include?('monitoring')
 
       Rake::Task['jenkins:generate_rake_run_step'].invoke('', File.basename(minion, '.feature'), 'features/build_validation/init_clients', "run_sets/build_validation/build_validation_init_client_#{minion}.yml")
       Rake::Task['jenkins:generate_rake_run_step'].reenable

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -269,6 +269,15 @@ namespace :jenkins do
     instances = []
     ENV.select { |k, _v| k.include?('MINION') || k.include?('PROXY') || k.include?('CLIENT') || k.include?('MONITORING') }.each do |key, _value|
       # Convert ENV variables into testsuite variables
+      # Proxy can be either containerized or traditional
+      if key == 'PROXY'
+        key =
+          if is_containerized_server
+            'PROXY_CONTAINER'
+          else
+            'PROXY_TRADITIONAL'
+          end
+      end
       instance = key.to_s.downcase
       instances << instance.gsub('sshminion', 'ssh_minion')
     end

--- a/testsuite/features/build_validation/init_clients/proxy_container.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_container.feature
@@ -25,7 +25,7 @@ Feature: Setup containerized proxy
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-proxy_key" from "activationKeys"
+    And I select "1-proxy_container_key" from "activationKeys"
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
 

--- a/testsuite/features/build_validation/init_clients/proxy_traditional.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_traditional.feature
@@ -30,7 +30,7 @@ Feature: Setup SUSE Manager proxy
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-proxy_key" from "activationKeys"
+    And I select "1-proxy_traditional_key" from "activationKeys"
     And I click on "Bootstrap"
     And I wait until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "proxy"

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -144,7 +144,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until the channel "sles15-sp4-devel-uyuni-client-x86_64" has been synced
 
 @sle15sp5_minion
-@salt_migration_minion
   Scenario: Add SUSE Linux Enterprise Server 15 SP5
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
@@ -175,7 +174,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @uyuni
 @sle15sp5_minion
-@salt_migration_minion
   Scenario: Add SUSE Linux Enterprise Server 15 SP5 Uyuni Client tools
     When I use spacewalk-common-channel to add channel "sles15-sp5-devel-uyuni-client" with arch "x86_64"
     And I wait until the channel "sles15-sp5-devel-uyuni-client-x86_64" has been synced

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -222,7 +222,8 @@ PACKAGE_BY_CLIENT = {
 # Then take a look at the Parent Channel selections
 BASE_CHANNEL_BY_CLIENT = {
   'SUSE Manager' => {
-    'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool for x86_64',
+    'proxy_container' => 'SLE-Micro-5.5-Pool for x86_64',
+    'proxy_traditional' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool for x86_64',
     'sle_minion' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
     'ssh_minion' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
     'rhlike_minion' => 'RHEL8-Pool for x86_64',
@@ -291,7 +292,9 @@ BASE_CHANNEL_BY_CLIENT = {
     'salt_migration_minion' => 'SLE-Product-SLES15-SP5-Pool for x86_64'
   },
   'Uyuni' => {
-    'proxy' => 'openSUSE Leap 15.5 (x86_64)',
+    # WORKAROUND until https://github.com/SUSE/spacewalk/issues/23053 will be done
+    'proxy_container' => 'openSUSE Leap 15.5 (x86_64)',
+    'proxy_traditional' => 'openSUSE Leap 15.5 (x86_64)',
     'sle_minion' => 'openSUSE Leap 15.5 (x86_64)',
     'ssh_minion' => 'openSUSE Leap 15.5 (x86_64)',
     'rhlike_minion' => 'RHEL8-Pool for x86_64',

--- a/testsuite/run_sets/build_validation/build_validation_init_proxy.yml
+++ b/testsuite/run_sets/build_validation/build_validation_init_proxy.yml
@@ -1,8 +1,0 @@
-# This file describes the order of features in a Build Validation test suite run.
-
-## Init proxy BEGIN ###
-
-- features/build_validation/init_clients/proxy_traditional.feature
-- features/build_validation/init_clients/proxy_container.feature
-
-## Init proxy END ###


### PR DESCRIPTION
## What does this PR change?

This PR

1. a)  adapts the Rakefile for the two proxy variants (containerized, traditional) introduced with https://github.com/uyuni-project/uyuni/pull/8352.

### Example
```bash
[2024-03-12T13:35:18.790Z] + ./terracumber-cli --outputdir /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf --gitfolder /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results/sumaform --parallelism 60 --logfile /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results/60/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_NUMBER=60; export BUILD_VALIDATION=true; export CAPYBARA_TIMEOUT=60; export DEFAULT_TIMEOUT=500;  cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_activation_key_proxy'
[2024-03-12T13:35:25.322Z] Running command...
[2024-03-12T13:35:25.322Z] /usr/bin/ruby.ruby2.5 -S bundle exec cucumber --profile default -f html -o results/60/output_20240312143519-build_validation_add_activation_key_proxy.html -f json -o results/60/output_20240312143519-build_validation_add_activation_key_proxy.json -f junit -o results_junit -f pretty -r features features/build_validation/add_activation_keys/proxy_add_activation_key.feature features/build_validation/add_activation_keys/proxy_add_activation_key.feature
[2024-03-12T13:35:25.322Z] Minion IP address or domain name variable empty
[2024-03-12T13:35:25.322Z] Buildhost IP address or domain name variable empty
[2024-03-12T13:35:25.322Z] Red Hat-like minion IP address or domain name variable empty
[2024-03-12T13:35:25.322Z] Debian-like minion IP address or domain name variable empty
[2024-03-12T13:35:25.322Z] SSH minion IP address or domain name variable empty
[2024-03-12T13:35:25.322Z] PXE boot MAC address variable empty
[2024-03-12T13:35:25.322Z] KVM server minion IP address or domain name variable empty
[2024-03-12T13:35:25.322Z] Nested VM hostname empty
[2024-03-12T13:35:25.322Z] Nested VM MAC address empty
[2024-03-12T13:35:25.322Z] Capybara APP Host: https://suma-bv-50-srv.mgr.suse.de:8888/
[2024-03-12T13:35:25.322Z] Initializing a twopence node for 'server'.
[2024-03-12T13:35:25.322Z] Node: suma-bv-50-srv, OS Version: 15-SP6, Family: sles
[2024-03-12T13:35:25.322Z] Initializing a twopence node for 'server'.
[2024-03-12T13:35:25.322Z] Node: suma-bv-50-srv, OS Version: 15-SP6, Family: sles
[2024-03-12T13:35:25.322Z] Activating XML-RPC API
[2024-03-12T13:35:25.322Z] No such file or directory - features/build_validation/add_activation_keys/proxy_add_activation_key.feature. You can use `cucumber --init` to get started.
```

```bash
suma-bv-50-ctl:~/spacewalk/testsuite # cat run_sets/build_validation/build_validation_add_activation_key_proxy.yml
- features/build_validation/add_activation_keys/proxy_add_activation_key.feature
- features/build_validation/add_activation_keys/proxy_add_activation_key.feature

suma-bv-50-ctl:~/spacewalk/testsuite # ll features/build_validation/add_activation_keys | grep proxy
-rw-r--r-- 1 root root 449 Mar 12 14:26 proxy_container_add_activation_key.feature
-rw-r--r-- 1 root root 457 Mar 12 14:26 proxy_traditional_add_activation_key.feature
```

b) But we still have an issue with our pipeline because the rake task name changed (e.g. `*_proxy` -> `*_proxy_container`) :
https://github.com/SUSE/susemanager-ci/blob/a76732f7678c8625650946d09d1ab3f3cbb3ff4b/jenkins_pipelines/environments/common/pipeline-build-validation.groovy#L106
```groovy
[2024-03-13T14:44:03.650Z] + ./terracumber-cli --outputdir /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf --gitfolder /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results/sumaform --parallelism 60 --logfile /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results/62/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_NUMBER=62; export BUILD_VALIDATION=true; export CAPYBARA_TIMEOUT=60; export DEFAULT_TIMEOUT=500;  cd /root/spacewalk/testsuite; rake cucumber:build_validation_add_maintenance_update_repositories_proxy'
[2024-03-13T14:44:04.213Z] Running command...
[2024-03-13T14:44:04.213Z] rake aborted!
[2024-03-13T14:44:04.213Z] Don't know how to build task 'cucumber:build_validation_add_maintenance_update_repositories_proxy' (See the list of available tasks with `rake --tasks`)
[2024-03-13T14:44:04.213Z] Did you mean?  cucumber:build_validation_centos7_minion_add_iso
```

```bash
suma-bv-50-ctl:~/spacewalk/testsuite # rake -T | grep proxy
rake cucumber:build_validation_add_activation_key_proxy_container                         # Run Cucumber features
rake cucumber:build_validation_add_maintenance_update_repositories_proxy_container        # Run Cucumber features
rake cucumber:build_validation_create_bootstrap_repository_proxy_container                # Run Cucumber features
rake cucumber:build_validation_init_proxy                                                 # Run Cucumber features
rake cucumber:build_validation_retail_proxy                                               # Run Cucumber features
rake cucumber:github_validation_proxy                                                     # Run Cucumber features
rake cucumber:min_proxy                                                                   # Run Cucumber features
rake parallel:min_proxy                                                                   # Run Cucumber min_proxy features in parallel
```

2. fixes the proxy activation key label
3. adds missing proxy constants
4. Remove the Salt migration tag from the sync of SLES 15 SP5
5. Dynamically create the proxy run sets, too.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!