### PR TITLE
CI: Add and enable non-authorized container registry

### DIFF
--- a/.github/workflows/acceptance_tests_common.yml
+++ b/.github/workflows/acceptance_tests_common.yml
@@ -11,6 +11,7 @@ on:
 env:
   UYUNI_PROJECT: uyuni-project
   UYUNI_VERSION: master
+  NO_AUTH_REGISTRY: no_auth_registry
   CUCUMBER_PUBLISH_TOKEN: ${{ secrets.CUCUMBER_PUBLISH_TOKEN }}
 jobs:
   paths-filter:
@@ -65,8 +66,8 @@ jobs:
         run: ./testsuite/podman_runner/01_setup_tmp_dirs.sh
       - name: create-podman-network
         run: ./testsuite/podman_runner/02_setup_network.sh
-      - name: start_controller
-        run: ./testsuite/podman_runner/03_run_controller.sh 
+      - name: start_controller_and_registry
+        run: ./testsuite/podman_runner/03_run_controller_and_registry.sh 
       - name: create_ssh_conf
         run: ./testsuite/podman_runner/04_setup_ssh_controller.sh 
       - name: install_gems_in_controller

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -159,3 +159,33 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+  build-and-push-registry-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ci-container-registry
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./testsuite/dockerfiles/container-registry/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/testsuite/dockerfiles/container-registry/Dockerfile
+++ b/testsuite/dockerfiles/container-registry/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry:2
+

--- a/testsuite/features/secondary/min_docker_api.feature
+++ b/testsuite/features/secondary/min_docker_api.feature
@@ -13,9 +13,9 @@
 # - features/secondary/buildhost_docker_build_image.feature
 # - features/secondary/buildhost_docker_auth_registry.feature
 
-@skip_if_github_validation
 @skip_if_cloud
 @scope_building_container_images
+@no_auth_registry
 Feature: API "image" namespace for containers and sub-namespaces
 
   Scenario: Test "image.store" namespace

--- a/testsuite/features/secondary/min_docker_api.feature
+++ b/testsuite/features/secondary/min_docker_api.feature
@@ -23,12 +23,14 @@ Feature: API "image" namespace for containers and sub-namespaces
     And I list image store types and image stores via API
     And I set and get details of image store via API
 
+  @scc_credentials
   Scenario: Test "image.profiles" namespace
     When I create and delete profiles via API
     And I create and delete profile custom values via API
     And I list image profiles via API
     And I set and get profile details via API
 
+  @scc_credentials
   Scenario: Cleanup: remove custom system info
     Given I am authorized for the "Admin" section
     When I follow the left menu "Systems > Custom System Info"

--- a/testsuite/features/secondary/srv_docker_advanced_content_management.feature
+++ b/testsuite/features/secondary/srv_docker_advanced_content_management.feature
@@ -14,7 +14,7 @@ Feature: Advanced content management
     And I enter "docker_admin" as "label"
     And I enter the URI of the registry as "uri"
     And I click on "create-btn"
-
+  @scc_credentials
   Scenario: Create a profile as Docker admin
     When I follow the left menu "Images > Profiles"
     And I follow "Create"
@@ -43,6 +43,7 @@ Feature: Advanced content management
   Scenario: Log in as docker user
     Given I am authorized as "docker" with password "docker"
 
+  @scc_credentials
   Scenario: Cleanup: remove Docker profile
     Given I am authorized as "docker" with password "docker"
     When I follow the left menu "Images > Profiles"

--- a/testsuite/features/secondary/srv_docker_cve_audit.feature
+++ b/testsuite/features/secondary/srv_docker_cve_audit.feature
@@ -20,6 +20,7 @@ Feature: CVE audit for content management
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
+  @scc_credentials
   Scenario: Audit images, searching for a known CVE number
     When I follow the left menu "Audit > CVE Audit"
     And I select "1999" from "cveIdentifierYear"

--- a/testsuite/podman_runner/03_run_controller_and_registry.sh
+++ b/testsuite/podman_runner/03_run_controller_and_registry.sh
@@ -3,5 +3,6 @@ set -ex
 src_dir=$(cd $(dirname "$0")/../.. && pwd -P)
 
 sudo -i podman run --rm -d --network network -v /tmp/testing:/tmp --name controller -h controller -v ${src_dir}/testsuite:/testsuite ghcr.io/$UYUNI_PROJECT/uyuni/ci-test-controller-dev:$UYUNI_VERSION
+sudo -i podman run --rm -d --network network --name $NO_AUTH_REGISTRY -h $NO_AUTH_REGISTRY ghcr.io/$UYUNI_PROJECT/uyuni/ci-container-registry:$UYUNI_VERSION
 
 sudo podman ps

--- a/testsuite/podman_runner/12_run_core_tests.sh
+++ b/testsuite/podman_runner/12_run_core_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-sudo -i podman exec controller bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:github_validation_core"
+sudo -i podman exec controller bash -c "export NO_AUTH_REGISTRY=${NO_AUTH_REGISTRY} && export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:github_validation_core"

--- a/testsuite/podman_runner/17_run_init_clients_tests.sh
+++ b/testsuite/podman_runner/17_run_init_clients_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-sudo -i podman exec controller bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:github_validation_init_clients"
+sudo -i podman exec controller bash -c "export NO_AUTH_REGISTRY=${NO_AUTH_REGISTRY} && export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && rake cucumber:github_validation_init_clients"

--- a/testsuite/podman_runner/18_run_secondary_tests.sh
+++ b/testsuite/podman_runner/18_run_secondary_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -xe
-sudo -i podman exec controller bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export TAGS=\"\\\"not @flaky\\\"\" && cd /testsuite && rake cucumber:secondary"
+sudo -i podman exec controller bash -c "export NO_AUTH_REGISTRY=${NO_AUTH_REGISTRY} && export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export TAGS=\"\\\"not @flaky\\\"\" && cd /testsuite && rake cucumber:secondary"

--- a/testsuite/podman_runner/19_run_secondary_parallelizable_tests.sh
+++ b/testsuite/podman_runner/19_run_secondary_parallelizable_tests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -xe
 sudo -i podman exec controller bash -c "zypper ref && zypper -n install expect"
-sudo -i podman exec controller bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export TAGS=\"\\\"not @flaky\\\"\" && cd /testsuite && rake cucumber:secondary_parallelizable"
+sudo -i podman exec controller bash -c "export NO_AUTH_REGISTRY=${NO_AUTH_REGISTRY} && export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && export TAGS=\"\\\"not @flaky\\\"\" && cd /testsuite && rake cucumber:secondary_parallelizable"

--- a/testsuite/podman_runner/19_run_secondary_parallelizable_tests_subset.sh
+++ b/testsuite/podman_runner/19_run_secondary_parallelizable_tests_subset.sh
@@ -7,4 +7,4 @@ then
     exit 1
 fi
 
-sudo -i podman exec controller bash -c "export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && export TAGS=\"\\\"not @flaky\\\"\" && rake cucumber:secondary_parallelizable_${1}"
+sudo -i podman exec controller bash -c "export NO_AUTH_REGISTRY=${NO_AUTH_REGISTRY} && export CUCUMBER_PUBLISH_TOKEN=${CUCUMBER_PUBLISH_TOKEN} && export PROVIDER=podman && export SERVER=server && export HOSTNAME=controller && export SSH_MINION=opensusessh && export MINION=sle_minion && export RHLIKE_MINION=rhlike_minion && cd /testsuite && export TAGS=\"\\\"not @flaky\\\"\" && rake cucumber:secondary_parallelizable_${1}"

--- a/testsuite/podman_runner/run
+++ b/testsuite/podman_runner/run
@@ -2,6 +2,7 @@
 
 export UYUNI_PROJECT=uyuni-project
 export UYUNI_VERSION=master
+export NO_AUTH_REGISTRY=no_auth_registry
 
 set -x
 set -e
@@ -9,7 +10,7 @@ set -e
 ./00_setup_env.sh
 ./01_setup_tmp_dirs.sh
 ./02_setup_network.sh
-./03_run_controller.sh
+./03_run_controller_and_registry.sh
 ./04_setup_ssh_controller.sh
 ./05_install_gems_in_controller.sh
 ./06_collect_and_tag_flaky_tests_in_controller.sh


### PR DESCRIPTION
## What does this PR change?

This goes after merging https://github.com/uyuni-project/uyuni/pull/8811 and having build and pushed the container registry.

This enables the non-authenticated container registry tests.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/20677

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
