### PR TITLE
Add ids on the bootstrap errors modal textareas

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -37,7 +37,7 @@ Feature: Negative tests for bootstrapping normal minions
     When I click on "Details"
     And I wait at most 10 seconds until I see modal containing "Error Details" text
     Then I should see a "Standard Error" text
-    And I should see "Could not resolve hostname not-existing-name: Name or service not known" in the textarea
+    And I should see "Could not resolve hostname not-existing-name: Name or service not known" in the stderr textarea
     When I close the modal dialog
 
   Scenario: Bootstrap a SLES minion with wrong SSH credentials
@@ -53,7 +53,7 @@ Feature: Negative tests for bootstrapping normal minions
     When I click on "Details"
     And I wait at most 10 seconds until I see modal containing "Error Details" text
     Then I should see a "Standard Error" text
-    And I should see "Permission denied (publickey,keyboard-interactive)." or "Password authentication failed" in the textarea
+    And I should see "Permission denied (publickey" or "Password authentication failed" in the stderr textarea
     When I close the modal dialog
 
   Scenario: Bootstrap a SLES minion with wrong SSH port number
@@ -69,5 +69,5 @@ Feature: Negative tests for bootstrapping normal minions
     When I click on "Details"
     And I wait at most 10 seconds until I see modal containing "Error Details" text
     Then I should see a "Standard Error" text
-    And I should see "port 11: Connection refused" or "port 11: Invalid argument" in the textarea
+    And I should see "port 11: Connection refused" or "port 11: Network is unreachable" in the stderr textarea
     When I close the modal dialog

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -41,7 +41,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
     When I click on "Details"
     And I wait at most 10 seconds until I see modal containing "Error Details" text
     Then I should see a "Standard Error" text
-    And I should see "Permission denied, no authentication information" in the textarea
+    And I should see "Permission denied, no authentication information" or "Permission denied (publickey,password,keyboard-interactive)" in the stderr textarea
     When I close the modal dialog
 
   Scenario: Bootstrap a SLES minion using SSH key

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -612,14 +612,14 @@ end
 #
 # Test for text in a snippet textarea
 #
-Then(/^I should see "([^"]*)" in the textarea$/) do |text|
-  within('textarea') do
+Then(/^I should see "([^"]*)" in the ([^ ]+) textarea$/) do |text, id|
+  within(:xpath, ".//textarea[@data-testid='#{id}']") do
     raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
   end
 end
 
-Then(/^I should see "([^"]*)" or "([^"]*)" in the textarea$/) do |text1, text2|
-  within('textarea') do
+Then(/^I should see "([^"]*)" or "([^"]*)" in the ([^ ]+) textarea$/) do |text1, text2, id|
+  within(:xpath, ".//textarea[@data-testid='#{id}']") do
     raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
   end
 end

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -47,19 +47,40 @@ class ErrorDetailsDialog extends React.Component<ErrorDetailsDialogProps> {
           {this.props.error.standardOutput && (
             <div className="form-group">
               <label className="control-label">Standard Output:</label>
-              <textarea readOnly disabled className="form-control" value={this.props.error.standardOutput} rows={5} />
+              <textarea
+                readOnly
+                disabled
+                className="form-control"
+                data-testid="stdout"
+                value={this.props.error.standardOutput}
+                rows={5}
+              />
             </div>
           )}
           {this.props.error.standardError && (
             <div className="form-group">
               <label className="control-label">Standard Error:</label>
-              <textarea readOnly disabled className="form-control" value={this.props.error.standardError} rows={5} />
+              <textarea
+                readOnly
+                disabled
+                className="form-control"
+                data-testid="stderr"
+                value={this.props.error.standardError}
+                rows={5}
+              />
             </div>
           )}
           {this.props.error.result && (
             <div className="form-group">
               <label className="control-label">Result:</label>
-              <textarea readOnly disabled className="form-control" value={this.props.error.result} rows={5} />
+              <textarea
+                readOnly
+                disabled
+                className="form-control"
+                data-testid="result"
+                value={this.props.error.result}
+                rows={5}
+              />
             </div>
           )}
         </>


### PR DESCRIPTION
## What does this PR change?

In order to disambiguate which textarea to look for in the testsuite we need to add ids and use them in the tests.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- Cucumber tests were fixed

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
