### PR TITLE
Coco attestation UI - Audit

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9052,6 +9052,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="mirror-credentials.jsp.verify" xml:space="preserve">
         <source>verify credentials</source>
       </trans-unit>
+      <trans-unit id="confidentialcomputing.nav.title" xml:space="preserve">
+        <source>Confidential Computing</source>
+      </trans-unit>
       <trans-unit id="subscriptionmatching.nav.title" xml:space="preserve">
         <source>Subscription Matching</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -9117,7 +9117,8 @@ public class SystemHandler extends BaseHandler {
     public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User loggedInUser, Integer sid, Date earliest,
                                                                         Integer offset, Integer limit) {
         Server server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);
-        return attestationManager.listCoCoAttestationReports(loggedInUser, server, earliest, offset, limit);
+        return attestationManager.listCoCoAttestationReportsForUserAndServer(loggedInUser, server, earliest,
+            offset, limit);
     }
 
     /**

--- a/java/code/src/com/suse/manager/attestation/AttestationManager.java
+++ b/java/code/src/com/suse/manager/attestation/AttestationManager.java
@@ -214,6 +214,17 @@ public class AttestationManager {
     }
 
     /**
+     * Return the number of existing reports for the given user
+     *
+     * @param userIn the user
+     * @return returns a list of reports
+     */
+    public long countCoCoAttestationReports(User userIn) {
+        return factory.countCoCoAttestationReports(userIn);
+    }
+
+
+    /**
      * Return the count of attestation report the given server
      *
      * @param userIn the user
@@ -289,6 +300,29 @@ public class AttestationManager {
             throw new LookupException(msg);
         }
         return optRes;
+    }
+
+    /**
+     * Return a list of reports for the given user
+     *
+     * @param userIn the user
+     * @param pc page control object
+     * @return returns a list of reports
+     */
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User userIn, PageControl pc) {
+        return factory.listCoCoAttestationReports(userIn, pc);
+    }
+
+    /**
+     * Return a list of reports for the given user
+     *
+     * @param userIn the user
+     * @param offset number of reports to skip
+     * @param limit maximum number of reports
+     * @return returns a list of reports
+     */
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User userIn, int offset, int limit) {
+        return factory.listCoCoAttestationReports(userIn, offset, limit);
     }
 
     private void ensureSystemAccessible(User userIn, Server serverIn) {

--- a/java/code/src/com/suse/manager/attestation/AttestationManager.java
+++ b/java/code/src/com/suse/manager/attestation/AttestationManager.java
@@ -219,8 +219,8 @@ public class AttestationManager {
      * @param userIn the user
      * @return returns a list of reports
      */
-    public long countCoCoAttestationReports(User userIn) {
-        return factory.countCoCoAttestationReports(userIn);
+    public long countCoCoAttestationReportsForUser(User userIn) {
+        return factory.countCoCoAttestationReportsForUser(userIn);
     }
 
 
@@ -231,9 +231,9 @@ public class AttestationManager {
      * @param serverIn the server
      * @return returns the number of attestation reports
      */
-    public long countCoCoAttestationReports(User userIn, Server serverIn) {
+    public long countCoCoAttestationReportsForUserAndServer(User userIn, Server serverIn) {
         ensureSystemAccessible(userIn, serverIn);
-        return factory.countCoCoAttestationReports(serverIn);
+        return factory.countCoCoAttestationReportsForServer(serverIn);
     }
 
     /**
@@ -244,9 +244,10 @@ public class AttestationManager {
      * @param pc page control object
      * @return returns a list of reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User userIn, Server serverIn, PageControl pc) {
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForUserAndServer(User userIn, Server serverIn,
+                                                                                        PageControl pc) {
         ensureSystemAccessible(userIn, serverIn);
-        return factory.listCoCoAttestationReports(serverIn, pc);
+        return factory.listCoCoAttestationReportsForServer(serverIn, pc);
     }
 
     /**
@@ -259,10 +260,11 @@ public class AttestationManager {
      * @param limit maximum number of reports
      * @return returns a list of reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User userIn, Server serverIn, Date earliest,
-                                                                        int offset, int limit) {
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForUserAndServer(User userIn, Server serverIn,
+                                                                                        Date earliest, int offset,
+                                                                                        int limit) {
         ensureSystemAccessible(userIn, serverIn);
-        return factory.listCoCoAttestationReports(serverIn, earliest, offset, limit);
+        return factory.listCoCoAttestationReportsForServer(serverIn, earliest, offset, limit);
     }
 
     /**
@@ -309,8 +311,8 @@ public class AttestationManager {
      * @param pc page control object
      * @return returns a list of reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User userIn, PageControl pc) {
-        return factory.listCoCoAttestationReports(userIn, pc);
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForUser(User userIn, PageControl pc) {
+        return factory.listCoCoAttestationReportsForUser(userIn, pc);
     }
 
     /**
@@ -321,8 +323,8 @@ public class AttestationManager {
      * @param limit maximum number of reports
      * @return returns a list of reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User userIn, int offset, int limit) {
-        return factory.listCoCoAttestationReports(userIn, offset, limit);
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForUser(User userIn, int offset, int limit) {
+        return factory.listCoCoAttestationReportsForUser(userIn, offset, limit);
     }
 
     private void ensureSystemAccessible(User userIn, Server serverIn) {

--- a/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
+++ b/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
@@ -150,11 +150,11 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
         commitHappened();
 
-        assertEquals(2, mgr.countCoCoAttestationReports(user, server));
-        assertEquals(1, mgr.countCoCoAttestationReports(user, server3));
+        assertEquals(2, mgr.countCoCoAttestationReportsForUserAndServer(user, server));
+        assertEquals(1, mgr.countCoCoAttestationReportsForUserAndServer(user, server3));
 
-        assertThrows(PermissionException.class, () -> mgr.countCoCoAttestationReports(user, server2));
-        assertThrows(PermissionException.class, () -> mgr.countCoCoAttestationReports(user2, server));
+        assertThrows(PermissionException.class, () -> mgr.countCoCoAttestationReportsForUserAndServer(user, server2));
+        assertThrows(PermissionException.class, () -> mgr.countCoCoAttestationReportsForUserAndServer(user2, server));
     }
 
     @Test
@@ -169,8 +169,8 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
         commitHappened();
 
-        List<ServerCoCoAttestationReport> reports = mgr.listCoCoAttestationReports(user, server, new Date(0), 0,
-                Integer.MAX_VALUE);
+        List<ServerCoCoAttestationReport> reports = mgr.listCoCoAttestationReportsForUserAndServer(user, server,
+            new Date(0), 0, Integer.MAX_VALUE);
         assertEquals(2, reports.size());
 
         ServerCoCoAttestationReport latestReport = mgr.lookupLatestCoCoAttestationReport(user, server);
@@ -201,8 +201,8 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
         commitHappened();
 
-        assertEquals(3, mgr.countCoCoAttestationReports(user));
-        assertEquals(5, mgr.countCoCoAttestationReports(user2));
+        assertEquals(3, mgr.countCoCoAttestationReportsForUser(user));
+        assertEquals(5, mgr.countCoCoAttestationReportsForUser(user2));
     }
 
     @Test
@@ -228,11 +228,11 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
         commitHappened();
 
-        List<ServerCoCoAttestationReport> reports = mgr.listCoCoAttestationReports(user, 0, Integer.MAX_VALUE);
+        List<ServerCoCoAttestationReport> reports = mgr.listCoCoAttestationReportsForUser(user, 0, Integer.MAX_VALUE);
         assertEquals(3, reports.size());
         assertTrue(reports.stream().allMatch(r -> List.of(server, server3).contains(r.getServer())));
 
-        reports = mgr.listCoCoAttestationReports(user2, 0, Integer.MAX_VALUE);
+        reports = mgr.listCoCoAttestationReportsForUser(user2, 0, Integer.MAX_VALUE);
         assertEquals(5, reports.size());
         assertTrue(reports.stream().allMatch(r -> List.of(server2, server4).contains(r.getServer())));
     }
@@ -250,16 +250,16 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
             TimeUnit.SECONDS.sleep(2);
         }
         HibernateFactory.getSession().clear();
-        List<ServerCoCoAttestationReport> reports = mgr.listCoCoAttestationReports(user, server, new Date(0), 0,
-                Integer.MAX_VALUE);
+        List<ServerCoCoAttestationReport> reports = mgr.listCoCoAttestationReportsForUserAndServer(user, server,
+            new Date(0), 0, Integer.MAX_VALUE);
         assertEquals(10, reports.size());
 
-        List<ServerCoCoAttestationReport> reports2 = mgr.listCoCoAttestationReports(user, server,
+        List<ServerCoCoAttestationReport> reports2 = mgr.listCoCoAttestationReportsForUserAndServer(user, server,
                 new Date((epochStart + 10) * 1000L), 0, Integer.MAX_VALUE);
         assertTrue(reports2.get(0).getModified().compareTo(new Date((epochStart + 10) * 1000L)) >= 0);
         assertEquals(5, reports2.size());
 
-        reports2 = mgr.listCoCoAttestationReports(user, server, new Date(0), 5, 2);
+        reports2 = mgr.listCoCoAttestationReportsForUserAndServer(user, server, new Date(0), 5, 2);
         assertEquals(2, reports2.size());
         assertEquals(reports.get(6), reports2.get(0));
         assertEquals(reports.get(7), reports2.get(1));

--- a/java/code/src/com/suse/manager/model/attestation/AttestationFactory.java
+++ b/java/code/src/com/suse/manager/model/attestation/AttestationFactory.java
@@ -202,7 +202,7 @@ public class AttestationFactory extends HibernateFactory {
      * @param user the user
      * @return returns a list or reports
      */
-    public long countCoCoAttestationReports(User user) {
+    public long countCoCoAttestationReportsForUser(User user) {
         return getSession()
             .createQuery("SELECT COUNT(r.id) FROM UserImpl u " +
                 "JOIN u.servers s " +
@@ -217,7 +217,7 @@ public class AttestationFactory extends HibernateFactory {
      * @param serverIn the server
      * @return returns a list or reports
      */
-    public long countCoCoAttestationReports(Server serverIn) {
+    public long countCoCoAttestationReportsForServer(Server serverIn) {
         return getSession()
             .createQuery("SELECT COUNT(*) FROM ServerCoCoAttestationReport r WHERE r.server = :server", Long.class)
             .setParameter("server", serverIn)
@@ -230,8 +230,8 @@ public class AttestationFactory extends HibernateFactory {
      * @param pc page control object
      * @return returns a list or reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(Server serverIn, PageControl pc) {
-        return listCoCoAttestationReports(serverIn, new Date(0), pc.getStart() - 1, pc.getPageSize());
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForServer(Server serverIn, PageControl pc) {
+        return listCoCoAttestationReportsForServer(serverIn, new Date(0), pc.getStart() - 1, pc.getPageSize());
     }
 
     /**
@@ -242,8 +242,8 @@ public class AttestationFactory extends HibernateFactory {
      * @param limitIn maximal number of reports
      * @return returns a list or reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(Server serverIn, Date earliestIn,
-                                                                        int offsetIn, int limitIn) {
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForServer(Server serverIn, Date earliestIn,
+                                                                                 int offsetIn, int limitIn) {
         return getSession()
                 .createQuery("FROM ServerCoCoAttestationReport " +
                         "WHERE server = :server " +
@@ -262,8 +262,8 @@ public class AttestationFactory extends HibernateFactory {
      * @param pc page control object
      * @return returns a list or reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User user, PageControl pc) {
-        return listCoCoAttestationReports(user, pc.getStart() - 1, pc.getPageSize());
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForUser(User user, PageControl pc) {
+        return listCoCoAttestationReportsForUser(user, pc.getStart() - 1, pc.getPageSize());
     }
 
     /**
@@ -273,7 +273,7 @@ public class AttestationFactory extends HibernateFactory {
      * @param limitIn maximal number of reports
      * @return returns a list or reports
      */
-    public List<ServerCoCoAttestationReport> listCoCoAttestationReports(User user, int offsetIn, int limitIn) {
+    public List<ServerCoCoAttestationReport> listCoCoAttestationReportsForUser(User user, int offsetIn, int limitIn) {
         return getSession()
             .createQuery("SELECT r FROM UserImpl u " +
                 "JOIN u.servers s " +

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -38,6 +38,7 @@ import com.suse.manager.webui.controllers.ActivationKeysController;
 import com.suse.manager.webui.controllers.AnsibleController;
 import com.suse.manager.webui.controllers.CSVDownloadController;
 import com.suse.manager.webui.controllers.CVEAuditController;
+import com.suse.manager.webui.controllers.ConfidentialComputingController;
 import com.suse.manager.webui.controllers.DownloadController;
 import com.suse.manager.webui.controllers.FormulaCatalogController;
 import com.suse.manager.webui.controllers.FormulaController;
@@ -134,12 +135,17 @@ public class Router implements SparkApplication {
         HttpApiRegistry httpApiRegistry = new HttpApiRegistry();
         FrontendLogController frontendLogController = new FrontendLogController();
         DownloadController downloadController = new DownloadController(paygManager);
+        ConfidentialComputingController confidentialComputingController =
+                new ConfidentialComputingController(attestationManager);
 
         // Login
         LoginController.initRoutes(jade);
 
         //CVEAudit
         CVEAuditController.initRoutes(jade);
+
+        // Confidential Computing
+        confidentialComputingController.initRoutes(jade);
 
         initContentManagementRoutes(jade, kubernetesManager);
 

--- a/java/code/src/com/suse/manager/webui/controllers/ConfidentialComputingController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ConfidentialComputingController.java
@@ -99,9 +99,9 @@ public class ConfidentialComputingController {
         PageControlHelper pageHelper = new PageControlHelper(request);
         PageControl pc = pageHelper.getPageControl();
 
-        long totalSize = attestationManager.countCoCoAttestationReports(user);
+        long totalSize = attestationManager.countCoCoAttestationReportsForUser(user);
 
-        List<CoCoAttestationReportJson> reportsJson = attestationManager.listCoCoAttestationReports(user, pc)
+        List<CoCoAttestationReportJson> reportsJson = attestationManager.listCoCoAttestationReportsForUser(user, pc)
             .stream()
             .map(CoCoAttestationReportJson::new)
             .collect(Collectors.toList());

--- a/java/code/src/com/suse/manager/webui/controllers/ConfidentialComputingController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ConfidentialComputingController.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.controllers;
+
+import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
+import static spark.Spark.get;
+
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.listview.PageControl;
+
+import com.suse.manager.attestation.AttestationManager;
+import com.suse.manager.webui.utils.PageControlHelper;
+import com.suse.manager.webui.utils.gson.CoCoAttestationReportJson;
+import com.suse.manager.webui.utils.gson.PagedDataResultJson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
+
+public class ConfidentialComputingController {
+
+    private static final Gson GSON = new GsonBuilder()
+        .registerTypeAdapter(Date.class, new ECMAScriptDateAdapter())
+        .serializeNulls()
+        .create();
+
+    private final AttestationManager attestationManager;
+
+    /**
+     * Default constructor
+     * @param attestationManagerIn the attestation manager
+     */
+    public ConfidentialComputingController(AttestationManager attestationManagerIn) {
+        this.attestationManager = attestationManagerIn;
+    }
+
+    /**
+     * Initialize routes for Confidential Computing.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/audit/confidential-computing",
+            withUserPreferences(withCsrfToken(withUser(this::show))), jade);
+
+        get("/manager/api/audit/confidential-computing/listAttestations",
+            asJson(withUser(this::listAllAttestations)));
+    }
+
+    /**
+     * Displays the confidential computing global reports page
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return the ModelAndView object to render the page
+     */
+    public ModelAndView show(Request request, Response response, User user) {
+        return new ModelAndView(new HashMap<>(), "templates/audit/confidential-computing.jade");
+    }
+
+    /**
+     * List all the attestation reports available for this user
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return the ModelAndView object to render the page
+     */
+    public String listAllAttestations(Request request, Response response, User user) {
+        PageControlHelper pageHelper = new PageControlHelper(request);
+        PageControl pc = pageHelper.getPageControl();
+
+        long totalSize = attestationManager.countCoCoAttestationReports(user);
+
+        List<CoCoAttestationReportJson> reportsJson = attestationManager.listCoCoAttestationReports(user, pc)
+            .stream()
+            .map(CoCoAttestationReportJson::new)
+            .collect(Collectors.toList());
+
+        return json(GSON, response, new PagedDataResultJson<>(reportsJson, totalSize, Collections.emptySet()),
+            new TypeToken<>() { });
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -550,9 +550,10 @@ public class MinionsAPI {
         PageControlHelper pageHelper = new PageControlHelper(request);
         PageControl pc = pageHelper.getPageControl();
 
-        long totalSize = attestationManager.countCoCoAttestationReports(user, server);
+        long totalSize = attestationManager.countCoCoAttestationReportsForUserAndServer(user, server);
 
-        List<CoCoAttestationReportJson> reportsJson = attestationManager.listCoCoAttestationReports(user, server, pc)
+        List<CoCoAttestationReportJson> reportsJson =
+            attestationManager.listCoCoAttestationReportsForUserAndServer(user, server, pc)
             .stream()
             .map(CoCoAttestationReportJson::new)
             .collect(Collectors.toList());

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -338,7 +338,9 @@ public class MenuTree {
                         .addChild(new MenuItem("audit.nav.logreview")
                                 .addChild(new MenuItem("Overview").withPrimaryUrl("/rhn/audit/Overview.do"))
                                 .addChild(new MenuItem("Reviews").withPrimaryUrl("/rhn/audit/Machine.do"))
-                                .addChild(new MenuItem("Search").withPrimaryUrl("/rhn/audit/Search.do"))));
+                                .addChild(new MenuItem("Search").withPrimaryUrl("/rhn/audit/Search.do"))))
+                .addChild(new MenuItem("confidentialcomputing.nav.title")
+                        .withPrimaryUrl("/rhn/manager/audit/confidential-computing"));
     }
 
     private MenuItem getConfigurationNode(Map<String, Boolean> adminRoles) {

--- a/java/code/src/com/suse/manager/webui/templates/audit/confidential-computing.jade
+++ b/java/code/src/com/suse/manager/webui/templates/audit/confidential-computing.jade
@@ -1,0 +1,10 @@
+include ../common.jade
+
+#confidential-computing
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
+
+script(type='text/javascript').
+    spaImportReactPage('audit/coco')
+        .then(function(module) { module.renderer('confidential-computing') });

--- a/java/spacewalk-java.changes.mackdk.coco-attestation-ui-audit
+++ b/java/spacewalk-java.changes.mackdk.coco-attestation-ui-audit
@@ -1,0 +1,1 @@
+- Added support for confidential computing UI in audit

--- a/web/html/src/components/CoCoScansList.tsx
+++ b/web/html/src/components/CoCoScansList.tsx
@@ -148,20 +148,26 @@ class CoCoScansList extends React.Component<Props, State> {
     const attestationList = (
       <TopPanel title={t("Confidential Computing Attestations")} icon="fa fa-list">
         {messages}
-        <SectionToolbar>
-          <div className="action-button-wrapper">
-            <span className="btn-group pull-right">
-              <AsyncButton
-                id="run-btn"
-                icon="fa-refresh"
-                action={this.onRunAttestation}
-                text={t("Schedule Attestation")}
-              />
-            </span>
-          </div>
-        </SectionToolbar>
+        {this.props.serverId !== undefined && (
+          <SectionToolbar>
+            <div className="action-button-wrapper">
+              <span className="btn-group pull-right">
+                <AsyncButton
+                  id="run-btn"
+                  icon="fa-refresh"
+                  action={this.onRunAttestation}
+                  text={t("Schedule Attestation")}
+                />
+              </span>
+            </div>
+          </SectionToolbar>
+        )}
         <CoCoAttestationTable
-          dataUrl={`/rhn/manager/api/systems/${this.props.serverId}/details/coco/listAttestations`}
+          dataUrl={
+            this.props.serverId
+              ? `/rhn/manager/api/systems/${this.props.serverId}/details/coco/listAttestations`
+              : "/rhn/manager/api/audit/confidential-computing/listAttestations"
+          }
           showSystem={this.props.serverId === undefined}
           onReportDetails={this.onDetails}
         />

--- a/web/html/src/manager/audit/coco/coco-global-scans-list.renderer.tsx
+++ b/web/html/src/manager/audit/coco/coco-global-scans-list.renderer.tsx
@@ -1,0 +1,7 @@
+import * as React from "react";
+
+import SpaRenderer from "core/spa/spa-renderer";
+
+import CoCoScansList from "components/CoCoScansList";
+
+export const renderer = (id) => SpaRenderer.renderNavigationReact(<CoCoScansList />, document.getElementById(id));

--- a/web/html/src/manager/audit/index.ts
+++ b/web/html/src/manager/audit/index.ts
@@ -1,4 +1,5 @@
 export default {
+  "audit/coco": () => import("./coco/coco-global-scans-list.renderer"),
   "audit/cveaudit": () => import("./cveaudit/cveaudit"),
   "audit/subscription-matching": () => import("./subscription-matching/subscription-matching"),
 };

--- a/web/spacewalk-web.changes.mackdk.coco-attestation-ui-audit
+++ b/web/spacewalk-web.changes.mackdk.coco-attestation-ui-audit
@@ -1,0 +1,1 @@
+- Added confidential computing UI in audit


### PR DESCRIPTION
## What does this PR change?

This PR adds a UI page to display the attestation reports on all systems accessible by the user under Audt > Confidential Computing. This listing behaves the same as the the one from https://github.com/uyuni-project/uyuni/pull/8597, without the system filtering, and reuses the same components.

Note: this change is merging to branch `coco-attestation-part2`.

## GUI diff

After:
![image](https://github.com/uyuni-project/uyuni/assets/2292684/eebc1ba7-a426-4571-b773-e8344c53878d)

- [X] **DONE**

## Documentation
- Documentation WIP https://github.com/SUSE/spacewalk/issues/23652

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23563

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
