### PR TITLE
Revert kickstart render URL back to Cobbler host

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -356,7 +356,7 @@ public class KickstartUrlHelper {
         Profile prof = Profile.lookupById(
                 CobblerXMLRPCHelper.getAutomatedConnection(),
                         data.getCobblerId());
-        return "http://" + ConfigDefaults.get().getJavaHostname() + COBBLER_URL_BASE_PATH +
+        return "http://" + ConfigDefaults.get().getCobblerHost() + COBBLER_URL_BASE_PATH +
                     prof.getName();
     }
 }

--- a/java/spacewalk-java.changes.oholecek.revert_one_cobbler_host
+++ b/java/spacewalk-java.changes.oholecek.revert_one_cobbler_host
@@ -1,0 +1,1 @@
+- revert kickstart render URL back to Cobbler host (bsc#1225494)


### PR DESCRIPTION
## What does this PR change?

This partially reverts https://github.com/uyuni-project/uyuni/commit/66a6f2c493a59fbab4f72bec7c583818a71be135

It turns out this URL is not propagated outside, but rather used for internal autoyast/kickstart render.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered by BV testsuite

- [X] **DONE**

## Links

Issue(s): # https://bugzilla.suse.com/show_bug.cgi?id=1225494
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
