### PR TITLE
Fix schema migration for 'rhnChannelNewestPackageView'

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-1.7.56.13-to-susemanager-schema-1.7.56.18/01_123-rhnChannelNewestPackageView.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-1.7.56.13-to-susemanager-schema-1.7.56.18/01_123-rhnChannelNewestPackageView.sql
@@ -17,9 +17,8 @@
 --
 -- this is much more readable with ts=4, enjoy!
 
-create or replace view
-rhnChannelNewestPackageView
-as
+DROP VIEW IF EXISTS rhnChannelNewestPackageView;
+CREATE VIEW rhnChannelNewestPackageView AS
 SELECT channel_id,
        name_id,
        evr_id,

--- a/schema/spacewalk/upgrade/susemanager-schema-1.7.56.20-to-susemanager-schema-1.7.57/00_015-evr_t-max-replace.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-1.7.56.20-to-susemanager-schema-1.7.57/00_015-evr_t-max-replace.sql
@@ -12,9 +12,8 @@ rhnServerNeededView
 AS
 select 1.0, 1.0, 1.0, 1.0, 1.0, 1.0 from dual;
 
-create or replace view
-rhnChannelNewestPackageView
-as
+DROP VIEW IF EXISTS rhnChannelNewestPackageView;
+CREATE VIEW rhnChannelNewestPackageView AS
 SELECT 1.0 as channel_id,
        1.0 as name_id,
        1.0 as evr_id,

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/015-ignore-retracted-pkgs-in-newest-pkgs-view.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/015-ignore-retracted-pkgs-in-newest-pkgs-view.sql
@@ -9,9 +9,8 @@
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
 
-create or replace view
-rhnChannelNewestPackageView
-as
+DROP VIEW IF EXISTS rhnChannelNewestPackageView;
+CREATE VIEW rhnChannelNewestPackageView AS
 SELECT channel_id,
        name_id,
        evr_id,

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.17-to-susemanager-schema-4.3.18/000-ptf-package-visibility.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.17-to-susemanager-schema-4.3.18/000-ptf-package-visibility.sql
@@ -13,9 +13,8 @@ CREATE OR REPLACE VIEW susePackageExcludingPartOfPtf AS
 ;
 
 -- Update the view for the newest package to exclude packages part of a PTF
-create or replace view
-rhnChannelNewestPackageView
-as
+DROP VIEW IF EXISTS rhnChannelNewestPackageView;
+CREATE VIEW rhnChannelNewestPackageView AS
 SELECT channel_id,
        name_id,
        evr_id,

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-rhnChannelNewestPackageView-fix-duplicates.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-rhnChannelNewestPackageView-fix-duplicates.sql
@@ -1,6 +1,5 @@
-create or replace view
-rhnChannelNewestPackageView
-as
+DROP VIEW IF EXISTS rhnChannelNewestPackageView;
+CREATE VIEW rhnChannelNewestPackageView AS
 SELECT channel_id,
        name_id,
        evr_id,

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/400-ptf-package-visibility.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.3-to-susemanager-schema-4.4.4/400-ptf-package-visibility.sql
@@ -13,9 +13,8 @@ CREATE OR REPLACE VIEW susePackageExcludingPartOfPtf AS
 ;
 
 -- Update the view for the newest package to exclude packages part of a PTF
-create or replace view
-rhnChannelNewestPackageView
-as
+DROP VIEW IF EXISTS rhnChannelNewestPackageView;
+CREATE VIEW rhnChannelNewestPackageView AS
 SELECT channel_id,
        name_id,
        evr_id,


### PR DESCRIPTION
postgresql doesn't allow removing columns when replacing views. This PR modifies the older migration scripts for `rhnChannelNewestPackageView` to use `DROP/CREATE VIEW` statements instead of `REPLACE VIEW`.

## GUI diff

No difference.


## Documentation
- No documentation needed: Schema bugfix

## Test coverage
- No tests: already covered

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
