### PR TITLE
Fix layout mismatch in patches management in the updated theme

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -68,7 +68,8 @@ public enum ViewHelper {
         "/rhn/account/EditAddress.do",
         "/rhn/multiorg/OrgConfigDetails.do",
         "/rhn/manager/notification-messages",
-        "rhn/channels/software/Search.do"
+        "rhn/channels/software/Search.do",
+        "/rhn/errata/manage/CloneErrata.do"
     );
 
     ViewHelper() { }

--- a/java/spacewalk-java.changes.eth.patches-management
+++ b/java/spacewalk-java.changes.eth.patches-management
@@ -1,0 +1,1 @@
+- Fix layout mismatch in patches management

--- a/web/html/src/branding/css/base/forms.scss
+++ b/web/html/src/branding/css/base/forms.scss
@@ -60,3 +60,10 @@ input[type="checkbox"] {
     min-height: 28px;
   }
 }
+
+.checkbox {
+  display: block;
+  position: relative;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}

--- a/web/html/src/core/spa/view-helper.ts
+++ b/web/html/src/core/spa/view-helper.ts
@@ -13,6 +13,7 @@ const BOOTSTRAP_READY_PAGES: string[] = [
   "/rhn/multiorg/OrgConfigDetails.do",
   "/rhn/manager/notification-messages",
   "rhn/channels/software/Search.do",
+  "/rhn/errata/manage/CloneErrata.do",
 ];
 
 export const onEndNavigate = () => {

--- a/web/spacewalk-web.changes.eth.patches-management
+++ b/web/spacewalk-web.changes.eth.patches-management
@@ -1,0 +1,1 @@
+- Fix layout mismatch in patches management


### PR DESCRIPTION
## What does this PR change?

This PR relies on https://github.com/uyuni-project/uyuni/pull/8844 being merged first.

Fix broken layout elements and alignment in patches management.

## GUI diff

Before:

<img width="1239" alt="330820362-8809ae4e-13f9-4ef1-b49f-6748d79e5595" src="https://github.com/uyuni-project/uyuni/assets/3171718/2c23ff7c-c899-4ea9-9e2c-943c1b208a43">


After:

<img width="1649" alt="Screenshot 2024-05-30 at 19 33 03" src="https://github.com/uyuni-project/uyuni/assets/3171718/5b8a7dc3-66c9-4090-9e48-144a86837f1b">


- [x] **DONE**

## Documentation
- No documentation needed: UI bugfix.

- [x] **DONE**

## Test coverage
- No tests: UI bugfix.

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/8740

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
