### PR TITLE
uyuni-configfiles-sync: prevent RPM scriptlets to restart services during startup

### DIFF
--- a/containers/server-image/uyuni-configfiles-sync
+++ b/containers/server-image/uyuni-configfiles-sync
@@ -224,23 +224,23 @@ run_scripts() {
         # https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#ordering
         PREIN_SCRIPT=$(rpm -q --qf "%{PREIN}" $PKG)
         if [ ! "$PREIN_SCRIPT" = "(none)" ]; then
-            echo "$PREIN_SCRIPT" | sh -s -- 2
+            echo "$PREIN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 2
         fi
         POSTIN_SCRIPT=$(rpm -q --qf "%{POSTIN}" $PKG)
         if [ ! "$POSTIN_SCRIPT" = "(none)" ]; then
-            echo "$POSTIN_SCRIPT" | sh -s -- 2
+            echo "$POSTIN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 2
         fi
         PREUN_SCRIPT=$(rpm -q --qf "%{PREUN}" $PKG)
         if [ ! "$PREUN_SCRIPT" = "(none)" ]; then
-            echo "$PREUN_SCRIPT" | sh -s -- 1
+            echo "$PREUN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 1
         fi
         POSTUN_SCRIPT=$(rpm -q --qf "%{POSTUN}" $PKG)
         if [ ! "$POSTUN_SCRIPT" = "(none)" ]; then
-            echo "$POSTUN_SCRIPT" | sh -s -- 1
+            echo "$POSTUN_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 1
         fi
         POSTTRANS_SCRIPT=$(rpm -q --qf "%{POSTTRANS}" $PKG)
         if [ ! "$POSTTRANS_SCRIPT" = "(none)" ]; then
-            echo "$POSTTRANS_SCRIPT" | sh -s -- 2
+            echo "$POSTTRANS_SCRIPT" | DISABLE_RESTART_ON_UPDATE=1 sh -s -- 2
         fi
     done
 }


### PR DESCRIPTION
## What does this PR change?

This PR makes RPM scriptlets executed by `uyuni-configfiles-sync` to simulate a package upgrade to not trigger service restart in order to prevent getting stuck while trying to restart service during startup, even before the actual service should start.

On an stuck scenario, we see this, where apparently `/usr/bin/systemctl try-restart postfix.service` is stuck:
```
root      2707  0.0  0.3  26784 15332 ?        Ss   13:11   0:00 /usr/bin/python3 /usr/sbin/uyuni-update-config
root      2716  0.0  0.1   9708  4088 ?        S    13:11   0:00  \_ /bin/bash /usr/bin/uyuni-configfiles-sync sync
root      6974  0.0  0.0   9336  3472 ?        S    13:12   0:00      \_ sh -s -- 1
root      6997  0.0  0.0   9336  2008 ?        S    13:12   0:00          \_ sh -s -- 1
root      6998  0.0  0.1  29020  7768 ?        S    13:12   0:00              \_ /usr/bin/systemctl try-restart postfix.service
```

The RPM scriptlet execution done by `uyuni-configfiles-sync` shouldn't be triggering any restart of services at this point, as `uyuni-configfiles-sync` is actually expected at the begining of the initialization stack, before other services are started by systemd.

This issue is currently affecting our sumaform deployments for the containerized server.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
