### PR TITLE
QE: Add SLE15SP4 LTSS to activation keys

### DIFF
--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -32,6 +32,7 @@ Feature: Update activation keys
     And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64"
     And I wait until "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
+    And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
@@ -49,6 +50,7 @@ Feature: Update activation keys
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
+    And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
@@ -62,9 +64,13 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
     And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64"
     And I wait until "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
+    And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
 
@@ -82,6 +88,7 @@ Feature: Update activation keys
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
+    And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
 
@@ -95,9 +102,13 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I wait until "SLE-Module-DevTools15-SP4-Updates for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Pool for x86_64" has been checked
+    And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
     And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64"
     And I wait until "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
+    And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
 
@@ -115,6 +126,7 @@ Feature: Update activation keys
     And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
+    And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
 
@@ -153,7 +165,6 @@ Feature: Update activation keys
     And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
-
 
 @containerized_server
 @uyuni
@@ -221,6 +232,7 @@ Feature: Update activation keys
     And I follow "Terminal Key x86_64" in the content area
     And I wait for child channels to appear
     And I check "Fake-RPM-SUSE-Channel"
+    And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key Terminal Key x86_64 has been modified" text
 
@@ -232,5 +244,6 @@ Feature: Update activation keys
     And I follow "Terminal Key x86_64" in the content area
     And I wait for child channels to appear
     And I check "Fake-RPM-Terminal-Channel"
+    And I wait until "Fake-RPM-Terminal-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key Terminal Key x86_64 has been modified" text

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -29,6 +29,8 @@ Feature: Update activation keys
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64"
+    And I wait until "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
@@ -60,6 +62,8 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64"
+    And I wait until "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
@@ -91,6 +95,8 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I include the recommended child channels
     And I check "SLE-Module-DevTools15-SP4-Pool for x86_64"
+    And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64"
+    And I wait until "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" has been checked
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Update Activation Key"
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
@@ -182,6 +188,8 @@ Feature: Update activation keys
     And I wait until "SLE-Module-Desktop-Applications15-SP4-Updates for x86_64" has been checked
     And I check "SLE-Module-Containers15-SP4-Pool for x86_64"
     And I wait until "SLE-Module-Containers15-SP4-Updates for x86_64" has been checked
+    And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64"
+    And I wait until "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been modified" text
 


### PR DESCRIPTION
## What does this PR change?

This PR adds

- missing SLE15 SP4 LTSS child channel to the right activation keys
- missing checks for some of the child channels

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!