### PR TITLE
Fixed missing pagination buttons icon

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
@@ -550,9 +550,7 @@ public class ListTagUtil {
         for (String linkNameIn : linkNames) {
             String[] linkData = links.get(linkNameIn);
             ListTagUtil.write(pageContext, "<button ");
-            ListTagUtil.write(pageContext, "class=\"btn btn-default btn-xs ");
-            ListTagUtil.write(pageContext, linkData[0]);
-
+            ListTagUtil.write(pageContext, "class=\"btn btn-default btn-xs");
             // if the link is disabled...
             if (linkData[1] == null) {
                 ListTagUtil.write(pageContext, " disabled");
@@ -565,7 +563,11 @@ public class ListTagUtil {
             }
             ListTagUtil.write(pageContext, "\" title=\"");
             ListTagUtil.write(pageContext, linkData[3]);
-            ListTagUtil.write(pageContext, "\"></button>");
+            ListTagUtil.write(pageContext, "\">");
+            ListTagUtil.write(pageContext, "<i class=\"");
+            ListTagUtil.write(pageContext, linkData[0]);
+            ListTagUtil.write(pageContext, "\"></i>");
+            ListTagUtil.write(pageContext, "</button>");
         }
         ListTagUtil.write(pageContext, "</div>");
     }

--- a/java/spacewalk-java.changes.bisht-richa.fix-missing-pagination-icon
+++ b/java/spacewalk-java.changes.bisht-richa.fix-missing-pagination-icon
@@ -1,0 +1,1 @@
+- Fix missing icons in pagination buttons


### PR DESCRIPTION
## What does this PR change?
Fixed missing icons in pagination buttons:

https://localhost:8080/rhn/admin/SatSchedules.do
https://localhost:8080/rhn/systems/details/packages/PackageList.do?sid=1000010006&

## GUI diff

No difference.

Before:
<img width="1563" alt="Screenshot 2024-05-17 at 9 41 59" src="https://github.com/uyuni-project/uyuni/assets/18264463/678c6b83-a305-4d4f-ac88-4f237048cc0e">

After:
<img width="1383" alt="Screenshot 2024-05-17 at 9 42 52" src="https://github.com/uyuni-project/uyuni/assets/18264463/319cff4f-ea87-4b9a-8114-58821209000b">

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: **add explanation**


- [x] **DONE**

## Links

Issue(s): #8728
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
