### PR TITLE
Replace getCobblerHost by getJavaHostname

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -417,7 +417,7 @@ public class DownloadFile extends DownloadAction {
             if (helper.isProxyRequest()) {
                 // Search/replacing all instances of cobbler host with host
                 // we pass in, for use with Spacewalk Proxy.
-                outputStr = outputStr.replaceAll(ConfigDefaults.get().getCobblerHost(), helper.getForwardedHost());
+                outputStr = outputStr.replaceAll(ConfigDefaults.get().getJavaHostname(), helper.getForwardedHost());
             }
 
             setContentInfo(response, outputStr.length(), CONTENT_TYPE_TEXT_XML);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartManager.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartManager.java
@@ -84,7 +84,7 @@ public class KickstartManager extends BaseManager {
         String retval = renderKickstart(url);
         // Search/replacing all instances of cobbler host with host
         // we pass in, for use with Spacewalk Proxy.
-        retval = retval.replaceAll(ConfigDefaults.get().getCobblerHost(), host);
+        retval = retval.replaceAll(ConfigDefaults.get().getJavaHostname(), host);
         return retval;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -356,7 +356,7 @@ public class KickstartUrlHelper {
         Profile prof = Profile.lookupById(
                 CobblerXMLRPCHelper.getAutomatedConnection(),
                         data.getCobblerId());
-        return "http://" + ConfigDefaults.get().getCobblerHost() + COBBLER_URL_BASE_PATH +
+        return "http://" + ConfigDefaults.get().getJavaHostname() + COBBLER_URL_BASE_PATH +
                     prof.getName();
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/SSMScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/SSMScheduleCommand.java
@@ -234,7 +234,7 @@ public class SSMScheduleCommand {
         com.setProxy(proxy);
         com.setNetworkDevice(networkType, networkInterface);
         if (proxy == null) {
-            com.setKickstartServerName(ConfigDefaults.get().getCobblerHost());
+            com.setKickstartServerName(ConfigDefaults.get().getJavaHostname());
         }
         else {
             com.setKickstartServerName(proxy.getHostname());

--- a/java/spacewalk-java.changes.oholecek.replace_cobblerhost_by_javahost
+++ b/java/spacewalk-java.changes.oholecek.replace_cobblerhost_by_javahost
@@ -1,0 +1,2 @@
+- use java hostname instead of cobbler hostname in autoinstallation
+  snippets and urls (bsc#1224441)


### PR DESCRIPTION
## What does this PR change?

Moving to the containerized server required cobbler host setting to be set to localhost. Because of this we cannot use getCobblerHost when constructing profile URLs or cobbler profiles. This PR changes some last occurrences or getCobblerHost usages. 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24383
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
