### PR TITLE
Reenable the dark sidebar version

### DIFF
--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -384,7 +384,7 @@ nav.navbar-pf {
       border-width: 0 0 1px 0;
       padding-right: 3em;
       height: 3em;
-      color: @aside-search-text-color;
+      color: @aside-search-text-color !important;
 
       &::placeholder {
         color: rgba(@aside-search-text-color, 0.75);

--- a/web/html/src/branding/css/base/theme.scss
+++ b/web/html/src/branding/css/base/theme.scss
@@ -381,7 +381,7 @@ nav.navbar-pf {
       border-width: 0 0 1px 0;
       padding-right: 3em;
       height: 3em;
-      color: $aside-search-text-color;
+      color: $aside-search-text-color !important;
 
       &::placeholder {
         color: rgba($aside-search-text-color, 0.75);

--- a/web/html/src/branding/css/susemanager-dark-variables.less
+++ b/web/html/src/branding/css/susemanager-dark-variables.less
@@ -1,0 +1,8 @@
+@import "susemanager-light-variables.less";
+
+@aside-background: @eos-bc-pine-500;
+@aside-menu-text: @eos-bc-white;
+@aside-search-text-color: @eos-bc-white;
+@aside-footer-text: @eos-bc-white;
+@aside-footer-border: @eos-bc-dt-gray-700;
+@aside-search-border: @eos-bc-dt-gray-700;

--- a/web/html/src/branding/css/susemanager-dark-variables.scss
+++ b/web/html/src/branding/css/susemanager-dark-variables.scss
@@ -1,0 +1,8 @@
+@import "./susemanager-light-variables.scss";
+
+$aside-background: $eos-bc-pine-500;
+$aside-menu-text: $eos-bc-white;
+$aside-search-text-color: $eos-bc-white;
+$aside-footer-text: $eos-bc-white;
+$aside-footer-border: $eos-bc-dt-gray-700;
+$aside-search-border: $eos-bc-dt-gray-700;

--- a/web/html/src/branding/css/susemanager-dark.less
+++ b/web/html/src/branding/css/susemanager-dark.less
@@ -1,0 +1,25 @@
+@theme: "susemanager-dark";
+
+@import "./body.less";
+@import "./susemanager/fonts.less";
+
+.old-theme {
+  @import url(bootstrap/less/bootstrap.less);
+
+  @import "clearfix.less";
+  @import "mixins.less";
+  @import "susemanager/variables.less";
+  @import "susemanager-dark-variables.less";
+
+  display: flex;
+  flex-direction: column;
+  background: @body-background;
+  font-family: @body-font;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-size: @font-size-base;
+  line-height: 1.5;
+  color: @body-color;
+
+  @import "susemanager/index.less";
+}

--- a/web/html/src/branding/css/susemanager-dark.scss
+++ b/web/html/src/branding/css/susemanager-dark.scss
@@ -1,0 +1,26 @@
+$theme: "susemanager-dark";
+
+@import "./body.scss";
+@import "./fonts.scss";
+
+@import "./bootstrap5-scaffolding-variables.scss";
+
+.new-theme {
+  @import "bootstrap5/scss/bootstrap";
+
+  @import "./mixins.scss";
+  @import "./susemanager/variables.scss";
+  @import "./susemanager-dark-variables.scss";
+
+  display: flex;
+  flex-direction: column;
+  background: $body-background;
+  font-family: $body-font;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-size: $font-size-base;
+  line-height: 1.5;
+  color: $body-color;
+
+  @import "./susemanager/index.scss";  
+}

--- a/web/html/src/branding/css/susemanager/variables.less
+++ b/web/html/src/branding/css/susemanager/variables.less
@@ -6,6 +6,7 @@
 @eos-bc-green-100: #e4f6ee;
 @eos-bc-green-500: #30ba78;
 @eos-bc-green-900: #0e7e3c;
+// TODO: This name should be -1000 or similar
 @eos-bc-pine-500: #0c322c;
 @eos-bc-cerulean-100: #b3e8f6;
 @eos-bc-cerulean-500: #00b2e2;
@@ -15,6 +16,7 @@
 @eos-bc-red-900: #c5161f;
 @eos-bc-yellow-100: #ffecb5;
 @eos-bc-yellow-500: #ffc107;
+@eos-bc-yellow-600: #cc7e00;
 @eos-bc-yellow-900: #ff9e02;
 @eos-bc-blue-500: #2453ff;
 @eos-bc-persimmon-500: #fe7c3f;
@@ -26,10 +28,13 @@
 @eos-bc-gray-900: #686565;
 @eos-bc-gray-1000: #141823;
 @eos-bc-white: #fff;
+@eos-bc-dt-gray-700: #57595f;
+// TODO: These names are wrong, they should probably be -900 and -1000
 @eos-bc-dt-gray-100: #2b2e38;
 @eos-bc-dt-gray-200: #1f222b;
 
 @uyuni-blue-900: #0d2c40;
+// TODO: This name should be -800 or -700
 @uyuni-blue-100: #314c5d;
 @uyuni-gray-100: #dcddde;
 @uyuni-gray-300: #cccccc;

--- a/web/html/src/branding/css/susemanager/variables.scss
+++ b/web/html/src/branding/css/susemanager/variables.scss
@@ -6,6 +6,7 @@
 $eos-bc-green-100: #e4f6ee;
 $eos-bc-green-500: #30ba78;
 $eos-bc-green-900: #0e7e3c;
+// TODO: This name should be -1000 or similar
 $eos-bc-pine-500: #0c322c;
 $eos-bc-cerulean-100: #b3e8f6;
 $eos-bc-cerulean-500: #00b2e2;
@@ -27,10 +28,13 @@ $eos-bc-gray-700: #757575;
 $eos-bc-gray-900: #686565;
 $eos-bc-gray-1000: #141823;
 $eos-bc-white: #fff;
+$eos-bc-dt-gray-700: #57595f;
+// TODO: These names are wrong, they should probably be -900 and -1000
 $eos-bc-dt-gray-100: #2b2e38;
 $eos-bc-dt-gray-200: #1f222b;
 
 $uyuni-blue-900: #0d2c40;
+// TODO: This name should be -800 or -700
 $uyuni-blue-100: #314c5d;
 $uyuni-gray-100: #dcddde;
 $uyuni-gray-300: #cccccc;

--- a/web/html/src/build/webpack.config.js
+++ b/web/html/src/build/webpack.config.js
@@ -105,11 +105,10 @@ module.exports = (env, argv) => {
       "javascript/manager/main": "./manager/index.ts",
       "css/uyuni": path.resolve(__dirname, "../branding/css/uyuni.less"),
       "css/susemanager-fullscreen": path.resolve(__dirname, "../branding/css/susemanager-fullscreen.less"),
-      // TODO: We're removing the dark theme for now
-      "css/susemanager-dark": path.resolve(__dirname, "../branding/css/susemanager-light.less"),
       "css/susemanager-light": path.resolve(__dirname, "../branding/css/susemanager-light.less"),
+      "css/susemanager-dark": path.resolve(__dirname, "../branding/css/susemanager-dark.less"),
       "css/updated-susemanager-light": path.resolve(__dirname, "../branding/css/susemanager-light.scss"),
-      "css/updated-susemanager-dark": path.resolve(__dirname, "../branding/css/susemanager-light.scss"),
+      "css/updated-susemanager-dark": path.resolve(__dirname, "../branding/css/susemanager-dark.scss"),
       "css/updated-uyuni": path.resolve(__dirname, "../branding/css/uyuni.scss"),
     },
     output: {

--- a/web/spacewalk-web.changes.eth.dark-theme
+++ b/web/spacewalk-web.changes.eth.dark-theme
@@ -1,0 +1,1 @@
+- Fix dark sidebar color scheme


### PR DESCRIPTION
## What does this PR change?

We initially piped both the light and dark sidebar theme into one file to make the core theme migration easier, now both work and I've reintegrated it.

## GUI diff

<img width="2048" alt="Screenshot 2024-05-01 at 19 35 26" src="https://github.com/uyuni-project/uyuni/assets/3171718/48ee98b6-f39e-4b91-b698-25e1ee2df014">

<img width="2048" alt="Screenshot 2024-05-01 at 19 35 40" src="https://github.com/uyuni-project/uyuni/assets/3171718/e6f1e5b0-f07d-41a1-8213-07618f373351">


- [x] **DONE**

## Documentation
- Docs ticket already exists

- [x] **DONE**

## Test coverage
- No tests: theme

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/18940

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
