### PR TITLE
Enable automatic bundle migration for all minions

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/switch_to_bundle/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/switch_to_bundle/mgr_switch_to_venv_minion.sls
@@ -1,9 +1,9 @@
-{%- set avoid_venv_salt_minion = salt['pillar.get']('mgr_avoid_venv_salt_minion') %}
-{%- set is_salt_ssh = salt['pillar.get']('contact_method') in ['ssh-push', 'ssh-push-tunnel'] %}
-{%- set is_saltboot = salt['file.file_exists']('/etc/ImageVersion') %}
+{%- set avoid_salt_bundle = salt['pillar.get']('mgr_avoid_venv_salt_minion', false) == true %}
+{%- set is_not_salt_ssh = salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
+{%- set is_not_saltboot = salt['file.file_exists']('/etc/ImageVersion') == false %}
+{%- set is_not_salt_bundle = "venv-salt-minion" not in grains["pythonexecutable"] %}
 
-{%- if grains['saltversion'] == '3000' and not is_salt_ssh and 
-       not avoid_venv_salt_minion == true and not is_saltboot %}
+{%- if not avoid_salt_bundle and is_not_salt_bundle and is_not_salt_ssh and is_not_saltboot %}
 
 include:
   - util.mgr_switch_to_venv_minion

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
@@ -7,9 +7,9 @@
                             not salt['file.replace'](venv_susemanager_conf, '^master: .*', 'master: ' + pillar['mgr_server'],
                                                      dry_run=True, show_changes=False, ignore_if_missing=True) %}
 {%- if managed_minion or venv_managed_minion %}
-{%- set pkgs_installed = salt['pkg.info_installed']() %}
-{%- set venv_minion_installed = pkgs_installed.get('venv-salt-minion', False) and True %}
-{%- set venv_minion_available = venv_minion_installed or salt['pkg.latest_version']('venv-salt-minion') or False %}
+{%- set pkgs_installed = salt['pkg.list_pkgs']() %}
+{%- set venv_minion_installed = 'venv-salt-minion' in pkgs_installed %}
+{%- set venv_minion_available = venv_minion_installed or 'venv-salt-minion' in salt['pkg.list_repo_pkgs']() %}
 {%- if venv_minion_available %}
 include:
   - services.salt-minion

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.bundle-migration-all
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.bundle-migration-all
@@ -1,0 +1,1 @@
+- Migrate all Salt versions to Salt Bundle

--- a/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
@@ -58,18 +58,14 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
 
-  Scenario: Install the Salt Bundle on the minion
-    When I install packages "venv-salt-minion" on this "salt_migration_minion"
-    Then "venv-salt-minion" should be installed on "salt_migration_minion"
-
   Scenario: Migrate the minion to the Salt bundle
-    Given the Salt master can reach "salt_migration_minion"
-    When I migrate "salt_migration_minion" from salt-minion to venv-salt-minion
+    When I apply highstate on "salt_migration_minion"
+    Then "venv-salt-minion" should be installed on "salt_migration_minion"
+    And I wait until "venv-salt-minion" service is active on "salt_migration_minion"
 
   Scenario: Purge the minion from the old salt-minion leftovers
     When I purge salt-minion on "salt_migration_minion" after a migration
 
-  # This will fail until bsc#1209251 will be fixed
   Scenario: Check if the Salt bundle migration was successful
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area


### PR DESCRIPTION
## What does this PR change?

Open the classic salt-minion.rpm -> Salt Bundle migration to all Salt versions (not just 3000).

## GUI diff

No difference.

- [x] **DONE**

## Documentation

Need to check if we document which versions will get migrated. We need to document that all minions will get turned into venv-salt-minion automatically to prevent confusion.

- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage

I updated the build validation test, but it's still WIP. Previously, `venv-salt-minion` was installed manually before running the migration. That's not what we tell our customer, I think we can skip it.

- Cucumber tests were adapted

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23754
Port(s): Just for Uyuni and the upcoming SUMA 5.0 release

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
