### PR TITLE
Make frontend code ownership more granular

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,8 @@ java/conf/cobbler/snippets/ @uyuni-project/python
 mgr_bootstrap_data.py
 
 # Frontend
-web/ @uyuni-project/frontend
+web/html/ @uyuni-project/frontend
+web/setup.sh @uyuni-project/frontend
 branding/ @uyuni-project/frontend
 *.jsp @uyuni-project/frontend
 *.jspf @uyuni-project/frontend


### PR DESCRIPTION
## What does this PR change?

See title, right now frontend is marked as owners for conf directories, po files, etc other things that are not directly under our umbrella.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: codeowners

- [x] **DONE**

## Test coverage
- No tests: nothing to test

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
