### PR TITLE
Remove hardcoded ARG PRODUCT_VERSION and let the container push script control it

### DIFF
--- a/containers/server-attestation-image/Dockerfile
+++ b/containers/server-attestation-image/Dockerfile
@@ -18,7 +18,6 @@ ARG PRODUCT=Uyuni
 ARG VENDOR="Uyuni project"
 ARG URL="https://www.uyuni-project.org/"
 ARG REFERENCE_PREFIX="registry.opensuse.org/uyuni"
-ARG PRODUCT_VERSION="2024.02"
 
 # Build Service required labels
 # labelprefix=org.opensuse.uyuni.server-attestation

--- a/containers/server-attestation-image/server-attestation-image.changes.deneb-alpha.remove_not_needed_arg_server-attestation-image
+++ b/containers/server-attestation-image/server-attestation-image.changes.deneb-alpha.remove_not_needed_arg_server-attestation-image
@@ -1,0 +1,2 @@
+- Remove hardcoded ARG PRODUCT_VERSION and let the container push 
+  script control it


### PR DESCRIPTION
## What does this PR change?

Remove hardcoded ARG PRODUCT_VERSION and let the container push script control it.

Tested via:
* https://build.suse.de/projects/home:deneb_alpha:branches:Devel:Galaxy:Manager:Head_BETA2/packages/server-attestation-image/files/Dockerfile?expand=1
* https://build.opensuse.org/projects/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master_2024_03/packages/server-attestation-image/files/Dockerfile?expand=1

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **only Dockerfile argument change**

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/23611 https://github.com/SUSE/spacewalk/issues/24034

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
