### PR TITLE
enable interserver sync tests

### DIFF
--- a/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
@@ -1,11 +1,11 @@
 # Copyright (c) 2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_github_validation
 Feature: Export and import configuration channels with new ISS implementation
   Distribute configuration between servers
   Run export and import with ISS v2
 
+@skip_if_github_validation
   Scenario: Install inter server sync package
     When I install packages "inter-server-sync" on this "server"
     Then "inter-server-sync" should be installed on "server"

--- a/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
@@ -1,11 +1,11 @@
 # Copyright (c) 2021-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_github_validation
 Feature: Export and import software channels with new ISS implementation
   Distribute software between servers
   Run export and import with ISS v2
 
+@skip_if_github_validation
   Scenario: Install inter server sync package
     When I install packages "inter-server-sync" on this "server"
     Then "inter-server-sync" should be installed on "server"


### PR DESCRIPTION
## What does this PR change?

CI: enable interserver sync tests

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/20960
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
