### PR TITLE
QE: Add and improve cleanup for the containerized proxy

### DIFF
--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -18,8 +18,10 @@ Feature: Setup containerized proxy
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-# TODO: Enable the following scenarios once the team fixes the SLE Micro bootstrapping issues
-@skip
+  Scenario: Clean up sumaform leftovers on the containerized proxy
+    When I perform a full salt minion cleanup on "proxy"
+    And I reboot the "proxy" host through SSH, waiting until it comes back
+
   Scenario: Bootstrap the proxy host as a salt minion
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
@@ -33,12 +35,10 @@ Feature: Setup containerized proxy
 
 # workaround for bsc#1218146
 # Once we start using Leap Micro #23811 in Uyuni Proxy, we need to remove this Cucumber tag
-@skip
 @susemanager
   Scenario: Reboot the proxy host
     When I reboot the "proxy" host through SSH, waiting until it comes back
 
-@skip
   Scenario: Wait until the proxy host appears
     When I wait until onboarding is completed for "proxy"
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -505,6 +505,10 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   if use_salt_bundle
     if slemicro_host?(host)
       node.run('transactional-update --continue -n pkg rm venv-salt-minion', check_errors: false)
+      # SLE Micro could have also installed salt-minion
+      _result, code = node.run('rpm -q salt-minion', check_errors: false)
+      node.run('transactional-update --continue -n pkg rm salt-minion', check_errors: false) if code.zero?
+      node.run('rm -Rf /var/cache/salt/minion /var/run/salt /run/salt /var/log/salt /etc/salt', check_errors: false) if code.zero?
     elsif rh_host?(host)
       node.run('yum -y remove --setopt=clean_requirements_on_remove=1 venv-salt-minion', check_errors: false)
     elsif deb_host?(host)

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -194,7 +194,9 @@ def suse_host?(name)
 end
 
 def slemicro_host?(name)
-  (name.include? 'slemicro') || (name.include? 'micro')
+  node = get_target(name)
+  os_family = node.os_family
+  (name.include? 'slemicro') || (name.include? 'micro') || os_family.include?('sle-micro') || os_family.include?('suse-microos')
 end
 
 def rh_host?(name)


### PR DESCRIPTION
## What does this PR change?

This PR 
- adds a Salt (`salt-minion`, `venv-salt-minion`) cleanup for the containerized proxy. Furthermore, in case of SLE Micro, `salt-minion` could be installed alongside `venv-salt-minion`, so we also remove it, if it is installed.
- onboards the containerized proxy as regular Minion again
- fixes the `slemicro_host` method, which did not work for e.g. a SLE Micro proxy because we only checked for the minion name

I ran the cleanup command manually on the proxy, and we need to reboot it after the cleanup.

### Test suite run on `dominik-srv.mgr.suse.de` with a HEAD environment:

```bash
dominik-ctl:~/spacewalk/testsuite # cucumber features/init_clients/proxy_container.feature
(...)
# Bootstrap the proxy as a Pod
@containerized_server @scope_containerized_proxy @proxy
Feature: Setup containerized proxy
  In order to use a containerized proxy with the server
  As the system administrator
  I want to register the containerized proxy on the server

  Scenario: Log in as admin user                  # features/init_clients/proxy_container.feature:18
      This scenario ran at: 2024-04-08 17:24:17 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:399
      This scenario took: 12 seconds

  Scenario: Clean up sumaform leftovers on the containerized proxy         # features/init_clients/proxy_container.feature:21
      This scenario ran at: 2024-04-08 17:24:29 +0200
Initializing a twopence node for 'proxy'.
Host 'proxy' is alive with determined hostname dominik-pxy and FQDN dominik-pxy.mgr.suse.de
Node: dominik-pxy, OS Version: 5.5, Family: sle-micro
true
Using Salt bundle steps
Node: dominik-pxy, OS Version: 5.5, Family: sle-micro
SLE Micro host
transactional-update -n pkg rm venv-salt-minion returned status code = 0.
Output:
'Checking for newer version.
transactional-update 4.1.6 started
Options: -n pkg rm venv-salt-minion
Separate /var detected.
2024-04-08 17:24:34 tukit 4.1.6 started
2024-04-08 17:24:34 Options: -c8 open
2024-04-08 17:24:34 Using snapshot 8 as base for new snapshot 9.
2024-04-08 17:24:34 /var/lib/overlay/8/etc
2024-04-08 17:24:34 Syncing /etc of previous snapshot 7 as base into new snapshot "/.snapshots/9/snapshot"
2024-04-08 17:24:34 SELinux is enabled.
ID: 9
2024-04-08 17:24:35 Transaction completed.
Calling zypper remove
2024-04-08 17:24:36 tukit 4.1.6 started
2024-04-08 17:24:36 Options: callext 9 zypper -R {} remove -y venv-salt-minion
2024-04-08 17:24:37 Executing `zypper -R /tmp/transactional-update-ArtHLl remove -y venv-salt-minion`:
Reading installed packages...
Resolving package dependencies...

The following package is going to be REMOVED:
  venv-salt-minion

1 package to remove.
After the operation, 110.2 MiB will be freed.
Continue? [y/n/v/...? shows all options] (y): y
(1/1) Removing venv-salt-minion-3006.0-150000.3.51.2.x86_64 [..
Running in chroot, ignoring command 'stop'
Running in chroot, ignoring command 'daemon-reload'
libsemanage.semanage_direct_remove_key: Removing last venv-salt-minion module (no other venv-salt-minion module exists at another priority).
.done]
2024-04-08 17:24:45 Application returned with exit status 0.
2024-04-08 17:24:45 Transaction completed.
Trying to rebuild kdump initrd
2024-04-08 17:24:46 tukit 4.1.6 started
2024-04-08 17:24:46 Options: close 9
2024-04-08 17:24:47 New default snapshot is #9 (/.snapshots/9/snapshot).
2024-04-08 17:24:47 Transaction completed.

Please reboot your machine to activate the changes and avoid data loss.
New default snapshot is #9 (/.snapshots/9/snapshot).
transactional-update finished
'
rpm -q salt-minion returned status code = 0.
Output:
'salt-minion-3006.0-150500.4.24.2.x86_64
'
transactional-update --continue -n pkg rm salt-minion returned status code = 0.
Output:
'Checking for newer version.
transactional-update 4.1.6 started
Options: --continue -n pkg rm salt-minion
Separate /var detected.
2024-04-08 17:24:48 tukit 4.1.6 started
2024-04-08 17:24:48 Options: -c9 open
2024-04-08 17:24:49 Using snapshot 9 as base for new snapshot 10.
2024-04-08 17:24:49 /var/lib/overlay/9/etc
ID: 10
2024-04-08 17:24:49 Transaction completed.
Calling zypper remove
2024-04-08 17:24:50 tukit 4.1.6 started
2024-04-08 17:24:50 Options: callext 10 zypper -R {} remove -y salt-minion
2024-04-08 17:24:51 Executing `zypper -R /tmp/transactional-update-AW2UtJ remove -y salt-minion`:
Reading installed packages...
Resolving package dependencies...

The following 3 packages are going to be REMOVED:
  patterns-microos-salt_minion salt-minion salt-transactional-update

The following pattern is going to be REMOVED:
  microos-salt_minion

3 packages to remove.
After the operation, 43.4 KiB will be freed.
Continue? [y/n/v/...? shows all options] (y): y
(1/3) Removing patterns-microos-salt_minion-5.5.1-150500.1.1.x86_64 [..done]
(2/3) Removing salt-minion-3006.0-150500.4.24.2.x86_64 [..
Running in chroot, ignoring command 'stop'
Running in chroot, ignoring command 'daemon-reload'
.done]
(3/3) Removing salt-transactional-update-3006.0-150500.4.24.2.x86_64 [..done]
2024-04-08 17:24:53 Application returned with exit status 0.
2024-04-08 17:24:53 Transaction completed.
Trying to rebuild kdump initrd
2024-04-08 17:24:54 tukit 4.1.6 started
2024-04-08 17:24:54 Options: close 10
2024-04-08 17:24:55 New default snapshot is #10 (/.snapshots/10/snapshot).
2024-04-08 17:24:55 Transaction completed.

Please reboot your machine to activate the changes and avoid data loss.
New default snapshot is #10 (/.snapshots/10/snapshot).
transactional-update finished
'
 returned status code = 0.
Output:
''
    When I perform a full salt minion cleanup on "proxy"                   # features/step_definitions/salt_steps.rb:503
reboot returned status code = 0.
Output:
''
Node dominik-pxy is offline.
Node dominik-pxy is online.
    And I reboot the "proxy" host through SSH, waiting until it comes back # features/step_definitions/command_steps.rb:1514
      This scenario took: 53 seconds

  Scenario: Bootstrap the proxy host as a salt minion          # features/init_clients/proxy_container.feature:25
      This scenario ran at: 2024-04-08 17:25:22 +0200
    When I follow the left menu "Systems > Bootstrapping"      # features/step_definitions/navigation_steps.rb:337
    Then I should see a "Bootstrap Minions" text               # features/step_definitions/navigation_steps.rb:589
    When I enter the hostname of "proxy" as "hostname"         # features/step_definitions/navigation_steps.rb:435
      The hostname of proxy is dominik-pxy.mgr.suse.de
    And I enter "22" as "port"                                 # features/step_definitions/navigation_steps.rb:220
    And I enter "root" as "user"                               # features/step_definitions/navigation_steps.rb:220
    And I enter "linux" as "password"                          # features/step_definitions/navigation_steps.rb:220
    And I select "1-PROXY-KEY-x86_64" from "activationKeys"    # features/step_definitions/navigation_steps.rb:164
    And I click on "Bootstrap"                                 # features/step_definitions/navigation_steps.rb:256
    And I wait until I see "Bootstrap process initiated." text # features/step_definitions/navigation_steps.rb:39
      This scenario took: 48 seconds

  # workaround for bsc#1218146
  # Once we start using Leap Micro #23811 in Uyuni Proxy, we need to remove this Cucumber tag
  @susemanager
  Scenario: Reboot the proxy host                                           # features/init_clients/proxy_container.feature:39
      This scenario ran at: 2024-04-08 17:26:10 +0200
reboot returned status code = 0.
Output:
''
Node dominik-pxy is offline.
Node dominik-pxy is online.
    When I reboot the "proxy" host through SSH, waiting until it comes back # features/step_definitions/command_steps.rb:1514
      This scenario took: 26 seconds

  Scenario: Wait until the proxy host appears             # features/init_clients/proxy_container.feature:42
      This scenario ran at: 2024-04-08 17:26:36 +0200
    When I wait until onboarding is completed for "proxy" # features/step_definitions/setup_steps.rb:208
      This scenario took: 116 seconds

  Scenario: Generate containerized proxy configuration                                                                    # features/init_clients/proxy_container.feature:45
      This scenario ran at: 2024-04-08 17:28:32 +0200
    When I generate the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy on the server           # features/step_definitions/command_steps.rb:1433
.
.
    And I copy the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy from the server to the proxy # features/step_definitions/command_steps.rb:1454
      This scenario took: 7 seconds

  Scenario: Set-up the containerized proxy service to support Avahi # features/init_clients/proxy_container.feature:49
      This scenario ran at: 2024-04-08 17:28:39 +0200
    When I add avahi hosts in containerized proxy configuration     # features/step_definitions/command_steps.rb:1459
      Record not added - avahi domain was not detected
      This scenario took: 0 seconds

  Scenario: Run a containerized proxy                                                # features/init_clients/proxy_container.feature:52
      This scenario ran at: 2024-04-08 17:28:39 +0200
    When I run "mgrpxy install podman /tmp/proxy_container_config.tar.gz" on "proxy" # features/step_definitions/command_steps.rb:748
      This scenario took: 45 seconds

  Scenario: Wait until containerized proxy service is active                # features/init_clients/proxy_container.feature:55
      This scenario ran at: 2024-04-08 17:29:24 +0200
    And I wait until "uyuni-proxy-pod" service is active on "proxy"         # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-httpd" service is active on "proxy"       # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-salt-broker" service is active on "proxy" # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-squid" service is active on "proxy"       # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-ssh" service is active on "proxy"         # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-tftpd" service is active on "proxy"       # features/step_definitions/command_steps.rb:281
    And I wait until port "8022" is listening on "proxy" container          # features/step_definitions/command_steps.rb:1480
    And I wait until port "80" is listening on "proxy" container            # features/step_definitions/command_steps.rb:1480
    And I wait until port "443" is listening on "proxy" container           # features/step_definitions/command_steps.rb:1480
    And I visit "Proxy" endpoint of this "proxy"                            # features/step_definitions/navigation_steps.rb:1046
      This scenario took: 5 seconds

  Scenario: containerized proxy should be registered automatically  # features/init_clients/proxy_container.feature:67
      This scenario ran at: 2024-04-08 17:29:29 +0200
    When I follow the left menu "Systems"                           # features/step_definitions/navigation_steps.rb:337
    And I wait until I see the name of "proxy", refreshing the page # features/step_definitions/navigation_steps.rb:102
      This scenario took: 1 seconds

10 scenarios (10 passed)
30 steps (30 passed)
5m13.186s
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!