### PR TITLE
add SLE 12 SP5 LTSS channel families and remove Liberty HA LTSS 7

### DIFF
--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -128,10 +128,6 @@
     "name" : "SUSE Linux Enterprise RedHat Expanded Support HA"
   },
   {
-    "label" : "RES-HA-7-LTSS-X86",
-    "name" : "SUSE Linux Enterprise RedHat Expanded Support HA LTSS"
-  },
-  {
     "label" : "SES",
     "name" : "SUSE Enterprise Storage"
   },
@@ -282,6 +278,26 @@
   {
     "label" : "SLES12-SP4-LTSS-Z",
     "name" : "SUSE Linux Enterprise Server LTSS 12 SP4 Z-Series"
+  },
+  {
+    "label" : "SLES12-SP5-LTSS-ARM64",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP5 ARM64"
+  },
+  {
+    "label" : "SLES12-SP5-LTSS-CORE-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS CORE 12 SP5 x86_64"
+  },
+  {
+    "label" : "SLES12-SP5-LTSS-PPC",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP5 PPC"
+  },
+  {
+    "label" : "SLES12-SP5-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP5 x86_64"
+  },
+  {
+    "label" : "SLES12-SP5-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 12 SP5 Z-Series"
   },
   {
     "label" : "SLES15-GA-LTSS-PPC",

--- a/susemanager-sync-data/susemanager-sync-data.changes.mc.sle12sp5-ltss-channel_families
+++ b/susemanager-sync-data/susemanager-sync-data.changes.mc.sle12sp5-ltss-channel_families
@@ -1,0 +1,2 @@
+- add SLE 12 SP5 LTSS channel families
+- remove Liberty HA LTSS 7 channel family


### PR DESCRIPTION
## What does this PR change?

Add new SLES12 SP5 LTSS product classes.
Removed Liberty HA LTSS 7 product class

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24457

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
