### PR TITLE
Use java.hostname to compute the FQDN for system provisioning

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartHelper.java
@@ -287,7 +287,7 @@ public class KickstartHelper {
             log.debug("Kickstart host from proxy header: {}", firstProxy);
             return firstProxy;
         }
-        return ConfigDefaults.get().getCobblerHost();
+        return ConfigDefaults.get().getJavaHostname();
     }
 
     /**

--- a/java/spacewalk-java.changes.cbosdo.migration_fix
+++ b/java/spacewalk-java.changes.cbosdo.migration_fix
@@ -1,0 +1,1 @@
+- Fix FQDN in URLs for system provisioning


### PR DESCRIPTION

## What does this PR change?

`cobbler.host` is now set to `localhost` and should not be used to get the real server's FQDN.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
