### PR TITLE
CI: skip scheduled actions on forks

### DIFF
--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   acceptance-tests-secondary:
     # Skip running scheduled jobs on forks
-    if: (github.event_name == 'schedule' && github.repository == 'uyuni-project/uyuni') || (github.event_name != 'schedule')
+    if: (github.repository == 'uyuni-project/uyuni' || github.event_name != 'schedule')
     uses: ./.github/workflows/acceptance_tests_common.yml
     with:
       secondary_tests: "18_run_secondary_tests.sh"

--- a/.github/workflows/acceptance_tests_secondary.yml
+++ b/.github/workflows/acceptance_tests_secondary.yml
@@ -12,6 +12,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   acceptance-tests-secondary:
+    # Skip running scheduled jobs on forks
+    if: (github.event_name == 'schedule' && github.repository == 'uyuni-project/uyuni') || (github.event_name != 'schedule')
     uses: ./.github/workflows/acceptance_tests_common.yml
     with:
       secondary_tests: "18_run_secondary_tests.sh"

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -12,6 +12,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 jobs:
   acceptance-tests-secondary-parallel:
+    # Skip running scheduled jobs on forks
+    if: (github.event_name == 'schedule' && github.repository == 'uyuni-project/uyuni') || (github.event_name != 'schedule')
     uses: ./.github/workflows/acceptance_tests_common.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/acceptance_tests_secondary_parallel.yml
+++ b/.github/workflows/acceptance_tests_secondary_parallel.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   acceptance-tests-secondary-parallel:
     # Skip running scheduled jobs on forks
-    if: (github.event_name == 'schedule' && github.repository == 'uyuni-project/uyuni') || (github.event_name != 'schedule')
+    if: (github.repository == 'uyuni-project/uyuni' || github.event_name != 'schedule')
     uses: ./.github/workflows/acceptance_tests_common.yml
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What does this PR change?

Otherwise creates a lot of noise.
Scheduled actions are meant for upstream, as reference jobs to compare the results of your Pull Request.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

[Issue(s)](https://github.com/SUSE/spacewalk/issues/23654)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
