### PR TITLE
add onFailAction hook to handle failing actions similar to canceled a…

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action.java
+++ b/java/code/src/com/redhat/rhn/domain/action/Action.java
@@ -378,6 +378,15 @@ public class Action extends BaseDomainHelper implements Serializable, WebSocketA
     }
 
     /**
+     * Hook when an action failed.
+     * @param serverActionIn the {@link ServerAction} which failed
+     */
+    public void onFailAction(ServerAction serverActionIn) {
+        // Something to do, when an action failed.
+        // Override this method for specific action.
+    }
+
+    /**
      * @param server server to which action is linked
      * @param currentUser user
      * @return string which is used on system history details

--- a/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -15,9 +15,46 @@
 package com.redhat.rhn.domain.action;
 
 
+import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.domain.action.server.ServerAction;
+
+import com.suse.manager.attestation.AttestationManager;
+import com.suse.manager.model.attestation.CoCoAttestationStatus;
+import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Objects;
+import java.util.Optional;
+
 /**
  * CoCoAttestationAction - Class representing TYPE_COCO_ATTESTATION
  */
 public class CoCoAttestationAction extends Action {
+    private static final Logger LOG = LogManager.getLogger(CoCoAttestationAction.class);
 
+    @Override
+    public void onFailAction(ServerAction serverActionIn) {
+        AttestationManager attestationManager = GlobalInstanceHolder.ATTESTATION_MANAGER;
+        if (!Objects.equals(serverActionIn.getParentAction(), this)) {
+            LOG.error("This is not the action which belongs to the passed server action");
+            return;
+        }
+        try {
+            Optional<ServerCoCoAttestationReport> report = attestationManager.lookupReportByServerAndAction(
+                    serverActionIn.getServer(), this);
+            report.ifPresent(rep -> {
+                if (rep.getResults().isEmpty()) {
+                    // results are not initialized yet. So we need to set the report status
+                    // directly to failed.
+                    rep.setStatus(CoCoAttestationStatus.FAILED);
+                }
+            });
+        }
+        catch (Exception e) {
+            LOG.log(Level.ERROR, e);
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -62,6 +63,9 @@ public class ServerAction extends ActionChild implements Serializable {
      * @param statusIn to set
     */
     public void setStatus(ActionStatus statusIn) {
+        if (Objects.equals(statusIn, ActionFactory.STATUS_FAILED) && !Objects.equals(status, statusIn)) {
+            Optional.ofNullable(getParentAction()).ifPresent(pa -> pa.onFailAction(this));
+        }
         this.status = statusIn;
     }
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1718,14 +1718,23 @@ public class SaltUtils {
     private void handleCocoAttestationResult(Action action, ServerAction serverAction, JsonElement jsonResult) {
         AttestationManager mgr = new AttestationManager();
 
-        Optional<ServerCoCoAttestationReport> optReport = mgr.lookupReportByServerAndAction(
-                serverAction.getServer(), action);
+        Optional<ServerCoCoAttestationReport> optReport =
+                mgr.lookupReportByServerAndAction(serverAction.getServer(), action);
         if (optReport.isEmpty()) {
             serverAction.setStatus(ActionFactory.STATUS_FAILED);
             serverAction.setResultMsg("Failed to find a report entry");
             return;
         }
         ServerCoCoAttestationReport report = optReport.get();
+
+        if (jsonResult == null) {
+            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            if (StringUtils.isBlank(serverAction.getResultMsg())) {
+                serverAction.setResultMsg("Error while request attestation data from target system:\n" +
+                       "Got no result from system");
+            }
+            return;
+        }
 
         try {
             CoCoAttestationRequestData requestData = Json.GSON.fromJson(jsonResult, CoCoAttestationRequestData.class);
@@ -1734,7 +1743,7 @@ public class SaltUtils {
         }
         catch (JsonSyntaxException e) {
             String msg = "Failed to parse the attestation result:\n";
-            msg += Optional.ofNullable(jsonResult)
+            msg += Optional.of(jsonResult)
                     .map(JsonElement::toString)
                     .orElse("Got no result");
             LOG.error(msg);
@@ -1744,12 +1753,7 @@ public class SaltUtils {
         }
         if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
             String msg = "Error while request attestation data from target system:\n";
-            if (jsonResult == null) {
-                msg += "Got no result from system";
-            }
-            else {
-                msg += getJsonResultWithPrettyPrint(jsonResult);
-            }
+            msg += getJsonResultWithPrettyPrint(jsonResult);
             serverAction.setResultMsg(msg);
             if (report.getResults().isEmpty()) {
                 // results are not initialized yet. So we need to set the report status


### PR DESCRIPTION
## What does this PR change?

Handle failing actions similar to canceled actions via a hook.
This is a different approach as in https://github.com/uyuni-project/uyuni/pull/8619

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
