### PR TITLE
Fix bootstrap of res with zypper installed

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -196,6 +196,7 @@ fi
 
 INSTALLER=zypper
 
+# the order matters: see bsc#1222347
 if [ -x /usr/bin/dnf ]; then
     INSTALLER=yum
 elif [ -x /usr/bin/yum ]; then

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -198,10 +198,10 @@ INSTALLER=zypper
 
 if [ -x /usr/bin/dnf ]; then
     INSTALLER=yum
-elif [ -x /usr/bin/zypper ]; then
-    INSTALLER=zypper
 elif [ -x /usr/bin/yum ]; then
     INSTALLER=yum
+elif [ -x /usr/bin/zypper ]; then
+    INSTALLER=zypper
 elif [ -x /usr/bin/apt ]; then
     INSTALLER=apt
 fi

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.fix-bootstrap-of-res-with-zypper-installed
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.fix-bootstrap-of-res-with-zypper-installed
@@ -1,0 +1,1 @@
+- fix liberty bootstrapping when zypper is installed (bsc#1222347)

--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -49,6 +49,7 @@ function exit_with_message_code() {
     exit 0
 }
 
+# the order matters: see bsc#1222347
 if [ -x /usr/bin/dnf ]; then
     INSTALLER=yum
 elif [ -x /usr/bin/yum ]; then

--- a/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
+++ b/susemanager-utils/susemanager-sls/salt-ssh/preflight.sh
@@ -51,10 +51,10 @@ function exit_with_message_code() {
 
 if [ -x /usr/bin/dnf ]; then
     INSTALLER=yum
-elif [ -x /usr/bin/zypper ]; then
-    INSTALLER=zypper
 elif [ -x /usr/bin/yum ]; then
     INSTALLER=yum
+elif [ -x /usr/bin/zypper ]; then
+    INSTALLER=zypper
 elif [ -x /usr/bin/apt ]; then
     INSTALLER=apt
 else

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.fix-bootstrap-of-res-with-zypper-installed
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.fix-bootstrap-of-res-with-zypper-installed
@@ -1,0 +1,1 @@
+- fix liberty bootstrapping when zypper is installed (bsc#1222347)


### PR DESCRIPTION
## What does this PR change?

On a Liberty system it could happen that `zypper` is installed together with dnf or yum.
On Liberty 7 this cause problems as zypper is preferred over yum and with this the wrong bootstrap repo URL is generated.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24069

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
