### PR TITLE
QE: Fix proxy activation key

### DIFF
--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -158,7 +158,6 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I select the parent channel for the "proxy_container" from "selectedBaseChannel"
     And I wait for child channels to appear
-    And I check "openSUSE Leap Micro 5.5 (x86_64)"
     And I check "SLE Micro 5.5 Update Repository (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap Micro 5.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap Micro 5.5 (x86_64) (Development)"


### PR DESCRIPTION
## What does this PR change?

This fixes the activation key update of the proxy for Uyuni.
![image](https://github.com/uyuni-project/uyuni/assets/12104291/fe724393-6a72-4962-b43a-5f11f4e3b9f6)


```bash
(...)
Feature: Update activation keys
  In order to register systems to the spacewalk server
  As admin
  I want to update activation keys to use synchronized base products

  Scenario: Log in as admin user                  # features/dom.feature:7
      This scenario ran at: 2024-04-18 10:59:47 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:400
      This scenario took: 13 seconds

  Scenario: Update the openSUSE Leap Micro 5.5 Proxy Host key with synced base product   # features/dom.feature:10
      This scenario ran at: 2024-04-18 11:00:00 +0200
    When I follow the left menu "Systems > Activation Keys"                              # features/step_definitions/navigation_steps.rb:338
    And I follow "Proxy Key x86_64" in the content area                                  # features/step_definitions/navigation_steps.rb:298
    And I wait for child channels to appear                                              # features/step_definitions/navigation_steps.rb:192
    And I select the parent channel for the "proxy_container" from "selectedBaseChannel" # features/step_definitions/navigation_steps.rb:176
    And I wait for child channels to appear                                              # features/step_definitions/navigation_steps.rb:192
    And I check "SLE Micro 5.5 Update Repository (x86_64)"                               # features/step_definitions/navigation_steps.rb:154
    And I check "Uyuni Client Tools for openSUSE Leap Micro 5.5 (x86_64)"                # features/step_definitions/navigation_steps.rb:154
    And I check "Uyuni Client Tools for openSUSE Leap Micro 5.5 (x86_64) (Development)"  # features/step_definitions/navigation_steps.rb:154
    And I click on "Update Activation Key"                                               # features/step_definitions/navigation_steps.rb:257
    Then I should see a "Activation key Proxy Key x86_64 has been modified" text         # features/step_definitions/navigation_steps.rb:590
      This scenario took: 2 seconds

2 scenarios (2 passed)
11 steps (11 passed)
0m15.304s
```

![image](https://github.com/uyuni-project/uyuni/assets/12104291/501e32af-e2da-4d8b-be6e-234a30276b3d)


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!