### PR TITLE
Address test suite dependencies not included in the container images

### DIFF
--- a/testsuite/features/build_validation/core/srv_first_settings.feature
+++ b/testsuite/features/build_validation/core/srv_first_settings.feature
@@ -9,6 +9,12 @@ Feature: Very first settings
   Scenario: Cleanup Salt files
     When I run "rm -Rf /srv/salt/*" on "server"
 
+  Scenario: Install testsuite packages
+    When I install package "iputils" on this "server"
+    And I install package "expect" on this "server"
+    And I install package "wget" on this "server"
+    And I install package "OpenIPMI" on this "server"
+
 @skip_if_containerized_server
   Scenario: Create admin user and first organization
     Given I access the host the first time

--- a/testsuite/features/core/srv_first_settings.feature
+++ b/testsuite/features/core/srv_first_settings.feature
@@ -22,6 +22,12 @@ Feature: Very first settings
   Scenario: Cleanup Salt files
     When I run "rm -Rf /srv/salt/*" on "server"
 
+  Scenario: Install testsuite packages
+    When I install package "iputils" on this "server"
+    And I install package "expect" on this "server"
+    And I install package "wget" on this "server"
+    And I install package "OpenIPMI" on this "server"
+
 @skip_if_containerized_server
   Scenario: Create admin user and first organization
     Given I access the host the first time


### PR DESCRIPTION
## What does this PR change?

Install required packages from sumaform testsuite container in the Host OS operating server container instead.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23666
Port(s): https://github.com/SUSE/spacewalk/tree/23666-address-test-suite-dependencies-not-included-in-the-container-images

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
