### PR TITLE
Add FQDNs from the proxy configuration to existing system

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2198,6 +2198,11 @@ public class SystemManager extends BaseManager {
             }
             info.setSshPort(port);
             info.setSshPublicKey(sshPublicKey.getBytes());
+
+            // Add the FQDNs as some may not be already known
+            server.getFqdns().addAll(fqdns.stream()
+                .filter(fqdn -> !fqdn.contains("*"))
+                .map(fqdn -> new ServerFQDN(server, fqdn)).collect(Collectors.toList()));
             return server;
         }
         Server server = ServerFactory.createServer();

--- a/java/spacewalk-java.changes.cbosdo.multi-fqdn
+++ b/java/spacewalk-java.changes.cbosdo.multi-fqdn
@@ -1,0 +1,2 @@
+- Add FQDNs from proxy configuration to existing system 
+  (bsc#1222336)


### PR DESCRIPTION
## What does this PR change?

A previous PR added the FQDNs from the proxy configuration to the new system created (foreign), but not to the existing one.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Cucumber tests were failing

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24066

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
