### PR TITLE
QE: Skip proxy host onboarding

### DIFF
--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -22,6 +22,7 @@ Feature: Setup containerized proxy
     When I perform a full salt minion cleanup on "proxy"
     And I reboot the "proxy" host through SSH, waiting until it comes back
 
+@skip
   Scenario: Bootstrap the proxy host as a salt minion
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
@@ -36,9 +37,11 @@ Feature: Setup containerized proxy
 # workaround for bsc#1218146
 # Once we start using Leap Micro #23811 in Uyuni Proxy, we need to remove this Cucumber tag
 @susemanager
+@skip
   Scenario: Reboot the proxy host
     When I reboot the "proxy" host through SSH, waiting until it comes back
 
+@skip
   Scenario: Wait until the proxy host appears
     When I wait until onboarding is completed for "proxy"
 


### PR DESCRIPTION
## What does this PR change?

This PR skips again the scenarios to bootstrap and assure the onboarding of the Proxy Host.
For now, we have an issue after onboarding, as it takes too much time to retrieve the system from the system.searchByName API endpoint.
As consequence of this issue, the generated proxy configuration doesn't match with the Proxy Host systemId, and the proxy container fails authentication to the server.

**Bug**: https://bugzilla.suse.com/show_bug.cgi?id=1222628
**Slack thread**: https://suse.slack.com/archives/C02CLB6AGJ3/p1712742621440079

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were skipped

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
