### PR TITLE
Migrate notification messages page to Bootstrap 5

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -66,7 +66,8 @@ public enum ViewHelper {
         "/rhn/account/AccountDeactivation.do",
         "/rhn/account/Addresses.do",
         "/rhn/account/EditAddress.do",
-        "/rhn/multiorg/OrgConfigDetails.do"
+        "/rhn/multiorg/OrgConfigDetails.do",
+        "/rhn/manager/notification-messages"
     );
 
     ViewHelper() { }

--- a/java/spacewalk-java.changes.etheryte.config-pages-3.1
+++ b/java/spacewalk-java.changes.etheryte.config-pages-3.1
@@ -1,0 +1,1 @@
+- Migrate notification messages page to Bootstrap 5

--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -20,9 +20,13 @@ function onDocumentReadyGeneral(){
   scrollTopBehavior();
 }
 
+let isReady = false;
 /* Getting the screen size to create a fixed padding-bottom in the Section tag to make both columns the same size */
 // On window load and resize
-jQuery(window).on("load resize", alignContentDimensions);
+jQuery(window).on("load resize", () => {
+  isReady = true;
+  alignContentDimensions();
+});
 
 // Ensure legacy layouts update their sizes when global notifications are added/removed
 var isListening = false;
@@ -59,6 +63,10 @@ function scrollTopBehavior() {
 // A container function for what should be fired
 // to set HTML tag dimensions
 function alignContentDimensions() {
+  if (!isReady) {
+    return;
+  }
+
   sstStyle();
   navbarToggleMobile();
 }

--- a/web/html/src/branding/css/base/fixes.scss
+++ b/web/html/src/branding/css/base/fixes.scss
@@ -34,3 +34,12 @@ div.checkbox.icon-wrapper i.fa {
 .form-group {
   @extend .row;
 }
+
+// We use float utilities from Bootstrap 3 in a number of places, this emulates the same behavior. Over time we should be able to refactor these out.
+.pull-right {
+  float: right !important;
+}
+
+.pull-left {
+  float: left !important;
+}

--- a/web/html/src/branding/css/base/setup-wizard.less
+++ b/web/html/src/branding/css/base/setup-wizard.less
@@ -308,9 +308,6 @@ ul.product-list {
 }
 
 .multiple-select-wrapper {
-  .d-inline-block;
-  width: 35%;
-  vertical-align: top;
   ul {
     border: 0;
     input {

--- a/web/html/src/branding/css/base/setup-wizard.scss
+++ b/web/html/src/branding/css/base/setup-wizard.scss
@@ -308,9 +308,6 @@ ul.product-list {
 }
 
 .multiple-select-wrapper {
-  @extend .d-inline-block;
-  width: 35%;
-  vertical-align: top;
   ul {
     border: 0;
     input {

--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -589,13 +589,6 @@ nav.navbar-pf {
       float: right;
       width: auto;
     }
-    .spacewalk-list-filter {
-      min-width: 33%;
-
-      input.with-bottom-margin {
-        margin-bottom: 0.5em;
-      }
-    }
   }
 }
 
@@ -608,13 +601,6 @@ nav.navbar-pf {
   .col-md-9 {
     padding-right: 0;
   }
-}
-.display-number {
-  .input-sm;
-  display: inline-block;
-  width: 5.2em;
-  border: 1px solid #dddddd;
-  background-color: @eos-bc-gray-100;
 }
 .view-systems-registered {
   .input-sm;
@@ -801,14 +787,6 @@ i[class~="fa-right"] {
 .btn.spacewalk-btn-margin-vertical {
   margin: 1em 0;
 }
-//tabs - adding a margin to all tabs
-ul.nav.nav-tabs {
-  margin-bottom: 0.25rem;
-}
-//tabs - adding a margin button to the last UL
-ul.nav.nav-tabs:last-child {
-  margin-bottom: 1rem;
-}
 
 // Rewriting
 // Jumbotron
@@ -930,7 +908,6 @@ i.spacewalk-help-link {
 
 /* Override rules from bootstrap for nav-tabs*/
 .nav-tabs {
-  margin-bottom: 0.4em;
   li {
     min-width: 60px;
     a,

--- a/web/html/src/branding/css/base/theme.scss
+++ b/web/html/src/branding/css/base/theme.scss
@@ -586,13 +586,6 @@ nav.navbar-pf {
       float: right;
       width: auto;
     }
-    .spacewalk-list-filter {
-      min-width: 33%;
-
-      input.with-bottom-margin {
-        margin-bottom: 0.5em;
-      }
-    }
   }
 }
 
@@ -805,14 +798,6 @@ i[class~="fa-right"] {
 .btn.spacewalk-btn-margin-vertical {
   margin: 1em 0;
 }
-//tabs - adding a margin to all tabs
-ul.nav.nav-tabs {
-  margin-bottom: 0.25rem;
-}
-//tabs - adding a margin button to the last UL
-ul.nav.nav-tabs:last-child {
-  margin-bottom: 1rem;
-}
 
 // Rewriting
 // Jumbotron
@@ -937,7 +922,6 @@ i.spacewalk-help-link {
 
 /* Override rules from bootstrap for nav-tabs*/
 .nav-tabs {
-  margin-bottom: 0.4em;
   li {
     min-width: 60px;
     a,

--- a/web/html/src/branding/css/susemanager/components/buttons.less
+++ b/web/html/src/branding/css/susemanager/components/buttons.less
@@ -1,15 +1,8 @@
-.onSuma({
-  @import "buttons.suma.less";
-});
-
-.onUyuni({
-  @import "buttons.uyuni.less";
-});
-
-button.is-plain {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
+button.is-plain,
+.btn-link {
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
   background: none;
   border: none;
   border-radius: 0;
@@ -23,3 +16,30 @@ button.is-plain {
   user-select: text;
   padding: 0;
 }
+
+.btn-link {
+  &,
+  &:active,
+  &:focus,
+  &:disabled,
+  &.disabled {
+    &,
+    &:hover {
+      color: @link-color;
+      font-weight: normal;
+    }
+
+    &:not(:disabled):not(.disabled):not(.text-muted):hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+
+.onSuma({
+  @import "buttons.suma.less";
+});
+
+.onUyuni({
+  @import "buttons.uyuni.less";
+});

--- a/web/html/src/branding/css/susemanager/components/buttons.scss
+++ b/web/html/src/branding/css/susemanager/components/buttons.scss
@@ -4,18 +4,19 @@
 .btn-success,
 .btn-warning,
 .btn-danger {
+  // We use flex to ensure icons etc are correctly aligned in buttons
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5em;
   font-size: $font-size-base;
+
+  i.fa:first-child:last-child {
+    margin: 0;
+  }
 }
 
-@include onSuma {
-  @import "buttons.suma.scss";
-}
-
-@include onUyuni {
-  @import "buttons.uyuni.scss";
-}
-
-button.is-plain {
+button.is-plain,
+.btn-link {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   appearance: none !important;
@@ -31,4 +32,30 @@ button.is-plain {
   text-decoration: none;
   user-select: text;
   padding: 0;
+}
+
+.btn-link {
+  &,
+  &:active,
+  &:focus,
+  &:disabled,
+  &.disabled {
+    &,
+    &:hover {
+      color: $link-color;
+      font-weight: normal;
+    }
+
+    &:not(:disabled):not(.disabled):not(.text-muted):hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+@include onSuma {
+  @import "buttons.suma.scss";
+}
+
+@include onUyuni {
+  @import "buttons.uyuni.scss";
 }

--- a/web/html/src/branding/css/susemanager/components/buttons.suma.scss
+++ b/web/html/src/branding/css/susemanager/components/buttons.suma.scss
@@ -4,11 +4,6 @@
 .btn-success,
 .btn-warning,
 .btn-danger {
-  // We use flex to ensure icons etc are correctly aligned in buttons
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5em;
-
   color: inherit;
   font-weight: bold;
   padding: 8px 16px;
@@ -73,24 +68,6 @@
   i[class*="icon-"],
   i[class*="spacewalk-icon"] {
     margin: 0;
-  }
-}
-
-.btn-link {
-  &,
-  &:active,
-  &:focus,
-  &:disabled,
-  &.disabled {
-    &,
-    &:hover {
-      color: $link-color;
-      font-weight: normal;
-    }
-
-    &:not(:disabled):not(.disabled):not(.text-muted):hover {
-      text-decoration: underline;
-    }
   }
 }
 

--- a/web/html/src/branding/css/susemanager/components/buttons.uyuni.scss
+++ b/web/html/src/branding/css/susemanager/components/buttons.uyuni.scss
@@ -4,6 +4,8 @@
 .btn-success,
 .btn-warning,
 .btn-danger {
+  --bs-border-width: 1px;
+
   padding: 6px 12px;
   border-radius: $border-radius;
 
@@ -24,25 +26,37 @@
 // These are grandfathered old styles so we're consistent between Bootstrap 3 and 5
 .btn-default {
   background-image: linear-gradient(to bottom, #fff 0%, #e6e6e6 100%);
-  border-color: #ccc;
   color: #5F5F5F;
+
+  &, &:disabled, &.disabled {
+    border-color: #ccc;
+  }
 }
 
 .btn-primary,
 .btn-success {
   background-image: linear-gradient(to bottom, #00da92 0%, #00C081 100%);
-  border-color: #00C081;
   color: #fff;
+
+  &, &:disabled, &.disabled {
+    border-color: #00C081;
+  }
 }
 
 .btn-warning {
   color: #fff;
   background: #f0ad4e;
-  border-color: #eea236;
+
+  &, &:disabled, &.disabled {
+    border-color: #eea236;
+  }
 }
 
 .btn-danger {
   color: #fff;
   background: #d9534f;
-  border-color: #d43f3a;
+
+  &, &:disabled, &.disabled {
+    border-color: #d43f3a;
+  }
 }

--- a/web/html/src/branding/css/susemanager/components/date-time-picker.less
+++ b/web/html/src/branding/css/susemanager/components/date-time-picker.less
@@ -52,6 +52,11 @@
 .form-control.date-time-picker-wrapper {
   padding: 0 !important;
   position: relative;
+
+  .form-control {
+    border: none !important;
+    border-radius: 0 !important;
+  }
 }
 
 .react-datepicker__input-container,

--- a/web/html/src/branding/css/susemanager/components/date-time-picker.scss
+++ b/web/html/src/branding/css/susemanager/components/date-time-picker.scss
@@ -52,6 +52,11 @@
 .form-control.date-time-picker-wrapper {
   padding: 0 !important;
   position: relative;
+
+  .form-control {
+    border: none !important;
+    border-radius: 0 !important;
+  }
 }
 
 .react-datepicker__input-container,

--- a/web/html/src/branding/css/susemanager/components/inputs.less
+++ b/web/html/src/branding/css/susemanager/components/inputs.less
@@ -46,6 +46,11 @@
   }
 }
 
+.form-control-static {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
 // TODO: Bind this class to the react-select control once we upgrade react-select, see https://react-select.com/styles#the-classnames-prop
 .form-control--react-select > div:first-of-type {
   &:hover {

--- a/web/html/src/branding/css/susemanager/components/inputs.less
+++ b/web/html/src/branding/css/susemanager/components/inputs.less
@@ -65,6 +65,12 @@ select[size] {
   height: auto;
 }
 
+.input-group > .form-control {
+  &:not(:first-child):not(:last-child) {
+    border-radius: 0 !important;
+  }
+}
+
 .input-group-addon {
   border-color: @input-border-color !important;
   background: @gray-lighter;

--- a/web/html/src/branding/css/susemanager/components/inputs.scss
+++ b/web/html/src/branding/css/susemanager/components/inputs.scss
@@ -2,7 +2,6 @@ $input-height: 35px;
 
 @at-root {
   :root {
-    --bs-border-width: 1px;
     --bs-border-color: #{$input-border-color};
     --bs-border-radius: #{$border-radius};
   }
@@ -62,6 +61,11 @@ $input-height: 35px;
   }
 }
 
+.form-control-static {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
 // TODO: Bind this class to the react-select control once we upgrade react-select, see https://react-select.com/styles#the-classnames-prop
 .form-control--react-select > div:first-of-type {
   &:hover {
@@ -77,6 +81,7 @@ select[size] {
 }
 
 .input-group-text {
+  --bs-border-width: 1px;
   font-size: 1em;
   background: $gray-lighter;
   padding: 6px 12px;

--- a/web/html/src/branding/css/susemanager/components/nav.less
+++ b/web/html/src/branding/css/susemanager/components/nav.less
@@ -1,27 +1,38 @@
-.nav-tabs li {
-  a {
-    color: @eos-bc-gray-1000;
+.nav-tabs {
+  margin-bottom: 0.25rem;
+  border-bottom: 1px solid @eos-bc-gray-100;
 
-    &:hover {
-      border-color: @eos-bc-green-500;
-      padding-bottom: 1px;
-      border-bottom-width: 5px;
-      text-decoration: none !important;
-    }
-
-    &:active, &:focus {
-      color: @eos-bc-gray-1000;
-      background: transparent;
-    }
-
-    // TODO: Check disabled states
+  &:last-child {
+    margin-bottom: 1rem;
   }
 
-  &.active {
+  li {
+    margin-bottom: -1px;
+
     a {
-      &, &:hover, &:active, &:focus {
+      color: @eos-bc-gray-1000;
+  
+      &:hover {
+        border-color: @eos-bc-green-500;
+        padding-bottom: 1px;
+        border-bottom-width: 5px;
+        text-decoration: none !important;
+      }
+  
+      &:active, &:focus {
         color: @eos-bc-gray-1000;
+        background: transparent;
+      }
+  
+      // TODO: Check disabled states
+    }
+  
+    &.active {
+      a {
+        &, &:hover, &:active, &:focus {
+          color: @eos-bc-gray-1000;
+        }
       }
     }
-  }
+  }  
 }

--- a/web/html/src/branding/css/susemanager/components/nav.scss
+++ b/web/html/src/branding/css/susemanager/components/nav.scss
@@ -1,27 +1,38 @@
-.nav-tabs li {
-  a {
-    color: $eos-bc-gray-1000;
+.nav-tabs {
+  margin-bottom: 0.25rem;
+  border-bottom: 1px solid $eos-bc-gray-100;
 
-    &:hover {
-      border-color: $eos-bc-green-500;
-      padding-bottom: 1px;
-      border-bottom-width: 5px;
-      text-decoration: none !important;
-    }
-
-    &:active, &:focus {
-      color: $eos-bc-gray-1000;
-      background: transparent;
-    }
-
-    // TODO: Check disabled states
+  &:last-child {
+    margin-bottom: 1rem;
   }
 
-  &.active {
+  li {
+    margin-bottom: -1px;
+
     a {
-      &, &:hover, &:active, &:focus {
+      color: $eos-bc-gray-1000;
+  
+      &:hover {
+        border-color: $eos-bc-green-500;
+        padding-bottom: 1px;
+        border-bottom-width: 5px;
+        text-decoration: none !important;
+      }
+  
+      &:active, &:focus {
         color: $eos-bc-gray-1000;
+        background: transparent;
+      }
+  
+      // TODO: Check disabled states
+    }
+  
+    &.active {
+      a {
+        &, &:hover, &:active, &:focus {
+          color: $eos-bc-gray-1000;
+        }
       }
     }
-  }
+  }  
 }

--- a/web/html/src/branding/css/susemanager/components/panels.scss
+++ b/web/html/src/branding/css/susemanager/components/panels.scss
@@ -7,6 +7,7 @@
   }
 
   .panel-footer {
+    padding: 10px 15px;
     background: transparent !important;
 
     &:empty {

--- a/web/html/src/branding/css/susemanager/components/panels.uyuni.scss
+++ b/web/html/src/branding/css/susemanager/components/panels.uyuni.scss
@@ -21,4 +21,9 @@
       }
     }
   }
+
+  .panel-footer {
+    border-top: 1px solid $eos-bc-gray-100;
+    background: #f5f5f5 !important;
+  }
 }

--- a/web/html/src/branding/css/susemanager/components/tables.less
+++ b/web/html/src/branding/css/susemanager/components/tables.less
@@ -14,23 +14,10 @@
   align-items: center;
 }
 
-.table-search-wrapper {
-  flex: 1;
-
-  .form-group {
-    margin: 0;
-  }
-}
-
 .table-input-search {
+  display: block;
+  width: 100%;
   max-width: 500px;
-  display: inline-block;
-  margin-bottom: 4px;
-}
-
-.table-search-select-all {
-  margin-top: 4px;
-  margin-left: 4px;
 }
 
 thead tr {
@@ -50,4 +37,17 @@ tbody tr td,
 .list-row-odd,
 .list-row-even {
   background: transparent !important;
+}
+
+.display-number {
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 3px;
+  display: inline-block;
+  width: fit-content;
+  border: none;
+  color: @eos-bc-gray-700;
+  background-color: @eos-bc-gray-100;
 }

--- a/web/html/src/branding/css/susemanager/components/tables.scss
+++ b/web/html/src/branding/css/susemanager/components/tables.scss
@@ -14,23 +14,10 @@
   align-items: center;
 }
 
-.table-search-wrapper {
-  flex: 1;
-
-  .form-group {
-    margin: 0;
-  }
-}
-
 .table-input-search {
+  display: block;
+  width: 100%;
   max-width: 500px;
-  display: inline-block;
-  margin-bottom: 4px;
-}
-
-.table-search-select-all {
-  margin-top: 4px;
-  margin-left: 4px;
 }
 
 thead tr {
@@ -50,4 +37,17 @@ tbody tr td,
 .list-row-odd,
 .list-row-even {
   background: transparent !important;
+}
+
+.display-number {
+  height: 30px;
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.5;
+  border-radius: 3px;
+  display: inline-block;
+  width: fit-content;
+  border: none;
+  color: $eos-bc-gray-700;
+  background-color: $eos-bc-gray-100;
 }

--- a/web/html/src/components/table/SearchField.tsx
+++ b/web/html/src/components/table/SearchField.tsx
@@ -54,7 +54,6 @@ export function SearchField(props: SearchFieldProps) {
           defaultValue={props.field}
           options={props.options}
           onChange={(name: string | undefined, value: string) => {
-            console.log("onChange", name, value);
             props.onSearchField?.(value);
           }}
         />

--- a/web/html/src/components/table/SearchField.tsx
+++ b/web/html/src/components/table/SearchField.tsx
@@ -53,12 +53,16 @@ export function SearchField(props: SearchFieldProps) {
           placeholder={t("Select a filter")}
           defaultValue={props.field}
           options={props.options}
-          onChange={(name: string | undefined, value: string) => props.onSearchField?.(value)}
+          onChange={(name: string | undefined, value: string) => {
+            console.log("onChange", name, value);
+            props.onSearchField?.(value);
+          }}
         />
       )}
       <div className="form-group">
         <input
           className="form-control table-input-search"
+          data-testid="default-table-search"
           value={props.criteria || ""}
           placeholder={props.placeholder}
           type="text"

--- a/web/html/src/components/table/SearchPanel.module.less
+++ b/web/html/src/components/table/SearchPanel.module.less
@@ -12,6 +12,10 @@
       flex-shrink: 0;
     }
 
+    >:first-child {
+      min-width: 100%;
+    }
+
     :global(.form-group) {
       margin: 0;
 

--- a/web/html/src/components/table/SearchPanel.module.less
+++ b/web/html/src/components/table/SearchPanel.module.less
@@ -1,0 +1,27 @@
+:global(.old-theme),
+:global(.new-theme) {
+  .searchPanel {
+    display: flex;
+    flex-wrap: wrap;
+    flex: 1 0 auto;
+    min-width: 33%;
+    align-items: center;
+    gap: 5px;
+
+    > * {
+      flex-shrink: 0;
+    }
+
+    :global(.form-group) {
+      margin: 0;
+
+      > * {
+        padding: 0;
+      }
+    }
+  }
+
+  .pagination {
+    margin-left: 10px;
+  }
+}

--- a/web/html/src/components/table/SearchPanel.tsx
+++ b/web/html/src/components/table/SearchPanel.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 
 import { cloneReactElement } from "components/utils";
 
+import styles from "./SearchPanel.module.less";
+
 type SearchPanelProps = {
   /** number representing the number of the first displayed item */
   fromItem: number;
@@ -43,7 +45,7 @@ type SearchPanelProps = {
 /** Panel containing the search fields for a table */
 export function SearchPanel(props: SearchPanelProps) {
   return (
-    <div className="spacewalk-list-filter table-search-wrapper">
+    <div className={`spacewalk-list-filter ${styles.searchPanel}`}>
       {React.Children.toArray(props.children).map((child) =>
         cloneReactElement(child, {
           criteria: props.criteria,
@@ -52,7 +54,7 @@ export function SearchPanel(props: SearchPanelProps) {
           onSearchField: props.onSearchField,
         })
       )}
-      <div className="d-inline-block table-search-select-all">
+      <div className={styles.pagination}>
         <span>
           {t("Items {from} - {to} of {total}", { from: props.fromItem, to: props.toItem, total: props.itemCount })}
           &nbsp;&nbsp;

--- a/web/html/src/components/table/Table.test.tsx
+++ b/web/html/src/components/table/Table.test.tsx
@@ -156,7 +156,7 @@ describe("Table component", () => {
         <Column columnKey="value" cell={(item) => item.value} />
       </Table>
     );
-    const input = screen.getByRole("textbox");
+    const input = screen.getByTestId("default-table-search");
     await type(input, "Value 1");
 
     expect(screen.queryByText("Value 0")).toBe(null);

--- a/web/html/src/components/table/TableDataHandler.module.less
+++ b/web/html/src/components/table/TableDataHandler.module.less
@@ -1,0 +1,6 @@
+:global(.old-theme),
+:global(.new-theme) {
+  .searchField {
+    min-width: 100%;
+  }
+}

--- a/web/html/src/components/table/TableDataHandler.module.less
+++ b/web/html/src/components/table/TableDataHandler.module.less
@@ -1,6 +1,0 @@
-:global(.old-theme),
-:global(.new-theme) {
-  .searchField {
-    min-width: 100%;
-  }
-}

--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -4,7 +4,7 @@ import _isEqual from "lodash/isEqual";
 
 import { pageSize } from "core/user-preferences";
 
-import { cloneReactElement, Loading } from "components/utils";
+import { Loading } from "components/utils";
 
 import { AsyncDataProvider, PageControl, SimpleDataProvider } from "utils/data-providers";
 import { Comparator, PagedData } from "utils/data-providers";
@@ -14,7 +14,6 @@ import { ItemsPerPageSelector, PaginationBlock } from "../pagination";
 import { Header } from "./Header";
 import { SearchField } from "./SearchField";
 import { SearchPanel } from "./SearchPanel";
-import styles from "./TableDataHandler.module.less";
 
 type ChildrenArgsProps = {
   currItems: Array<any>;
@@ -396,13 +395,8 @@ export class TableDataHandler extends React.Component<Props, State> {
                   selectedCount={selectedItems.length}
                   selectable={isSelectable}
                 >
-                  <div className={styles.searchField}>{this.props.searchField}</div>
-                  {React.Children.toArray(this.props.additionalFilters).map((child, index) =>
-                    cloneReactElement(child, {
-                      key: index,
-                      props: Object.prototype.hasOwnProperty.call(child, "props") ? (child as any).props : undefined,
-                    })
-                  )}
+                  {this.props.searchField}
+                  {this.props.additionalFilters}
                 </SearchPanel>
                 <div className="spacewalk-list-head-addons-extra table-items-per-page-wrapper">
                   <ItemsPerPageSelector

--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -4,7 +4,7 @@ import _isEqual from "lodash/isEqual";
 
 import { pageSize } from "core/user-preferences";
 
-import { Loading } from "components/utils";
+import { cloneReactElement, Loading } from "components/utils";
 
 import { AsyncDataProvider, PageControl, SimpleDataProvider } from "utils/data-providers";
 import { Comparator, PagedData } from "utils/data-providers";
@@ -14,6 +14,7 @@ import { ItemsPerPageSelector, PaginationBlock } from "../pagination";
 import { Header } from "./Header";
 import { SearchField } from "./SearchField";
 import { SearchPanel } from "./SearchPanel";
+import styles from "./TableDataHandler.module.less";
 
 type ChildrenArgsProps = {
   currItems: Array<any>;
@@ -395,10 +396,13 @@ export class TableDataHandler extends React.Component<Props, State> {
                   selectedCount={selectedItems.length}
                   selectable={isSelectable}
                 >
-                  {this.props.searchField}
-                  {this.props.additionalFilters?.map((filter, i) => (
-                    <span key={"additional-filter-" + i}>{filter}&nbsp;</span>
-                  ))}
+                  <div className={styles.searchField}>{this.props.searchField}</div>
+                  {React.Children.toArray(this.props.additionalFilters).map((child, index) =>
+                    cloneReactElement(child, {
+                      key: index,
+                      props: Object.prototype.hasOwnProperty.call(child, "props") ? (child as any).props : undefined,
+                    })
+                  )}
                 </SearchPanel>
                 <div className="spacewalk-list-head-addons-extra table-items-per-page-wrapper">
                   <ItemsPerPageSelector

--- a/web/html/src/components/table/TableFilter.tsx
+++ b/web/html/src/components/table/TableFilter.tsx
@@ -42,7 +42,7 @@ export const TableFilter = (props) => {
   };
 
   return (
-    <Form model={model} onChange={onChange} title={t("Filter")} className="row">
+    <Form model={model} onChange={onChange} title={t("Filter")} divClass="row">
       <div className="col-sm-4">
         <Select
           name="filter"

--- a/web/html/src/core/spa/view-helper.ts
+++ b/web/html/src/core/spa/view-helper.ts
@@ -11,6 +11,7 @@ const BOOTSTRAP_READY_PAGES: string[] = [
   "/rhn/account/Addresses.do",
   "/rhn/account/EditAddress.do",
   "/rhn/multiorg/OrgConfigDetails.do",
+  "/rhn/manager/notification-messages",
 ];
 
 export const onEndNavigate = () => {

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -554,7 +554,7 @@ class Products extends React.Component<ProductsProps> {
 
   render() {
     const archFilter = (
-      <div className="multiple-select-wrapper">
+      <div className="multiple-select-wrapper table-input-search">
         {/* TODO: Remove this <Form> wrapper once https://github.com/SUSE/spacewalk/issues/14250 is implemented */}
         <Form>
           <Select

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -413,7 +413,7 @@ class NotificationMessages extends React.Component<Props, State> {
     );
 
     const typeFilter = (
-      <div className="multiple-select-wrapper">
+      <div className="multiple-select-wrapper table-input-search">
         {/* TODO: Remove this <Form> wrapper once https://github.com/SUSE/spacewalk/issues/14250 is implemented */}
         <Form>
           <Select

--- a/web/spacewalk-web.changes.etheryte.config-pages-3.1
+++ b/web/spacewalk-web.changes.etheryte.config-pages-3.1
@@ -1,0 +1,1 @@
+- Migrate notification messages page to Bootstrap 5


### PR DESCRIPTION
## What does this PR change?

This PR is a followup to https://github.com/uyuni-project/uyuni/pull/8628, the three last commits are new, the rest are from the old PR.

This PR migrates the notification messages page to Bootstrap 5, and also fixes numerous small layout bugs in the process.

## GUI diff

Before:

<img width="1696" alt="Screenshot 2024-04-19 at 19 14 09" src="https://github.com/uyuni-project/uyuni/assets/3171718/e3faeea0-9776-4034-ae73-4ec80d1d63ac">


After:
<img width="1695" alt="Screenshot 2024-04-19 at 19 14 14" src="https://github.com/uyuni-project/uyuni/assets/3171718/7f47a81e-f285-47ac-ab52-2759db12c003">


- [x] **DONE**

## Documentation
- Docs ticket already exists.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/18940

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
