### PR TITLE
QE: Remove nested VM leftovers

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -42,7 +42,6 @@ Possible values are currently:
 | Debian-like Salt minion         | ```$deblike_minion```    | ```$DEBLIKE_MINION```                                    | ```"deblike_minion"```   | ```"minion"```             |
 | PXE-boot minion                 | None                     | ```$PXEBOOT_MAC```                                       | ```"pxeboot_minion"```   | ```"pxeboot"```            |
 | KVM virtual host minion         | ```$kvm_server```        | ```$VIRTHOST_KVM_URL``` and ```$VIRTHOST_KVM_PASSWORD``` | ```"kvm_server"```       | ```"virthost"```           |
-| Salt bundle migration minion (nested VM)  | ```$salt_migration_minion```      | ```$MIN_NESTED```                                        | ```"salt_migration_minion"```       |      ```"virthost"```       |
 
 These names are such for historical reasons and might be made better in the future.
 

--- a/testsuite/features/step_definitions/vm_steps.rb
+++ b/testsuite/features/step_definitions/vm_steps.rb
@@ -24,7 +24,7 @@ When(/^I create a (leap|sles|rhlike|deblike) virtual machine named "([^"]*)" (wi
     name = 'sles-disk-image-template.qcow2'
     net = 'salt-sles'
     os = 'sle15sp4'
-    mac = ENV.fetch('MAC_MIN_NESTED', 'RANDOM')
+    mac = 'RANDOM'
   when 'rhlike'
     name = 'rhlike-disk-image-template.qcow2'
     net = 'salt-rhlike'

--- a/testsuite/features/support/twopence_env.rb
+++ b/testsuite/features/support/twopence_env.rb
@@ -17,8 +17,6 @@ unless $build_validation
   warn 'SSH minion IP address or domain name variable empty' if ENV['SSH_MINION'].nil?
   warn 'PXE boot MAC address variable empty' if ENV['PXEBOOT_MAC'].nil?
   warn 'KVM server minion IP address or domain name variable empty' if ENV['VIRTHOST_KVM_URL'].nil?
-  warn 'Nested VM hostname empty' if ENV['MIN_NESTED'].nil?
-  warn 'Nested VM MAC address empty' if ENV['MAC_MIN_NESTED'].nil?
 end
 
 # Dictionaries to obtain host or node from the Twopence objects


### PR DESCRIPTION
## What does this PR change?

Remove some leftovers from the time when we had the Salt Bundle migration tests as nested VM in our CI.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!