### PR TITLE
QE: Improve apply patch in BV

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -40,9 +40,7 @@ Feature: Smoke tests for <client>
     And I wait until I see "Upgrade Packages" text
     And I follow "Patches" in the content area
     When I wait until I see "Relevant Patches" text
-    And I select "Non-Critical" from "type"
-    And I click on "Show"
-    When I check the first patch in the list
+    When I check the first patch in the list, that does not require a reboot
     And I click on "Apply Patches"
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -795,8 +795,14 @@ Then(/^I check the row with the "([^"]*)" text$/) do |text|
   step %(I check "#{text}" in the list)
 end
 
-When(/^I check the first patch in the list$/) do
-  step 'I check the first row in the list'
+When(/^I check the first patch in the list, that does not require a reboot$/) do
+  row = find(:xpath, '//section//div[@class=\'table-responsive\']/table/tbody/tr', match: :first)
+  reboot_required = row.has_xpath?('.//*[contains(@title,\'Reboot Required\')]')
+  if reboot_required
+    step 'I check the second row in the list'
+  else
+    step 'I check the first row in the list'
+  end
 end
 
 When(/^I click on the red confirmation button$/) do
@@ -897,6 +903,13 @@ When(/^I uncheck row with "([^"]*)" and "([^"]*)" in the list$/) do |text1, text
   raise ScriptError, "xpath: #{top_level_xpath_query} not found" if row.nil?
 
   row.set(false)
+end
+
+When(/^I check the second row in the list$/) do
+  within(:xpath, '//section') do
+    row = find(:xpath, '//div[@class=\'table-responsive\']/table/tbody/tr[2]/td')
+    row.find(:xpath, './/input[@type=\'checkbox\']', match: :first).set(true)
+  end
 end
 
 When(/^I check the first row in the list$/) do


### PR DESCRIPTION
## What does this PR change?

Sometimes we don't have any available non-critical patches.
Let's perform a different test strategy, let's don't filter by the kind of patch but let's assure the patch doesn't require a reboot, if so, we select the next patch.

Note: If we have two consecutive patches requiring reboot, bad luck 🤣

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
