### PR TITLE
Do not take default value (SLES) for Fedora distro

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -89,6 +89,7 @@ Feature: Cobbler and distribution autoinstallation
     When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Upload Kickstart/AutoYaST File"
     When I enter "fedora_kickstart_profile_upload" as "kickstartLabel"
+    And I select "fedora_kickstart_distro" from "kstreeId"
     And I attach the file "/example.ks" to "fileUpload"
     And I click on "Create"
     Then I should see a "Autoinstallation: fedora_kickstart_profile_upload" text


### PR DESCRIPTION
## What does this PR change?

![image](https://github.com/uyuni-project/uyuni/assets/1932575/371e8182-63a8-4a72-b216-f641a9775f73)

this default value made us use SLES kernel for a Fedora distro...


## Links

Ports:
 * 4.3: https://github.com/SUSE/spacewalk/pull/24454


## Changelogs

- [x] No changelog needed
