### PR TITLE
Fix header layout alignment bugs (bsc#1225072)

### DIFF
--- a/web/html/src/branding/css/base/notifications.less
+++ b/web/html/src/branding/css/base/notifications.less
@@ -12,7 +12,7 @@
     background-color: @notification-badge;
     position: absolute;
     left: 19px;
-    top: -2px;
+    top: -5px;
     color: #333;
     font-size: 0.9em;
     min-width: 19px;

--- a/web/html/src/branding/css/base/notifications.scss
+++ b/web/html/src/branding/css/base/notifications.scss
@@ -12,7 +12,7 @@
     background-color: $notification-badge;
     position: absolute;
     left: 19px;
-    top: -2px;
+    top: -5px;
     color: #333;
     font-size: 0.9em;
     min-width: 19px;

--- a/web/html/src/branding/css/base/theme.less
+++ b/web/html/src/branding/css/base/theme.less
@@ -295,6 +295,7 @@ nav.navbar-pf {
       display: flex;
       flex-direction: column;
       gap: 4px;
+      margin: 0;
     }
     input[type="search"],
     select.form-control {

--- a/web/html/src/branding/css/base/theme.scss
+++ b/web/html/src/branding/css/base/theme.scss
@@ -292,6 +292,7 @@ nav.navbar-pf {
       display: flex;
       flex-direction: column;
       gap: 4px;
+      margin: 0;
     }
     input[type="search"],
     select.form-control {

--- a/web/html/src/branding/css/susemanager/components/header.less
+++ b/web/html/src/branding/css/susemanager/components/header.less
@@ -55,6 +55,7 @@
   }
 
   a {
+    position: relative;
     display: flex !important;
     align-items: center;
     padding: 4px 12px !important;

--- a/web/html/src/branding/css/susemanager/components/header.scss
+++ b/web/html/src/branding/css/susemanager/components/header.scss
@@ -59,6 +59,7 @@
   }
 
   a {
+    position: relative;
     display: flex !important;
     align-items: center;
     padding: 4px 12px !important;

--- a/web/spacewalk-web.changes.eth.header-alignment
+++ b/web/spacewalk-web.changes.eth.header-alignment
@@ -1,0 +1,1 @@
+- Fix header layout alignment bugs (bsc#1225072)


### PR DESCRIPTION
## What does this PR change?

Fixes the search box and the bell alignment in the header. Fixing this issue by itself is easier than detangling the breaking change back out.

## GUI diff

Before:

<img width="317" alt="Screenshot 2024-05-23 at 14 30 09" src="https://github.com/uyuni-project/uyuni/assets/3171718/e0e9d040-cc17-44dc-9664-b069110c1245">


After:

<img width="369" alt="Screenshot 2024-05-23 at 14 30 23" src="https://github.com/uyuni-project/uyuni/assets/3171718/8826261d-b10b-4c19-a995-2534282ba1f6">


- [x] **DONE**

## Documentation
- No documentation needed: bugfix.

- [x] **DONE**

## Test coverage
- No tests: UI bugfix.

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1225072

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
