### PR TITLE
replace symlink to kernel and initrd in salt filesystem with regular files

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -585,8 +586,8 @@ public class KickstartableTree extends BaseDomainHelper {
 
             for (Path copyFrom : targets) {
                 Path copyTo = fullDir.resolve(copyFrom.getFileName());
-                if (!pathExists(copyTo.toString())) {
-                    Files.copy(copyFrom, copyTo);
+                if (!Files.exists(copyTo) || Files.isSymbolicLink(copyTo)) {
+                    Files.copy(copyFrom, copyTo, StandardCopyOption.REPLACE_EXISTING);
                 }
             }
         }

--- a/java/spacewalk-java.changes.mc.Manager-4.3-force-overwrite-symlink
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-force-overwrite-symlink
@@ -1,0 +1,1 @@
+- replace symlink to kernel and initrd in salt filesystem with regular files (bsc#1220221)


### PR DESCRIPTION
## What does this PR change?

symlinks in the salt filesystem are not supported anymore.
This PR replace symlinks with regular files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24465

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
