### PR TITLE
QE: Fix global variabel in Rakefile

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -272,7 +272,7 @@ namespace :jenkins do
       # Proxy can be either containerized or traditional
       if key == 'PROXY'
         key =
-          if is_containerized_server
+          if $is_containerized_server
             'PROXY_CONTAINER'
           else
             'PROXY_TRADITIONAL'


### PR DESCRIPTION
## What does this PR change?

Fixes a global variable in the Rakefile introduced in https://github.com/uyuni-project/uyuni/pull/8451

```bash
[2024-03-25T09:14:26.706Z] + ./terracumber-cli --outputdir /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results --tf susemanager-ci/terracumber_config/tf_files/SUSEManager-5.0-build-validation-NUE.tf --gitfolder /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results/sumaform --parallelism 30 --logfile /home/jenkins/workspace/manager-5.0-qe-build-validation-NUE/results/73/testsuite.log --runstep cucumber --cucumber-cmd 'export BUILD_NUMBER=73; export BUILD_VALIDATION=true; export CAPYBARA_TIMEOUT=60; export DEFAULT_TIMEOUT=500;  cd /root/spacewalk/testsuite; rake jenkins:generate_rake_files_build_validation'

[2024-03-25T09:14:27.267Z] Running command...
[2024-03-25T09:14:27.267Z] rake aborted!
[2024-03-25T09:14:27.267Z] NameError: undefined local variable or method `is_containerized_server' for main:Object
[2024-03-25T09:14:27.267Z] /root/spacewalk/testsuite/Rakefile:275:in `block (3 levels) in <top (required)>'
[2024-03-25T09:14:27.267Z] /root/spacewalk/testsuite/Rakefile:270:in `each'
[2024-03-25T09:14:27.267Z] /root/spacewalk/testsuite/Rakefile:270:in `block (2 levels) in <top (required)>'
[2024-03-25T09:14:27.267Z] Tasks: TOP => jenkins:generate_rake_files_build_validation
[2024-03-25T09:14:27.267Z] (See full trace by running task with --trace)
script returned exit code 1
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!