### PR TITLE
QE: Add proxy and RBS extensions 5.0 to BV

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -703,22 +703,19 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @susemanager
 @proxy
-  Scenario: Add SUSE Manager Proxy 4.3
+  Scenario: Add SUSE Manager Proxy Extension 5.0
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Manager Proxy 4.3" as the filtered product description
-    And I select "SUSE Manager Proxy 4.3 x86_64" as a product
-    Then I should see the "SUSE Manager Proxy 4.3 x86_64" selected
-    When I open the sub-list of the product "SUSE Manager Proxy 4.3 x86_64"
-    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
-    And I select "Containers Module 15 SP4 x86_64" as a product
-    Then I should see the "Containers Module 15 SP4 x86_64" selected
+    And I enter "SUSE Manager Proxy Extension 5.0" as the filtered product description
+    When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.5 x86_64"
+    And I select "SUSE Manager Proxy Extension 5.0" as a product
+    Then I should see the "SUSE Manager Proxy Extension 5.0" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Manager Proxy 4.3 x86_64" product has been added
-    And I wait until all synchronized channels for "suma-proxy-43" have finished
+    And I wait until I see "SUSE Manager Proxy Extension 5.0 x86_64" product has been added
+    And I wait until all synchronized channels for "suma-proxy-extension-50" have finished
 
 @cloud
 @proxy
@@ -736,22 +733,19 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @susemanager
 @proxy
-  Scenario: Add SUSE Manager Retail Branch Server 4.3
+  Scenario: Add SUSE Manager Retail Branch Server Extension 5.0
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Manager Retail Branch Server 4.3" as the filtered product description
-    And I select "SUSE Manager Retail Branch Server 4.3 x86_64" as a product
-    Then I should see the "SUSE Manager Retail Branch Server 4.3 x86_64" selected
-    When I open the sub-list of the product "SUSE Manager Retail Branch Server 4.3 x86_64"
-    And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
-    And I select "Containers Module 15 SP4 x86_64" as a product
-    Then I should see the "Containers Module 15 SP4 x86_64" selected
+    And I enter "SUSE Manager Retail Branch Server Extension 5.0" as the filtered product description
+    When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.5 x86_64"
+    And I select "SUSE Manager Retail Branch Server Extension 5.0" as a product
+    Then I should see the "SUSE Manager Retail Branch Server Extension 5.0" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Manager Retail Branch Server 4.3 x86_64" product has been added
-    And I wait until all synchronized channels for "suma-retail-branch-server-43" have finished
+    And I wait until I see "SUSE Manager Retail Branch Server Extension 5.0 x86_64" product has been added
+    And I wait until all synchronized channels for "suma-retail-branch-server-extension-50" have finished
 
 # There are no channels for Retail under Uyuni
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -944,29 +944,15 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         ubuntu-2204-amd64-main-security-amd64
         ubuntu-22.04-suse-manager-tools-amd64
       ],
-    'suma-proxy-43' => # CHECKED
+    'suma-proxy-extension-50' => # CHECKED
       %w[
-        sle-product-suse-manager-proxy-4.3-pool-x86_64
-        sle-product-suse-manager-proxy-4.3-updates-x86_64
-        sle-module-suse-manager-proxy-4.3-pool-x86_64
-        sle-module-suse-manager-proxy-4.3-updates-x86_64
-        sle-module-basesystem15-sp4-pool-x86_64-proxy-4.3
-        sle-module-basesystem15-sp4-updates-x86_64-proxy-4.3
-        sle-module-containers15-sp4-pool-x86_64-proxy-4.3
-        sle-module-containers15-sp4-updates-x86_64-proxy-4.3
+        suse-manager-proxy-5.0-pool-x86_64
+        suse-manager-proxy-5.0-updates-x86_64
       ],
-    'suma-retail-branch-server-43' => # CHECKED
+    'suma-retail-branch-server-extension-50' => # CHECKED
       %w[
-        sle-product-suse-manager-retail-branch-server-4.3-pool-x86_64
-        sle-product-suse-manager-retail-branch-server-4.3-updates-x86_64
-        sle-module-suse-manager-retail-branch-server-4.3-pool-x86_64
-        sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64
-        sle-module-basesystem15-sp4-pool-x86_64-smrbs-4.3
-        sle-module-basesystem15-sp4-updates-x86_64-smrbs-4.3
-        sle-module-server-applications15-sp4-pool-x86_64-smrbs-4.3
-        sle-module-server-applications15-sp4-updates-x86_64-smrbs-4.3
-        sle-module-suse-manager-proxy-4.3-pool-x86_64-smrbs
-        sle-module-suse-manager-proxy-4.3-updates-x86_64-smrbs
+        suse-manager-retail-branch-server-5.0-pool-x86_64
+        suse-manager-retail-branch-server-5.0-updates-x86_64
       ]
   },
   'Uyuni' => {
@@ -1475,12 +1461,6 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-server-applications15-sp5-pool-x86_64' => 60,
   'sle-module-server-applications15-sp5-updates-s390x' => 120,
   'sle-module-server-applications15-sp5-updates-x86_64' => 60,
-  'sle-module-suse-manager-proxy-4.3-pool-x86_64' => 60,
-  'sle-module-suse-manager-proxy-4.3-pool-x86_64-smrbs' => 60,
-  'sle-module-suse-manager-proxy-4.3-updates-x86_64' => 60,
-  'sle-module-suse-manager-proxy-4.3-updates-x86_64-smrbs' => 60,
-  'sle-module-suse-manager-retail-branch-server-4.3-pool-x86_64' => 60,
-  'sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64' => 60,
   'sle-product-sles15-sp1-ltss-updates-x86_64' => 1500,
   'sle-product-sles15-sp1-pool-x86_64' => 60,
   'sle-product-sles15-sp1-updates-x86_64' => 60,
@@ -1497,10 +1477,6 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-product-sles15-sp5-pool-x86_64' => 60,
   'sle-product-sles15-sp5-updates-s390x' => 60,
   'sle-product-sles15-sp5-updates-x86_64' => 60,
-  'sle-product-suse-manager-proxy-4.3-pool-x86_64' => 60,
-  'sle-product-suse-manager-proxy-4.3-updates-x86_64' => 60,
-  'sle-product-suse-manager-retail-branch-server-4.3-pool-x86_64' => 60,
-  'sle-product-suse-manager-retail-branch-server-4.3-updates-x86_64' => 60,
   'sles12-sp5-installer-updates-x86_64' => 60,
   'sles12-sp5-pool-x86_64' => 180,
   'sles12-sp5-updates-x86_64' => 2280,
@@ -1513,6 +1489,10 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sll-9-updates-x86_64' => 720,
   'sll-as-9-updates-x86_64' => 1620,
   'sll-cb-9-updates-x86_64' => 2640,
+  'suse-manager-proxy-5.0-pool-x86_64' => 60,
+  'suse-manager-proxy-5.0-updates-x86_64' => 60,
+  'suse-manager-retail-branch-server-5.0-pool-x86_64' => 60,
+  'suse-manager-retail-branch-server-5.0-updates-x86_64' => 60,
   'suse-microos-5.1-devel-uyuni-client-x86_64' => 60,
   'suse-microos-5.1-pool-x86_64' => 60,
   'suse-microos-5.1-updates-x86_64' => 300,
@@ -1550,6 +1530,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
 }.freeze
 
 EMPTY_CHANNELS = %w[
+  suse-manager-proxy-5.0-updates-x86_64
+  suse-manager-retail-branch-server-5.0-updates-x86_64
   sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64
   sle-manager-tools15-beta-pool-x86_64-sp4
   fake-base-channel-suse-like


### PR DESCRIPTION
## What does this PR change?

This will adapt reposync in BV for SUMA to sync the correct channels for the containerized proxy (Proxy Extension 5.0 and RBS Extension 5.0). The old channels for 4.3 are deleted.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
