### PR TITLE
Update the message as this requirement is not valid anymore

### DIFF
--- a/spacecmd/src/spacecmd/proxy.py
+++ b/spacecmd/src/spacecmd/proxy.py
@@ -33,7 +33,7 @@ def help_proxy_container_config(self):
     print(_('''usage: proxy_container_config [options] PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL ROOT_CA CRT KEY
 
 parameters:
-  PROXY_FQDN  the unique, DNS-resolvable FQDN of this proxy. It should be different from any registered clients.
+  PROXY_FQDN  the unique, DNS-resolvable FQDN of this proxy.
   SERVER_FQDN the fully qualified domain name of the server to connect to proxy to.
   MAX_CACHE   the maximum cache size in MB. 60% of the storage is a good value.
   EMAIL       the email of the proxy administrator
@@ -90,7 +90,7 @@ def help_proxy_container_config_generate_cert(self):
     print(_('''usage: proxy_container_config_generate_cert PROXY_FQDN SERVER_FQDN MAX_CACHE EMAIL
 
 parameters:
-  PROXY_FQDN  the unique, DNS-resolvable FQDN of this proxy. It should be different from any registered clients.
+  PROXY_FQDN  the unique, DNS-resolvable FQDN of this proxy.
   SERVER_FQDN the fully qualified domain name of the server to connect to proxy to.
   MAX_CACHE   the maximum cache size in MB. 60% of the storage is a good value.
   EMAIL       the email of the proxy administrator

--- a/web/html/src/manager/proxy/container-config.tsx
+++ b/web/html/src/manager/proxy/container-config.tsx
@@ -197,7 +197,7 @@ export function ProxyConfig() {
         <Text
           name="proxyFQDN"
           label={t("Proxy FQDN")}
-          hint={t("The unique, DNS-resolvable FQDN of this proxy. It should be different from any registered clients.")}
+          hint={t("The unique, DNS-resolvable FQDN of this proxy.")}
           required
           placeholder={t("e.g., proxy.domain.com")}
           labelClass="col-md-3"


### PR DESCRIPTION
## What does this PR change?

This requirement is not valid anymore for the proxy so removing it.


## GUI diff

No difference.

Before:
<img width="1326" alt="Screenshot 2024-05-20 at 4 43 39 PM" src="https://github.com/uyuni-project/uyuni/assets/12951268/113506fc-b13d-4cd1-8054-67ea7ce68172">

After:

<img width="1326" alt="Screenshot 2024-05-20 at 4 43 56 PM" src="https://github.com/uyuni-project/uyuni/assets/12951268/3f6a06d1-e572-4631-8a6e-2be0a8fdabf8">

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**


- [x] **DONE**

## Test coverage
- No tests: Only a label change and that isn't covered by tests.



- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
