### PR TITLE
drop system password as identifier on scc system registration

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductSet.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductSet.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.domain.product;
 
+import static com.suse.utils.Predicates.isAbsent;
+
 import com.redhat.rhn.common.util.RpmVersionComparator;
 import com.redhat.rhn.domain.server.InstalledProduct;
 
@@ -129,16 +131,14 @@ public class SUSEProductSet {
      * @param addonProduct the addonProduct to add
      */
     public void addAddonProduct(SUSEProduct addonProduct) {
-        if (addonProducts == null) {
-            addonProducts = new ArrayList<>();
+        if (addonProduct == null) {
+            return;
         }
-        if (addonProduct != null) {
-            if (PRODUCTNAME_BLACKLIST.contains(addonProduct.getName()) &&
-                    new RpmVersionComparator().compare(addonProduct.getVersion(), "15") < 0) {
-                return;
-            }
-            addonProducts.add(addonProduct);
+        if (PRODUCTNAME_BLACKLIST.contains(addonProduct.getName()) &&
+                new RpmVersionComparator().compare(addonProduct.getVersion(), "15") < 0) {
+            return;
         }
+        addonProducts.add(addonProduct);
     }
 
     /**
@@ -146,7 +146,7 @@ public class SUSEProductSet {
      * @return true if there is no products.
      */
     public boolean isEmpty() {
-        return baseProduct == null && addonProducts.isEmpty();
+        return baseProduct == null && isAbsent(addonProducts);
     }
 
     /**

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014--2021 SUSE LLC
+ * Copyright (c) 2014--2024 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -308,7 +308,7 @@ public class SCCWebClient implements SCCClient {
 
         LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/systems");
         if (LOG.isDebugEnabled()) {
-            LOG.debug(gson.toJson(payload));
+            LOG.debug("Request body: {}", gson.toJson(payload));
         }
 
         try {
@@ -316,8 +316,12 @@ public class SCCWebClient implements SCCClient {
             HttpResponse response = httpClient.executeRequest(request, username, password);
 
             int responseCode = response.getStatusLine().getStatusCode();
+            String responseBody = EntityUtils.toString(response.getEntity());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Response code: {}", responseCode);
+                LOG.debug("Response body: {}", responseBody);
+            }
             if (responseCode == HttpStatus.SC_CREATED) {
-                String responseBody = EntityUtils.toString(response.getEntity());
                 return gson.fromJson(responseBody, SCCOrganizationSystemsUpdateResponse.class);
             }
             else {

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationContext.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 SUSE LLC
+ * Copyright (c) 2023--2024 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -18,7 +18,6 @@ package com.suse.scc.registration;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 
-import com.suse.scc.SCCSystemId;
 import com.suse.scc.client.SCCClient;
 import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
@@ -34,8 +33,8 @@ public class SCCSystemRegistrationContext {
     private final List<SCCRegCacheItem> items;
     private final SCCCredentials primaryCredential;
 
-    private final Map<SCCSystemId, SCCRegCacheItem> itemsBySccSystemId;
-    private final Map<SCCSystemId, SCCRegisterSystemJson> pendingRegistrationSystems;
+    private final Map<String, SCCRegCacheItem> itemsByLogin;
+    private final Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin;
 
     private final List<SCCRegCacheItem> paygSystems;
 
@@ -56,8 +55,8 @@ public class SCCSystemRegistrationContext {
         this.items = itemsIn;
         this.primaryCredential = primaryCredentialIn;
 
-        this.itemsBySccSystemId = new HashMap<>();
-        this.pendingRegistrationSystems = new HashMap<>();
+        this.itemsByLogin = new HashMap<>();
+        this.pendingRegistrationSystemsByLogin = new HashMap<>();
         this.registeredSystems = new ArrayList<>();
         this.paygSystems = new ArrayList<>();
     }
@@ -74,12 +73,12 @@ public class SCCSystemRegistrationContext {
         return primaryCredential;
     }
 
-    public Map<SCCSystemId, SCCRegCacheItem> getItemsBySccSystemId() {
-        return itemsBySccSystemId;
+    public Map<String, SCCRegCacheItem> getItemsByLogin() {
+        return itemsByLogin;
     }
 
-    public Map<SCCSystemId, SCCRegisterSystemJson> getPendingRegistrationSystems() {
-        return pendingRegistrationSystems;
+    public Map<String, SCCRegisterSystemJson> getPendingRegistrationSystemsByLogin() {
+        return pendingRegistrationSystemsByLogin;
     }
 
     public List<SCCSystemCredentialsJson> getRegisteredSystems() {

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationCreateUpdateSystems.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationCreateUpdateSystems.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 SUSE LLC
+ * Copyright (c) 2023--2024 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -31,7 +31,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * This class is responsible for creating and executing the batch requests in SCC.
+ * This class is responsible for the registration process of the systems in SCC.
+ * It splits the systems into batches. Each batch is included in the body of a rest call is executed to the SCC API.
+ * A successful call returns a set of @{link SCCSystemCredentialsJson} objects.
  */
 public class SCCSystemRegistrationCreateUpdateSystems implements SCCSystemRegistrationContextHandler {
     private static final Logger LOG = LogManager.getLogger(SCCSystemRegistrationCreateUpdateSystems.class);
@@ -40,7 +42,7 @@ public class SCCSystemRegistrationCreateUpdateSystems implements SCCSystemRegist
     public void handle(SCCSystemRegistrationContext context) {
         final int batchSize = Config.get().getInt(ConfigDefaults.REG_BATCH_SIZE, 50);
         final List<SCCRegisterSystemJson> pendingRegistrationSystems =
-                new ArrayList<>(context.getPendingRegistrationSystems().values());
+                new ArrayList<>(context.getPendingRegistrationSystemsByLogin().values());
 
         // split items into batches
         List<List<SCCRegisterSystemJson>> systemsBatches = splitListIntoBatches(pendingRegistrationSystems, batchSize);

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
@@ -25,26 +25,26 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 
-import com.suse.scc.SCCSystemId;
 import com.suse.scc.model.SCCHwInfoJson;
 import com.suse.scc.model.SCCMinProductJson;
 import com.suse.scc.model.SCCRegisterSystemJson;
-import com.suse.utils.Opt;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.security.SecureRandom;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * This object goal is to filter the cached items that require registration and build their own payload entry for the
- * SCC rest call.
+ * This class represents the first step in the registration process for SCC systems.
+ * It is responsible for collecting SCC registration cached items that require registration and  sets up auxiliary
+ * structures for subsequent steps.
+ * In SCC, systems items are identified by their login credentials.
  */
 public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegistrationContextHandler {
     private static final Logger LOG = LogManager.getLogger(SCCSystemRegistrationSystemDataAcquisitor.class);
@@ -55,9 +55,8 @@ public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegis
             if (isSccRegistrationRequired(cacheItem)) {
                 LOG.debug("Forward registration of {}", cacheItem);
                 getPayload(cacheItem).ifPresent(payload -> {
-                    SCCSystemId sccSystemId = new SCCSystemId(payload.getLogin(), payload.getPassword());
-                    context.getItemsBySccSystemId().put(sccSystemId, cacheItem);
-                    context.getPendingRegistrationSystems().put(sccSystemId, payload);
+                    context.getItemsByLogin().put(payload.getLogin(), cacheItem);
+                    context.getPendingRegistrationSystemsByLogin().put(payload.getLogin(), payload);
                 });
             }
             else {
@@ -79,15 +78,15 @@ public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegis
 
     private Optional<SCCRegisterSystemJson> getPayload(SCCRegCacheItem rci) {
         return rci.getOptServer().map(srv -> {
-            List<SCCMinProductJson> products = Opt.fold(srv.getInstalledProductSet(),
-                            (Supplier<List<SUSEProduct>>) LinkedList::new,
-                            s -> {
-                                List<SUSEProduct> prd = new LinkedList<>();
-                                prd.add(s.getBaseProduct());
-                                prd.addAll(s.getAddonProducts());
-                                return prd;
-                            }
-                    ).stream()
+            List<SCCMinProductJson> products = srv.getInstalledProductSet().stream()
+                    .flatMap(product -> {
+                        Stream<SUSEProduct> productsStream = Stream.of(product.getBaseProduct());
+                        if (product.getAddonProducts() != null) {
+                            productsStream = Stream.concat(productsStream, product.getAddonProducts().stream());
+                        }
+                        return productsStream;
+                    })
+                    .filter(Objects::nonNull)
                     .map(SCCMinProductJson::new)
                     .collect(Collectors.toList());
 

--- a/java/code/src/com/suse/scc/test/registration/AbstractSCCSystemRegistrationTest.java
+++ b/java/code/src/com/suse/scc/test/registration/AbstractSCCSystemRegistrationTest.java
@@ -39,8 +39,9 @@ public class AbstractSCCSystemRegistrationTest extends BaseTestCaseWithUser {
 
     /**
      * Sets up systems for testing purposes.
-     * @param systemSize    number of systems to create
-     * @param paygSystemSize    number of aditional payg systems to create
+     *
+     * @param systemSize     number of systems to create
+     * @param paygSystemSize number of aditional payg systems to create
      * @throws Exception if createTestSystem fails
      */
     protected void setupSystems(int systemSize, int paygSystemSize) throws Exception {

--- a/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationCreateUpdateSystemsTest.java
+++ b/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationCreateUpdateSystemsTest.java
@@ -16,7 +16,6 @@ package com.suse.scc.test.registration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.suse.scc.SCCSystemId;
 import com.suse.scc.client.SCCClientException;
 import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCWebClient;
@@ -171,8 +170,8 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         final SCCSystemRegistrationContext context =
                 new SCCSystemRegistrationContext(sccWebClient, null, getCredentials());
         for (int i = 0; i < systemSize; i++) {
-            context.getPendingRegistrationSystems().put(
-                    new SCCSystemId("SCCSystemId.login" + i, "SCCSystemId.pwd" + i),
+            context.getPendingRegistrationSystemsByLogin().put(
+                    "SCCSystemId.login" + i,
                     new SCCRegisterSystemJson(
                             "SCCRegisterSystemJson.login" + i, "SCCRegisterSystemJson.pwd" + i,
                             null, null, null, null)

--- a/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationUpdateCachedItemsTest.java
+++ b/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationUpdateCachedItemsTest.java
@@ -24,7 +24,6 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
-import com.suse.scc.SCCSystemId;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.registration.SCCSystemRegistrationContext;
 import com.suse.scc.registration.SCCSystemRegistrationUpdateCachedItems;
@@ -78,7 +77,7 @@ public class SCCSystemRegistrationUpdateCachedItemsTest extends BaseTestCaseWith
         // pre-conditions
         assertEquals(0, context.getItems().size());
         assertEquals(0, context.getRegisteredSystems().size());
-        assertEquals(0, context.getPendingRegistrationSystems().size());
+        assertEquals(0, context.getPendingRegistrationSystemsByLogin().size());
         assertEquals(0, context.getPaygSystems().size());
 
         // execution
@@ -87,7 +86,7 @@ public class SCCSystemRegistrationUpdateCachedItemsTest extends BaseTestCaseWith
         // assertions
         assertEquals(0, context.getItems().size());
         assertEquals(0, context.getRegisteredSystems().size());
-        assertEquals(0, context.getPendingRegistrationSystems().size());
+        assertEquals(0, context.getPendingRegistrationSystemsByLogin().size());
         assertEquals(0, context.getPaygSystems().size());
     }
 
@@ -98,10 +97,10 @@ public class SCCSystemRegistrationUpdateCachedItemsTest extends BaseTestCaseWith
      *      - after, the 7 systems will still be in context.getRegisteredSystems() but there will be 7 items having a
      *      SccId;
      * - 7 failed to register;
-     *      - before there are 14 systems in context.getPendingRegistrationSystems() & there will be no items having a
-     *      registration error time;
-     *      - after, 7 systems will remain in context.getPendingRegistrationSystems() but there will be 7 items having a
-     *      registration error time;
+     *      - before there are 14 systems in context.getPendingRegistrationSystemsByLogin() & there will be no items
+     *      having a registration error time;
+     *      - after, 7 systems will remain in context.getPendingRegistrationSystemsByLogin() but there will be 7 items
+     *      having a registration error time;
      * - 7 are PAYG systems;
      *      - before the 7 systems will be in context.getPaygSystems() & all 21 systems are marked as requiring
      *      registration;
@@ -114,11 +113,11 @@ public class SCCSystemRegistrationUpdateCachedItemsTest extends BaseTestCaseWith
         this.setupSystems(21);
         final SCCSystemRegistrationContext context = new SCCSystemRegistrationContext(null, testSystems, null);
         for (int i = 0; i < 14; i++) {
-            SCCSystemId sccSystemId = new SCCSystemId("login" + i, "password" + i);
-            SCCSystemCredentialsJson sccSystemCredentialsJson = new SCCSystemCredentialsJson(sccSystemId.getLogin(),
-                    sccSystemId.getPassword(), Long.valueOf(i));
-            context.getItemsBySccSystemId().put(sccSystemId, testSystems.get(i));
-            context.getPendingRegistrationSystems().put(sccSystemId, null);
+            String login = "login" + i;
+            SCCSystemCredentialsJson sccSystemCredentialsJson = new SCCSystemCredentialsJson(login, login +
+                    "_password", Long.valueOf(i));
+            context.getItemsByLogin().put(login, testSystems.get(i));
+            context.getPendingRegistrationSystemsByLogin().put(login, null);
             if (i < 7) {
                 context.getRegisteredSystems().add(sccSystemCredentialsJson);
             }
@@ -132,7 +131,7 @@ public class SCCSystemRegistrationUpdateCachedItemsTest extends BaseTestCaseWith
         assertEquals(7, context.getRegisteredSystems().size());
         assertEquals(0, context.getItems().stream().filter(p -> p.getOptSccId().isPresent()).count());
 
-        assertEquals(14, context.getPendingRegistrationSystems().size());
+        assertEquals(14, context.getPendingRegistrationSystemsByLogin().size());
         assertEquals(0, context.getItems().stream().filter(p -> p.getOptRegistrationErrorTime().isPresent()).count());
 
 
@@ -148,7 +147,7 @@ public class SCCSystemRegistrationUpdateCachedItemsTest extends BaseTestCaseWith
         assertEquals(7, context.getRegisteredSystems().size());
         assertEquals(7, context.getItems().stream().filter(p -> p.getOptSccId().isPresent()).count());
 
-        assertEquals(7, context.getPendingRegistrationSystems().size());
+        assertEquals(7, context.getPendingRegistrationSystemsByLogin().size());
         assertEquals(7, context.getItems().stream().filter(p -> p.getOptRegistrationErrorTime().isPresent()).count());
 
         assertEquals(7, context.getPaygSystems().size());

--- a/java/spacewalk-java.changes.rjpmestre.bsc1219634.bsc1221182
+++ b/java/spacewalk-java.changes.rjpmestre.bsc1219634.bsc1221182
@@ -1,0 +1,1 @@
+- drop system password as identifier on scc system registration (bsc#1219634, bsc#1221182)


### PR DESCRIPTION
## What does this PR change?

Both login and password are required by SCC for system registration. However, only the 'login' field is relevant for matching previously registered systems next to SCC. This commit removes the reliance on the 'password' field as an identifier for SCC register cached items.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered (updated)

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23649

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
