### PR TITLE
QE: Fix the ks param used in Cobbler

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -156,8 +156,8 @@ Feature: Cobbler and distribution autoinstallation
   Scenario: Test for PXE environment files
     Given cobblerd is running
     When I wait until file "/srv/tftpboot/pxelinux.cfg/default" exists on server
-    And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "ks=.*fedora_kickstart_profile:1" on server
-    And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "ks=.*fedora_kickstart_profile_upload:1" on server
+    And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "inst.ks=.*fedora_kickstart_profile:1" on server
+    And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "inst.ks=.*fedora_kickstart_profile_upload:1" on server
     And I wait until file "/srv/tftpboot/images/fedora_kickstart_distro:1:SUSETest/initrd.img" exists on server
     And I wait until file "/srv/tftpboot/images/fedora_kickstart_distro:1:SUSETest/vmlinuz" exists on server
     And I wait until file "/srv/tftpboot/menu.c32" exists on server
@@ -168,7 +168,7 @@ Feature: Cobbler and distribution autoinstallation
 
   Scenario: Create a cobbler system record via API
     When I create a system record
-    And I wait until file "/srv/tftpboot/pxelinux.cfg/01-00-22-22-77-ee-cc" contains "ks=.*testserver:1" on server
+    And I wait until file "/srv/tftpboot/pxelinux.cfg/01-00-22-22-77-ee-cc" contains "inst.ks=.*testserver:1" on server
     Then the cobbler report should contain "testserver.example.com" for cobbler system name "testserver:1"
     And the cobbler report should contain "1.1.1.1" for cobbler system name "testserver:1"
     And the cobbler report should contain "00:22:22:77:ee:cc" for cobbler system name "testserver:1"

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -101,7 +101,7 @@ When(/^I trigger cobbler system record on the "([^"]*)"$/) do |host|
       And I am on the Systems overview page of this "#{host}"
       And I follow "Provisioning"
       And I click on "Create PXE installation configuration"
-      And I wait until file "/srv/tftpboot/pxelinux.cfg/01-*" contains "ks=" on server
+      And I wait until file "/srv/tftpboot/pxelinux.cfg/01-*" contains "inst.ks=" on server
     )
   end
 end


### PR DESCRIPTION
## What does this PR change?

Attempt to fix https://github.com/SUSE/spacewalk/issues/19184
With this suggestion: https://github.com/SUSE/spacewalk/issues/19184#issuecomment-1920802458

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
