### PR TITLE
Don't accept periods as valid characters in distribution label

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -5692,7 +5692,7 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.tree.invalidlabel" xml:space="preserve">
-        <source>The label is not formatted properly.  The label should contain only letters, numbers, hyphens, periods, and underscores.  It must also be at least 4 characters long</source>
+        <source>The label is not formatted properly. The label should contain only letters, numbers, hyphens, and underscores. It must also be at least 4 characters long</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/TreeEdit.do</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -19766,7 +19766,7 @@ the &lt;a href="/rhn/kickstart/ActivationKeysList.do?ksid={0}"&gt;Activation Key
       <trans-unit id="treecreate.jsp.header1" xml:space="preserve">
         <source>The following details are needed to define an autoinstallable distribution. The tree path field should be a valid path to an installation tree located on this @@PRODUCT_NAME@@ server.&lt;br/&gt;&lt;br/&gt;
 
-The Distribution Label field should contain only letters, numbers, hyphens, periods, and underscores. It must also be at least 4 characters long.&lt;br/&gt;&lt;br/&gt;
+The Distribution Label field should contain only letters, numbers, hyphens, and underscores. It must also be at least 4 characters long.&lt;br/&gt;&lt;br/&gt;
 
 The Tree Path, Base Channel, and Installer Generation should always match. This generally means that the versions for each field should be from the same version of @@ENTERPRISE_LINUX_NAME@@.&lt;br/&gt;&lt;br/&gt;
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/BaseTreeEditOperation.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/BaseTreeEditOperation.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
  * BaseTreeEditCommand
  */
 public abstract class BaseTreeEditOperation extends BasePersistOperation {
+    public static final String VALIDATE_LABEL_REGEX = "^([-_0-9A-Za-z]{1,255})$";
     private static final String INVALID_INITRD = "kickstart.tree.invalidinitrd";
     private static final String INVALID_KERNEL = "kickstart.tree.invalidkernel";
     protected KickstartableTree tree;
@@ -148,13 +149,12 @@ public abstract class BaseTreeEditOperation extends BasePersistOperation {
      * Validate the label to make sure:
      *
      * "The Distribution Label field should contain only letters, numbers, hyphens,
-     * periods, and underscores. It must also be at least 4 characters long."
+     * and underscores. It must also be at least 4 characters long."
      *
      * @return boolean if its valid or not
      */
     public boolean validateLabel() {
-        String regEx = "^([-_0-9A-Za-z@.]{1,255})$";
-        Pattern pattern = Pattern.compile(regEx);
+        Pattern pattern = Pattern.compile(VALIDATE_LABEL_REGEX);
         Matcher matcher = pattern.matcher(this.getTree().getLabel());
         return matcher.matches();
     }

--- a/java/spacewalk-java.changes.welder.bsc1219317
+++ b/java/spacewalk-java.changes.welder.bsc1219317
@@ -1,0 +1,1 @@
+- Don't accept periods as valid characters in distribution label (bsc#1219317)


### PR DESCRIPTION
## What does this PR change?

It removes the dots (periods) from the list of valid characters for distribution label as it causes NPE.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23575

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
