### PR TITLE
Make sure "hostname" package is available

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -97,6 +97,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -94,6 +94,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -97,6 +97,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -94,6 +94,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -97,6 +97,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -94,6 +94,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -97,6 +97,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -94,6 +94,7 @@
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
+        <package name="hostname"/>
 
 	<package name="dracut-saltboot"/>
         <package name="mdadm"/>


### PR DESCRIPTION
## What does this PR change?

This PR adds "hostname" to the Kiwi OS image profile.

This utility is needed on the retail terminal for the bootstrap test after mass import.


## Links

No ports: profiles are shared between all branches.


## Changelogs

- [x] No changelog needed
