### PR TITLE
Fix issv1 scc data import

### DIFF
--- a/python/spacewalk/server/importlib/suseProductsImport.py
+++ b/python/spacewalk/server/importlib/suseProductsImport.py
@@ -104,14 +104,14 @@ class SuseUpgradePathsImport(GenericPackageImport):
         pid_trans = {}
         for item in self.batch:
             if item["from_product_id"] not in pid_trans:
-                pid_trans[
-                    item["from_product_id"]
-                ] = self.backend.lookupSuseProductIdByProductId(item["from_product_id"])
+                pid_trans[item["from_product_id"]] = (
+                    self.backend.lookupSuseProductIdByProductId(item["from_product_id"])
+                )
             item["from_pdid"] = pid_trans[item["from_product_id"]]
             if item["to_product_id"] not in pid_trans:
-                pid_trans[
-                    item["to_product_id"]
-                ] = self.backend.lookupSuseProductIdByProductId(item["to_product_id"])
+                pid_trans[item["to_product_id"]] = (
+                    self.backend.lookupSuseProductIdByProductId(item["to_product_id"])
+                )
             item["to_pdid"] = pid_trans[item["to_product_id"]]
             self._data.append(item)
 
@@ -138,14 +138,14 @@ class SuseProductExtensionsImport(GenericPackageImport):
         pid_trans = {}
         for item in self.batch:
             if item["product_id"] not in pid_trans:
-                pid_trans[
-                    item["product_id"]
-                ] = self.backend.lookupSuseProductIdByProductId(item["product_id"])
+                pid_trans[item["product_id"]] = (
+                    self.backend.lookupSuseProductIdByProductId(item["product_id"])
+                )
             item["product_pdid"] = pid_trans[item["product_id"]]
             if item["root_id"] not in pid_trans:
-                pid_trans[
-                    item["root_id"]
-                ] = self.backend.lookupSuseProductIdByProductId(item["root_id"])
+                pid_trans[item["root_id"]] = (
+                    self.backend.lookupSuseProductIdByProductId(item["root_id"])
+                )
             item["root_pdid"] = pid_trans[item["root_id"]]
             if item["ext_id"] not in pid_trans:
                 pid_trans[item["ext_id"]] = self.backend.lookupSuseProductIdByProductId(
@@ -178,9 +178,9 @@ class SuseProductRepositoriesImport(GenericPackageImport):
         rid_trans = {}
         for item in self.batch:
             if item["product_id"] not in pid_trans:
-                pid_trans[
-                    item["product_id"]
-                ] = self.backend.lookupSuseProductIdByProductId(item["product_id"])
+                pid_trans[item["product_id"]] = (
+                    self.backend.lookupSuseProductIdByProductId(item["product_id"])
+                )
             item["product_pdid"] = pid_trans[item["product_id"]]
             if item["rootid"] not in pid_trans:
                 pid_trans[item["rootid"]] = self.backend.lookupSuseProductIdByProductId(
@@ -192,10 +192,10 @@ class SuseProductRepositoriesImport(GenericPackageImport):
                     item["repo_id"]
                 )
             item["repo_pdid"] = rid_trans[item["repo_id"]]
-            if item['parent_channel_label'] == 'None':
-                item['parent_channel_label'] = None
-            if item['update_tag'] == 'None':
-                item['update_tag'] = None
+            if item["parent_channel_label"] == "None":
+                item["parent_channel_label"] = None
+            if item["update_tag"] == "None":
+                item["update_tag"] = None
             self._data.append(item)
 
     def fix(self):

--- a/python/spacewalk/server/importlib/suseProductsImport.py
+++ b/python/spacewalk/server/importlib/suseProductsImport.py
@@ -192,6 +192,10 @@ class SuseProductRepositoriesImport(GenericPackageImport):
                     item["repo_id"]
                 )
             item["repo_pdid"] = rid_trans[item["repo_id"]]
+            if item['parent_channel_label'] == 'None':
+                item['parent_channel_label'] = None
+            if item['update_tag'] == 'None':
+                item['update_tag'] = None
             self._data.append(item)
 
     def fix(self):

--- a/python/spacewalk/spacewalk-backend.changes.mc.Manager-4.3
+++ b/python/spacewalk/spacewalk-backend.changes.mc.Manager-4.3
@@ -1,0 +1,1 @@
+- fix inserting NULL into some columns during ISSv1 sync (bsc#1220980)


### PR DESCRIPTION
## What does this PR change?

While ISSv1, columns with NULL data are sometimes say "None" and that is inserted as string to the DB.
This convert 'None' to NULL during import.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/23942

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
