### PR TITLE
PTF channels are custom channels too

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -390,7 +390,7 @@ end
 When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
   time_spent = 0
   checking_rate = 10
-  if channel.include?('custom_channel')
+  if channel.include?('custom_channel') || channel.include?('ptf')
     log 'Timeout of 10 minutes for a custom channel'
     timeout = 600
   elsif TIMEOUT_BY_CHANNEL_NAME[channel].nil?


### PR DESCRIPTION
## What does this PR change?

Sync time for PTF custom channel is close to the default maximum of 60 seconds and sometimes over it.

This PR takes the standard default for custom channels for PTF custom channels as well.


## Links

Port(s):
* 4.3: https://github.com/SUSE/spacewalk/pull/24444


## Changelogs

- [x ] No changelog needed
