### PR TITLE
QE: Wait until Sync Now button is available

### DIFF
--- a/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
+++ b/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
@@ -37,5 +37,6 @@ Feature: Add a Maintenance Update custom channel and the custom repositories for
     And I follow "Custom Channel for monitoring_server"
     And I follow "Repositories" in the content area
     And I follow "Sync"
+    And I wait until button "Sync Now" becomes enabled
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled" text or "No repositories are currently associated with this channel" text

--- a/testsuite/features/build_validation/add_non_MU_repositories/centos7_minion_add_iso.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/centos7_minion_add_iso.feature
@@ -42,6 +42,7 @@ Feature: Add the CentOS 7 distribution custom repositories
     And I follow "Custom Channel for CentOS 7 DVD"
     And I follow "Repositories" in the content area
     And I follow "Sync"
+    And I wait until button "Sync Now" becomes enabled
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled" text
 

--- a/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
+++ b/testsuite/features/build_validation/add_non_MU_repositories/rocky8_minion_add_iso_and_build_clm.feature
@@ -67,6 +67,7 @@ Feature: Add the Rocky 8 distribution custom repositories
     And I follow "Custom Channel for Rocky 8 DVD"
     And I follow "Repositories" in the content area
     And I follow "Sync"
+    And I wait until button "Sync Now" becomes enabled
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled" text
 


### PR DESCRIPTION
## What does this PR change?

Improvement to don't see:

```bash
[2024-04-19T07:02:00.595Z] Scenario: Synchronize the repositories in the custom channel for monitoring_server                                          # features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature:33
[2024-04-19T07:02:00.595Z] This scenario ran at: 2024-04-19 08:59:53 +0200
[2024-04-19T07:02:00.595Z] When I follow the left menu "Software > Manage > Channels"                                                                # features/step_definitions/navigation_steps.rb:337
[2024-04-19T07:02:00.595Z] And I enter "monitoring_server" as the filtered channel name                                                              # features/step_definitions/navigation_steps.rb:848
[2024-04-19T07:02:00.595Z] And I click on the filter button                                                                                          # features/step_definitions/navigation_steps.rb:810
[2024-04-19T07:02:00.595Z] And I follow "Custom Channel for monitoring_server"                                                                       # features/step_definitions/navigation_steps.rb:282
[2024-04-19T07:02:00.595Z] And I follow "Repositories" in the content area                                                                           # features/step_definitions/navigation_steps.rb:297
[2024-04-19T07:02:00.595Z] And I follow "Sync"                                                                                                       # features/step_definitions/navigation_steps.rb:282
[2024-04-19T07:02:00.595Z] And I click on "Sync Now"                                                                                                 # features/step_definitions/navigation_steps.rb:256
[2024-04-19T07:02:00.595Z]       Unable to find visible button "Sync Now" that is not disabled (Capybara::ElementNotFound)
[2024-04-19T07:02:00.595Z]       ./features/support/commonlib.rb:141:in `click_button_and_wait'
[2024-04-19T07:02:00.595Z]       ./features/step_definitions/navigation_steps.rb:257:in `/^I click on "([^"]*)"$/'
[2024-04-19T07:02:00.595Z]       features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature:40:in `I click on "Sync Now"`
[2024-04-19T07:02:00.595Z] Then I should see a "Repository sync scheduled" text or "No repositories are currently associated with this channel" text # features/step_definitions/navigation_steps.rb:593
(...)
[2024-04-19T07:03:08.216Z] This scenario took: 62 seconds
[2024-04-19T07:03:08.216Z] 
[2024-04-19T07:03:08.216Z] Failing Scenarios:
[2024-04-19T07:03:08.216Z] cucumber features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature:33 # Scenario: Synchronize the repositories in the custom channel for monitoring_server
[2024-04-19T07:03:08.216Z] 
[2024-04-19T07:03:08.216Z] 5 scenarios (1 failed, 4 passed)
[2024-04-19T07:03:08.216Z] 26 steps (1 failed, 1 skipped, 24 passed)
[2024-04-19T07:03:08.216Z] 4m12.685s
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
