### PR TITLE
Add Ubuntu 24.04

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -166,9 +166,13 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     @Override
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
-                isRedHat6() || isRedHat7() || isRedHat8() || isRedHat9() || isAlibaba2() || isAmazon2() ||
-                isAmazon2023() || isRocky8() || isRocky9() || isDebian12() || isDebian11() || isDebian10();
+        return isSLES12() || isSLES15() || isLeap15() ||
+                isUbuntu1804() || isUbuntu2004() || isUbuntu2204() || isUbuntu2404() ||
+                isRedHat6() || isRedHat7() || isRedHat8() || isRedHat9() ||
+                isAlibaba2() ||
+                isAmazon2() || isAmazon2023() ||
+                isRocky8() || isRocky9() ||
+                isDebian10() || isDebian11() || isDebian12();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2338,9 +2338,13 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * @return <code>true</code> if OS supports monitoring
      */
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
-                isRedHat6() || isRedHat7() || isRedHat8() || isAlibaba2() || isAmazon2() || isAmazon2023() ||
-                isRocky8() || isRocky9() || isDebian12() || isDebian11() || isDebian10();
+        return isSLES12() || isSLES15() || isLeap15() ||
+                isUbuntu1804() || isUbuntu2004() || isUbuntu2204() || isUbuntu2404() ||
+                isRedHat6() || isRedHat7() || isRedHat8() ||
+                isAlibaba2() ||
+                isAmazon2() || isAmazon2023() ||
+                isRocky8() || isRocky9() ||
+                isDebian10() || isDebian11() || isDebian12();
     }
 
     /**
@@ -2415,6 +2419,10 @@ public class Server extends BaseDomainHelper implements Identifiable {
 
     boolean isUbuntu2204() {
         return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("22.04");
+    }
+
+    boolean isUbuntu2404() {
+        return ServerConstants.UBUNTU.equals(getOs()) && getRelease().equals("24.04");
     }
 
     boolean isDebian12() {

--- a/java/spacewalk-java.changes.mayrstefan.add-ubuntu-24.04
+++ b/java/spacewalk-java.changes.mayrstefan.add-ubuntu-24.04
@@ -1,0 +1,1 @@
+- Add detection of Ubuntu 24.04

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mayrstefan.add-ubuntu-24.04
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mayrstefan.add-ubuntu-24.04
@@ -1,0 +1,1 @@
+- Enable basic support for Ubuntu 24.04 LTS

--- a/susemanager-utils/testing/automation/update-obs-environment-cr-project.sh
+++ b/susemanager-utils/testing/automation/update-obs-environment-cr-project.sh
@@ -6,6 +6,7 @@ clients="Ubuntu1604-Uyuni-Client-Tools;xUbuntu_16.04 \
     Ubuntu1804-Uyuni-Client-Tools;xUbuntu_18.04 \
     Ubuntu2004-Uyuni-Client-Tools;xUbuntu_20.04 \
     Ubuntu2204-Uyuni-Client-Tools;xUbuntu_22.04 \
+    Ubuntu2404-Uyuni-Client-Tools;xUbuntu_22.04 \
     openSUSE_Leap_15-Uyuni-Client-Tools;openSUSE_Leap_15.0 \
     openSUSE_Leap_42-Uyuni-Client-Tools;openSUSE_Leap_42.3 \
     SLE15-Uyuni-Client-Tools;SLE_15 \

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -364,6 +364,10 @@ PKGLISTUBUNTU2204 = [
     "venv-salt-minion",
 ]
 
+PKGLISTUBUNTU2404 = [
+    "venv-salt-minion",
+]
+
 PKGLISTDEBIAN9 = [
     "apt-transport-https",
     "bsdmainutils",
@@ -1944,6 +1948,12 @@ DATA = {
         "BASECHANNEL": "ubuntu-22.04-pool-amd64-uyuni",
         "PKGLIST": PKGLISTUBUNTU2204,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/ubuntu/22/4/bootstrap/",
+        "TYPE": "deb",
+    },
+    "ubuntu-24.04-amd64-uyuni": {
+        "BASECHANNEL": "ubuntu-24.04-pool-amd64-uyuni",
+        "PKGLIST": PKGLISTUBUNTU2404,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/ubuntu/24/4/bootstrap/",
         "TYPE": "deb",
     },
     "debian9-amd64": {

--- a/susemanager/susemanager.changes.mayrstefan.add-ubuntu-24.04
+++ b/susemanager/susemanager.changes.mayrstefan.add-ubuntu-24.04
@@ -1,0 +1,1 @@
+- Enable bootstrapping for Ubuntu 24.04 LTS

--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -327,6 +327,20 @@ Feature: Sanity checks
     And "ubuntu2204_ssh_minion" should communicate with the server using public interface
     And the clock from "ubuntu2204_ssh_minion" should be exact
 
+@ubuntu2404_minion
+  Scenario: The Ubuntu 24.04 minion is healthy
+    Then "ubuntu2404_minion" should have a FQDN
+    And reverse resolution should work for "ubuntu2404_minion"
+    And "ubuntu2404_minion" should communicate with the server using public interface
+    And the clock from "ubuntu2404_minion" should be exact
+
+@ubuntu2404_ssh_minion
+  Scenario: The Ubuntu 24.04 Salt SSH minion is healthy
+    Then "ubuntu2404_ssh_minion" should have a FQDN
+    And reverse resolution should work for "ubuntu2404_ssh_minion"
+    And "ubuntu2404_ssh_minion" should communicate with the server using public interface
+    And the clock from "ubuntu2404_ssh_minion" should be exact
+
 @debian10_minion
   Scenario: The Debian 10 minion is healthy
     Then "debian10_minion" should have a FQDN

--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -98,6 +98,10 @@ Feature: Create bootstrap repositories
   Scenario: Create the bootstrap repository for a Ubuntu 22.04 minion
     When I create the bootstrap repository for "ubuntu2204_minion" on the server
 
+@ubuntu2404_minion
+  Scenario: Create the bootstrap repository for a Ubuntu 24.04 minion
+    When I create the bootstrap repository for "ubuntu2404_minion" on the server
+
 @debian10_minion
   Scenario: Create the bootstrap repository for a Debian 10 minion
     When I create the bootstrap repository for "debian10_minion" on the server

--- a/testsuite/features/build_validation/init_clients/ubuntu2404_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2404_minion.feature
@@ -1,0 +1,46 @@
+# Copyright (c) 2020-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new Ubuntu minion
+#  2) subscribe it to a base channel for testing
+
+@ubuntu2404_minion
+Feature: Bootstrap a Ubuntu 24.04 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a Ubuntu 24.04 minion
+    When I perform a full salt minion cleanup on "ubuntu2404_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a Ubuntu 24.04 minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "ubuntu2404_minion" as "hostname"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I enter "22" as "port"
+    And I enter "linux" as "password"
+    And I select "1-ubuntu2404_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    And I wait until I see "Bootstrap process initiated." text
+    And I wait until onboarding is completed for "ubuntu2404_minion"
+
+@proxy
+  Scenario: Check connection from Ubuntu 24.04 minion to proxy
+    Given I am on the Systems overview page of this "ubuntu2404_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of Ubuntu 24.04 minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "ubuntu2404_minion" hostname
+
+  Scenario: Check events history for failures on Ubuntu 24.04 minion
+    Given I am on the Systems overview page of this "ubuntu2404_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/ubuntu2404_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2404_ssh_minion.feature
@@ -1,0 +1,32 @@
+# Copyright (c) 2020-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new Ubuntu minion via salt-ssh
+#  2) subscribe it to a base channel for testing
+
+@ubuntu2404_ssh_minion
+Feature: Bootstrap a Ubuntu 24.04 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a Ubuntu 24.04 Salt SSH minion
+    When I perform a full salt minion cleanup on "ubuntu2404_ssh_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a SSH-managed Ubuntu 24.04 minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "ubuntu2404_ssh_minion" as "hostname"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I enter "22" as "port"
+    And I select "1-ubuntu2404_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I check "manageWithSSH"
+    And I click on "Bootstrap"
+    And I wait until I see "Bootstrap process initiated." text
+    And I wait until onboarding is completed for "ubuntu2404_ssh_minion"
+
+  Scenario: Check events history for failures on SSH-managed Ubuntu 24.04 minion
+    Given I am on the Systems overview page of this "ubuntu2404_ssh_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -642,6 +642,26 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until all synchronized channels for "ubuntu-2204" have finished
 
 @susemanager
+@ubuntu2404_minion
+  Scenario: Add Ubuntu 24.04
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "currently running" text
+    And I wait until I do not see "Loading" text
+    And I enter "Ubuntu 24.04" as the filtered product description
+    And I select "Ubuntu 24.04" as a product
+    Then I should see the "Ubuntu 24.04" selected
+    When I click the Add Product button
+    And I wait until I see "Ubuntu 24.04" product has been added
+    And I wait until all synchronized channels for "ubuntu-2404" have finished
+
+@uyuni
+@ubuntu2404_minion
+  Scenario: Add Ubuntu 24.04
+    When I use spacewalk-common-channel to add all "ubuntu-2404" channels with arch "amd64-deb"
+    And I wait until all synchronized channels for "ubuntu-2404" have finished
+
+@susemanager
 @debian10_minion
   Scenario: Add Debian 10
     Given I am authorized for the "Admin" section

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -57,6 +57,8 @@ ENV_VAR_BY_HOST = {
   'ubuntu2004_ssh_minion' => 'UBUNTU2004_SSHMINION',
   'ubuntu2204_minion' => 'UBUNTU2204_MINION',
   'ubuntu2204_ssh_minion' => 'UBUNTU2204_SSHMINION',
+  'ubuntu2404_minion' => 'UBUNTU2404_MINION',
+  'ubuntu2404_ssh_minion' => 'UBUNTU2404_SSHMINION',
   'debian10_minion' => 'DEBIAN10_MINION',
   'debian10_ssh_minion' => 'DEBIAN10_SSHMINION',
   'debian11_minion' => 'DEBIAN11_MINION',
@@ -200,6 +202,8 @@ PACKAGE_BY_CLIENT = {
   'ubuntu2004_ssh_minion' => 'bison',
   'ubuntu2204_minion' => 'bison',
   'ubuntu2204_ssh_minion' => 'bison',
+  'ubuntu2404_minion' => 'bison',
+  'ubuntu2404_ssh_minion' => 'bison',
   'debian10_minion' => 'bison',
   'debian10_ssh_minion' => 'bison',
   'debian11_minion' => 'bison',
@@ -277,6 +281,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'ubuntu2004_ssh_minion' => 'ubuntu-2004-amd64-main for amd64',
     'ubuntu2204_minion' => 'ubuntu-2204-amd64-main for amd64',
     'ubuntu2204_ssh_minion' => 'ubuntu-2204-amd64-main for amd64',
+    'ubuntu2404_minion' => 'ubuntu-2404-amd64-main for amd64',
+    'ubuntu2404_ssh_minion' => 'ubuntu-2404-amd64-main for amd64',
     'debian10_minion' => 'debian-10-pool for amd64',
     'debian10_ssh_minion' => 'debian-10-pool for amd64',
     'debian11_minion' => 'debian-11-pool for amd64',
@@ -348,6 +354,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'ubuntu2004_ssh_minion' => 'Ubuntu 20.04 LTS AMD64 Base for Uyuni',
     'ubuntu2204_minion' => 'Ubuntu 22.04 LTS AMD64 Base for Uyuni',
     'ubuntu2204_ssh_minion' => 'Ubuntu 22.04 LTS AMD64 Base for Uyuni',
+    'ubuntu2404_minion' => 'Ubuntu 24.04 LTS AMD64 Base for Uyuni',
+    'ubuntu2404_ssh_minion' => 'Ubuntu 24.04 LTS AMD64 Base for Uyuni',
     'debian10_minion' => 'Debian 10 (buster) pool for amd64 for Uyuni',
     'debian10_ssh_minion' => 'Debian 10 (buster) pool for amd64 for Uyuni',
     'debian11_minion' => 'Debian 11 (bullseye) pool for amd64 for Uyuni',
@@ -401,6 +409,7 @@ LABEL_BY_BASE_CHANNEL = {
     'rockylinux-9 for x86_64' => 'no-appstream-9-result-rockylinux-9-x86_64',
     'ubuntu-2004-amd64-main for amd64' => 'ubuntu-2004-amd64-main-amd64',
     'ubuntu-2204-amd64-main for amd64' => 'ubuntu-2204-amd64-main-amd64',
+    'ubuntu-2404-amd64-main for amd64' => 'ubuntu-2404-amd64-main-amd64',
     'debian-10-pool for amd64' => 'debian-10-pool-amd64',
     'debian-11-pool for amd64' => 'debian-11-pool-amd64',
     'debian-12-pool for amd64' => 'debian-12-pool-amd64',
@@ -432,6 +441,7 @@ LABEL_BY_BASE_CHANNEL = {
     'Rocky Linux 9 (x86_64)' => 'no-appstream-9-result-rockylinux-9-x86_64',
     'Ubuntu 20.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2004-pool-amd64-uyuni',
     'Ubuntu 22.04 LTS AMD64 Base for Uyuni' => 'ubuntu-22.04-pool-amd64-uyuni',
+    'Ubuntu 24.04 LTS AMD64 Base for Uyuni' => 'ubuntu-24.04-pool-amd64-uyuni',
     'Debian 10 (buster) pool for amd64 for Uyuni' => 'debian-10-pool-amd64-uyuni',
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian-11-pool-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian-12-pool-amd64-uyuni',
@@ -469,6 +479,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'rockylinux-9 for x86_64' => 'rockylinux-9-x86_64',
     'ubuntu-2004-amd64-main for amd64' => 'ubuntu-20.04-amd64',
     'ubuntu-2204-amd64-main for amd64' => 'ubuntu-22.04-amd64',
+    'ubuntu-2404-amd64-main for amd64' => 'ubuntu-24.04-amd64',
     'debian-10-pool for amd64' => 'debian10-amd64',
     'debian-11-pool for amd64' => 'debian11-amd64',
     'debian-12-pool for amd64' => 'debian12-amd64',
@@ -500,6 +511,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'Rocky Linux 9 (x86_64)' => 'rockylinux9-x86_64-uyuni',
     'Ubuntu 20.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2004-amd64-uyuni',
     'Ubuntu 22.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2204-amd64-uyuni',
+    'Ubuntu 24.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2404-amd64-uyuni',
     'Debian 10 (buster) pool for amd64 for Uyuni' => 'debian10-amd64-uyuni',
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian11-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian12-amd64-uyuni',
@@ -538,6 +550,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'rockylinux-9 for x86_64' => nil,
     'ubuntu-2004-amd64-main for amd64' => nil,
     'ubuntu-2204-amd64-main for amd64' => nil,
+    'ubuntu-2404-amd64-main for amd64' => nil,
     'debian-10-pool for amd64' => 'debian-10-pool-amd64',
     'debian-11-pool for amd64' => 'debian-11-pool-amd64',
     'debian-12-pool for amd64' => 'debian-12-pool-amd64',
@@ -568,6 +581,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'Rocky Linux 9 (x86_64)' => nil,
     'Ubuntu 20.04 LTS AMD64 Base for Uyuni' => nil,
     'Ubuntu 22.04 LTS AMD64 Base for Uyuni' => nil,
+    'Ubuntu 24.04 LTS AMD64 Base for Uyuni' => nil,
     'Debian 10 (buster) pool for amd64 for Uyuni' => 'debian10-amd64-uyuni',
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian11-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian12-amd64-uyuni',
@@ -625,6 +639,8 @@ PKGARCH_BY_CLIENT = {
   'ubuntu2004_ssh_minion' => 'amd64',
   'ubuntu2204_minion' => 'amd64',
   'ubuntu2204_ssh_minion' => 'amd64',
+  'ubuntu2404_minion' => 'amd64',
+  'ubuntu2404_ssh_minion' => 'amd64',
   'debian10_minion' => 'amd64',
   'debian10_ssh_minion' => 'amd64',
   'debian11_minion' => 'amd64',
@@ -943,6 +959,13 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         ubuntu-2204-amd64-main-updates-amd64
         ubuntu-2204-amd64-main-security-amd64
         ubuntu-22.04-suse-manager-tools-amd64
+      ],
+    'ubuntu-2404' => # CHECKED
+      %w[
+        ubuntu-2404-amd64-main-amd64
+        ubuntu-2404-amd64-main-updates-amd64
+        ubuntu-2404-amd64-main-security-amd64
+        ubuntu-24.04-suse-manager-tools-amd64
       ],
     'suma-proxy-43' => # CHECKED
       %w[
@@ -1267,6 +1290,18 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         ubuntu-2204-amd64-universe-updates-uyuni
         ubuntu-2204-amd64-universe-uyuni
         ubuntu-2204-amd64-uyuni-client-devel
+      ],
+    'ubuntu-2404' => # CHECKED
+      %w[
+        ubuntu-24.04-pool-amd64-uyuni
+        ubuntu-2404-amd64-main-security-uyuni
+        ubuntu-2404-amd64-main-updates-uyuni
+        ubuntu-2404-amd64-main-uyuni
+        ubuntu-2404-amd64-universe-backports-uyuni
+        ubuntu-2404-amd64-universe-security-uyuni
+        ubuntu-2404-amd64-universe-updates-uyuni
+        ubuntu-2404-amd64-universe-uyuni
+        ubuntu-2404-amd64-uyuni-client-devel
       ],
     'uyuni-proxy' => # CHECKED
       %w[

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -314,6 +314,14 @@ Before('@ubuntu2204_ssh_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['ubuntu2204_ssh_minion']
 end
 
+Before('@ubuntu2404_minion') do
+  skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['ubuntu2404_minion']
+end
+
+Before('@ubuntu2404_ssh_minion') do
+  skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['ubuntu2404_ssh_minion']
+end
+
 Before('@debian10_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['debian10_minion']
 end

--- a/testsuite/run_sets/build_validation/build_validation_init_clients.yml
+++ b/testsuite/run_sets/build_validation/build_validation_init_clients.yml
@@ -37,6 +37,8 @@
 - features/build_validation/init_clients/ubuntu2004_ssh_minion.feature
 - features/build_validation/init_clients/ubuntu2204_minion.feature
 - features/build_validation/init_clients/ubuntu2204_ssh_minion.feature
+- features/build_validation/init_clients/ubuntu2404_minion.feature
+- features/build_validation/init_clients/ubuntu2404_ssh_minion.feature
 
 - features/build_validation/init_clients/debian10_minion.feature
 - features/build_validation/init_clients/debian10_ssh_minion.feature

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3650,6 +3650,179 @@ checksum = sha256
 base_channels = ubuntu-22.04-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu2204-Uyuni-Client-Tools/xUbuntu_22.04/
 
+[ubuntu-2404-pool-amd64-uyuni]
+label     = ubuntu-24.04-pool-amd64-uyuni
+checksum  = sha256
+archs     = amd64-deb
+repo_type = deb
+name      = Ubuntu 24.04 LTS AMD64 Base for Uyuni
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url  = http://localhost/pub/repositories/empty-deb/?uniquekey=2404-uyuni
+
+[ubuntu-2404-amd64-main-uyuni]
+label     = ubuntu-2404-amd64-main-uyuni
+checksum  = sha256
+archs     = amd64-deb
+repo_type = deb
+name      = Ubuntu 24.04 LTS AMD64 Main for Uyuni
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble/main/binary-amd64/
+
+[ubuntu-2404-amd64-main-updates-uyuni]
+label     = ubuntu-2404-amd64-main-updates-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Main Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-updates/main/binary-amd64/
+
+[ubuntu-2404-amd64-main-security-uyuni]
+label     = ubuntu-2404-amd64-main-security-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Main Security for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-security/main/binary-amd64/
+
+[ubuntu-2404-amd64-universe-uyuni]
+label     = ubuntu-2404-amd64-universe-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Universe for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble/universe/binary-amd64/
+
+[ubuntu-2404-amd64-universe-updates-uyuni]
+label     = ubuntu-2404-amd64-universe-updates-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Universe Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-updates/universe/binary-amd64/
+
+[ubuntu-2404-amd64-universe-security-uyuni]
+label     = ubuntu-2404-amd64-universe-security-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Universe Security Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/
+
+[ubuntu-2404-amd64-main-backports-uyuni]
+label     = ubuntu-2404-amd64-main-backports-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Main Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-backports/main/binary-amd64/
+
+[ubuntu-2404-amd64-multiverse-backports-uyuni]
+label     = ubuntu-2404-amd64-multiverse-backports-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Multiverse Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-backports/multiverse/binary-amd64/
+
+[ubuntu-2404-amd64-restricted-backports-uyuni]
+label     = ubuntu-2404-amd64-restricted-backports-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Restricted Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-backports/restricted/binary-amd64/
+
+[ubuntu-2404-amd64-universe-backports-uyuni]
+label     = ubuntu-2404-amd64-universe-backports-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Universe Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-backports/universe/binary-amd64/
+
+[ubuntu-2404-amd64-multiverse-uyuni]
+label     = ubuntu-2404-amd64-multiverse-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Multiverse for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble/multiverse/binary-amd64/
+
+[ubuntu-2404-amd64-restricted-uyuni]
+label     = ubuntu-2404-amd64-restricted-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Restricted for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble/restricted/binary-amd64/
+
+[ubuntu-2404-amd64-multiverse-security-uyuni]
+label     = ubuntu-2404-amd64-multiverse-security-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Multiverse Security for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://security.ubuntu.com/ubuntu/dists/noble-security/multiverse/binary-amd64/
+
+[ubuntu-2404-amd64-restricted-security-uyuni]
+label     = ubuntu-2404-amd64-restricted-security-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Restricted Security for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://security.ubuntu.com/ubuntu/dists/noble-security/restricted/binary-amd64/
+
+[ubuntu-2404-amd64-multiverse-updates-uyuni]
+label     = ubuntu-2404-amd64-multiverse-updates-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Multiverse Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-updates/multiverse/binary-amd64/
+
+[ubuntu-2404-amd64-restricted-updates-uyuni]
+label     = ubuntu-2404-amd64-restricted-updates-uyuni
+name      = Ubuntu 24.04 LTS AMD64 Restricted Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/noble-updates/restricted/binary-amd64/
+
+[ubuntu-2404-amd64-uyuni-client]
+label     = ubuntu-2404-amd64-uyuni-client
+name      = Uyuni Client Tools for Ubuntu 24.04 AMD64
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2404-Uyuni-Client-Tools/xUbuntu_24.04/
+
+[ubuntu-2404-amd64-uyuni-client-devel]
+label     = ubuntu-2404-amd64-uyuni-client-devel
+name      = Uyuni Client Tools for Ubuntu 24.04 AMD64 (Development)
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-24.04-pool-amd64-uyuni
+repo_url  = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu2404-Uyuni-Client-Tools/xUbuntu_24.04/
+
 [debian-9-pool-amd64-uyuni]
 label    = debian-9-pool-amd64-uyuni
 checksum = sha256

--- a/utils/spacewalk-utils.changes.mayrstefan.add-ubuntu-24.04
+++ b/utils/spacewalk-utils.changes.mayrstefan.add-ubuntu-24.04
@@ -1,0 +1,1 @@
+- Add repositories for Ubuntu 22.04 LTS


### PR DESCRIPTION
## What does this PR change?

This is some basic preparation to support Ubuntu 24.04 LTS which will be released next month

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls): will be added when Ubuntu 24.04 has been officially released. This PR just prepares Uyuni for it

- [ ] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #8448

- [x] **DONE**

## Changelogs

Changelogs were added to the commits

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
