### PR TITLE
Fixed wrong quotes in healthcheck command

### DIFF
--- a/containers/server-attestation-image/Dockerfile
+++ b/containers/server-attestation-image/Dockerfile
@@ -33,6 +33,6 @@ LABEL org.openbuildservice.disturl="%DISTURL%"
 LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-attestation:${PRODUCT_VERSION}.%RELEASE%"
 # endlabelprefix
 
-HEALTHCHECK --interval=5m --timeout=5s --retries=1 CMD ["pgrep -f /usr/sbin/coco-attestation"]
+HEALTHCHECK --interval=5m --timeout=5s --retries=1 CMD ["pgrep", "-f", "/usr/sbin/coco-attestation"]
 
 CMD ["/usr/sbin/coco-attestation"]


### PR DESCRIPTION
## What does this PR change?

Follow-uip to https://github.com/uyuni-project/uyuni/pull/8669, fixing the wrong format of the quotes for the command

## GUI diff

 No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: no code changes
- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
