### PR TITLE
Increase reboot info beacon interval

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2514,6 +2514,10 @@ public class Server extends BaseDomainHelper implements Identifiable {
         return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("9");
     }
 
+    public boolean isRedHat() {
+        return ServerConstants.REDHAT.equals(getOsFamily());
+    }
+
     boolean isAlibaba2() {
         return ServerConstants.ALIBABA.equals(getOs());
     }

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -46,14 +46,13 @@ public class MinionGeneralPillarGenerator extends MinionPillarGeneratorBase {
     public static final String CATEGORY = "general";
 
     private static final int PKGSET_INTERVAL = 5;
-    private static final Integer REBOOT_INFO_INTERVAL = 10;
 
     private static final Map<String, Object> PKGSET_BEACON_PROPS = new HashMap<>();
-    private static final Map<String, Object> REBOOT_INFO_BEACON_PROPS = new HashMap<>();
+    private static final Map<String, Object> REBOOT_INFO_BEACON_PROPS = Map.of("interval", 30);
+    private static final Map<String, Object> REBOOT_INFO_BEACON_PROPS_RH = Map.of("interval", 180);
 
     static {
         PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
-        REBOOT_INFO_BEACON_PROPS.put("interval", REBOOT_INFO_INTERVAL);
     }
 
     /**
@@ -95,10 +94,10 @@ public class MinionGeneralPillarGenerator extends MinionPillarGeneratorBase {
         // this add the configuration for the beacon that tell us when the
         // minion packages are modified locally
         if (minion.getOsFamily().equalsIgnoreCase("suse") ||
-                minion.getOsFamily().equalsIgnoreCase("redhat") ||
+                minion.isRedHat() ||
                 minion.getOsFamily().equalsIgnoreCase("debian")) {
             beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
-            beaconConfig.put("reboot_info", REBOOT_INFO_BEACON_PROPS);
+            beaconConfig.put("reboot_info", minion.isRedHat() ? REBOOT_INFO_BEACON_PROPS_RH : REBOOT_INFO_BEACON_PROPS);
         }
         if (!beaconConfig.isEmpty()) {
             pillar.add("beacons", beaconConfig);

--- a/java/spacewalk-java.changes.welder.reboot-beacon-interval
+++ b/java/spacewalk-java.changes.welder.reboot-beacon-interval
@@ -1,0 +1,1 @@
+- Increase reboot info beacon interval

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.6-to-susemanager-schema-5.0.7/200-enable-pillar-refresh.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.6-to-susemanager-schema-5.0.7/200-enable-pillar-refresh.sql
@@ -1,0 +1,4 @@
+INSERT INTO rhnTaskQueue (id, org_id, task_name, task_data)
+SELECT nextval('rhn_task_queue_id_seq'), id, 'upgrade_satellite_all_systems_pillar_refresh', 0
+FROM web_customer
+WHERE id = 1;


### PR DESCRIPTION
## What does this PR change?

It modifies the reboot info beacon execution interval. It extends the interval from 10 seconds to 180 seconds for Red Hat-like systems and to 30 seconds for other systems.

The main reason for changing it is that the `dnf needs-restarting` command executed for RH-like might be too resource-intensive for the systems. Even for the other systems, checking every 10 seconds seems to be too often, so increasing to 30 seconds can be more suitable.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8457

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
