### PR TITLE
Fix attestation image HEALTHCHECK

### DIFF
--- a/containers/server-attestation-image/Dockerfile
+++ b/containers/server-attestation-image/Dockerfile
@@ -33,6 +33,6 @@ LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-attestation:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
 
-HEALTHCHECK --interval=5s --timeout=5s --retries=5 CMD ["ps -xa | grep -v grep | grep /usr/sbin/coco-attestation"]
+HEALTHCHECK --interval=5m --timeout=5s --retries=1 CMD ["pgrep -f /usr/sbin/coco-attestation"]
 
 CMD ["/usr/sbin/coco-attestation"]

--- a/containers/server-attestation-image/server-attestation-image.changes.mackdk.fix-attestation-image-healthcheck
+++ b/containers/server-attestation-image/server-attestation-image.changes.mackdk.fix-attestation-image-healthcheck
@@ -1,0 +1,1 @@
+- Fixed issue with HEALTHCHECK command


### PR DESCRIPTION
## What does this PR change?

This PR fixes the command used for the health check of  the attestation container to make sure the status is correctly reported as `healthy`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: no code changes

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
