### PR TITLE
Keep Python linting container up to date

### DIFF
--- a/.github/workflows/python-checkstyle.yml
+++ b/.github/workflows/python-checkstyle.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   checkstyle:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/home/mczernek/containers/opensuse_factory_containerfile/uyuni-lint:latest
+    container: registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers_tw/uyuni-master-python:latest
 
     steps:
     - uses: actions/checkout@v4

--- a/python/README.md
+++ b/python/README.md
@@ -65,7 +65,7 @@ linting/lint.sh -a
 Alternatively, you can use the provided container to run `pylint` and `black` manually:
 
 ```
-podman run --rm -it -v $UYUNI_ROOT:/mgr registry.opensuse.org/home/mczernek/containers/opensuse_factory_containerfile/uyuni-lint:latest bash
+podman run --rm -it -v $UYUNI_ROOT:/mgr registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers_tw/uyuni-master-python:latest bash
 black -t py36 path/to/file.py
 pylint --rcfile=/root/.pylintrc /path/to/file.py
 ```

--- a/python/linting/lint.sh
+++ b/python/linting/lint.sh
@@ -12,7 +12,7 @@ if ! git rev-parse 2>/dev/null; then
 fi
 
 ENGINE="${CONTAINER_ENGINE:-podman}"
-IMAGE='registry.opensuse.org/home/mczernek/containers/opensuse_factory_containerfile/uyuni-lint'
+IMAGE='registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers_tw/uyuni-master-python'
 TAG='latest'
 GITROOT="$(git rev-parse --show-toplevel)"
 MOUNT="/mgr"
@@ -43,12 +43,16 @@ function help() {
   echo "  $(basename ${0}) python"
 }
 
+function ensure_latest_container_image() {
+  $ENGINE pull --quiet $IMAGE
+}
+
 function execute_black() {
-  "$ENGINE" run --rm -v ${GITROOT}:${MOUNT} ${IMAGE}:${TAG} black -t py36 "$@"
+  $ENGINE run --rm -v ${GITROOT}:${MOUNT} ${IMAGE}:${TAG} black -t py36 "$@"
 }
 
 function execute_lint() {
-  "$ENGINE" run --rm -v ${GITROOT}:${MOUNT} ${IMAGE}:${TAG} pylint --rcfile /root/.pylintrc "$@"
+  $ENGINE run --rm -v ${GITROOT}:${MOUNT} ${IMAGE}:${TAG} pylint --rcfile /root/.pylintrc "$@"
 }
 
 function get_all_py_files() {
@@ -57,6 +61,7 @@ function get_all_py_files() {
 }
 
 function main() {
+  ensure_latest_container_image
   if [[ "${CHECK_ALL_FILES}" == "true" ]]; then
     files="$(get_all_py_files)"
     echo "Linting and formatting: $files"


### PR DESCRIPTION
In this PR, I:

- Migrate the container image from my fork to the `systemsmanagement` build
- Modify `lint.sh` so that the local container image is always up to date before execution

relates to fails in https://github.com/uyuni-project/uyuni/pull/8421

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed