### PR TITLE
QE: Fix constants for proxy in 5.0 and Uyuni BV environments

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -227,6 +227,7 @@ PACKAGE_BY_CLIENT = {
 # Then take a look at the Parent Channel selections
 BASE_CHANNEL_BY_CLIENT = {
   'SUSE Manager' => {
+    'proxy' => 'SLE-Micro-5.5-Pool for x86_64',
     'proxy_container' => 'SLE-Micro-5.5-Pool for x86_64',
     'proxy_traditional' => 'SLE-Product-SUSE-Manager-Proxy-4.3-Pool for x86_64',
     'sle_minion' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
@@ -299,6 +300,7 @@ BASE_CHANNEL_BY_CLIENT = {
     'salt_migration_minion' => 'SLE-Product-SLES15-SP5-Pool for x86_64'
   },
   'Uyuni' => {
+    'proxy' => 'openSUSE Leap Micro 5.5 (x86_64)',
     'proxy_container' => 'openSUSE Leap Micro 5.5 (x86_64)',
     'proxy_traditional' => 'openSUSE Leap 15.5 (x86_64)',
     'sle_minion' => 'openSUSE Leap 15.5 (x86_64)',


### PR DESCRIPTION
## What does this PR change?

In CI, we still distinguish between Proxy Containerized and Classic Proxy.
In BV, for 5.0/Uyuni, we just have one kind of proxy (containerized).

So, we need to fix the constants adding a key for "proxy"

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were fixed

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
