### PR TITLE
QE: The step to run mgr-sync will now fail if the error code is different than expected values 0 or 1

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -705,7 +705,8 @@ Then(/^I wait until mgr-sync refresh is finished$/) do
   # mgr-sync refresh is a slow operation, we don't use the default timeout
   cmd = 'spacecmd -u admin -p admin api sync.content.listProducts | grep SLES'
   repeat_until_timeout(timeout: 1800, message: '\'mgr-sync refresh\' did not finish') do
-    result, _code = get_target('server').run(cmd, check_errors: false)
+    # If the error code is different than 0 (grep matches) or 1 (no grep matches), the command failed.
+    result, _code = get_target('server').run(cmd, successcodes: [0, 1], check_errors: true)
     break if result.include? 'SLES'
 
     sleep 5


### PR DESCRIPTION
## What does this PR change?

In our current Build Validation pass, we suspected that this step might be failing silently.
So we want to improve the verbosity of it, without printing the whole output on every iteration, as this will overload our logs.

As we expect to have error code 0 o 1 from the grep command piped to spacecmd command, we decided to fail the step if the error code is different than these values.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
