### PR TITLE
prevent NPE when listing history events without completion time

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/HistoryEvent.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/HistoryEvent.java
@@ -74,6 +74,10 @@ public class HistoryEvent extends BaseDto {
         String dateFormat = "yyyy-MM-dd kk:mm:ss";
         SimpleDateFormat format = new SimpleDateFormat(dateFormat);
 
+        if (completedIn == null) {
+            this.completed = null;
+            return;
+        }
         try {
             this.completed = format.parse(completedIn);
         }

--- a/java/spacewalk-java.changes.mcalmer.fix-NPE-in-event-history
+++ b/java/spacewalk-java.changes.mcalmer.fix-NPE-in-event-history
@@ -1,0 +1,1 @@
+- prevent NPE when listing history events without completion time (bsc#1146701)


### PR DESCRIPTION
## What does this PR change?

A queued action has no completion time set.
When querying the history, a date string NULL is valid.
Just set completion time to null as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/9132
Port(s): https://github.com/SUSE/spacewalk/pull/24481

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
