### PR TITLE
Fix PXE system filter to actually store results

### DIFF
--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.fix_pxe_system_translations
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.fix_pxe_system_translations
@@ -1,1 +1,1 @@
-- fix pxe system entries filter to actually store results
+- fix pxe system entries filter to actually store results (bsc#1225165)

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.fix_pxe_system_translations
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.oholecek.fix_pxe_system_translations
@@ -1,0 +1,1 @@
+- fix pxe system entries filter to actually store results

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -104,7 +104,10 @@ class HttpResponseDataFilteredPXE(HttpResponseDataFiltered):
         entry = ""
         entry_name = ""
         in_entry = False
-        for line in self._content.decode("utf-8").splitlines():
+        # make sure there is an empty line at the end so translation
+        # is actually stored
+        content = self._content.decode("utf-8") + "\n"
+        for line in content.splitlines():
             if in_entry:
                 if line.startswith(" ") or line.startswith("\t"):
                     entry += line + "\n"


### PR DESCRIPTION
## What does this PR change?

In filters we rely on that there is some non label entry which does not begins with whitespace. However system entries generated by cobbler does not have it.
This commit adds an empty line after content so there is always one.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): # TBD
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
