### PR TITLE
Fix host identifier

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
@@ -48,11 +48,11 @@ import java.util.Set;
  */
 public class VirtualHostManagerProcessor {
 
+    private static final Logger LOGGER = LogManager.getLogger(VirtualHostManagerProcessor.class);
     private final VirtualHostManager virtualHostManager;
     private final Map<String, HostJson> virtualHosts;
     private Set<Server> serversToDelete;
     private Set<VirtualHostManagerNodeInfo> nodesToDelete;
-    private Logger log;
     private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     /**
@@ -62,9 +62,7 @@ public class VirtualHostManagerProcessor {
      * @param managerIn the virtual host manager
      * @param virtualHostsIn the virtual hosts information from JSON
      */
-    public VirtualHostManagerProcessor(VirtualHostManager managerIn,
-            Map<String, HostJson> virtualHostsIn) {
-        this.log = LogManager.getLogger(VirtualHostManagerProcessor.class);
+    public VirtualHostManagerProcessor(VirtualHostManager managerIn, Map<String, HostJson> virtualHostsIn) {
         this.virtualHostManager = managerIn;
         this.virtualHosts = virtualHostsIn;
         this.serversToDelete = new HashSet<>();
@@ -79,24 +77,24 @@ public class VirtualHostManagerProcessor {
      * mapping.
      */
     public void processMapping() {
-        log.debug("Processing Virtual Host Manager: {}", virtualHostManager);
+        LOGGER.debug("Processing Virtual Host Manager: {}", virtualHostManager);
         if (virtualHosts == null) {
-            log.error("Virtual Host Manager {}: Please check the virtual-host-gatherer logfile.",
+            LOGGER.error("Virtual Host Manager {}: Please check the virtual-host-gatherer logfile.",
                     virtualHostManager.getLabel());
             return;
         }
         serversToDelete.addAll(virtualHostManager.getServers());
         nodesToDelete.addAll(virtualHostManager.getNodes());
         virtualHosts.forEach((key, value) -> {
-            log.debug("Processing host: {}", key);
+            LOGGER.debug("Processing host: {}", key);
             processVirtualHost(key, value);
         });
         serversToDelete.forEach(srv -> {
-            log.debug("Removing link to virtual host: {}", srv.getName());
+            LOGGER.debug("Removing link to virtual host: {}", srv.getName());
             virtualHostManager.removeServer(srv);
         });
         nodesToDelete.forEach(node -> {
-            log.debug("Removing virtual host node: {}", node.getName());
+            LOGGER.debug("Removing virtual host node: {}", node.getName());
             virtualHostManager.removeNode(node);
         });
     }
@@ -178,7 +176,7 @@ public class VirtualHostManagerProcessor {
                 VirtualInstanceFactory.getInstance().getVirtualInstanceType(candidate);
         if (type == null) { // fallback
             type = VirtualInstanceFactory.getInstance().getFullyVirtType();
-            log.warn("Can't find virtual instance type for string '{}'. Defaulting to '{}'", candidate, type);
+            LOGGER.warn("Can't find virtual instance type for string '{}'. Defaulting to '{}'", candidate, type);
         }
         return type;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
@@ -51,9 +51,9 @@ public class VirtualHostManagerProcessor {
     private static final Logger LOGGER = LogManager.getLogger(VirtualHostManagerProcessor.class);
     private final VirtualHostManager virtualHostManager;
     private final Map<String, HostJson> virtualHosts;
-    private Set<Server> serversToDelete;
-    private Set<VirtualHostManagerNodeInfo> nodesToDelete;
-    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    private final Set<Server> serversToDelete;
+    private final Set<VirtualHostManagerNodeInfo> nodesToDelete;
+    private final SystemEntitlementManager systemEntitlementManager;
 
     /**
      * Instantiates a new virtual host manager processor, will update a virtual
@@ -67,6 +67,7 @@ public class VirtualHostManagerProcessor {
         this.virtualHosts = virtualHostsIn;
         this.serversToDelete = new HashSet<>();
         this.nodesToDelete = new HashSet<>();
+        this.systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     }
 
     /**

--- a/java/code/src/com/suse/manager/gatherer/GathererRunner.java
+++ b/java/code/src/com/suse/manager/gatherer/GathererRunner.java
@@ -50,7 +50,7 @@ public class GathererRunner {
     /**
      * Logger for this class
      */
-    private static Logger logger = LogManager.getLogger(GathererRunner.class);
+    private static final Logger LOGGER = LogManager.getLogger(GathererRunner.class);
 
     /**
      * Call gatherer --list-modules and return the result
@@ -66,7 +66,7 @@ public class GathererRunner {
 
         int exitcode = e.execute(args.toArray(new String[0]));
         if (exitcode != 0) {
-            logger.error(e.getLastCommandErrorMessage());
+            LOGGER.error(e.getLastCommandErrorMessage());
             return null;
         }
         return new GathererJsonIO().readGathererModules(e.getLastCommandOutput());
@@ -105,10 +105,10 @@ public class GathererRunner {
                 String uri = builder.build().toString();
                 env.put("http_proxy", uri);
                 env.put("https_proxy", uri);
-                logger.debug("Set http(s)_proxy to {}", uri);
+                LOGGER.debug("Set http(s)_proxy to {}", uri);
             }
             catch (URISyntaxException e) {
-                logger.error("URI syntax exception when setting Proxy: {}", e.getMessage());
+                LOGGER.error("URI syntax exception when setting Proxy: {}", e.getMessage());
             }
         }
         int debuglevel = Config.get().getInt("debug", 0);
@@ -121,7 +121,7 @@ public class GathererRunner {
         String noProxy = Config.get().getString(HttpClientAdapter.NO_PROXY);
         if (!StringUtils.isEmpty(noProxy)) {
             env.put("no_proxy", noProxy);
-            logger.debug("Set no_proxy to {}", noProxy);
+            LOGGER.debug("Set no_proxy to {}", noProxy);
         }
 
         String[] envp = new String[env.size()];
@@ -149,7 +149,7 @@ public class GathererRunner {
                     }
                 }
                 catch (Exception e) {
-                    logger.error("Error reading stderr from external process", e);
+                    LOGGER.error("Error reading stderr from external process", e);
                 }
             });
             errStreamReader.start();
@@ -167,17 +167,17 @@ public class GathererRunner {
 
             int exitCode = p.waitFor();
             if (exitCode != 0) {
-                logger.error("Error while calling the virtual-host-gatherer, exit code {}", exitCode);
-                logger.error("Please check the virtual-host-gatherer logfile.");
+                LOGGER.error("Error while calling the virtual-host-gatherer, exit code {}", exitCode);
+                LOGGER.error("Please check the virtual-host-gatherer logfile.");
                 return null;
             }
         }
         catch (IOException ioe) {
-            logger.error("execute(String[])", ioe);
+            LOGGER.error("execute(String[])", ioe);
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            logger.error("execute(String[])", e);
+            LOGGER.error("execute(String[])", e);
         }
         return hosts;
     }

--- a/java/code/src/com/suse/manager/gatherer/HostJson.java
+++ b/java/code/src/com/suse/manager/gatherer/HostJson.java
@@ -31,6 +31,12 @@ public class HostJson {
     /** Host Identifier. */
     private String hostIdentifier;
 
+    /**
+     * For VMWare we had to change the value for the host identifier. This fields contains the value previously used,
+     * to allow the code to match and update the value.
+     */
+    private String fallbackHostIdentifier;
+
     /** Total CPU socket count. */
     private Integer totalCpuSockets;
 
@@ -84,6 +90,14 @@ public class HostJson {
      */
     public String getHostIdentifier() {
         return hostIdentifier;
+    }
+
+    /**
+     * Gets the fallback host identifier
+     * @return the fallback host identifier
+     */
+    public String getFallbackHostIdentifier() {
+        return fallbackHostIdentifier;
     }
 
     /**
@@ -206,6 +220,14 @@ public class HostJson {
      */
     public void setHostIdentifier(String hostIdentifierIn) {
         this.hostIdentifier = hostIdentifierIn;
+    }
+
+    /**
+     * Sets the fallback host identifier.
+     * @param hostUuidIn the fallback host identifier
+     */
+    public void setFallbackHostIdentifier(String hostUuidIn) {
+        this.fallbackHostIdentifier = hostUuidIn;
     }
 
     /**

--- a/java/spacewalk-java.changes.mackdk.fix-host-identifier
+++ b/java/spacewalk-java.changes.mackdk.fix-host-identifier
@@ -1,0 +1,2 @@
+- Improve handling of virtual-host-gather host identifier from a 
+  VMWare virtualization host (bsc#1218724)


### PR DESCRIPTION
## What does this PR change?

This PR handles the change of host identifier in virtual-host-gatherer when dealing with VMWare hosts. This is needed because the current field is not reliable when dealing with an update of the VMWare OS.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23401
Port(s): https://github.com/SUSE/spacewalk/pull/24001
Related change: https://github.com/uyuni-project/virtual-host-gatherer/pull/37


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
