### PR TITLE
reschedule failed ssh actions caused by a connection error due to a scheduled reboot

### DIFF
--- a/java/spacewalk-java.changes.mc.Manager-4.3-reschedule-ssh-actions-after-reboot
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-reschedule-ssh-actions-after-reboot
@@ -1,0 +1,2 @@
+- reschedule failed ssh actions caused by a connection error due
+  to a scheduled reboot


### PR DESCRIPTION
## What does this PR change?

When a state.apply contains a reboot and the minion is managed via salt-ssh using an unprivileged user, ssh return
` System is going down. Unprivileged users are not permitted to log in anymore. ...`
This cause a problem when a package list refresh should happen after a system update.

This PR detect this case and reschedule the action 3 Minutes later, by reducing the "remaining tries" counter.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/23980

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
