### PR TITLE
Coco fix arch

### DIFF
--- a/containers/server-attestation-image/Dockerfile
+++ b/containers/server-attestation-image/Dockerfile
@@ -4,10 +4,15 @@
 ARG BASE=registry.suse.com/bci/bci-base:15.5
 FROM $BASE
 
+# Architecture specific attestation modules are specified via project configuration
+ARG ARCH_SPECIFIC_MODULES
+
 # Main packages
 RUN zypper ref && zypper --non-interactive up
 RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-licenses --force-resolution \
-    uyuni-coco-attestation uyuni-coco-attestation-module-snpguest javassist apache-commons-ognl
+    uyuni-coco-attestation-core \
+    ${ARCH_SPECIFIC_MODULES} \
+    javassist apache-commons-ognl
 
 ARG PRODUCT=Uyuni
 ARG VENDOR="Uyuni project"

--- a/containers/server-attestation-image/server-attestation-image.changes.mackdk.coco-fix-arch
+++ b/containers/server-attestation-image/server-attestation-image.changes.mackdk.coco-fix-arch
@@ -1,0 +1,2 @@
+- Ensure the architecture specific modules are installed only for 
+  the correct container


### PR DESCRIPTION
## What does this PR change?

This PR ensures the package for the snpguest attestation module is not built if the architecture is not `x86_86`, since the tool `snpguest` would not be available. It also change the way the container is built: the architecture specific module is only added to the image if the container is of the correct architecture. This requires changing the Project Config in OBS by adding the following snippet:

```
%if "%_repository" == "containers"

%ifarch x86_64
BuildFlags: dockerarg:ARCH_SPECIFIC_MODULES=uyuni-coco-attestation-module-snpguest
%endif

%endif
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: the change only affects packaging

- [X] **DONE**

## Test coverage
- No tests: the change only affects packaging

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
