### PR TITLE
Avoid hairpin problem with rhnpush

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -510,10 +510,10 @@ Given(/^metadata generation finished for "([^"]*)"$/) do |channel|
   get_target('server').run_until_ok("ls /var/cache/rhn/repodata/#{channel}/*updateinfo.xml.gz")
 end
 
-When(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |arg1, arg2|
-  srvurl = "https://#{get_target('server').full_hostname}/APP"
-  command = "rhnpush --server=#{srvurl} -u admin -p admin --nosig -c #{arg2} #{arg1} "
+When(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |package, channel|
+  command = "rhnpush -u admin -p admin --nosig -c #{channel} #{package}"
   get_target('server').run(command, timeout: 500)
+  # TODO: instead of next line, wait for package to appear inside /var/spacewalk/packages
   get_target('server').run('ls -lR /var/spacewalk/packages', timeout: 500)
 end
 


### PR DESCRIPTION
## What does this PR change?

Don't use `--server` parameter of `rhnpush` as it triggers the hairpin problem.


## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/21384

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/24064

Bug: https://bugzilla.suse.com/show_bug.cgi?id=1222325


## Changelogs

- [x] No changelog needed
