### PR TITLE
Remove obsolete proxy installation messages (bsc#1224778)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -21377,14 +21377,8 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
           <context context-type="sourcefile">/systems/details/Connection.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="sdc.details.proxy.unlicensed" xml:space="preserve">
-        <source>The WebUI @@PRODUCT_NAME@@ Proxy installer is obsolete. Please use the command line installer from package spacewalk-proxy-installer.</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/systems/details/ProxyClients.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="sdc.details.proxy.licensed" xml:space="preserve">
-        <source>This machine is currently a licensed @@PRODUCT_NAME@@ Proxy (v{0}).</source>
+        <source>This machine is currently a licensed @@PRODUCT_NAME@@ Proxy.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/ProxyClients.do</context>
         </context-group>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/proxyclients.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/proxyclients.jsp
@@ -14,11 +14,8 @@
     <rhn:require acl="not system_has_foreign_entitlement()">
     <c:choose>
       <c:when test="${requestScope.version != null}">
-        <p><bean:message key="sdc.details.proxy.licensed" arg0="${requestScope.version}" /></p>
+        <p><bean:message key="sdc.details.proxy.licensed" /></p>
       </c:when>
-      <c:otherwise>
-        <p><bean:message key="sdc.details.proxy.unlicensed" /></p>
-      </c:otherwise>
     </c:choose>
     </rhn:require>
     <rl:listset name="systemListSet" legend="system">

--- a/java/spacewalk-java.changes.mbussolotto.proxy_message
+++ b/java/spacewalk-java.changes.mbussolotto.proxy_message
@@ -1,0 +1,1 @@
+- Remove obsolete proxy installation messages (bsc#1224778)


### PR DESCRIPTION
## What does this PR change?

Remove obsolete proxy installation messages (bsc#1224778)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24374

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
