### PR TITLE
Change order of Retail features

### DIFF
--- a/testsuite/run_sets/build_validation/build_validation_retail_proxy.yml
+++ b/testsuite/run_sets/build_validation/build_validation_retail_proxy.yml
@@ -1,5 +1,10 @@
 # This file describes the order of features in a Build Validation test suite run.
 
+## Build Kiwi images
+## (expected time of building is around 20 minutes per image)
+- features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+- features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
+
 ## Prepare configuration for branch server
 - features/build_validation/retail/proxy_traditional_branch_network.feature
 - features/build_validation/retail/proxy_container_branch_network.feature

--- a/testsuite/run_sets/build_validation/build_validation_retail_sle12.yml
+++ b/testsuite/run_sets/build_validation/build_validation_retail_sle12.yml
@@ -5,9 +5,5 @@
 ## Prepare configuration for terminal
 - features/build_validation/retail/sle12sp5_terminal_prepare.feature
 
-## Build Kiwi image
-## (expected time of building is around 20 minutes)
-- features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
-
-## Deployment of retail terminal
+## Deploy Retail terminal
 - features/build_validation/retail/sle12sp5_terminal_deploy.feature

--- a/testsuite/run_sets/build_validation/build_validation_retail_sle15.yml
+++ b/testsuite/run_sets/build_validation/build_validation_retail_sle15.yml
@@ -5,9 +5,5 @@
 ## Prepare configuration for terminal
 - features/build_validation/retail/sle15sp4_terminal_prepare.feature
 
-## Build Kiwi image
-## (expected time of building is around 20 minutes)
-- features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
-
-## Deployment of retail terminal
+## Deploy Retail terminal
 - features/build_validation/retail/sle15sp4_terminal_deploy.feature


### PR DESCRIPTION
## What does this PR change?

With containerized server and proxy, one cannot prepare that Saltboot group formula before he/she has built the images. It is not possible anymore to prepare the proxy, then build the images.

The reason why it worked in a non-containerized setup is that Retail used an image-sync state at the end.


## Links

No port, 5.0 only.


## Changelogs

- [x] No changelog needed
