### PR TITLE
Call update-ca-certificates on startup of hub xmlrpc container

### DIFF
--- a/containers/server-hub-xmlrpc-api-image/Dockerfile
+++ b/containers/server-hub-xmlrpc-api-image/Dockerfile
@@ -26,4 +26,4 @@ LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-hub-xmlrpc-api:${PRODUC
 # endlabelprefix
 LABEL org.uyuni.version="${PRODUCT_VERSION}"
 
-CMD ["/usr/bin/hub-xmlrpc-api"]
+CMD update-ca-certificates && hub-xmlrpc-api

--- a/containers/server-hub-xmlrpc-api-image/server-hub-xmlrpc-api-image.changes.nadvornik.hub-update
+++ b/containers/server-hub-xmlrpc-api-image/server-hub-xmlrpc-api-image.changes.nadvornik.hub-update
@@ -1,0 +1,1 @@
+- Call update-ca-certificates on startup


### PR DESCRIPTION
## What does this PR change?

Call update-ca-certificates on startup of hub xmlrpc container.
Without this change the service does not see the certificates mounted in  /etc/pki/trust/anchors volume.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: bugfix
- [ ] **DONE**

## Test coverage
TBD

- [ ] **DONE**

## Links

https://github.com/uyuni-project/uyuni-tools/issues/292

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
