### PR TITLE
Switch RELEASE_STAGE to released and EULA to sle-eula

### DIFF
--- a/rel-eng/container_push.sh
+++ b/rel-eng/container_push.sh
@@ -27,10 +27,10 @@ fi
 PRODUCT_VERSION=$(echo ${PRODUCT_VERSION,,} | sed -r 's/ /-/g')
 
 # Possible values: beta, sle-eula
-EULA=beta
+EULA=sle-eula
 
 # Possible values: alpha, beta, released
-RELEASE_STAGE=beta
+RELEASE_STAGE=released
 
 if [ -f "${SRPM_PKG_DIR}/Dockerfile" ]; then
   NAME="${PKG_NAME%%-image}"


### PR DESCRIPTION
## What does this PR change?

This is GMC and we can now start to push the containers as released and with the final `sle-eula` EULA.

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: this is an internal script

- [x] **DONE**

## Links

Relate(s): https://github.com/SUSE/spacewalk/issues/23747 and https://github.com/SUSE/spacewalk/issues/23749 and https://github.com/uyuni-project/uyuni-tools/pull/353

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
