### PR TITLE
Apply reboot method changes for transactional systems in the bootstrap script

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -1004,6 +1004,17 @@ beacons:
   reboot_info:
     - interval: 10
 EOF
+
+    if ! test -f /etc/transactional-update.conf; then
+        cp /usr/etc/transactional-update.conf /etc/transactional-update.conf
+    fi
+
+    . /etc/transactional-update.conf
+    if [ -z "$REBOOT_METHOD" ] || [ "$REBOOT_METHOD" = "auto" ]; then
+        sed -i '/^REBOOT_METHOD=/d' /etc/transactional-update.conf
+        echo "REBOOT_METHOD=systemd" >> /etc/transactional-update.conf
+    fi
+
 fi # -n SNAPSHOT_ID
 fi # REGISTER_THIS_BOX eq 1
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.welder.fix-slemicro-reboot-method
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.welder.fix-slemicro-reboot-method
@@ -1,0 +1,1 @@
+- Apply reboot method changes for transactional systems in the bootstrap script


### PR DESCRIPTION
## What does this PR change?

See title.

In the bootstrap salt state we already do the same, but when the bootstrap is using script the reboot method e currently not being changed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
