### PR TITLE
Fix Java 17 upgrade issue with container proxy configuration generation

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -364,7 +364,7 @@ public class ProxyHandler extends BaseHandler {
             SSLCertData certData = new SSLCertData(nullable(proxyName), cnames, nullable(country),
                     nullable(state), nullable(city), nullable(org), nullable(orgUnit), nullable(sslEmail));
             return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
-                    maxCache.longValue(), email, null, Collections.emptyList(), null, caCrtKey, caPassword, certData);
+                    maxCache.longValue(), email, null, List.of(), null, caCrtKey, caPassword, certData);
         }
         catch (InstantiationException e) {
             LOG.error("Failed to generate proxy system id", e);

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2282,7 +2282,7 @@ public class SystemManager extends BaseManager {
         // Check the SSL files using mgr-ssl-cert-setup
         try {
             String certificate = saltApi.checkSSLCert(rootCaCert, proxyPair,
-                    intermediateCAs != null ? intermediateCAs : Collections.emptyList());
+                    intermediateCAs != null ? intermediateCAs : List.of());
             httpdConfig.put("server_crt", certificate);
             httpdConfig.put("server_key", proxyPair.getKey());
         }


### PR DESCRIPTION
## What does this PR change?

Collections.emptyList() is private and can no longer be accessed at runtime when serializing to Json. List.of() doesn't have this problem.

## GUI diff

No difference.

- [X] **DONE**

## Test coverage
- No tests: covered by cucumber tests

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
