### PR TITLE
Update landing page layouts

### DIFF
--- a/java/code/webapp/WEB-INF/pages/yourrhn.jsp
+++ b/java/code/webapp/WEB-INF/pages/yourrhn.jsp
@@ -20,17 +20,19 @@
 <c:choose>
   <c:when test="${requestScope.anyListsSelected == 'true'}">
     <div class="row">
-      <c:if test="${requestScope.tasks == 'y'}">
-      <div class="col-md-6" id="tasks-pane" >
-        <script type="text/javascript">
-          ajax("tasks", "", makeRendererHandler("tasks-pane", false).callback, "text/html")
-        </script>
-      </div>
-      </c:if>
       <c:if test="${requestScope.subscriptionWarning == 'y'}">
       <div id="subscription-warning" class="col-md-12">
         <script type="text/javascript">
           ajax("subscription-warning", "", makeRendererHandler("subscription-warning", false).callback);
+        </script>
+      </div>
+      </c:if>
+    </div>
+    <div class="row">
+      <c:if test="${requestScope.tasks == 'y'}">
+      <div class="col-md-6" id="tasks-pane" >
+        <script type="text/javascript">
+          ajax("tasks", "", makeRendererHandler("tasks-pane", false).callback, "text/html")
         </script>
       </div>
       </c:if>

--- a/java/spacewalk-java.changes.eth.subscription-warning
+++ b/java/spacewalk-java.changes.eth.subscription-warning
@@ -1,0 +1,1 @@
+- Update landing page layouts


### PR DESCRIPTION
## What does this PR change?

The diff view is not very good for this PR. In short, this PR simply moves the subscription warning element into a row of its own so if it isn't visible, it doesn't break the rest of the layout into a new line. Since it's full width anyway, it would need to have a row of its own in any case.

## GUI diff

Before:

<img width="2047" alt="Screenshot 2024-03-26 at 14 17 20" src="https://github.com/uyuni-project/uyuni/assets/3171718/4ee17ce4-b556-4fd7-9865-80414369da82">


After:

<img width="2048" alt="Screenshot 2024-03-26 at 14 22 21" src="https://github.com/uyuni-project/uyuni/assets/3171718/a44594e5-a9c5-427d-ad43-612267a09958">


- [x] **DONE**

## Documentation
- No documentation needed: I stepped on this as a part of the Bootstrap upgrade and there is already a docs ticket to upgrade screenshots for this.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
