### PR TITLE
Add detailed process output from the attestation module

### DIFF
--- a/java/code/src/com/suse/manager/model/attestation/CoCoAttestationResult.java
+++ b/java/code/src/com/suse/manager/model/attestation/CoCoAttestationResult.java
@@ -43,6 +43,7 @@ public class CoCoAttestationResult {
     private CoCoAttestationStatus status;
     private String description;
     private String details;
+    private String processOutput;
     private Date attested;
 
     /**
@@ -100,6 +101,14 @@ public class CoCoAttestationResult {
     }
 
     /**
+     * @return return the process output if available
+     */
+    @Column(name = "process_output")
+    protected String getProcessOutput() {
+        return processOutput;
+    }
+
+    /**
      * @return the time this result was attested
      */
     @Column(name = "attested")
@@ -113,6 +122,14 @@ public class CoCoAttestationResult {
     @Transient
     public Optional<String> getDetailsOpt() {
         return Optional.ofNullable(details);
+    }
+
+    /**
+     * @return return the details if available
+     */
+    @Transient
+    public Optional<String> getProcessOutputOpt() {
+        return Optional.ofNullable(processOutput);
     }
 
     /**
@@ -155,6 +172,10 @@ public class CoCoAttestationResult {
      */
     public void setDetails(String detailsIn) {
         details = detailsIn;
+    }
+
+    public void setProcessOutput(String processOutputIn) {
+        this.processOutput = processOutputIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/gson/CoCoAttestationResultJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/CoCoAttestationResultJson.java
@@ -37,6 +37,8 @@ public class CoCoAttestationResultJson {
 
     private final String details;
 
+    private final String processOutput;
+
     private final Date attestationTime;
 
 
@@ -53,6 +55,7 @@ public class CoCoAttestationResultJson {
         this.description = result.getDescription();
         this.attestationTime = result.getAttested();
         this.details = result.getDetailsOpt().orElse(null);
+        this.processOutput = result.getProcessOutputOpt().orElse(null);
     }
 
     public long getId() {
@@ -81,6 +84,10 @@ public class CoCoAttestationResultJson {
 
     public String getDetails() {
         return details;
+    }
+
+    public String getProcessOutput() {
+        return processOutput;
     }
 
     public Date getAttestationTime() {

--- a/java/spacewalk-java.changes.mackdk.coco-attestation-add-full-logs
+++ b/java/spacewalk-java.changes.mackdk.coco-attestation-add-full-logs
@@ -1,0 +1,1 @@
+- Added column to store the process output of the attestation

--- a/microservices/coco-attestation/attestation-core/src/main/resources/mappers/attestation-result.xml
+++ b/microservices/coco-attestation/attestation-core/src/main/resources/mappers/attestation-result.xml
@@ -44,6 +44,7 @@
           UPDATE suseCoCoAttestationResult
              SET status = #{status}
                     , details = #{details}
+                    , process_output = #{processOutput}
                 <if test="status.name() == 'SUCCEEDED'">
                     , attested = #{attested}
                 </if>

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Worker class for verifying the reports with SNPGuest
@@ -37,11 +38,15 @@ public class SNPGuestWorker implements AttestationWorker {
 
     private static final Logger LOGGER = LogManager.getLogger(SNPGuestWorker.class);
 
+    private static final int INDENT_SIZE = 4;
+
     private final VerificationDirectoryProvider directoryProvider;
 
     private final SNPGuestWrapper snpGuest;
 
     private final ByteSequenceFinder sequenceFinder;
+
+    private final StringBuilder outputBuilder;
 
     /**
      * Default constructor.
@@ -61,23 +66,26 @@ public class SNPGuestWorker implements AttestationWorker {
         this.directoryProvider = directoryProviderIn;
         this.snpGuest = snpGuestWrapperIn;
         this.sequenceFinder = sequenceFinderIn;
+        this.outputBuilder = new StringBuilder();
     }
 
     @Override
     public boolean process(SqlSession session, AttestationResult result) {
+        // Reset the output string builder
+        outputBuilder.setLength(0);
 
         try {
             LOGGER.debug("Processing attestation result {}", result.getId());
 
             AttestationReport report = session.selectOne("SNPGuestModule.retrieveReport", result.getReportId());
             if (report == null) {
-                LOGGER.error("Unable to retrieve attestation report for result {}", result.getId());
+                appendError("Unable to retrieve attestation report for result");
                 return false;
             }
 
              LOGGER.debug("Loaded report {}", report);
              if (report.getCpuGeneration() == EpycGeneration.UNKNOWN) {
-                LOGGER.error("Unable to identify Epyc processor generation for attestation report {}", report.getId());
+                 appendError("Unable to identify Epyc processor generation for attestation report");
                 return false;
             }
 
@@ -85,8 +93,11 @@ public class SNPGuestWorker implements AttestationWorker {
                 // Ensure the nonce is present in the report
                 sequenceFinder.setSequence(report.getRandomNonce());
                 if (sequenceFinder.search(report.getReport()) == -1) {
-                    LOGGER.error("The report does not contain the expected random nonce");
+                    appendError("The report does not contain the expected random nonce");
                     return false;
+                }
+                else {
+                    appendSuccess("The report contains the expected random nonce");
                 }
 
                 // Reference to the paths snpguest needs to work with
@@ -96,30 +107,36 @@ public class SNPGuestWorker implements AttestationWorker {
                 // Download the VCEK for this cpu model
                 ProcessOutput processOutput = snpGuest.fetchVCEK(report.getCpuGeneration(), certsPath, reportPath);
                 if (processOutput.getExitCode() != 0 || !workingDir.isVCEKAvailable()) {
-                    LOGGER.error("Unable to retrieve VCEK file. SNPGuest return {}", processOutput.getExitCode());
+                    appendError("Unable to retrieve VCEK file", processOutput);
                     return false;
+                }
+                else {
+                    appendSuccess("VCEK fetched successfully", processOutput);
                 }
 
                 // Verify the certificates
                 processOutput = snpGuest.verifyCertificates(certsPath);
                 if (processOutput.getExitCode() != 0) {
-                    LOGGER.error("Unable to verify the validity of the certificates. SNPGuest return {}",
-                        processOutput.getExitCode());
+                    appendError("Unable to verify the validity of the certificates", processOutput);
                     return false;
+                }
+                else {
+                    appendSuccess("Certification chain validated successfully", processOutput);
                 }
 
                 // Verify the actual attestation report
                 processOutput = snpGuest.verifyAttestation(certsPath, reportPath);
                 if (processOutput.getExitCode() != 0) {
-                    LOGGER.error("Unable to verify the attestation report. SNPGuest return {}",
-                        processOutput.getExitCode());
+                    appendError("Unable to verify the attestation report", processOutput);
                     return false;
+                }
+                else {
+                    appendSuccess("Attestation report correctly verified", processOutput);
                 }
 
                 processOutput = snpGuest.displayReport(reportPath);
                 if (processOutput.getExitCode() != 0) {
-                    LOGGER.error("Unable to get the attestation report in human readable format. SNPGuest return {}",
-                        processOutput.getExitCode());
+                    appendError("Unable to get the attestation report in human readable format", processOutput);
                     return false;
                 }
 
@@ -129,9 +146,82 @@ public class SNPGuestWorker implements AttestationWorker {
             return true;
         }
         catch (Exception ex) {
-            LOGGER.error("Unable to process attestation result {}", result.getId(), ex);
+            String exceptionMessage = Optional.ofNullable(ex.getMessage()).orElse(ex.getClass().getName());
+            appendError("Unable to process attestation result: " + exceptionMessage, ex);
+        }
+        finally {
+            result.setProcessOutput(outputBuilder.toString());
         }
 
         return false;
+    }
+
+    private void appendError(String message) {
+        appendOutput(message, null);
+        LOGGER.error(message);
+    }
+
+    private void appendError(String message, ProcessOutput processOutput) {
+        appendOutput(message, processOutput);
+        LOGGER.error(message);
+    }
+
+    private void appendError(String message, Exception ex) {
+        appendOutput(message, null);
+        LOGGER.error(message, ex);
+    }
+
+    private void appendSuccess(String message) {
+        appendOutput(message, null);
+    }
+    private void appendSuccess(String message, ProcessOutput output) {
+        appendOutput(message, output);
+    }
+
+    private void appendOutput(String message, ProcessOutput processOutput) {
+        outputBuilder.append("- ").append(message);
+
+        String processDetails = getProcessOutputDetails(processOutput);
+        if (!processDetails.isEmpty()) {
+            outputBuilder.append(":")
+                .append(System.lineSeparator())
+                .append(processDetails);
+        }
+        else {
+            outputBuilder.append(System.lineSeparator());
+        }
+    }
+
+    private static String getProcessOutputDetails(ProcessOutput processOutput) {
+        if (processOutput == null) {
+            return "";
+        }
+
+        StringBuilder processBuilder = new StringBuilder();
+        if (processOutput.getExitCode() != 0) {
+            processBuilder.append(" ".repeat(INDENT_SIZE)).append("- Exit code: ")
+                .append(processOutput.getExitCode())
+                .append(System.lineSeparator());
+        }
+
+        if (processOutput.hasStandardOutput()) {
+            processBuilder.append(" ".repeat(INDENT_SIZE)).append("- Standard output: >")
+                .append(System.lineSeparator());
+            processOutput.getStandardOutput().lines()
+                .forEach(line -> {
+                    processBuilder.append(" ".repeat(INDENT_SIZE * 2)).append(line).append(System.lineSeparator());
+                });
+        }
+
+        if (processOutput.hasStandardError()) {
+            processBuilder.append(" ".repeat(INDENT_SIZE)).append("- Standard error: >")
+                .append(System.lineSeparator());
+            processOutput.getStandardError().lines()
+                .forEach(line -> {
+                    processBuilder.append(" ".repeat(INDENT_SIZE * 2)).append(line).append(System.lineSeparator());
+                });
+        }
+
+        return processBuilder.toString();
     }
 }

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/ProcessOutput.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/ProcessOutput.java
@@ -53,8 +53,24 @@ public class ProcessOutput {
         return exitCode;
     }
 
+    /**
+     * Check if this process output has a non-empty standard output
+     * @return true if the standard output is not null and not blank
+     */
+    public boolean hasStandardOutput() {
+        return standardOutput != null && !standardOutput.isBlank();
+    }
+
     public String getStandardOutput() {
         return standardOutput;
+    }
+
+    /**
+     * Check if this process output has a non-empty standard error
+     * @return true if the standard error is not null and not blank
+     */
+    public boolean hasStandardError() {
+        return standardError != null && !standardError.isBlank();
     }
 
     public String getStandardError() {

--- a/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationResult.java
+++ b/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationResult.java
@@ -29,6 +29,7 @@ public class AttestationResult {
     private AttestationStatus status;
     private String description;
     private String details;
+    private String processOutput;
     private OffsetDateTime attested;
 
     public long getId() {
@@ -79,6 +80,14 @@ public class AttestationResult {
         this.details = detailsIn;
     }
 
+    public String getProcessOutput() {
+        return processOutput;
+    }
+
+    public void setProcessOutput(String processOutputIn) {
+        this.processOutput = processOutputIn;
+    }
+
     public OffsetDateTime getAttested() {
         return attested;
     }
@@ -112,7 +121,6 @@ public class AttestationResult {
             .add("resultType=" + resultType)
             .add("status='" + status + "'")
             .add("description='" + description + "'")
-            .add("details='" + details + "'")
             .add("attested=" + attested)
             .toString();
     }

--- a/schema/spacewalk/common/tables/suseCoCoAttestationResult.sql
+++ b/schema/spacewalk/common/tables/suseCoCoAttestationResult.sql
@@ -11,19 +11,20 @@
 
 CREATE TABLE suseCoCoAttestationResult
 (
-        id          NUMERIC NOT NULL
-                      CONSTRAINT suse_cocoatt_res_id_pk PRIMARY KEY,
-        report_id   NUMERIC NOT NULL
-                      CONSTRAINT suse_cocoatt_res_rid_fk
-                        REFERENCES suseServerCoCoAttestationReport (id)
-                        ON DELETE CASCADE,
-        result_type NUMERIC     NOT NULL,
-        status      VARCHAR(32) NOT NULL
-                      CONSTRAINT suse_cocoatt_res_st_ck
-                        CHECK(status IN ('PENDING', 'SUCCEEDED', 'FAILED')),
-        description VARCHAR(256) NOT NULL,
-        details     TEXT NULL,
-        attested    TIMESTAMPTZ NULL
+        id              NUMERIC NOT NULL
+                          CONSTRAINT suse_cocoatt_res_id_pk PRIMARY KEY,
+        report_id       NUMERIC NOT NULL
+                          CONSTRAINT suse_cocoatt_res_rid_fk
+                            REFERENCES suseServerCoCoAttestationReport (id)
+                            ON DELETE CASCADE,
+        result_type     NUMERIC     NOT NULL,
+        status          VARCHAR(32) NOT NULL
+                          CONSTRAINT suse_cocoatt_res_st_ck
+                            CHECK(status IN ('PENDING', 'SUCCEEDED', 'FAILED')),
+        description     VARCHAR(256) NOT NULL,
+        details         TEXT NULL,
+        process_output  TEXT NULL,
+        attested        TIMESTAMPTZ NULL
 );
 
 CREATE SEQUENCE suse_cocoatt_res_id_seq;

--- a/schema/spacewalk/susemanager-schema.changes.mackdk.coco-attestation-add-full-logs
+++ b/schema/spacewalk/susemanager-schema.changes.mackdk.coco-attestation-add-full-logs
@@ -1,0 +1,1 @@
+- Added column to store the process output of the attestation

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.6-to-susemanager-schema-5.0.7/002-coco-add-process-output.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.6-to-susemanager-schema-5.0.7/002-coco-add-process-output.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+ALTER TABLE susecocoattestationresult
+    ADD COLUMN IF NOT EXISTS process_output  TEXT NULL;

--- a/web/html/src/components/coco-attestation/CoCoReport.tsx
+++ b/web/html/src/components/coco-attestation/CoCoReport.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
 import { ActionLink, SystemLink } from "../links";
-import { BootstrapPanel } from "../panels/BootstrapPanel";
 import { TabContainer } from "../tab-container";
 import CoCoResult from "./CoCoResult";
 import { AttestationReport, renderStatus, renderTime } from "./Utils";
@@ -34,54 +33,78 @@ class CoCoReport extends React.Component<Props, State> {
     const report: AttestationReport = this.props.report;
 
     const overview = (
-      <BootstrapPanel key="overview">
-        <div className="table-responsive">
-          <table className="table">
-            <tbody>
-              <tr>
-                <td>{t("Status:")}</td>
-                <td>{report.statusDescription}</td>
-              </tr>
-              <tr>
-                <td>{t("System")}:</td>
-                <td>
-                  <SystemLink id={report.systemId}>{report.systemName}</SystemLink> ({report.systemId})
-                </td>
-              </tr>
-              <tr>
-                <td>{t("Environment Type")}:</td>
-                <td>{report.environmentTypeDescription}</td>
-              </tr>
-              <tr>
-                <td>{t("Created on")}:</td>
-                <td>{renderTime(report.creationTime)}</td>
-              </tr>
-              <tr>
-                <td>{t("Last modified on")}:</td>
-                <td>{renderTime(report.modificationTime)}</td>
-              </tr>
-              {report.actionId && (
-                <tr>
-                  <td>{t("Action")}:</td>
-                  <td>
-                    <ActionLink id={report.actionId}>
-                      {report.actionScheduledBy
-                        ? t("{actionName} scheduled by {actionScheduledBy}", report)
-                        : report.actionName}
-                    </ActionLink>
-                  </td>
-                </tr>
-              )}
-              {report.status === "SUCCEEDED" && (
-                <tr>
-                  <td>{t("Attested on")}:</td>
-                  <td>{renderTime(report.attestationTime)}</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </BootstrapPanel>
+      <div className="panel panel-default" key="overview">
+        <ul className="list-group">
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("Status:")}</strong>
+              </div>
+              <div className="col-md-10">{report.statusDescription}</div>
+            </div>
+          </li>
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("System")}:</strong>
+              </div>
+              <div className="col-md-10">
+                <SystemLink id={report.systemId}>{report.systemName}</SystemLink> ({report.systemId})
+              </div>
+            </div>
+          </li>
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("Environment Type")}:</strong>
+              </div>
+              <div className="col-md-10">{report.environmentTypeDescription}</div>
+            </div>
+          </li>
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("Created on")}:</strong>
+              </div>
+              <div className="col-md-10">{renderTime(report.creationTime)}</div>
+            </div>
+          </li>
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("Last modified on")}:</strong>
+              </div>
+              <div className="col-md-10">{renderTime(report.modificationTime)}</div>
+            </div>
+          </li>
+          {report.actionId && (
+            <li className="list-group-item">
+              <div className="row">
+                <div className="col-md-2">
+                  <strong>{t("Action")}:</strong>
+                </div>
+                <div className="col-md-10">
+                  <ActionLink id={report.actionId}>
+                    {report.actionScheduledBy
+                      ? t("{actionName} scheduled by {actionScheduledBy}", report)
+                      : report.actionName}
+                  </ActionLink>
+                </div>
+              </div>
+            </li>
+          )}
+          {report.status === "SUCCEEDED" && (
+            <li className="list-group-item">
+              <div className="row">
+                <div className="col-md-2">
+                  <strong>{t("Attested on")}:</strong>
+                </div>
+                <div className="col-md-10">{renderTime(report.attestationTime)}</div>
+              </div>
+            </li>
+          )}
+        </ul>
+      </div>
     );
 
     const labels = report.results.map((result) => (

--- a/web/html/src/components/coco-attestation/CoCoResult.tsx
+++ b/web/html/src/components/coco-attestation/CoCoResult.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
 
-import { BootstrapPanel } from "components/panels/BootstrapPanel";
-
 import { AttestationResult, renderTime } from "./Utils";
 
 type Props = {
@@ -13,52 +11,68 @@ class CoCoResult extends React.Component<Props> {
   render = () => {
     const result = this.props.result;
     return (
-      <BootstrapPanel key={result.id}>
-        <div className="table-responsive">
-          <table className="table">
-            <tbody>
-              <tr>
-                <td>{t("Result Type:")}</td>
-                <td>{result.resultTypeLabel}</td>
-              </tr>
-              <tr>
-                <td>{t("Description:")}</td>
-                <td>{result.description}</td>
-              </tr>
-              <tr>
-                <td>{t("Status:")}</td>
-                <td>{result.statusDescription}</td>
-              </tr>
-              {result.status === "SUCCEEDED" && (
-                <tr>
-                  <td>{t("Attested on")}:</td>
-                  <td>{renderTime(result.attestationTime)}</td>
-                </tr>
-              )}
-              {result.details && (
-                <tr>
-                  <td>{t("Details")}:</td>
-                  <td>
-                    <div className="row">
-                      <pre>{result.details}</pre>
-                    </div>
-                  </td>
-                </tr>
-              )}
-              {result.processOutput && (
-                <tr>
-                  <td>{t("Process Output")}:</td>
-                  <td>
-                    <div className="row">
-                      <pre>{result.processOutput}</pre>
-                    </div>
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </BootstrapPanel>
+      <div className="panel panel-default" key={result.id}>
+        <ul className="list-group">
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("Result Type:")}</strong>
+              </div>
+              <div className="col-md-10">{result.resultTypeLabel}</div>
+            </div>
+          </li>
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("Description:")}</strong>
+              </div>
+              <div className="col-md-10">{result.description}</div>
+            </div>
+          </li>
+          <li className="list-group-item">
+            <div className="row">
+              <div className="col-md-2">
+                <strong>{t("Status:")}</strong>
+              </div>
+              <div className="col-md-10">{result.statusDescription}</div>
+            </div>
+          </li>
+          {result.status === "SUCCEEDED" && (
+            <li className="list-group-item">
+              <div className="row">
+                <div className="col-md-2">
+                  <strong>{t("Attested on:")}</strong>
+                </div>
+                <div className="col-md-10">{renderTime(result.attestationTime)}</div>
+              </div>
+            </li>
+          )}
+          {result.details && (
+            <li className="list-group-item">
+              <div className="row">
+                <div className="col-md-2">
+                  <strong>{t("Details")}:</strong>
+                </div>
+                <div className="col-md-10">
+                  <pre>{result.details}</pre>
+                </div>
+              </div>
+            </li>
+          )}
+          {result.processOutput && (
+            <li className="list-group-item">
+              <div className="row">
+                <div className="col-md-2">
+                  <strong>{t("Process Output")}:</strong>
+                </div>
+                <div className="col-md-10">
+                  <pre>{result.processOutput}</pre>
+                </div>
+              </div>
+            </li>
+          )}
+        </ul>
+      </div>
     );
   };
 }

--- a/web/html/src/components/coco-attestation/CoCoResult.tsx
+++ b/web/html/src/components/coco-attestation/CoCoResult.tsx
@@ -35,18 +35,26 @@ class CoCoResult extends React.Component<Props> {
                   <td>{renderTime(result.attestationTime)}</td>
                 </tr>
               )}
-              <tr>
-                <td>{t("Details")}:</td>
-                <td>
-                  {result.details && result.details.trim().length > 0 ? (
+              {result.details && (
+                <tr>
+                  <td>{t("Details")}:</td>
+                  <td>
                     <div className="row">
                       <pre>{result.details}</pre>
                     </div>
-                  ) : (
-                    t("N/A")
-                  )}
-                </td>
-              </tr>
+                  </td>
+                </tr>
+              )}
+              {result.processOutput && (
+                <tr>
+                  <td>{t("Process Output")}:</td>
+                  <td>
+                    <div className="row">
+                      <pre>{result.processOutput}</pre>
+                    </div>
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>

--- a/web/html/src/components/coco-attestation/Utils.tsx
+++ b/web/html/src/components/coco-attestation/Utils.tsx
@@ -22,6 +22,7 @@ export type AttestationResult = {
   statusDescription: string;
   description: string;
   details: string;
+  processOutput: string;
   attestationTime: Date;
 };
 

--- a/web/spacewalk-web.changes.mackdk.coco-attestation-add-full-logs
+++ b/web/spacewalk-web.changes.mackdk.coco-attestation-add-full-logs
@@ -1,0 +1,1 @@
+- Display the attestation process output if available


### PR DESCRIPTION
## What does this PR change?

This PR adds a new field in the attestation result to allow the attestation module to store the full processing output. This could help to diagnose any issue during the attestation and inspect the full execution.

## GUI diff

After:

- In case of attestation failed:
![image](https://github.com/uyuni-project/uyuni/assets/2292684/84c22b9f-2ff6-42da-844a-b3970d9a70d8)
- In case of attestation succeeded:
![image](https://github.com/uyuni-project/uyuni/assets/2292684/eca972de-e526-4059-86bd-ea817b2c33e9)
- When not used:
![image](https://github.com/uyuni-project/uyuni/assets/2292684/4b6f9896-f8b0-444e-9324-8bc338a4c13f)

- [X] **DONE**

## Documentation
- Documentation WIP
- [ ] **DONE**

## Test coverage
- Unit tests were updated

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
