### PR TITLE
Retail - fix proxy name

### DIFF
--- a/testsuite/features/build_validation/retail/proxy_container_branch_network.feature
+++ b/testsuite/features/build_validation/retail/proxy_container_branch_network.feature
@@ -9,9 +9,12 @@ Feature: Prepare the containerized branch server for PXE booting
   As the system administrator
   I prepare the branch network in containerized setup
 
-  Scenario: Activate the branch network on the proxy
-    When I connect the second interface of the proxy to the private network
-    And I restart all proxy containers to let them pick new network configuration
+  Scenario: Adapt the proxy for Retail
+    When I rename the proxy for Retail
+    And I connect the second interface of the proxy to the private network
+    And I restart all proxy containers
+
+  Scenario: Check the branch network
     Then the "dhcp_dns" host should be present on private network
     And name resolution should work on private network
 

--- a/testsuite/features/init_clients/proxy_container_branch_network.feature
+++ b/testsuite/features/init_clients/proxy_container_branch_network.feature
@@ -11,13 +11,16 @@
 @scope_containerized_proxy
 @proxy
 @private_net
-Feature: Setup containerized proxy
+Feature: Prepare the containerized branch server for PXE booting
   In order to use a containerized proxy as a Retail Branch server
   As the system administrator
   I make sure the network setup is as expected
 
-  Scenario: Activate the branch network on the proxy
-    When I connect the second interface of the proxy to the private network
-    And I restart all proxy containers to let them pick new network configuration
+  Scenario: Adapt the proxy for Retail
+    When I rename the proxy for Retail
+    And I connect the second interface of the proxy to the private network
+    And I restart all proxy containers
+
+  Scenario: Check the branch network
     Then the "dhcp_dns" host should be present on private network
     And name resolution should work on private network

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -102,6 +102,11 @@ Then(/^"([^"]*)" should communicate with the server using public interface$/) do
   get_target('server').run("ping -n -c 1 #{node.public_ip}")
 end
 
+When(/^I rename the proxy for Retail$/) do
+  node = get_target('proxy')
+  node.run('sed -i "s/^proxy_fqdn:.*$/proxy_fqdn: proxy.example.org/" /etc/uyuni/proxy/config.yaml')
+end
+
 When(/^I connect the second interface of the proxy to the private network$/) do
   node = get_target('proxy')
   _result, return_code = node.run('which nmcli')
@@ -125,7 +130,7 @@ When(/^I connect the second interface of the proxy to the private network$/) do
   node.run(cmd)
 end
 
-When(/^I restart all proxy containers to let them pick new network configuration$/) do
+When(/^I restart all proxy containers$/) do
   node = get_target('proxy')
   node.run('systemctl restart uyuni-proxy-httpd.service')
   node.run('systemctl restart uyuni-proxy-salt-broker.service')


### PR DESCRIPTION
## What does this PR change?

This PR sets the name of the proxy to its name on the private network in prevision for pxeboot via Cobbler or Retail.


## Links

No ports.


## Changelogs

- [x] No changelog needed
