### PR TITLE
fix byte-buddy runtime dependency

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -43,6 +43,10 @@
     <available file="${java.lib.dir}/byte-buddy/byte-buddy.jar"/>
   </condition>
 
+  <condition property="byte-buddy-dep" value="byte-buddy/byte-buddy-dep.jar" else="byte-buddy-dep.jar">
+    <available file="${java.lib.dir}/byte-buddy/byte-buddy-dep.jar"/>
+  </condition>
+
   <available file="${java.lib.dir}/hibernate/hibernate-commons-annotations.jar" type="file"
 	  property="hibernate-commons-annotations" value="hibernate/hibernate-commons-annotations"/>
   <available file="${java.lib.dir}/hibernate-commons-annotations/hibernate-commons-annotations.jar" type="file"
@@ -115,7 +119,7 @@
     <available file="${java.lib.dir}/hibernate5/hibernate-core.jar" type="file"/>
   </condition>
 
-  <property name="hibernate5deps" value="${hibernate5files} ${hibernate-commons-annotations} slf4j/api jpa-api/jakarta.persistence-api ${byte-buddy} jboss-logging javassist log4j/log4j-slf4j-impl ${ehcache} classmate/classmate statistics hibernate-types/hibernate-types-52 jackson-databind jackson-core jackson-annotations"/>
+  <property name="hibernate5deps" value="${hibernate5files} ${hibernate-commons-annotations} slf4j/api jpa-api/jakarta.persistence-api ${byte-buddy} ${byte-buddy-dep} jboss-logging javassist log4j/log4j-slf4j-impl ${ehcache} classmate/classmate statistics hibernate-types/hibernate-types-52 jackson-databind jackson-core jackson-annotations"/>
 
   <property name="c3p0" value="c3p0"/>
   <available file="${java.lib.dir}/mchange-commons/mchange-commons-java.jar" type="file" property="c3p0" value="${c3p0} mchange-commons/mchange-commons-java"/>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -5,7 +5,8 @@
         <dependency org="suse" name="antlr" rev="2.7.7" />
         <dependency org="suse" name="asm" rev="9.3" />
         <dependency org="suse" name="bcel" rev="5.2" />
-        <dependency org="suse" name="byte-buddy" rev="1.11.12" />
+        <dependency org="suse" name="byte-buddy" rev="1.14.16" />
+        <dependency org="suse" name="byte-buddy-dep" rev="1.14.16" />
         <dependency org="suse" name="c3p0" rev="0.9.5.5" />
         <dependency org="suse" name="cglib" rev="3.3.0" />
         <dependency org="suse" name="classmate" rev="1.5.1" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -21,7 +21,13 @@ artifacts:
   - artifact: bcel
     repository: Leap
   - artifact: byte-buddy
-    repository: Uyuni_Other
+    package: byte-buddy
+    repository: Leap_sle
+    jar: byte-buddy.jar
+  - artifact: byte-buddy-dep
+    package: byte-buddy
+    repository: Leap_sle
+    jar: byte-buddy-dep.jar
   - artifact: c3p0
     repository: Leap
   - artifact: cglib

--- a/java/spacewalk-java.changes.mbussolotto.byte-buddyy
+++ b/java/spacewalk-java.changes.mbussolotto.byte-buddyy
@@ -1,0 +1,3 @@
+- fetch byte-buddy dependencies from Leap_sle
+- add byte-buddy-dep dependency
+- require byte-buddy and byte-buddy-dep using maven dependencies

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -89,7 +89,8 @@ BuildRequires:  apache-commons-jexl
 BuildRequires:  apache-commons-lang3 >= 3.4
 BuildRequires:  apache-commons-logging
 BuildRequires:  bcel
-BuildRequires:  byte-buddy >= 1.11
+BuildRequires:  mvn(net.bytebuddy:byte-buddy) >= 1.14
+BuildRequires:  mvn(net.bytebuddy:byte-buddy-dep) >= 1.14
 BuildRequires:  c3p0 >= 0.9.1
 BuildRequires:  cglib
 BuildRequires:  classmate
@@ -176,7 +177,8 @@ Requires:       apache-commons-jexl
 Requires:       apache-commons-lang3
 Requires:       apache-commons-logging
 Requires:       bcel
-Requires:       byte-buddy >= 1.11
+Requires:       mvn(net.bytebuddy:byte-buddy) >= 1.14
+Requires:       mvn(net.bytebuddy:byte-buddy-dep) >= 1.14
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 Requires:       classmate
@@ -351,7 +353,8 @@ Requires:       apache-commons-codec
 Requires:       apache-commons-lang3
 Requires:       apache-commons-logging
 Requires:       bcel
-Requires:       byte-buddy >= 1.11
+Requires:       mvn(net.bytebuddy:byte-buddy) >= 1.14
+Requires:       mvn(net.bytebuddy:byte-buddy-dep) >= 1.14
 Requires:       c3p0 >= 0.9.1
 Requires:       cglib
 Requires:       classmate


### PR DESCRIPTION
## What does this PR change?

fix byte-buddy runtime dependency. Testing it here: https://build.opensuse.org/project/show/home:mbussolotto:branches:systemsmanagement:Uyuni:Master

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8859

- [ ] **DONE**

## Changelogs

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
