### PR TITLE
QE: maintain browser session after a scenario fails

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -127,6 +127,7 @@ end
 After do |scenario|
   current_epoch = Time.new.to_i
   log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
+
   if scenario.failed?
     begin
       Dir.mkdir('screenshots') unless File.directory?('screenshots')
@@ -143,10 +144,12 @@ After do |scenario|
     ensure
       print_server_logs
       previous_url = current_url
+      page.instance_variable_set(:@touched, false)
       step 'I am authorized for the "Admin" section'
       visit previous_url
     end
   end
+
   page.instance_variable_set(:@touched, false)
 end
 


### PR DESCRIPTION
## What does this PR change?

< Placeholder >

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/20097
Port(s): Manager 4.3 https://github.com/SUSE/spacewalk/pull/24043

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
