### PR TITLE
Update `uyuni_roster_config` generation (`cobbler.host` -> `java.hostname`)

### DIFF
--- a/spacewalk/admin/salt-secrets-config.py
+++ b/spacewalk/admin/salt-secrets-config.py
@@ -76,11 +76,11 @@ with cfg_component("web") as CFG:
             }
         )
 
-with redirect_stderr(io.StringIO()) as f, cfg_component("cobbler") as CFG:
+with redirect_stderr(io.StringIO()) as f, cfg_component("java") as CFG:
     try:
         uyuni_roster_config.update(
             {
-                "host": CFG.HOST,
+                "host": CFG.HOSTNAME,
             }
         )
     except AttributeError:

--- a/spacewalk/admin/spacewalk-admin.changes.agraul.use-java-hostname-uyuni-roster
+++ b/spacewalk/admin/spacewalk-admin.changes.agraul.use-java-hostname-uyuni-roster
@@ -1,0 +1,1 @@
+- Use java.hostname for uyuni roster configuration

--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -217,7 +217,7 @@ if [[ $REPO_HOST == "localhost" ]] && command -v selinuxenabled && selinuxenable
     if ! selinux_policy_loaded; then
         echo "(portcon tcp ${REPO_PORT} (system_u object_r ssh_port_t ((s0)(s0))))" >$SELINUX_POLICY_FILENAME
         if ! semodule -i $SELINUX_POLICY_FILENAME; then
-            exit_with_message_code "Error: Failed to install SELinux policy." 7
+            exit_with_message_code "Error: Failed to install SELinux policy with port=${REPO_PORT}." 7
         fi
     fi
 fi


### PR DESCRIPTION
## What does this PR change?
Follow up of https://github.com/uyuni-project/uyuni/pull/8462: also use `java.hostname` to generate `uyuni_roster_config` 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered
This bug was discovered via https://ci.suse.de/view/Manager/view/Manager-Test/job/manager-TEST-Hexagon-acceptance-tests/1257/testReport/, ssh-push-tunnel failed because of the wrong hostname.

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
