### PR TITLE
QE: additional checks in Salt packages lock scenarios

### DIFF
--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -89,6 +89,7 @@ Feature: Lock packages on SLES salt minion
     When I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
+    And package "milkyway-dummy-2.0-1.1" is reported as pending to be locked
     When I wait until event "Lock packages scheduled by admin" is completed
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     And "milkyway-dummy-2.0-1.1" is locked on "sle_minion"
@@ -108,6 +109,7 @@ Feature: Lock packages on SLES salt minion
     When I check row with "orion-dummy-1.1-1.1" and arch of "sle_minion"
     And I click on "Lock"
     Then I should see a "Packages has been requested for being locked." text
+    And package "orion-dummy-1.1-1.1" is reported as pending to be locked
     When I follow "Lock / Unlock"
     And I enter "hoag-dummy-1.1-1.1" as the filtered package name
     And I click on the filter button
@@ -117,6 +119,7 @@ Feature: Lock packages on SLES salt minion
     And I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
     And I click on "Unlock"
     Then I should see a "Packages has been requested for being unlocked." text
+    And package "milkyway-dummy-2.0-1.1" is reported as pending to be unlocked
     When I wait until event "Lock packages scheduled by admin" is completed
     Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
     And "milkyway-dummy-2.0-1.1" is unlocked on "sle_minion"


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/20168

One scenario of this feature can fail for the reason detailed in the issue's comments: at times, an event has not yet been completed when we check for the state that results from it.
These makes the test flaky despite everything else actually working fine and the feature working as intended.

Although the root cause of this behavior lies in the way we check for completed events, this PR introduces a few more checks to standardize the scenarios and - hopefully - make the whole thing more robust.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/20168
Port(s): 4.3 https://github.com/SUSE/spacewalk/pull/24506

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
