### PR TITLE
Fix OutOfBoundsException when downloading file from /ks/dist/

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -615,7 +615,7 @@ public class DownloadFile extends DownloadAction {
             }
             else {
                 String[] split = StringUtils.split(path, '/');
-                if (split[0].equals("repodata")) {
+                if (split.length > 0 && split[0].equals("repodata")) {
                     split[0] = child.getLabel();
                 }
                 diskPath = Config.get().getString(ConfigDefaults.REPOMD_CACHE_MOUNT_POINT, "/pub") +

--- a/java/spacewalk-java.changes.cbosdo.ks-fix
+++ b/java/spacewalk-java.changes.cbosdo.ks-fix
@@ -1,0 +1,1 @@
+- Fix out of bounds error getting /ks/dist/ URL with no path


### PR DESCRIPTION
## What does this PR change?

Getting the first item of an array without checking the array length in the first place is not a good idea. I wonder how that hasn't been an issue since 2009.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: trivial
- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
