### PR TITLE
QE: Add opensuse 15.6 support only for aarch64 on BV

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -397,6 +397,20 @@ Feature: Sanity checks
     And "opensuse155arm_ssh_minion" should communicate with the server using public interface
     And the clock from "opensuse155arm_ssh_minion" should be exact
 
+  @opensuse156arm_minion
+  Scenario: The openSUSE 15.6 ARM minion is healthy
+    Then "opensuse156arm_minion" should have a FQDN
+    And reverse resolution should work for "opensuse156arm_minion"
+    And "opensuse156arm_minion" should communicate with the server using public interface
+    And the clock from "opensuse156arm_minion" should be exact
+
+  @opensuse156arm_ssh_minion
+  Scenario: The openSUSE 15.6 ARM SSH minion is healthy
+    Then "opensuse156arm_ssh_minion" should have a FQDN
+    And reverse resolution should work for "opensuse156arm_ssh_minion"
+    And "opensuse156arm_ssh_minion" should communicate with the server using public interface
+    And the clock from "opensuse156arm_ssh_minion" should be exact
+
 @sle15sp5s390_minion
   Scenario: The SLES 15 SP5 s390x minion is healthy
     Then "sle15sp5s390_minion" should have a FQDN

--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -118,6 +118,10 @@ Feature: Create bootstrap repositories
   Scenario: Create the bootstrap repository for a OpenSUSE 15.5 ARM minion
     When I create the bootstrap repository for "opensuse155arm_minion" on the server
 
+@opensuse156arm_minion
+  Scenario: Create the bootstrap repository for a OpenSUSE 15.6 ARM minion
+    When I create the bootstrap repository for "opensuse156arm_minion" on the server
+
 @sle15sp5s390_minion
   Scenario: Create the bootstrap repository for a SLES 15 SP5 s390x minion
     When I create the bootstrap repository for "sle15sp5s390_minion" on the server

--- a/testsuite/features/build_validation/init_clients/opensuse156arm_minion.feature
+++ b/testsuite/features/build_validation/init_clients/opensuse156arm_minion.feature
@@ -1,0 +1,47 @@
+# Copyright (c) 2024 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@opensuse156arm_minion
+Feature: Bootstrap a openSUSE 15.6 ARM Salt minion
+
+  Scenario: Clean up sumaform leftovers on a openSUSE 15.6 ARM Salt minion
+    When I perform a full salt minion cleanup on "opensuse156arm_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a openSUSE 15.6 ARM minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "opensuse156arm_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-opensuse156arm_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    And I wait until I see "Bootstrap process initiated." text
+    And I wait until onboarding is completed for "opensuse156arm_minion"
+
+  Scenario: Check the new bootstrapped openSUSE 15.6 ARM minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    Then I should see a "accepted" text
+    And the Salt master can reach "opensuse156arm_minion"
+
+@proxy
+  Scenario: Check connection from openSUSE 15.6 ARM minion to proxy
+    Given I am on the Systems overview page of this "opensuse156arm_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of openSUSE 15.6 ARM minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "opensuse156arm_minion" hostname
+
+  Scenario: Check events history for failures on openSUSE 15.6 ARM minion
+    Given I am on the Systems overview page of this "opensuse156arm_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/opensuse156arm_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/opensuse156arm_ssh_minion.feature
@@ -1,0 +1,42 @@
+# Copyright (c) 2024 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@opensuse156arm_ssh_minion
+Feature: Bootstrap a openSUSE 15.6 ARM Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a openSUSE 15.6 ARM Salt SSH minion
+    When I perform a full salt minion cleanup on "opensuse156arm_ssh_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a openSUSE 15.6 ARM system managed via salt-ssh
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I enter the hostname of "opensuse156arm_ssh_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select "1-opensuse156arm_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
+    And I wait until onboarding is completed for "opensuse156arm_ssh_minion"
+
+@proxy
+  Scenario: Check connection from openSUSE 15.6 ARM SSH minion to proxy
+    Given I am on the Systems overview page of this "opensuse156arm_ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of openSUSE 15.6 ARM SSH minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "opensuse156arm_ssh_minion" hostname
+
+  Scenario: Check events history for failures on openSUSE 15.6 ARM SSH minion
+    Given I am on the Systems overview page of this "opensuse156arm_ssh_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -415,6 +415,27 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I use spacewalk-common-channel to add all "leap15.5" channels with arch "aarch64"
     And I wait until all synchronized channels for "leap15.5-aarch64" have finished
 
+@susemanager
+@opensuse156arm_minion
+  Scenario: Add openSUSE 15.6 for ARM
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "currently running" text
+    And I wait until I do not see "Loading" text
+    And I enter "openSUSE Leap 15.6 aarch64" as the filtered product description
+    And I select "openSUSE Leap 15.6 aarch64" as a product
+    Then I should see the "openSUSE Leap 15.6 aarch64" selected
+    When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
+    And I wait until I see "openSUSE Leap 15.6 aarch64" product has been added
+    And I wait until all synchronized channels for "leap15.6-aarch64" have finished
+
+@uyuni
+@opensuse156arm_minion
+  Scenario: Add openSUSE 15.6 for ARM Uyuni Client tools
+    When I use spacewalk-common-channel to add all "leap15.6" channels with arch "aarch64"
+    And I wait until all synchronized channels for "leap15.6-aarch64" have finished
+
 @sle15sp5s390_minion
   Scenario: Add SUSE Linux Enterprise Server 15 SP5 for s390x
     Given I am authorized for the "Admin" section

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -67,6 +67,8 @@ ENV_VAR_BY_HOST = {
   'opensuse154arm_ssh_minion' => 'OPENSUSE154ARM_SSHMINION',
   'opensuse155arm_minion' => 'OPENSUSE155ARM_MINION',
   'opensuse155arm_ssh_minion' => 'OPENSUSE155ARM_SSHMINION',
+  'opensuse156arm_minion' => 'OPENSUSE156ARM_MINION',
+  'opensuse156arm_ssh_minion' => 'OPENSUSE156ARM_SSHMINION',
   'sle15sp5s390_minion' => 'SLE15SP5S390_MINION',
   'sle15sp5s390_ssh_minion' => 'SLE15SP5S390_SSHMINION',
   'salt_migration_minion' => 'SALT_MIGRATION_MINION'
@@ -211,6 +213,8 @@ PACKAGE_BY_CLIENT = {
   'opensuse154arm_ssh_minion' => 'bison',
   'opensuse155arm_minion' => 'bison',
   'opensuse155arm_ssh_minion' => 'bison',
+  'opensuse156arm_minion' => 'bison',
+  'opensuse156arm_ssh_minion' => 'bison',
   'sle15sp5s390_minion' => 'bison',
   'sle15sp5s390_ssh_minion' => 'bison',
   'salt_migration_minion' => 'bison'
@@ -288,6 +292,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'opensuse154arm_ssh_minion' => 'openSUSE-Leap-15.4-Pool for aarch64',
     'opensuse155arm_minion' => 'openSUSE-Leap-15.5-Pool for aarch64',
     'opensuse155arm_ssh_minion' => 'openSUSE-Leap-15.5-Pool for aarch64',
+    'opensuse156arm_minion' => 'openSUSE-Leap-15.6-Pool for aarch64',
+    'opensuse156arm_ssh_minion' => 'openSUSE-Leap-15.6-Pool for aarch64',
     'sle15sp5s390_minion' => 'SLE-Product-SLES15-SP5-Pool for s390x',
     'sle15sp5s390_ssh_minion' => 'SLE-Product-SLES15-SP5-Pool for s390x',
     'salt_migration_minion' => 'SLE-Product-SLES15-SP5-Pool for x86_64'
@@ -358,6 +364,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'opensuse154arm_ssh_minion' => 'openSUSE Leap 15.4 (aarch64)',
     'opensuse155arm_minion' => 'openSUSE Leap 15.5 (aarch64)',
     'opensuse155arm_ssh_minion' => 'openSUSE Leap 15.5 (aarch64)',
+    'opensuse156arm_minion' => 'openSUSE Leap 15.6 (aarch64)',
+    'opensuse156arm_ssh_minion' => 'openSUSE Leap 15.6 (aarch64)',
     'sle15sp5s390_minion' => 'SLE-Product-SLES15-SP5-Pool for s390x',
     'sle15sp5s390_ssh_minion' => 'SLE-Product-SLES15-SP5-Pool for s390x',
     'salt_migration_minion' => 'SLE-Product-SLES15-SP5-Pool for x86_64'
@@ -405,11 +413,13 @@ LABEL_BY_BASE_CHANNEL = {
     'debian-11-pool for amd64' => 'debian-11-pool-amd64',
     'debian-12-pool for amd64' => 'debian-12-pool-amd64',
     'openSUSE-Leap-15.4-Pool for aarch64' => 'opensuse-leap-15.4-pool-aarch64',
-    'openSUSE-Leap-15.5-Pool for aarch64' => 'opensuse-leap-15.5-pool-aarch64'
+    'openSUSE-Leap-15.5-Pool for aarch64' => 'opensuse-leap-15.5-pool-aarch64',
+    'openSUSE-Leap-15.6-Pool for aarch64' => 'opensuse-leap-15.6-pool-aarch64'
   },
   'Uyuni' => {
     'openSUSE Leap 15.4 (x86_64)' => 'opensuse_leap15_4-x86_64',
     'openSUSE Leap 15.5 (x86_64)' => 'opensuse_leap15_5-x86_64',
+    'openSUSE Leap 15.6 (x86_64)' => 'opensuse_leap15_6-x86_64',
     'SLES12-SP5-Pool for x86_64' => 'sles12-sp5-pool-x86_64',
     'SLE-Product-SLES15-SP1-Pool for x86_64' => 'sle-product-sles15-sp1-pool-x86_64',
     'SLE-Product-SLES15-SP2-Pool for x86_64' => 'sle-product-sles15-sp2-pool-x86_64',
@@ -436,7 +446,8 @@ LABEL_BY_BASE_CHANNEL = {
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian-11-pool-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian-12-pool-amd64-uyuni',
     'openSUSE Leap 15.4 (aarch64)' => 'opensuse_leap15_4-aarch64',
-    'openSUSE Leap 15.5 (aarch64)' => 'opensuse_leap15_5-aarch64'
+    'openSUSE Leap 15.5 (aarch64)' => 'opensuse_leap15_5-aarch64',
+    'openSUSE Leap 15.6 (aarch64)' => 'opensuse_leap15_6-aarch64'
   }
 }.freeze
 
@@ -473,11 +484,13 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'debian-11-pool for amd64' => 'debian11-amd64',
     'debian-12-pool for amd64' => 'debian12-amd64',
     'openSUSE-Leap-15.4-Pool for aarch64' => 'openSUSE-Leap-15.4-aarch64',
-    'openSUSE-Leap-15.5-Pool for aarch64' => 'openSUSE-Leap-15.5-aarch64'
+    'openSUSE-Leap-15.5-Pool for aarch64' => 'openSUSE-Leap-15.5-aarch64',
+    'openSUSE-Leap-15.6-Pool for aarch64' => 'openSUSE-Leap-15.6-aarch64'
   },
   'Uyuni' => {
     'openSUSE Leap 15.4 (x86_64)' => 'openSUSE-Leap-15.4-x86_64-uyuni',
     'openSUSE Leap 15.5 (x86_64)' => 'openSUSE-Leap-15.5-x86_64-uyuni',
+    'openSUSE Leap 15.6 (x86_64)' => 'openSUSE-Leap-15.6-x86_64-uyuni',
     'SLES12-SP5-Pool for x86_64' => 'SLE-12-SP5-x86_64',
     'SLE-Product-SLES15-SP1-Pool for x86_64' => 'SLE-15-SP1-x86_64',
     'SLE-Product-SLES15-SP2-Pool for x86_64' => 'SLE-15-SP2-x86_64',
@@ -504,7 +517,8 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian11-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian12-amd64-uyuni',
     'openSUSE Leap 15.4 (aarch64)' => 'openSUSE-Leap-15.4-aarch64-uyuni',
-    'openSUSE Leap 15.5 (aarch64)' => 'openSUSE-Leap-15.5-aarch64-uyuni'
+    'openSUSE Leap 15.5 (aarch64)' => 'openSUSE-Leap-15.5-aarch64-uyuni',
+    'openSUSE Leap 15.6 (aarch64)' => 'openSUSE-Leap-15.6-aarch64-uyuni'
   }
 }.freeze
 
@@ -542,11 +556,13 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'debian-11-pool for amd64' => 'debian-11-pool-amd64',
     'debian-12-pool for amd64' => 'debian-12-pool-amd64',
     'openSUSE-Leap-15.4-Pool for aarch64' => nil,
-    'openSUSE-Leap-15.5-Pool for aarch64' => nil
+    'openSUSE-Leap-15.5-Pool for aarch64' => nil,
+    'openSUSE-Leap-15.6-Pool for aarch64' => nil
   },
   'Uyuni' => {
     'openSUSE Leap 15.4 (x86_64)' => nil,
     'openSUSE Leap 15.5 (x86_64)' => nil,
+    'openSUSE Leap 15.6 (x86_64)' => nil,
     'SLES12-SP5-Pool for x86_64' => nil,
     'SLE-Product-SLES15-SP1-Pool for x86_64' => 'sle-product-sles15-sp1-pool-x86_64',
     'SLE-Product-SLES15-SP2-Pool for x86_64' => 'sle-product-sles15-sp2-pool-x86_64',
@@ -572,7 +588,8 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian11-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian12-amd64-uyuni',
     'openSUSE Leap 15.4 (aarch64)' => nil,
-    'openSUSE Leap 15.5 (aarch64)' => nil
+    'openSUSE Leap 15.5 (aarch64)' => nil,
+    'openSUSE Leap 15.6 (aarch64)' => nil
   }
 }.freeze
 
@@ -635,6 +652,8 @@ PKGARCH_BY_CLIENT = {
   'opensuse154arm_ssh_minion' => 'aarch64',
   'opensuse155arm_minion' => 'aarch64',
   'opensuse155arm_ssh_minion' => 'aarch64',
+  'opensuse156arm_minion' => 'aarch64',
+  'opensuse156arm_ssh_minion' => 'aarch64',
   'sle15sp5s390_minion' => 's390x',
   'sle15sp5s390_ssh_minion' => 's390x'
 }.freeze
@@ -878,6 +897,15 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         opensuse_leap15_5-x86_64-backports-updates
         opensuse_leap15_5-x86_64-sle-updates
       ],
+    'leap15.6-x86_64' =>
+      %w[
+        opensuse_leap15_6-x86_64
+        opensuse_leap15_6-x86_64-non-oss
+        opensuse_leap15_6-x86_64-non-oss-updates
+        opensuse_leap15_6-x86_64-updates
+        opensuse_leap15_6-x86_64-backports-updates
+        opensuse_leap15_6-x86_64-sle-updates
+      ],
     'leap15.4-aarch64' =>
       %w[
         opensuse-backports-15.4-updates-aarch64
@@ -894,6 +922,15 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         opensuse-sle-15.5-updates-aarch64
         sle-manager-tools15-updates-aarch64-opensuse-15.5
         sle-manager-tools15-pool-aarch64-opensuse-15.5
+      ],
+    'leap15.6-aarch64' =>
+      %w[
+        opensuse-backports-15.6-updates-aarch64
+        opensuse-leap-15.6-pool-aarch64
+        opensuse-leap-15.6-updates-aarch64
+        opensuse-sle-15.6-updates-aarch64
+        sle-manager-tools15-updates-aarch64-opensuse-15.6
+        sle-manager-tools15-pool-aarch64-opensuse-15.6
       ],
     'suse-microos-5.1' => # CHECKED
       %w[
@@ -1180,6 +1217,18 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         opensuse_leap15_5-uyuni-client-devel-x86_64
         uyuni-proxy-devel-leap-x86_64
       ],
+    'leap15.6-x86_64' => # CHECKED
+      %w[
+        opensuse_leap15_6-x86_64
+        opensuse_leap15_6-x86_64-backports-updates
+        opensuse_leap15_6-x86_64-non-oss
+        opensuse_leap15_6-x86_64-non-oss-updates
+        opensuse_leap15_6-x86_64-updates
+        opensuse_leap15_6-x86_64-sle-updates
+        opensuse_leap15_6-uyuni-client-x86_64
+        opensuse_leap15_6-uyuni-client-devel-x86_64
+        uyuni-proxy-devel-leap-x86_64
+      ],
     'leap15.4-aarch64' => # CHECKED
       %w[
         opensuse_leap15_4-aarch64
@@ -1199,6 +1248,16 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         opensuse_leap15_5-aarch64-sle-updates
         opensuse_leap15_5-aarch64-updates
         opensuse_leap15_5-uyuni-client-devel-aarch64
+      ],
+    'leap15.6-aarch64' => # CHECKED
+      %w[
+        opensuse_leap15_6-aarch64
+        opensuse_leap15_6-aarch64-backports-updates
+        opensuse_leap15_6-aarch64-non-oss
+        opensuse_leap15_6-aarch64-non-oss-updates
+        opensuse_leap15_6-aarch64-sle-updates
+        opensuse_leap15_6-aarch64-updates
+        opensuse_leap15_6-uyuni-client-devel-aarch64
       ],
     'leap-micro5.5-x86_64' => # CHECKED
       %w[
@@ -1358,6 +1417,21 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'opensuse_leap15_5-x86_64-non-oss-updates' => 120,
   'opensuse_leap15_5-x86_64-sle-updates' => 5400,
   'opensuse_leap15_5-x86_64-updates' => 60,
+  'opensuse_leap15_6-aarch64' => 10_020,
+  'opensuse_leap15_6-aarch64-backports-updates' => 420,
+  'opensuse_leap15_6-aarch64-non-oss' => 60,
+  'opensuse_leap15_6-aarch64-non-oss-updates' => 60,
+  'opensuse_leap15_6-aarch64-sle-updates' => 4140,
+  'opensuse_leap15_6-aarch64-updates' => 60,
+  'opensuse_leap15_6-uyuni-client-devel-aarch64' => 60,
+  'opensuse_leap15_6-uyuni-client-devel-x86_64' => 60,
+  'opensuse_leap15_6-uyuni-client-x86_64' => 60,
+  'opensuse_leap15_6-x86_64' => 10_380,
+  'opensuse_leap15_6-x86_64-backports-updates' => 360,
+  'opensuse_leap15_6-x86_64-non-oss' => 60,
+  'opensuse_leap15_6-x86_64-non-oss-updates' => 120,
+  'opensuse_leap15_6-x86_64-sle-updates' => 5400,
+  'opensuse_leap15_6-x86_64-updates' => 60,
   'opensuse_micro5_5-uyuni-client-x86_64' => 60,
   'opensuse_micro5_5-uyuni-client-devel-x86_64' => 60,
   'opensuse_micro5_5-x86_64' => 240,

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -402,6 +402,14 @@ Before('@opensuse155arm_ssh_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['opensuse155arm_ssh_minion']
 end
 
+Before('@opensuse156arm_minion') do
+  skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['opensuse156arm_minion']
+end
+
+Before('@opensuse156arm_ssh_minion') do
+  skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['opensuse156arm_ssh_minion']
+end
+
 Before('@sle15sp5s390_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['sle15sp5s390_minion']
 end

--- a/testsuite/run_sets/build_validation/build_validation_init_clients.yml
+++ b/testsuite/run_sets/build_validation/build_validation_init_clients.yml
@@ -49,6 +49,8 @@
 - features/build_validation/init_clients/opensuse154arm_ssh_minion.feature
 - features/build_validation/init_clients/opensuse155arm_minion.feature
 - features/build_validation/init_clients/opensuse155arm_ssh_minion.feature
+- features/build_validation/init_clients/opensuse156arm_minion.feature
+- features/build_validation/init_clients/opensuse156arm_ssh_minion.feature
 - features/build_validation/init_clients/sle15sp5s390_minion.feature
 - features/build_validation/init_clients/sle15sp5s390_ssh_minion.feature
 


### PR DESCRIPTION
## What does this PR change?
Adds support for openSUSE Leap 15.6 aarch 64 on BV

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23848
Port(s): 
- 4.3 https://github.com/SUSE/spacewalk/pull/24261

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
