### PR TITLE
Backport: Add filters for rpmlint in package spacewalk-web (#24083)

### DIFF
--- a/web/spacewalk-web-rpmlintrc
+++ b/web/spacewalk-web-rpmlintrc
@@ -1,0 +1,2 @@
+addFilter("W: explicit-lib-dependency");
+addFilter("W: filename-too-long-for-joliet");

--- a/web/spacewalk-web.changes.raul.fix_lint_errors
+++ b/web/spacewalk-web.changes.raul.fix_lint_errors
@@ -1,0 +1,3 @@
+- Add two filters for rpmlint in package spacewalk-web:
+  explicit-lib-dependency and filename-too-long-for-joliet
+  * Added: spacewalk-web-rpmlintrc

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -39,6 +39,7 @@ Release:        0
 URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 Source1:        node-modules.tar.gz
+Source2:	spacewalk-web-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires(pre):  uyuni-base-common


### PR DESCRIPTION
## What does this PR change?

Backports https://github.com/SUSE/spacewalk/pull/24083

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): Partially fixes https://github.com/SUSE/spacewalk/issues/20836
Port(s): https://github.com/SUSE/spacewalk/pull/24083

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
