### PR TITLE
Do not hardcode release version in the source URL

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.deneb-alpha.fix_release_reference
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.deneb-alpha.fix_release_reference
@@ -1,0 +1,2 @@
+- In the source URL use a macro for specifying the release version 
+  instead of hardcoding it

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.deneb-alpha.fix_release_reference
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.deneb-alpha.fix_release_reference
@@ -1,2 +1,2 @@
-- In the source URL use a macro for specifying the release version 
-  instead of hardcoding it
+- Switch the default release version to 0 and update the source
+  URL

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -36,7 +36,7 @@ Summary:        Static Salt state files for SUSE Manager
 License:        Apache-2.0 AND LGPL-2.1-only
 Group:          Applications/Internet
 Source:         %{name}-%{version}.tar.gz
-Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-1/susemanager-utils/susemanager-sls/%{name}-rpmlintrc
+Source1:        https://raw.githubusercontent.com/uyuni-project/uyuni/%{name}-%{version}-0/susemanager-utils/susemanager-sls/%{name}-rpmlintrc
 Requires(pre):  coreutils
 Requires(posttrans):spacewalk-admin
 Requires:       susemanager-build-keys-web >= 15.4.2


### PR DESCRIPTION
## What does this PR change?

Autobuild team asked to not force a `Release: 1` in the spec file but instead, they asked to keep `Release: 0` letting OBS to automatically handle the release change.

@sbluhm reported that this switch is unfortunately breaking the build of some sources where the hardcoded `Release: 1` value was used for downloading also additional sources like for example rpmlint filters. spec files we are doing from `Release: 1` to `Release: 0`.
~The PR switches the affected  URL to use the %{release} macro instead of hardcoding it's value.~
Using the %{release} macro doesn't work for building in Copr. The PR is switching the  URL from `1` to `0`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal spec file change

- [x] **DONE**

## Links

- NONE

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
