### PR TITLE
Speed-up mgrutil.remove_ssh_known_host runner function

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -1,16 +1,19 @@
-#  pylint: disable=missing-module-docstring
+"""A collection of utility runner functions for Uyuni."""
+
 from subprocess import Popen, PIPE
 import logging
 import stat
 import grp
 import shlex
 import os
+import os.path
 import shutil
 import salt.utils
 import tempfile
 from salt.utils.minions import CkMinions
 
 import certs.mgr_ssl_cert_setup
+
 
 log = logging.getLogger(__name__)
 
@@ -106,8 +109,12 @@ def chain_ssh_cmd(
 
 
 def remove_ssh_known_host(user, hostname, port):
+    """Remove an SSH known host entry from Salt SSH's database."""
+    config_path = os.path.join(os.path.expanduser(f"~{user}"), ".ssh", "known_hosts")
+    if not os.path.exists(config_path):
+        config_path = None
     # pylint: disable-next=undefined-variable
-    return __salt__["salt.cmd"]("ssh.rm_known_host", user, hostname, None, port)
+    return __salt__["salt.cmd"]("ssh.rm_known_host", user, hostname, config_path, port)
 
 
 def _cmd(cmd):

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.speedup-mgrutil-remove-known-host
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.speedup-mgrutil-remove-known-host
@@ -1,0 +1,1 @@
+- Speed-up mgrutil.remove_ssh_known_host runner (bsc#1223312)


### PR DESCRIPTION
## What does this PR change?

`mgrutil.remove_ssh_known_host` uses Salt's `ssh.rm_known_host` function. `ssh.rm_known_host` computes the path to the `known_hosts` file if that is not passed. This computation can take a long time because it uses the generic `user.info` function, which can be slow when users configure e.g. winbindd to provide user/group information.

We now bypass this potentially expensive computation and try to find the config file ourselves.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: we don't have environments where we can test the runtime performance of "slow" directory servers.

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24171
Port(s): https://github.com/SUSE/spacewalk/pull/24315

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
