### PR TITLE
Disable Cobbler automatic sync + work around UI bug

### DIFF
--- a/testsuite/features/reposync/srv_disable_scheduled_reposync.feature
+++ b/testsuite/features/reposync/srv_disable_scheduled_reposync.feature
@@ -1,13 +1,23 @@
-# Copyright (c) 2019-2023 SUSE LLC
+# Copyright (c) 2019-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Delete the scheduled task for mgr-sync-refresh
+Feature: Do not let Taskomatic tasks interfer with our tests
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Delete scheduled mgr-sync-refresh task
+  Scenario: Disable scheduled reposyncs
     When I follow the left menu "Admin > Task Schedules"
     And I follow "mgr-sync-refresh-default"
     And I choose "disabled"
     And I click on "Update Schedule"
+    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
+    And I click on "Delete Schedule"
+
+  Scenario: Disable scheduled Cobbler syncs
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "cobbler-sync-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
+    And I click on "Delete Schedule"


### PR DESCRIPTION
## What does this PR change?

* Disable Cobbler automatic sync so it does not interfer with Cobbler tests
   Notes:
   * the automated cobbler sync remains needed in 4.3
   * it will get removed in 5.1
* Make existing scenario work despite existing bug


## Links

Port: (the workaround part only)
 * 4.3: https://github.com/SUSE/spacewalk/pull/24440


## Changelogs

- [ ] No changelog needed
