### PR TITLE
Fix modal backwards compatibility event handling, fix layout inconsistencies

### DIFF
--- a/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials.jsp
@@ -9,11 +9,11 @@
         <script type="text/javascript" src="/javascript/susemanager-setup-wizard.js?cb=${rhn:getConfig('web.buildtimestamp')}"></script>
         <script type="text/javascript" src="/javascript/susemanager-setup-wizard-mirror-credentials.js?cb=${rhn:getConfig('web.buildtimestamp')}"></script>
         <!-- MODAL: Edit credentials -->
-        <div class="modal fade" id="modal-edit-credentials">
+        <div class="modal" id="modal-edit-credentials">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-close"></i></button>
                         <h4 class="modal-title"><bean:message key="mirror-credentials.jsp.modal-edit.title" /></h4>
                     </div>
                     <div class="modal-body">
@@ -53,11 +53,11 @@
         </div>
 
         <!-- MODAL: Delete credentials -->
-        <div class="modal fade" id="modal-delete-credentials">
+        <div class="modal" id="modal-delete-credentials">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-close"></i></button>
                         <h4 class="modal-title"><bean:message key="mirror-credentials.jsp.modal-delete.title" /></h4>
                     </div>
                     <div class="modal-body">
@@ -84,11 +84,11 @@
         </div>
 
         <!-- MODAL: List subscriptions -->
-        <div class="modal fade" id="modal-list-subscriptions">
+        <div class="modal" id="modal-list-subscriptions">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"><i class="fa fa-close"></i></button>
                         <h4 class="modal-title"><bean:message key="mirror-credentials.jsp.modal-subscriptions.title" /></h4>
                     </div>
                     <div id="modal-list-subscriptions-body" class="modal-body">

--- a/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
+++ b/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
@@ -158,12 +158,12 @@
     </div>
 
     <%-- Modal delete confirm dialog --%>
-    <div class="modal fade" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="confirm-modal-title" aria-hidden="true">
+    <div class="modal" id="confirm-modal" tabindex="-1" role="dialog" aria-labelledby="confirm-modal-title" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close"
-                        data-dismiss="modal">&times;</button>
+                        data-dismiss="modal"><i class="fa fa-close"></i></button>
                     <h4 class="modal-title" id="confirm-modal-title">
                         <bean:message key="actionchain.jsp.modaltitle"/>
                     </h4>

--- a/java/code/webapp/WEB-INF/pages/ssm/systems/deleteconfirmdialog.jspf
+++ b/java/code/webapp/WEB-INF/pages/ssm/systems/deleteconfirmdialog.jspf
@@ -4,12 +4,12 @@
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean" %>
 <c:choose>
     <c:when test="${saltMinionsPresent}">
-        <div class="modal fade text-left" role="dialog" aria-labelledby="addPinPopUpLabel" id="confirmDeleteDialog">
+        <div class="modal text-left" role="dialog" aria-labelledby="addPinPopUpLabel" id="confirmDeleteDialog">
             <div class="modal-dialog">
               <div class="modal-content">
                 <div class="modal-header">
                   <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <span aria-hidden="true"><i class="fa fa-close"></i></span>
                   </button>
                   <h4 class="modal-title"><bean:message key="ssm.delete.systems.header" /></h4>
                 </div>

--- a/java/spacewalk-java.changes.eth.modal-event
+++ b/java/spacewalk-java.changes.eth.modal-event
@@ -1,0 +1,1 @@
+- Fix modal layout inconsistencies

--- a/web/html/src/branding/css/bootstrap5-scaffolding-variables.scss
+++ b/web/html/src/branding/css/bootstrap5-scaffolding-variables.scss
@@ -1,8 +1,6 @@
 $grid-gutter-width: 30px;
 
-$modal-content-bg: white;
-$modal-header-padding: 15px;
-$modal-inner-padding: 15px;
+$modal-sm: 300px;
 $modal-md: 600px;
-$modal-lg: 600px;
-$modal-xl: 600px;
+$modal-lg: 900px;
+$modal-xl: 900px;

--- a/web/html/src/branding/css/susemanager/components/modal.less
+++ b/web/html/src/branding/css/susemanager/components/modal.less
@@ -23,6 +23,11 @@
   &:focus {
     outline: none;
   }
+
+  .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 .modal-footer {

--- a/web/html/src/branding/css/susemanager/components/modal.less
+++ b/web/html/src/branding/css/susemanager/components/modal.less
@@ -1,15 +1,23 @@
 .modal-header {
+  padding: 15px;
+
   .close {
     border: 1px solid #000;
     border-radius: 2px;
     width: 22px;
     height: 22px;
     box-sizing: content-box;
-    padding: 0 0 0 1px;
+    padding: 0;
+    margin: 0;
     opacity: 0.4;
+    font-size: 14px;
 
     &:hover {
       opacity: 0.6;
+    }
+
+    .fa {
+      margin: 0;
     }
   }
 }
@@ -17,6 +25,7 @@
 .modal-body {
   height: auto;
   overflow-y: auto;
+  padding: 15px;
   
   &,
   &:active,
@@ -32,13 +41,26 @@
 
 .modal-footer {
   margin: 0;
+  padding: 15px;
+  border-top: 1px solid #e5e5e5;
 }
 
+.modal-backdrop,
 .modal-overlay {
   position: fixed;
   inset: 0px;
   background-color: @modal-backdrop-color;
   z-index: @zindex-modal-background;
+}
+
+.modal-backdrop.in,
+.modal-backdrop.show {
+  opacity: 1;
+}
+
+.modal-content {
+  background: white;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
 }
 
 .ReactModal__Content {

--- a/web/html/src/branding/css/susemanager/components/modal.scss
+++ b/web/html/src/branding/css/susemanager/components/modal.scss
@@ -38,6 +38,11 @@
   &:focus {
     outline: none;
   }
+
+  .row {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 .modal-footer {

--- a/web/html/src/branding/css/susemanager/components/modal.scss
+++ b/web/html/src/branding/css/susemanager/components/modal.scss
@@ -1,5 +1,10 @@
+.modal.show {
+  display: block;
+}
+
 .modal-header {
   border-bottom: 1px solid #e5e5e5;
+  padding: 15px;
 
   .close {
     border: 1px solid #000;
@@ -7,20 +12,23 @@
     width: 22px;
     height: 22px;
     box-sizing: content-box;
-    padding: 0 0 0 1px;
+    padding: 0;
+    margin: 0;
+    opacity: 0.4;
+    font-size: 14px;
 
     // Emulate the old theme verbatim
-    margin-top: -2px;
-    font-size: 21px;
-    font-weight: bold;
     line-height: 1;
     color: #000;
     text-shadow: 0 1px 0 #fff;
-    opacity: 0.4;
     order: 1;
 
     &:hover {
       opacity: 0.6;
+    }
+
+    .fa {
+      margin: 0;
     }
   }
 
@@ -32,6 +40,7 @@
 .modal-body {
   height: auto;
   overflow-y: auto;
+  padding: 15px;
   
   &,
   &:active,
@@ -47,8 +56,15 @@
 
 .modal-footer {
   margin: 0;
+  padding: 15px;
+  border-top: 1px solid #e5e5e5;
+
+  .btn + .btn {
+    margin-left: 5px;
+  }
 }
 
+.modal-backdrop,
 .modal-overlay {
   position: fixed;
   inset: 0px;
@@ -56,11 +72,17 @@
   z-index: $zindex-modal-backdrop;
 }
 
+.modal-backdrop.in,
+.modal-backdrop.show {
+  opacity: 1;
+}
+
 .modal-dialog {
   margin: 30px auto;
 }
 
 .modal-content {
+  background: white;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
 }
 

--- a/web/html/src/branding/css/susemanager/components/tables.less
+++ b/web/html/src/branding/css/susemanager/components/tables.less
@@ -29,6 +29,7 @@ thead tr {
     border-width: 0 !important;
     color: @eos-bc-gray-1000 !important;
     font-weight: bold !important;
+    background: transparent;
   }
 }
 

--- a/web/html/src/branding/css/susemanager/components/tables.scss
+++ b/web/html/src/branding/css/susemanager/components/tables.scss
@@ -29,6 +29,7 @@ thead tr {
     border-width: 0 !important;
     color: $eos-bc-gray-1000 !important;
     font-weight: bold !important;
+    background: transparent;
   }
 }
 

--- a/web/html/src/components/dialog/Dialog.tsx
+++ b/web/html/src/components/dialog/Dialog.tsx
@@ -51,7 +51,9 @@ export function Dialog(props: DialogProps) {
                 aria-label="Close"
                 onClick={() => props.onClose?.()}
               >
-                <span aria-hidden="true">&times;</span>
+                <span aria-hidden="true">
+                  <i className="fa fa-close"></i>
+                </span>
               </button>
             )}
             {props.title ? <h4 className="modal-title">{props.title}</h4> : null}

--- a/web/html/src/components/dialog/util.ts
+++ b/web/html/src/components/dialog/util.ts
@@ -1,18 +1,19 @@
 export function showDialog(dialogId: string) {
-  jQuery("#" + dialogId)
+  const dialog = jQuery("#" + dialogId)
     .modal("show")
     // Here and below, these manual handlers offer compatibility between Bootstrap 3 and 5, we can drop these after the migration is complete
-    .addClass("show");
+    .addClass("show")
+    .on("hide.bs.modal", () => {
+      dialog.removeClass("show");
+
+      if (jQuery(".modal.in").length === 0) {
+        jQuery(".modal-backdrop.show").removeClass("show");
+      }
+    });
 
   jQuery(".modal-backdrop.in").addClass("show");
 }
 
 export function hideDialog(dialogId: string) {
-  jQuery("#" + dialogId)
-    .modal("hide")
-    .removeClass("show");
-
-  if (jQuery(".modal.in").length === 0) {
-    jQuery(".modal-backdrop.show").removeClass("show");
-  }
+  jQuery("#" + dialogId).modal("hide");
 }

--- a/web/html/src/components/dialog/util.ts
+++ b/web/html/src/components/dialog/util.ts
@@ -1,10 +1,14 @@
 export function showDialog(dialogId: string) {
+  // The base event is "hide.bs.modal", we only want to remove the listener we added so we add a namespace, see https://api.jquery.com/event.namespace/
+  const namespacedEventName = "hide.bs.modal.namespace-dialog-util";
+
   const dialog = jQuery("#" + dialogId)
     .modal("show")
     // Here and below, these manual handlers offer compatibility between Bootstrap 3 and 5, we can drop these after the migration is complete
     .addClass("show")
-    .on("hide.bs.modal", () => {
-      dialog.removeClass("show");
+    .off(namespacedEventName)
+    .on(namespacedEventName, () => {
+      dialog.removeClass("show").off(namespacedEventName);
 
       if (jQuery(".modal.in").length === 0) {
         jQuery(".modal-backdrop.show").removeClass("show");

--- a/web/html/src/components/popup.tsx
+++ b/web/html/src/components/popup.tsx
@@ -42,14 +42,16 @@ export class PopUp extends React.Component<Props> {
     }
 
     return (
-      <div className="modal fade" tabIndex="-1" role="dialog" id={this.props.id} {...bootStrapModalOptionalProps}>
+      <div className="modal" tabIndex="-1" role="dialog" id={this.props.id} {...bootStrapModalOptionalProps}>
         <div className={"modal-dialog " + (this.props.className ? this.props.className : "")}>
           <div className="modal-content">
             {!this.props.hideHeader && (
               <div className="modal-header">
                 {closableModal && (
                   <button type="button" className="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
+                    <span aria-hidden="true">
+                      <i className="fa fa-close"></i>
+                    </span>
                   </button>
                 )}
                 {this.props.title ? <h4 className="modal-title">{this.props.title}</h4> : null}

--- a/web/spacewalk-web.changes.eth.modal-event
+++ b/web/spacewalk-web.changes.eth.modal-event
@@ -1,0 +1,1 @@
+- Fix modal backwards compatibility event handling


### PR DESCRIPTION
## What does this PR change?

The backwards compatibility fix we have for Bootstrap 3 and 5 modals was incomplete and the overlay was not always hidden properly. This PR fixes the issue.

Also fix a number of small layout inconsistencies between different pages, fix the icon not being an actual icon like elsewhere, etc.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

https://suse.slack.com/archives/C02D130RBA6/p1716280210173269

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
