### PR TITLE
Remove Enable Remote Configuration' nor 'Enable Remote Commands' from bootstrap scrip

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/BootstrapConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/BootstrapConfigAction.java
@@ -80,8 +80,6 @@ public class BootstrapConfigAction extends BaseConfigAction {
                 cmd.setSslPath(form.getString(SSL_CERT));
                 cmd.setSaltEnabled((Boolean) form.get(SALT));
                 cmd.setEnableGpg((Boolean) form.get(ENABLE_GPG));
-                cmd.setAllowConfigActions((Boolean) form.get(ALLOW_CONFIG_ACTIONS));
-                cmd.setAllowRemoteCommands((Boolean) form.get(ALLOW_REMOTE_COMMANDS));
                 cmd.setHttpProxy(form.getString(HTTP_PROXY));
                 cmd.setHttpProxyUsername(form.getString(HTTP_PROXY_USERNAME));
                 cmd.setHttpProxyPassword(form.getString(HTTP_PROXY_PASSWORD));
@@ -103,8 +101,6 @@ public class BootstrapConfigAction extends BaseConfigAction {
             form.set(SSL_CERT, caCertPath);
             form.set(SALT, Boolean.TRUE);
             form.set(ENABLE_GPG, Boolean.TRUE);
-            form.set(ALLOW_CONFIG_ACTIONS, Boolean.FALSE);
-            form.set(ALLOW_REMOTE_COMMANDS, Boolean.FALSE);
         }
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/BootstrapConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/BootstrapConfigAction.java
@@ -46,8 +46,6 @@ public class BootstrapConfigAction extends BaseConfigAction {
     public static final String SALT = "salt";
 
     public static final String ENABLE_GPG = "gpg";
-    public static final String ALLOW_CONFIG_ACTIONS = "allow-config-actions";
-    public static final String ALLOW_REMOTE_COMMANDS = "allow-remote-commands";
     public static final String HTTP_PROXY = "http-proxy";
     public static final String HTTP_PROXY_USERNAME = "http-proxy-username";
     public static final String HTTP_PROXY_PASSWORD = "http-proxy-password";

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/test/BootstrapConfigActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/test/BootstrapConfigActionTest.java
@@ -61,10 +61,6 @@ public class BootstrapConfigActionTest extends RhnPostMockStrutsTestCase {
                 CACertPathUtil.processCACertPath());
         assertEquals(Boolean.TRUE,
                 form.get(BootstrapConfigAction.ENABLE_GPG));
-        assertEquals(Boolean.FALSE,
-                form.get(BootstrapConfigAction.ALLOW_CONFIG_ACTIONS));
-        assertEquals(Boolean.FALSE,
-                form.get(BootstrapConfigAction.ALLOW_REMOTE_COMMANDS));
         assertEquals(Boolean.TRUE,
                 form.get(BootstrapConfigAction.SALT));
         assertEquals("", form.getString(BootstrapConfigAction.HTTP_PROXY));

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -9236,20 +9236,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <target>দূরবর্তী কনফিগারেশন সক্রিয় করুন</target>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <target>দূরবর্তী কমান্ড সক্রিয় করুন</target>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <target>ক্লায়েন্ট HTTP প্রক্সি</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
@@ -8717,18 +8717,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_cs.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_cs.xml
@@ -9810,20 +9810,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <target/>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -9706,20 +9706,6 @@ Bitte beachten Sie, dass möglicherweise noch einige manuelle Konfigurationen di
         </context-group>
         <target>Client-GPG-Überprüfung aktivieren</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Aktiviere dezentrale Konfiguration</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Dezentralen Befehl aktivieren</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -8670,18 +8670,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -9275,20 +9275,6 @@ Tenga en cuenta que podría ser necesario configurar manualmente estos scripts. 
         </context-group>
         <target>Activar la revisión del GPG del cliente</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Activar configuración remota</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Permitir comandos remotos</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -9705,20 +9705,6 @@ Veuillez noter qu'une configuration manuelle de ces scripts peut toujours être 
         </context-group>
         <target>Activer la vérification GPG du client</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Activer la configuration à distance</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Activer les commandes à distance</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -9378,20 +9378,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>ક્લાઈન્ટ GPG ચકાસણી સક્રિય કરો</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>દૂરસ્થ રૂપરેખાંકન સક્રિય કરો</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>દૂરસ્થ આદેશો સક્રિય કરો</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -9378,20 +9378,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>क्लाइंट GPG जांच स्क्रिय करें</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>दूरस्थ विन्यास सक्रिय करें</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>दूरस्थ कमांड सक्रिय करें</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -9789,20 +9789,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>Abilita controllo Client GPG</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Abilita Configurazione Remota</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Abilita Comandi Remoti</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -9824,20 +9824,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>クライアント GPG チェックを有効にする</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>リモート設定を有効にする</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>リモートコマンドを有効にする</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -9823,20 +9823,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>클라이언트 GPG 확인 작업 활성</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>원격 설정 활성</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>원격 명령 활성</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -9377,20 +9377,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>ਕਲਾਂਈਟ GPG ਜਾਂਚ ਯੋਗ</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>ਰਿਮੋਟ ਸੰਰਚਨਾ ਯੋਗ</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>ਰਿਮੋਟ ਕਮਾਂਡਾਂ ਚਲਾਓ</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -9711,20 +9711,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>Ativar verificação GPG do Cliente</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Ativar Configuração Remota</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Ativar Comandos Remotos</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -9316,20 +9316,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>Включить проверку GPG</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Включить удаленную конфигурацию</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>Разрешить выполнение удаленных команд</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_si.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_si.xml
@@ -9838,20 +9838,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <target/>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_sk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_sk.xml
@@ -9815,20 +9815,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <target/>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -9378,20 +9378,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>கிளையன் GPG சோதிப்பதை செயல்படுத்தவும்</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>தூரத்து கட்டமைப்பினை செயல்படுத்தவும்</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>தொலை கட்டளைகளை செயல்படுத்தவும்</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
@@ -8976,18 +8976,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh-HK.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh-HK.xml
@@ -9838,20 +9838,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <target/>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <target/>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -9824,20 +9824,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target state="translated">启用客户端 GPG 检查</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target state="translated">启用远程配置</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target state="translated">启用远程命令</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -9701,20 +9701,6 @@ Please note that some manual configuration of these scripts may still be require
         </context-group>
         <target>啟用用戶端 GPG 檢查</target>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-config-actions" xml:space="preserve">
-        <source>Enable Remote Configuration</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>啟用遠端設定</target>
-      </trans-unit>
-      <trans-unit id="bootstrap.jsp.allow-remote-commands" xml:space="preserve">
-        <source>Enable Remote Commands</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-        <target>啟用遠端指令</target>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.http-proxy" xml:space="preserve">
         <source>Client HTTP Proxy</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/manager/satellite/ConfigureBootstrapCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/ConfigureBootstrapCommand.java
@@ -36,8 +36,6 @@ public class ConfigureBootstrapCommand extends BaseConfigureCommand
     private Boolean saltEnabled;
     private String sslPath;
     private Boolean enableGpg;
-    private Boolean allowConfigActions;
-    private Boolean allowRemoteCommands;
     private String httpProxy;
     private String httpProxyUsername;
     private String httpProxyPassword;
@@ -99,39 +97,6 @@ public class ConfigureBootstrapCommand extends BaseConfigureCommand
         return null;
 
     }
-
-
-    /**
-     * @return Returns the allowConfigActions.
-     */
-    public Boolean getAllowConfigActions() {
-        return allowConfigActions;
-    }
-
-
-    /**
-     * @param allowConfigActionsIn The allowConfigActions to set.
-     */
-    public void setAllowConfigActions(Boolean allowConfigActionsIn) {
-        this.allowConfigActions = allowConfigActionsIn;
-    }
-
-
-    /**
-     * @return Returns the allowRemoteCommands.
-     */
-    public Boolean getAllowRemoteCommands() {
-        return allowRemoteCommands;
-    }
-
-
-    /**
-     * @param allowRemoteCommandsIn The allowRemoteCommands to set.
-     */
-    public void setAllowRemoteCommands(Boolean allowRemoteCommandsIn) {
-        this.allowRemoteCommands = allowRemoteCommandsIn;
-    }
-
 
     /**
      * @return Returns the enableGpg.

--- a/java/code/src/com/redhat/rhn/manager/satellite/ConfigureBootstrapCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/ConfigureBootstrapCommand.java
@@ -63,12 +63,6 @@ public class ConfigureBootstrapCommand extends BaseConfigureCommand
         List args = new LinkedList<>();
         args.add("/usr/bin/sudo");
         args.add("/usr/bin/rhn-bootstrap");
-        if (BooleanUtils.toBooleanDefaultIfNull(this.allowConfigActions, false)) {
-            args.add("--allow-config-actions");
-        }
-        if (BooleanUtils.toBooleanDefaultIfNull(this.allowRemoteCommands, false)) {
-            args.add("--allow-remote-commands");
-        }
         if (!BooleanUtils.toBooleanDefaultIfNull(this.enableGpg, false)) {
             args.add("--no-gpg");
         }

--- a/java/code/src/com/redhat/rhn/manager/satellite/test/ConfigureBootstrapCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/test/ConfigureBootstrapCommandTest.java
@@ -44,8 +44,6 @@ public class ConfigureBootstrapCommandTest extends BaseTestCaseWithUser {
         assertNotNull(cmd.getUser());
         cmd.setHostname("localhost");
         cmd.setSslPath("/tmp/somepath.cert");
-        cmd.setAllowRemoteCommands(Boolean.TRUE);
-        cmd.setAllowConfigActions(Boolean.TRUE);
         cmd.setEnableGpg(Boolean.FALSE);
         cmd.setHttpProxy("proxy-host.redhat.com");
         cmd.setHttpProxyUsername("username");
@@ -60,7 +58,7 @@ public class ConfigureBootstrapCommandTest extends BaseTestCaseWithUser {
 
         @Override
         public int execute(String[] args) {
-            if (args.length != 11) {
+            if (args.length != 9) {
                 return -1;
             }
             if (!args[0].equals("/usr/bin/sudo")) {
@@ -69,26 +67,26 @@ public class ConfigureBootstrapCommandTest extends BaseTestCaseWithUser {
             else if (!args[1].equals("/usr/bin/rhn-bootstrap")) {
                 return -3;
             }
-            else if (!args[4].startsWith("--no-gpg")) {
+            else if (!args[2].startsWith("--no-gpg")) {
+                return -4;
+            }
+            else if (!args[3].startsWith("--hostname=localhost")) {
+                return -5;
+            }
+            else if (!args[4].startsWith("--traditional")) {
+                return -6;
+            }
+            else if (!args[5].startsWith("--ssl-cert=/tmp/somepath.cert")) {
                 return -7;
             }
-            else if (!args[5].startsWith("--hostname=localhost")) {
+            else if (!args[6].startsWith("--http-proxy=proxy-host.redhat.com")) {
                 return -8;
             }
-            else if (!args[6].startsWith("--traditional")) {
+            else if (!args[7].startsWith("--http-proxy-username=username")) {
                 return -9;
             }
-            else if (!args[7].startsWith("--ssl-cert=/tmp/somepath.cert")) {
+            else if (!args[8].startsWith("--http-proxy-password=password")) {
                 return -10;
-            }
-            else if (!args[8].startsWith("--http-proxy=proxy-host.redhat.com")) {
-                return -11;
-            }
-            else if (!args[9].startsWith("--http-proxy-username=username")) {
-                return -12;
-            }
-            else if (!args[10].startsWith("--http-proxy-password=password")) {
-                return -13;
             }
             else {
                 return 0;

--- a/java/code/src/com/redhat/rhn/manager/satellite/test/ConfigureBootstrapCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/test/ConfigureBootstrapCommandTest.java
@@ -69,12 +69,6 @@ public class ConfigureBootstrapCommandTest extends BaseTestCaseWithUser {
             else if (!args[1].equals("/usr/bin/rhn-bootstrap")) {
                 return -3;
             }
-            else if (!args[2].equals("--allow-config-actions")) {
-                return -4;
-            }
-            else if (!args[3].startsWith("--allow-remote-commands")) {
-                return -5;
-            }
             else if (!args[4].startsWith("--no-gpg")) {
                 return -7;
             }

--- a/java/code/webapp/WEB-INF/pages/admin/config/bootstrap.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/config/bootstrap.jsp
@@ -57,26 +57,6 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="allow-config-actions">
-                            <bean:message key="bootstrap.jsp.allow-config-actions"/>
-                        </label>
-                        <div class="col-lg-6">
-                            <div class="checkbox">
-                                    <html:checkbox property="allow-config-actions" styleId="allow-config-actions"/>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="col-lg-3 control-label" for="allow-remote-commands">
-                            <bean:message key="bootstrap.jsp.allow-remote-commands"/>
-                        </label>
-                        <div class="col-lg-6">
-                            <div class="checkbox">
-                                    <html:checkbox property="allow-remote-commands" styleId="allow-remote-commands" />
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-group">
                         <label class="col-lg-3 control-label" for="http-proxy">
                             <bean:message key="bootstrap.jsp.http-proxy"/>
                         </label>

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -382,8 +382,6 @@
             <form-property name="salt"  type="java.lang.Boolean"/>
             <form-property name="ssl"  type="java.lang.Boolean"/>
             <form-property name="gpg"  type="java.lang.Boolean"/>
-            <form-property name="allow-config-actions"  type="java.lang.Boolean"/>
-            <form-property name="allow-remote-commands"  type="java.lang.Boolean"/>
             <form-property name="http-proxy"  type="java.lang.String"/>
             <form-property name="http-proxy-username"  type="java.lang.String"/>
             <form-property name="http-proxy-password"  type="java.lang.String"/>

--- a/java/spacewalk-java.changes.abid.remove-tradtional-stack-related-options
+++ b/java/spacewalk-java.changes.abid.remove-tradtional-stack-related-options
@@ -1,0 +1,1 @@
+- remove the allow-config-actions and allow-remote-commands options from the bootstrap script

--- a/spacewalk/certs-tools/mgr-bootstrap.sgml
+++ b/spacewalk/certs-tools/mgr-bootstrap.sgml
@@ -126,22 +126,6 @@
         </listitem>
     </varlistentry>
     <varlistentry>
-        <term>--allow-config-actions</term>
-        <listitem>
-            <para>boolean; allow all configuration actions - requires
-            installing certain rhncfg-* RPMs probably via an activation
-            key.</para>
-        </listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>--allow-remote-commands</term>
-        <listitem>
-            <para>boolean; allow arbitrary remote commands - requires
-            installing certain rhncfg-* RPMs probably via an activation
-            key.</para>
-        </listitem>
-    </varlistentry>
-    <varlistentry>
         <term>--no-gpg</term>
         <listitem>
             <para>(not recommended) boolean; turn off GPG verification by the clients.</para>
@@ -191,7 +175,7 @@
 
 <RefSect1><Title>Examples</Title>
 <simplelist>
-        <member><command>&EXECUTABLE; --activation-key XXX --http-proxy="" --allow-config-actions --allow-remote-commands</command></member>
+        <member><command>&EXECUTABLE; --activation-key XXX --http-proxy="" </command></member>
         <member><command>&EXECUTABLE; --activation-key XXX --gpg-key ~/taw-pub.key</command></member>
 </simplelist>
 </RefSect1>

--- a/spacewalk/certs-tools/rhn_bootstrap.py
+++ b/spacewalk/certs-tools/rhn_bootstrap.py
@@ -237,8 +237,6 @@ def getDefaultOptions():
         "http-proxy": "",
         "http-proxy-username": "",
         "http-proxy-password": "",
-        "allow-config-actions": 0,
-        "allow-remote-commands": 0,
         "no-bundle": 0,
         "force-bundle": 0,
         "no-gpg": 0,


### PR DESCRIPTION

## What does this PR change?

After traditional stack removal, 'Enable Remote Configuration' nor 'Enable Remote Commands' in bootstrap script doesn't make sense and this PR removes them.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: These options were only meaningful in traditional stack context.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
