### PR TITLE
Fix error when providing invalid modules on enable/disable appstream API call

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchAppStreamException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchAppStreamException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+
+public class NoSuchAppStreamException extends FaultException {
+
+    /**
+     * Constructor
+     */
+    public NoSuchAppStreamException() {
+        this("None of the provided appstreams exist on the system");
+    }
+
+    /**
+     * Constructor
+     * @param cause the cause (which is saved for later retrieval by the
+     * Throwable.getCause() method). (A null value is permitted, and indicates
+     * that the cause is nonexistent or unknown.)
+     */
+    public NoSuchAppStreamException(Throwable cause) {
+        super(-308, "noSuchAppStream", "No such appstream", cause);
+    }
+
+    /**
+     * Constructor
+     * @param message exception message
+     */
+    public NoSuchAppStreamException(String message) {
+        super(-308, "noSuchAppStream", message);
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/appstreams/AppStreamsManager.java
+++ b/java/code/src/com/redhat/rhn/manager/appstreams/AppStreamsManager.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.manager.appstreams;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.appstream.AppStreamActionDetails;
@@ -24,6 +25,7 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.action.ActionChainManager;
+import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -121,6 +123,27 @@ public class AppStreamsManager {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    /**
+     * Return a set of appstreams available on the given system
+     *
+     * @param serverId the id of the system
+     * @param user     the user
+     * @return set of appstreams
+     * @throws LookupException
+     */
+    public static Set<String> getSystemAppStreams(Long serverId, User user) throws LookupException {
+        Set<String> appStreams = new HashSet<>();
+        SystemManager.lookupByIdAndUser(serverId, user)
+                .getChannels()
+                .stream()
+                .filter(Channel::isModular)
+                .forEach(channel -> {
+                    AppStreamsManager.listChannelAppStreams(channel.getId()).forEach(appStream ->
+                        appStreams.add(appStream.getName() + ":" + appStream.getStream()));
+                });
+        return appStreams;
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

Fix an error from occurring when providing an invalid module/stream combination that does not exist on the system

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**
- [x] **DONE**

## Links

Issue(s): 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
