### PR TITLE
BV: Fix mark second check box/row in a list

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -909,7 +909,7 @@ end
 
 When(/^I check the second row in the list$/) do
   within(:xpath, '//section') do
-    row = find(:xpath, '//div[@class=\'table-responsive\']/table/tbody/tr[2]/td')
+    row = find(:xpath, '//div[@class=\'table-responsive\']/table/tbody/tr[2]/td', match: :first)
     row.find(:xpath, './/input[@type=\'checkbox\']', match: :first).set(true)
   end
 end


### PR DESCRIPTION
## What does this PR change?

Fix mark second check box/row in a list.
As it is now, it raise an ambiguous matching error.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
