### PR TITLE
Remove the visit message at the end of the setup

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -170,7 +170,6 @@ if ($opts{'upgrade'}) {
       wait_for_tomcat() or exit 56;
   }
   print Spacewalk::Setup::loc("Installation complete.\n");
-  print Spacewalk::Setup::loc("Visit https://%s to create the $product_name administrator account.\n", $answers{hostname});
 }
 
 exit 0;

--- a/spacewalk/setup/spacewalk-setup.changes.cbosdo.setup-message
+++ b/spacewalk/setup/spacewalk-setup.changes.cbosdo.setup-message
@@ -1,0 +1,2 @@
+- Remove the message to create the admin user in the setup as this 
+  is now done by mgradm


### PR DESCRIPTION
## What does this PR change?

This is already done by mgradm in a more visible way.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: setup message

- [X] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8671

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
