### PR TITLE
Use redirect instead of proxypass for rewritten cobbler autoyast link

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.cobbler_proxy_redirect
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.cobbler_proxy_redirect
@@ -1,0 +1,2 @@
+- use redirect instead of proxypass for rewritten cobbler
+  autoyast link (bsc#1225520)

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -206,8 +206,8 @@ WSGIScriptAlias /tftpsync/delete /srv/www/tftpsync/delete"""
         file.write(
             f"""ProxyPass /cobbler_api https://{config['server']}/download/cobbler_api
 ProxyPassReverse /cobbler_api https://{config['server']}/download/cobbler_api
-RewriteRule ^/cblr/svc/op/ks/(.*)$ /download/$0 [P,L]
-RewriteRule ^/cblr/svc/op/autoinstall/(.*)$ /download/$0 [P,L]
+RewriteRule ^/cblr/svc/op/ks/(.*)$ /download/$0 [R,L]
+RewriteRule ^/cblr/svc/op/autoinstall/(.*)$ /download/$0 [R,L]
 ProxyPass /cblr https://{config['server']}/cblr
 ProxyPassReverse /cblr https://{config['server']}/cblr
 ProxyPass /cobbler https://{config['server']}/cobbler


### PR DESCRIPTION
## What does this PR change?

Proxying apache is trying to connect to itself using host IP address. This however fails because of hairpin problem. Using redirect moves this responsibility to the client, at the expense of revealing this rewritten URL and one more TCP roundtrip.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered by BV testsuite

- [X] **DONE**

## Links

Issue(s): # https://bugzilla.suse.com/show_bug.cgi?id=1225520
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
