### PR TITLE
Strip whitespace from .deb package metadata (bsc#1214387)

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -318,7 +318,7 @@ class DebRepo:
             lines = chunk.split("\n")
             checksums = {}
             for line in lines:
-                pair = line.split(" ", 1)
+                pair = tuple(p.strip() for p in line.split(" ", 1))
                 if pair[0] == "Package:":
                     package.name = pair[1]
                 elif pair[0] == "Architecture:":

--- a/python/spacewalk/spacewalk-backend.changes.agraul.strip-whitespace-deb-pkg-metadata
+++ b/python/spacewalk/spacewalk-backend.changes.agraul.strip-whitespace-deb-pkg-metadata
@@ -1,0 +1,1 @@
+- Strip whitespace from .deb package metadata (bsc#1214387)


### PR DESCRIPTION
## What does this PR change?

Strip whitespace from debian package metadata

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/23981

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
