### PR TITLE
distinguish between different SUSE versions when detecting if a reboot is needed

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/reboot_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/reboot_info.py
@@ -43,8 +43,10 @@ def reboot_required():
     elif __grains__["os_family"] == "Debian":
         result = os.path.exists("/var/run/reboot-required")
     elif __grains__["os_family"] == "Suse":
-        result = os.path.exists("/run/reboot-needed") or os.path.exists(
-            "/boot/do_purge_kernels"
+        result = (
+            os.path.exists("/run/reboot-needed")
+            if __grains__["osmajorrelease"] >= 12
+            else os.path.exists("/boot/do_purge_kernels")
         )
     elif __grains__["os_family"] == "RedHat":
         cmd = (

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_reboot_info.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_reboot_info.py
@@ -44,11 +44,17 @@ def test_reboot_required_debian(file_exists, result):
 
 
 @pytest.mark.parametrize(
-    "file_exists, result",
-    [(True, True), (False, False)],
+    "os_major_release, file_exists, result",
+    [
+        (15, True, True),
+        (15, False, False),
+        (11, True, True),
+        (11, False, False),
+    ],
 )
-def test_reboot_required_suse(file_exists, result):
+def test_reboot_required_suse(os_major_release, file_exists, result):
     reboot_info.__grains__["os_family"] = "Suse"
+    reboot_info.__grains__["osmajorrelease"] = os_major_release
     with patch("os.path.exists", return_value=file_exists):
         assert reboot_info.reboot_required()["reboot_required"] == result
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.fix-reboot-required-detection
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.fix-reboot-required-detection
@@ -1,0 +1,2 @@
+- distinguish between different SUSE versions when detecting if a
+  reboot is needed (bsc#1220903, bsc#1221571)


### PR DESCRIPTION
## What does this PR change?

When detecting if a reboot is needed on a SUSE system, check only on SLES11 for the `do_purge_kernels` file.
Since SLES 12 we have `reboot-needed` and this should be used exclusivly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23984
Port(s): https://github.com/SUSE/spacewalk/pull/23986

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
