### PR TITLE
Removed Java 17 only feature in autogenerated equals

### DIFF
--- a/java/code/src/com/suse/cloud/PaygComplainceInfo.java
+++ b/java/code/src/com/suse/cloud/PaygComplainceInfo.java
@@ -111,10 +111,11 @@ public class PaygComplainceInfo {
             return true;
         }
 
-        if (!(o instanceof PaygComplainceInfo that)) {
+        if (!(o instanceof PaygComplainceInfo)) {
             return false;
         }
 
+        PaygComplainceInfo that = (PaygComplainceInfo) o;
         return new EqualsBuilder()
             .append(paygInstance, that.paygInstance)
             .append(compliant, that.compliant)


### PR DESCRIPTION
## What does this PR change?

This PR restores compatibility with Java 11 by removing a pattern matching `instanceof` introduced in the `equals()` autogenerated by the IDE.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
