### PR TITLE
Avoid sending empty events to the master with reboot_info beacon

### DIFF
--- a/susemanager-utils/susemanager-sls/src/beacons/reboot_info.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/reboot_info.py
@@ -4,6 +4,12 @@ Watch system status and fire an event to SUSE Manager indicating
 when a reboot is required.
 """
 
+import logging
+
+
+log = logging.getLogger(__name__)
+
+
 __virtualname__ = "reboot_info"
 
 
@@ -45,7 +51,18 @@ def beacon(config):
     ret = []
 
     # pylint: disable-next=undefined-variable
-    result = __salt__["reboot_info.reboot_required"]()
+    try:
+        result = __salt__["reboot_info.reboot_required"]()
+    except KeyError:
+        # reboot_info salt module could be not yet in synchronized
+        return ret
+    except Exception as e:  # pylint: disable=broad-except
+        log.error(
+            "Error while executing 'reboot_info.reboot_required': %s",
+            e,
+            exc_info=True,
+        )
+        return ret
     reboot_needed = result.get("reboot_required", False)
 
     # pylint: disable-next=undefined-variable

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-reboot_info-beacon
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-reboot_info-beacon
@@ -1,0 +1,1 @@
+- Avoid sending empty events with reboot_info beacon


### PR DESCRIPTION
## What does this PR change?

Avoid sending empty events to the master in case if reboot_info salt module is not yet synchronized

## GUI diff

No difference.
## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: too complex to test it properly

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/23526


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
