### PR TITLE
Fix payg client detection

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -949,6 +949,12 @@ public class ActionFactory extends HibernateFactory {
      * @return true if the action was stopped due to byos servers within it, false otherwise
      */
     public static boolean rejectScheduleActionIfByos(Action action) {
+        if (action.getActionType().equals(ActionFactory.TYPE_HARDWARE_REFRESH_LIST)) {
+            // Hardware refresh detect PAYG/BYOS type and refresh it. This should be possible also
+            // for BYOS systems in case the former detection failed. On error PAYG is set to false,
+            // and we need a way to repeat the detection.
+            return false;
+        }
         List<MinionSummary> byosMinions = MinionServerFactory.findByosServers(action);
         if (CollectionUtils.isNotEmpty(byosMinions)) {
             LOG.error("To manage BYOS or DC servers from SUSE Manager PAYG, SCC credentials must be " +

--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -556,13 +556,6 @@ public class HardwareMapper {
     }
 
     /**
-     * Map PAYG information for the server to the database.
-     */
-    public void mapPaygInfo() {
-        server.setPayg(grains.getOptionalAsBoolean("is_payg_instance").orElse(false));
-    }
-
-    /**
      * Get the memory amount to set. Most of the times we don't want to update it since a better value comes from
      * the virtual host, but for foreign hosts and systems with no memory set, take the value seen from the guest OS:
      * it's better than no value at all.

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -482,8 +482,9 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 .orElseThrow(() -> new SaltException("Missing systeminfo result. Aborting registration."));
 
             ValueMap grains = systemInfo.getGrains();
+            PublicCloudInstanceFlavor instanceFlavor = PublicCloudInstanceFlavor.UNKNOWN;
             if (cloudPaygManager.isPaygInstance() && !cloudPaygManager.hasSCCCredentials()) {
-                PublicCloudInstanceFlavor instanceFlavor = saltApi.getInstanceFlavor(minionId);
+                instanceFlavor = saltApi.getInstanceFlavor(minionId);
                 if (!RegistrationUtils.isAllowedOnPayg(systemQuery, minionId, Collections.emptySet(), grains,
                                                        instanceFlavor)) {
                     Object[] args = {minionId};
@@ -562,7 +563,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             minion.setHostname(grains.getOptionalAsString(FQDN).orElse(null));
             minion.setCpe(cpe);
             systemInfo.getKernelLiveVersion().ifPresent(minion::setKernelLiveVersion);
-
+            minion.setPayg(instanceFlavor.equals(PublicCloudInstanceFlavor.PAYG));
 
             String serverArch = String.format("%s-%s", osarch,
                     osfamily.equals("Debian") ? "debian-linux" : "redhat-linux");

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -121,7 +121,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -229,7 +228,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         }
         assertEquals(3, minion.getPackages().size());
 
-        minion.getInstalledProducts().stream().forEach(product -> {
+        minion.getInstalledProducts().forEach(product -> {
             assertEquals("sles", product.getName().toLowerCase());
             assertEquals("sles",  product.getSUSEProduct().getName());
             assertEquals("12.1", product.getVersion());
@@ -293,7 +292,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
-    public void testApplyPackageDeltaWithDuplicates() throws Exception {
+    public void testApplyPackageDeltaWithDuplicates() {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
 
         Map<String, Change<Xor<String, List<Pkg.Info>>>> install = Json.GSON.fromJson(new InputStreamReader(getClass()
@@ -312,7 +311,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
-    public void testsPackageDeltaFromStateApply() throws Exception {
+    public void testsPackageDeltaFromStateApply() {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         assertEquals(0, minion.getPackages().size());
 
@@ -586,7 +585,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals(3, minion.getPackages().size());
 
         assertEquals(1, minion.getInstalledProducts().size());
-        minion.getInstalledProducts().stream().forEach(product -> {
+        minion.getInstalledProducts().forEach(product -> {
             assertEquals("res", product.getName());
             assertEquals("7", product.getVersion());
             assertNull(product.getRelease());
@@ -833,7 +832,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateGrainsFqdns() throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.ppc64.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.ppc64.json", server -> {
             assertNotNull(server);
             assertEquals(2, server.getFqdns().size());
         });
@@ -841,7 +840,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateCustomFqdns() throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.x86.custom.fqdns.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.x86.custom.fqdns.json", server -> {
             assertNotNull(server);
             assertEquals(5, server.getFqdns().size());
             List<String> collect = server.getFqdns().stream().map(ServerFQDN::getName).collect(Collectors.toList());
@@ -853,7 +852,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateNetworkModuleFqdns() throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.x86.json", server -> {
             assertNotNull(server);
             assertEquals(2, server.getFqdns().size());
         });
@@ -861,7 +860,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateX86LongCPUValues()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.cpulongval.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.cpulongval.x86.json", server -> {
             assertNotNull(server);
             assertNotNull(server.getCpu());
 
@@ -879,7 +878,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdatePPC64()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.ppc64.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.ppc64.json", server -> {
             assertNotNull(server);
             assertNotNull(server.getCpu());
 
@@ -934,7 +933,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateScsiDevices()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.scsi.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.scsi.x86.json", server -> {
             assertNotNull(server);
             assertNotNull(server.getCpu());
 
@@ -948,7 +947,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdatePrimaryIPv4Only()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4only.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4only.x86.json", server -> {
             Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                     NetworkInterface::getName,
                     Function.identity()
@@ -963,7 +962,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdatePrimaryIPv4OnlyLocalhost()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4onlylocalhost.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4onlylocalhost.x86.json", server -> {
             Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                     NetworkInterface::getName,
                     Function.identity()
@@ -978,7 +977,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdatetPrimaryIPv6Only()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv6only.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv6only.x86.json", server -> {
             Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                     NetworkInterface::getName,
                     Function.identity()
@@ -992,7 +991,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdatetPrimaryIPV4IPv6()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4ipv6.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4ipv6.x86.json", server -> {
             Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                     NetworkInterface::getName,
                     Function.identity()
@@ -1006,7 +1005,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testHardwareProfileChangeNetworkIP()  throws Exception {
         MinionServer minion = testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4ipv6.x86.json",
-            (server) -> {
+            server -> {
                 Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream()
                     .collect(Collectors.toMap(
                             NetworkInterface::getName,
@@ -1035,7 +1034,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileMultiIP()  throws Exception {
-        MinionServer minion = testHardwareProfileUpdate("hardware.profileupdate.multi-ipv4.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.multi-ipv4.json", server -> {
             Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                     NetworkInterface::getName,
                     Function.identity()));
@@ -1054,7 +1053,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testHardwareProfileNoNetworkIPChange()  throws Exception {
         MinionServer minion = testHardwareProfileUpdate("hardware.profileupdate.primary_ips_ipv4ipv6.x86.json",
-            (server) -> {
+            server -> {
                 Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream()
                     .collect(Collectors.toMap(
                             NetworkInterface::getName,
@@ -1093,8 +1092,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JsonObject obj = getJsonElement("hardware.profileupdate.primary_ips_empty_ssh.x86.json");
         JsonElement element = obj.get("suma-ref31-min-centos7.mgr.suse.de");
 
-        Set<NetworkInterface> oldIfs = new HashSet<>();
-        oldIfs.addAll(server.getNetworkInterfaces());
+        Set<NetworkInterface> oldIfs = new HashSet<>(server.getNetworkInterfaces());
 
         saltUtils.updateServerAction(sa, 0L, true, "n/a", element,
                 Optional.of(Xor.right("state.apply")));
@@ -1114,7 +1112,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateS390() throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.s390.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.s390.json", server -> {
             assertNotNull(server);
             assertNotNull(server.getCpu());
 
@@ -1211,7 +1209,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileInfiniband()  throws Exception {
-        MinionServer minion = testHardwareProfileUpdate("hardware.profileupdate.infiniband.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.infiniband.json", server -> {
             Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                     NetworkInterface::getName,
                     Function.identity()
@@ -1222,13 +1220,13 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileXenHost()  throws Exception {
-        MinionServer minion = testHardwareProfileUpdate("hardware.profileupdate.xen-host.json",
-                (server) -> assertFalse(server.isVirtualGuest(), "system should not be a virtual guest"));
+        testHardwareProfileUpdate("hardware.profileupdate.xen-host.json",
+                server -> assertFalse(server.isVirtualGuest(), "system should not be a virtual guest"));
     }
 
     @Test
     public void testHardwareProfilePublicCloud()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.public_cloud.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.public_cloud.json", server -> {
             assertNotNull(server);
             assertEquals("iabcdef1234567890", server.getVirtualInstance().getUuid());
             assertFalse(server.isPayg(), "Unexpected: instance is PAYG but should not");
@@ -1237,7 +1235,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfilePublicCloudPayg()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.public_cloud_payg.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.public_cloud_payg.json", server -> {
             assertNotNull(server);
             assertEquals("iabcdef1234567890", server.getVirtualInstance().getUuid());
             assertTrue(server.isPayg(), "Unexpected: instance is BYOS but should not");
@@ -1288,6 +1286,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         return JsonParser.GSON.fromJson(jsonString, JsonObject.class);
     }
 
+    @Test
     public void testStateApplyActionTestMode() throws Exception {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("abcdefg.vagrant.local");
@@ -1299,7 +1298,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         ApplyStatesAction action = ActionManager.scheduleApplyStates(
                 user,
-                Arrays.asList(minion.getId()),
+                Collections.singletonList(minion.getId()),
                 new ArrayList<>(),
                 new Date());
 
@@ -1338,8 +1337,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         ApplyStatesAction action = ActionManager.scheduleApplyStates(
                 user,
-                Arrays.asList(minion.getId()),
-                Arrays.asList(ApplyStatesEventMessage.CHANNELS),
+                Collections.singletonList(minion.getId()),
+                List.of(ApplyStatesEventMessage.CHANNELS),
                 new Date());
 
         ServerAction sa = ActionFactoryTest.createServerAction(minion, action);
@@ -1364,13 +1363,13 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         messageAction.execute(message);
 
         assertEquals(
-            Arrays.asList(sa),
+                List.of(sa),
             action.getServerActions().stream().filter(
                 serverAction -> serverAction.getServer().equals(minion)
             ).collect(java.util.stream.Collectors.toList()));
 
         // Verify the action status
-        assertEquals(sa.getStatus(), ActionFactory.STATUS_FAILED);
+        assertEquals(ActionFactory.STATUS_FAILED, sa.getStatus());
         context().assertIsSatisfied();
     }
 
@@ -1456,14 +1455,12 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ImageProfile profile = ImageTestUtils.createImageProfile(imageName, store, user);
 
         ImageInfo imgInfoBuild1 = doTestContainerImageBuild(server, imageName, imageVersion, profile,
-                (imgInfo) -> {
-                    // assert initial revision number
-                    assertEquals(1, imgInfo.getRevisionNumber());
-                });
+                // assert initial revision number
+                imgInfo -> assertEquals(1, imgInfo.getRevisionNumber()));
 
         doTestContainerImageInspect(server, imageName, imageVersion, profile, imgInfoBuild1,
                 digest1,
-                (imgInfo) -> {
+                imgInfo -> {
             // assertions after inspect
             // reload imgInfo to get the build history
             imgInfo = TestUtils.reload(imgInfo);
@@ -1482,10 +1479,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
 
         ImageInfo imgInfoBuild2 = doTestContainerImageBuild(server, imageName, imageVersion, profile,
-                (imgInfo) -> {
-                    // assert revision number incremented
-                    assertEquals(2, imgInfo.getRevisionNumber());
-                });
+                // assert revision number incremented
+                imgInfo -> assertEquals(2, imgInfo.getRevisionNumber()));
 
         // build of new revision obsoletes the previous one
         imgInfoBuild1 = TestUtils.reload(imgInfoBuild1);
@@ -1493,7 +1488,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         doTestContainerImageInspect(server, imageName, imageVersion, profile, imgInfoBuild2,
                 digest2,
-                (imgInfo) -> {
+                imgInfo -> {
             // reload imgInfo to get the build history
             imgInfo = TestUtils.reload(imgInfo);
             assertNotNull(imgInfo);
@@ -1527,19 +1522,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ImageProfile profile = ImageTestUtils.createImageProfile(imageName, store, user);
 
         ImageInfo imgInfoBuild1 = doTestContainerImageBuild(server, imageName, imageVersion1, profile,
-                (imgInfo) -> {
-                    // assert initial revision number
-                    assertEquals(1, imgInfo.getRevisionNumber());
-                });
+                // assert initial revision number
+                imgInfo -> assertEquals(1, imgInfo.getRevisionNumber()));
         doTestContainerImageInspect(server, imageName, imageVersion1, profile, imgInfoBuild1,
                 digest,
-                (imgInfo) -> {
+                imgInfo -> {
             // assertions after inspect
             // reload imgInfo to get the build history
             imgInfo = TestUtils.reload(imgInfo);
             assertNotNull(imgInfo);
             // test that the history of the build was updated correctly
-            assertEquals(1, imgInfo.getRepoDigests().stream().count());
+            assertEquals(1, (long) imgInfo.getRepoDigests().size());
             assertEquals(
                     "docker-registry:5000/" + imageName + "@sha256:" + digest,
                     imgInfo.getRepoDigests().stream()
@@ -1551,7 +1544,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
 
         ImageInfo imgInfoBuild2 = doTestContainerImageBuild(server, imageName, imageVersion2, profile,
-                (imgInfo) -> {
+                imgInfo -> {
                     // assert revision number incremented
                     assertEquals(1, imgInfo.getRevisionNumber());
                     assertNotEquals(imgInfoBuild1.getId(), imgInfo.getId());
@@ -1559,7 +1552,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         doTestContainerImageInspect(server, imageName, imageVersion2, profile, imgInfoBuild2,
                 digest,
-                (imgInfo) -> {
+                imgInfo -> {
             // reload imgInfo to get the build history
             imgInfo = TestUtils.reload(imgInfo);
             assertNotNull(imgInfo);
@@ -1589,7 +1582,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ImageStore store = ImageTestUtils.createImageStore("test-docker-registry:5000", user);
 
         doTestContainerImageImport(server, imageName, imageVersion, store,
-                (imgInfo) -> {
+                imgInfo -> {
                     // reload imgInfo to get the build history
                     imgInfo = TestUtils.reload(imgInfo);
                     assertNotNull(imgInfo);
@@ -1685,7 +1678,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         messageAction.execute(message);
 
         assertTrue(ImageInfoFactory.lookupByName(imageName, imageVersion, store.getId()).isPresent());
-        ImageInfo imgInfo = ImageInfoFactory.lookupByName(imageName, imageVersion, store.getId()).get();
+        ImageInfo imgInfo = ImageInfoFactory.lookupByName(imageName, imageVersion, store.getId()).orElse(null);
         assertNotNull(imgInfo);
 
         // other assertions after inspection
@@ -1850,7 +1843,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ActivationKey key = ImageTestUtils.createActivationKey(user);
         ImageProfile profile = ImageTestUtils.createKiwiImageProfile("my-kiwi-image", key, user);
 
-        ImageInfo image = doTestKiwiImageInspect(server, profile, "image.inspect.kiwi.json", (info) -> {
+        ImageInfo image = doTestKiwiImageInspect(server, profile, "image.inspect.kiwi.json", info -> {
             assertNotNull(info.getInspectAction().getId());
             assertEquals(286, info.getPackages().size());
 
@@ -1879,7 +1872,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         (Map<String, Map<String, Map<String, Object>>>) map.get("images");
             assertEquals("https://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("url"));
-            assertEquals(Long.valueOf(1490026496), images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
+            assertEquals(1490026496L, images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
             assertEquals("a64dbc025c748bde968b888db6b7b9e3",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("hash"));
         });
@@ -1943,7 +1936,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         (Map<String, Map<String, Map<String, Object>>>) map.get("images");
             assertEquals("https://ftp/saltboot/image/POS_Image_JeOS6.x86_64-6.0.0-1/POS_Image_JeOS6.x86_64-6.0.0",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("url"));
-            assertEquals(Long.valueOf(1490026496), images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
+            assertEquals(1490026496L, images.get("POS_Image_JeOS6").get("6.0.0-1").get("size"));
             assertEquals("a64dbc025c748bde968b888db6b7b9e3",
                         images.get("POS_Image_JeOS6").get("6.0.0-1").get("hash"));
             assertEquals("gzip", images.get("POS_Image_JeOS6").get("6.0.0-1").get("compressed"));
@@ -2154,7 +2147,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Map<LocalCall<?>, List<MinionSummary>> calls = saltServerActionService.callsForAction(action);
 
         // artifically expire tokens
-        action.getDetails().getAccessTokens().stream().forEach(t -> t.setMinion(null));
+        action.getDetails().getAccessTokens().forEach(t -> t.setMinion(null));
         HibernateFactory.getSession().flush();
 
         // Setup an event message from file contents
@@ -2172,8 +2165,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     private void assertTokenChannel(MinionServer minion, Channel channel) {
         assertTrue(minion.getAccessTokens().stream()
-                .filter(token -> token.getChannels().size() == 1 && token.getChannels().contains(channel))
-                .findFirst().isPresent(), channel.getLabel());
+                .anyMatch(token -> token.getChannels().size() == 1 && token.getChannels().contains(channel)),
+                channel.getLabel());
     }
 
     @Test
@@ -2237,9 +2230,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         messageAction.execute(message);
 
         // Verify the action status
-        assertEquals(action.getServerActions().stream()
+        assertEquals(ActionFactory.STATUS_FAILED, action.getServerActions().stream()
                 .filter(serverAction -> serverAction.getServer().equals(minion))
-                .findAny().get().getStatus(), ActionFactory.STATUS_FAILED);
+                .findAny().get().getStatus());
 
         // Verify the action message
         assertTrue(action.getServerActions().stream()
@@ -2263,14 +2256,14 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Date earliestAction = new Date();
         ApplyStatesAction applyHighstate = ActionManager.scheduleApplyStates(
                 user,
-                Arrays.asList(minion.getId()),
+                Collections.singletonList(minion.getId()),
                 new ArrayList<>(),
                 earliestAction);
 
         ScriptActionDetails sad = ActionFactory.createScriptActionDetails(
                 "root", "root", 10L, "#!/bin/csh\necho hello");
         ScriptRunAction runScript = ActionManager.scheduleScriptRun(
-                user, Arrays.asList(minion.getId()), "Run script test", sad, earliestAction);
+                user, Collections.singletonList(minion.getId()), "Run script test", sad, earliestAction);
 
         ServerAction saHighstate = ActionFactoryTest.createServerAction(minion, applyHighstate);
         applyHighstate.addServerAction(saHighstate);
@@ -2330,8 +2323,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         SystemManager.giveCapability(minion.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
 
-        ApplyStatesAction applyHighstate = ActionManager.scheduleApplyStates(user, Arrays.asList(minion.getId()),
-                new ArrayList<>(), new Date());
+        ApplyStatesAction applyHighstate = ActionManager.scheduleApplyStates(user,
+                Collections.singletonList(minion.getId()), new ArrayList<>(), new Date());
 
         ServerAction saHighstate = ActionFactoryTest.createServerAction(minion, applyHighstate);
         applyHighstate.addServerAction(saHighstate);
@@ -2367,8 +2360,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         SystemManager.giveCapability(minion.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
 
-        ApplyStatesAction applyHighstate = ActionManager.scheduleApplyStates(user, Arrays.asList(minion.getId()),
-                new ArrayList<>(), new Date());
+        ApplyStatesAction applyHighstate = ActionManager.scheduleApplyStates(user,
+                Collections.singletonList(minion.getId()), new ArrayList<>(), new Date());
 
         ServerAction saHighstate = ActionFactoryTest.createServerAction(minion, applyHighstate);
         applyHighstate.addServerAction(saHighstate);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -786,6 +786,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             assertNotNull(server.getDmi().getVendor());
             assertFalse(server.getDevices().isEmpty());
             assertFalse(server.getNetworkInterfaces().isEmpty());
+            assertFalse(server.isPayg(), "Unexpected: system is PAYG but it should not");
 
             Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                     NetworkInterface::getName,
@@ -1227,9 +1228,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfilePublicCloud()  throws Exception {
-        MinionServer minion = testHardwareProfileUpdate("hardware.profileupdate.public_cloud.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.public_cloud.json", (server) -> {
             assertNotNull(server);
             assertEquals("iabcdef1234567890", server.getVirtualInstance().getUuid());
+            assertFalse(server.isPayg(), "Unexpected: instance is PAYG but should not");
+        });
+    }
+
+    @Test
+    public void testHardwareProfilePublicCloudPayg()  throws Exception {
+        testHardwareProfileUpdate("hardware.profileupdate.public_cloud_payg.json", (server) -> {
+            assertNotNull(server);
+            assertEquals("iabcdef1234567890", server.getVirtualInstance().getUuid());
+            assertTrue(server.isPayg(), "Unexpected: instance is BYOS but should not");
         });
     }
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.public_cloud_payg.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.public_cloud_payg.json
@@ -111,7 +111,7 @@
                 "duration": 0.653,
                 "__run_num__": 5,
                 "changes": {
-                    "ret": "BYOS"
+                    "ret": "PAYG"
                 }
             },
             "mgrcompat_|-smbios-records-baseboard_|-smbios.records_|-module_run": {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.x86.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/hardware.profileupdate.x86.json
@@ -103,6 +103,17 @@
                     }
                 }
             },
+            "mgrcompat_|-instance-flavor_|-sumautil.instance_flavor_|-module_run": {
+                "comment": "Module function sumautil.instance_flavor executed",
+                "name": "sumautil.instance_flavor",
+                "start_time": "12:58:12.422344",
+                "result": true,
+                "duration": 0.653,
+                "__run_num__": 5,
+                "changes": {
+                    "ret": "This minion does not run in a public cloud."
+                }
+            },
             "mgrcompat_|-smbios-records-baseboard_|-smbios.records_|-module_run": {
                 "comment": "Module function smbios.records executed",
                 "name": "smbios.records",

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -1954,7 +1954,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(Optional.of(pil)));
                 }},
                 ACTIVATION_KEY_SUPPLIER,
-                (optMinion, machineId, key) -> assertTrue(optMinion.isPresent()),
+                (optMinion, machineId, key) -> {
+                    assertTrue(optMinion.isPresent());
+                    assertFalse(optMinion.get().isPayg(), "Unexpected: instance is PAYG");
+                },
                 DEFAULT_CONTACT_METHOD);
     }
 
@@ -1981,7 +1984,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, key)));
                     allowing(saltServiceMock).getInstanceFlavor(MINION_ID);
-                    will(returnValue(SumaUtil.PublicCloudInstanceFlavor.PAYG));
+                    will(returnValue(SumaUtil.PublicCloudInstanceFlavor.BYOS));
                     List<ProductInfo> pil = new ArrayList<>();
                     ProductInfo pi = new ProductInfo(
                             product.getName(),
@@ -1994,7 +1997,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(Optional.of(pil)));
                 }},
                 ACTIVATION_KEY_SUPPLIER,
-                (optMinion, machineId, key) -> assertTrue(optMinion.isPresent()),
+                (optMinion, machineId, key) -> {
+                    assertTrue(optMinion.isPresent());
+                    assertFalse(optMinion.get().isPayg(), "Unexpected: instance is PAYG");
+                },
                 DEFAULT_CONTACT_METHOD);
     }
 
@@ -2013,7 +2019,10 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(SumaUtil.PublicCloudInstanceFlavor.PAYG));
                 }},
                 ACTIVATION_KEY_SUPPLIER,
-                (optMinion, machineId, key) -> assertTrue(optMinion.isPresent()),
+                (optMinion, machineId, key) -> {
+                    assertTrue(optMinion.isPresent());
+                    assertTrue(optMinion.get().isPayg(), "Unexpected: instance is not PAYG");
+                },
                 DEFAULT_CONTACT_METHOD);
     }
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1862,7 +1862,7 @@ public class SaltUtils {
                     result.getCustomFqdns().stream()
                 ).distinct().collect(Collectors.toList())
         );
-        hwMapper.mapPaygInfo();
+        server.setPayg(result.getInstanceFlavor().map(o -> o.equals("PAYG")).orElse(false));
 
         // Let the action fail in case there is error messages
         if (!hwMapper.getErrors().isEmpty()) {

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/HwProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/HwProfileUpdateSlsResult.java
@@ -56,6 +56,9 @@ public class HwProfileUpdateSlsResult {
     @SerializedName("mgrcompat_|-network-modules_|-sumautil.get_net_modules_|-module_run")
     private StateApplyResult<Ret<Map<String, Optional<String>>>> networkModules;
 
+    @SerializedName("mgrcompat_|-instance-flavor_|-sumautil.instance_flavor_|-module_run")
+    private StateApplyResult<Ret<Optional<String>>> instanceFlavor;
+
     @SerializedName("mgrcompat_|-dns_fqdns_|-mgrnet.dns_fqdns_|-module_run")
     private Optional<StateApplyResult<Optional<Ret<Map<String, List<String>>>>>> fqdnsFromMgrNetModule =
             Optional.empty();
@@ -147,6 +150,16 @@ public class HwProfileUpdateSlsResult {
             return Collections.emptyMap();
         }
         return networkModules.getChanges().getRet();
+    }
+
+    /**
+     * @return the flavor of the instance
+     */
+    public Optional<String> getInstanceFlavor() {
+        if (instanceFlavor == null) {
+            return Optional.empty();
+        }
+        return instanceFlavor.getChanges().getRet();
     }
 
     /**

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-payg-client-detection
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-payg-client-detection
@@ -1,0 +1,1 @@
+- fix PAYG client detection during Hardware refresh (bsc#1225940)

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-payg-client-detection
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-payg-client-detection
@@ -1,1 +1,3 @@
+- allow running Hardware refresh for BYOS Clients on a SUMA PAYG Server
+  to allow re-detection of the instance flavor (bsc#1225940)
 - fix PAYG client detection during Hardware refresh (bsc#1225940)

--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -73,6 +73,18 @@ network-modules:
       - mgrcompat: sync_modules
 {%- endif %}
 
+instance-flavor:
+  mgrcompat.module_run:
+    - name: sumautil.instance_flavor
+    - require:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_states
+      - saltutil: sync_modules
+{%- else %}
+      - mgrcompat: sync_states
+      - mgrcompat: sync_modules
+{%- endif %}
+
 {% if grains['cpuarch'] in ['i386', 'i486', 'i586', 'i686', 'x86_64'] %}
 smbios-records-bios:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-fix-payg-client-detection
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mc.Manager-4.3-fix-payg-client-detection
@@ -1,0 +1,1 @@
+- fix PAYG client detection during Hardware refresh (bsc#1225940)


### PR DESCRIPTION
## What does this PR change?

PR https://github.com/uyuni-project/uyuni/pull/8331 changed the instance flavor check and moved it from grains into an execution module.
But the hardware refresh was forgotten and still test for the grain. As this grain does not exist anymore, all systems are
set to BYOS.
This makes it impossible to run any action on these clients when we have a SUSE Manager Server PAYG.

Also when this is fixed, the re-detection is impossible as it require to execute an action on BYOS systems.
So this PR allow to run a Hardware refresh also on BYOS systems to be able to fix instance type.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24501

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
