### PR TITLE
Coco attestation UI - System Set Manager

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9578,7 +9578,10 @@ For a detailed analysis, please refer to the log files.
         <source>This system does not have any Confidential Computing capability.</source>
       </trans-unit>
       <trans-unit id="system.audit.coco.configUpdated">
-        <source>The Confidential Computing configuration for this system has been updated successfully.</source>
+        <source>The Confidential Computing configuration has been updated successfully.</source>
+      </trans-unit>
+      <trans-unit id="system.audit.coco.configNotUpdated">
+        <source>An error occurred while updating the Confidential Computing configuration. Please check the server logs for detailed information.</source>
       </trans-unit>
     </body>
   </file>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4897,6 +4897,12 @@ organization. You may grant or remove the organization administrator role in the
                 <context context-type="sourcefile">/rhn/ssm/Index.do</context>
             </context-group>
         </trans-unit>
+        <trans-unit id="ssm.overview.audit.coco_schedule">
+            <source>&lt;a href="/rhn/manager/systems/ssm/coco/schedule"&gt;Schedule&lt;/a&gt; a new Confidential Computing attestation for selected systems</source>
+            <context-group name="ctx">
+                <context context-type="sourcefile">/rhn/ssm/Index.do</context>
+            </context-group>
+        </trans-unit>
         <trans-unit id="ssm.overview.misc">
           <source>Misc</source>
         <context-group name="ctx">
@@ -5117,6 +5123,9 @@ organization. You may grant or remove the organization administrator role in the
         </trans-unit>
         <trans-unit id="ssm.coco.tabs.configure">
             <source>Configure</source>
+        </trans-unit>
+        <trans-unit id="ssm.coco.tabs.schedule">
+            <source>Schedule</source>
         </trans-unit>
       <trans-unit id="ssm.misc.index.tabs.hardware">
           <source>Hardware</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4885,6 +4885,18 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/ssm/Index.do</context>
         </context-group>
         </trans-unit>
+        <trans-unit id="ssm.overview.audit">
+            <source>Audit</source>
+            <context-group name="ctx">
+                <context context-type="sourcefile">/rhn/ssm/Index.do</context>
+            </context-group>
+        </trans-unit>
+        <trans-unit id="ssm.overview.audit.coco_configure">
+            <source>&lt;a href="/rhn/manager/systems/ssm/coco/settings"&gt;Configure&lt;/a&gt; Confidential Computing for selected systems</source>
+            <context-group name="ctx">
+                <context context-type="sourcefile">/rhn/ssm/Index.do</context>
+            </context-group>
+        </trans-unit>
         <trans-unit id="ssm.overview.misc">
           <source>Misc</source>
         <context-group name="ctx">
@@ -5099,6 +5111,12 @@ organization. You may grant or remove the organization administrator role in the
             <context-group name="ctx">
                 <context context-type="sourcefile">/rhn/systems/ssm/misc/SoftwareRefresh.do</context>
             </context-group>
+        </trans-unit>
+        <trans-unit id="ssm.coco.index">
+            <source>Confidential Computing</source>
+        </trans-unit>
+        <trans-unit id="ssm.coco.tabs.configure">
+            <source>Configure</source>
         </trans-unit>
       <trans-unit id="ssm.misc.index.tabs.hardware">
           <source>Hardware</source>

--- a/java/code/src/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionController.java
@@ -143,6 +143,8 @@ public class MinionController {
                 withCsrfToken(withDocsLocale(withUser(MinionController::ssmProxy))), jade);
         get("/manager/systems/ssm/coco/settings",
                 withCsrfToken(withDocsLocale(withUser(MinionController::ssmCoCoSettings))), jade);
+        get("/manager/systems/ssm/coco/schedule",
+            withCsrfToken(withDocsLocale(withUser(MinionController::ssmCoCoSchedule))), jade);
     }
 
     private static void initPTFRoutes(JadeTemplateEngine jade) {
@@ -665,5 +667,32 @@ public class MinionController {
         addCoCoMetadata(data);
 
         return new ModelAndView(data, "templates/ssm/coco-ssm-settings.jade");
+    }
+
+    /**
+     * Handler for the ssm confidential computing schedule page
+     *
+     * @param request the request object
+     * @param response the response object
+     * @param user the current user
+     * @return the ModelAndView object to render the page
+     */
+    public static ModelAndView ssmCoCoSchedule(Request request, Response response, User user) {
+        Map<String, Object> data = new HashMap<>();
+
+        data.put("entityType", "SSM");
+        data.put("tabs", ViewHelper.getInstance().renderNavigationMenu(request, "/WEB-INF/nav/ssm.xml"));
+        data.put("systemSupport", Json.GSON.toJson(
+            MinionServerFactory.lookupByIds(SsmManager.listServerIds(user))
+                .map(minionServer -> Map.of(
+                    "id", minionServer.getId(),
+                    "name", minionServer.getName(),
+                    "cocoSupport", minionServer.doesOsSupportCoCoAttestation()
+                ))
+                .collect(Collectors.toList())
+        ));
+        addActionChains(user, data);
+
+        return new ModelAndView(data, "templates/ssm/coco-ssm-schedule.jade");
     }
 }

--- a/java/code/src/com/suse/manager/webui/templates/ssm/coco-ssm-schedule.jade
+++ b/java/code/src/com/suse/manager/webui/templates/ssm/coco-ssm-schedule.jade
@@ -1,0 +1,18 @@
+proxy.jade.spacewalk-toolbar-h1
+  h1
+    i.fa.spacewalk-icon-system-groups
+    | #{' System Set Manager Overview '}
+    a(href="/docs/#{docsLocale}/reference/systems/ssm-overview.html", target="_blank")
+      i.fa.fa-question-circle.spacewalk-help-link
+
+!{tabs}
+#coco-schedule
+
+script(type="text/javascript").
+    window.csrfToken = "#{csrf_token}";
+    window.systemSupport = !{systemSupport};
+    window.actionChains = !{actionChains};
+
+script(type='text/javascript').
+    spaImportReactPage('systems/coco-schedule')
+        .then(function(module) { module.renderer('coco-schedule') });

--- a/java/code/src/com/suse/manager/webui/templates/ssm/coco-ssm-settings.jade
+++ b/java/code/src/com/suse/manager/webui/templates/ssm/coco-ssm-settings.jade
@@ -1,0 +1,18 @@
+proxy.jade.spacewalk-toolbar-h1
+  h1
+    i.fa.spacewalk-icon-system-groups
+    | #{' System Set Manager Overview '}
+    a(href="/docs/#{docsLocale}/reference/systems/ssm-overview.html", target="_blank")
+      i.fa.fa-question-circle.spacewalk-help-link
+
+!{tabs}
+#coco-settings
+
+script(type="text/javascript").
+    window.csrfToken = "#{csrf_token}";
+    window.systemSupport = !{systemSupport};
+    window.availableEnvironmentTypes = !{availableEnvironmentTypes};
+
+script(type='text/javascript').
+    spaImportReactPage('systems/coco-settings')
+        .then(function(module) { module.renderer('coco-settings') });

--- a/java/code/src/com/suse/manager/webui/utils/gson/SystemScheduledRequestJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/SystemScheduledRequestJson.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.utils.gson;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class SystemScheduledRequestJson extends ScheduledRequestJson {
+    private final List<Long> serverIds;
+
+    /**
+     * Default constructor
+     * @param serverIdsIn the list of servers
+     */
+    public SystemScheduledRequestJson(List<Long> serverIdsIn) {
+        this.serverIds = serverIdsIn;
+    }
+
+    public List<Long> getServerIds() {
+        return serverIds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SystemScheduledRequestJson that)) {
+            return false;
+        }
+        return Objects.equals(serverIds, that.serverIds) &&
+            Objects.equals(getEarliest(), that.getEarliest()) &&
+            Objects.equals(getActionChain(), that.getActionChain());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(serverIds, getEarliest(), getActionChain());
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SystemScheduledRequestJson.class.getSimpleName() + "[", "]")
+            .add("serverIds=" + getServerIds())
+            .add("earliest=" + getEarliest())
+            .add("actionChain=" + getActionChain())
+            .toString();
+    }
+}
+

--- a/java/code/src/com/suse/manager/webui/utils/gson/SystemsCoCoSettingsJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/SystemsCoCoSettingsJson.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.utils.gson;
+
+import com.suse.manager.model.attestation.CoCoEnvironmentType;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class SystemsCoCoSettingsJson extends CoCoSettingsJson {
+
+    private final List<Long> serverIds;
+
+    /**
+     * Default constructor
+     * @param serverIdIn the list of servers id
+     * @param supportedIn if confidential computing is supported
+     * @param enabledIn if the configuration is enabled
+     * @param environmentTypeIn the environment type
+     * @param attestOnBootIn true if attestation is performed on boot
+     */
+    public SystemsCoCoSettingsJson(List<Long> serverIdIn, boolean supportedIn, boolean enabledIn,
+                                   CoCoEnvironmentType environmentTypeIn, boolean attestOnBootIn) {
+        super(supportedIn, enabledIn, environmentTypeIn, attestOnBootIn);
+        this.serverIds = serverIdIn;
+    }
+
+    public List<Long> getServerIds() {
+        return serverIds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SystemsCoCoSettingsJson that)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        return Objects.equals(serverIds, that.serverIds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), serverIds);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", SystemsCoCoSettingsJson.class.getSimpleName() + "[", "]")
+            .add("serverIds=" + getServerIds())
+            .add("supported=" + isSupported())
+            .add("enabled=" + isEnabled())
+            .add("environmentType=" + getEnvironmentType())
+            .add("attestOnBoot=" + isAttestOnBoot())
+            .toString();
+    }
+}

--- a/java/code/webapp/WEB-INF/nav/ssm.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm.xml
@@ -93,6 +93,9 @@
             <rhn-tab name="ssm.coco.tabs.configure">
                 <rhn-tab-url>/rhn/manager/systems/ssm/coco/settings</rhn-tab-url>
             </rhn-tab>
+            <rhn-tab name="ssm.coco.tabs.schedule">
+                <rhn-tab-url>/rhn/manager/systems/ssm/coco/schedule</rhn-tab-url>
+            </rhn-tab>
         </rhn-tab>
     </rhn-tab>
 

--- a/java/code/webapp/WEB-INF/nav/ssm.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm.xml
@@ -84,9 +84,16 @@
                 acl="all_systems_in_set_have_feature(ftr_power_management)"/>
     </rhn-tab>
 
-    <rhn-tab name="Audit" acl="all_systems_in_set_have_feature(ftr_system_audit)">
-        <rhn-tab-url>/rhn/systems/ssm/audit/ScheduleXccdf.do</rhn-tab-url>
-        <rhn-tab-url>/rhn/systems/ssm/audit/ScheduleXccdfSubmit.do</rhn-tab-url>
+    <rhn-tab name="Audit" acl="all_systems_in_set_have_feature(ftr_system_audit)" url="/rhn/systems/ssm/audit/ScheduleXccdf.do">
+        <rhn-tab name="OpenSCAP" url="/rhn/systems/ssm/audit/ScheduleXccdf.do">
+            <rhn-tab-url>/rhn/systems/ssm/audit/ScheduleXccdf.do</rhn-tab-url>
+            <rhn-tab-url>/rhn/systems/ssm/audit/ScheduleXccdfSubmit.do</rhn-tab-url>
+        </rhn-tab>
+        <rhn-tab name="ssm.coco.index" url="/rhn/manager/systems/ssm/coco/settings">
+            <rhn-tab name="ssm.coco.tabs.configure">
+                <rhn-tab-url>/rhn/manager/systems/ssm/coco/settings</rhn-tab-url>
+            </rhn-tab>
+        </rhn-tab>
     </rhn-tab>
 
     <rhn-tab name="States" acl="any_system_with_salt_entitlement()">

--- a/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
@@ -168,6 +168,7 @@
                             <li><bean:message key="ssm.overview.misc.scap"/></li>
                         </rhn:require>
                         <li><bean:message key="ssm.overview.audit.coco_configure"/></li>
+                        <li><bean:message key="ssm.overview.audit.coco_schedule"/></li>
                     </ul>
                 </div>
             </div>

--- a/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
@@ -159,6 +159,22 @@
         <li class="list-group-item">
             <div class="row">
                 <div class="col-sm-2">
+                  <rhn:icon type="header-search" title="ssm.overview.misc" />
+                    <bean:message key="ssm.overview.audit"/>
+                </div>
+                <div class="col-sm-10">
+                    <ul class="list-unstyled">
+                        <rhn:require acl="all_systems_in_set_have_feature(ftr_system_audit)">
+                            <li><bean:message key="ssm.overview.misc.scap"/></li>
+                        </rhn:require>
+                        <li><bean:message key="ssm.overview.audit.coco_configure"/></li>
+                    </ul>
+                </div>
+            </div>
+        </li>
+        <li class="list-group-item">
+            <div class="row">
+                <div class="col-sm-2">
                   <rhn:icon type="header-event-history" title="ssm.overview.misc" />
                     <bean:message key="ssm.overview.misc"/>
                 </div>
@@ -182,9 +198,6 @@
                         </rhn:require>
                         <rhn:require acl="all_systems_in_set_have_feature(ftr_system_lock)">
                             <li><bean:message key="ssm.overview.misc.lock"/></li>
-                        </rhn:require>
-                        <rhn:require acl="all_systems_in_set_have_feature(ftr_system_audit)">
-                            <li><bean:message key="ssm.overview.misc.scap"/></li>
                         </rhn:require>
                         <rhn:require acl="all_systems_in_set_have_feature(ftr_reboot)">
                             <li><bean:message key="ssm.overview.misc.reboot"/></li>

--- a/java/spacewalk-java.changes.mackdk.coco-attestation-ui-ssm-new
+++ b/java/spacewalk-java.changes.mackdk.coco-attestation-ui-ssm-new
@@ -1,0 +1,2 @@
+- Added support for Confidential Computing in the System Set 
+  Manager

--- a/web/html/src/components/CoCoScansList.tsx
+++ b/web/html/src/components/CoCoScansList.tsx
@@ -85,7 +85,11 @@ class CoCoScansList extends React.Component<Props, State> {
         });
       })
       .catch((err) => {
-        this.setState({ messages: MessagesUtils.error(t("Unable to perform action.")) });
+        this.setState({
+          messages: MessagesUtils.error(
+            t("Unable to schedule action. Please check the server logs for detailed information.")
+          ),
+        });
       });
   };
 

--- a/web/html/src/components/CoCoSettingsForm.tsx
+++ b/web/html/src/components/CoCoSettingsForm.tsx
@@ -1,42 +1,20 @@
 import * as React from "react";
 
-import { Messages, MessageType, Utils as MessagesUtils } from "components/messages";
-import { TopPanel } from "components/panels/TopPanel";
-
-import Network from "utils/network";
-
 import { AsyncButton, Button } from "./buttons";
+import { Settings } from "./coco-attestation/Utils";
 import { BootstrapPanel } from "./panels/BootstrapPanel";
-import { CronTimes, RecurringEventPicker, RecurringType } from "./picker/recurring-event-picker";
+import { RecurringEventPicker } from "./picker/recurring-event-picker";
 import { SectionToolbar } from "./section-toolbar/section-toolbar";
 import { Toggler } from "./toggler";
-import { Loading } from "./utils";
 
 type Props = {
-  /** The id of the system to be shown */
-  serverId: number;
-
-  /** Environment types */
+  initialData: Settings;
   availableEnvironmentTypes: object;
-
   showOnScheduleOption?: boolean;
+  saveHandler: (data: Settings) => void;
 };
 
-type State = {
-  checksForEnvironmentTooltip: string;
-  messages: MessageType[];
-  supported: boolean;
-  enabled: boolean;
-  environmentType: string;
-  attestOnBoot: boolean;
-  attestOnSchedule: boolean;
-  scheduleName?: string;
-  scheduleType?: RecurringType;
-  scheduleCron?: string;
-  scheduleCronTimes?: CronTimes;
-  originalData?: any;
-  loading: boolean;
-};
+type State = Settings;
 
 class CoCoSettingsForm extends React.Component<Props, State> {
   public static readonly defaultProps: Partial<Props> = {
@@ -47,41 +25,9 @@ class CoCoSettingsForm extends React.Component<Props, State> {
     super(props);
 
     this.state = {
-      checksForEnvironmentTooltip: "",
-      messages: [],
-      supported: false,
-      enabled: false,
-      environmentType: Object.values(props.availableEnvironmentTypes)[0],
-      attestOnBoot: false,
-      attestOnSchedule: false,
-      loading: true,
+      ...this.props.initialData,
     };
-
-    this.init();
   }
-
-  init = () => {
-    this.setState({ loading: true });
-
-    Network.get(`/rhn/manager/api/systems/${this.props.serverId}/details/coco/settings`).then(
-      this.handleResult,
-      this.handleRequestError
-    );
-  };
-
-  onSave = () => {
-    const data = {
-      supported: this.state.supported,
-      enabled: this.state.enabled,
-      environmentType: this.state.environmentType,
-      attestOnBoot: this.state.attestOnBoot,
-    };
-
-    return Network.post(`/rhn/manager/api/systems/${this.props.serverId}/details/coco/settings`, data).then(
-      this.handleResult,
-      this.handleRequestError
-    );
-  };
 
   toggleCocoAttestation = (value) => {
     this.setState({
@@ -90,24 +36,15 @@ class CoCoSettingsForm extends React.Component<Props, State> {
   };
 
   environmentTypeChanged = (event) => {
-    this.setState({
-      environmentType: event.target.value,
-      checksForEnvironmentTooltip: t(`The enviroment {environment} supports the following checks: <br/>`, {
-        environment: event.target.value,
-      }),
-    });
+    this.setState({ environmentType: event.target.value });
   };
 
   toggleAttestOnBoot = (value) => {
-    this.setState({
-      attestOnBoot: value,
-    });
+    this.setState({ attestOnBoot: value });
   };
 
   toggleAttestOnSchedule = (value) => {
-    this.setState({
-      attestOnSchedule: value,
-    });
+    this.setState({ attestOnSchedule: value });
   };
 
   onScheduleNameChanged = (scheduleName) => {
@@ -126,163 +63,111 @@ class CoCoSettingsForm extends React.Component<Props, State> {
     this.setState({ scheduleCron: cron });
   };
 
-  handleResult = (result) => {
-    if (!result.success) {
-      this.setState({
-        messages: MessagesUtils.error(result.messages),
-        loading: false,
-      });
-    } else if (!result.data.supported) {
-      this.setState({
-        supported: false,
-        messages: MessagesUtils.warning(result.messages),
-        loading: false,
-      });
-    } else {
-      this.setState({
-        messages: MessagesUtils.success(result.messages),
-        supported: true,
-        enabled: result.data.enabled,
-        environmentType: result.data.environmentType,
-        attestOnBoot: result.data.attestOnBoot,
-        loading: false,
-        originalData: result.data,
-      });
-    }
-  };
-
-  handleRequestError = (err) => {
+  onResetChanges = () => {
     this.setState({
-      messages: Network.responseErrorMessage(err),
-      supported: false,
-      enabled: false,
-      environmentType: Object.values(this.props.availableEnvironmentTypes)[0],
-      attestOnBoot: false,
-      loading: false,
+      ...this.props.initialData,
     });
   };
 
-  onResetChanges = () => {
-    this.setState((prevState) => ({
-      messages: prevState.originalData === undefined ? MessagesUtils.error(t("Unable to revert changes")) : [],
-      enabled: prevState.originalData?.enabled ?? prevState.enabled,
-      environmentType: prevState.originalData?.environmentType ?? prevState.environmentType,
-      attestOnBoot: prevState.originalData?.attestOnBoot ?? prevState.attestOnBoot,
-    }));
-  };
-
-  render = () => {
-    if (this.state.loading) {
-      return (
-        <div className="panel panel-default">
-          <Loading />
-        </div>
-      );
-    } else {
-      const messages = <Messages items={this.state.messages} />;
-
-      const form = (
-        <>
-          <p>{t("On this page you can configure Confidential Computing settings for this server.")}</p>
-          <SectionToolbar>
-            <div className="action-button-wrapper">
-              <span className="btn-group pull-right">
-                <AsyncButton id="save-btn" icon="fa-floppy-o" action={this.onSave} text={t("Save")} />
-                <Button
-                  id="reset-btn"
-                  icon="fa-undo"
-                  text={t("Reset Changes")}
-                  className="btn btn-default"
-                  handler={this.onResetChanges}
+  render(): React.ReactNode {
+    return (
+      <>
+        <SectionToolbar>
+          <div className="action-button-wrapper">
+            <span className="btn-group pull-right">
+              <AsyncButton
+                id="save-btn"
+                icon="fa-floppy-o"
+                action={() => this.props.saveHandler(this.state as Settings)}
+                text={t("Save")}
+              />
+              <Button
+                id="reset-btn"
+                icon="fa-undo"
+                text={t("Reset Changes")}
+                className="btn btn-default"
+                handler={this.onResetChanges}
+              />
+            </span>
+          </div>
+        </SectionToolbar>
+        <BootstrapPanel>
+          <div className="form-horizontal">
+            <div className="form-group">
+              <div className="col-md-offset-3 col-md-6">
+                <Toggler
+                  className="checkbox"
+                  text={t("Enable attestation")}
+                  value={this.state.enabled}
+                  handler={this.toggleCocoAttestation}
                 />
-              </span>
+              </div>
             </div>
-          </SectionToolbar>
-          <BootstrapPanel>
-            <div className="form-horizontal">
+            <div className="form-group">
+              <label className="col-md-3 control-label">{t("Environment Type")}:</label>
+              <div className="col-md-6">
+                <select
+                  value={this.state.environmentType ?? undefined}
+                  onChange={this.environmentTypeChanged}
+                  className="form-control"
+                  name="activationKeys"
+                  disabled={!this.state.enabled}
+                >
+                  {Object.keys(this.props.availableEnvironmentTypes).map((k) => (
+                    <option key={k} value={k}>
+                      {this.props.availableEnvironmentTypes[k]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="form-group">
+              <label className="col-md-3 control-label">{t("Executions")}:</label>
+              <div className="col-md-6">
+                <Toggler
+                  className="checkbox"
+                  text={t("Peform attestation during the boot process")}
+                  value={this.state.attestOnBoot}
+                  handler={this.toggleAttestOnBoot}
+                  disabled={!this.state.enabled}
+                />
+              </div>
+            </div>
+            {this.props.showOnScheduleOption && (
               <div className="form-group">
                 <div className="col-md-offset-3 col-md-6">
                   <Toggler
                     className="checkbox"
-                    text={t("Enable attestation")}
-                    value={this.state.enabled}
-                    handler={this.toggleCocoAttestation}
-                  />
-                </div>
-              </div>
-              <div className="form-group">
-                <label className="col-md-3 control-label">{t("Environment Type")}:</label>
-                <div className="col-md-6">
-                  <select
-                    value={this.state.environmentType ?? undefined}
-                    onChange={this.environmentTypeChanged}
-                    className="form-control"
-                    name="activationKeys"
-                    disabled={!this.state.enabled}
-                  >
-                    {Object.keys(this.props.availableEnvironmentTypes).map((k) => (
-                      <option key={k} value={k}>
-                        {this.props.availableEnvironmentTypes[k]}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-              <div className="form-group">
-                <label className="col-md-3 control-label">{t("Executions")}:</label>
-                <div className="col-md-6">
-                  <Toggler
-                    className="checkbox"
-                    text={t("Peform attestation during the boot process")}
-                    value={this.state.attestOnBoot}
-                    handler={this.toggleAttestOnBoot}
+                    text={t("Peform attestation on a schedule")}
+                    value={this.state.attestOnSchedule}
+                    handler={this.toggleAttestOnSchedule}
                     disabled={!this.state.enabled}
                   />
                 </div>
               </div>
-              {this.props.showOnScheduleOption && (
-                <div className="form-group">
-                  <div className="col-md-offset-3 col-md-6">
-                    <Toggler
-                      className="checkbox"
-                      text={t("Peform attestation on a schedule")}
-                      value={this.state.attestOnSchedule}
-                      handler={this.toggleAttestOnSchedule}
-                      disabled={!this.state.enabled}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
+            )}
+          </div>
+        </BootstrapPanel>
+        {this.state.attestOnSchedule && (
+          <BootstrapPanel title={t("Select a schedule")}>
+            <RecurringEventPicker
+              mode="Inline"
+              hideScheduleName
+              timezone={window.timezone}
+              scheduleName={this.state.scheduleName}
+              type={this.state.scheduleType}
+              cron={this.state.scheduleCron}
+              cronTimes={this.state.scheduleCronTimes}
+              onScheduleNameChanged={this.onScheduleNameChanged}
+              onTypeChanged={this.onTypeChanged}
+              onCronTimesChanged={this.onCronTimesChanged}
+              onCronChanged={this.onCustomCronChanged}
+            />
           </BootstrapPanel>
-          {this.state.attestOnSchedule && (
-            <BootstrapPanel title={t("Select a schedule")}>
-              <RecurringEventPicker
-                mode="Inline"
-                hideScheduleName
-                timezone={window.timezone}
-                scheduleName={this.state.scheduleName}
-                type={this.state.scheduleType}
-                cron={this.state.scheduleCron}
-                cronTimes={this.state.scheduleCronTimes}
-                onScheduleNameChanged={this.onScheduleNameChanged}
-                onTypeChanged={this.onTypeChanged}
-                onCronTimesChanged={this.onCronTimesChanged}
-                onCronChanged={this.onCustomCronChanged}
-              />
-            </BootstrapPanel>
-          )}
-        </>
-      );
-
-      return (
-        <TopPanel title={t("Settings")} icon="fa fa-pencil-square-o">
-          {messages}
-          {this.state.supported ? form : null}
-        </TopPanel>
-      );
-    }
-  };
+        )}
+      </>
+    );
+  }
 }
 
 export default CoCoSettingsForm;

--- a/web/html/src/components/coco-attestation/CoCoSettingsForm.tsx
+++ b/web/html/src/components/coco-attestation/CoCoSettingsForm.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 
-import { AsyncButton, Button } from "./buttons";
-import { Settings } from "./coco-attestation/Utils";
-import { BootstrapPanel } from "./panels/BootstrapPanel";
-import { RecurringEventPicker } from "./picker/recurring-event-picker";
-import { SectionToolbar } from "./section-toolbar/section-toolbar";
-import { Toggler } from "./toggler";
+import { AsyncButton, Button } from "../buttons";
+import { BootstrapPanel } from "../panels/BootstrapPanel";
+import { RecurringEventPicker } from "../picker/recurring-event-picker";
+import { SectionToolbar } from "../section-toolbar/section-toolbar";
+import { Toggler } from "../toggler";
+import { Settings } from "./Utils";
 
 type Props = {
   initialData: Settings;

--- a/web/html/src/components/coco-attestation/Utils.tsx
+++ b/web/html/src/components/coco-attestation/Utils.tsx
@@ -1,6 +1,18 @@
 import React from "react";
 
 import { FromNow } from "components/datetime";
+import { CronTimes, RecurringType } from "components/picker/recurring-event-picker";
+
+export type Settings = {
+  enabled: boolean;
+  environmentType: string;
+  attestOnBoot: boolean;
+  attestOnSchedule: boolean;
+  scheduleName?: string;
+  scheduleType?: RecurringType;
+  scheduleCron?: string;
+  scheduleCronTimes?: CronTimes;
+};
 
 export type AttestationResult = {
   id: number;

--- a/web/html/src/components/target-systems.tsx
+++ b/web/html/src/components/target-systems.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+
+import { pageSize } from "core/user-preferences";
+
+import { SystemLink } from "./links";
+import { TopPanel } from "./panels/TopPanel";
+import { Column } from "./table/Column";
+import { Table } from "./table/Table";
+
+export type SystemData = {
+  id: number;
+  name: string;
+} & Record<string, any>;
+
+type Props = {
+  systemsData: Array<SystemData>;
+};
+
+export class TargetSystems extends React.Component<Props> {
+  render(): React.ReactNode {
+    return (
+      <TopPanel title={t("Target Systems")}>
+        <Table
+          selectable={false}
+          data={this.props.systemsData}
+          identifier={(system: SystemData) => system.id}
+          initialItemsPerPage={pageSize}
+          emptyText={t("No systems specified.")}
+        >
+          <Column
+            columnClass="text-center"
+            headerClass="text-center"
+            columnKey="system"
+            header={t("System")}
+            cell={(system: SystemData) => <SystemLink id={system.id}>{system.name}</SystemLink>}
+          />
+          {this.props.children}
+        </Table>
+      </TopPanel>
+    );
+  }
+}

--- a/web/html/src/manager/minion/coco/coco-settings.renderer.tsx
+++ b/web/html/src/manager/minion/coco/coco-settings.renderer.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
-import CoCoSettingsForm from "components/CoCoSettingsForm";
+import CoCoSettings from "./coco-settings";
 
 // See java/code/src/com/suse/manager/webui/templates/minion/coco-settings.jade
 declare global {
@@ -15,7 +15,7 @@ declare global {
 
 export const renderer = (id) =>
   SpaRenderer.renderNavigationReact(
-    <CoCoSettingsForm
+    <CoCoSettings
       serverId={window.serverId}
       availableEnvironmentTypes={window.availableEnvironmentTypes ?? []}
       // TODO: enable when the backend implementation is ready

--- a/web/html/src/manager/minion/coco/coco-settings.tsx
+++ b/web/html/src/manager/minion/coco/coco-settings.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
+import CoCoSettingsForm from "components/coco-attestation/CoCoSettingsForm";
 import { Settings } from "components/coco-attestation/Utils";
-import CoCoSettingsForm from "components/CoCoSettingsForm";
 import { Messages, MessageType, Utils as MessagesUtils } from "components/messages";
 import { TopPanel } from "components/panels/TopPanel";
 import { Loading } from "components/utils";

--- a/web/html/src/manager/minion/coco/coco-settings.tsx
+++ b/web/html/src/manager/minion/coco/coco-settings.tsx
@@ -1,0 +1,124 @@
+import * as React from "react";
+
+import { Settings } from "components/coco-attestation/Utils";
+import CoCoSettingsForm from "components/CoCoSettingsForm";
+import { Messages, MessageType, Utils as MessagesUtils } from "components/messages";
+import { TopPanel } from "components/panels/TopPanel";
+import { Loading } from "components/utils";
+
+import Network from "utils/network";
+
+type Props = {
+  serverId: number;
+  availableEnvironmentTypes: object;
+  showOnScheduleOption?: boolean;
+};
+
+type State = {
+  messages: MessageType[];
+  supported: boolean;
+  settings: Settings;
+  loading: boolean;
+};
+
+class CoCoSettings extends React.Component<Props, State> {
+  public static readonly defaultProps: Partial<Props> = {
+    showOnScheduleOption: true,
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      messages: [],
+      supported: false,
+      loading: true,
+      settings: {
+        enabled: false,
+        environmentType: Object.values(this.props.availableEnvironmentTypes)[0],
+        attestOnBoot: false,
+        attestOnSchedule: false,
+      },
+    };
+
+    this.init();
+  }
+
+  init(): void {
+    this.setState({ loading: true });
+
+    Network.get(`/rhn/manager/api/systems/${this.props.serverId}/details/coco/settings`).then(
+      this.handleResult,
+      this.handleRequestError
+    );
+  }
+
+  render(): React.ReactNode {
+    if (this.state.loading) {
+      return (
+        <div className="panel panel-default">
+          <Loading />
+        </div>
+      );
+    }
+
+    return (
+      <TopPanel title={t("Settings")} icon="fa fa-pencil-square-o">
+        <Messages items={this.state.messages} />
+        {this.state.supported && (
+          <CoCoSettingsForm
+            initialData={this.state.settings}
+            saveHandler={this.onSave}
+            availableEnvironmentTypes={this.props.availableEnvironmentTypes}
+            showOnScheduleOption={this.props.showOnScheduleOption}
+          />
+        )}
+      </TopPanel>
+    );
+  }
+
+  onSave = (data: Settings) => {
+    Network.post(`/rhn/manager/api/systems/${this.props.serverId}/details/coco/settings`, data).then(
+      this.handleResult,
+      this.handleRequestError
+    );
+  };
+
+  handleResult = (result) => {
+    if (!result.success) {
+      this.setState({
+        messages: MessagesUtils.error(result.messages),
+        loading: false,
+      });
+    } else if (!result.data.supported) {
+      this.setState({
+        supported: false,
+        messages: MessagesUtils.warning(result.messages),
+        loading: false,
+      });
+    } else {
+      this.setState({
+        messages: MessagesUtils.success(result.messages),
+        supported: true,
+        settings: result.data,
+        loading: false,
+      });
+    }
+  };
+
+  handleRequestError = (err) => {
+    this.setState({
+      messages: Network.responseErrorMessage(err),
+      supported: false,
+      loading: false,
+      settings: {
+        enabled: false,
+        environmentType: Object.values(this.props.availableEnvironmentTypes)[0],
+        attestOnBoot: false,
+        attestOnSchedule: false,
+      },
+    });
+  };
+}
+
+export default CoCoSettings;

--- a/web/html/src/manager/systems/coco/ssm-schedule.renderer.tsx
+++ b/web/html/src/manager/systems/coco/ssm-schedule.renderer.tsx
@@ -1,0 +1,19 @@
+import SpaRenderer from "core/spa/spa-renderer";
+
+import { SystemData } from "components/target-systems";
+
+import CoCoSSMSchedule from "./ssm-schedule";
+
+// See java/code/src/com/suse/manager/webui/templates/ssm/coco-ssm-schedule.jade
+declare global {
+  interface Window {
+    systemSupport?: SystemData[];
+    actionChains?: any;
+  }
+}
+
+export const renderer = (id) =>
+  SpaRenderer.renderNavigationReact(
+    <CoCoSSMSchedule systemSupport={window.systemSupport ?? []} actionChains={window.actionChains} />,
+    document.getElementById(id)
+  );

--- a/web/html/src/manager/systems/coco/ssm-schedule.tsx
+++ b/web/html/src/manager/systems/coco/ssm-schedule.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+
+import { ActionChain, ActionSchedule } from "components/action-schedule";
+import { AsyncButton } from "components/buttons";
+import { ActionChainLink, ActionLink } from "components/links";
+import { Messages, MessageType, Utils as MessagesUtils } from "components/messages";
+import { TopPanel } from "components/panels/TopPanel";
+import { SectionToolbar } from "components/section-toolbar/section-toolbar";
+import { Column } from "components/table/Column";
+import { SystemData, TargetSystems } from "components/target-systems";
+
+import { LocalizedMoment, localizedMoment } from "utils/datetime";
+import Network from "utils/network";
+
+type Props = {
+  systemSupport: Array<SystemData>;
+  actionChains: Array<ActionChain>;
+};
+
+type State = {
+  messages: MessageType[];
+  earliest: LocalizedMoment;
+  actionChain?: ActionChain;
+};
+
+class CoCoSSMSchedule extends React.Component<Props, State> {
+  public constructor(props) {
+    super(props);
+
+    this.state = {
+      messages: [],
+      earliest: localizedMoment(),
+    };
+  }
+
+  onActionChainChanged = (actionChain) => {
+    this.setState({ actionChain: actionChain });
+  };
+
+  onDateTimeChanged = (date) => {
+    this.setState({ earliest: date });
+  };
+
+  onSchedule = () => {
+    const request = {
+      serverIds: this.props.systemSupport.filter((system) => system.cocoSupport).map((system) => system.id),
+      actionType: "coco.attestation",
+      earliest: this.state.earliest,
+      actionChain: this.state.actionChain ? this.state.actionChain.text : null,
+    };
+
+    Network.post(`/rhn/manager/api/systems/coco/scheduleAction`, request)
+      .then((data) => {
+        // Notify the successful outcome
+        const msg = MessagesUtils.info(
+          request.actionChain ? (
+            <span>
+              {t('Action has been successfully added to the action chain <link>"{name}"</link>.', {
+                name: request.actionChain,
+                link: (str) => <ActionChainLink id={data}>{str}</ActionChainLink>,
+              })}
+            </span>
+          ) : (
+            <span>
+              {t("The action has been <link>scheduled</link>.", {
+                link: (str) => <ActionLink id={data}>{str}</ActionLink>,
+              })}
+            </span>
+          )
+        );
+
+        this.setState({ messages: msg });
+      })
+      .catch((err) => {
+        this.setState({
+          messages: MessagesUtils.error(
+            t("Unable to schedule action. Please check the server logs for detailed information.")
+          ),
+        });
+      });
+  };
+
+  render(): React.ReactNode {
+    return (
+      <>
+        <TopPanel title="Confidential Computing Schedule">
+          <Messages items={this.state.messages} />
+          <SectionToolbar>
+            <div className="action-button-wrapper">
+              <div className="btn-group pull-right">
+                <AsyncButton
+                  className="btn-default"
+                  defaultType="btn-danger"
+                  text={t("Schedule")}
+                  action={this.onSchedule}
+                />
+              </div>
+            </div>
+          </SectionToolbar>
+          <ActionSchedule
+            earliest={this.state.earliest}
+            actionChains={this.props.actionChains}
+            onActionChainChanged={this.onActionChainChanged}
+            onDateTimeChanged={this.onDateTimeChanged}
+            systemIds={this.props.systemSupport.filter((system) => system.cocoSupport).map((system) => system.id)}
+            actionType="coco.attestation"
+          />
+        </TopPanel>
+        <TargetSystems systemsData={this.props.systemSupport}>
+          <Column
+            columnClass="text-center"
+            headerClass="text-center"
+            columnKey="cocoSupport"
+            header={t("Confidential Computing Capability")}
+            cell={(system: SystemData) => (system.cocoSupport ? t("Yes") : t("No"))}
+          />
+        </TargetSystems>
+      </>
+    );
+  }
+}
+
+export default CoCoSSMSchedule;

--- a/web/html/src/manager/systems/coco/ssm-settings.renderer.tsx
+++ b/web/html/src/manager/systems/coco/ssm-settings.renderer.tsx
@@ -1,0 +1,22 @@
+import SpaRenderer from "core/spa/spa-renderer";
+
+import { SystemData } from "components/target-systems";
+
+import CoCoSSMSettings from "./ssm-settings";
+
+// See java/code/src/com/suse/manager/webui/templates/ssm/coco-ssm-settings.jade
+declare global {
+  interface Window {
+    systemSupport?: SystemData[];
+    availableEnvironmentTypes?: any;
+  }
+}
+
+export const renderer = (id) =>
+  SpaRenderer.renderNavigationReact(
+    <CoCoSSMSettings
+      systemSupport={window.systemSupport ?? []}
+      availableEnvironmentTypes={window.availableEnvironmentTypes ?? []}
+    />,
+    document.getElementById(id)
+  );

--- a/web/html/src/manager/systems/coco/ssm-settings.tsx
+++ b/web/html/src/manager/systems/coco/ssm-settings.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+
+import CoCoSettingsForm from "components/coco-attestation/CoCoSettingsForm";
+import { Settings } from "components/coco-attestation/Utils";
+import { Messages, MessageType, Utils as MessagesUtils } from "components/messages";
+import { TopPanel } from "components/panels/TopPanel";
+import { Column } from "components/table/Column";
+import { SystemData, TargetSystems } from "components/target-systems";
+
+import Network from "utils/network";
+
+type Props = {
+  systemSupport: SystemData[];
+  availableEnvironmentTypes: object;
+};
+
+type State = {
+  messages: MessageType[];
+};
+
+class CoCoSSMSettings extends React.Component<Props, State> {
+  private readonly emptySettings: Settings;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      messages: [],
+    };
+
+    this.emptySettings = {
+      enabled: false,
+      environmentType: Object.values(this.props.availableEnvironmentTypes)[0],
+      attestOnBoot: false,
+      attestOnSchedule: false,
+    };
+  }
+
+  onSave = (data: Settings) => {
+    const request = {
+      serverIds: this.props.systemSupport.filter((system) => system.cocoSupport).map((system) => system.id),
+      ...data,
+    };
+
+    Network.post(`/rhn/manager/api/systems/coco/settings`, request).then(
+      (response) =>
+        this.setState({
+          messages: response.success
+            ? MessagesUtils.success(response.messages)
+            : MessagesUtils.error(response.messages),
+        }),
+      (err) => this.setState({ messages: Network.responseErrorMessage(err) })
+    );
+  };
+
+  render(): React.ReactNode {
+    return (
+      <>
+        <TopPanel title="Confidential Computing Settings">
+          <Messages items={this.state.messages} />
+          <CoCoSettingsForm
+            initialData={this.emptySettings}
+            saveHandler={this.onSave}
+            availableEnvironmentTypes={this.props.availableEnvironmentTypes}
+            showOnScheduleOption={false}
+          />
+        </TopPanel>
+        <TargetSystems systemsData={this.props.systemSupport}>
+          <Column
+            columnClass="text-center"
+            headerClass="text-center"
+            columnKey="cocoSupport"
+            header={t("Confidential Computing Capability")}
+            cell={(system: SystemData) => (system.cocoSupport ? t("Yes") : t("No"))}
+          />
+        </TargetSystems>
+      </>
+    );
+  }
+}
+
+export default CoCoSSMSettings;

--- a/web/html/src/manager/systems/index.ts
+++ b/web/html/src/manager/systems/index.ts
@@ -12,4 +12,5 @@ export default {
   "systems/list/all": () => import("./all-list.renderer"),
   "systems/details/mgr-server-info": () => import("./details/mgr-server-info.renderer"),
   "systems/coco-settings": () => import("./coco/ssm-settings.renderer"),
+  "systems/coco-schedule": () => import("./coco/ssm-schedule.renderer"),
 };

--- a/web/html/src/manager/systems/index.ts
+++ b/web/html/src/manager/systems/index.ts
@@ -11,4 +11,5 @@ export default {
   "systems/list/virtual": () => import("./virtual-list.renderer"),
   "systems/list/all": () => import("./all-list.renderer"),
   "systems/details/mgr-server-info": () => import("./details/mgr-server-info.renderer"),
+  "systems/coco-settings": () => import("./coco/ssm-settings.renderer"),
 };

--- a/web/spacewalk-web.changes.mackdk.coco-attestation-ui-ssm-new
+++ b/web/spacewalk-web.changes.mackdk.coco-attestation-ui-ssm-new
@@ -1,0 +1,2 @@
+- Added pages to configure and schedule Confidential Computing 
+  attestations from the System Set Manager


### PR DESCRIPTION
## What does this PR change?

This PR adds Confidential Computing support in the System Set Manager. In particular, two new pages are added to allow configuring and scheduling attestations on multiple systems.

## GUI diff

After:
![image](https://github.com/uyuni-project/uyuni/assets/2292684/721b1605-7c78-4106-a54b-f409bad865d4)
![image](https://github.com/uyuni-project/uyuni/assets/2292684/aa01e99c-3c1e-452b-9772-75ffe9a67219)
![image](https://github.com/uyuni-project/uyuni/assets/2292684/13d791c8-3e1d-4c7b-bc3d-56bd80d4a899)

- [X] **DONE**

## Documentation
- Documentation work in progress
- [ ] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23562

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
