### PR TITLE
QE: Refactor how Cobbler items are deleted

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_buildiso.feature
+++ b/testsuite/features/secondary/srv_cobbler_buildiso.feature
@@ -10,24 +10,24 @@ Feature: Cobbler buildiso
     When I start local monitoring of Cobbler
     And I backup Cobbler settings file
 
-  Scenario: Log in as testing user in the cobbler buildiso context
+  Scenario: Log in as testing user in the Cobbler buildiso context
     Given I am authorized as "testing" with password "testing"
     And I am logged in via the Cobbler API as user "testing" with password "testing"
 
-  Scenario: Copy cobbler profiles on the server in the cobbler buildiso context
+  Scenario: Copy cobbler profiles on the server in the Cobbler buildiso context
     When I copy autoinstall mocked files on server
 
-  Scenario: Create a dummy distro in the cobbler buildiso context
+  Scenario: Create a dummy distro in the Cobbler buildiso context
     Given cobblerd is running
     When I create distro "buildisodistro"
 
-  Scenario: Create dummy profiles in the cobbler buildiso context
+  Scenario: Create dummy profiles in the Cobbler buildiso context
     Given distro "buildisodistro" exists
     When I create profile "orchid" for distro "buildisodistro"
     And I create profile "flame" for distro "buildisodistro"
     And I create profile "pearl" for distro "buildisodistro"
 
-  Scenario: Check cobbler created a distro and profiles in the cobbler buildiso context
+  Scenario: Check cobbler created a distro and profiles in the Cobbler buildiso context
     When I follow the left menu "Systems > Autoinstallation > Profiles"
     Then I should see a "buildisodistro" text
     And I should see a "orchid" text
@@ -39,53 +39,61 @@ Feature: Cobbler buildiso
     When I create system "testsystem" for profile "orchid"
     And I add the Cobbler parameter "name-servers" with value "9.9.9.9" to item "system" with name "testsystem"
 
-  Scenario: Prepare the cobbler buildiso context
+  Scenario: Prepare the Cobbler buildiso context
     When I prepare Cobbler for the buildiso command
 
-  Scenario: Run Cobbler buildiso with all profiles and check isolinux config file in the cobbler buildiso context
+  Scenario: Run Cobbler buildiso with all profiles and check isolinux config file in the Cobbler buildiso context
     When I run Cobbler buildiso for distro "buildisodistro" and all profiles
     And I check Cobbler buildiso ISO "profile_all" with xorriso
     And I check the Cobbler parameter "nameserver" with value "9.9.9.9" in the isolinux.cfg
     And I cleanup xorriso temp files
 
-  Scenario: Run Cobbler buildiso with selected profile in the cobbler buildiso context
+  Scenario: Run Cobbler buildiso with selected profile in the Cobbler buildiso context
     When I run Cobbler buildiso for distro "buildisodistro" and profile "orchid"
     And I check Cobbler buildiso ISO "orchid" with xorriso
     And I cleanup xorriso temp files
 
-  Scenario: Run Cobbler buildiso with selected profile and without dns entries in the cobbler buildiso context
+  Scenario: Run Cobbler buildiso with selected profile and without dns entries in the Cobbler buildiso context
     When I run Cobbler buildiso for distro "buildisodistro" and profile "orchid" without dns entries
     And I check Cobbler buildiso ISO "orchid" with xorriso
     And I cleanup xorriso temp files
 
-  Scenario: Run Cobbler buildiso airgapped with all profiles in the cobbler buildiso context
+  Scenario: Run Cobbler buildiso airgapped with all profiles in the Cobbler buildiso context
     When I run Cobbler buildiso "airgapped" for distro "buildisodistro"
     And I check Cobbler buildiso ISO "airgapped" with xorriso
     And I cleanup xorriso temp files
 
-  Scenario: Run Cobbler buildiso standalone with all profiles in the cobbler buildiso context
+  Scenario: Run Cobbler buildiso standalone with all profiles in the Cobbler buildiso context
     When I run Cobbler buildiso "standalone" for distro "buildisodistro"
     And I check Cobbler buildiso ISO "standalone" with xorriso
     And I cleanup xorriso temp files
 
-  Scenario: Cleanup: delete test distro and profiles in the cobbler buildiso context
+  Scenario: Cleanup: delete test system in the Cobbler buildiso context
     Given I am authorized as "testing" with password "testing"
-    # the order is important here. First systems, then profiles then distros
     When I remove system "testsystem"
-    And I remove profile "orchid" as user "testing" with password "testing"
-    And I remove profile "flame" as user "testing" with password "testing"
-    And I remove profile "pearl" as user "testing" with password "testing"
-    And I remove distro "buildisodistro" as user "testing" with password "testing"
-    And I follow the left menu "Systems > Autoinstallation > Profiles"
-    Then I should not see a "buildisodistro" text
-    And I should not see a "orchid" text
+
+  Scenario: Cleanup: delete test profile in the Cobbler buildiso context
+    Given I am authorized as "testing" with password "testing"
+    And I remove profile "orchid"
+    And I remove profile "flame"
+    And I remove profile "pearl"
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
+    Then I should not see a "orchid" text
     And I should not see a "flame" text
     And I should not see a "flame" text
 
-  Scenario: Cleanup: Remove buildiso tmpdir and built ISO file in the cobbler buildiso context
+  Scenario: Cleanup: delete test distro in the Cobbler buildiso context
+    Given I am authorized as "testing" with password "testing"
+    And I remove distro "buildisodistro"
+    And I follow the left menu "Systems > Autoinstallation > Profiles"
+    Then I should not see a "buildisodistro" text
+
+  Scenario: Cleanup: Remove buildiso tmpdir and built ISO file in the Cobbler buildiso context
     When I cleanup after Cobbler buildiso
-    And I log out from Cobbler via the API
 
 @flaky
   Scenario: Check for errors in Cobbler monitoring
     Then the local logs for Cobbler should not contain errors
+
+  Scenario: Logout from the Cobbler API
+    When I log out from Cobbler via the API

--- a/testsuite/features/secondary/srv_cobbler_buildiso.feature
+++ b/testsuite/features/secondary/srv_cobbler_buildiso.feature
@@ -53,7 +53,6 @@ Feature: Cobbler buildiso
     And I check Cobbler buildiso ISO "orchid" with xorriso
     And I cleanup xorriso temp files
 
-  # TODO: Fails unless https://github.com/cobbler/cobbler/issues/2995 is fixed
   Scenario: Run Cobbler buildiso with selected profile and without dns entries in the cobbler buildiso context
     When I run Cobbler buildiso for distro "buildisodistro" and profile "orchid" without dns entries
     And I check Cobbler buildiso ISO "orchid" with xorriso
@@ -71,8 +70,12 @@ Feature: Cobbler buildiso
 
   Scenario: Cleanup: delete test distro and profiles in the cobbler buildiso context
     Given I am authorized as "testing" with password "testing"
+    # the order is important here. First systems, then profiles then distros
     When I remove system "testsystem"
-    And I remove kickstart profiles and distros
+    And I remove profile "orchid" as user "testing" with password "testing"
+    And I remove profile "flame" as user "testing" with password "testing"
+    And I remove profile "pearl" as user "testing" with password "testing"
+    And I remove distro "buildisodistro" as user "testing" with password "testing"
     And I follow the left menu "Systems > Autoinstallation > Profiles"
     Then I should not see a "buildisodistro" text
     And I should not see a "orchid" text

--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -174,7 +174,8 @@ Feature: Cobbler and distribution autoinstallation
     And the cobbler report should contain "00:22:22:77:ee:cc" for cobbler system name "testserver:1"
 
   Scenario: Cleanup: delete test distro and profiles
-    When I remove kickstart profiles and distros
+    When I remove distro "testdistro" as user "testing" with password "testing"
+    And I remove profile "testprofile" as user "testing" with password "testing"
     And I log out from Cobbler via the API
 
 @flaky

--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -173,11 +173,15 @@ Feature: Cobbler and distribution autoinstallation
     And the cobbler report should contain "1.1.1.1" for cobbler system name "testserver:1"
     And the cobbler report should contain "00:22:22:77:ee:cc" for cobbler system name "testserver:1"
 
-  Scenario: Cleanup: delete test distro and profiles
-    When I remove distro "testdistro" as user "testing" with password "testing"
-    And I remove profile "testprofile" as user "testing" with password "testing"
-    And I log out from Cobbler via the API
+  Scenario: Cleanup: delete test profile
+    When I remove profile "testprofile"
+
+  Scenario: Cleanup: delete test distro
+    When I remove distro "testdistro"
 
 @flaky
   Scenario: Check for errors in Cobbler monitoring
     Then the local logs for Cobbler should not contain errors
+
+  Scenario: Logout from the Cobbler API
+    When I log out from Cobbler via the API

--- a/testsuite/features/secondary/srv_cobbler_profile.feature
+++ b/testsuite/features/secondary/srv_cobbler_profile.feature
@@ -18,6 +18,7 @@ Feature: Edit Cobbler profiles
 
   Scenario: Log in as testing user
     Given I am authorized as "testing" with password "testing"
+    And I am logged in via the Cobbler API as user "testing" with password "testing"
 
   Scenario: Start Cobbler monitoring
     When I start local monitoring of Cobbler
@@ -141,3 +142,6 @@ Feature: Edit Cobbler profiles
 @flaky
   Scenario: Check for errors in Cobbler monitoring
     Then the local logs for Cobbler should not contain errors
+
+  Scenario: Logout from the Cobbler API
+    When I log out from Cobbler via the API

--- a/testsuite/features/secondary/srv_cobbler_profile.feature
+++ b/testsuite/features/secondary/srv_cobbler_profile.feature
@@ -95,15 +95,48 @@ Feature: Edit Cobbler profiles
       | inst.repo   | http://ise.cobbler.test |
       | self_update | http://ise.cobbler.test |
 
-  Scenario: Cleanup: delete test distros and profiles
-    When I remove kickstart profiles and distros
-    And I follow the left menu "Systems > System List"
+  Scenario: Cleanup: delete test system
+    When I follow the left menu "Systems > System List"
     And I wait until I see the "isesystem_api" system, refreshing the page
     And I follow "isesystem_api"
     And I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
+
+  Scenario: Cleanup: delete test profiles
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
+    Then I should see a "iseprofile_ui" text
+    And I follow "iseprofile_ui"
+    Then I should see a "Autoinstallation: iseprofile_ui" text
+    And I follow "Delete Autoinstallation"
+    And I click on "Delete Autoinstallation"
+    Then I should see a "Autoinstallation was deleted successfully" text
+    And I should not see a "iseprofile_ui" text
+    And I should see a "iseprofile_api" text
+    And I follow "iseprofile_api"
+    Then I should see a "Autoinstallation: iseprofile_api" text
+    And I follow "Delete Autoinstallation"
+    And I click on "Delete Autoinstallation"
+    Then I should see a "Autoinstallation was deleted successfully" text
+    And I should not see a "iseprofile_api" text
+
+  Scenario: Cleanup: delete test distibutions
+    When I follow the left menu "Systems > Autoinstallation > Distributions"
+    Then I should see a "isedistro_ui" text
+    And I follow "isedistro_ui"
+    Then I should see a " Edit Autoinstallable Distribution" text
+    And I follow "Delete Distribution"
+    And I click on "Delete Distribution"
+    Then I should see a "Autoinstallable Distribution deleted successfully" text
+    And I should not see a "isedistro_ui" text
+    And I should see a "isedistro_api" text
+    And I follow "isedistro_api"
+    Then I should see a " Edit Autoinstallable Distribution" text
+    And I follow "Delete Distribution"
+    And I click on "Delete Distribution"
+    Then I should see a "Autoinstallable Distribution deleted successfully" text
+    And I should not see a "isedistro_api" text
 
 @flaky
   Scenario: Check for errors in Cobbler monitoring

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -22,7 +22,7 @@ When(/^I log out from Cobbler via the API$/) do
   $cobbler_test.logout
 end
 
-# distro and profile management
+# distro, profile and system management
 Given(/^distro "([^"]*)" exists$/) do |distro|
   raise ScriptError, "Distro #{distro} does not exist" unless $cobbler_test.element_exists('distros', distro)
 end
@@ -63,31 +63,6 @@ When(/^I remove distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do
   ct = ::CobblerTest.new
   ct.login(user, pwd)
   ct.distro_remove(system)
-end
-
-When(/^I remove kickstart profiles and distros$/) do
-  # -------------------------------
-  # Cleanup kickstart distros and their profiles, if any.
-
-  # Get all distributions: created from UI or from API.
-  distros = get_target('server').run('cobbler distro list')[0].split
-
-  # The name of distros created in the UI has the form: distro_label + suffix
-  user_details = $api_test.user.get_details('testing')
-  suffix = ":#{user_details['org_id']}:#{user_details['org_name'].delete(' ')}"
-
-  distros_ui =
-    distros.select { |distro| distro.end_with? suffix }
-           .map { |distro| distro.split(':')[0] }
-  distros_api = distros.reject { |distro| distro.end_with? suffix }
-  distros_ui.each { |distro| $api_test.kickstart.tree.delete_tree_and_profiles(distro) }
-  # -------------------------------
-  # Remove profiles and distros created with the API.
-
-  # We have already deleted the profiles from the UI; delete all the remaning ones.
-  profiles = get_target('server').run('cobbler profile list')[0].split
-  profiles.each { |profile| get_target('server').run("cobbler profile remove --name '#{profile}'") }
-  distros_api.each { |distro| get_target('server').run("cobbler distro remove --name '#{distro}'") }
 end
 
 # cobbler reports

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -53,16 +53,12 @@ When(/^I remove system "([^"]*)"$/) do |system|
   $cobbler_test.system_remove(system)
 end
 
-When(/^I remove profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |system, user, pwd|
-  ct = ::CobblerTest.new
-  ct.login(user, pwd)
-  ct.profile_remove(system)
+When(/^I remove profile "([^"]*)"$/) do |profile|
+  $cobbler_test.profile_remove(profile)
 end
 
-When(/^I remove distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |system, user, pwd|
-  ct = ::CobblerTest.new
-  ct.login(user, pwd)
-  ct.distro_remove(system)
+When(/^I remove distro "([^"]*)"$/) do |distro|
+  $cobbler_test.distro_remove(distro)
 end
 
 # cobbler reports

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -315,7 +315,7 @@ class CobblerTest
   #
   # @param name [String] The name of the distribution to be removed.
   def distro_remove(name)
-    raise(::IndexError, "Distribution cannot be found. #{$ERROR_INFO}") unless distro_exists(name)
+    raise(::IndexError, "Distribution cannot be found. #{$ERROR_INFO}") unless element_exists('distros', name)
 
     begin
       @server.call('remove_distro', name, @token)
@@ -331,7 +331,7 @@ class CobblerTest
   #
   # @param name [String] The name of the profile to be removed.
   def profile_remove(name)
-    raise(::IndexError, "Profile cannot be found. #{$ERROR_INFO}") unless profile_exists(name)
+    raise(::IndexError, "Profile cannot be found. #{$ERROR_INFO}") unless element_exists('profiles', name)
 
     begin
       @server.call('remove_profile', name, @token)


### PR DESCRIPTION
## What does this PR change?

This 
- will remove the very disruptive step `When(/^I remove kickstart profiles and distros$/)` since it is causing issues across all our CIs. With this step we basically remove every profile and distribution regardless if it was created in the current feature or not.
  In Cobbler, we first need to delete a system to be then able to delete the profile that was assigned to this system. The same applies for a distribution. Before being able to delete a distribution, the associated profile needs to be deleted beforehand.
  So instead of calling `I remove kickstart profiles and distros`, only the system, profile and distribution that was created in the currently executed feature will also get deleted at the end of this feature.
- fix some of the Cobbler spelling mistakes (`Cobbler` vs. `cobbler`)
- uses a global login for each feature instead of logging in in different scenarios.
- replace `distro_exists()` and `profile_exists()` with `element_exists()`: Not sure how it worked until now, since Erwan removed those 2 methods ~1 year ago.

Fixes https://github.com/SUSE/spacewalk/issues/23447
![image](https://github.com/uyuni-project/uyuni/assets/12104291/d7515ba6-b8fe-4d08-861a-c4771b34d453)


Test run for e.g. the major Cobbler profile test overhaul:

```bash
cucumber features/secondary/srv_cobbler_profile.feature 
(...)
  Scenario: Cleanup: delete test system                                    # features/secondary/srv_cobbler_profile.feature:97
      This scenario ran at: 2024-05-21 16:26:35 +0200
    When I follow the left menu "Systems > System List"                    # features/step_definitions/navigation_steps.rb:337
    And I wait until I see the "isesystem_api" system, refreshing the page # features/step_definitions/navigation_steps.rb:102
    And I follow "isesystem_api"                                           # features/step_definitions/navigation_steps.rb:284
    And I follow "Delete System"                                           # features/step_definitions/navigation_steps.rb:284
    Then I should see a "Confirm System Profile Deletion" text             # features/step_definitions/navigation_steps.rb:590
    When I click on "Delete Profile"                                       # features/step_definitions/navigation_steps.rb:256
    And I wait until I see "has been deleted" text                         # features/step_definitions/navigation_steps.rb:39
      This scenario took: 4 seconds

  Scenario: Cleanup: delete test profiles                                # features/secondary/srv_cobbler_profile.feature:106
      This scenario ran at: 2024-05-21 16:26:39 +0200
    When I follow the left menu "Systems > Autoinstallation > Profiles"  # features/step_definitions/navigation_steps.rb:337
    Then I should see a "iseprofile_ui" text                             # features/step_definitions/navigation_steps.rb:590
    And I follow "iseprofile_ui"                                         # features/step_definitions/navigation_steps.rb:284
    Then I should see a "Autoinstallation: iseprofile_ui" text           # features/step_definitions/navigation_steps.rb:590
    And I follow "Delete Autoinstallation"                               # features/step_definitions/navigation_steps.rb:284
    And I click on "Delete Autoinstallation"                             # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Autoinstallation was deleted successfully" text # features/step_definitions/navigation_steps.rb:590
    And I should not see a "iseprofile_ui" text                          # features/step_definitions/navigation_steps.rb:638
    And I should see a "iseprofile_api" text                             # features/step_definitions/navigation_steps.rb:590
    And I follow "iseprofile_api"                                        # features/step_definitions/navigation_steps.rb:284
    Then I should see a "Autoinstallation: iseprofile_api" text          # features/step_definitions/navigation_steps.rb:590
    And I follow "Delete Autoinstallation"                               # features/step_definitions/navigation_steps.rb:284
    And I click on "Delete Autoinstallation"                             # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Autoinstallation was deleted successfully" text # features/step_definitions/navigation_steps.rb:590
    And I should not see a "iseprofile_api" text                         # features/step_definitions/navigation_steps.rb:638
      This scenario took: 7 seconds

  Scenario: Cleanup: delete test distibutions                                    # features/secondary/srv_cobbler_profile.feature:123
      This scenario ran at: 2024-05-21 16:26:46 +0200
    When I follow the left menu "Systems > Autoinstallation > Distributions"     # features/step_definitions/navigation_steps.rb:337
    Then I should see a "isedistro_ui" text                                      # features/step_definitions/navigation_steps.rb:590
    And I follow "isedistro_ui"                                                  # features/step_definitions/navigation_steps.rb:284
    Then I should see a " Edit Autoinstallable Distribution" text                # features/step_definitions/navigation_steps.rb:590
    And I follow "Delete Distribution"                                           # features/step_definitions/navigation_steps.rb:284
    And I click on "Delete Distribution"                                         # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Autoinstallable Distribution deleted successfully" text # features/step_definitions/navigation_steps.rb:590
    And I should not see a "isedistro_ui" text                                   # features/step_definitions/navigation_steps.rb:638
    And I should see a "isedistro_api" text                                      # features/step_definitions/navigation_steps.rb:590
    And I follow "isedistro_api"                                                 # features/step_definitions/navigation_steps.rb:284
    Then I should see a " Edit Autoinstallable Distribution" text                # features/step_definitions/navigation_steps.rb:590
    And I follow "Delete Distribution"                                           # features/step_definitions/navigation_steps.rb:284
    And I click on "Delete Distribution"                                         # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Autoinstallable Distribution deleted successfully" text # features/step_definitions/navigation_steps.rb:590
    And I should not see a "isedistro_api" text                                  # features/step_definitions/navigation_steps.rb:638
      This scenario took: 5 seconds

4 scenarios (4 passed)
42 steps (42 passed)
0m27.801s
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23447
Ports(s): # Manager 4.3:
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!