### PR TITLE
Remove unused apache exporter from server image

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -44,7 +44,6 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     virtualization-formulas \
     uyuni-config-formula \
     inter-server-sync \
-    golang-github-lusitaniae-apache_exporter \
     golang-github-prometheus-node_exporter \
     prometheus-postgres_exporter \
     golang-github-QubitProducts-exporter_exporter \

--- a/containers/server-image/server-image.changes.cbosdo.apache-exporter
+++ b/containers/server-image/server-image.changes.cbosdo.apache-exporter
@@ -1,0 +1,1 @@
+- Remove unused apache exporter from server


### PR DESCRIPTION
## What does this PR change?

See title

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: package removed from image

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24217

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
