### PR TITLE
Fix: Wrong key for a list of channels

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -114,7 +114,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add openSUSE Leap Micro 5.5 product, including Uyuni Client Tools
     When I use spacewalk-common-channel to add all "leap-micro5.5" channels with arch "x86_64"
     And I use spacewalk-common-channel to add all "leap-micro5.5-client-tools" channels with arch "x86_64"
-    And I wait until all synchronized channels for "leap-micro5.5" have finished
+    And I wait until all synchronized channels for "leap-micro5.5-x86_64" have finished
+    And I wait until all synchronized channels for "leap-micro5.5-client-tools-x86_64" have finished
 
 @proxy
 @susemanager


### PR DESCRIPTION
## What does this PR change?

We need to specify the arch in the key for Leap. It diverge from the rest of key names, because we manage several architectures in the map.
In the future, we should align the naming of these keys, appending the arch to all of them.

Note: It only affects Uyuni, not SUMA.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Mangaer-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
