### PR TITLE
Optimize AppStreams related queries

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -885,9 +885,6 @@ SELECT P.id, P.summary, PP.name as provider
 
 <mode name="system_available_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
-      WITH appstreamPackage AS (
-        SELECT package_id, max(module_id) as module_id FROM suseAppstreamPackage GROUP BY package_id
-      )
 SELECT rp.id AS package_id,
        pn.name || '-' || evr_t_as_vre_simple(latest.evr) AS NVRE,
        rp.summary AS summary,
@@ -922,13 +919,14 @@ SELECT rp.id AS package_id,
            JOIN rhnPackage rp ON rp.name_id = latest.name_id
                              AND rp.evr_id =  lookup_evr((latest.evr).epoch, (latest.evr).version, (latest.evr).release, (latest.evr).type)
                              AND rp.package_arch_id = latest.arch_id
-           LEFT JOIN appstreamPackage appStreamPkg on appStreamPkg.package_id = rp.id
+           LEFT JOIN suseAppstreamPackage appStreamPkg on appStreamPkg.package_id = rp.id
            LEFT JOIN suseAppstream appStream on appStream.channel_id = latest.channel_id and appStream.id = appStreamPkg.module_id
           WHERE EXISTS (
                          SELECT 1 FROM rhnChannelPackage rcp
                            JOIN rhnServerChannel rsc ON rsc.channel_id = rcp.channel_id
                           WHERE rcp.package_id = rp.id
                             AND rsc.server_id = :sid)
+    GROUP BY rp.id, pn.name, latest.evr, latest.arch_id, latest.arch_label, pn.id, appStream.name, appStream.stream
     ORDER BY UPPER(pn.name)
   </query>
 </mode>
@@ -1161,9 +1159,6 @@ SELECT  COUNT(pn.id) AS COUNT
 
 <mode name="system_upgradable_package_list" class="com.redhat.rhn.frontend.dto.UpgradablePackageListItem">
   <query params="sid">
-      WITH appstreamPackage AS (
-      SELECT package_id, max(module_id) as module_id FROM suseAppstreamPackage GROUP BY package_id
-      )
 SELECT  n.id AS id,
         n.id AS name_id,
         lookup_evr(((latest.evr)).epoch, (latest.evr).version, (latest.evr).release, (latest.evr).type) AS evr_id,
@@ -1203,7 +1198,7 @@ SELECT  n.id AS id,
   LEFT JOIN rhnPackage p ON p.name_id = latest.package_name_id
      AND p.evr_id = latest.package_evr_id
      AND p.package_arch_id = latest.package_arch_id
-  LEFT JOIN appstreamPackage ap on ap.package_id = p.id
+  LEFT JOIN suseAppstreamPackage ap on ap.package_id = p.id
   LEFT JOIN suseAppstream a on a.id = ap.module_id
  where sp.server_id = :sid
  order by upper(n.name)

--- a/schema/spacewalk/common/tables/suseAppstream.sql
+++ b/schema/spacewalk/common/tables/suseAppstream.sql
@@ -31,4 +31,7 @@ CREATE TABLE suseAppstream(
 CREATE UNIQUE INDEX idx_uq_as_module_nsvca
     ON suseAppstream(channel_id, name, stream, version, context, arch);
 
+CREATE INDEX suse_appstream_name_stream_arch_idx
+  ON suseAppStream (name, stream, arch);
+
 CREATE SEQUENCE suse_as_module_seq;

--- a/schema/spacewalk/common/tables/suseAppstreamApi.sql
+++ b/schema/spacewalk/common/tables/suseAppstreamApi.sql
@@ -22,3 +22,6 @@ CREATE TABLE suseAppstreamApi(
         modified        TIMESTAMPTZ DEFAULT (current_timestamp) NOT NULL,
         CONSTRAINT uq_as_api UNIQUE (module_id, rpm)
 );
+
+CREATE INDEX suse_appstream_api_rpm_idx
+  ON suseAppStreamApi (rpm);

--- a/schema/spacewalk/common/tables/suseServerAppstream.sql
+++ b/schema/spacewalk/common/tables/suseServerAppstream.sql
@@ -25,4 +25,7 @@ CREATE TABLE suseServerAppstream(
     arch    VARCHAR(16) NOT NULL
 );
 
+CREATE INDEX suse_srvappstream_name_stream_arch_idx
+  ON suseServerAppStream (name, stream, arch);
+
 CREATE SEQUENCE suse_as_servermodule_seq;

--- a/schema/spacewalk/susemanager-schema.changes.welder.optimize-appstream-queries
+++ b/schema/spacewalk/susemanager-schema.changes.welder.optimize-appstream-queries
@@ -1,0 +1,1 @@
+- Optimize AppStreams related queries

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.7-to-susemanager-schema-5.0.8/001-optimize-appstreams-hidden-packages-views.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.7-to-susemanager-schema-5.0.8/001-optimize-appstreams-hidden-packages-views.sql
@@ -1,22 +1,5 @@
---
--- Copyright (c) 2024 SUSE LLC
---
--- This software is licensed to you under the GNU General Public License,
--- version 2 (GPLv2). There is NO WARRANTY for this software, express or
--- implied, including the implied warranties of MERCHANTABILITY or FITNESS
--- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
--- along with this software; if not, see
--- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
---
--- Red Hat trademarks are not licensed under GPLv2. No permission is
--- granted to use or replicate Red Hat trademarks that are incorporated
--- in this software or its documentation.
---
 CREATE OR REPLACE VIEW suseServerAppStreamHiddenPackagesView AS
 
--- If a package is part of any appstream,
--- and this appstream is not enabled in
--- a server, it should appear here.
 SELECT DISTINCT sasp.package_id AS pid, sc.server_id AS sid
 FROM rhnserverchannel sc
     INNER JOIN suseappstream sas ON sas.channel_id = sc.channel_id
@@ -28,9 +11,6 @@ WHERE ssa.id IS NULL
 
 UNION
 
--- If a package is part of an enabled appstream, all the packages
--- whose name matches with appstream api need to be filtered out
--- except the packages that are part of the enabled appstream.
 SELECT DISTINCT p.id AS pid, server_stream.server_id AS sid
 FROM suseServerAppstream server_stream
     INNER JOIN suseAppstream appstream ON appstream.name = server_stream.name
@@ -45,3 +25,12 @@ WHERE NOT EXISTS (
     WHERE server_id = server_stream.server_id
         AND package_id = p.id
 );
+
+CREATE INDEX IF NOT EXISTS suse_appstream_name_stream_arch_idx
+  ON suseAppStream (name, stream, arch);
+
+CREATE INDEX IF NOT EXISTS suse_srvappstream_name_stream_arch_idx
+  ON suseServerAppStream (name, stream, arch);
+
+CREATE INDEX IF NOT EXISTS suse_appstream_api_rpm_idx
+  ON suseAppStreamApi (rpm);


### PR DESCRIPTION
## What does this PR change?

It fixes `suseServerAppStreamHiddenPackagesView` by considering the `stream` column when joining `suseAppstream` and `suseServerAppstream` tables and includes new indexes to optimize the queries on it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24195

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
