### PR TITLE
remove virtual-host-gatherer-Kubernetes module

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -51,7 +51,6 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     spacecmd \
     javamail \
     libyui-ncurses-pkg16 \
-    virtual-host-gatherer-Kubernetes \
     virtual-host-gatherer-libcloud \
     virtual-host-gatherer-Libvirt \
     virtual-host-gatherer-Nutanix \

--- a/containers/server-image/server-image.changes.mc.drop-vhm-kubernetes
+++ b/containers/server-image/server-image.changes.mc.drop-vhm-kubernetes
@@ -1,0 +1,1 @@
+- remove virtual-host-gatherer-Kubernetes module


### PR DESCRIPTION
## What does this PR change?

SUMA should not connect to Kubernetes. Let's drop the Kubernetes module from the image.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/23946

- [x] **DONE**

## Test coverage
- No tests: **no tests for dropped features**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23907

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
