### PR TITLE
Container proxy: use SSL cert cnames as FQDNs

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -42,6 +42,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.suse.manager.api.ReadOnly;
 import com.suse.manager.ssl.SSLCertData;
 import com.suse.manager.ssl.SSLCertGenerationException;
+import com.suse.manager.ssl.SSLCertManager;
 import com.suse.manager.ssl.SSLCertPair;
 
 import org.apache.logging.log4j.LogManager;
@@ -293,7 +294,8 @@ public class ProxyHandler extends BaseHandler {
             }
 
             return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
-                    maxCache.longValue(), email, rootCA, intermediateCAs, proxyCrtKey, null, null, null);
+                    maxCache.longValue(), email, rootCA, intermediateCAs, proxyCrtKey, null, null, null,
+                    new SSLCertManager());
         }
         catch (InstantiationException e) {
             LOG.error("Failed to generate proxy system id", e);
@@ -364,7 +366,8 @@ public class ProxyHandler extends BaseHandler {
             SSLCertData certData = new SSLCertData(nullable(proxyName), cnames, nullable(country),
                     nullable(state), nullable(city), nullable(org), nullable(orgUnit), nullable(sslEmail));
             return systemManager.createProxyContainerConfig(loggedInUser, proxyName, proxyPort, server,
-                    maxCache.longValue(), email, null, List.of(), null, caCrtKey, caPassword, certData);
+                    maxCache.longValue(), email, null, List.of(), null, caCrtKey, caPassword, certData,
+                    new SSLCertManager());
         }
         catch (InstantiationException e) {
             LOG.error("Failed to generate proxy system id", e);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.cloud.CloudPaygManager;
 import com.suse.manager.ssl.SSLCertData;
+import com.suse.manager.ssl.SSLCertManager;
 import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
@@ -179,9 +180,12 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
         SystemManager mockSystemManager = mock(SystemManager.class);
         context().checking(new Expectations() {{
-            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, 8022, server, 2048L, email,
-                    "ROOT_CA", List.of("CA1", "CA2"), new SSLCertPair("PROXY_CERT", "PROXY_KEY"),
-                    null, null, null);
+            allowing(mockSystemManager).createProxyContainerConfig(
+                    with(equal(user)), with(equal(proxy)), with(equal(8022)), with(equal(server)), with(equal(2048L)),
+                    with(equal(email)), with(equal("ROOT_CA")), with(equal(List.of("CA1", "CA2"))),
+                    with(equal(new SSLCertPair("PROXY_CERT", "PROXY_KEY"))),
+                    with(aNull(SSLCertPair.class)), with(aNull(String.class)), with(aNull(SSLCertData.class)),
+                    with(any(SSLCertManager.class)));
             will(returnValue(dummyConfig));
         }});
 
@@ -200,11 +204,14 @@ public class ProxyHandlerTest extends RhnJmockBaseTestCase {
 
         SystemManager mockSystemManager = mock(SystemManager.class);
         context().checking(new Expectations() {{
-            allowing(mockSystemManager).createProxyContainerConfig(user, proxy, 22, server, 2048L, email,
-                    null, Collections.emptyList(), null,
-                    new SSLCertPair("CACert", "CAKey"), "CAPass",
-                    new SSLCertData(proxy, List.of("cname1", "cname2"), "DE", "Bayern", "Nurnberg",
-                            "ACME", "ACME Tests", "coyote@acme.lab"));
+            allowing(mockSystemManager).createProxyContainerConfig(
+                    with(equal(user)), with(equal(proxy)), with(equal(22)), with(equal(server)), with(equal(2048L)),
+                    with(equal(email)), with(aNull(String.class)), with(equal(Collections.emptyList())),
+                    with(aNull(SSLCertPair.class)),
+                    with(equal(new SSLCertPair("CACert", "CAKey"))), with(equal("CAPass")),
+                    with(equal(new SSLCertData(proxy, List.of("cname1", "cname2"), "DE", "Bayern",
+                            "Nurnberg", "ACME", "ACME Tests", "coyote@acme.lab"))),
+                    with(any(SSLCertManager.class)));
             will(returnValue(dummyConfig));
         }});
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -130,6 +130,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.metrics.SystemsCollector;
+import com.suse.manager.ssl.SSLCertManager;
 import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -1933,6 +1934,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         String sshPushKey = "DummySshPushKey";
         String sshPushPubKey = "DummySshPushPubKey";
 
+        SSLCertManager certManager = mock(SSLCertManager.class);
+
         context().checking(new Expectations() {{
             allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)),
                     with(equal(SaltSSHService.SUMA_SSH_PUB_KEY)));
@@ -1942,10 +1945,12 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             allowing(saltServiceMock)
                     .checkSSLCert(with(equal(rootCA)), with(equal(new SSLCertPair(cert, key))), with(equal(otherCAs)));
             will(returnValue(apacheCert));
+            allowing(certManager).getNamesFromSslCert("Dummy cert");
+            will(returnValue(Set.of("pxy.mgr.lab", "pxy-test.mgr.lab")));
         }});
 
         byte[] actual = systemManager.createProxyContainerConfig(user, proxyName, 8022, serverName, maxCache, email,
-                rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null);
+                rootCA, otherCAs, new SSLCertPair(cert, key), null, null, null, certManager);
         Map<String, String> content = readTarData(actual);
 
         Map<String, Object> configYaml = new Yaml().load(content.get("config.yaml"));

--- a/java/code/src/com/suse/manager/ssl/SSLCertData.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertData.java
@@ -17,8 +17,10 @@ package com.suse.manager.ssl;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -145,5 +147,21 @@ public class SSLCertData {
         return hostnameParts.length > 2 ?
                 StringUtils.join(hostnameParts, ".", 0, hostnameParts.length - 2) :
                 this.getCn();
+    }
+
+    /**
+     * Return the set of aggregates cn and cnames.
+     *
+     * @return all cnames and cn without duplicate.
+     */
+    public Set<String> getAllCnames() {
+        Set<String> allCnames = new HashSet<>();
+        if (cn != null) {
+            allCnames.add(cn);
+        }
+        if (cnames != null) {
+            allCnames.addAll(cnames);
+        }
+        return allCnames;
     }
 }

--- a/java/code/src/com/suse/manager/utils/ExecHelper.java
+++ b/java/code/src/com/suse/manager/utils/ExecHelper.java
@@ -54,10 +54,11 @@ public class ExecHelper {
      *
      * @param command the command to run
      * @param input the value to pass as standard input of the process
+     * @return the command output
      *
      * @throws RhnRuntimeException if anything wrong happens or if the exit code is not 0
      */
-    public void exec(List<String> command, String input) throws RhnRuntimeException {
+    public String exec(List<String> command, String input) throws RhnRuntimeException {
         Process process;
         try {
             process = runtimeSupplier.get().exec(command.toArray(new String[0]));
@@ -83,6 +84,7 @@ public class ExecHelper {
                 String errMsg = new String(process.getErrorStream().readAllBytes());
                 throw new RhnRuntimeException(TOOL_FAILED_MSG + errMsg);
             }
+            return new String(process.getInputStream().readAllBytes());
         }
         catch (InterruptedException err) {
             LOG.error(err);

--- a/java/code/src/com/suse/manager/webui/controllers/ProxyController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProxyController.java
@@ -29,6 +29,7 @@ import com.redhat.rhn.manager.system.SystemsExistException;
 
 import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
 import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
+import com.suse.manager.ssl.SSLCertManager;
 import com.suse.manager.webui.utils.SparkApplicationHelper;
 import com.suse.manager.webui.utils.gson.ProxyContainerConfigJson;
 
@@ -119,7 +120,7 @@ public class ProxyController {
             byte[] config = systemManager.createProxyContainerConfig(user, data.getProxyFqdn(),
                     data.getProxyPort(), data.getServerFqdn(), data.getMaxCache(), data.getEmail(),
                     data.getRootCA(), data.getIntermediateCAs(), data.getProxyCertPair(),
-                    data.getCaPair(), data.getCaPassword(), data.getCertData());
+                    data.getCaPair(), data.getCaPassword(), data.getCertData(), new SSLCertManager());
             String filename = data.getProxyFqdn().split("\\.")[0];
             request.session().attribute(filename + "-config.tar.gz", config);
 

--- a/java/code/src/com/suse/manager/webui/controllers/test/ProxyControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/ProxyControllerTest.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.testing.SparkTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.ssl.SSLCertData;
+import com.suse.manager.ssl.SSLCertManager;
 import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.controllers.ProxyController;
 
@@ -62,7 +63,8 @@ public class ProxyControllerTest extends BaseControllerTestCase {
                     with(equal(user)), with(equal("pxy.acme.lab")), with(equal(8022)), with(equal("srv.acme.lab")),
                     with(equal(2048L)), with(equal("coyote@acme.lab")), with(equal("Root CA")),
                     with(equal(List.of("CA1", "CA2"))), with(equal(new SSLCertPair("CERT", "KEY"))),
-                    with(aNull(SSLCertPair.class)), with(aNull(String.class)), with(aNull(SSLCertData.class)));
+                    with(aNull(SSLCertPair.class)), with(aNull(String.class)), with(aNull(SSLCertData.class)),
+                    with(any(SSLCertManager.class)));
             will(returnValue(data));
         }});
 
@@ -86,7 +88,8 @@ public class ProxyControllerTest extends BaseControllerTestCase {
                     with(aNull(String.class)), with(aNull(List.class)), with(aNull(SSLCertPair.class)),
                     with(equal(new SSLCertPair("CA CERT", "CA KEY"))), with(equal("secret")),
                     with(equal(new SSLCertData("pxy.acme.lab", List.of("cname1", "cname2"), "DE", "Bavaria", "Nurnberg",
-                            "SUSE", "SUSE Unit", "roadrunner@acme.lab"))));
+                            "SUSE", "SUSE Unit", "roadrunner@acme.lab"))),
+                    with(any(SSLCertManager.class)));
             will(returnValue(data));
         }});
 

--- a/java/spacewalk-java.changes.cbosdo.multi-fqdn
+++ b/java/spacewalk-java.changes.cbosdo.multi-fqdn
@@ -1,0 +1,1 @@
+- Proxy container: use SSL cert cnames as fqdns (bsc#1222336)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -243,6 +243,7 @@ Requires:       mvn(org.apache.tomcat:tomcat-servlet-api) > 8
 Requires:       mvn(org.hibernate:hibernate-c3p0)
 Requires:       mvn(org.hibernate:hibernate-core)
 Requires:       mvn(org.hibernate:hibernate-ehcache)
+Requires:       openssl
 # libtcnative-1-0 is only recommended in tomcat.
 # We want it always to prevent warnings about openssl cannot be used
 Requires:       tomcat-native


### PR DESCRIPTION
## What does this PR change?

Since there is no hardware refresh to provide the list of all the FQDNs of the proxy we will use the SSL certificate subject CN and alternate names as FQDNs.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24066

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
