### PR TITLE
Set the permissions on the exported GPG key in salt folder

### DIFF
--- a/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
+++ b/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
@@ -156,6 +156,7 @@ if [[  $ACTION = "enable" ]]; then
         echo "DONE. Exported key ${ENABLE_KEYID} to ${GPG_SALT_EXPORT_FILE}."
         chmod 644 $GPG_SALT_EXPORT_FILE
         gpg --batch --export --armor --output $GPG_ARMOR_SALT_EXPORT_FILE $ENABLE_KEYID
+        chmod 644 ${GPG_ARMOR_SALT_EXPORT_FILE}
         echo "DONE. Exported key ${ENABLE_KEYID} to ${GPG_ARMOR_SALT_EXPORT_FILE}."
     fi
 

--- a/python/spacewalk/spacewalk-backend.changes.cbosdo.Manager-4.3
+++ b/python/spacewalk/spacewalk-backend.changes.cbosdo.Manager-4.3
@@ -1,0 +1,1 @@
+- Set permissions on exported Salt GPG key (bsc#122996)


### PR DESCRIPTION
## What does this PR change?

Some users may have a umask setting too strict permissions on the GPG key exported in /srv/susemanager/salt/gpg/. Enforcing the permissions to avoid issues when applying the salt state.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: untested python script

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24155
Port(s): https://github.com/SUSE/spacewalk/pull/24173

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
