### PR TITLE
QE: Build Host entitlement adds some extra minutes to apply the salt high-state

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -27,7 +27,7 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     When I bootstrap "sle12sp5_buildhost" using bootstrap script with activation key "1-sle12sp5_buildhost_key" from the proxy
     And I wait at most 10 seconds until Salt master sees "sle12sp5_buildhost" as "unaccepted"
     And I accept "sle12sp5_buildhost" key in the Salt master
-    And I wait until onboarding is completed for "sle12sp5_buildhost"
+    And I wait at most 500 seconds until onboarding is completed for "sle12sp5_buildhost"
 
   Scenario: Apply the highstate to the SLES 12 SP5 build host
     Given I am on the Systems overview page of this "sle12sp5_buildhost"

--- a/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
@@ -27,7 +27,7 @@ Feature: Prepare buildhost and build OS image for SLES 15 SP4
     When I bootstrap "sle15sp4_buildhost" using bootstrap script with activation key "1-sle15sp4_buildhost_key" from the proxy
     And I wait at most 10 seconds until Salt master sees "sle15sp4_buildhost" as "unaccepted"
     And I accept "sle15sp4_buildhost" key in the Salt master
-    And I wait until onboarding is completed for "sle15sp4_buildhost"
+    And I wait at most 500 seconds until onboarding is completed for "sle15sp4_buildhost"
 
   Scenario: Apply the highstate to the SLES 15 SP4 build host
     Given I am on the Systems overview page of this "sle15sp4_buildhost"

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -23,8 +23,9 @@ Feature: Bootstrap a build host via the GUI
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I follow the left menu "Systems > System List > All"
+    # the build host entitlement adds some extra minutes to apply the salt high-state
     And I wait at most 500 seconds until I see the name of "build_host", refreshing the page
-    And I wait until onboarding is completed for "build_host"
+    And I wait at most 500 seconds until onboarding is completed for "build_host"
     Then the Salt master can reach "build_host"
 
 @proxy

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -205,16 +205,20 @@ When(/^I wait at most (\d+) seconds until I see the name of "([^"]*)", refreshin
   end
 end
 
-When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
+When(/^I wait at most (\d+) seconds until onboarding is completed for "([^"]*)"$/) do |seconds, host|
   steps %(
     When I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "#{host}", refreshing the page
     And I follow this "#{host}" link
     And I wait until I see "System Status" text
-    And I wait 180 seconds until the event is picked up and #{DEFAULT_TIMEOUT} seconds until the event "Apply states" is completed
-    And I wait 180 seconds until the event is picked up and #{DEFAULT_TIMEOUT} seconds until the event "Hardware List Refresh" is completed
-    And I wait 180 seconds until the event is picked up and #{DEFAULT_TIMEOUT} seconds until the event "Package List Refresh" is completed
+    And I wait 180 seconds until the event is picked up and #{seconds} seconds until the event "Apply states" is completed
+    And I wait 180 seconds until the event is picked up and #{seconds} seconds until the event "Hardware List Refresh" is completed
+    And I wait 180 seconds until the event is picked up and #{seconds} seconds until the event "Package List Refresh" is completed
   )
+end
+
+When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
+  steps %(I wait at most #{DEFAULT_TIMEOUT} seconds until onboarding is completed for "#{host}")
 end
 
 Then(/^I should see "([^"]*)" via spacecmd$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Build Host entitlement adds some extra minutes to apply the salt high-state.
So we need to wait some more minutes until the onboarding is completed. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
