### PR TITLE
replace server urls on tftp pull

### DIFF
--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.jmozd.fix_http_in_system_profiles
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.jmozd.fix_http_in_system_profiles
@@ -1,1 +1,2 @@
 - replace central server URLs in system profiles, instead point to the proxy host
+  (bsc#1223855)

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.jmozd.fix_http_in_system_profiles
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.jmozd.fix_http_in_system_profiles
@@ -1,0 +1,1 @@
+- replace central server URLs in system profiles, instead point to the proxy host

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -212,11 +212,14 @@ class TFTPHandler(BaseHandler):
         # accept only mac based config and defaults file
         if path.startswith("pxelinux.cfg/01-"):
             # request specific system configuration
-            logging.debug(f"Got request for system PXE {path}, forwarding as is")
-            return HttpResponseData(f"{target}/tftp/{path}", capath)
+            logging.debug(f"Got request for system PXE {path}, filtering HTTP")
+            return HttpResponseDataFilteredPXE(
+                f"{target}/tftp/{path}", capath, self._proxyFqdn, self._serverFqdn
+            )
         elif path.startswith("grub/system"):
-            logging.debug(f"Got request for system GRUB {path}, forwarding as is")
-            return HttpResponseData(f"{target}/tftp/{path}", capath)
+            logging.debug(f"Got request for system GRUB {path}, filtering HTTP")
+            return HttpResponseDataFilteredGrub(
+                f"{target}/tftp/{path}", capath, self._proxyFqdn, self._serverFqdn
         elif path.startswith("pxelinux.cfg/default"):
             # server local default
             logging.debug(f"Got request for {path}, filtering HTTP")


### PR DESCRIPTION
## What does this PR change?

The tftp proxy pulls system profiles for PXE boot from the central Uyuni server, where Cobbler generates these pointing typically to the central server's host for http-fetching profiles and installable. When pointing the client to a proxy for installation, these requests should go to the proxy's host instead.
This change adds code in the containerized tftp gateway to replace the according host entries in URLs for grub (grub/system/\*) and pxelinux (pxelinux.cfg/01-\*) PXE profiles.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: unsure if the test automatism does handle the test case

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1223855

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
