### PR TITLE
QE: Remove sumaform cleanup of the container proxy

### DIFF
--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -18,10 +18,6 @@ Feature: Setup containerized proxy
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Clean up sumaform leftovers on the containerized proxy
-    When I perform a full salt minion cleanup on "proxy"
-    And I reboot the "proxy" host through SSH, waiting until it comes back
-
   Scenario: Bootstrap the proxy host as a salt minion
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text


### PR DESCRIPTION
## What does this PR change?

According to @vzhestkov, this is a bad thing and we should not use it anymore. ~So I disabled the scenario temporarily~ So I removed this scenario after testing it on the HEAD CI, to see if that fixes https://github.com/SUSE/spacewalk/issues/24360

Slack thread: https://suse.slack.com/archives/C02D134507M/p1715932883653409

### Steps done
 
- tainted the proxy resources with terraform and let them be recreated
- remove the already present Salt key in `/var/lib/salt/.ssh/known_hosts` on the server container
- comment out the cleanup scenario
- rerun the feature:

```bash
suma-head-ctl:~/spacewalk/testsuite # cucumber features/init_clients/proxy_container.feature
Capybara APP Host: https://suma-head-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname suma-head-srv and FQDN suma-head-srv.mgr.suse.de
Node: suma-head-srv, OS Version: 15-SP6, Family: sles
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname suma-head-srv and FQDN suma-head-srv.mgr.suse.de
Node: suma-head-srv, OS Version: 15-SP6, Family: sles
Activating XML-RPC API
Using the default profile...
# Copyright (c) 2024 SUSE LLC
# Licensed under the terms of the MIT license.
#
# The scenarios in this feature are skipped if:
# * there is no proxy ($proxy is nil)
# * there is no scope @scope_containerized_proxy
#
# Bootstrap the proxy as a Pod
@containerized_server @scope_containerized_proxy @proxy @under_debugging
Feature: Setup containerized proxy
  In order to use a containerized proxy with the server
  As the system administrator
  I want to register the containerized proxy on the server

  Scenario: Log in as admin user                  # features/init_clients/proxy_container.feature:19
      This scenario ran at: 2024-05-17 11:16:31 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:401
      This scenario took: 13 seconds

  # Scenario: Clean up sumaform leftovers on the containerized proxy
  #   When I perform a full salt minion cleanup on "proxy"
  #   And I reboot the "proxy" host through SSH, waiting until it comes back
  Scenario: Bootstrap the proxy host as a salt minion          # features/init_clients/proxy_container.feature:26
      This scenario ran at: 2024-05-17 11:16:44 +0200
    When I follow the left menu "Systems > Bootstrapping"      # features/step_definitions/navigation_steps.rb:339
    Then I should see a "Bootstrap Minions" text               # features/step_definitions/navigation_steps.rb:591
Initializing a twopence node for 'proxy'.
Host 'proxy' is alive with determined hostname suma-head-pxy and FQDN suma-head-pxy.mgr.suse.de
Node: suma-head-pxy, OS Version: 5.5, Family: sle-micro
    When I enter the hostname of "proxy" as "hostname"         # features/step_definitions/navigation_steps.rb:437
      The hostname of proxy is suma-head-pxy.mgr.suse.de
    And I enter "22" as "port"                                 # features/step_definitions/navigation_steps.rb:220
    And I enter "root" as "user"                               # features/step_definitions/navigation_steps.rb:220
    And I enter "linux" as "password"                          # features/step_definitions/navigation_steps.rb:220
    And I select "1-PROXY-KEY-x86_64" from "activationKeys"    # features/step_definitions/navigation_steps.rb:164
    And I click on "Bootstrap"                                 # features/step_definitions/navigation_steps.rb:256
    And I wait until I see "Bootstrap process initiated." text # features/step_definitions/navigation_steps.rb:39
      This scenario took: 27 seconds

  Scenario: Reboot the proxy host                                           # features/init_clients/proxy_container.feature:37
      This scenario ran at: 2024-05-17 11:17:11 +0200
reboot returned status code = 0.
Output:
''
Node suma-head-pxy is offline.
Node suma-head-pxy is online.
    When I reboot the "proxy" host through SSH, waiting until it comes back # features/step_definitions/command_steps.rb:1563
      This scenario took: 26 seconds

  Scenario: Wait until the proxy host appears             # features/init_clients/proxy_container.feature:40
      This scenario ran at: 2024-05-17 11:17:37 +0200
    When I wait until onboarding is completed for "proxy" # features/step_definitions/setup_steps.rb:220
      This scenario took: 141 seconds

  Scenario: Generate containerized proxy configuration                                                                    # features/init_clients/proxy_container.feature:43
      This scenario ran at: 2024-05-17 11:19:58 +0200
    When I generate the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy on the server           # features/step_definitions/command_steps.rb:1477
.
.
    And I copy the configuration "/tmp/proxy_container_config.tar.gz" of containerized proxy from the server to the proxy # features/step_definitions/command_steps.rb:1503
      This scenario took: 7 seconds

  Scenario: Set up the containerized proxy service to support Avahi # features/init_clients/proxy_container.feature:47
      This scenario ran at: 2024-05-17 11:20:05 +0200
    When I add avahi hosts in containerized proxy configuration     # features/step_definitions/command_steps.rb:1508
      Record not added - avahi domain was not detected
      This scenario took: 0 seconds

  Scenario: Run a containerized proxy                                                # features/init_clients/proxy_container.feature:50
      This scenario ran at: 2024-05-17 11:20:05 +0200
    When I run "mgrpxy install podman /tmp/proxy_container_config.tar.gz" on "proxy" # features/step_definitions/command_steps.rb:753
      This scenario took: 60 seconds

  Scenario: Wait until containerized proxy service is active                # features/init_clients/proxy_container.feature:53
      This scenario ran at: 2024-05-17 11:21:05 +0200
    And I wait until "uyuni-proxy-pod" service is active on "proxy"         # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-httpd" service is active on "proxy"       # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-salt-broker" service is active on "proxy" # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-squid" service is active on "proxy"       # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-ssh" service is active on "proxy"         # features/step_definitions/command_steps.rb:281
    And I wait until "uyuni-proxy-tftpd" service is active on "proxy"       # features/step_definitions/command_steps.rb:281
    And I wait until port "8022" is listening on "proxy" container          # features/step_definitions/command_steps.rb:1529
    And I wait until port "80" is listening on "proxy" container            # features/step_definitions/command_steps.rb:1529
    And I wait until port "443" is listening on "proxy" container           # features/step_definitions/command_steps.rb:1529
    And I visit "Proxy" endpoint of this "proxy"                            # features/step_definitions/navigation_steps.rb:1063
      This scenario took: 5 seconds

  Scenario: The containerized proxy should be registered automatically # features/init_clients/proxy_container.feature:65
      This scenario ran at: 2024-05-17 11:21:10 +0200
    When I follow the left menu "Systems"                              # features/step_definitions/navigation_steps.rb:339
    And I wait until I see the name of "proxy", refreshing the page    # features/step_definitions/navigation_steps.rb:102
      This scenario took: 1 seconds

9 scenarios (9 passed)
28 steps (28 passed)
4m39.583s
```


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24360
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!