### PR TITLE
Report db for CoCo Attestation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ java/out
 out/
 java/buildconf/checkstyle.cache.src
 reports/
+!reporting/reports/
 *.mypy*
 
 # VS Code

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/CoCoAttestationReport_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/CoCoAttestationReport_queries.xml
@@ -1,0 +1,64 @@
+<!--
+  ~ Copyright (c) 2024 SUSE LLC
+  ~
+  ~ This software is licensed to you under the GNU General Public License,
+  ~ version 2 (GPLv2). There is NO WARRANTY for this software, express or
+  ~ implied, including the implied warranties of MERCHANTABILITY or FITNESS
+  ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+  ~ along with this software; if not, see
+  ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+  -->
+<datasource_modes>
+
+<mode name="CoCoAttestation">
+    <query params="report_id, limit">
+          SELECT suseservercocoattestationreport.id AS report_id
+                    , suseservercocoattestationreport.server_id AS system_id
+                    , suseservercocoattestationreport.action_id AS action_id
+                    , (CASE suseservercocoattestationreport.env_type
+                          WHEN 0 THEN 'NONE'
+                          WHEN 1 THEN 'KVM_AMD_EPYC_MILAN'
+                          WHEN 2 THEN 'KVM_AMD_EPYC_GENOA'
+                          ELSE NULL END) AS environment_type
+                    , suseservercocoattestationreport.status
+                    , suseservercocoattestationreport.created AS create_time
+                    , COUNT(CASE susecocoattestationresult.status WHEN 'SUCCEEDED' THEN 1 ELSE NULL END) AS pass
+                    , COUNT(CASE susecocoattestationresult.status WHEN 'FAILED' THEN 1 ELSE NULL END) AS fail
+            FROM suseservercocoattestationreport
+                    LEFT JOIN susecocoattestationresult ON suseservercocoattestationreport.id = susecocoattestationresult.report_id
+           WHERE suseservercocoattestationreport.id &gt; :report_id
+        GROUP BY suseservercocoattestationreport.id
+                    , suseservercocoattestationreport.server_id
+                    , suseservercocoattestationreport.action_id
+                    , suseservercocoattestationreport.env_type
+                    , suseservercocoattestationreport.status
+                    , suseservercocoattestationreport.created
+        ORDER BY report_id
+           FETCH FIRST :limit ROWS WITH TIES
+    </query>
+</mode>
+
+<mode name="CoCoAttestationResult">
+    <query params="report_id, result_type, limit">
+        SELECT susecocoattestationresult.report_id
+             , susecocoattestationresult.result_type AS result_type_id
+             , (CASE susecocoattestationresult.result_type
+                   WHEN 0 THEN 'NONE'
+                   WHEN 1 THEN 'SEV_SNP'
+                   WHEN 2 THEN 'SECURE_BOOT'
+                   WHEN 3 THEN 'AZURE_SEV_SNP'
+                   WHEN 4 THEN 'AZURE_SECURE_BOOT'
+                   WHEN 5 THEN 'AZURE_DISK_ENCRYPTED'
+                   ELSE NULL END) AS result_type
+             , susecocoattestationresult.status AS result_status
+             , susecocoattestationresult.description
+             , susecocoattestationresult.details
+             , susecocoattestationresult.attested AS attestation_time
+          FROM susecocoattestationresult
+          WHERE (susecocoattestationresult.report_id, susecocoattestationresult.result_type) &gt; (:report_id, :result_type)
+        ORDER BY report_id, result_type_id
+        FETCH FIRST :limit ROWS WITH TIES
+    </query>
+</mode>
+
+</datasource_modes>

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/file-list.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/file-list.xml
@@ -32,6 +32,7 @@
     <template name="SystemReport_queries" filename="xml/SystemReport_queries.xml" />
     <template name="ChannelReport_queries" filename="xml/ChannelReport_queries.xml" />
     <template name="ScapReport_queries" filename="xml/ScapReport_queries.xml" />
+    <template name="CoCoAttestationReport_queries" filename="xml/CoCoAttestationReport_queries.xml"/>
 
     <!-- queries used to test the datasource system -->
     <template name="test_queries" filename="xml/test_queries.xml" />

--- a/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/HubReportDbUpdateWorker.java
@@ -57,7 +57,7 @@ public class HubReportDbUpdateWorker implements QueueWorker {
             "SystemNetAddressV6", "SystemOutdated", "SystemGroupMember", "SystemEntitlement", "SystemErrata",
             "SystemPackageInstalled", "SystemPackageUpdate", "SystemCustomInfo", "Account", "AccountGroup",
             "Channel", "ChannelPackage", "ChannelRepository", "ChannelErrata", "Errata", "Package", "Repository",
-            "XccdScan", "XccdScanResult"
+            "XccdScan", "XccdScanResult", "CoCoAttestation", "CoCoAttestationResult"
             );
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDbUpdateTask.java
@@ -42,6 +42,7 @@ public class ReportDbUpdateTask extends RhnJavaJob {
     private static final String SYSTEM_REPORT_QUERIES = "SystemReport_queries";
     private static final String CHANNEL_REPORT_QUERIES = "ChannelReport_queries";
     private static final String SCAP_REPORT_QUERIES = "ScapReport_queries";
+    private static final String COCO_ATTESTATION_REPORT_QUERIES = "CoCoAttestationReport_queries";
     // Common fields
     private static final String SYSTEM_ID = "system_id";
     private static final String HISTORY_ID = "history_id";
@@ -63,6 +64,8 @@ public class ReportDbUpdateTask extends RhnJavaJob {
     public static final String IDENT_ID = "ident_id";
     public static final String PACKAGE_ID = "package_id";
     public static final String REPOSITORY_ID = "repository_id";
+    public static final String REPORT_ID = "report_id";
+    public static final String RESULT_TYPE = "result_type";
 
     private final int batchSize;
 
@@ -152,6 +155,11 @@ public class ReportDbUpdateTask extends RhnJavaJob {
                 Map.of(SCAN_ID, 0));
             fillReportDbTable(rh.getSession(), SCAP_REPORT_QUERIES, "XccdScanResult",
                 Map.of(SCAN_ID, 0, RULE_ID, 0, IDENT_ID, 0));
+
+            fillReportDbTable(rh.getSession(), COCO_ATTESTATION_REPORT_QUERIES, "CoCoAttestation",
+                    Map.of(REPORT_ID, 0));
+            fillReportDbTable(rh.getSession(), COCO_ATTESTATION_REPORT_QUERIES, "CoCoAttestationResult",
+                    Map.of(REPORT_ID, 0, RESULT_TYPE, 0));
 
             dbHelper.analyzeReportDb(rh.getSession());
 

--- a/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentType.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoEnvironmentType.java
@@ -25,6 +25,7 @@ public enum CoCoEnvironmentType {
     KVM_AMD_EPYC_GENOA(2, List.of(CoCoResultType.SEV_SNP, CoCoResultType.SECURE_BOOT)),
     AZURE(3, List.of(CoCoResultType.AZURE_SEV_SNP, CoCoResultType.AZURE_SECURE_BOOT,
                     CoCoResultType.AZURE_DISK_ENCRYPTED));
+    // ATTENTION: KEEP CoCoAttestationReport_queries.xml up to date !
 
     private final long value;
     private final String descriptionKey;

--- a/java/code/src/com/suse/manager/model/attestation/CoCoResultType.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoResultType.java
@@ -25,6 +25,7 @@ public enum CoCoResultType {
     AZURE_SEV_SNP(3),
     AZURE_SECURE_BOOT(4),
     AZURE_DISK_ENCRYPTED(5);
+    // ATTENTION: KEEP CoCoAttestationReport_queries.xml up to date !
 
     private final int value;
     private final String labelKey;

--- a/java/spacewalk-java.changes.mc.report-db-coco
+++ b/java/spacewalk-java.changes.mc.report-db-coco
@@ -1,0 +1,1 @@
+- create data for confidential compute attestation in the report database

--- a/reporting/reports/data/coco-attestation
+++ b/reporting/reports/data/coco-attestation
@@ -1,0 +1,43 @@
+
+synopsis:
+
+  Confidential Compute Attestations Reports
+
+description:
+
+  List the Confidential Compute Attestations performed for each system.
+
+columns:
+
+  mgm_id The id of the management server instance that contains this data
+  report_id The id of the report
+  system_id The id of the system
+  event_id The id of the action that triggered the attestation
+  hostname The hostname that identifies the system
+  organization The organization that owns this data
+  environment_type The type of the environment of the attested system
+  report_status The status of the report
+  pass The number of passed attestation results
+  fail The number of failed attestation results
+  create_time When the attestation was started
+  synced_date The timestamp of when this data was last refreshed.
+
+sql:
+
+  SELECT * FROM (
+      SELECT mgm_id
+            , report_id
+            , system_id
+            , action_id AS event_id
+            , hostname
+            , organization
+            , environment_type
+            , report_status
+            , pass
+            , fail
+            , create_time
+            , synced_date
+      FROM CoCoAttestationReport
+  ) X
+  -- where placeholder
+  ORDER BY mgm_id, system_id, event_id

--- a/reporting/reports/data/coco-attestation-results
+++ b/reporting/reports/data/coco-attestation-results
@@ -1,0 +1,43 @@
+
+synopsis:
+
+  Results of Confidential Compute Attestations
+
+description:
+
+  List the Confidential Compute Attestations results performed for each report and system.
+
+columns:
+
+  mgm_id The id of the management server instance that contains this data
+  report_id The id of the report
+  result_type_id The id of the result type
+  system_id The id of the system
+  hostname The hostname that identifies this system
+  organization The organization that owns this data
+  environment_type The type of the environment of the attested system
+  result_type The type of the result
+  result_status The status of the result
+  description The result description
+  attestation_time The time when this result was attested
+  synced_date The timestamp of when this data was last refreshed.
+
+sql:
+
+  SELECT * FROM (
+      SELECT mgm_id
+            , report_id
+            , result_type_id
+            , system_id
+            , hostname
+            , organization
+            , environment_type
+            , result_type
+            , result_status
+            , description
+            , attestation_time
+            , synced_date
+        FROM CoCoAttestationResultReport
+  ) X
+  -- where placeholder
+  ORDER BY mgm_id, report_id, result_type_id

--- a/reporting/spacewalk-reports.changes.mc.report-db-coco
+++ b/reporting/spacewalk-reports.changes.mc.report-db-coco
@@ -1,0 +1,1 @@
+- add reports for confidential compute attestation

--- a/schema/reportdb/check_reportdb_doc
+++ b/schema/reportdb/check_reportdb_doc
@@ -10,13 +10,18 @@ def dict_equal(a, b):
     type_b = type(b)
 
     if type_a != type_b:
+        sys.stderr.write("Type_a '{}' != Type_b '{}'\n".format(type_a, type_b))
         return False
 
     if isinstance(a, dict):
         if len(a) != len(b):
+            sys.stderr.write("dicts have different number of values\n")
+            sys.stderr.write("{}\n".format(a))
+            sys.stderr.write("{}\n".format(b))
             return False
         for key in a:
             if key not in b:
+                sys.stderr.write("Key '{}' exists in a, but not in b\n".format(key))
                 return False
             if not dict_equal(a[key], b[key]):
                 return False
@@ -24,11 +29,15 @@ def dict_equal(a, b):
 
     elif isinstance(a, list):
         if len(a) != len(b):
+            sys.stderr.write("lists have a different number of values\n")
+            sys.stderr.write("{}\n".format(a))
+            sys.stderr.write("{}\n".format(b))
             return False
         while len(a):
             x = a.pop()
             index = dict_indexof(x, b)
             if index == -1:
+                sys.stderr.write("position of elements in list are different")
                 return False
             del b[index]
         return True

--- a/schema/reportdb/common/tables/CoCoAttestation.sql
+++ b/schema/reportdb/common/tables/CoCoAttestation.sql
@@ -1,0 +1,28 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE CoCoAttestation
+(
+    mgm_id              NUMERIC NOT NULL,
+    report_id           NUMERIC NOT NULL,
+    system_id           NUMERIC NOT NULL,
+    action_id           NUMERIC NOT NULL,
+    environment_type    VARCHAR(120),
+    status              VARCHAR(32),
+    create_time         TIMESTAMPTZ,
+    pass                NUMERIC,
+    fail                NUMERIC,
+    synced_date         TIMESTAMPTZ DEFAULT (current_timestamp)
+);
+
+ALTER TABLE CoCoAttestation
+  ADD CONSTRAINT CoCoAttestation_pk PRIMARY KEY (mgm_id, report_id);
+

--- a/schema/reportdb/common/tables/CoCoAttestationResult.sql
+++ b/schema/reportdb/common/tables/CoCoAttestationResult.sql
@@ -1,0 +1,27 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE CoCoAttestationResult
+(
+    mgm_id              NUMERIC NOT NULL,
+    report_id           NUMERIC NOT NULL,
+    result_type_id      NUMERIC NOT NULL,
+    result_type         VARCHAR(128),
+    result_status       VARCHAR(32),
+    description         VARCHAR(256),
+    details             TEXT,
+    attestation_time    TIMESTAMPTZ,
+    synced_date         TIMESTAMPTZ DEFAULT (current_timestamp)
+);
+
+ALTER TABLE CoCoAttestationResult
+  ADD CONSTRAINT CoCoAttestationResult_pk PRIMARY KEY (mgm_id, report_id, result_type_id);
+

--- a/schema/reportdb/common/views/CoCoAttestationReport.sql
+++ b/schema/reportdb/common/views/CoCoAttestationReport.sql
@@ -1,0 +1,31 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE OR REPLACE VIEW CoCoAttestationReport AS
+  SELECT CoCoAttestation.mgm_id
+            , CoCoAttestation.report_id
+            , System.system_id
+            , CoCoAttestation.action_id
+            , System.hostname
+            , System.organization
+            , CoCoAttestation.environment_type
+            , CoCoAttestation.status AS report_status
+            , CoCoAttestation.pass
+            , CoCoAttestation.fail
+            , CoCoAttestation.create_time
+            , CoCoAttestation.synced_date
+    FROM CoCoAttestation 
+            LEFT JOIN System ON ( CoCoAttestation.mgm_id = System.mgm_id AND CoCoAttestation.system_id = System.system_id )
+ORDER BY CoCoAttestation.mgm_id
+            , CoCoAttestation.report_id
+            , System.system_id
+            , CoCoAttestation.create_time
+;

--- a/schema/reportdb/common/views/CoCoAttestationResultReport.sql
+++ b/schema/reportdb/common/views/CoCoAttestationResultReport.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE OR REPLACE VIEW CoCoAttestationResultReport AS
+  SELECT CoCoAttestationResult.mgm_id
+            , CoCoAttestationResult.report_id
+            , CoCoAttestationResult.result_type_id
+            , System.system_id
+            , System.hostname
+            , System.organization
+            , CoCoAttestation.environment_type
+            , CoCoAttestationResult.result_type
+            , CoCoAttestationResult.result_status
+            , CoCoAttestationResult.description
+            , CoCoAttestationResult.attestation_time
+            , CoCoAttestationResult.synced_date
+    FROM CoCoAttestationResult
+            LEFT JOIN CoCoAttestation ON (CoCoAttestationResult.mgm_id = CoCoAttestation.mgm_id AND CoCoAttestationResult.report_id = CoCoAttestation.report_id)
+            LEFT JOIN System ON ( CoCoAttestationResult.mgm_id = System.mgm_id AND CoCoAttestation.system_id = System.system_id )
+ORDER BY mgm_id, report_id, result_type_id
+;

--- a/schema/reportdb/common/views/views.deps
+++ b/schema/reportdb/common/views/views.deps
@@ -28,6 +28,9 @@ ChannelPackagesReport                  :: Channel \
 ChannelsReport                         :: Channel \
                                           ChannelPackage
 ClonedChannelsReport                   :: Channel
+CoCoAttestationReport                  :: System
+CoCoAttestationResultReport            :: CoCoAttestation \
+                                          System
 CustomChannelsReport                   :: Channel \
                                           ChannelRepository
 CustomInfoReport                       :: System \

--- a/schema/reportdb/postgres/docs/tables/CoCoAttestation.pre
+++ b/schema/reportdb/postgres/docs/tables/CoCoAttestation.pre
@@ -1,0 +1,37 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+COMMENT ON TABLE CoCoAttestation
+  IS 'The list of Confidential Compute Attestations performed on a system';
+
+COMMENT ON COLUMN CoCoAttestation.mgm_id
+  IS 'The id of the BRAND_NAME instance that contains this data';
+COMMENT ON COLUMN CoCoAttestation.report_id
+  IS 'The id of the report';
+COMMENT ON COLUMN CoCoAttestation.system_id
+  IS 'The id of the system';
+COMMENT ON COLUMN CoCoAttestation.action_id
+  IS 'The id of the action that triggered the attestation';
+COMMENT ON COLUMN CoCoAttestation.environment_type
+  IS 'The type of the environment of the attested system';
+COMMENT ON COLUMN CoCoAttestation.status
+  IS 'The status of the attestation';
+COMMENT ON COLUMN CoCoAttestation.create_time
+  IS 'The timestamp when the attestation was started';
+COMMENT ON COLUMN CoCoAttestation.pass
+  IS 'The number of passed attestation results';
+COMMENT ON COLUMN CoCoAttestation.fail
+  IS 'The number of failed attestation results';
+COMMENT ON COLUMN CoCoAttestation.synced_date
+  IS 'The timestamp of when this data was last refreshed.';
+
+ALTER TABLE CoCoAttestation
+    ADD CONSTRAINT CoCoAttestation_system_action_fkey FOREIGN KEY (mgm_id, system_id, action_id) REFERENCES SystemAction(mgm_id, system_id, action_id);

--- a/schema/reportdb/postgres/docs/tables/CoCoAttestationResult.pre
+++ b/schema/reportdb/postgres/docs/tables/CoCoAttestationResult.pre
@@ -1,0 +1,35 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+COMMENT ON TABLE CoCoAttestationResult
+  IS 'List the Confidential Compute Attestations results performed for each report and system';
+
+COMMENT ON COLUMN CoCoAttestationResult.mgm_id
+  IS 'The id of the BRAND_NAME instance that contains this data';
+COMMENT ON COLUMN CoCoAttestationResult.report_id
+  IS 'The id of the report';
+COMMENT ON COLUMN CoCoAttestationResult.result_type_id
+  IS 'The id of the result type';
+COMMENT ON COLUMN CoCoAttestationResult.result_type
+  IS 'The type of the result';
+COMMENT ON COLUMN CoCoAttestationResult.result_status
+  IS 'The status of the result';
+COMMENT ON COLUMN CoCoAttestationResult.description
+  IS 'The description of the result';
+COMMENT ON COLUMN CoCoAttestationResult.details
+  IS 'The details of the performed test';
+COMMENT ON COLUMN CoCoAttestationResult.attestation_time
+  IS 'The timestamp with the time of the attestation';
+COMMENT ON COLUMN CoCoAttestationResult.synced_date
+  IS 'The timestamp of when this data was last refreshed.';
+
+ALTER TABLE CoCoAttestationResult
+    ADD CONSTRAINT CoCoAttestationResult_report_fkey FOREIGN KEY (mgm_id, report_id) REFERENCES CoCoAttestation(mgm_id, report_id);

--- a/schema/reportdb/postgres/docs/views/CoCoAttestationReport.pre
+++ b/schema/reportdb/postgres/docs/views/CoCoAttestationReport.pre
@@ -1,0 +1,38 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+COMMENT ON VIEW CoCoAttestationReport
+  IS 'List the Confidential Compute Attestations performed for each system.';
+
+COMMENT ON COLUMN CoCoAttestationReport.mgm_id
+  IS 'The id of the BRAND_NAME instance that contains this data';
+COMMENT ON COLUMN CoCoAttestationReport.report_id
+  IS 'The id of the security scan';
+COMMENT ON COLUMN CoCoAttestationReport.system_id
+  IS 'The id of the system';
+COMMENT ON COLUMN CoCoAttestationReport.action_id
+  IS 'The id of the action that triggered the scan';
+COMMENT ON COLUMN CoCoAttestationReport.hostname
+  IS 'The hostname that identifies this system';
+COMMENT ON COLUMN CoCoAttestationReport.organization
+  IS 'The organization that owns this data';
+COMMENT ON COLUMN CoCoAttestationReport.environment_type
+  IS 'The type of the environment of the attested system';
+COMMENT ON COLUMN CoCoAttestationReport.report_status
+  IS 'The status of the report';
+COMMENT ON COLUMN CoCoAttestationReport.pass
+  IS 'The number of passed rules';
+COMMENT ON COLUMN CoCoAttestationReport.fail
+  IS 'The number of failed rules';
+COMMENT ON COLUMN CoCoAttestationReport.create_time
+  IS 'When the attestation was started';
+COMMENT ON COLUMN CoCoAttestationReport.synced_date
+  IS 'The timestamp of when this data was last refreshed.';

--- a/schema/reportdb/postgres/docs/views/CoCoAttestationResultReport.pre
+++ b/schema/reportdb/postgres/docs/views/CoCoAttestationResultReport.pre
@@ -1,0 +1,36 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+COMMENT ON VIEW CoCoAttestationResultReport
+  IS 'List the Confidential Compute Attestations results performed for each report and system.';
+
+COMMENT ON COLUMN CoCoAttestationResultReport.mgm_id
+  IS 'The id of the BRAND_NAME instance that contains this data';
+COMMENT ON COLUMN CoCoAttestationResultReport.report_id
+  IS 'The id of the report';
+COMMENT ON COLUMN CoCoAttestationResultReport.result_type_id
+  IS 'The id of the result type';
+COMMENT ON COLUMN CoCoAttestationResultReport.system_id
+  IS 'The id of the system';
+COMMENT ON COLUMN CoCoAttestationResultReport.hostname
+  IS 'The hostname that identifies this system';
+COMMENT ON COLUMN CoCoAttestationResultReport.organization
+  IS 'The organization that owns this data';
+COMMENT ON COLUMN CoCoAttestationResultReport.environment_type
+  IS 'The type of the environment of the attested system';
+COMMENT ON COLUMN CoCoAttestationResultReport.result_type
+  IS 'The type of the result';
+COMMENT ON COLUMN CoCoAttestationResultReport.result_status
+  IS 'The status of the result';
+COMMENT ON COLUMN CoCoAttestationResultReport.attestation_time
+  IS 'The timestamp when this result was attested';
+COMMENT ON COLUMN CoCoAttestationResultReport.synced_date
+  IS 'The timestamp of when this data was last refreshed.';

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/001-add-CoCoAttestation.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/001-add-CoCoAttestation.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE IF NOT EXISTS CoCoAttestation
+(
+    mgm_id              NUMERIC NOT NULL,
+    report_id           NUMERIC NOT NULL,
+    system_id           NUMERIC NOT NULL,
+    action_id           NUMERIC NOT NULL,
+    environment_type    VARCHAR(120),
+    status              VARCHAR(32),
+    create_time         TIMESTAMPTZ,
+    pass                NUMERIC,
+    fail                NUMERIC,
+    synced_date         TIMESTAMPTZ DEFAULT (current_timestamp),
+
+    CONSTRAINT CoCoAttestation_pk PRIMARY KEY (mgm_id, report_id)
+);

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/002-add-CoCoAttestationResult.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/002-add-CoCoAttestationResult.sql
@@ -1,0 +1,25 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TABLE IF NOT EXISTS CoCoAttestationResult
+(
+    mgm_id              NUMERIC NOT NULL,
+    report_id           NUMERIC NOT NULL,
+    result_type_id      NUMERIC NOT NULL,
+    result_type         VARCHAR(128),
+    result_status       VARCHAR(32),
+    description         VARCHAR(256),
+    details             TEXT,
+    attestation_time    TIMESTAMPTZ,
+    synced_date         TIMESTAMPTZ DEFAULT (current_timestamp),
+
+    CONSTRAINT CoCoAttestationResult_pk PRIMARY KEY (mgm_id, report_id, result_type_id)
+);

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/003-add-view-CoCoAttestationReport.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/003-add-view-CoCoAttestationReport.sql
@@ -1,0 +1,31 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE OR REPLACE VIEW CoCoAttestationReport AS
+  SELECT CoCoAttestation.mgm_id
+            , CoCoAttestation.report_id
+            , System.system_id
+            , CoCoAttestation.action_id
+            , System.hostname
+            , System.organization
+            , CoCoAttestation.environment_type
+            , CoCoAttestation.status AS report_status
+            , CoCoAttestation.pass
+            , CoCoAttestation.fail
+            , CoCoAttestation.create_time
+            , CoCoAttestation.synced_date
+    FROM CoCoAttestation 
+            LEFT JOIN System ON ( CoCoAttestation.mgm_id = System.mgm_id AND CoCoAttestation.system_id = System.system_id )
+ORDER BY CoCoAttestation.mgm_id
+            , CoCoAttestation.report_id
+            , System.system_id
+            , CoCoAttestation.create_time
+;

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/004-add-view-CoCoAttestationResultReport.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.4-to-uyuni-reportdb-schema-5.0.5/004-add-view-CoCoAttestationResultReport.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE OR REPLACE VIEW CoCoAttestationResultReport AS
+  SELECT CoCoAttestationResult.mgm_id
+            , CoCoAttestationResult.report_id
+            , CoCoAttestationResult.result_type_id
+            , System.system_id
+            , System.hostname
+            , System.organization
+            , CoCoAttestation.environment_type
+            , CoCoAttestationResult.result_type
+            , CoCoAttestationResult.result_status
+            , CoCoAttestationResult.description
+            , CoCoAttestationResult.attestation_time
+            , CoCoAttestationResult.synced_date
+    FROM CoCoAttestationResult
+            LEFT JOIN CoCoAttestation ON (CoCoAttestationResult.mgm_id = CoCoAttestation.mgm_id AND CoCoAttestationResult.report_id = CoCoAttestation.report_id)
+            LEFT JOIN System ON ( CoCoAttestationResult.mgm_id = System.mgm_id AND CoCoAttestation.system_id = System.system_id )
+ORDER BY mgm_id, report_id, result_type_id
+;

--- a/schema/reportdb/uyuni-reportdb-schema.changes.mc.coco-attestation-part2
+++ b/schema/reportdb/uyuni-reportdb-schema.changes.mc.coco-attestation-part2
@@ -1,0 +1,1 @@
+- add tables and report views for confidential compute attestation


### PR DESCRIPTION
## What does this PR change?

Add Confidential Compute Attestation Reports also to the report database and create some default reports

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Part of the bug CoCo docs

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23565

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
