### PR TITLE
Fix layout on wide content areas

### DIFF
--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -45,6 +45,7 @@ header {
   display: flex;
   flex: 1 1 auto;
   overflow: hidden;
+  max-width: 100vw;
 
   aside {
     overflow: auto !important;
@@ -133,8 +134,9 @@ section {
   margin-left: 0;
   aside {
     .make-xs-column(2);
-    min-width: max(300px, 17%);
-    max-width: min(400px, 17%);
+    width: 17%;
+    min-width: 300px;
+    max-width: 400px;
     background: @aside-background;
     border-right: none;
     /* erasing the predefined paddings in the columns */

--- a/web/html/src/branding/css/base/theme.scss
+++ b/web/html/src/branding/css/base/theme.scss
@@ -45,6 +45,7 @@ header {
   display: flex;
   flex: 1 1 auto;
   overflow: hidden;
+  max-width: 100vw;
 
   aside {
     overflow: auto !important;
@@ -132,8 +133,9 @@ section {
   margin-right: 0;
   margin-left: 0;
   aside {
-    min-width: max(300px, 17%);
-    max-width: min(400px, 17%);
+    width: 17%;
+    min-width: 300px;
+    max-width: 400px;
     background: $aside-background;
     border-right: none;
     /* erasing the predefined paddings in the columns */

--- a/web/spacewalk-web.changes.eth.master
+++ b/web/spacewalk-web.changes.eth.master
@@ -1,0 +1,1 @@
+- Fix layout on wide content areas


### PR DESCRIPTION
## What does this PR change?

The latest round of UI updates broke pages that have very wide content such as logs. This fix addresses that immediate problem, we can simplify the core layout itself after we've finished the Bootstrap upgrade.

## GUI diff

Before:

<img width="2160" alt="Screenshot 2024-03-14 at 18 24 28" src="https://github.com/uyuni-project/uyuni/assets/3171718/2ee70efb-c233-488f-85f3-99438002f5b3">


After:

<img width="2160" alt="Screenshot 2024-03-14 at 18 24 31" src="https://github.com/uyuni-project/uyuni/assets/3171718/156904b1-80fe-483c-9732-b9360f354219">


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: stylesheets

- [x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1220343

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
