### PR TITLE
AlmaLinux 9 powertools was renamed into CRB (bsc#1222110)

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -991,11 +991,11 @@
                 "installer_updates" : false
             },
             {
-                "id" : -479,
-                "url" : "https://mirrors.almalinux.org/mirrorlist/9/powertools",
-                "name" : "almalinux9-powertools",
+                "id" : -553,
+                "url" : "https://mirrors.almalinux.org/mirrorlist/9/crb",
+                "name" : "almalinux9-crb",
                 "distro_target" : null,
-                "description" : "AlmaLinux 9 PowerTools",
+                "description" : "AlmaLinux 9 PowerTools/CRB",
                 "enabled" : false,
                 "autorefresh" : true,
                 "installer_updates" : false

--- a/susemanager-sync-data/susemanager-sync-data.changes.mc.Manager-4.3-fix-almalinux-powertools
+++ b/susemanager-sync-data/susemanager-sync-data.changes.mc.Manager-4.3-fix-almalinux-powertools
@@ -1,0 +1,1 @@
+- AlmaLinux 9 powertools was renamed into CRB (bsc#1222110)


### PR DESCRIPTION
## What does this PR change?

Alma Linux 9 renamed powertools channel into "crb"

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24057

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
