### PR TITLE
Do not ignore ONTIMEOUT pxe in cobbler case

### DIFF
--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.fix_ontimeout_cobbler
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.fix_ontimeout_cobbler
@@ -1,0 +1,1 @@
+- Do not ignore ONTIMEOUT pxe in cobbler case (bsc#1223850)

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -132,9 +132,9 @@ class HttpResponseDataFilteredPXE(HttpResponseDataFiltered):
                 else:
                     if not line.startswith(
                         "ONTIMEOUT"
-                    ):  # ONTIMEOUT points to deleted entry
+                    ):  # ONTIMEOUT points to deleted entry in saltboot case
                         saltboot_content += line + "\n"
-                        cobbler_content += line + "\n"
+                    cobbler_content += line + "\n"
         if have_entry:
             self._content = saltboot_content.encode("utf-8")
         else:


### PR DESCRIPTION
## What does this PR change?

Recent addition of cobbler translations also made cobbler to ignore ONTIMEOUT syslinux entries, like saltboot does because it generates new one. This is not correct in cobbler scenario.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: covered by integration/acceptance tests

- [X] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/24249
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
