### PR TITLE
QE: use real channels in product migration features

### DIFF
--- a/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
@@ -47,13 +47,14 @@ Feature: Migrate a SLES 15 SP3 Salt minion to 15 SP4
     And I install Salt packages from "sle15sp3_minion"
     And I disable repositories after installing Salt on this "sle15sp3_minion"
 
-  Scenario: Subscribe the SLES minion to a base channel
+  Scenario: Subscribe the SLES minion to a SLES 15 SP4 child channel
     Given I am on the Systems overview page of this "sle15sp3_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Test-Base-Channel-x86_64"
-    And I wait until I do not see "Loading..." text
+    And I should see the child channel "SLE15-SP4-Installer-Updates for x86_64" "unselected"
+    When I select the child channel "SLE15-SP4-Installer-Updates for x86_64"
+    Then I should see the child channel "SLE15-SP4-Installer-Updates for x86_64" "selected"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
@@ -48,13 +48,14 @@ Feature: Migrate a SLES 15 SP3 Salt SSH minion to 15 SP4
     And I install Salt packages from "sle15sp3_ssh_minion"
     And I disable repositories after installing Salt on this "sle15sp3_ssh_minion"
 
-  Scenario: Subscribe the SSH-managed SLES minion to a base channel
+  Scenario: Subscribe the SSH-managed SLES minion to a SLES 15 SP4 child channel
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Test-Base-Channel-x86_64"
-    And I wait until I do not see "Loading..." text
+    And I should see the child channel "SLE15-SP4-Installer-Updates for x86_64" "unselected"
+    When I select the child channel "SLE15-SP4-Installer-Updates for x86_64"
+    Then I should see the child channel "SLE15-SP4-Installer-Updates for x86_64" "selected"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
@@ -59,13 +59,14 @@ Feature: Migrate a SLE Micro 5.4 Salt minion to SLE Micro 5.5
     And I reboot the "slemicro54_minion" minion through the web UI
     And I disable repositories after installing Salt on this "slemicro54_minion"
 
-  Scenario: Subscribe the SLE Micro minion to a base channel
+  Scenario: Subscribe the SLE Micro minion to SLE Micro 5.5 child channels
     Given I am on the Systems overview page of this "slemicro54_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Test-Base-Channel-x86_64"
-    And I wait until I do not see "Loading..." text
+    And I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "unselected"
+    When I select the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5"
+    Then I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "selected"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
@@ -60,13 +60,14 @@ Feature: Migrate a SLE Micro 5.4 Salt SSH minion to SLE Micro 5.5
     And I reboot the "slemicro54_ssh_minion" minion through the web UI
     And I disable repositories after installing Salt on this "slemicro54_ssh_minion"
 
-  Scenario: Subscribe the SSH-managed SLE Micro minion to a base channel
+  Scenario: Subscribe the SSH-managed SLE Micro minion to SLE Micro 5.5 child channels
     Given I am on the Systems overview page of this "slemicro54_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "Test-Base-Channel-x86_64"
-    And I wait until I do not see "Loading..." text
+    And I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "unselected"
+    When I select the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5"
+    Then I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "selected"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"


### PR DESCRIPTION
## What does this PR change?

After a product migration takes place in BV, we should use real channels from the new product version (and therefore new base channel) to test whether it is possible to successfully subscribe the minion to a new child channel.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were  modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24233
Port(s): Manager 4.3 https://github.com/SUSE/spacewalk/pull/24316

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
