### PR TITLE
Re-enable mass import checks

### DIFF
--- a/testsuite/features/secondary/proxy_container_retail_mass_import.feature
+++ b/testsuite/features/secondary/proxy_container_retail_mass_import.feature
@@ -26,13 +26,10 @@ Feature: Mass import of Retail terminals behind a containerized proxy
     And I am on the Systems page
     Then I should see the terminals imported from the configuration file
 
-  # This bug prevents using mgr-bootstrap command:
-  #   https://bugzilla.suse.com/show_bug.cgi?id=1220864
-  # TODO: skipped section begin ###############################################
-  # Remove @skip tags when bug is resolved
-@skip
   Scenario: Bootstrap the PXE boot minion
-    When I create bootstrap script for "proxy.example.org" hostname and set the activation key "1-TERMINAL-KEY-x86_64" in the bootstrap script on the proxy
+    # Workaround for bsc#1220864 - Containerized Proxy has not mgr-bootstrap command
+    When I create the bootstrap script for "proxy.example.org" hostname and "1-TERMINAL-KEY-x86_64" activation key on "server"
+    And I copy the bootstrap script from server to proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     # Workaround: Increase timeout temporarily get rid of timeout issues
     And I wait at most 350 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
@@ -40,7 +37,6 @@ Feature: Mass import of Retail terminals behind a containerized proxy
     Then I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "pxeboot_minion", refreshing the page
 
-@skip
   Scenario: Check connection from bootstrapped terminal to proxy
     Given I am on the Systems page
     When I follow "pxeboot" terminal
@@ -48,7 +44,6 @@ Feature: Mass import of Retail terminals behind a containerized proxy
     And I follow "Connection" in the content area
     Then I should see a "proxy.example.org" text
 
-@skip
   Scenario: Install a package on the bootstrapped terminal
     Given I am on the Systems page
     When I follow "pxeboot" terminal
@@ -62,7 +57,6 @@ Feature: Mass import of Retail terminals behind a containerized proxy
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
 
-@skip
   Scenario: Remove the package from the bootstrapped terminal
     Given I am on the Systems page
     When I follow "pxeboot" terminal
@@ -76,10 +70,8 @@ Feature: Mass import of Retail terminals behind a containerized proxy
     Then I should see a "1 package removal has been scheduled" text
     When I wait until event "Package Removal scheduled by admin" is completed
 
-@skip
   Scenario: Cleanup: make sure salt-minion is stopped after mass import
     When I wait until Salt client is inactive on the PXE boot minion
-  # TODO: skipped section end #################################################
 
   Scenario: Cleanup: delete all imported Retail terminals
     Given I am on the Systems page

--- a/testsuite/features/secondary/proxy_traditional_retail_mass_import.feature
+++ b/testsuite/features/secondary/proxy_traditional_retail_mass_import.feature
@@ -49,7 +49,7 @@ Feature: Mass import of Retail terminals behind a traditional proxy
     And I disable repositories after installing branch server
 
   Scenario: Bootstrap the PXE boot minion
-    When I create bootstrap script for "proxy.example.org" hostname and set the activation key "1-TERMINAL-KEY-x86_64" in the bootstrap script on the proxy
+    When I create the bootstrap script for "proxy.example.org" hostname and "1-TERMINAL-KEY-x86_64" activation key on "proxy"
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     # Workaround: Increase timeout temporarily get rid of timeout issues
     And I wait at most 350 seconds until Salt master sees "pxeboot_minion" as "unaccepted"

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -205,16 +205,25 @@ When(/^I reboot the (Retail|Cobbler) terminal "([^"]*)"$/) do |context, host|
   get_target('proxy').run("expect -f /tmp/#{file} #{ipv6} #{context}")
 end
 
-When(/^I create bootstrap script for "([^"]+)" hostname and set the activation key "([^"]*)" in the bootstrap script on the proxy$/) do |host, key|
+When(/^I create the bootstrap script for "([^"]+)" hostname and "([^"]*)" activation key on "([^"]*)"$/) do |hostname, key, host|
+  node = get_target(host)
   # WORKAROUND: Revert once pxeboot autoinstallation contains venv-salt-minion
   # force_bundle = use_salt_bundle ? '--force-bundle' : ''
-  # get_target('proxy').run("mgr-bootstrap #{force_bundle}")
-  get_target('proxy').run("mgr-bootstrap --hostname=#{host}")
+  # get_target(host).run("mgr-bootstrap #{force_bundle}")
+  node.run("mgr-bootstrap --hostname=#{hostname}")
 
-  get_target('proxy').run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
-  output, _code = get_target('proxy').run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
+  node.run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
+  output, _code = node.run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
   raise ScriptError, "Key: #{key} not included" unless output.include? key
-  raise ScriptError, "Hostname: #{host} not included" unless output.include? host
+  raise ScriptError, "Hostname: #{hostname} not included" unless output.include? hostname
+end
+
+When(/^I copy the bootstrap script from server to proxy$/) do
+  scriptfile = '/srv/www/htdocs/pub/bootstrap/bootstrap.sh'
+  tmpfile = '/tmp/bootstrap.sh'
+  file_extract(get_target('server'), scriptfile, tmpfile)
+  get_target('proxy').run('mkdir -p /srv/www/htdocs/pub/bootstrap')
+  file_inject(get_target('proxy'), tmpfile, scriptfile)
 end
 
 When(/^I bootstrap pxeboot minion via bootstrap script on the proxy$/) do


### PR DESCRIPTION
## What does this PR change?

Initial motivation was to remove the failure at the cleanup of mass imported minions and have one red less.

This PR re-enables mass import checks by working around bsc#1220864.


## Links

None, 5.0 only.


## Changelogs

- [x] No changelog needed
