### PR TITLE
[PostgreSQL exporter] Fix password parsing

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
@@ -19,6 +19,10 @@ postgres_exporter:
   cmd.run:
     - name: /usr/bin/rpm --query --info prometheus-postgres_exporter || /usr/bin/rpm --query --info golang-github-wrouesnel-postgres_exporter
 
+postgres_exporter_cleanup:
+  file.absent:
+    - name: /etc/sysconfig/prometheus-postgres_exporter
+
 postgres_exporter_configuration:
   file.managed:
     - name: /etc/postgres_exporter/postgres_exporter_queries.yaml
@@ -31,15 +35,23 @@ postgres_exporter_configuration:
 
 postgres_exporter_service:
   file.managed:
-    - name: /etc/sysconfig/prometheus-postgres_exporter
-    - source: salt://srvmonitoring/prometheus-postgres_exporter
+    - names:
+      - /etc/systemd/system/prometheus-postgres_exporter.service.d/60-server.conf:
+        - source: salt://srvmonitoring/prometheus-postgres_exporter
+        - user: root
+        - mode: 644
+      - /etc/postgres_exporter/pg_passwd:
+        - source: salt://srvmonitoring/pg_passwd
+        - user: prometheus
+        - mode: 600
+    - makedirs: True
     - template: jinja
-    - user: root
     - group: root
-    - mode: 644
     - require:
       - cmd: postgres_exporter
       - file: postgres_exporter_configuration
+  module.run:
+    - name: service.systemctl_reload
   service.running:
     - name: prometheus-postgres_exporter
     - enable: True

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/pg_passwd
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/pg_passwd
@@ -1,0 +1,1 @@
+{{ pillar['db_pass'] }}

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/prometheus-postgres_exporter
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/prometheus-postgres_exporter
@@ -1,19 +1,6 @@
-## Path:           Applications/PostgreSQLExporter
-## Description:    Prometheus exporter for PostgreSQL
-## Type:           string()
-## Default:        "postgresql://user:passwd@localhost:5432/database?sslmode=disable"
-## ServiceRestart: postgres-exporter
-#
-# Connection URL to postgresql instance
-#
-DATA_SOURCE_NAME="postgresql://{{ pillar['db_user'] }}:{{ pillar['db_pass'] }}@{{ pillar['db_host'] }}:{{ pillar['db_port'] }}/{{ pillar['db_name'] }}?sslmode=disable"
-
-## Path:           Applications/PostgreSQLExporter
-## Description:    Prometheus exporter for PostgreSQL
-## Type:           string()
-## Default:        ""
-## ServiceRestart: postgres-exporter
-#
-# Extra options for postgres-exporter
-#
-POSTGRES_EXPORTER_PARAMS="--extend.query-path /etc/postgres_exporter/postgres_exporter_queries.yaml"
+[Service]
+EnvironmentFile=
+Environment="DATA_SOURCE_URI={{ pillar['db_host'] }}:{{ pillar['db_port'] }}/{{ pillar['db_name'] }}?sslmode=disable"
+Environment="DATA_SOURCE_USER={{ pillar['db_user'] }}"
+Environment="DATA_SOURCE_PASS_FILE=/etc/postgres_exporter/pg_passwd"
+Environment="POSTGRES_EXPORTER_PARAMS=--extend.query-path /etc/postgres_exporter/postgres_exporter_queries.yaml"

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.witek.pg_exporter_pass
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.witek.pg_exporter_pass
@@ -1,0 +1,2 @@
+- Fix parsing passwords with special characters for PostgreSQL
+  exporter


### PR DESCRIPTION
## What does this PR change?

Fix parsing passwords with special characters for PostgreSQL exporter configuration.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: The user experience stays the same.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): SUSE/spacewalk#24030

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
