### PR TITLE
QE: Review migration features

### DIFF
--- a/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
@@ -14,7 +14,7 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
   Scenario: Do some basic testing on the minion without Salt bundle
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
-    When I enter command "file /etc/salt"
+    When I enter command "file /etc/salt/minion.d"
     And I enter the hostname of "salt_migration_minion" as "target"
     And I click on preview
     Then I should see a "Target systems (1)" text
@@ -23,7 +23,7 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     And I click on run
     And I wait until I do not see "pending" text
     And I expand the results for "salt_migration_minion"
-    Then I should see "/etc/salt: directory" in the command output for "salt_migration_minion"
+    Then I should see "/etc/salt/minion.d: directory" in the command output for "salt_migration_minion"
 
   @susemanager
   Scenario: Subscribe the minion to the SLES 15 SP5 channel and enable client tools in the Salt migration context
@@ -69,22 +69,22 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
   Scenario: Check if the Salt bundle migration was successful
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
-    When I enter command "file /etc/salt"
+    When I enter command "file /etc/salt/minion.d"
     And I click on preview
     Then I should see "salt_migration_minion" hostname
     And I wait until I do not see "pending" text
     When I click on run
     And I wait until I do not see "pending" text
     And I expand the results for "salt_migration_minion"
-    Then I should see "/etc/salt: cannot open `/etc/salt' (No such file or directory)" in the command output for "salt_migration_minion"
-    When I enter command "file /etc/venv-salt-minion"
+    Then I should see "/etc/salt/minion.d: cannot open `/etc/salt/minion.d' (No such file or directory)" in the command output for "salt_migration_minion"
+    When I enter command "file /etc/venv-salt-minion/minion.d"
     And I click on preview
     Then I should see "salt_migration_minion" hostname
     And I wait until I do not see "pending" text
     When I click on run
     And I wait until I do not see "pending" text
     And I expand the results for "salt_migration_minion"
-    Then I should see "/etc/venv-salt-minion: directory" in the command output for "salt_migration_minion"
+    Then I should see "/etc/venv-salt-minion/minion.d: directory" in the command output for "salt_migration_minion"
 
   Scenario: Do some basic testing on the minion with the Salt bundle in the Salt migration context
     Given I am on the Systems overview page of this "salt_migration_minion"

--- a/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
@@ -7,6 +7,17 @@ Feature: Migrate a SLES 15 SP3 Salt minion to 15 SP4
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  # Having OS salt packages which are not up to date installed on the minion
+  # will not allow it to undergo a Product migration
+  Scenario: Remove OS salt leftovers from the SLE 15 SP3 minion
+    When I remove package "salt" from this "sle15sp3_minion" without error control
+
+  Scenario: Update Package List of this SLE 15 SP3 minion
+    Given I am on the Systems overview page of this "sle15sp3_minion"
+    And I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh" is completed
+
   Scenario: Migrate this minion to SLE 15 SP4
     Given I am on the Systems overview page of this "sle15sp3_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
@@ -7,6 +7,17 @@ Feature: Migrate a SLES 15 SP3 Salt SSH minion to 15 SP4
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  # Having OS salt packages which are not up to date installed on the minion
+  # will not allow it to undergo a Product migration
+  Scenario: Remove OS salt leftovers from this SLE 15 SP3 SSH minion
+    When I remove package "salt" from this "sle15sp3_ssh_minion" without error control
+
+  Scenario: Update Package List of this SLE 15 SP3 SSH minion
+    Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
+    And I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh" is completed
+
   Scenario: Migrate this SSH minion to SLE 15 SP4
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
@@ -7,6 +7,27 @@ Feature: Migrate a SLE Micro 5.4 Salt minion to SLE Micro 5.5
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  # Having OS salt packages which are not up to date installed on the minion
+  # will not allow it to undergo a Product migration
+  Scenario: Remove OS salt leftovers from this SLE Micro 5.4 minion
+    When I remove package "salt" from this "slemicro54_minion" without error control
+
+  Scenario: Reboot this SLE Micro 5.4 minion and wait until reboot is completed
+    Given I am on the Systems overview page of this "slemicro54_minion"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    Then I should see a "Reboot completed." text
+
+  Scenario: Update Package List of this SLE Micro 5.4 minion
+    Given I am on the Systems overview page of this "slemicro54_minion"
+    And I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh" is completed
+
   Scenario: Migrate this minion to SLE Micro 5.5
     Given I am on the Systems overview page of this "slemicro54_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
@@ -7,6 +7,27 @@ Feature: Migrate a SLE Micro 5.4 Salt SSH minion to SLE Micro 5.5
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  # Having OS salt packages which are not up to date installed on the minion
+  # will not allow it to undergo a Product migration
+  Scenario: Remove OS salt leftovers from this SLE Micro 5.4 SSH minion
+    When I remove package "salt" from this "slemicro54_ssh_minion" without error control
+  
+  Scenario: Reboot this SLE Micro 5.4 SSH minion and wait until reboot is completed
+    Given I am on the Systems overview page of this "slemicro54_minion"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    Then I should see a "Reboot completed." text
+
+  Scenario: Update Package List of this SLE Micro 5.4 SSH minion
+    Given I am on the Systems overview page of this "slemicro54_ssh_minion"
+    And I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I wait until event "Package List Refresh" is completed
+
   Scenario: Migrate this SSH minion to SLE Micro 5.5
     Given I am on the Systems overview page of this "slemicro54_ssh_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -926,7 +926,7 @@ When(/^I install packages? "([^"]*)" on this "([^"]*)"((?: without error control
     successcodes = [0]
     not_found_msg = 'Unable to locate package'
   elsif transactional_system?(host)
-    cmd = "transactional-update pkg install -n #{package}"
+    cmd = "transactional-update pkg install -y #{package}"
     successcodes = [0, 100, 101, 102, 103, 106]
     not_found_msg = 'not found in package names'
   else
@@ -965,6 +965,9 @@ When(/^I remove packages? "([^"]*)" from this "([^"]*)"((?: without error contro
   elsif deb_host?(host)
     cmd = "dpkg --remove #{package}"
     successcodes = [0]
+  elsif transactional_system?(host)
+    cmd = "transactional-update pkg rm -y #{package}"
+    successcodes = [0, 100, 101, 102, 103, 106]
   else
     cmd = "zypper --non-interactive remove -y #{package}"
     successcodes = [0, 100, 101, 102, 103, 104, 106]


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/24233

Removes unused and not up to date OS salt packages from minions which are going to attempt a Product migration.

Not sure if this is a bug, but having those packages on the minion will otherwise stop product migrations as long as they are not updated to the last version (even if the system is using venv-salt or is managed via SSH).

I've also noticed a place in which we use **-n** with **transactional update** but I think we meant to use **-y** to skip the prompt for confirming packages installation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber test features and step definitions were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24233
Port(s): SUMA 4.3 https://github.com/SUSE/spacewalk/pull/24304

- [x] **DONE**

## Changelogs


- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
