### PR TITLE
Fix unschedule action chains

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/InProgressSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/InProgressSystemsAction.java
@@ -48,7 +48,7 @@ import javax.servlet.http.HttpServletResponse;
 public class InProgressSystemsAction extends RhnSetAction {
 
     /** Logger instance */
-    private static Logger log = LogManager.getLogger(InProgressSystemsAction.class);
+    private static final Logger LOG = LogManager.getLogger(InProgressSystemsAction.class);
 
     /**
      * Removes unscheduleaction set from server actions.
@@ -89,7 +89,7 @@ public class InProgressSystemsAction extends RhnSetAction {
 
         try {
             ActionFactory.removeActionForSystemSet(aid, "unscheduleaction", user);
-            /**
+            /*
              * If we've unscheduled the action for more than one system, send the pluralized
              * version of the message.
              */
@@ -110,7 +110,7 @@ public class InProgressSystemsAction extends RhnSetAction {
             strutsDelegate.saveMessages(request, msgs);
         }
         catch (TaskomaticApiException e) {
-            log.error("Could not unschedule action:", e);
+            LOG.error("Could not unschedule action:", e);
             ActionErrors errors = new ActionErrors();
             strutsDelegate.addError(errors, "taskscheduler.down");
             strutsDelegate.saveMessages(request, errors);

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
@@ -311,12 +311,13 @@ public class TaskoFactory extends HibernateFactory {
     }
 
     /**
-     * lookup schedule by label
+     * list schedule by label
+     *
      * @param jobLabel schedule label
-     * @return schedule
+     * @return list of schedule
      */
-    public static TaskoSchedule lookupScheduleByLabel(String jobLabel) {
-        return singleton.lookupObjectByNamedQuery("TaskoSchedule.lookupByLabel", Map.of("job_label", jobLabel));
+    public static List<TaskoSchedule> listScheduleByLabel(String jobLabel) {
+        return singleton.listObjectsByNamedQuery("TaskoSchedule.lookupByLabel", Map.of("job_label", jobLabel));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -84,7 +84,7 @@ public class TaskomaticApi {
         }
     }
 
-    private Object invoke(String name, Object...args) throws TaskomaticApiException {
+    protected Object invoke(String name, Object...args) throws TaskomaticApiException {
         try {
             return getClient().invoke(name, args);
         }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2621,8 +2621,7 @@ public class SaltServerActionService {
                             .filter(sa -> sa.getServerId().equals(minion.get().getId()))
                             .filter(sa -> !ActionFactory.STATUS_FAILED.equals(sa.getStatus()))
                             .filter(sa -> !ActionFactory.STATUS_COMPLETED.equals(sa.getStatus()))
-                            .findFirst())
-                    .ifPresent(sa -> sa.fail(message.orElse("Prerequisite failed")));
+                            .findFirst()).ifPresent(sa -> sa.fail(message.orElse("Prerequisite failed")));
 
             // walk dependent server actions recursively and set them to failed
             Deque<Long> actionIdsDependencies = new ArrayDeque<>();
@@ -2858,7 +2857,7 @@ public class SaltServerActionService {
 
                                 serverAction.ifPresent(this::setActionAsPickedUp);
                             });
-                    }
+                        }
                 });
             }
             else {

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-unschedule-action-chains
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-unschedule-action-chains
@@ -1,0 +1,2 @@
+- when an action is unscheduled which belong to an action chain
+  unschedule the action chain as well (bsc#1221784)


### PR DESCRIPTION
## What does this PR change?

When unscheduling an action which is part of an action chain, the action chain becomes visible again.
But when you try to schedule it again, it fails as the "action chain executor" job label was not removed.

When we schedule an action chain, we do not create "minion-action-executor-" tasko schedules like for single actions.
We create one "minion-action-chain-executor-" for the chain.
The actions are created, but not scheduled.

When unscheduling now the actions, we need to check if they belong to an action chain and unschedule the action chain when it is the last action which gets removed now.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24018

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
