### PR TITLE
QE: 5.0 BV fixes

### DIFF
--- a/testsuite/features/build_validation/add_non_MU_repositories/alma8_minion_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/alma8_minion_build_clm.feature
@@ -29,12 +29,12 @@ Feature: Add the Alma 8 distribution custom repositories
     # "almalinux8-appstream for x86_64" is already checked
     And I check "Custom Channel for alma8_minion"
     And I click on "Save"
-    Then I should see a "EL8-Manager-Tools-Pool for x86_64 Alma" text
+    Then I should see a "RES8-Manager-Tools-Pool for x86_64 Alma" text
     When I click on "Attach/Detach Filters"
-    And I check "php-8.1: enable module php:8.1"
-    And I check "ruby-3.1: enable module ruby:3.1"
+    And I check "python-3.6: enable module python36:3.6"
+    And I check "ruby-2.7: enable module ruby:2.7"
     And I click on "Save"
-    Then I should see a "php-8.1: enable module php:8.1" text
+    Then I should see a "python-3.6: enable module python36:3.6" text
     When I click on "Add Environment"
     And I enter "result" as "name"
     And I enter "result" as "label"
@@ -63,10 +63,10 @@ Feature: Add the Alma 8 distribution custom repositories
     And I click on "Save"
     Then I should see a "AlmaLinux 8 AppStream (x86_64)" text
     When I click on "Attach/Detach Filters"
-    And I check "php-8.1: enable module php:8.1"
-    And I check "ruby-3.1: enable module ruby:3.1"
+    And I check "python-3.6: enable module python36:3.6"
+    And I check "ruby-2.7: enable module ruby:2.7"
     And I click on "Save"
-    Then I should see a "php-8.1: enable module php:8.1" text
+    Then I should see a "python-3.6: enable module python36:3.6" text
     When I click on "Add Environment"
     And I enter "result" as "name"
     And I enter "result" as "label"


### PR DESCRIPTION
## What does this PR change?

- There is no PHP 8.1 available in AlmaLinux 8, so we need to use a different filter
  ![image](https://github.com/uyuni-project/uyuni/assets/12104291/ee897424-8757-48cb-91f8-52ac9e63870d)
- The child channel is also a different one (the same we already have for Rocky 8): `RES8-Manager-Tools-Pool for x86_64 Alma`
  ![image](https://github.com/uyuni-project/uyuni/assets/12104291/de003960-5d70-4998-b28d-d969a72ba429)


Probably copy-paste errors from the AlmaLinux 9 feature file.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
