### PR TITLE
QE: Skip Proxy Host onboarding in CI and BV

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy_container.feature
+++ b/testsuite/features/build_validation/init_clients/proxy_container.feature
@@ -18,6 +18,8 @@ Feature: Setup containerized proxy
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+# TODO: Enable the following scenarios once the team fixes the SLE Micro bootstrapping issues
+@skip
   Scenario: Bootstrap the proxy host as a salt minion
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
@@ -31,10 +33,12 @@ Feature: Setup containerized proxy
 
 # workaround for bsc#1218146
 # Once we start using Leap Micro #23811 in Uyuni Proxy, we need to remove this Cucumber tag
+@skip
 @susemanager
   Scenario: Reboot the proxy host
     When I reboot the "proxy" host through SSH, waiting until it comes back
 
+@skip
   Scenario: Wait until the proxy host appears
     When I wait until onboarding is completed for "proxy"
 

--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -18,6 +18,8 @@ Feature: Setup containerized proxy
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+# TODO: Enable the following scenarios once the team fixes the SLE Micro bootstrapping issues
+@skip
   Scenario: Bootstrap the proxy host as a salt minion
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
@@ -31,10 +33,12 @@ Feature: Setup containerized proxy
 
 # workaround for bsc#1218146
 # Once we start using Leap Micro #23811 in Uyuni Proxy, we need to remove this Cucumber tag
+@skip
 @susemanager
   Scenario: Reboot the proxy host
     When I reboot the "proxy" host through SSH, waiting until it comes back
 
+@skip
   Scenario: Wait until the proxy host appears
     When I wait until onboarding is completed for "proxy"
 


### PR DESCRIPTION
## What does this PR change?

Skip Proxy Host onboarding in CI and BV, until we fix the multiple issues we have onboarding SLE Micro.
Internal doc: https://confluence.suse.com/pages/viewpage.action?pageId=1460437109

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were skipped

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
