### PR TITLE
Exclude AppStream information from package profile update for Centos 7 and older (bsc1224476)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -16,9 +16,11 @@ products:
     - name: pkg.list_products
 {% elif grains['os_family'] == 'RedHat' %}
 {% include 'packages/redhatproductinfo.sls' %}
+{% if grains['osmajorrelease'] >= 8 %}
 modules:
   mgrcompat.module_run:
     - name: appstreams.get_enabled_modules
+{% endif %}
 {% elif grains['os_family'] == 'Debian' %}
 debianrelease:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.cbbayburt.bsc1224476
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.cbbayburt.bsc1224476
@@ -1,0 +1,2 @@
+- Exclude AppStream information from package profile update for 
+  Centos 7 and older (bsc1224476)


### PR DESCRIPTION
Our `appstreams` module is not available for Centos 7 and older (no `dnf`). This PR excludes gathering module information from the package profile update for these distributions.

## GUI diff

No difference.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: already covered

## Links

Fixes https://github.com/SUSE/spacewalk/issues/24372

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
