### PR TITLE
QE: Perform mgr-push through a minion instead of running it from the server

### DIFF
--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -1,6 +1,8 @@
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle_minion
+@scc_credentials
 Feature: Push a package with unset vendor
   In order to distribute software to the clients
   As an authorized user
@@ -9,9 +11,23 @@ Feature: Push a package with unset vendor
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Push a package with unset vendor
-    When I copy unset package file on server
-    And I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "fake-base-channel-suse-like" channel
+  Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I wait until I see "Upgrade Packages" text
+    And I follow "Install"
+    And I wait until I see "Installable Packages" text
+    And I enter "mgr-push" as the filtered package name
+    And I click on the filter button
+    And I check "mgr-push" in the list
+    And I click on "Install Selected Packages"
+    And I click on "Confirm"
+    Then I should see a "1 package install has been scheduled for" text
+    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+
+  Scenario: Push a package with unset vendor through the SLES minion
+    When I copy unset package file on "sle_minion"
+    And I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "fake-base-channel-suse-like" channel through "sle_minion"
     Then I should see package "subscription-tools-1.0-0.noarch" in channel "Fake-Base-Channel-SUSE-like"
 
   Scenario: Check vendor of package displayed in web UI

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1305,9 +1305,9 @@ When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   node.run("#{salt_call} --local --file-root=/usr/share/susemanager/salt --module-dirs=/usr/share/susemanager/salt/ --log-level=info --retcode-passthrough state.apply " + state)
 end
 
-When(/^I copy unset package file on server$/) do
+When(/^I copy unset package file on "(.*?)"$/) do |minion|
   base_dir = "#{File.dirname(__FILE__)}/../upload_files/unset_package/"
-  return_code = file_inject(get_target('server'), "#{base_dir}subscription-tools-1.0-0.noarch.rpm", '/root/subscription-tools-1.0-0.noarch.rpm')
+  return_code = file_inject(get_target(minion), "#{base_dir}subscription-tools-1.0-0.noarch.rpm", '/root/subscription-tools-1.0-0.noarch.rpm')
   raise ScriptError, 'File injection failed' unless return_code.zero?
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -510,11 +510,10 @@ Given(/^metadata generation finished for "([^"]*)"$/) do |channel|
   get_target('server').run_until_ok("ls /var/cache/rhn/repodata/#{channel}/*updateinfo.xml.gz")
 end
 
-When(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |package, channel|
-  command = "rhnpush -u admin -p admin --nosig -c #{channel} #{package}"
-  get_target('server').run(command, timeout: 500)
-  # TODO: instead of next line, wait for package to appear inside /var/spacewalk/packages
-  get_target('server').run('ls -lR /var/spacewalk/packages', timeout: 500)
+When(/^I push package "([^"]*)" into "([^"]*)" channel through "([^"]*)"$/) do |package, channel, minion|
+  command = "mgrpush -u admin -p admin --server=#{get_target('server').full_hostname} --nosig -c #{channel} #{package}"
+  get_target(minion).run(command, timeout: 500)
+  get_target('server').run_until_ok("find . -name \"#{package}\" | grep -q \"#{package}\"", timeout: 500)
 end
 
 Then(/^I should see package "([^"]*)" in channel "([^"]*)"$/) do |pkg, channel|


### PR DESCRIPTION
## What does this PR change?

Card: https://github.com/SUSE/spacewalk/issues/24072

Now the official strategy when using rhnpush/mgrpush is to run it outside the server container.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were refactored

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
