### PR TITLE
Fix Junit 5 test execution

### DIFF
--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -466,6 +466,9 @@
                     <include name="**/junit-platform-*.jar"/>
                     <include name="**/junit-jupiter-*.jar"/>
                 </fileset>
+                <fileset dir="/usr/share/java/open-test-reporting/">
+                    <include name="**/*.jar" />
+                </fileset>
             </classpath>
 
             <classpath refid="managertestjars"/>


### PR DESCRIPTION
## What does this PR change?

This PR adds on the classpath the new `open-test-reporting` dependency required by the latest junit5 package.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: change affects only the testing phase

- [X] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24442

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
