### PR TITLE
More elegant code suggested by Ondrej

### DIFF
--- a/testsuite/features/secondary/proxy_container_retail_mass_import.feature
+++ b/testsuite/features/secondary/proxy_container_retail_mass_import.feature
@@ -29,7 +29,6 @@ Feature: Mass import of Retail terminals behind a containerized proxy
   Scenario: Bootstrap the PXE boot minion
     # Workaround for bsc#1220864 - Containerized Proxy has not mgr-bootstrap command
     When I create the bootstrap script for "proxy.example.org" hostname and "1-TERMINAL-KEY-x86_64" activation key on "server"
-    And I copy the bootstrap script from server to proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     # Workaround: Increase timeout temporarily get rid of timeout issues
     And I wait at most 350 seconds until Salt master sees "pxeboot_minion" as "unaccepted"

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -210,20 +210,11 @@ When(/^I create the bootstrap script for "([^"]+)" hostname and "([^"]*)" activa
   # WORKAROUND: Revert once pxeboot autoinstallation contains venv-salt-minion
   # force_bundle = use_salt_bundle ? '--force-bundle' : ''
   # get_target(host).run("mgr-bootstrap #{force_bundle}")
-  node.run("mgr-bootstrap --hostname=#{hostname}")
+  node.run("mgr-bootstrap --hostname=#{hostname} --activation-keys=#{key}")
 
-  node.run("sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh")
   output, _code = node.run('cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh')
   raise ScriptError, "Key: #{key} not included" unless output.include? key
   raise ScriptError, "Hostname: #{hostname} not included" unless output.include? hostname
-end
-
-When(/^I copy the bootstrap script from server to proxy$/) do
-  scriptfile = '/srv/www/htdocs/pub/bootstrap/bootstrap.sh'
-  tmpfile = '/tmp/bootstrap.sh'
-  file_extract(get_target('server'), scriptfile, tmpfile)
-  get_target('proxy').run('mkdir -p /srv/www/htdocs/pub/bootstrap')
-  file_inject(get_target('proxy'), tmpfile, scriptfile)
 end
 
 When(/^I bootstrap pxeboot minion via bootstrap script on the proxy$/) do

--- a/testsuite/features/upload_files/bootstrap-pxeboot.exp
+++ b/testsuite/features/upload_files/bootstrap-pxeboot.exp
@@ -1,15 +1,11 @@
 set address [lindex $argv 0]
 
-spawn /usr/bin/scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null /srv/www/htdocs/pub/bootstrap/bootstrap.sh root@$address:/root/bootstrap.sh
-expect {
-	"*?assword:*" { send "linux\r"; interact }
-	eof { exit }
-}
-
 spawn /usr/bin/ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $address
 match_max 100000
 expect "*?assword:*"
 send -- "linux\r"
+expect "#"
+send -- "curl -O -L http://proxy.example.org/pub/bootstrap/bootstrap.sh\r"
 expect "#"
 send -- "chmod 750 /root/bootstrap.sh\r"
 expect "#"


### PR DESCRIPTION
## What does this PR change?

Follow-up of https://github.com/uyuni-project/uyuni/pull/8818:

* pass the activation key as a parameter when building the bootstrap script
* pick up bootstrap script directly from minion with curl instead of doing 2 scp copies

## Links

Ports:
* 4.3: https://github.com/SUSE/spacewalk/pull/24420


## Changelogs

- [x] No changelog needed
