### PR TITLE
Add and handle billing data service

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -26,6 +26,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     ${EXTRAPACKAGES} \
     ${PRODUCT_PATTERN_PREFIX}_server \
     ${PRODUCT_PATTERN_PREFIX}_retail \
+    billing-data-service \
     spacewalk-utils-extras \
     grub2-x86_64-efi \
     ed \

--- a/containers/server-image/server-image.changes.mc.add-and-handle-billing-data-service
+++ b/containers/server-image/server-image.changes.mc.add-and-handle-billing-data-service
@@ -1,1 +1,1 @@
-- install billing-data-service in the container required for PAYG
+- PAYG requires to install billing-data-service in the container

--- a/containers/server-image/server-image.changes.mc.add-and-handle-billing-data-service
+++ b/containers/server-image/server-image.changes.mc.add-and-handle-billing-data-service
@@ -1,0 +1,1 @@
+- install billing-data-service in the container required for PAYG

--- a/python/billingdataservice/billing-data-service.changes.mc.add-and-handle-billing-data-service
+++ b/python/billingdataservice/billing-data-service.changes.mc.add-and-handle-billing-data-service
@@ -1,2 +1,2 @@
-- make service depending on environment valiable
-- enable service by default
+- Make billing-data-service depending on environment variable
+- Enable service by default

--- a/python/billingdataservice/billing-data-service.changes.mc.add-and-handle-billing-data-service
+++ b/python/billingdataservice/billing-data-service.changes.mc.add-and-handle-billing-data-service
@@ -1,0 +1,2 @@
+- make service depending on environment valiable
+- enable service by default

--- a/python/billingdataservice/billing-data-service.service
+++ b/python/billingdataservice/billing-data-service.service
@@ -3,6 +3,7 @@ Description=SUSE Manager PAYG billing data service
 After=local-fs.target network.target postgresql.service
 Before=tomcat.service taskomatic.service
 Requires=postgresql.service
+ConditionEnvironment=ISPAYG=1
 
 [Service]
 Type=simple

--- a/python/billingdataservice/billing-data-service.spec
+++ b/python/billingdataservice/billing-data-service.spec
@@ -74,6 +74,11 @@ done
 %postun
 %service_del_postun billing-data-service.service
 
+%posttrans
+if [ -f %{_unitdir}/billing-data-service.service ]; then
+    /usr/bin/systemctl --quiet enable billing-data-service.service 2>&1 ||:
+fi
+
 %files
 %license LICENSE
 %dir %{_sysconfdir}/sysconfig

--- a/python/billingdataservice/payg-service-override.conf
+++ b/python/billingdataservice/payg-service-override.conf
@@ -1,3 +1,2 @@
 [Unit]
 Requires=billing-data-service.service
-Requires=csp-billing-adapter.service

--- a/spacewalk/admin/mgr-check-payg.service
+++ b/spacewalk/admin/mgr-check-payg.service
@@ -2,6 +2,7 @@
 Description=Check and install payg billing service.
 Before=tomcat.service
 Before=taskomatic.service
+ConditionEnvironment=ISPAYG=1
 
 [Service]
 ExecStart=/usr/sbin/spacewalk-startup-helper check-billing-service

--- a/spacewalk/admin/mgr-check-payg.service
+++ b/spacewalk/admin/mgr-check-payg.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Check and install payg billing service.
+Description=Check and install PAYG billing service.
 Before=tomcat.service
 Before=taskomatic.service
 ConditionEnvironment=ISPAYG=1

--- a/spacewalk/admin/spacewalk-admin.changes.mc.add-and-handle-billing-data-service
+++ b/spacewalk/admin/spacewalk-admin.changes.mc.add-and-handle-billing-data-service
@@ -1,1 +1,1 @@
-- remove enforcing billing-adapter-service as it is running outside of the container
+- Remove enforcing billing-adapter-service as it is running outside of the container

--- a/spacewalk/admin/spacewalk-admin.changes.mc.add-and-handle-billing-data-service
+++ b/spacewalk/admin/spacewalk-admin.changes.mc.add-and-handle-billing-data-service
@@ -1,0 +1,1 @@
+- remove enforcing billing-adapter-service as it is running outside of the container

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -59,7 +59,6 @@ enforce_service_installed_running() {
 
 check_billing_service() {
   enforce_service_installed_running billing-data-service billing-data-service
-  enforce_service_installed_running csp-billing-adapter-service csp-billing-adapter
 }
 
 check_schema_version() {


### PR DESCRIPTION
## What does this PR change?

The billing-data-service is needed for SUMA PAYG Public Cloud image.
As we do not want a special container, we install it by default inside of the container and enable the service.

The service has a condition to only start when ISPAYG environment variable is set. This should be done by "mgradm install"
via the service file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24287

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
