### PR TITLE
Do not sync RBS for proxy product

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -946,7 +946,6 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-product-suse-manager-proxy-4.3-pool-x86_64
         sle-product-suse-manager-proxy-4.3-updates-x86_64
         sle-module-suse-manager-proxy-4.3-pool-x86_64
-        sle-module-suse-manager-proxy-4.3-pool-x86_64-smrbs
         sle-module-suse-manager-proxy-4.3-updates-x86_64
         sle-module-basesystem15-sp4-pool-x86_64-proxy-4.3
         sle-module-basesystem15-sp4-updates-x86_64-proxy-4.3


### PR DESCRIPTION
## What does this PR change?

It looks like an error of mine in commit 6b1dc87


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/23962


## Changelogs

- [x] No changelog needed
