### PR TITLE
Remove dangling bits in autoinstallation cancel

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartFactory.java
@@ -997,10 +997,7 @@ public class KickstartFactory extends HibernateFactory {
             List<KickstartSession> ksSessions = kickstartSessionQuery.list();
             for (KickstartSession ks : ksSessions) {
                 log.debug("Failing kickstart associated with action: {}", ks.getId());
-                ks.setState(failed);
-                ks.setAction(null);
-
-                setKickstartSessionHistoryMessage(ks, failed, KICKSTART_CANCELLED_MESSAGE);
+                ks.markFailed(KICKSTART_CANCELLED_MESSAGE);
             }
         }
     }

--- a/java/code/src/com/redhat/rhn/manager/system/CancelKickstartSessionOperation.java
+++ b/java/code/src/com/redhat/rhn/manager/system/CancelKickstartSessionOperation.java
@@ -14,11 +14,22 @@
  */
 package com.redhat.rhn.manager.system;
 
+import com.redhat.rhn.common.RhnRuntimeException;
+import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.kickstart.KickstartSession;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.SystemPendingEventDto;
+import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemRemoveCommand;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * DeleteSystemFromActionOperation - deletes a system from an action
@@ -49,6 +60,23 @@ public class CancelKickstartSessionOperation
         ksession.markFailed(failedMessage);
         KickstartFactory.saveKickstartSession(ksession);
 
+        // Create and schedule a CobblerSystemRemoveCommand
+        CobblerSystemRemoveCommand cobblerRemove = new CobblerSystemRemoveCommand(user, server);
+        cobblerRemove.store();
+
+        // Remove any possible autoinstallation initiate actions from the server
+        DataResult<SystemPendingEventDto> pendingActions = SystemManager.systemPendingEvents(server.getId(), null);
+
+        String rebootName = ActionFactory.TYPE_KICKSTART_INITIATE.getName();
+        List<Action> actions = pendingActions.stream().filter(action -> action.getActionName().equals(rebootName))
+                .map(action -> ActionManager.lookupAction(user, action.getId()))
+                .collect(Collectors.toList());
+        try {
+            ActionManager.cancelActions(user, actions, List.of(server.getId()));
+        }
+        catch (TaskomaticApiException eIn) {
+            throw new RhnRuntimeException(eIn);
+        }
         return null;
     }
 

--- a/java/spacewalk-java.changes.cbosdo.ks-cancel
+++ b/java/spacewalk-java.changes.cbosdo.ks-cancel
@@ -1,0 +1,2 @@
+- Remove initiate action and cobbler system profile when
+  cancelling autoinstallion (bsc#1220259)


### PR DESCRIPTION
## What does this PR change?

When cancelling an autoinstallation, the cobbler system profile needs to be removed and the initiate action has to be canceled.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23790

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
