### PR TITLE
reposync: fix createPath after move

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -49,7 +49,7 @@ from uyuni.common import fileutils
 from spacewalk.common import rhnLog, rhnMail, suseLib
 from spacewalk.common.rhnTB import fetchTraceback
 from spacewalk.common import repo
-from spacewalk.common.fileutils import chown_chmod_path
+from spacewalk.common.fileutils import chown_chmod_path, create_path
 from spacewalk.common.rhnConfig import cfg_component
 
 # pylint: disable-next=ungrouped-imports
@@ -903,7 +903,7 @@ class RepoSync(object):
         self.update_servers()
 
         # update permissions
-        fileutils.createPath(
+        create_path(
             os.path.join(mount_point, "rhn")
         )  # if the directory exists update ownership only
         # pylint: disable-next=invalid-name
@@ -2160,7 +2160,7 @@ class RepoSync(object):
             else:
                 self.ks_install_type = "generic_rpm"
 
-        fileutils.createPath(os.path.join(mount_point, ks_path))
+        create_path(os.path.join(mount_point, ks_path))
         # Make sure images are included
         to_download = set()
         to_download.add(treeinfo_path)

--- a/python/test/unit/spacewalk/satellite_tools/test_reposync.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_reposync.py
@@ -1316,7 +1316,7 @@ def _mock_sync(reposync, rs):
 
     rs.update_date = Mock()
 
-    reposync.fileutils.createPath = Mock()
+    reposync.create_path = Mock()
     reposync.os.walk = Mock(return_value=[])
     reposync.subprocess.call = Mock()
     return rs


### PR DESCRIPTION
## What does this PR change?

This was moved to spacewalk.common.fileutils. It's still available as createPath, but we can use the snake_case version as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered 
- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
