### PR TITLE
use filter when acting on Patch List > All

### DIFF
--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -74,6 +74,8 @@ Feature: Retracted patches
 
   Scenario: Retracted packages in the patch detail
     When I follow the left menu "Patches > Patch List > All"
+    And I enter "dummy" as the filtered synopsis
+    And I click on the filter button
     And I follow "rute-dummy-0815"
     Then I should see a "Status: Retracted" text
     When I go back
@@ -85,6 +87,8 @@ Feature: Retracted patches
 
   Scenario: Retracted packages in the patches list
     When I follow the left menu "Patches > Patch List > All"
+    And I enter "dummy" as the filtered synopsis
+    And I click on the filter button
     Then the table row for "rute-dummy-0815" should contain "retracted" icon
     And the table row for "rute-dummy-0816" should not contain "retracted" icon
     And the table row for "rute-dummy-0817" should contain "retracted" icon

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -70,6 +70,8 @@ Feature: Clone a channel
 
   Scenario: Check that new patches exists
     When I follow the left menu "Patches > Patch List > All"
+    And I enter "dummy" as the filtered synopsis
+    And I click on the filter button
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     Then I should see a "CL-hoag-dummy-7890" link
     And I should see a "CL-virgo-dummy-3456" link
@@ -78,6 +80,8 @@ Feature: Clone a channel
 
   Scenario: Check CL-hoag-dummy-7890 patches
     When I follow the left menu "Patches > Patch List > All"
+    And I enter "dummy" as the filtered synopsis
+    And I click on the filter button
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-hoag-dummy-7890"
     Then I should see a "CL-hoag-dummy-7890 - Security Advisory" text
@@ -86,6 +90,8 @@ Feature: Clone a channel
 
   Scenario: Check CM-virgo-dummy-3456 patches
     When I follow the left menu "Patches > Patch List > All"
+    And I enter "dummy" as the filtered synopsis
+    And I click on the filter button
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-virgo-dummy-3456"
     Then I should see a "CL-virgo-dummy-3456 - Bug Fix Advisory" text


### PR DESCRIPTION
## What does this PR change?

In Uyuni we have the Leap Micro patches in the "All Patches" list. This result in multiple pages and we need to use the filter to see the expected results on the first page.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24447

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
