### PR TITLE
fix typo on notification

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -259,8 +259,8 @@ def create_bootstrap_failure_notification(label, messages: List[str]):
     notification_type = "CreateBootstrapRepoFailed"
     with cfg_component("java") as cfg:
         if (
-            cfg.notification_type_disabled
-            and notification_type in cfg.notification_type_disabled.split(",")
+            cfg.notifications_type_disabled
+            and notification_type in cfg.notifications_type_disabled.split(",")
         ):
             return None
 

--- a/susemanager/susemanager.changes.mbussolotto.notification
+++ b/susemanager/susemanager.changes.mbussolotto.notification
@@ -1,0 +1,1 @@
+- fix typo in notification


### PR DESCRIPTION
## What does this PR change?

Runing `mgr-create-bootstrap-repo` I had this error:
```
Traceback (most recent call last):
  File "/usr/sbin/mgr-create-bootstrap-repo", line 1082, in <module>
    sys.exit(abs(main() or 0))
  File "/usr/sbin/mgr-create-bootstrap-repo", line 1060, in main
    r = create_repo(elabel, opts, mgr_bootstrap_data, additional=args)
  File "/usr/sbin/mgr-create-bootstrap-repo", line 845, in create_repo
    create_bootstrap_failure_notification(label, messages)
  File "/usr/sbin/mgr-create-bootstrap-repo", line 262, in create_bootstrap_failure_notification
    cfg.notification_type_disabled
  File "/usr/lib/python3.6/site-packages/spacewalk/common/rhnConfig.py", line 254, in __getattr__
    raise AttributeError(key)
AttributeError: notification_type_disabled
```
looks like it's a typo, the configuration in `/usr/share/rhn/config-defaults/rhn_java.conf`  is called `java.notifications_type_disabled`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
