### PR TITLE
fix chained container proxies configuration

### DIFF
--- a/java/buildconf/LICENSE.txt
+++ b/java/buildconf/LICENSE.txt
@@ -1,5 +1,5 @@
 ^/\*$
-^ \* Copyright \(c\) (20([0123]\d|20)--)?20(1\d|2[01234]) (Red Hat, Inc.|SUSE LLC)$
+(^ \* Copyright \(c\) (20([0123]\d|20)--)?20(1\d|2[01234]) (Red Hat, Inc.|SUSE LLC)$)+
 ^ \*$
 ^ \* This software is licensed to you under the GNU General Public License,$
 ^ \* version 2 \(GPLv2\). There is NO WARRANTY for this software, express or$

--- a/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.hbm.xml
@@ -12,6 +12,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             </generator>
         </id>
         <property name="sshPort" type="integer" column="ssh_port" />
+        <property name="sshPublicKey" column="ssh_public_key" type="binary" />
         <one-to-one name="server"
             class="com.redhat.rhn.domain.server.Server"
             constrained="true"/>

--- a/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ProxyInfo.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009--2012 Red Hat, Inc.
+ * Copyright (c) 2024 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -29,6 +30,7 @@ public class ProxyInfo {
     private PackageEvr version;
     private Long id;
     private Integer sshPort;
+    private byte[] sshPublicKey;
 
     /**
      * @return the id
@@ -87,6 +89,20 @@ public class ProxyInfo {
         sshPort = sshPortIn;
     }
 
+    /**
+     * @return value of sshPublicKey
+     */
+    public byte[] getSshPublicKey() {
+        return sshPublicKey;
+    }
+
+    /**
+     * @param sshPublicKeyIn value of sshPublicKey
+     */
+    public void setSshPublicKey(byte[] sshPublicKeyIn) {
+        sshPublicKey = sshPublicKeyIn;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -103,6 +119,7 @@ public class ProxyInfo {
                 .append(server, proxyInfo.server)
                 .append(version, proxyInfo.version)
                 .append(sshPort, proxyInfo.sshPort)
+                .append(sshPublicKey, proxyInfo.sshPublicKey)
                 .isEquals();
     }
 
@@ -112,6 +129,7 @@ public class ProxyInfo {
                 .append(server)
                 .append(version)
                 .append(sshPort)
+                .append(sshPublicKey)
                 .toHashCode();
     }
 }

--- a/java/spacewalk-java.changes.rjpmestre.fix_chained_container_proxies_configuration
+++ b/java/spacewalk-java.changes.rjpmestre.fix_chained_container_proxies_configuration
@@ -1,0 +1,1 @@
+- Fix chained container proxies configuration

--- a/schema/spacewalk/common/tables/rhnProxyInfo.sql
+++ b/schema/spacewalk/common/tables/rhnProxyInfo.sql
@@ -1,5 +1,6 @@
 --
 -- Copyright (c) 2008 Red Hat, Inc.
+-- Copyright (c) 2024 SUSE LLC
 --
 -- This software is licensed to you under the GNU General Public License,
 -- version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -23,6 +24,7 @@ CREATE TABLE rhnProxyInfo
                       CONSTRAINT rhn_proxy_info_peid_fk
                           REFERENCES rhnPackageEVR (id),
     ssh_port      NUMERIC,
+    ssh_public_key BYTEA,
     created             TIMESTAMPTZ
                             DEFAULT (current_timestamp) NOT NULL,
     modified            TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes.rjpmestre.fix_chained_container_proxies_configuration
+++ b/schema/spacewalk/susemanager-schema.changes.rjpmestre.fix_chained_container_proxies_configuration
@@ -1,0 +1,1 @@
+- Fix chained container proxies configuration

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.6-to-susemanager-schema-5.0.7/100-update-proxy-info.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.6-to-susemanager-schema-5.0.7/100-update-proxy-info.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rhnProxyInfo ADD COLUMN IF NOT EXISTS ssh_public_key BYTEA;


### PR DESCRIPTION
## What does this PR change?

Currently, when creating a proxy configuration either through the UI under `Systems/Proxy Configuration` or using `spacecmd proxy_container_config_generate_cert`, the generated ssh.yaml always references server_ssh_key_pub as the SSH key for the SUMA instance, regardless of the specified server/parent FQDN.

This PR addresses this issue by checking whether the server/parent FQDN refers to the actual SUMA instance itself or an already registered proxy. Then, ssh.yaml should reference either SUMA's (`/srv/susemanager/salt/salt_ssh/mgr_ssh_id.pub`) or the proxy SSH key (now stored in `rhnproxyinfo` table)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8157

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
