### PR TITLE
Remove package sync not available message

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -25127,12 +25127,6 @@ given channel.</source>
 &lt;/p&gt;
         </source>
       </trans-unit>
-      <trans-unit id="compare.jsp.noprovisioning" xml:space="preserve">
-        <source>Syncing the packages to the list above is not available for this system.</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">NOTFILLEDOUT</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="activation-key.jsp.config-auto-deploy-highstate-tooltip" xml:space="preserve">
         <source>If the system is registered via Salt, the highstate will be executed on registration if this checkbox is selected.</source>
       </trans-unit>

--- a/java/code/webapp/WEB-INF/pages/systems/details/packages/profiles/compareprofiles.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/details/packages/profiles/compareprofiles.jsp
@@ -68,14 +68,6 @@
                         value="<bean:message key="compare.jsp.syncpackageto" arg0="${fn:escapeXml(requestScope.profilename)}"/>" />
                 </div>
             </rhn:require>
-
-            <rhn:require acl="not system_feature(ftr_delta_action)"
-                mixins="com.redhat.rhn.common.security.acl.SystemAclHandler">
-                <div align="left">
-                    <hr />
-                    <strong><bean:message key="compare.jsp.noprovisioning" /></strong>
-                </div>
-            </rhn:require>
         </c:if>
 
         <html:hidden property="sid" value="${param.sid}" />

--- a/java/spacewalk-java.changes.parlt.remove-package-sync-not-available-msg
+++ b/java/spacewalk-java.changes.parlt.remove-package-sync-not-available-msg
@@ -1,0 +1,2 @@
+- Remove package sync not available message in Software > Packages > Profile 
+  since it's no longer available for supported clients (bsc1221279)


### PR DESCRIPTION
## What does this PR change?

Remove the `"When comparing a client to a stored profile, the message "Syncing the packages to the list above is not available for this system."` message from System > Software > Packages > Profile to not confuse users that it might be available under certain circumstances. Traditional clients are no longer supported and the feature wasn't implemented to work with salt clients.

Leave the rest of the code intact for now since we might want to bring it back for salt clients in the future.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/2879)

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23915

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
