### PR TITLE
Revert tbz images support because it clash with bundle builds.

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/kiwi_info.py
@@ -198,7 +198,6 @@ _compression_types = [
     {"suffix": ".gz", "compression": "gzip"},
     {"suffix": ".bz", "compression": "bzip"},
     {"suffix": ".xz", "compression": "xz"},
-    {"suffix": ".tar.xz", "compression": "xz"},
     {"suffix": ".install.iso", "compression": None},
     {"suffix": ".iso", "compression": None},
     {"suffix": ".qcow2", "compression": None},

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.oholecek.add_squash_fs
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.oholecek.add_squash_fs
@@ -1,1 +1,1 @@
-- Recognize squashfs and tbz build results from kiwi (bsc#1216085)
+- Recognize squashfs build results from kiwi (bsc#1216085)


### PR DESCRIPTION
## What does this PR change?

Bundle builds create`.tar.xz` files as well for other file formats, so we need to come up with different matching method.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: revert

- [X] **DONE**

## Test coverage
- No tests: revert, caught by integration tests

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
