### PR TITLE
QE: Wait 10 min to sync custom channels

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -388,7 +388,10 @@ end
 When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
   time_spent = 0
   checking_rate = 10
-  if TIMEOUT_BY_CHANNEL_NAME[channel].nil?
+  if channel.include?('custom_channel')
+    log 'Timeout of 10 minutes for a custom channel'
+    timeout = 600
+  elsif TIMEOUT_BY_CHANNEL_NAME[channel].nil?
     log "Unknown timeout for channel #{channel}, assuming one minute"
     timeout = 60
   else


### PR DESCRIPTION
## What does this PR change?

This occurred for several Minions, therefore let's have more than 1 minute for that kind of channels:
```bash
[2024-04-19T07:47:03.931Z] Scenario: Wait for running reposyncs to finish after adding custom channel for alma9_minion # features/build_validation/add_MU_repositories/alma9_minion_add_maintenance_update_repositories.feature:44
[2024-04-19T07:47:03.931Z] This scenario ran at: 2024-04-19 09:43:46 +0200
[2024-04-19T07:47:03.931Z] Timeout after 60 seconds (Timeout.timeout): Channel not fully synced
[2024-04-19T07:47:03.931Z] When I wait until the channel "custom_channel_alma9_minion" has been synced               # features/step_definitions/command_steps.rb:388
[2024-04-19T07:47:03.931Z] Unknown timeout for channel custom_channel_alma9_minion, assuming one minute
[2024-04-19T07:47:03.931Z] /var/cache/rhn/repodata/custom_channel_alma9_minion/*primary.xml.gz contains 0 packages
[2024-04-19T07:47:03.931Z] /var/cache/rhn/repodata/custom_channel_alma9_minion/*primary.xml.gz contains 0 packages
[2024-04-19T07:47:03.931Z] /var/cache/rhn/repodata/custom_channel_alma9_minion/*primary.xml.gz contains 0 packages
[2024-04-19T07:47:03.931Z] execution expired
[2024-04-19T07:47:03.931Z] Then the "custom_channel_alma9_minion" reposync logs should not report errors             # features/step_definitions/command_steps.rb:366
[2024-04-19T07:47:03.931Z]       Errors during custom_channel_alma9_minion reposync:
[2024-04-19T07:47:03.931Z]       error: /tmp/tmpuu02cg6_: key 1 import failed.
[2024-04-19T07:47:03.931Z]        (ScriptError)
[2024-04-19T07:47:03.931Z]       ./features/step_definitions/command_steps.rb:372:in `block (2 levels) in <top (required)>'
[2024-04-19T07:47:03.931Z]       ./features/step_definitions/command_steps.rb:368:in `each'
[2024-04-19T07:47:03.931Z]       ./features/step_definitions/command_steps.rb:368:in `/^the "([^"]*)" reposync logs should not report errors$/'
[2024-04-19T07:47:03.931Z]       features/build_validation/add_MU_repositories/alma9_minion_add_maintenance_update_repositories.feature:46:in `the "custom_channel_alma9_minion" reposync logs should not report errors'
```


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage

- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
