### PR TITLE
do not check for billing-data-service as it run inside of the container

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
@@ -40,6 +40,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 
@@ -242,7 +243,7 @@ public class PaygAuthDataExtractor {
     protected PaygInstanceInfo extractAuthDataLocal() {
         try (BufferedReader json = Files.newBufferedReader(PAYG_INSTANCE_INFO_JSON)) {
             PaygInstanceInfo instanceInfo = GSON.fromJson(json, PaygInstanceInfo.class);
-            if (Duration.between(instanceInfo.getTimestamp(), LocalDateTime.now()).toMinutes() > VALIDITY_MINUTES) {
+            if (Duration.between(instanceInfo.getTimestamp(), Instant.now()).toMinutes() > VALIDITY_MINUTES) {
                 throw new PaygDataExtractException("Local PAYG Instance info is outdated.");
             }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/beans/PaygInstanceInfo.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/beans/PaygInstanceInfo.java
@@ -17,7 +17,7 @@ package com.redhat.rhn.taskomatic.task.payg.beans;
 
 import com.google.gson.annotations.SerializedName;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -37,7 +37,7 @@ public class PaygInstanceInfo {
     @SerializedName("certs")
     private Map<String, String> certificates;
     @SerializedName("timestamp")
-    private LocalDateTime timestamp;
+    private long timestamp;
 
     /**
      * Constructor for type CLOUDRMT
@@ -53,7 +53,7 @@ public class PaygInstanceInfo {
         this.basicAuth = basicAuthIn;
         this.headerAuth = headerAuthIn;
         this.rmtHost = rmtHostIn;
-        this.timestamp = LocalDateTime.now();
+        this.timestamp = Instant.now().getEpochSecond();
     }
 
     /**
@@ -68,7 +68,7 @@ public class PaygInstanceInfo {
         this.headerAuth = headerAuthIn;
         this.certificates = certificatesIn;
         this.repositories = repositoriesIn;
-        this.timestamp = LocalDateTime.now();
+        this.timestamp = Instant.now().getEpochSecond();
     }
 
     public String getType() {
@@ -127,11 +127,11 @@ public class PaygInstanceInfo {
         certificates = certificatesIn;
     }
 
-    public LocalDateTime getTimestamp() {
-        return timestamp;
+    public Instant getTimestamp() {
+        return Instant.ofEpochSecond(timestamp);
     }
 
-    public void setTimestamp(LocalDateTime timestampIn) {
+    public void setTimestamp(long timestampIn) {
         this.timestamp = timestampIn;
     }
 }

--- a/java/code/src/com/suse/cloud/CloudPaygManager.java
+++ b/java/code/src/com/suse/cloud/CloudPaygManager.java
@@ -169,6 +169,10 @@ public class CloudPaygManager {
                 LOG.error("The CSP Billing Adapter service has errors.");
             }
 
+            if (!complainceInfo.isMeteringAccessible()) {
+                LOG.error("Billing Data Service is not accessible.");
+            }
+
             return false;
         }
 

--- a/java/code/src/com/suse/cloud/PaygComplainceInfo.java
+++ b/java/code/src/com/suse/cloud/PaygComplainceInfo.java
@@ -43,6 +43,9 @@ public class PaygComplainceInfo {
     @SerializedName("billingServiceStatus")
     private final boolean billingAdapterHealthy;
 
+    @SerializedName("hasMeteringAccess")
+    private final boolean meteringAccessible;
+
     private final long timestamp;
 
     /**
@@ -50,7 +53,7 @@ public class PaygComplainceInfo {
      */
     public PaygComplainceInfo() {
         // By default, assume it's a compliant BYOS instance
-        this(CloudProvider.None, false, false, true, true);
+        this(CloudProvider.None, false, false, true, true, true);
     }
 
     /**
@@ -60,19 +63,21 @@ public class PaygComplainceInfo {
      * @param hasModifiedPackages if some packages are modified
      * @param isAdapterRunning if the required billing adapter service is running
      * @param isAdapterHealthy if the required billing adapter service is healthy. The value is forced to
+     * @param hasMeteringAccess if there is access to the metering API
      * <code>false</code> when the other parameter <code>isAdapterRunning</code> is set to false.
      */
     public PaygComplainceInfo(CloudProvider provider, boolean isPayg, boolean hasModifiedPackages,
-                              boolean isAdapterRunning, boolean isAdapterHealthy) {
+                              boolean isAdapterRunning, boolean isAdapterHealthy, boolean hasMeteringAccess) {
         paygInstance = isPayg;
 
         cloudProvider = provider;
         anyPackageModified = hasModifiedPackages;
         billingAdapterRunning = isAdapterRunning;
         billingAdapterHealthy = isAdapterRunning && isAdapterHealthy;
+        meteringAccessible = hasMeteringAccess;
 
         // Set the compliant flag accordingly to the value received
-        compliant = billingAdapterRunning && billingAdapterHealthy && !anyPackageModified;
+        compliant = meteringAccessible && billingAdapterRunning && billingAdapterHealthy && !anyPackageModified;
 
         timestamp = Instant.now().getEpochSecond();
     }
@@ -101,6 +106,10 @@ public class PaygComplainceInfo {
         return billingAdapterHealthy;
     }
 
+    public boolean isMeteringAccessible() {
+        return meteringAccessible;
+    }
+
     public Instant getTimestamp() {
         return Instant.ofEpochSecond(timestamp);
     }
@@ -122,6 +131,7 @@ public class PaygComplainceInfo {
             .append(anyPackageModified, that.anyPackageModified)
             .append(billingAdapterRunning, that.billingAdapterRunning)
             .append(billingAdapterHealthy, that.billingAdapterHealthy)
+            .append(meteringAccessible, that.meteringAccessible)
             .append(timestamp, that.timestamp)
             .append(cloudProvider, that.cloudProvider)
             .isEquals();
@@ -136,6 +146,7 @@ public class PaygComplainceInfo {
             .append(anyPackageModified)
             .append(billingAdapterRunning)
             .append(billingAdapterHealthy)
+            .append(meteringAccessible)
             .append(timestamp)
             .toHashCode();
     }
@@ -149,6 +160,7 @@ public class PaygComplainceInfo {
             .append("anyPackageModified", isAnyPackageModified())
             .append("billingAdapterRunning", isBillingAdapterRunning())
             .append("billingAdapterHealthy", isBillingAdapterHealthy())
+            .append("isMeteringAccessible", isMeteringAccessible())
             .append("timestamp", getTimestamp())
             .toString();
     }

--- a/java/code/src/com/suse/cloud/test/CloudPaygManagerTest.java
+++ b/java/code/src/com/suse/cloud/test/CloudPaygManagerTest.java
@@ -139,6 +139,15 @@ public class CloudPaygManagerTest extends BaseTestCaseWithUser {
         assertTrue(cpm.checkRefreshCache(false), "Not refreshed");
         assertFalse(cpm.isCompliant(), "Unexpected: Is compliant");
 
+        // test 8 - api access denied
+        cpm = new TestCloudPaygManagerBuilder()
+                .withPaygInstance()
+                .withoutMeteringApiAccess()
+                .build();
+
+        assertTrue(cpm.checkRefreshCache(false), "Not refreshed");
+        assertFalse(cpm.isCompliant(), "Unexpected: Is compliant");
+
         cpm = new TestCloudPaygManagerBuilder()
             .withPaygInstance()
             .build();

--- a/java/code/src/com/suse/cloud/test/TestCloudPaygManagerBuilder.java
+++ b/java/code/src/com/suse/cloud/test/TestCloudPaygManagerBuilder.java
@@ -36,6 +36,7 @@ public class TestCloudPaygManagerBuilder {
     private boolean billingAdapterRunning;
     private boolean billingAdapterHealthy;
     private boolean packageModified;
+    private boolean meteringAccess;
     private Xor<TaskomaticApiException, Map<String, Object>> dimensionComputationSchedule;
     private boolean sccCredentials;
 
@@ -49,6 +50,7 @@ public class TestCloudPaygManagerBuilder {
             .withBillingDataServiceStatus("online")
             .withBillingAdapterRunning(true)
             .withOriginalPackages()
+            .withMeteringApiAccess()
             .withDimensionComputationScheduled(Map.of())
             .withSCCCredentials();
     }
@@ -98,6 +100,16 @@ public class TestCloudPaygManagerBuilder {
 
     public TestCloudPaygManagerBuilder withModifiedPackages() {
         packageModified = true;
+        return this;
+    }
+
+    public TestCloudPaygManagerBuilder withMeteringApiAccess() {
+        meteringAccess = true;
+        return this;
+    }
+
+    public TestCloudPaygManagerBuilder withoutMeteringApiAccess() {
+        meteringAccess = false;
         return this;
     }
 
@@ -158,7 +170,7 @@ public class TestCloudPaygManagerBuilder {
             @Override
             protected PaygComplainceInfo getInstanceComplianceInfo() {
                 return new PaygComplainceInfo(
-                    cloudProvider, payg, packageModified, billingAdapterRunning, billingAdapterHealthy
+                    cloudProvider, payg, packageModified, billingAdapterRunning, billingAdapterHealthy, meteringAccess
                 );
             }
         };

--- a/java/spacewalk-java.changes.mc.fix-payg-findings
+++ b/java/spacewalk-java.changes.mc.fix-payg-findings
@@ -1,0 +1,1 @@
+- fix PAYG data timestamp parsing

--- a/java/spacewalk-java.changes.mc.fix-payg-findings
+++ b/java/spacewalk-java.changes.mc.fix-payg-findings
@@ -1,1 +1,2 @@
+- parse hasMeteringAccess from compliance input file
 - fix PAYG data timestamp parsing

--- a/python/billingdataservice/billing-data-service.changes.mc.fix-payg-findings
+++ b/python/billingdataservice/billing-data-service.changes.mc.fix-payg-findings
@@ -1,1 +1,2 @@
+- listen on all addresses
 - fix condition handling for service start

--- a/python/billingdataservice/billing-data-service.changes.mc.fix-payg-findings
+++ b/python/billingdataservice/billing-data-service.changes.mc.fix-payg-findings
@@ -1,0 +1,1 @@
+- fix condition handling for service start

--- a/python/billingdataservice/billing-data-service.service
+++ b/python/billingdataservice/billing-data-service.service
@@ -3,10 +3,11 @@ Description=SUSE Manager PAYG billing data service
 After=local-fs.target network.target postgresql.service
 Before=tomcat.service taskomatic.service
 Requires=postgresql.service
-ConditionEnvironment=ISPAYG=1
 
 [Service]
 Type=simple
+PassEnvironment=ISPAYG
+ExecCondition=sh -c "test \"$ISPAYG\" == \"1\""
 ExecStart=/srv/billing-data-service/billing-data-service
 Restart=on-failure
 

--- a/python/billingdataservice/billing-data-service.sysconfig
+++ b/python/billingdataservice/billing-data-service.sysconfig
@@ -1,12 +1,12 @@
 ## Path:           System/Services
 ## Description:    The SUSE Manager Billing Data Service
 ## Type:           string()
-## Default:        "127.0.0.1"
+## Default:        "0.0.0.0"
 ## ServiceRestart: billing-data-service
 #
 # IP to listen on
 #
-LISTEN="127.0.0.1"
+LISTEN="0.0.0.0"
 
 ## Path:           System/Services
 ## Description:    The SUSE Manager Billing Data Service

--- a/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
@@ -229,8 +229,7 @@ def perform_compliants_checks():
             cloudProvider = "GCE"
 
         modifiedPackages = (
-            has_package_modifications("billing-data-service")
-            or has_package_modifications("csp-billing-adapter-service")
+            has_package_modifications("csp-billing-adapter-service")
             or has_package_modifications("python3-csp-billing-adapter")
             or has_package_modifications("python3-csp-billing-adapter-local")
         )

--- a/uyuni/uyuni-payg-timer/uyuni-payg-timer.changes.mc.fix-payg-findings
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-timer.changes.mc.fix-payg-findings
@@ -1,0 +1,1 @@
+- do not check for billing-data-service outside of the container


### PR DESCRIPTION
## What does this PR change?

billing-data-service is running inside of the container. No need to check for the package outside of the container

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
