### PR TITLE
Emulate Bootstrap 3 modals in Bootstrap 5

### DIFF
--- a/web/html/src/branding/css/bootstrap5-scaffolding-variables.scss
+++ b/web/html/src/branding/css/bootstrap5-scaffolding-variables.scss
@@ -1,1 +1,8 @@
 $grid-gutter-width: 30px;
+
+$modal-content-bg: white;
+$modal-header-padding: 15px;
+$modal-inner-padding: 15px;
+$modal-md: 600px;
+$modal-lg: 600px;
+$modal-xl: 600px;

--- a/web/html/src/branding/css/susemanager/components/modal.less
+++ b/web/html/src/branding/css/susemanager/components/modal.less
@@ -1,3 +1,19 @@
+.modal-header {
+  .close {
+    border: 1px solid #000;
+    border-radius: 2px;
+    width: 22px;
+    height: 22px;
+    box-sizing: content-box;
+    padding: 0 0 0 1px;
+    opacity: 0.4;
+
+    &:hover {
+      opacity: 0.6;
+    }
+  }
+}
+
 .modal-body {
   height: auto;
   overflow-y: auto;

--- a/web/html/src/branding/css/susemanager/components/modal.scss
+++ b/web/html/src/branding/css/susemanager/components/modal.scss
@@ -1,3 +1,34 @@
+.modal-header {
+  border-bottom: 1px solid #e5e5e5;
+
+  .close {
+    border: 1px solid #000;
+    border-radius: 2px;
+    width: 22px;
+    height: 22px;
+    box-sizing: content-box;
+    padding: 0 0 0 1px;
+
+    // Emulate the old theme verbatim
+    margin-top: -2px;
+    font-size: 21px;
+    font-weight: bold;
+    line-height: 1;
+    color: #000;
+    text-shadow: 0 1px 0 #fff;
+    opacity: 0.4;
+    order: 1;
+
+    &:hover {
+      opacity: 0.6;
+    }
+  }
+
+  .modal-title {
+    margin: 0;
+  }
+}
+
 .modal-body {
   height: auto;
   overflow-y: auto;
@@ -18,6 +49,14 @@
   inset: 0px;
   background-color: $modal-backdrop-color;
   z-index: $zindex-modal-backdrop;
+}
+
+.modal-dialog {
+  margin: 30px auto;
+}
+
+.modal-content {
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
 }
 
 .ReactModal__Content {

--- a/web/html/src/branding/css/susemanager/components/pre.scss
+++ b/web/html/src/branding/css/susemanager/components/pre.scss
@@ -1,0 +1,59 @@
+// This emulates the old theme verbatim, we can clean these styles up after the migration is done
+code,
+kbd,
+pre,
+samp {
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+
+code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 0;
+}
+
+kbd {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #fff;
+  background-color: #333;
+  border-radius: 0;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+
+kbd kbd {
+  padding: 0;
+  font-size: 100%;
+  font-weight: 700;
+  box-shadow: none;
+}
+
+pre {
+  display: block;
+  padding: 10px;
+  margin: 0 0 10.5px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #141823;
+  word-break: break-all;
+  word-wrap: break-word;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 0;
+}
+
+pre code {
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border-radius: 0;
+}
+
+.pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll;
+}

--- a/web/html/src/branding/css/susemanager/index.scss
+++ b/web/html/src/branding/css/susemanager/index.scss
@@ -26,6 +26,7 @@
 @import "./components/header.scss";
 @import "./components/text.scss";
 @import "./components/address.scss";
+@import "./components/pre.scss";
 
 @import "./bootstrap-fixes.scss";
 

--- a/web/html/src/components/dialog/util.ts
+++ b/web/html/src/components/dialog/util.ts
@@ -1,7 +1,18 @@
 export function showDialog(dialogId: string) {
-  jQuery("#" + dialogId).modal("show");
+  jQuery("#" + dialogId)
+    .modal("show")
+    // Here and below, these manual handlers offer compatibility between Bootstrap 3 and 5, we can drop these after the migration is complete
+    .addClass("show");
+
+  jQuery(".modal-backdrop.in").addClass("show");
 }
 
 export function hideDialog(dialogId: string) {
-  jQuery("#" + dialogId).modal("hide");
+  jQuery("#" + dialogId)
+    .modal("hide")
+    .removeClass("show");
+
+  if (jQuery(".modal.in").length === 0) {
+    jQuery(".modal-backdrop.show").removeClass("show");
+  }
 }

--- a/web/spacewalk-web.changes.eth.modal-diff
+++ b/web/spacewalk-web.changes.eth.modal-diff
@@ -1,1 +1,1 @@
-- Fix modal layouts on notification messages page
+- Fix modal layouts on notification messages page (bsc#1224401)

--- a/web/spacewalk-web.changes.eth.modal-diff
+++ b/web/spacewalk-web.changes.eth.modal-diff
@@ -1,0 +1,1 @@
+- Fix modal layouts on notification messages page


### PR DESCRIPTION
## What does this PR change?

Bootstrap 3 and 5 handle modals slightly differently, so we need to use a placeholder layout in 5 until we wrap up the migration. The new styles are mostly just verbatim copies of what 3 uses for modals so the look and feel is the same.

## GUI diff

Modals work again on the notification messages page.

<img width="1150" alt="Screenshot 2024-05-17 at 13 03 54" src="https://github.com/uyuni-project/uyuni/assets/3171718/2b652dbc-9a0a-4175-abe4-0c0414972e6c">


- [x] **DONE**

## Documentation
- No documentation needed: bugfix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1224401

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
