### PR TITLE
Move latest as the latest buildtag in pushed containers

### DIFF
--- a/rel-eng/container_push.sh
+++ b/rel-eng/container_push.sh
@@ -62,7 +62,7 @@ if [ -f "${SRPM_PKG_DIR}/Dockerfile" ]; then
 
   sed "/^ARG REFERENCE_PREFIX=.*$/aARG PRODUCT_VERSION=\"${PRODUCT_VERSION}\"" -i ${SRPM_PKG_DIR}/Dockerfile
   # Add version from rhn_web on top of version from tito to have a continuity with already relased versions
-  sed "/^#\!BuildTag:/s/$/ ${NAME}:${PRODUCT_VERSION} ${NAME}:${PRODUCT_VERSION}.%RELEASE%/" -i ${SRPM_PKG_DIR}/Dockerfile
+  sed "/^#\!BuildTag:/s/BuildTag:/BuildTag: ${NAME}:${PRODUCT_VERSION} ${NAME}:${PRODUCT_VERSION}.%RELEASE%/" -i ${SRPM_PKG_DIR}/Dockerfile
 
   rm ${SRPM_PKG_DIR}/${PKG_NAME}.spec
 fi


### PR DESCRIPTION
## What does this PR change?

The first tag is the only one that podman load will load for RPM contained images. In order to know which image is installed we need the one with the version first.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
