### PR TITLE
fix hairping problem during ssh push with tunnel

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -588,8 +588,7 @@ public class SaltSSHService {
     private Optional<String> remotePortForwarding(List<String> proxyPath,
                                                   String sshContactMethod) {
         if (ContactMethodUtil.SSH_PUSH_TUNNEL.equals(sshContactMethod)) {
-            return Optional.of(getSshPushRemotePort() + ":" +
-                    ConfigDefaults.get().getJavaHostname() + ":" + SSL_PORT);
+            return Optional.of(getSshPushRemotePort() + ":" + "localhost" + ":" + SSL_PORT);
         }
         return Optional.empty();
     }

--- a/java/spacewalk-java.changes.mcalmer.fix-sshpush-tunnel
+++ b/java/spacewalk-java.changes.mcalmer.fix-sshpush-tunnel
@@ -1,0 +1,1 @@
+- fix hairpin problem in ssh push with tunnel prevent bootstrapping (bsc#1226098, bsc#1223970)

--- a/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
+++ b/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
@@ -191,7 +191,7 @@ class UyuniRoster:
                     pushKey=PROXY_SSH_PUSH_KEY,
                     user=user,
                     pushPort=self.ssh_push_port_https,
-                    proxy=proxies[len(proxies) - 1].hostname,
+                    proxy="localhost",
                     sslPort=SSL_PORT,
                     minion=minion_id,
                     # pylint: disable-next=consider-using-f-string
@@ -247,7 +247,7 @@ class UyuniRoster:
                 {
                     # pylint: disable-next=consider-using-f-string
                     "remote_port_forwards": "%d:%s:%d"
-                    % (self.ssh_push_port_https, self.java_hostname, SSL_PORT)
+                    % (self.ssh_push_port_https, "localhost", SSL_PORT)
                 }
             )
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-sshpush-tunnel
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-sshpush-tunnel
@@ -1,0 +1,1 @@
+- fix hairpin problem in ssh push with tunnel prevent bootstrapping (bsc#1226098, bsc#1223970)


### PR DESCRIPTION
## What does this PR change?

When configuring ssh cascade for ssh push with tunnel via proxies, the last proxy command has a reverse port forwarding rule using the hostname of the proxy. That hostname is the name of the "host", but we land inside of the container which has its own network. 
To reach the given hostname, a connection is made to the host which redirect again inside of the container.

Also in case if the RPM based installed proxy, localhost should work as we want to redirect the local port always.
This should handle also the case of containerized SUSE Manager Server 5.0 with a plain SUSE Manager 4.3 proxy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24510 https://github.com/SUSE/spacewalk/issues/24290

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
