### PR TITLE
attestation on minion startup

### DIFF
--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -64,6 +64,7 @@ public class GlobalInstanceHolder {
     public static final SystemQuery SYSTEM_QUERY = SALT_SERVICE;
     public static final SaltApi SALT_API = SALT_SERVICE;
     public static final CloudPaygManager PAYG_MANAGER = new CloudPaygManager();
+    public static final AttestationManager ATTESTATION_MANAGER = new AttestationManager();
     public static final ServerGroupManager SERVER_GROUP_MANAGER = new ServerGroupManager(SALT_API);
     public static final FormulaManager FORMULA_MANAGER = new FormulaManager(SALT_API);
     public static final SaltUtils SALT_UTILS = new SaltUtils(SYSTEM_QUERY, SALT_API);
@@ -80,9 +81,9 @@ public class GlobalInstanceHolder {
     public static final KubernetesManager KUBERNETES_MANAGER = new KubernetesManager(SALT_API);
     public static final VirtManager VIRT_MANAGER = new VirtManagerSalt(SALT_API);
     public static final RegularMinionBootstrapper REGULAR_MINION_BOOTSTRAPPER =
-            new RegularMinionBootstrapper(SYSTEM_QUERY, SALT_API, PAYG_MANAGER);
+            new RegularMinionBootstrapper(SYSTEM_QUERY, SALT_API, PAYG_MANAGER, ATTESTATION_MANAGER);
     public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER =
-            new SSHMinionBootstrapper(SYSTEM_QUERY, SALT_API, PAYG_MANAGER);
+            new SSHMinionBootstrapper(SYSTEM_QUERY, SALT_API, PAYG_MANAGER, ATTESTATION_MANAGER);
     public static final MonitoringManager MONITORING_MANAGER = new FormulaMonitoringManager(SALT_API);
     public static final SystemEntitlementManager SYSTEM_ENTITLEMENT_MANAGER = new SystemEntitlementManager(
             new SystemUnentitler(VIRT_MANAGER, MONITORING_MANAGER, SERVER_GROUP_MANAGER),
@@ -93,7 +94,6 @@ public class GlobalInstanceHolder {
             ServerGroupFactory.SINGLETON, SALT_API);
     public static final MigrationManager MIGRATION_MANAGER = new MigrationManager(SERVER_GROUP_MANAGER);
     public static final WebsocketHeartbeatService WEBSOCKET_SESSION_MANAGER = new WebsocketHeartbeatService();
-    public static final AttestationManager ATTESTATION_MANAGER = new AttestationManager();
 
     public static final ViewHelper VIEW_HELPER = ViewHelper.getInstance();
     public static final ThrottlingService THROTTLING_SERVICE = new ThrottlingService();

--- a/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerGroup.hbm.xml
@@ -156,6 +156,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     </sql-query>
 
     <sql-query name="ServerGroup.lookupInactiveServerIds">
+        <return-scalar type="long" column="id"/>
         <![CDATA[
                                 SELECT S.id
                                         FROM rhnServerGroupMembers SGM

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/AdminConfigurationHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/AdminConfigurationHandlerTest.java
@@ -63,6 +63,7 @@ import com.redhat.rhn.testing.TestUtils;
 
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
@@ -97,10 +98,12 @@ public class AdminConfigurationHandlerTest extends BaseHandlerTestCase {
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attestationManager = new AttestationManager();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private RegularMinionBootstrapper regularMinionBootstrapper =
-            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper =
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -116,10 +116,12 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attestationManager = new AttestationManager();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private RegularMinionBootstrapper regularMinionBootstrapper =
-            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper =
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -37,6 +37,7 @@ import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.ssl.SSLCertData;
 import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
@@ -64,10 +65,11 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
     private final SaltApi saltApi = new TestSaltApi();
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final CloudPaygManager paygManager = new CloudPaygManager();
-    private final RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(
-            systemQuery, saltApi, paygManager);
+    private final AttestationManager attestationManager = new AttestationManager();
+    private final RegularMinionBootstrapper regularMinionBootstrapper =
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private final SSHMinionBootstrapper sshMinionBootstrapper =
-            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private final XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -81,27 +81,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * SystemConfigHandlerTest
  */
 @ExtendWith(JUnit5Mockery.class)
 public class ServerConfigHandlerTest extends BaseHandlerTestCase {
-    private TaskomaticApi taskomaticApi = new TaskomaticApi();
-    private SaltApi saltApi = new TestSaltApi();
-    private SystemQuery systemQuery = new TestSystemQuery();
-    private CloudPaygManager paygManager = new CloudPaygManager();
-    private AttestationManager attestationManager = new AttestationManager();
-    private RegularMinionBootstrapper regularMinionBootstrapper =
+    private final TaskomaticApi taskomaticApi = new TaskomaticApi();
+    private final SaltApi saltApi = new TestSaltApi();
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attestationManager = new AttestationManager();
+    private final RegularMinionBootstrapper regularMinionBootstrapper =
             new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper =
+    private final SSHMinionBootstrapper sshMinionBootstrapper =
             new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
-    private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
+    private final XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private ServerConfigHandler handler = new ServerConfigHandler(taskomaticApi, xmlRpcSystemHelper);
+    private final ServerConfigHandler handler = new ServerConfigHandler(taskomaticApi, xmlRpcSystemHelper);
 
     @RegisterExtension
     protected final Mockery mockContext = new JUnit5Mockery() {{
@@ -110,7 +109,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     }};
 
     @Test
-    public void testDeployConfiguration() throws Exception {
+    public void testDeployConfiguration() {
         // Create  global config channels
         ConfigChannel gcc1 = ConfigTestUtils.createConfigChannel(admin.getOrg(),
                 ConfigChannelType.normal());
@@ -205,8 +204,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
         srv1.setConfigChannels(List.of(gcc2), regular);
 
         //test add channels
-        handler.addChannels(admin, serverIds,
-                Stream.of(gcc1).map(cc -> cc.getLabel()).collect(Collectors.toList()), true);
+        handler.addChannels(admin, serverIds, List.of(gcc1.getLabel()), true);
 
         TestUtils.saveAndFlush(srv1);
         HibernateFactory.getSession().detach(srv1);
@@ -226,7 +224,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
 
         List<ConfigChannel> channels = List.of(gcc1, gcc2);
 
-        List<String> channelLabels = channels.stream().map(cc -> cc.getLabel()).collect(Collectors.toList());
+        List<String> channelLabels = channels.stream().map(ConfigChannel::getLabel).collect(Collectors.toList());
 
         //test set channels
         handler.setChannels(admin, serverIds, channelLabels);
@@ -252,8 +250,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
         srv1.setConfigChannels(List.of(gcc1), regular);
 
         //test add channels
-        handler.addChannels(admin, serverIds,
-                Stream.of(gcc2).map(cc -> cc.getLabel()).collect(Collectors.toList()), false);
+        handler.addChannels(admin, serverIds, List.of(gcc2.getLabel()), false);
 
         TestUtils.saveAndFlush(srv1);
         HibernateFactory.getSession().detach(srv1);
@@ -275,7 +272,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
 
         List<ConfigChannel> channels = List.of(gcc1, gcc2);
         List<String> channelLabels = channels.stream()
-                .map(cc -> cc.getLabel())
+                .map(ConfigChannel::getLabel)
                 .collect(Collectors.toList());
 
         srv1.setConfigChannels(channels, regular);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -54,6 +54,7 @@ import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -91,9 +92,11 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
     private CloudPaygManager paygManager = new CloudPaygManager();
+    private AttestationManager attestationManager = new AttestationManager();
     private RegularMinionBootstrapper regularMinionBootstrapper =
-            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper =
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
@@ -31,6 +31,7 @@ import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -52,9 +53,11 @@ public class SnapshotHandlerTest extends BaseHandlerTestCase {
     private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
     private CloudPaygManager paygManager = new CloudPaygManager();
+    private AttestationManager attestationManager = new AttestationManager();
     private RegularMinionBootstrapper regularMinionBootstrapper =
-            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper =
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
@@ -50,19 +50,19 @@ import java.util.Set;
  */
 public class SnapshotHandlerTest extends BaseHandlerTestCase {
 
-    private SaltApi saltApi = new TestSaltApi();
-    private SystemQuery systemQuery = new TestSystemQuery();
-    private CloudPaygManager paygManager = new CloudPaygManager();
-    private AttestationManager attestationManager = new AttestationManager();
-    private RegularMinionBootstrapper regularMinionBootstrapper =
+    private final SaltApi saltApi = new TestSaltApi();
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attestationManager = new AttestationManager();
+    private final RegularMinionBootstrapper regularMinionBootstrapper =
             new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper =
+    private final SSHMinionBootstrapper sshMinionBootstrapper =
             new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
-    private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
+    private final XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private SnapshotHandler handler = new SnapshotHandler(xmlRpcSystemHelper);
+    private final SnapshotHandler handler = new SnapshotHandler(xmlRpcSystemHelper);
 
     private ServerSnapshot generateSnapshot(Server server) {
         ServerSnapshot snap = new ServerSnapshot();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -63,20 +64,20 @@ import java.util.List;
  * ServerGroupHandlerTest
  */
 public class ServerGroupHandlerTest extends BaseHandlerTestCase {
-    private SaltApi saltApi = new TestSaltApi();
-    private SystemQuery systemQuery = new TestSystemQuery();
-    private CloudPaygManager paygManager = new CloudPaygManager();
-    private AttestationManager attestationManager = new AttestationManager();
-    private RegularMinionBootstrapper regularMinionBootstrapper =
+    private final SaltApi saltApi = new TestSaltApi();
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attestationManager = new AttestationManager();
+    private final RegularMinionBootstrapper regularMinionBootstrapper =
             new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper =
+    private final SSHMinionBootstrapper sshMinionBootstrapper =
             new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
-    private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
+    private final XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private ServerGroupManager manager = new ServerGroupManager(saltApi);
-    private ServerGroupHandler handler = new ServerGroupHandler(xmlRpcSystemHelper, manager);
+    private final ServerGroupManager manager = new ServerGroupManager(saltApi);
+    private final ServerGroupHandler handler = new ServerGroupHandler(xmlRpcSystemHelper, manager);
     private static final String NAME = "HAHAHA" + TestUtils.randomString();
     private static final String DESCRIPTION =  TestUtils.randomString();
 
@@ -145,7 +146,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         assertNotNull(manager.lookup(NAME, admin));
         User newbie = UserTestUtils.createUser("Hahaha", admin.getOrg().getId());
 
-        List logins = new ArrayList<>();
+        List<String> logins = new ArrayList<>();
         logins.add(newbie.getLogin());
 
 
@@ -158,7 +159,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         }
 
         handler.addOrRemoveAdmins(admin, group.getName(),
-                Arrays.asList(new String []{regular.getLogin()}), true);
+                Collections.singletonList(regular.getLogin()), true);
 
         regular.addPermanentRole(RoleFactory.SYSTEM_GROUP_ADMIN);
         handler.addOrRemoveAdmins(regular, group.getName(), logins, true);
@@ -214,12 +215,12 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
                                                     DESCRIPTION + "1");
         ServerGroup group2 = handler.create(admin, NAME + "2",
                                                     DESCRIPTION + "2");
-        List groups = handler.listGroupsWithNoAssociatedAdmins(admin);
+        List<ServerGroup> groups = handler.listGroupsWithNoAssociatedAdmins(admin);
         assertTrue(groups.contains(group));
         assertTrue(groups.contains(group1));
         assertTrue(groups.contains(group2));
 
-        List logins = new ArrayList<>();
+        List<String> logins = new ArrayList<>();
         logins.add(regular.getLogin());
         handler.addOrRemoveAdmins(admin, group1.getName(), logins, true);
         assertTrue(manager.canAccess(regular, group1));
@@ -249,7 +250,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         assertNotNull(manager.lookup(NAME, admin));
 
         User unpriv = UserTestUtils.createUser("Unpriv", admin.getOrg().getId());
-        List logins = new ArrayList<>();
+        List<String> logins = new ArrayList<>();
         logins.add(regular.getLogin());
         logins.add(unpriv.getLogin());
 
@@ -261,7 +262,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         Server server3 = ServerFactoryTest.createTestServer(regular, true);
 
         handler.addOrRemoveSystems(regular, group.getName(),
-                Arrays.asList(server3.getId().intValue()), Boolean.TRUE);
+                List.of(server3.getId().intValue()), Boolean.TRUE);
 
         List<Long> systems = new ArrayList<>();
         systems.add(server1.getId());
@@ -270,7 +271,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         handler.addOrRemoveSystems(regular, group.getName(), systems, Boolean.TRUE);
 
 
-        List actual = handler.listSystems(unpriv, group.getName());
+        List<Server> actual = handler.listSystems(unpriv, group.getName());
         assertTrue(actual.contains(server1));
 
         handler.addOrRemoveSystems(regular, group.getName(), systems,
@@ -301,7 +302,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         int preSize = handler.listAllGroups(admin).size();
 
         ManagedServerGroup group = ServerGroupTestUtils.createManaged(admin);
-        List groups = handler.listAllGroups(admin);
+        List<ManagedServerGroup> groups = handler.listAllGroups(admin);
         assertTrue(groups.contains(group));
         assertEquals(1, groups.size() - preSize);
     }
@@ -327,7 +328,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         boolean exceptCaught = false;
         int badValue = -80;
         try {
-            ServerGroup sg = handler.getDetails(admin, badValue);
+            handler.getDetails(admin, badValue);
         }
         catch (FaultException e) {
             exceptCaught = true;
@@ -338,9 +339,9 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
     @Test
     public void testGetDetailsByUnknownName() {
         boolean exceptCaught = false;
-        String badName = new String("intentionalBadName123456789");
+        String badName = "intentionalBadName123456789";
         try {
-            ServerGroup sg = handler.getDetails(admin, badName);
+            handler.getDetails(admin, badName);
         }
         catch (FaultException e) {
             exceptCaught = true;
@@ -355,7 +356,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         Server server = ServerTestUtils.createTestSystem(admin);
         Server server2 = ServerTestUtils.createTestSystem(admin);
 
-        List  test = new ArrayList<>();
+        List<Server>  test = new ArrayList<>();
         test.add(server);
         test.add(server2);
         manager.addServers(group, test, admin);
@@ -367,7 +368,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         TestUtils.saveAndFlush(server);
         TestUtils.saveAndFlush(group);
 
-        List list = handler.listInactiveSystemsInGroup(admin, group.getName(), 1);
+        List<Long> list = handler.listInactiveSystemsInGroup(admin, group.getName(), 1);
         assertEquals(1, list.size());
         assertEquals(server.getId().toString(), list.get(0).toString());
     }
@@ -378,7 +379,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         Server server = ServerTestUtils.createTestSystem(admin);
         Server server2 = ServerTestUtils.createTestSystem(admin);
 
-        List  test = new ArrayList<>();
+        List<Server>  test = new ArrayList<>();
         test.add(server);
         test.add(server2);
 
@@ -391,7 +392,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         TestUtils.saveAndFlush(server);
         TestUtils.saveAndFlush(group);
 
-        List list = handler.listActiveSystemsInGroup(admin, group.getName());
+        List<Long> list = handler.listActiveSystemsInGroup(admin, group.getName());
 
         assertEquals(1, list.size());
         assertEquals(server.getId().toString(), list.get(0).toString());
@@ -417,8 +418,8 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         ManagedServerGroup group1 = ServerGroupTestUtils.createManaged(admin);
         ManagedServerGroup group2 = ServerGroupTestUtils.createManaged(admin);
 
-        handler.subscribeConfigChannel(admin, group1.getName(), Arrays.asList(ccLabel1));
-        handler.subscribeConfigChannel(admin, group2.getName(), Arrays.asList(ccLabel2));
+        handler.subscribeConfigChannel(admin, group1.getName(), List.of(ccLabel1));
+        handler.subscribeConfigChannel(admin, group2.getName(), List.of(ccLabel2));
         List<ConfigChannel> assignedChannels1 = handler.listAssignedConfigChannels(admin, group1.getName());
         List<ConfigChannel> assignedChannels2 = handler.listAssignedConfigChannels(admin, group2.getName());
 
@@ -480,7 +481,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         assertContains(assignedChannels1, cc1);
         assertContains(assignedChannels1, cc2);
 
-        handler.unsubscribeConfigChannel(admin, group1.getName(), Arrays.asList(ccLabel1));
+        handler.unsubscribeConfigChannel(admin, group1.getName(), List.of(ccLabel1));
         assignedChannels1 = handler.listAssignedConfigChannels(admin, group1.getName());
         assertContains(assignedChannels1, cc2);
         assertFalse(assignedChannels1.contains(cc1), "Unexpected channel found");

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -43,6 +43,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -65,9 +66,11 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
     private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
     private CloudPaygManager paygManager = new CloudPaygManager();
+    private AttestationManager attestationManager = new AttestationManager();
     private RegularMinionBootstrapper regularMinionBootstrapper =
-            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper =
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerPtfTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerPtfTest.java
@@ -107,9 +107,11 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
         SystemQuery systemQuery = new TestSystemQuery();
         SaltApi saltApi = new TestSaltApi();
         CloudPaygManager paygMgr = new CloudPaygManager();
+        AttestationManager attMgr = new AttestationManager();
 
-        RegularMinionBootstrapper regularBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi, paygMgr);
-        SSHMinionBootstrapper sshBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygMgr);
+        RegularMinionBootstrapper regularBootstrapper =
+                new RegularMinionBootstrapper(systemQuery, saltApi, paygMgr, attMgr);
+        SSHMinionBootstrapper sshBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygMgr, attMgr);
         XmlRpcSystemHelper xmlRpcHelper = new XmlRpcSystemHelper(regularBootstrapper, sshBootstrapper);
 
         ServerGroupManager groupManager = new ServerGroupManager(saltApi);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -214,9 +214,11 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attestationManager = new AttestationManager();
     private RegularMinionBootstrapper regularMinionBootstrapper =
-            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper =
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.formula.Formula;
 import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
+import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.state.StateFactory;
@@ -163,7 +164,7 @@ public class ServerGroupHandler extends BaseHandler {
      *      #array_end()
      */
     @ReadOnly
-    public List listSystems(User loggedInUser, String systemGroupName) {
+    public List<Server> listSystems(User loggedInUser, String systemGroupName) {
         ManagedServerGroup group = serverGroupManager.lookup(systemGroupName, loggedInUser);
         return group.getServers();
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -132,9 +133,11 @@ public class UserExternalHandlerTest extends BaseHandlerTestCase {
         SaltApi saltApi = new TestSaltApi();
         SystemQuery systemQuery = new TestSystemQuery();
         CloudPaygManager paygManager = new CloudPaygManager();
+        AttestationManager attMgr = new AttestationManager();
         RegularMinionBootstrapper regularMinionBootstrapper =
-                new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-        SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+                new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr);
+        SSHMinionBootstrapper sshMinionBootstrapper =
+                new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,
                 sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -107,9 +107,11 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
             new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
     private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attestationManager = new AttestationManager();
     private RegularMinionBootstrapper regularMinionBootstrapper =
-            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi, paygManager);
+            new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
+    private SSHMinionBootstrapper sshMinionBootstrapper =
+            new SSHMinionBootstrapper(systemQuery, saltApi, paygManager, attestationManager);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -58,7 +58,8 @@ public class RhnServletListener implements ServletContextListener {
             GlobalInstanceHolder.SALT_API, GlobalInstanceHolder.SYSTEM_QUERY,
             GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE,
             GlobalInstanceHolder.SALT_UTILS,
-            GlobalInstanceHolder.PAYG_MANAGER);
+            GlobalInstanceHolder.PAYG_MANAGER,
+            GlobalInstanceHolder.ATTESTATION_MANAGER);
 
     private void startMessaging() {
         // Start the MessageQueue thread listening for

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -48,7 +48,7 @@ import javax.servlet.ServletContextListener;
  */
 public class RhnServletListener implements ServletContextListener {
 
-    private static Logger log = LogManager.getLogger(RhnServletListener.class);
+    private static final Logger LOG = LogManager.getLogger(RhnServletListener.class);
 
     private boolean hibernateStarted = false;
     private boolean loggingStarted = false;
@@ -81,15 +81,15 @@ public class RhnServletListener implements ServletContextListener {
     }
 
     private void logStart(String system) {
-        if (log.isDebugEnabled()) {
-            log.debug("{} started", system);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} started", system);
         }
         loggingStarted = true;
     }
 
     private void logStop(String system) {
-        if (log.isDebugEnabled()) {
-            log.debug("{}Starting ", system);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{}Starting ", system);
         }
         loggingStarted = false;
     }
@@ -139,18 +139,18 @@ public class RhnServletListener implements ServletContextListener {
             logStart("Salt reactor");
         }
 
-        log.debug("Starting upgrade check");
+        LOG.debug("Starting upgrade check");
         executeUpgradeStep();
 
-        log.debug("Executing startup tasks");
+        LOG.debug("Executing startup tasks");
         executeStartupTasks();
     }
 
     private void executeUpgradeStep() {
-        log.debug("calling UpgradeCommand.");
+        LOG.debug("calling UpgradeCommand.");
         UpgradeCommand cmd = new UpgradeCommand();
         cmd.store();
-        log.debug("UpgradeCommand done.");
+        LOG.debug("UpgradeCommand done.");
     }
 
     /**
@@ -186,10 +186,10 @@ public class RhnServletListener implements ServletContextListener {
             Driver driver = drivers.nextElement();
             try {
                 DriverManager.deregisterDriver(driver);
-                log.info("deregistering jdbc driver: {}", driver);
+                LOG.info("deregistering jdbc driver: {}", driver);
             }
             catch (SQLException e) {
-                log.warn("Error deregistering driver {}", driver);
+                LOG.warn("Error deregistering driver {}", driver);
             }
         }
     }

--- a/java/code/src/com/suse/manager/attestation/AttestationManager.java
+++ b/java/code/src/com/suse/manager/attestation/AttestationManager.java
@@ -208,24 +208,22 @@ public class AttestationManager {
 
     /**
      * Initialze the Attestation Results for a given report
-     * @param userIn the user
      * @param reportIn the report
      */
-    public void initializeResults(User userIn, ServerCoCoAttestationReport reportIn) {
-        Server server = reportIn.getServer();
-        ensureSystemAccessible(userIn, server);
+    public void initializeResults(ServerCoCoAttestationReport reportIn) {
+        if (Optional.ofNullable(reportIn.getServer()).isEmpty()) {
+            LOG.error("Report not linked to a system");
+            throw new LookupException("Report not linked to a system");
+        }
         factory.initResultsForReport(reportIn);
     }
 
     /**
-     * @param userIn the user
      * @param serverIn the server
      * @param actionIn the action
      * @return returns the attestation report for this server and action if available
      */
-    public Optional<ServerCoCoAttestationReport> lookupReportByServerAndAction(
-            User userIn, Server serverIn, Action actionIn) {
-        ensureSystemAccessible(userIn, serverIn);
+    public Optional<ServerCoCoAttestationReport> lookupReportByServerAndAction(Server serverIn, Action actionIn) {
         return factory.lookupReportByServerAndAction(serverIn, actionIn);
     }
 

--- a/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
+++ b/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
@@ -15,6 +15,7 @@
 package com.suse.manager.attestation.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -104,14 +105,13 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
     public void testInitializeAttestationResults() {
         mgr.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
         ServerCoCoAttestationReport report = mgr.initializeReport(user, server);
-        assertThrows(PermissionException.class, () -> mgr.initializeResults(user2, report));
 
         ServerCoCoAttestationReport brokenReport = new ServerCoCoAttestationReport();
-        assertThrows(LookupException.class, () -> mgr.initializeResults(user, brokenReport));
+        assertThrows(LookupException.class, () -> mgr.initializeResults(brokenReport));
 
-        mgr.initializeResults(user, report);
+        mgr.initializeResults(report);
         List<CoCoAttestationResult> results = report.getResults();
-        assertTrue(results.size() > 0);
+        assertFalse(results.isEmpty());
     }
 
     @Test
@@ -269,7 +269,7 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
 
     private void createFakeAttestationReport(User userIn, Server serverIn) {
         ServerCoCoAttestationReport report = mgr.initializeReport(userIn, serverIn);
-        mgr.initializeResults(userIn, report);
+        mgr.initializeResults(report);
         fakeSuccessfullAttestation(report);
     }
     private void fakeSuccessfullAttestation(ServerCoCoAttestationReport reportIn) {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -373,7 +373,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             // randomize a bit to prevent an attestation storm on a mass reboot action
             int rand = ThreadLocalRandom.current().nextInt(60, 90);
             Date scheduleAt = Date.from(Instant.now().plus(rand, ChronoUnit.SECONDS));
-            attestationManager.scheduleAttestationAction(null, minion, scheduleAt);
+            attestationManager.scheduleAttestationActionFromSystem(minion.getOrg(), minion, scheduleAt);
         }
         catch (TaskomaticApiException e) {
             LOG.error("Unable to schedule attestation action. ", e);

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -59,8 +59,11 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
+import com.suse.manager.model.attestation.ServerCoCoAttestationConfig;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
@@ -91,6 +94,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -102,6 +107,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -271,7 +277,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                         },
                         minionServer -> server.asMinionServer().filter(ms -> ms.equals(minionServer)).ifPresentOrElse(
                                 serverAsMinion -> {
-                                    // Case 2.2a
+                                    // Case 2.2a - minion_id and machine-id are the same
                                     updateAlreadyRegisteredInfo(minionId, machineId, minionServer);
                                     applyMinionStartStates(minionId, minionServer, saltbootInitrd);
                                 },
@@ -339,6 +345,35 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             // this is the time to update SystemInfo
             MinionList minionTarget = new MinionList(minionId);
             saltApi.updateSystemInfo(minionTarget);
+            scheduleCoCoAttestation(registeredMinion);
+        }
+    }
+
+    /**
+     * Schedule a Confidential Compute Attestation when the minion has CoCoAttestation
+     * enabled and attestOnBoot is enabled
+     *
+     * @param minion the minion
+     */
+    private void scheduleCoCoAttestation(MinionServer minion) {
+        AttestationManager mgr = new AttestationManager();
+        if (minion.getOptCocoAttestationConfig()
+                .filter(ServerCoCoAttestationConfig::isEnabled)
+                .filter(ServerCoCoAttestationConfig::isAttestOnBoot)
+                .isEmpty()) {
+            // no attestation configured or wanted on startup
+            return;
+        }
+
+        try {
+            // eariest 1 minute later to finish the boot process
+            // randomize a bit to prevent an attestation storm on a mass reboot action
+            int rand = ThreadLocalRandom.current().nextInt(60, 90);
+            Date scheduleAt = Date.from(Instant.now().plus(rand, ChronoUnit.SECONDS));
+            mgr.scheduleAttestationAction(null, minion, scheduleAt);
+        }
+        catch (TaskomaticApiException e) {
+            LOG.error("Unable to schedule attestation action. ", e);
         }
     }
 

--- a/java/code/src/com/suse/manager/reactor/test/RebootInfoBeaconTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RebootInfoBeaconTest.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.reactor.SaltReactor;
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
@@ -62,18 +63,20 @@ public class RebootInfoBeaconTest extends RhnJmockBaseTestCase {
         SaltService saltService = createSaltService();
         SaltServerActionService saltServerActionService = createSaltServerActionService(saltService, saltService);
         SaltUtils saltUtils = new SaltUtils(saltService, saltService);
+        AttestationManager attMgr = new AttestationManager();
         CloudPaygManager paygMgr = new CloudPaygManager();
         reactor = new SaltReactor(
             saltService,
             saltService,
             saltServerActionService,
             saltUtils,
-            paygMgr
+            paygMgr,
+            attMgr
         );
     }
 
     @Test
-    public void testRebootInfoEvent() throws Exception {
+    public void testRebootInfoEvent() {
         MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
         minion1.setMinionId("slemicro100001");
         minion1.setLastBoot(System.currentTimeMillis() / 1000);

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -78,6 +78,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessage;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
 import com.suse.manager.reactor.utils.test.RhelUtilsTest;
@@ -149,6 +150,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private SystemManager systemManager;
     private CloudPaygManager cloudManager4Test;
+    private AttestationManager attestationManager;
 
     @FunctionalInterface
     private interface ExpectationsFunction {
@@ -293,6 +295,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                return false;
            }
        };
+       attestationManager = new AttestationManager();
 
        context().checking(new Expectations() {{
            allowing(saltServiceMock).refreshPillar(with(any(MinionList.class)));
@@ -373,7 +376,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         }
 
         RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(saltServiceMock,
-                saltServiceMock, cloudManager4Test);
+                saltServiceMock, cloudManager4Test, attestationManager);
         action.execute(new RegisterMinionEventMessage(MINION_ID, startupGrains));
 
         // Verify the resulting system entry
@@ -2015,8 +2018,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
             }
         } });
 
-        RegisterMinionEventMessageAction action =
-                new RegisterMinionEventMessageAction(saltServiceMock, saltServiceMock, cloudManager4Test);
+        RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(saltServiceMock, saltServiceMock,
+                cloudManager4Test, attestationManager);
         action.execute(new RegisterMinionEventMessage(MINION_ID, Optional.of(DEFAULT_MINION_START_UP_GRAINS)));
     }
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1718,7 +1718,7 @@ public class SaltUtils {
     private void handleCocoAttestationResult(Action action, ServerAction serverAction, JsonElement jsonResult) {
         AttestationManager mgr = new AttestationManager();
 
-        Optional<ServerCoCoAttestationReport> optReport = mgr.lookupReportByServerAndAction(action.getSchedulerUser(),
+        Optional<ServerCoCoAttestationReport> optReport = mgr.lookupReportByServerAndAction(
                 serverAction.getServer(), action);
         if (optReport.isEmpty()) {
             serverAction.setStatus(ActionFactory.STATUS_FAILED);
@@ -1730,7 +1730,7 @@ public class SaltUtils {
         try {
             CoCoAttestationRequestData requestData = Json.GSON.fromJson(jsonResult, CoCoAttestationRequestData.class);
             report.setOutData(requestData.asMap());
-            mgr.initializeResults(action.getSchedulerUser(), report);
+            mgr.initializeResults(report);
         }
         catch (JsonSyntaxException e) {
             String msg = "Failed to parse the attestation result:\n";

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -127,7 +127,7 @@ public class Router implements SparkApplication {
         ProxyController proxyController = new ProxyController(systemManager);
         SaltSSHController saltSSHController = new SaltSSHController(saltApi);
         NotificationMessageController notificationMessageController =
-                new NotificationMessageController(systemQuery, saltApi, paygManager);
+                new NotificationMessageController(systemQuery, saltApi, paygManager, attestationManager);
         MinionsAPI minionsAPI = new MinionsAPI(saltApi, sshMinionBootstrapper, regularMinionBootstrapper,
                 saltKeyUtils, attestationManager);
         StatesAPI statesAPI = new StatesAPI(saltApi, taskomaticApi, serverGroupManager);

--- a/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessage;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -67,16 +68,20 @@ public class NotificationMessageController {
     private final SaltApi saltApi;
     private final SystemQuery systemQuery;
     private final CloudPaygManager paygManager;
+    private final AttestationManager attestationManager;
 
     /**
      * @param systemQueryIn instance for getting information from a system.
      * @param saltApiIn instance for getting information from a system.
      * @param paygMgrIn instance of {@link CloudPaygManager}
+     * @param attMgrIn instance of {@link AttestationManager}
      */
-    public NotificationMessageController(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn) {
+    public NotificationMessageController(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn,
+                                         AttestationManager attMgrIn) {
         this.saltApi = saltApiIn;
         this.systemQuery = systemQueryIn;
         this.paygManager = paygMgrIn;
+        this.attestationManager = attMgrIn;
     }
 
     /**
@@ -221,7 +226,7 @@ public class NotificationMessageController {
         String resultMessage = "Onboarding restarted of the minioniId '%s'";
 
         RegisterMinionEventMessageAction action =
-                new RegisterMinionEventMessageAction(systemQuery, saltApi, paygManager);
+                new RegisterMinionEventMessageAction(systemQuery, saltApi, paygManager, attestationManager);
         action.execute(new RegisterMinionEventMessage(minionId, Optional.empty()));
 
         Map<String, String> data = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.manager.system.AnsibleManager;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.controllers.utils.CommandExecutionException;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -72,6 +73,7 @@ public abstract class AbstractMinionBootstrapper {
     protected final SaltApi saltApi;
     protected final SystemQuery systemQuery;
     protected final CloudPaygManager paygManager;
+    protected final AttestationManager attestationManager;
 
     private static final int KEY_LENGTH_LIMIT = 1_000_000;
 
@@ -84,10 +86,12 @@ public abstract class AbstractMinionBootstrapper {
      * @param saltApiIn salt service
      * @param paygMgrIn cloudPaygManager
      */
-    protected AbstractMinionBootstrapper(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn) {
+    protected AbstractMinionBootstrapper(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn,
+                                         AttestationManager attMgrIn) {
         this.saltApi = saltApiIn;
         this.systemQuery = systemQueryIn;
         this.paygManager = paygMgrIn;
+        this.attestationManager = attMgrIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -48,6 +48,7 @@ import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.State.ApplyResult;
 import com.suse.salt.netapi.results.SSHResult;
+import com.suse.salt.netapi.results.StateApplyResult;
 import com.suse.utils.Opt;
 
 import org.apache.logging.log4j.LogManager;
@@ -276,9 +277,9 @@ public abstract class AbstractMinionBootstrapper {
                     saltApi.callSync(call, minionId).ifPresentOrElse(
                             res -> {
                                 // all results must be successful, otherwise we throw an exception
-                                List<Object> failedStates = res.entrySet().stream()
-                                        .filter(r -> !r.getValue().isResult())
-                                        .map(r -> r.getValue().getChanges())
+                                List<Object> failedStates = res.values().stream()
+                                        .filter(applyResultIn -> !applyResultIn.isResult())
+                                        .map(StateApplyResult::getChanges)
                                         .collect(Collectors.toList());
 
                                 if (!failedStates.isEmpty()) {

--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/RegularMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/RegularMinionBootstrapper.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
@@ -50,9 +51,11 @@ public class RegularMinionBootstrapper extends AbstractMinionBootstrapper {
      * @param systemQueryIn systemQuery to use
      * @param saltApiIn saltApi to use
      * @param paygMgrIn {@link CloudPaygManager} to use
+     * @param attMgrIn the attestation manager to use
      */
-    public RegularMinionBootstrapper(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn) {
-        super(systemQueryIn, saltApiIn, paygMgrIn);
+    public RegularMinionBootstrapper(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn,
+                                     AttestationManager attMgrIn) {
+        super(systemQueryIn, saltApiIn, paygMgrIn, attMgrIn);
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/SSHMinionBootstrapper.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -58,9 +59,11 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
      * @param systemQueryIn systemQuery to use
      * @param saltApiIn saltApi to use
      * @param paygMgrIn cloudPaygManager to use
+     * @param attMgrIn attestation manager to use
      */
-    public SSHMinionBootstrapper(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn) {
-        super(systemQueryIn, saltApiIn, paygMgrIn);
+    public SSHMinionBootstrapper(SystemQuery systemQueryIn, SaltApi saltApiIn, CloudPaygManager paygMgrIn,
+                                 AttestationManager attMgrIn) {
+        super(systemQueryIn, saltApiIn, paygMgrIn, attMgrIn);
     }
 
     @Override
@@ -123,7 +126,7 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
 
     // we want to override this in tests
     protected RegisterMinionEventMessageAction getRegisterAction() {
-        return new RegisterMinionEventMessageAction(systemQuery, saltApi, paygManager);
+        return new RegisterMinionEventMessageAction(systemQuery, saltApi, paygManager, attestationManager);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.webui.controllers.bootstrap.AbstractMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.BootstrapResult;
 import com.suse.manager.webui.services.impl.SaltSSHService;
@@ -59,6 +60,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
 
     protected SaltService saltServiceMock;
     protected CloudPaygManager paygManager;
+    protected AttestationManager attestationManager;
 
     // tested object, initialized in subclasses
     protected AbstractMinionBootstrapper bootstrapper;
@@ -70,6 +72,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
         paygManager = new CloudPaygManager();
+        attestationManager = new AttestationManager();
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
@@ -62,7 +62,7 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        bootstrapper = new RegularMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager);
+        bootstrapper = new RegularMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager, attestationManager);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
@@ -44,7 +44,7 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        bootstrapper = new SSHMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager);
+        bootstrapper = new SSHMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager, attestationManager);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
 
     private SSHMinionBootstrapper mockRegistrationBootstrapper(
             Optional<String> activationKeyLabel) {
-        return new SSHMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager) {
+        return new SSHMinionBootstrapper(saltServiceMock, saltServiceMock, paygManager, attestationManager) {
             @Override
             protected RegisterMinionEventMessageAction getRegisterAction() {
                 RegisterMinionEventMessageAction action =

--- a/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
@@ -44,10 +44,10 @@ public class InputValidatorTest  {
     private static final String PORT_ERROR_MESSAGE = "Port must be a number within range" +
             " 1-65535.";
 
-    private SaltApi saltApi = new TestSaltApi();
-    private SystemQuery systemQuery = new TestSystemQuery();
-    private CloudPaygManager paygManager = new CloudPaygManager();
-    private AttestationManager attMgr = new AttestationManager();
+    private final SaltApi saltApi = new TestSaltApi();
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final CloudPaygManager paygManager = new CloudPaygManager();
+    private final AttestationManager attMgr = new AttestationManager();
 
     /**
      * Test the check for required fields.

--- a/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.suse.cloud.CloudPaygManager;
+import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.webui.controllers.MinionsAPI;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -46,6 +47,7 @@ public class InputValidatorTest  {
     private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
     private CloudPaygManager paygManager = new CloudPaygManager();
+    private AttestationManager attMgr = new AttestationManager();
 
     /**
      * Test the check for required fields.
@@ -54,7 +56,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputUserEmpty() {
         String json = "{user: ''}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertEquals(2, validationErrors.size());
@@ -69,7 +71,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputUserLettersNumbers() {
         String json = "{user: 'Admin1', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -82,7 +84,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputUserDot() {
         String json = "{user: 'my.admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -95,7 +97,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputUserBackslash() {
         String json = "{user: 'domain\\\\admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -108,7 +110,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputUserDash() {
         String json = "{user: 'my-admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -121,7 +123,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputUserUnderscore() {
         String json = "{user: 'my_admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -134,7 +136,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputUserInvalid() {
         String json = "{user: '$(execme)', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertEquals(1, validationErrors.size());
@@ -148,7 +150,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputHostInvalid() {
         String json = "{user: 'toor', host: '`execme`'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertEquals(1, validationErrors.size());
@@ -162,7 +164,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputHostIPv4() {
         String json = "{user: 'toor', host: '192.168.1.1'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -175,7 +177,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputHostIPv6() {
         String json = "{user: 'toor', host: '[2001:0db8:0000:0000:0000:0000:1428:57ab]'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -188,7 +190,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputDefaultUser() {
         String json = "{}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertEquals(1, validationErrors.size());
@@ -202,7 +204,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputMinimal() {
         String json = "{host: 'host.domain.com', user: 'root'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -215,7 +217,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputPortEmpty() {
         String json = "{host: 'host.domain.com', user: 'root', port: ''}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
@@ -228,7 +230,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputPortRange() {
         String json = "{host: 'host.domain.com', user: 'root', port: '99999'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertEquals(1, validationErrors.size());
@@ -236,7 +238,7 @@ public class InputValidatorTest  {
 
         json = "{host: 'host.domain.com', user: 'root', port: '-1'}";
         input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager).createBootstrapParams(input);
+        params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr).createBootstrapParams(input);
         validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertEquals(1, validationErrors.size());
         assertTrue(validationErrors.contains(PORT_ERROR_MESSAGE));
@@ -249,7 +251,7 @@ public class InputValidatorTest  {
     public void testValidateBootstrapInputPortValid() {
         String json = "{host: 'host.domain.com', user: 'root', port: '8888'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager)
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi, paygManager, attMgr)
                 .createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());

--- a/java/spacewalk-java.changes.mc.attest-after-reboot
+++ b/java/spacewalk-java.changes.mc.attest-after-reboot
@@ -1,0 +1,1 @@
+- schedule an attestation on reboot if the client is configured to do so


### PR DESCRIPTION
## What does this PR change?

An attestation can become invalid after the system got rebooted.
Provide a mechnism to schedule a re-attestation after a reboot.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Part of the big doc for CoCo

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24082

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
