### PR TITLE
QE: Add distro cleanups to Cobbler distro feature

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -177,10 +177,55 @@ Feature: Cobbler and distribution autoinstallation
     And the cobbler report should contain "00:22:22:77:ee:cc" for cobbler system name "testserver:1"
 
   Scenario: Cleanup: delete test profile
+    # TODO: Move to SUMA API
     When I remove profile "testprofile"
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
+    Then I should see a "fedora_kickstart_profile" text
+    And I follow "fedora_kickstart_profile"
+    Then I should see a "Autoinstallation: fedora_kickstart_profile" text
+    And I follow "Delete Autoinstallation"
+    And I click on "Delete Autoinstallation"
+    Then I should see a "Autoinstallation was deleted successfully" text
+    And I should see a "fedora_kickstart_profile_upload" text
+    And I follow "fedora_kickstart_profile_upload"
+    Then I should see a "Autoinstallation: fedora_kickstart_profile_upload" text
+    And I follow "Delete Autoinstallation"
+    And I click on "Delete Autoinstallation"
+    Then I should see a "Autoinstallation was deleted successfully" text
+    And I should not see a "fedora_kickstart_profile" text
+    And I should not see a "fedora_kickstart_profile_upload" text
 
-  Scenario: Cleanup: delete test distro
+  Scenario: Cleanup: delete test distros
+    # TODO: Move to SUMA API
     When I remove distro "testdistro"
+    When I follow the left menu "Systems > Autoinstallation > Distributions"
+    Then I should see a "fedora_kickstart_distro" text
+    And I follow "fedora_kickstart_distro"
+    Then I should see a " Edit Autoinstallable Distribution" text
+    And I follow "Delete Distribution"
+    And I click on "Delete Distribution"
+    Then I should see a "Autoinstallable Distribution deleted successfully" text
+    And I follow "fedora_kickstart_distro_api"
+    Then I should see a " Edit Autoinstallable Distribution" text
+    And I follow "Delete Distribution"
+    And I click on "Delete Distribution"
+    Then I should see a "Autoinstallable Distribution deleted successfully" text
+    And I should see a "fedora_kickstart_distro_kernel_api" text
+    And I follow "fedora_kickstart_distro_kernel_api"
+    Then I should see a " Edit Autoinstallable Distribution" text
+    And I follow "Delete Distribution"
+    And I click on "Delete Distribution"
+    Then I should see a "Autoinstallable Distribution deleted successfully" text
+    And I should see a "SLE-15-FAKE" text
+    And I follow "SLE-15-FAKE"
+    Then I should see a " Edit Autoinstallable Distribution" text
+    And I follow "Delete Distribution"
+    And I click on "Delete Distribution"
+    Then I should see a "Autoinstallable Distribution deleted successfully" text
+    And I should not see a "fedora_kickstart_distro" text
+    And I should not see a "fedora_kickstart_distro_api" text
+    And I should not see a "fedora_kickstart_distro_kernel_api" text
+    And I should not see a "SLE-15-FAKE" text
 
 @flaky
   Scenario: Check for errors in Cobbler monitoring

--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -18,11 +18,13 @@ Feature: Cobbler and distribution autoinstallation
 
   Scenario: Ask cobbler to create a distribution via API
     Given cobblerd is running
+    # TODO: Move to SUMA API
     When I create distro "testdistro"
 
   Scenario: Create dummy profile
     Given cobblerd is running
     And distro "testdistro" exists
+    # TODO: Move to SUMA API
     When I create profile "testprofile" for distro "testdistro"
 
   Scenario: Check cobbler created distro and profile

--- a/testsuite/features/secondary/srv_cobbler_profile.feature
+++ b/testsuite/features/secondary/srv_cobbler_profile.feature
@@ -18,7 +18,6 @@ Feature: Edit Cobbler profiles
 
   Scenario: Log in as testing user
     Given I am authorized as "testing" with password "testing"
-    And I am logged in via the Cobbler API as user "testing" with password "testing"
 
   Scenario: Start Cobbler monitoring
     When I start local monitoring of Cobbler
@@ -140,6 +139,3 @@ Feature: Edit Cobbler profiles
 @flaky
   Scenario: Check for errors in Cobbler monitoring
     Then the local logs for Cobbler should not contain errors
-
-  Scenario: Logout from the Cobbler API
-    When I log out from Cobbler via the API


### PR DESCRIPTION
## What does this PR change?

More Cobbler related changes.
- removes the Cobbler API login in the Cobbler profile feature since the Cobbler API is not used there
- adds TODOs for switching the Cobbler API to the SUMA API in the Cobbler distro feature
- adds more distro removals in the Cobbler distro feature. The creation of those profiles are hidden behind the following steps, so it was not obvious that their cleanup was missing

```ruby
When(/^I create a kickstart tree via the API$/) do
  $api_test.kickstart.tree.create_distro('fedora_kickstart_distro_api', '/var/autoinstall/Fedora_12_i386/', 'fake-base-channel-rh-like', 'fedora18')
end

When(/^I create a kickstart tree with kernel options via the API$/) do
  $api_test.kickstart.tree.create_distro_w_kernel_options('fedora_kickstart_distro_kernel_api', '/var/autoinstall/Fedora_12_i386/', 'fake-base-channel-rh-like', 'fedora18', 'self_update=0', 'self_update=1')
end

When(/^I update a kickstart tree via the API$/) do
  $api_test.kickstart.tree.update_distro('fedora_kickstart_distro_api', '/var/autoinstall/Fedora_12_i386/', 'fake-base-channel-rh-like', 'generic_rpm', 'self_update=0', 'self_update=1')
end
```

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # Manager 4.3: https://github.com/SUSE/spacewalk/pull/24441
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
