### PR TITLE
QE: Re-order BV smoke tests in order to fix IPv6 issue

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -21,6 +21,23 @@ Feature: Smoke tests for <client>
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  Scenario: Check that Software package refresh works on a <client>
+    Given I am on the Systems overview page of this "<client>"
+    When I follow "Software" in the content area
+    And I wait until I see "Upgrade Packages" text
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh scheduled by admin" is completed
+
+  Scenario: Check that Hardware Refresh button works on a <client>
+    When I follow "Details" in the content area
+    And I wait until I see "System Status" text
+    And I follow "Hardware"
+    And I wait until I see "Refresh Hardware List" text
+    And I click on "Schedule Hardware Refresh"
+    Then I should see a "You have successfully scheduled a hardware profile refresh" text
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until there is no Salt job calling the module "hardware.profileupdate" on "<client>"
+
   Scenario: Client <client> grains are displayed correctly on the details page
     Given I am on the Systems overview page of this "<client>"
     Then the hostname for "<client>" should be correct
@@ -88,22 +105,6 @@ Feature: Smoke tests for <client>
     And I wait until I see "show response" text
     And I expand the results for "<client>"
     Then I should see "My remote command output" in the command output for "<client>"
-
-  Scenario: Check that Software package refresh works on a <client>
-    Given I am on the Systems overview page of this "<client>"
-    When I follow "Software" in the content area
-    And I wait until I see "Upgrade Packages" text
-    And I click on "Update Package List"
-    And I wait until event "Package List Refresh scheduled by admin" is completed
-
-  Scenario: Check that Hardware Refresh button works on a <client>
-    When I follow "Details" in the content area
-    And I wait until I see "System Status" text
-    And I follow "Hardware"
-    And I wait until I see "Refresh Hardware List" text
-    And I click on "Schedule Hardware Refresh"
-    Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
   Scenario: Subscribe a <client> to the configuration channel
     When I follow "Configuration" in the content area


### PR DESCRIPTION
## What does this PR change?

In order to show the correct IPv6 entry, we need to first have finished at least once the HW refresh.
Therefore, we re-ordered scenarios to match what we do in CI tests.

Issue example:
![image](https://github.com/uyuni-project/uyuni/assets/2827771/83d355ae-b985-4c93-81aa-993877fe599e)


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were re-orderer

- [x] **DONE**

## Links

Ports:
- https://github.com/SUSE/spacewalk/pull/24159

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
