### PR TITLE
QE: tidy some channels management scenarios

### DIFF
--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 SUSE LLC
+# Copyright (c) 2018-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_changing_software_channels
@@ -84,17 +84,17 @@ Feature: Channel subscription via SSM
 
 @sle_minion
 @susemanager
-  Scenario: Check old channels are still enabled on SLES minion before channel change completes
+  Scenario: Check via API old channels are still the same on SLES minion before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "17" channels should be enabled on "sle_minion"
-    And channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
+    Then channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
+    And channel "SLE15-SP4-Installer-Updates for x86_64" should be disabled on "sle_minion"
 
 @sle_minion
 @uyuni
-  Scenario: Check old channels are still enabled on SLES minion before channel change completes
+  Scenario: Check via API old channels are still the same on openSUSE minion before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "8" channels should be enabled on "sle_minion"
-    And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
+    Then channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
+    And channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development))" should be disabled on "sle_minion"
 
   Scenario: Wait 3 minutes for the scheduled action to be executed
     When I wait for "180" seconds
@@ -117,14 +117,14 @@ Feature: Channel subscription via SSM
 
 @sle_minion
 @susemanager
-  Scenario: Check the new channels are enabled on the SLES minion
+  Scenario: Check via API the new channels are enabled on the SLES minion
     When I refresh the metadata for "sle_minion"
     Then "2" channels should be enabled on "sle_minion"
     And channel "Fake-Base-Channel-SUSE-like" should be enabled on "sle_minion"
     And channel "Fake-Child-Channel-SUSE-like" should be enabled on "sle_minion"
 
 @uyuni
-  Scenario: Check the new channels are enabled on the SLES minion
+  Scenario: Check via API the new channels are enabled on the openSUSE minion
     When I refresh the metadata for "sle_minion"
     Then "2" channels should be enabled on "sle_minion"
     And channel "Fake-Base-Channel-SUSE-like" should be enabled on "sle_minion"

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -34,19 +34,17 @@ Feature: Assign child channel to a system
     And I wait until I do not see "Loading..." text
     And I should see "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" as unchecked
 
-# susemanager has the Client Tools channels more than uyuni. (+2)
-# in Head also Beta Client Tools Channels (+2)
 @susemanager
-  Scenario: Check old channels are still enabled on the system before channel change completes
+  Scenario: Check via API old channels are still the same on the system before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "17" channels should be enabled on "sle_minion"
-    And channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
+    Then channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
+    And channel "SLE15-SP4-Installer-Updates for x86_64" should be disabled on "sle_minion"
 
 @uyuni
-  Scenario: Check old channels are still enabled on the system before channel change completes
+  Scenario: Check via API old channels are still the same on the system before channel change completes
     When I refresh the metadata for "sle_minion"
-    Then "8" channels should be enabled on "sle_minion"
-    And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
+    Then channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
+    And channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development))" should be disabled on "sle_minion"
 
 @susemanager
   Scenario: Assign a child channel to the system
@@ -104,17 +102,15 @@ Feature: Assign child channel to a system
     And I should see "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" as checked
 
 @susemanager
-  Scenario: Check the new channels are enabled on the system
+  Scenario: Check via API the new channels are enabled on the system
     When I refresh the metadata for "sle_minion"
-    Then "18" channels should be enabled on "sle_minion"
-    And channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
+    Then channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
     And channel "SLE15-SP4-Installer-Updates for x86_64" should be enabled on "sle_minion"
 
 @uyuni
-  Scenario: Check the new channels are enabled on the system
+  Scenario: Check via API the new channels are enabled on the system
     When I refresh the metadata for "sle_minion"
-    Then "9" channels should be enabled on "sle_minion"
-    And channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
+    Then channel "openSUSE Leap 15.5 (x86_64)" should be enabled on "sle_minion"
     And channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" should be enabled on "sle_minion"
 
 @susemanager


### PR DESCRIPTION
## What does this PR change?

This PR aims to:

- make clear when API calls are used
- replace the naming SLES minion with openSUSE minion in some instances
- (the meaningful part) make these scenarios less flaky without adding complexity and/or maintenance overload

The scope of this feature should be to:

- verify the state of the channels before the action for changing channels is scheduled
- verify the state remains consistent after an action has been scheduled
- verify the state changes as expected once the action/event is complete
- verify both the UI and  API return the correct state of the channels for a given system before and after the action

To do so counting the initial number of enabled channels we would need one of:

1.  global variable
2.  hardcoded number which has been previously verified
3. some logic that can account for the presence of BETA channels, channels that should be present for a given system, added fake channels ....

1 is better to be avoided as long as possible, 2 is the current approach which is inherently flaky and subject to change, 3 would make this more robust but add complexity for little to no gains. 
We can still use the hardcoded  number for the Fake channels because that is probably not subject to changes anytime soon and is something strictly related to the context of this feature.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24432 https://github.com/SUSE/spacewalk/issues/21342
Port(s): (4.3) https://github.com/SUSE/spacewalk/pull/24445

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
