### PR TITLE
User with API ready only are only allowed to make GET requests

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthFilter.java
@@ -84,7 +84,9 @@ public class AuthFilter implements Filter {
             // Prevent read-only API users from using the web UI
             RequestContext requestContext = new RequestContext(hreq);
             User user = requestContext.getCurrentUser();
-            if (user != null && user.isReadOnly() && !hreq.getServletPath().startsWith("/manager/api")) {
+            if (user != null && user.isReadOnly() &&
+                    (!hreq.getServletPath().startsWith("/manager/api") ||
+                    !hreq.getMethod().equalsIgnoreCase("GET"))) {
                 SessionManager.purgeUserSessions(user);
                 authenticationService.redirectToLogin(hreq, (HttpServletResponse) response);
                 return;

--- a/java/spacewalk-java.changes.rmateus.master
+++ b/java/spacewalk-java.changes.rmateus.master
@@ -1,0 +1,1 @@
+- User with API ready only are only allowed to make GET requests


### PR DESCRIPTION
## What does this PR change?

Follow-up on the pr: https://github.com/uyuni-project/uyuni/pull/8465

All API action that are read-only are being published as GET request. This PR enhances the validation to only allow calling GET methods.

With the current implementation, those read-only users can still call API methods that are for UI usage and can make post requests to those. this happens because the API on UI methods are also using the same prefix "/manager/api".
With this change, all HTTP methods different from GET will be blocked.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
