### PR TITLE
Add app labels on the kubernetes deployments

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.helm-label
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.helm-label
@@ -1,0 +1,1 @@
+- Add app=uyuni-proxy label to the deployment

--- a/containers/proxy-helm/templates/deployment.yaml
+++ b/containers/proxy-helm/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: uyuni-proxy
   namespace: "{{ .Release.Namespace }}"
+labels:
+  app: uyuni-proxy
 spec:
   replicas: 1
   selector:

--- a/containers/server-helm/server-helm.changes.cbosdo.helm-label
+++ b/containers/server-helm/server-helm.changes.cbosdo.helm-label
@@ -1,0 +1,1 @@
+- Add app=uyuni label to the deployment

--- a/containers/server-helm/templates/deployment.yaml
+++ b/containers/server-helm/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: uyuni
   namespace: "{{ .Release.Namespace }}"
+labels:
+  app: uyuni
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
## What does this PR change?

Add the same app label on the deployment than on the pods. This will make it easier to search for the server and proxy deployments.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed:  mostly used for internal purpose
- [x] **DONE**

## Test coverage
- No tests: helm charts changes

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
