### PR TITLE
QE: fix scenario searching for existing patches

### DIFF
--- a/testsuite/features/secondary/min_check_patches_install.feature
+++ b/testsuite/features/secondary/min_check_patches_install.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_onboarding
@@ -22,7 +22,11 @@ Feature: Display patches
   Scenario: Check all patches exist
     When I follow the left menu "Patches > Patch List > Relevant"
     Then I should see an update in the list
-    When I wait until I see "virgo-dummy" text, refreshing the page
+    When I wait until I see "andromeda-dummy" text, refreshing the page
+    Then I should see a "andromeda-dummy-6789" link
+    When I enter "virgo-dummy" as the filtered synopsis
+    And I click on the filter button
+    And I wait until I see "virgo-dummy" text
     Then I should see a "virgo-dummy-3456" link
 
   Scenario: Check SLES release 6789 patches
@@ -46,6 +50,7 @@ Feature: Display patches
     When I follow "Software" in the content area
     And I follow "Patches" in the content area
     Then I should see a "Relevant Patches" text
+    And I should see a "Test update for andromeda-dummy" text
     And I should see a "Test update for virgo-dummy" text
 
   Scenario: Cleanup: regenerate search index for later tests


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/22610

Introduces some checks to verify both the patches for andromeda-dummy and virgo-dummy are present.
It should also take care of possible failures due to a patch not being displayed in the first page of results - the pages are limited to 100 results and virgo-dummy is usually at the end of a list of 120+ patches.

EDIT: verified on HEAD CI.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/22610
Port(s): (4.3) https://github.com/SUSE/spacewalk/pull/24436

- [x] **DONE**

## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"