### PR TITLE
Fix login via http api for read-only users

### DIFF
--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -134,7 +134,7 @@ public class HttpApiRegistry {
      * Register login/logout endpoints from {@link LoginController} to 'auth' namespace
      */
     private void registerAuthEndpoints() {
-        registrationHelper.addPostRoute(HTTP_API_ROOT + "auth/login", LoginController::login);
+        registrationHelper.addPostRoute(HTTP_API_ROOT + "auth/login", LoginController::apiLogin);
         registrationHelper.addPostRoute(HTTP_API_ROOT + "auth/logout", withUser(LoginController::logout));
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -147,13 +147,35 @@ public class LoginController {
     }
 
     /**
-     * Perform the login.
+     * Perform the webUI login.
      *
      * @param request the request object
      * @param response the response object
      * @return the JSON result of the login operation
      */
     public static String login(Request request, Response response) {
+        return performLogin(request, response, false);
+    }
+
+    /**
+     * Perform the http api login.
+     *
+     * @param request the request object
+     * @param response the response object
+     * @return the JSON result of the login operation
+     */
+    public static String apiLogin(Request request, Response response) {
+        return performLogin(request, response, true);
+    }
+
+    /**
+     * Perform the login.
+     *
+     * @param request the request object
+     * @param response the response object
+     * @return the JSON result of the login operation
+     */
+    private static String performLogin(Request request, Response response, boolean allowReadOnly) {
         Optional<String> errorMsg = Optional.empty();
         LoginCredentials creds = GSON.fromJson(request.body(), LoginCredentials.class);
         User user = LoginHelper.checkExternalAuthentication(request.raw(), new ArrayList<>(), new ArrayList<>());
@@ -165,7 +187,12 @@ public class LoginController {
             }
             else {
                 try {
-                    user = UserManager.loginUser(creds.getLogin(), creds.getPassword());
+                    if (allowReadOnly) {
+                        user = UserManager.loginReadOnlyUser(creds.getLogin(), creds.getPassword());
+                    }
+                    else {
+                        user = UserManager.loginUser(creds.getLogin(), creds.getPassword());
+                    }
                     log.info("LOCAL AUTH SUCCESS: [{}]", user.getLogin());
                 }
                 catch (LoginException e) {

--- a/java/spacewalk-java.changes.parlt.http-api-readonly-login
+++ b/java/spacewalk-java.changes.parlt.http-api-readonly-login
@@ -1,0 +1,1 @@
+- Fix login for read-only users when using http api (bsc#1221111)


### PR DESCRIPTION
## What does this PR change?

Since we restrict login for read-only user to the webUI. Login via http api was blocked for read-only users as well since they used the same endpoint.
Introduce a separate endpoint for login via http api to allow read-only users to login.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23904

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
