### PR TITLE
Choose correct profile

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -167,8 +167,13 @@ Feature: Cobbler and distribution autoinstallation
     And I wait until file "/srv/tftpboot/pxelinux.0" exists on server
 
   Scenario: Trigger the creation of a cobbler system record
-    When I trigger cobbler system record on the "sle_minion"
-    And I wait until file "/srv/tftpboot/pxelinux.cfg/01-*" contains "inst.ks=" on server
+    When I clear the caches on the server
+    And I am on the Systems overview page of this "sle_minion"
+    And I follow "Provisioning"
+    And I click on profile "testprofile"
+    And I click on "Create PXE installation configuration"
+    Then I should see a "System record created" text
+    And I wait until file "/srv/tftpboot/pxelinux.cfg/01-*" contains "autoyast=" on server
 
   Scenario: Create a cobbler system record via API
     When I create a system record

--- a/testsuite/features/step_definitions/cobbler_steps.rb
+++ b/testsuite/features/step_definitions/cobbler_steps.rb
@@ -62,19 +62,14 @@ When(/^I remove distro "([^"]*)"$/) do |distro|
 end
 
 # cobbler reports
-When(/^I trigger cobbler system record on the "([^"]*)"$/) do |host|
-  space = 'spacecmd -u admin -p admin'
-  get_target('server').run("#{space} clear_caches")
-  out, _code = get_target('server').run("#{space} system_details #{get_target(host).full_hostname}")
-  unless out.include? 'ssh-push-tunnel'
-    steps %(
-      Given I am authorized as "testing" with password "testing"
-      And I am on the Systems overview page of this "#{host}"
-      And I follow "Provisioning"
-      And I click on "Create PXE installation configuration"
-      Then I should see a "System record created" text
-    )
-  end
+When(/^I clear the caches on the server$/) do
+  node = get_target('server')
+  node.run('spacecmd -u admin -p admin clear_caches')
+end
+
+When(/I click on profile "([^"]*)"$/) do |profile|
+  xpath_query = "//a[text()='#{profile}']/../../td[1]/input[@type='radio']"
+  find(:xpath, xpath_query).click
 end
 
 Then(/^the cobbler report should contain "([^"]*)" for "([^"]*)"$/) do |text, host|


### PR DESCRIPTION
## What does this PR change?

This PR fixes the last failing Cobbler test.

The issue was that we were selecting by default the profile from Retail.

In addition to selecting the correct radio button, this code was rationalized.

There was also a bug in 4.3, "client" versus "sle_client".


## Links

Ports:
 * 4.3: https://github.com/SUSE/spacewalk/pull/24496


## Changelogs

- [x] No changelog needed
