### PR TITLE
checksum url failing because option -o have no space

### DIFF
--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -139,7 +139,7 @@ def get_checksum_path(dir, original_file_name, file_url)
       next unless response.is_a?(Net::HTTPSuccess)
 
       checksum_url = base_url + name
-      _output, code = server.run("cd #{dir} && curl --insecure #{checksum_url}-o #{name}", timeout: 10)
+      _output, code = server.run("cd #{dir} && curl --insecure #{checksum_url} -o #{name}", timeout: 10)
       return "#{dir}/#{name}" if code.zero?
     end
 


### PR DESCRIPTION
## What does this PR change?

Command `curl --insecure http://mirror.chpc.utah.edu/pub/centos/7/isos/x86_64/sha256sum.txt-o sha256sum.txt` is currently failing because we are missing a space between the url and the -o option

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
