### PR TITLE
in containers open the main database for the internal network

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -295,8 +295,11 @@ setup_db_postgres() {
             echo "local $MANAGER_DB_NAME postgres peer
     local $MANAGER_DB_NAME $MANAGER_USER scram-sha-256
     host $MANAGER_DB_NAME $MANAGER_USER 127.0.0.1/32 scram-sha-256
-    host $MANAGER_DB_NAME $MANAGER_USER ::1/128 scram-sha-256
-    " > /tmp/pg_hba.conf
+    host $MANAGER_DB_NAME $MANAGER_USER ::1/128 scram-sha-256" > /tmp/pg_hba.conf
+            if [ "$container" == "podman" -o -d /var/run/secrets/kubernetes.io ]; then
+                INT_NET=$(ip -o -4 addr show up scope global | head -1 | awk '{print $4}')
+                echo "host $MANAGER_DB_NAME $MANAGER_USER $INT_NET scram-sha-256" >> /tmp/pg_hba.conf
+            fi
             cat ${DATADIR}/pg_hba.conf >> /tmp/pg_hba.conf
             mv ${DATADIR}/pg_hba.conf ${DATADIR}/pg_hba.conf.bak
             mv /tmp/pg_hba.conf ${DATADIR}/pg_hba.conf

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -243,6 +243,13 @@ exists_user() {
     fi
 }
 
+run_in_container() {
+    if [ "$container" == "podman" -o "$container" == "docker" -o -d /var/run/secrets/kubernetes.io ]; then
+        return 0
+    fi
+    return 1
+}
+
 setup_db_postgres() {
     if [ $EXTERNALDB = 0 ]; then
         POSTGRESQLSERVICE=$(systemctl list-unit-files | grep -m 1 postgresql | cut -f1 -d. | tr -d '\n')
@@ -296,7 +303,7 @@ setup_db_postgres() {
     local $MANAGER_DB_NAME $MANAGER_USER scram-sha-256
     host $MANAGER_DB_NAME $MANAGER_USER 127.0.0.1/32 scram-sha-256
     host $MANAGER_DB_NAME $MANAGER_USER ::1/128 scram-sha-256" > /tmp/pg_hba.conf
-            if [ "$container" == "podman" -o -d /var/run/secrets/kubernetes.io ]; then
+            if run_in_container; then
                 INT_NET=$(ip -o -4 addr show up scope global | head -1 | awk '{print $4}')
                 echo "host $MANAGER_DB_NAME $MANAGER_USER $INT_NET scram-sha-256" >> /tmp/pg_hba.conf
             fi

--- a/susemanager/susemanager.changes.mc.container-open-db-for-internal-network
+++ b/susemanager/susemanager.changes.mc.container-open-db-for-internal-network
@@ -1,0 +1,1 @@
+- in containers open the main database for the internal network


### PR DESCRIPTION
## What does this PR change?

The main database should be accessible from the internal network when running in container.
This is needed when other containers connected to the same network need to work with the DB.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

Issue: https://github.com/SUSE/spacewalk/issues/23556

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
