### PR TITLE
Fix search icon button height

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -67,7 +67,8 @@ public enum ViewHelper {
         "/rhn/account/Addresses.do",
         "/rhn/account/EditAddress.do",
         "/rhn/multiorg/OrgConfigDetails.do",
-        "/rhn/manager/notification-messages"
+        "/rhn/manager/notification-messages",
+        "rhn/channels/software/Search.do"
     );
 
     ViewHelper() { }

--- a/web/html/src/branding/css/susemanager/components/buttons.suma.less
+++ b/web/html/src/branding/css/susemanager/components/buttons.suma.less
@@ -202,6 +202,7 @@
 .input-group-btn .btn {
   border-width: 1px;
   padding: 6px 12px;
+  height: 35px;
   z-index: 100;
 
   &:not(:disabled):not(.disabled):not(.text-muted):hover::after {

--- a/web/html/src/branding/css/susemanager/components/buttons.suma.less
+++ b/web/html/src/branding/css/susemanager/components/buttons.suma.less
@@ -202,7 +202,7 @@
 .input-group-btn .btn {
   border-width: 1px;
   padding: 6px 12px;
-  height: 35px;
+  height: @input-height;
   z-index: 100;
 
   &:not(:disabled):not(.disabled):not(.text-muted):hover::after {

--- a/web/html/src/branding/css/susemanager/components/buttons.suma.scss
+++ b/web/html/src/branding/css/susemanager/components/buttons.suma.scss
@@ -178,6 +178,7 @@
 .input-group-btn .btn {
   border-width: 1px;
   padding: 6px 12px;
+  height: 35px;
   z-index: 100;
 
   &:not(:disabled):not(.disabled):not(.text-muted):hover::after {

--- a/web/html/src/branding/css/susemanager/components/buttons.suma.scss
+++ b/web/html/src/branding/css/susemanager/components/buttons.suma.scss
@@ -178,13 +178,17 @@
 .input-group-btn .btn {
   border-width: 1px;
   padding: 6px 12px;
-  height: 35px;
+  height: $input-height;
   z-index: 100;
 
   &:not(:disabled):not(.disabled):not(.text-muted):hover::after {
     border-width: 1px;
     bottom: -1px;
     left: -1px;
+  }
+
+  &:last-child {
+    margin-left: -1px;
   }
 }
 

--- a/web/html/src/branding/css/susemanager/index.scss
+++ b/web/html/src/branding/css/susemanager/index.scss
@@ -14,8 +14,8 @@
 
 @import "./components/titles.scss";
 @import "./components/alerts.scss";
-@import "./components/buttons.scss";
 @import "./components/inputs.scss";
+@import "./components/buttons.scss";
 @import "./components/modal.scss";
 @import "./components/nav.scss";
 @import "./components/panels.scss";

--- a/web/html/src/core/spa/view-helper.ts
+++ b/web/html/src/core/spa/view-helper.ts
@@ -12,6 +12,7 @@ const BOOTSTRAP_READY_PAGES: string[] = [
   "/rhn/account/EditAddress.do",
   "/rhn/multiorg/OrgConfigDetails.do",
   "/rhn/manager/notification-messages",
+  "rhn/channels/software/Search.do",
 ];
 
 export const onEndNavigate = () => {

--- a/web/spacewalk-web.changes.bisht-richa.fix-search-icon-button-height
+++ b/web/spacewalk-web.changes.bisht-richa.fix-search-icon-button-height
@@ -1,0 +1,1 @@
+- Fix height of search icon button


### PR DESCRIPTION
## What does this PR change?
Fix the height of the search icon button

**add description**

## GUI diff

No difference.

Before:

<img width="1563" alt="Screenshot 2024-05-22 at 10 21 36" src="https://github.com/uyuni-project/uyuni/assets/18264463/11309507-2d2c-4528-96e4-46ac22b4a180">


After:

<img width="1488" alt="Screenshot 2024-05-22 at 10 15 36" src="https://github.com/uyuni-project/uyuni/assets/18264463/6ed78500-ecb5-473c-aa21-69311219749d">

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests:


- [x] **DONE**

## Links

Issue(s): #8755
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
