### PR TITLE
Add again the steps checking textareas without data-testid

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -612,6 +612,18 @@ end
 #
 # Test for text in a snippet textarea
 #
+Then(/^I should see "([^"]*)" in the textarea$/) do |text|
+  within('textarea') do
+    raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)
+  end
+end
+
+Then(/^I should see "([^"]*)" or "([^"]*)" in the textarea$/) do |text1, text2|
+  within('textarea') do
+    raise ScriptError, "Text '#{text1}' and '#{text2}' not found" unless check_text_and_catch_request_timeout_popup?(text1, text2: text2)
+  end
+end
+
 Then(/^I should see "([^"]*)" in the ([^ ]+) textarea$/) do |text, id|
   within(:xpath, ".//textarea[@data-testid='#{id}']") do
     raise ScriptError, "Text '#{text}' not found" unless check_text_and_catch_request_timeout_popup?(text)


### PR DESCRIPTION
## What does this PR change?

I was too prompt in replacing those steps with `data-testid` ones. Adding them back.

## Test coverage
- Cucumber tests were fixed

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
