### PR TITLE
Bump the WebUI to 5.0.0 RC for SUSE Manager and to Uyuni 2024.05 for Uyuni

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -58,12 +58,12 @@ web.config_delim_start = {|
 web.config_delim_end = |}
 
 # the version of SUSE Manager to show at the WebUI
-web.version = 5.0.0 Beta2
+web.version = 5.0.0 RC
 
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni = 2024.03
+web.version.uyuni = 2024.05
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 


### PR DESCRIPTION
## What does this PR change?

- Bump the WebUI to 5.0.0 RC for SUSE Manager and to Uyuni 2024.05 for Uyuni
- Please also note that the migrations schemas for the reportdb and susemanager-schema are available. no need of additional gitkeep

## GUI diff

Before: `5.0.0 Beta 2` for SUSE Manager and `2024.03` for Uyuni

After: `5.0.0 RC` for SUSE Manager and `2024.05` for Uyuni

- [x] **DONE**

## Documentation
- No documentation needed: this is just the string on the WebUI

- [x] **DONE**

## Test coverage
- No tests: no new tests needed

- [x] **DONE**

## Links

Relate(s): https://github.com/SUSE/spacewalk/issues/23744 and https://github.com/SUSE/spacewalk/issues/23742

- [x] **DONE**

## Changelogs

We have already other changes for spacewalk-web. No need to confuse the users with a changelog that mentions both Uyuni 2024.05 and SUSE Manager 5.0

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
