### PR TITLE
Fix transactional systems bootstrapping with preinstalled salt minion packages

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-bootstrap-for-t-u
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-bootstrap-for-t-u
@@ -1,0 +1,1 @@
+- Fix bootstrapping transactional systems if salt minion package is already installed.


### PR DESCRIPTION
## What does this PR change?

Fix transactional systems bootstrapping with preinstalled salt minion packages

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: tests are already present in cucumber and failing for some cases

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/23799

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
