### PR TITLE
QE: Temporary workaround as Salt SSH bootstrap takes much more than previous timeout to finish.

### DIFF
--- a/testsuite/features/build_validation/init_clients/alma8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/alma8_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a Alma 8 Salt SSH minion
     And I select "1-alma8_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "alma8_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/alma9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/alma9_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a Alma 9 Salt SSH minion
     And I select "1-alma9_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "alma9_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/centos7_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/centos7_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
     And I select "1-centos7_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "centos7_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/debian10_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/debian10_ssh_minion.feature
@@ -24,7 +24,8 @@ Feature: Bootstrap a Debian 10 Salt SSH minion
     And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "debian10_ssh_minion"
 
   Scenario: Check events history for failures on SSH-managed Debian 10 minion

--- a/testsuite/features/build_validation/init_clients/debian11_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/debian11_ssh_minion.feature
@@ -24,7 +24,8 @@ Feature: Bootstrap a Debian 11 Salt SSH minion
     And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "debian11_ssh_minion"
 
   Scenario: Check events history for failures on SSH-managed Debian 11 minion

--- a/testsuite/features/build_validation/init_clients/debian12_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/debian12_ssh_minion.feature
@@ -24,7 +24,8 @@ Feature: Bootstrap a Debian 12 Salt SSH minion
     And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "debian12_ssh_minion"
 
   Scenario: Check events history for failures on SSH-managed Debian 12 minion

--- a/testsuite/features/build_validation/init_clients/liberty9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/liberty9_ssh_minion.feature
@@ -23,7 +23,8 @@ Feature: Bootstrap a Liberty Linux 9 Salt SSH minion
     And I select "1-liberty9_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "liberty9_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/opensuse154arm_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/opensuse154arm_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a openSUSE 15.4 ARM Salt SSH minion
     And I select "1-opensuse154arm_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "opensuse154arm_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/opensuse155arm_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/opensuse155arm_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a openSUSE 15.5 ARM Salt SSH minion
     And I select "1-opensuse155arm_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "opensuse155arm_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/oracle9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/oracle9_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a Oracle 9 Salt SSH minion
     And I select "1-oracle9_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "oracle9_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/rhel9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/rhel9_ssh_minion.feature
@@ -21,7 +21,8 @@ Feature: Bootstrap a Rhel 9 SSH minion
     And I select "1-rhel9_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "rhel9_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/rocky8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/rocky8_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a Rocky 8 Salt SSH minion
     And I select "1-rocky8_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "rocky8_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/rocky9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/rocky9_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a Rocky 9 Salt SSH minion
     And I select "1-rocky9_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "rocky9_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle12sp5_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp5_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a SLES 12 SP5 Salt SSH minion
     And I select "1-sle12sp5_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "sle12sp5_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH minion
     And I select "1-sle15sp1_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "sle15sp1_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH minion
     And I select "1-sle15sp2_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "sle15sp2_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH minion
     And I select "1-sle15sp3_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "sle15sp3_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp4_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a SLES 15 SP4 Salt SSH minion
     And I select "1-sle15sp4_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "sle15sp4_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp5_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp5_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a SLES 15 SP5 Salt SSH minion
     And I select "1-sle15sp5_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "sle15sp5_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp5s390_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp5s390_ssh_minion.feature
@@ -19,7 +19,8 @@ Feature: Bootstrap a SLES 15 SP5 s390x Salt SSH minion
     And I select "1-sle15sp5s390_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "sle15sp5s390_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/slemicro51_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro51_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a SLE Micro 5.1 Salt SSH minion
     And I select "1-slemicro51_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "slemicro51_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/slemicro52_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro52_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a SLE Micro 5.2 Salt SSH minion
     And I select "1-slemicro52_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "slemicro52_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/slemicro53_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro53_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a SLE Micro 5.3 Salt SSH minion
     And I select "1-slemicro53_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "slemicro53_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/slemicro54_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro54_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLE Micro 5.4 Salt SSH minion
 
   Scenario: Clean up sumaform leftovers on a SLE Micro SSH 5.4 SSH minion
     When I perform a full salt minion cleanup on "slemicro54_ssh_minion"
-  
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
@@ -22,7 +22,8 @@ Feature: Bootstrap a SLE Micro 5.4 Salt SSH minion
     And I select "1-slemicro54_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "slemicro54_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/slemicro55_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro55_ssh_minion.feature
@@ -22,7 +22,8 @@ Feature: Bootstrap a SLE Micro 5.5 Salt SSH minion
     And I select "1-slemicro55_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "slemicro55_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2004_ssh_minion.feature
@@ -24,7 +24,8 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH minion
     And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "ubuntu2004_ssh_minion"
 
   Scenario: Check events history for failures on SSH-managed Ubuntu 20.04 minion

--- a/testsuite/features/build_validation/init_clients/ubuntu2204_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2204_ssh_minion.feature
@@ -24,7 +24,8 @@ Feature: Bootstrap a Ubuntu 22.04 Salt SSH minion
     And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "ubuntu2204_ssh_minion"
 
   Scenario: Check events history for failures on SSH-managed Ubuntu 22.04 minion

--- a/testsuite/features/github_validation/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/github_validation/init_clients/sle_ssh_minion.feature
@@ -14,7 +14,8 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I enter the hostname of "ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "ssh_minion", refreshing the page
 

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -15,7 +15,8 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -55,7 +55,8 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
     And I enter "linux" as "privKeyPwd"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
 
   Scenario: Check new minion bootstrapped with SSH key in System Overview page
     When I follow the left menu "Salt > Keys"

--- a/testsuite/features/secondary/min_deblike_ssh.feature
+++ b/testsuite/features/secondary/min_deblike_ssh.feature
@@ -38,7 +38,8 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "deblike_minion", refreshing the page
     And I wait until onboarding is completed for "deblike_minion"
@@ -107,7 +108,8 @@ Feature: Bootstrap a SSH-managed Debian-like minion and do some basic operations
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "deblike_minion", refreshing the page
     And I wait until onboarding is completed for "deblike_minion"

--- a/testsuite/features/secondary/min_rhlike_ssh.feature
+++ b/testsuite/features/secondary/min_rhlike_ssh.feature
@@ -37,7 +37,8 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "rhlike_minion", refreshing the page
     And I wait until onboarding is completed for "rhlike_minion"
@@ -107,7 +108,8 @@ Feature: Bootstrap a SSH-managed Red Hat-like minion and do some basic operation
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "rhlike_minion", refreshing the page
     And I wait until onboarding is completed for "rhlike_minion"

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -35,7 +35,8 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I select the hostname of "proxy" from "proxies" if present
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "ssh_minion"
 
   Scenario: The contact method is SSH tunnel on this minion

--- a/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
+++ b/testsuite/features/secondary/minssh_move_from_and_to_proxy.feature
@@ -36,7 +36,8 @@ Feature: Move a SSH minion from a proxy to direct connection
     And I select "1-SUSE-SSH-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies" if present
     And I click on "Bootstrap"
-    And I wait until I see "Bootstrap process initiated." text
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
     And I wait until onboarding is completed for "ssh_minion"
 
   Scenario: Check initial connection from minion to proxy


### PR DESCRIPTION
## What does this PR change?

This PR is a temporary workaround that change the time to wait until we see the message "Bootstrap process initiated" when bootstrapping SSH Minions, as it's taking more than 4 minutes now.
This is the reported bug [bsc#1222108](https://bugzilla.suse.com/show_bug.cgi?id=1222108)

**_NOTE:_**
Adding some Ion squad people here just for awareness of the issue, the bug and the workaround.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were changed

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
