### PR TITLE
Add execution permissions on healthcheck.sh

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -12,6 +12,7 @@ ARG EXTRAPACKAGES
 COPY timezone_alignment.sh /usr/bin
 
 COPY healthcheck.sh /usr/bin
+RUN chmod a+x /usr/bin/healthcheck.sh
 
 # Copy timezone link update service
 COPY timezone_alignment.service /usr/lib/systemd/system/

--- a/containers/server-image/server-image.changes.cbosdo.master
+++ b/containers/server-image/server-image.changes.cbosdo.master
@@ -1,0 +1,1 @@
+- Add execution permissions on healthcheck.sh (bsc#1223379)


### PR DESCRIPTION
## What does this PR change?

It seems the PUT command in Dockerfile strips the file permissions, enforcing the execution flag using a RUN command to be on the safe side.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24188
Port(s): # **add downstream PR(s), if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
