### PR TITLE
Remove stringtree-json dependency in favor of google gson

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -145,7 +145,7 @@
              commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate5deps}
              ${commons-compress} ${javamail} smtp jdom ${jmock-jars}
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars} ${tomcat-jars}
-             bcprov bcpg stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
+             bcprov bcpg postgresql-jdbc ongres-scram/client ongres-scram/common
              ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
              taglibs-standard-spec logdriver quartz slf4j-api log4j/log4j-slf4j-impl
              concurrent velocity-engine-core simple-core  mockobjects mockobjects-core mockobjects-jdk1.4-j2ee1.3 strutstest" />
@@ -201,7 +201,7 @@
              commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate5deps}
              ${commons-compress} ${tomcat-jars} ${javamail} jdom jsch
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars}
-             stringtree-json postgresql-jdbc ongres-scram/client ongres-scram/common
+             postgresql-jdbc ongres-scram/client ongres-scram/common
              ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
              taglibs-standard-spec quartz ${suse-common-jars} velocity-engine-core
              concurrent simple-core snakeyaml simple-xml ${commons-jexl}" />
@@ -214,7 +214,7 @@
              ${commons-validator} concurrent dom4j ${hibernate5deps} ${jta11-jars}
              ${jaf} ${jasper-jars} ${javamail} ${jaxb} jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
-             oro quartz stringtree-json sitemesh ${struts-jars}
+             oro quartz sitemesh ${struts-jars}
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              postgresql-jdbc ongres-scram/client ongres-scram/common ${stringprep-jars}
              snakeyaml simple-xml ${suse-common-jars} ${suse-runtime-jars}

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -92,7 +92,6 @@
         <dependency org="suse" name="spy" rev="0.8.7" />
         <dependency org="suse" name="statistics" rev="1.0.2" />
         <dependency org="suse" name="stax2-api" rev="3.1.4" />
-        <dependency org="suse" name="stringtree-json" rev="2.0.9" />
         <dependency org="suse" name="struts" rev="1.2.9" />
         <dependency org="suse" name="taglibs-standard-impl" rev="1.2.5" />
         <dependency org="suse" name="taglibs-standard-jstlel" rev="1.2.5" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -273,8 +273,6 @@ artifacts:
   - artifact: stax2-api
     package: woodstox
     repository: Uyuni_Other
-  - artifact: stringtree-json
-    repository: Uyuni_Other
   - artifact: struts
     repository: Uyuni_Other
   - artifact: taglibs-standard-impl

--- a/java/code/src/com/redhat/rhn/common/util/StringUtil.java
+++ b/java/code/src/com/redhat/rhn/common/util/StringUtil.java
@@ -23,8 +23,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.xml.utils.XMLChar;
-import org.stringtree.json.JSONReader;
-import org.stringtree.json.JSONWriter;
 
 import java.io.File;
 import java.net.URLEncoder;
@@ -696,27 +694,6 @@ public class StringUtil {
     public static String toPlainText(String html) {
         XmlToPlainText helper = new XmlToPlainText();
         return helper.convert(html);
-    }
-
-    /**
-     * Converts an object to json representation
-     * @param obj any object
-     * @return the jsoned representation
-     */
-    public static String toJson(Object obj) {
-        JSONWriter writer = new JSONWriter();
-        return writer.write(obj);
-    }
-
-    /**
-     * Converts a jsoned representation back to the object
-     * @param json json string
-     * @return the converted object.. The caller is expected to know the kind of
-     * returned object.
-     */
-    public static Object jsonToObject(String json) {
-        JSONReader reader = new JSONReader();
-        return reader.read(json);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/AuditSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/AuditSearchAction.java
@@ -24,6 +24,8 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.taglibs.list.ListTagHelper;
 import com.redhat.rhn.manager.audit.AuditManager;
 
+import com.suse.utils.Json;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionForm;
@@ -32,7 +34,6 @@ import org.apache.struts.action.ActionMapping;
 import org.apache.struts.action.ActionMessage;
 import org.apache.struts.action.ActionMessages;
 import org.apache.struts.action.DynaActionForm;
-import org.stringtree.json.JSONWriter;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -167,7 +168,6 @@ public class AuditSearchAction extends RhnAction {
         DateRangePicker.DatePickerResults dpresults;
         DynaActionForm dform = (DynaActionForm)form;
         HttpSession session = request.getSession(true);
-        JSONWriter jsonwr = new JSONWriter();
         List<AuditDto> result = null;
         long start, end;
         Map<String, String[]> typemap;
@@ -280,7 +280,7 @@ public class AuditSearchAction extends RhnAction {
         // or this is what they asked for
         if (result == null) {
             typemap = AuditManager.getAuditTypeMap();
-            request.setAttribute("auJsonTypes", jsonwr.write(typemap));
+            request.setAttribute("auJsonTypes", Json.GSON.toJson(typemap));
             request.setAttribute("machines", AuditManager.getMachines());
             request.setAttribute("types", prepareAuditTypes());
 

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -52,6 +52,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.user.UserManager;
 
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
+import com.suse.utils.Json;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -62,7 +63,6 @@ import org.apache.struts.action.ActionMapping;
 import org.apache.struts.action.ActionMessage;
 import org.apache.struts.action.ActionMessages;
 import org.apache.struts.action.DynaActionForm;
-import org.stringtree.json.JSONWriter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -768,8 +768,6 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
         }
         ctx.getRequest().setAttribute("parentChannelChecksums", parentChannelChecksums);
 
-        JSONWriter json = new JSONWriter();
-
         // base channel arches
         List<Map<String, String>> channelArches = new ArrayList<>();
         List<ChannelArch> arches = ChannelManager.getChannelArchitectures();
@@ -788,10 +786,10 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
                 .values());
         for (String arch : uniqueParentChannelArches) {
             archCompatMap.put(
-                    arch, json.write(ChannelManager.compatibleChildChannelArches(arch)));
+                    arch, Json.GSON.toJson(ChannelManager.compatibleChildChannelArches(arch)));
         }
         // empty string for when there is no parent, all arches are available
-        archCompatMap.put("", json.write(allArchConstruct));
+        archCompatMap.put("", Json.GSON.toJson(allArchConstruct));
         ctx.getRequest().setAttribute("archCompatMap", archCompatMap);
 
         // set the list of yum supported checksums

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/ActionChainSaveAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/ActionChainSaveAction.java
@@ -25,9 +25,10 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.ActionChainHelper;
 import com.redhat.rhn.frontend.struts.RequestContext;
 
+import com.suse.utils.Json;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.stringtree.json.JSONWriter;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -136,6 +137,6 @@ public class ActionChainSaveAction {
         Map<String, Object> result = new HashMap<>();
         result.put(SUCCESS_FIELD, success);
         result.put(TEXT_FIELD, LocalizationService.getInstance().getMessage(messageId));
-        return new JSONWriter().write(result);
+        return Json.GSON.toJson(result);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/ActionChainSaveActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/ActionChainSaveActionTest.java
@@ -29,8 +29,11 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.utils.Json;
+
+import com.google.gson.reflect.TypeToken;
+
 import org.junit.jupiter.api.Test;
-import org.stringtree.json.JSONReader;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -81,8 +84,8 @@ public class ActionChainSaveActionTest extends BaseTestCaseWithUser {
         String resultString = saveAction.save(actionChain.getId(), newLabel,
                 deletedEntries, deletedSortOrders, reorderedSortOrders, request);
 
-        Map<String, Object> result = (Map<String, Object>) new JSONReader()
-            .read(resultString);
+        Map<String, Object> result = Json.GSON.fromJson(resultString,
+            new TypeToken<Map<String, Object>>() { }.getType());
         assertEquals(true, result.get(ActionChainSaveAction.SUCCESS_FIELD));
         assertEquals(LocalizationService.getInstance().getMessage("actionchain.jsp.saved"),
             result.get(ActionChainSaveAction.TEXT_FIELD));

--- a/java/code/src/com/redhat/rhn/frontend/struts/ActionChainHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/ActionChainHelper.java
@@ -31,7 +31,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.DynaActionForm;
-import org.stringtree.json.JSONWriter;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -105,8 +104,7 @@ public class ActionChainHelper {
             populateActionChain(result, placeholder);
         }
 
-        String json = new JSONWriter().write(result);
-        request.setAttribute(EXISTING_ACTION_CHAINS_PROPERTY_NAME, json);
+        request.setAttribute(EXISTING_ACTION_CHAINS_PROPERTY_NAME, Json.GSON.toJson(result));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/struts/test/ActionChainHelperTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/test/ActionChainHelperTest.java
@@ -29,11 +29,12 @@ import com.redhat.rhn.frontend.struts.ActionChainHelper;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.utils.Json;
+
 import com.mockobjects.servlet.MockHttpServletRequest;
 
 import org.apache.struts.action.DynaActionForm;
 import org.junit.jupiter.api.Test;
-import org.stringtree.json.JSONWriter;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -98,9 +99,8 @@ public class ActionChainHelperTest extends BaseTestCaseWithUser {
         }
 
         MockHttpServletRequest request = TestUtils.getRequestWithSessionAndUser();
-        String s = new JSONWriter().write(result);
         request.addExpectedSetAttribute(
-            ActionChainHelper.EXISTING_ACTION_CHAINS_PROPERTY_NAME, s);
+            ActionChainHelper.EXISTING_ACTION_CHAINS_PROPERTY_NAME, Json.GSON.toJson(result));
 
         ActionChainHelper.prepopulateActionChains(request);
     }

--- a/java/spacewalk-java.changes.mackdk.drop-stringtree
+++ b/java/spacewalk-java.changes.mackdk.drop-stringtree
@@ -1,0 +1,1 @@
+- Remove stringtree-json dependency in favor of gson

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -140,7 +140,6 @@ BuildRequires:  snakeyaml >= 1.33
 BuildRequires:  spark-core
 BuildRequires:  spark-template-jade
 BuildRequires:  statistics
-BuildRequires:  stringtree-json
 BuildRequires:  struts >= 1.2.9
 BuildRequires:  tomcat >= 7
 BuildRequires:  tomcat-lib >= 7
@@ -228,7 +227,6 @@ Requires:       spacewalk-java-lib = %{version}
 Requires:       spark-core
 Requires:       spark-template-jade
 Requires:       statistics
-Requires:       stringtree-json
 Requires:       struts >= 1.2.9
 Requires:       sudo
 Requires:       susemanager-docs_en


### PR DESCRIPTION
## What does this PR change?

This PR replaces the usages of `stringtree-json` `JSONWriter` and `JSONReader` with calls to existing gson conversion methods.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
