### PR TITLE
QE: Remove salt-bundle previous directories before bootstrap a SLE Micro minion

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy_container.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_container.feature
@@ -15,6 +15,9 @@ Feature: Setup containerized proxy
   As the system administrator
   I want to register the containerized proxy on the server
 
+  Scenario: Pre-requisite: salt minion directories must not exist on the proxy host
+    When I remove salt minion directories on "proxy"
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -15,6 +15,9 @@ Feature: Setup containerized proxy
   As the system administrator
   I want to register the containerized proxy on the server
 
+  Scenario: Pre-requisite: salt minion directories must not exist on the proxy host
+    When I remove salt minion directories on "proxy"
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -500,6 +500,15 @@ When(/^I enter KVM Server password$/) do
   step %(I enter "#{ENV.fetch('VIRTHOST_KVM_PASSWORD', nil)}" as "password")
 end
 
+When(/^I remove salt minion directories on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  if use_salt_bundle
+    node.run('rm -Rf /root/salt /var/cache/venv-salt-minion /run/venv-salt-minion /var/venv-salt-minion.log /etc/venv-salt-minion /var/tmp/.root*', check_errors: false, runs_in_container: false)
+  else
+    node.run('rm -Rf /root/salt /var/cache/salt/minion /var/run/salt /run/salt /var/log/salt /etc/salt /var/tmp/.root*', check_errors: false, runs_in_container: false)
+  end
+end
+
 When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   node = get_target(host)
   if use_salt_bundle
@@ -512,7 +521,6 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
     else
       node.run('zypper --non-interactive remove --clean-deps -y venv-salt-minion', check_errors: false)
     end
-    node.run('rm -Rf /root/salt /var/cache/venv-salt-minion /run/venv-salt-minion /var/venv-salt-minion.log /etc/venv-salt-minion /var/tmp/.root*', check_errors: false)
   else
     if slemicro_host?(host)
       node.run('transactional-update --continue -n pkg rm salt salt-minion', check_errors: false)
@@ -523,8 +531,8 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
     else
       node.run('zypper --non-interactive remove --clean-deps -y salt salt-minion', check_errors: false)
     end
-    node.run('rm -Rf /root/salt /var/cache/salt/minion /var/run/salt /run/salt /var/log/salt /etc/salt /var/tmp/.root*', check_errors: false)
   end
+  step %(I remove salt minion directories on "#{host}")
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)
 end
 


### PR DESCRIPTION
## What does this PR change?

Following https://confluence.suse.com/pages/viewpage.action?pageId=1460437109
This PR attempts to by-pass the current issues onboarding a SLE Micro, in a way that we can cover this feature, in particular to bootstrap the Proxy Host.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
