### PR TITLE
CI: fix ansible and prometheus tests

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
 env:
-  UYUNI_PROJECT: uyuni-project
+  UYUNI_PROJECT: jordimassaguerpla
   UYUNI_VERSION: master
   CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
 jobs:

--- a/testsuite/dockerfiles/opensuse-minion/Dockerfile
+++ b/testsuite/dockerfiles/opensuse-minion/Dockerfile
@@ -1,8 +1,9 @@
 FROM opensuse/leap:15.5
 RUN zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/ Uyuni-Server-POOL-x86_64 && \
     zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/systemsmanagement:Uyuni:Test-Packages:Pool.repo && \
-    zypper ref -f && \
-    zypper -n install openssh-server openssh-clients hostname iproute2 venv-salt-minion andromeda-dummy milkyway-dummy virgo-dummy openscap-utils openscap-content scap-security-guide gzip udev dmidecode tar && \
+    zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/ tools_pool_repo && \
+   zypper ref -f && \
+    zypper -n install openssh-server openssh-clients hostname iproute2 venv-salt-minion andromeda-dummy milkyway-dummy virgo-dummy openscap-utils openscap-content scap-security-guide gzip udev dmidecode tar ansible golang-github-prometheus-prometheus golang-github-prometheus-alertmanager prometheus-blackbox_exporter golang-github-prometheus-node_exporter golang-github-prometheus-promu prometheus-postgres_exporter && \
     zypper clean -a
 RUN zypper -n ar --no-gpgcheck https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_repo_rpm_pool
 COPY etc_pam.d_sshd /etc/pam.d/sshd

--- a/testsuite/dockerfiles/rocky-minion/Dockerfile
+++ b/testsuite/dockerfiles/rocky-minion/Dockerfile
@@ -1,6 +1,6 @@
 FROM rockylinux:8
 COPY uyuni-tools-pool.repo /etc/yum.repos.d
-RUN yum -y install openssh-server venv-salt-minion openssh-clients iproute hostname openscap-utils scap-security-guide-redhat udev dmidecode tar
+RUN yum -y install openssh-server venv-salt-minion openssh-clients iproute hostname openscap-utils scap-security-guide-redhat udev dmidecode tar golang-github-prometheus-node_exporter prometheus-postgres_exporter
 COPY test_repo_rpm_pool.repo /etc/yum.repos.d
 COPY etc_pam.d_sshd /etc/pam.d/sshd
 CMD ssh-keygen -A && /usr/sbin/sshd -De

--- a/testsuite/dockerfiles/ubuntu-minion/Dockerfile
+++ b/testsuite/dockerfiles/ubuntu-minion/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 RUN echo "deb [trusted=yes] http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2204-Uyuni-Client-Tools/xUbuntu_22.04/ /" > /etc/apt/sources.list.d/uyuni-tools.list
 RUN apt-get update && \
-  apt-get -y install venv-salt-minion openssh-server openssh-client hostname iproute2 libopenscap8 scap-security-guide-ubuntu udev dmidecode tar && \
+  apt-get -y install venv-salt-minion openssh-server openssh-client hostname iproute2 libopenscap8 scap-security-guide-ubuntu udev dmidecode tar prometheus-apache-exporter prometheus-exporter-exporter prometheus-node-exporter prometheus-postgres-exporter && \
   apt-get clean
 RUN echo "deb [trusted=yes] https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/ /" > /etc/apt/sources.list.d/test_repo_deb_pool.list
 RUN mkdir /run/sshd

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -1,7 +1,6 @@
 # Copyright (c) 2021-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@skip_if_github_validation
 @scope_ansible
 Feature: Operate an Ansible control node in a normal minion
 
@@ -10,13 +9,14 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     When I deploy testing playbooks and inventory files to "sle_minion"
-
+@skip_if_github_validation	
 @susemanager
   Scenario: Pre-requisite: Enable client tools repositories
     When I enable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
 
-# TODO: Check why tools_update_repo is not available on the openSUSE minion
+    # TODO: Check why tools_update_repo is not available on the openSUSE minion
+@skip_if_github_validation
 @uyuni
   Scenario: Pre-requisite: Enable client tools repositories
     When I enable the repositories "tools_pool_repo os_pool_repo" on this "sle_minion"
@@ -89,13 +89,15 @@ Feature: Operate an Ansible control node in a normal minion
     Then I should see a "System properties changed" text
     And I remove package "orion-dummy" from this "sle_minion" without error control
     And I remove "/tmp/file.txt" from "sle_minion"
-
+	
+@skip_if_github_validation
 @susemanager
   Scenario: Cleanup: Disable client tools repositories
     Given I am on the Systems overview page of this "sle_minion"
     When I disable the repositories "tools_update_repo tools_pool_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
 
+@skip_if_github_validation
 @uyuni
   Scenario: Cleanup: Disable client tools repositories
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -4,7 +4,6 @@
 # - features/secondary/srv_monitoring.feature: as this feature disables/re-enables monitoring capabilities
 # - sumaform: as it is configuring monitoring to be enabled after deployment
 
-@skip_if_github_validation
 @scope_monitoring
 @scope_res
 @deblike_minion
@@ -13,6 +12,7 @@ Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
   As an authorized user
   I want to enable Prometheus exporters
 
+  @skip_if_github_validation
   Scenario: Pre-requisite: enable Prometheus exporters repository on the Debian-like minion
     When I enable the necessary repositories before installing Prometheus exporters on this "deblike_minion"
 
@@ -64,6 +64,7 @@ Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
-
+	
+  @skip_if_github_validation
   Scenario: Cleanup: disable Prometheus exporters repository on the Debian-like minion
     When I disable the necessary repositories before installing Prometheus exporters on this "deblike_minion" without error control

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -4,7 +4,6 @@
 # - features/secondary/srv_monitoring.feature : As this feature disable/re-enable monitoring capabilities
 # - sumaform : As it is configuring monitoring to be enabled after deployment
 
-@skip_if_github_validation
 @sle_minion
 @scope_monitoring
 Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
@@ -12,6 +11,7 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
   As an authorized user
   I want to enable Prometheus exporters
 
+  @skip_if_github_validation
   Scenario: Pre-requisite: enable Prometheus exporters repository on the minion
     When I enable the necessary repositories before installing Prometheus exporters on this "sle_minion"
     And I refresh the metadata for "sle_minion"
@@ -79,5 +79,6 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
 
+  @skip_if_github_validation
   Scenario: Cleanup: disable Prometheus exporters repository
     When I disable the necessary repositories before installing Prometheus exporters on this "sle_minion" without error control

--- a/testsuite/features/secondary/min_rhlike_monitoring.feature
+++ b/testsuite/features/secondary/min_rhlike_monitoring.feature
@@ -4,7 +4,6 @@
 # - features/secondary/srv_monitoring.feature: as this feature disables/re-enables monitoring capabilities
 # - sumaform: as it is configuring monitoring to be enabled after deployment
 
-@skip_if_github_validation
 @scope_monitoring
 @scope_res
 @rhlike_minion
@@ -13,6 +12,7 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
   As an authorized user
   I want to enable Prometheus exporters
 
+  @skip_if_github_validation
   Scenario: Pre-requisite: enable Prometheus exporters repository on the Red Hat-like minion
     When I enable the necessary repositories before installing Prometheus exporters on this "rhlike_minion"
 
@@ -65,5 +65,6 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed
 
+  @skip_if_github_validation
   Scenario: Cleanup: disable Prometheus exporters repository on the Red Hat-like minion
     When I disable the necessary repositories before installing Prometheus exporters on this "rhlike_minion" without error control

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -20,7 +20,6 @@
 # If this feature fails,
 # it could let the monitoring feature disabled for the Debian-like minion
 
-@skip_if_github_validation
 @skip_if_containerized_server
 @scope_monitoring
 Feature: Disable and re-enable monitoring of the server


### PR DESCRIPTION
## What does this PR change?

We need ansible and prometheus packages preinstalled in the images. This way, we do not depend on installing the packages from external infrastructure.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/20955
https://github.com/SUSE/spacewalk/issues/20670

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
