### PR TITLE
Fix bootstrap for transactional systems (bsc#1220705)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -192,6 +192,9 @@ salt-minion-package:
     - require:
       - file: bootstrap_repo
 
+{%- if not use_venv_salt %}
+{# transactional_update executor module is required for classic salt-minion only #}
+{# venv-salt-minion has its own venv executor module which invokes transactional_update if needed #}
 {{ salt_config_dir }}/minion.d/transactional_update.conf:
   file.managed:
     - source:
@@ -201,6 +204,7 @@ salt-minion-package:
     - makedirs: True
     - require:
       - file: {{ salt_config_dir }}/minion.d/susemanager.conf
+{%- endif %}
 {%- endif %}
 
 {# We must install "python3-contextvars" on DEB based distros, running Salt 3004, with Python version < 3.7, like Ubuntu 18.04 #}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -298,12 +298,12 @@ include:
 
 {# Change REBOOT_METHOD to systemd if it is default, otherwise don't change it #}
 
-{%- if not salt['file.file_exists']('/etc/transactional-update.conf') %}
-copy_conf_file_to_etc:
+copy_transactional_conf_file_to_etc:
   file.copy:
     - name: /etc/transactional-update.conf
     - source: /usr/etc/transactional-update.conf
-{%- endif %}
+    - unless:
+      - test -f /etc/transactional-update.conf
 
 transactional_update_set_reboot_method_systemd:
   file.keyvalue:
@@ -314,7 +314,7 @@ transactional_update_set_reboot_method_systemd:
     - uncomment: '# '
     - append_if_not_found: True
     - require:
-      - file: copy_conf_file_to_etc
+      - file: copy_transactional_conf_file_to_etc
     - unless:
       - grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
 


### PR DESCRIPTION
## What does this PR change?

There is a wrong conditional part in the bootstrap state which is causing erros on transactional systems.

Additionally it makes the config for `transactional_update` executor module conditional as it's not needed for the salt bundle.

## GUI diff

No difference.

Before:
Possible errors on bootstrapping the transactional system

After:
No such error

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/23846

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
