### PR TITLE
Prevent error in case of inconsistent subscription matcher message data

### DIFF
--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
@@ -13,6 +13,16 @@ type Props = {
   subscriptions: any;
 };
 
+const systemName = (systems, messageData) => {
+  if (!systems[messageData["id"]]) {
+    Loggerhead.warn("System: " + messageData["id"] + " not found in server data.");
+    Loggerhead.debug("Systems: " + JSON.stringify(systems));
+    Loggerhead.debug("Message Data: " + JSON.stringify(messageData));
+    return "-";
+  }
+  return systems[messageData["id"]].name;
+};
+
 class Messages extends React.Component<Props> {
   buildRows = (rawMessages, systems, subscriptions) => {
     return rawMessages.map(function (rawMessage, index) {
@@ -26,15 +36,15 @@ class Messages extends React.Component<Props> {
           break;
         case "physical_guest":
           message = t("Physical system is reported as virtual guest, please check hardware data");
-          additionalInformation = systems[data["id"]].name;
+          additionalInformation = systemName(systems, data);
           break;
         case "guest_with_unknown_host":
           message = t("Virtual guest has unknown host, assuming it is a physical system");
-          additionalInformation = systems[data["id"]].name;
+          additionalInformation = systemName(systems, data);
           break;
         case "unknown_cpu_count":
           message = t("System has an unknown number of sockets, assuming 16");
-          additionalInformation = systems[data["id"]].name;
+          additionalInformation = systemName(systems, data);
           break;
         case "hb_merge_subscriptions":
           message = t("Two subscriptions with the same part number are in a bundle - merged into a single one");
@@ -57,7 +67,7 @@ class Messages extends React.Component<Props> {
             ", " +
             t("System") +
             ": " +
-            systems[data["system_id"]].name;
+            systemName(systems, data);
           break;
         case "no_products_associated":
           message = t("Subscription with unsupported part number and no associated product has been ignored.");

--- a/web/spacewalk-web.changes.welder.bsc1221629
+++ b/web/spacewalk-web.changes.welder.bsc1221629
@@ -1,0 +1,1 @@
+- Prevent error in case of inconsistent subscription matcher message data (bsc#1221629)


### PR DESCRIPTION
## What does this PR change?

In the event of a message referencing a system that is not part of the list, the system name will now be displayed as "-" instead of presenting an error and showing a blank screen to the user.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23985

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
