### PR TITLE
BV: Keep init_proxy out of the Rakefile run_set generation

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -211,7 +211,7 @@ namespace :jenkins do
   task :generate_rake_files_init_clients, [:instances] do |_t, args|
     minions = args[:instances]
     minions.each do |minion|
-      next if minion.include?('monitoring')
+      next if minion.include?('monitoring') || minion.include?('proxy')
 
       Rake::Task['jenkins:generate_rake_run_step'].invoke('', File.basename(minion, '.feature'), 'features/build_validation/init_clients', "run_sets/build_validation/build_validation_init_client_#{minion}.yml")
       Rake::Task['jenkins:generate_rake_run_step'].reenable

--- a/testsuite/run_sets/build_validation/build_validation_init_proxy.yml
+++ b/testsuite/run_sets/build_validation/build_validation_init_proxy.yml
@@ -1,0 +1,7 @@
+# This file describes the order of features in a Build Validation test suite run.
+
+## Init proxy BEGIN ###
+
+- features/build_validation/init_clients/proxy.feature
+
+## Init proxy END ###


### PR DESCRIPTION
## What does this PR change?

Fix this issue:
![image](https://github.com/uyuni-project/uyuni/assets/2827771/349f53bd-3b1d-499b-b729-47115b2553a8)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports?

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
