### PR TITLE
stabilize refresh test

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/scc/SCCCachingFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/scc/SCCCachingFactory.java
@@ -319,7 +319,7 @@ public class SCCCachingFactory extends HibernateFactory {
         return getSession()
                 .createNamedQuery("BaseCredentials.getLastSCCRefreshDate", Date.class)
                 .uniqueResultOptional()
-                .map(lastModified -> {
+                .map(credsLastModified -> {
                     // When was the cache last modified?
                     return Opt.fold(
                             lastRefreshDateIn,
@@ -328,9 +328,9 @@ public class SCCCachingFactory extends HibernateFactory {
                                 return true;
                             },
                             modifiedCache -> {
-                                log.debug("COMPARE: {} and {} : {}", modifiedCache, lastModified,
-                                        lastModified.compareTo(modifiedCache));
-                                return lastModified.compareTo(modifiedCache) > 0;
+                                log.debug("COMPARE: {} and {} : {}", modifiedCache, credsLastModified,
+                                        credsLastModified.compareTo(modifiedCache));
+                                return credsLastModified.compareTo(modifiedCache) > 0;
                             }
                     );
                 })


### PR DESCRIPTION
## What does this PR change?

The `refreshNeeded()` test is a bit unstable. This try to make the test more stable

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were changed

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/23973

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
