### PR TITLE
fix matching epoch while creating ubuntu erratas

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -24,6 +24,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 /**
  * PackageDto
@@ -151,7 +152,11 @@ public class PackageDto extends BaseDto {
      * @return the epoch
      */
     public String getEpoch() {
-        return epoch;
+        // epoch may be set to single whitespace in the query
+        // we need to strip this away, but keep NULL
+        return Optional.ofNullable(epoch)
+                .map(String::trim)
+                .orElse(null);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/PackageDtoSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/PackageDtoSerializer.java
@@ -20,6 +20,8 @@ import com.suse.manager.api.ApiResponseSerializer;
 import com.suse.manager.api.SerializationBuilder;
 import com.suse.manager.api.SerializedApiResponse;
 
+import java.util.Optional;
+
 /**
  *
  * PackageSerializer
@@ -49,14 +51,9 @@ public class PackageDtoSerializer extends ApiResponseSerializer<PackageDto> {
     public SerializedApiResponse serialize(PackageDto src) {
         SerializationBuilder builder = new SerializationBuilder()
                 .add("name", src.getName())
+                .add("epoch", Optional.ofNullable(src.getEpoch()).orElse(""))
                 .add("version", src.getVersion())
-                .add("release", src.getRelease());
-
-        String epoch = src.getEpoch();
-        if (epoch == null || epoch.equals(" ")) {
-            epoch = "";
-        }
-        builder.add("epoch", epoch)
+                .add("release", src.getRelease())
                 .add("checksum", src.getChecksum())
                 .add("checksum_type", src.getChecksumType())
                 .add("id", src.getId())

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
@@ -173,8 +173,7 @@ public class PrimaryXmlWriter extends RepomdWriter {
         SimpleAttributesImpl attr = new SimpleAttributesImpl();
         attr.addAttribute("ver", sanitize(pkgId, pkgDto.getVersion()));
         attr.addAttribute("rel", sanitize(pkgId, pkgDto.getRelease()));
-        attr.addAttribute("epoch", sanitize(pkgId, getPackageEpoch(pkgDto
-                .getEpoch())));
+        attr.addAttribute("epoch", sanitize(pkgId, getPackageEpoch(pkgDto.getEpoch())));
         localHandler.startElement("version", attr);
         localHandler.endElement("version");
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RepomdWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RepomdWriter.java
@@ -114,8 +114,7 @@ public abstract class RepomdWriter {
         attr.clear();
         attr.addAttribute("ver", sanitize(pkgId, pkgDto.getVersion()));
         attr.addAttribute("rel", sanitize(pkgId, pkgDto.getRelease()));
-        attr.addAttribute("epoch", sanitize(pkgId,
-                getPackageEpoch(pkgDto.getEpoch())));
+        attr.addAttribute("epoch", sanitize(pkgId, getPackageEpoch(pkgDto.getEpoch())));
         handler.startElement("version", attr);
         handler.endElement("version");
     }

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-ubuntu-errata-epoch-matching
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-ubuntu-errata-epoch-matching
@@ -1,0 +1,1 @@
+- fix matching epoch while creating ubuntu erratas


### PR DESCRIPTION
## What does this PR change?

Our package DTOs report NULL epoch as a single whitespace.
Additionally we need to check epoch anyway different as NULL == "" == 0.
This PR trim the whitespace from epoch and simplify other places dealing with it.
Additionally it introduce a special equal function for epoch values in UbuntuErrataManager.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8134
Port(s): https://github.com/SUSE/spacewalk/pull/23970

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
