### PR TITLE
change java 17 syntax back to java 11 for uyuni bare installation

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/gson/SystemScheduledRequestJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/SystemScheduledRequestJson.java
@@ -39,9 +39,11 @@ public class SystemScheduledRequestJson extends ScheduledRequestJson {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof SystemScheduledRequestJson that)) {
+        if (!(o instanceof SystemScheduledRequestJson)) {
             return false;
         }
+        SystemScheduledRequestJson that = (SystemScheduledRequestJson) o;
+
         return Objects.equals(serverIds, that.serverIds) &&
             Objects.equals(getEarliest(), that.getEarliest()) &&
             Objects.equals(getActionChain(), that.getActionChain());

--- a/java/code/src/com/suse/manager/webui/utils/gson/SystemsCoCoSettingsJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/SystemsCoCoSettingsJson.java
@@ -48,9 +48,11 @@ public class SystemsCoCoSettingsJson extends CoCoSettingsJson {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof SystemsCoCoSettingsJson that)) {
+        if (!(o instanceof SystemsCoCoSettingsJson)) {
             return false;
         }
+        SystemsCoCoSettingsJson that = (SystemsCoCoSettingsJson) o;
+
         if (!super.equals(o)) {
             return false;
         }


### PR DESCRIPTION
## What does this PR change?

Uyuni bare installation will still run a few month with java 11.
So we need to stay with that syntax for a short while.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24192

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
