### PR TITLE
Add "expect" package to proxy

### DIFF
--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation
@@ -125,6 +125,13 @@ Feature: Update activation keys
     And I wait until "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" has been checked
     And I check "SUSE-Manager-Proxy-5.0-Pool for x86_64"
     And I check "SUSE-Manager-Proxy-5.0-Updates for x86_64"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key Proxy Key x86_64 has been modified" text
+    # TODO: remove when we use combustion
+    # 'expect' is needed for Cobbler and Retail tests
+    # It is complicated to add othewise on SLE Micro
+    When I follow "Packages"
+    And I enter "expect" as "packages"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 


### PR DESCRIPTION
## What does this PR change?

Temporary PR so `expect` package is available on the SLE micro based containerized proxy. This package is needed for Cobbler and Retail tests.

Might be removed in favour of a sumaform solution based on combustion.



## Links

No ports, 4.3 does not use sle micro containerized proxy.


## Changelogs

- [x] No changelog needed
