### PR TITLE
configure the database to provide enough connections for our default setup

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -1054,7 +1054,7 @@ fi
 
 if [ "$DO_SETUP" = "1" -o "$DO_MIGRATION" = "1" ]; then
     if [ $EXTERNALDB = "0" ]; then
-        /usr/bin/smdba system-check autotuning
+        /usr/bin/smdba system-check autotuning --max_connections=400
     fi
     if [ "$DO_SETUP" = "1" ]; then
         /usr/sbin/spacewalk-service stop

--- a/susemanager/susemanager.changes.mc.fix-default-db-connections
+++ b/susemanager/susemanager.changes.mc.fix-default-db-connections
@@ -1,0 +1,1 @@
+- configure the database to provide enough connections for our default setup


### PR DESCRIPTION
## What does this PR change?

When we initially configure SUMA/Uyuni we want to setup with 400 DB connections.
In a container we might have a postgresql.conf with a different value which must be explicit overwritten.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
