### PR TITLE
Use javaHostName instead of passed server name

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/KickstartHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/KickstartHandler.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.kickstart;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.channel.Channel;
@@ -32,7 +33,6 @@ import com.redhat.rhn.frontend.action.kickstart.KickstartIpRangeFilter;
 import com.redhat.rhn.frontend.action.kickstart.KickstartTreeUpdateType;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
-import com.redhat.rhn.frontend.xmlrpc.RhnXmlRpcServer;
 import com.redhat.rhn.manager.kickstart.KickstartCloneCommand;
 import com.redhat.rhn.manager.kickstart.KickstartDeleteCommand;
 import com.redhat.rhn.manager.kickstart.KickstartEditCommand;
@@ -112,7 +112,7 @@ public class KickstartHandler extends BaseHandler {
 
         return importFile(loggedInUser, profileLabel, virtualizationType,
                 kickstartableTreeLabel,
-                RhnXmlRpcServer.getServerName(), kickstartFileContents);
+                ConfigDefaults.get().getJavaHostname(), kickstartFileContents);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/KickstartTreeHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/KickstartTreeHandler.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.kickstart.tree;
 
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
@@ -24,7 +25,6 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.kickstart.KickstartableTreeDetail;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
-import com.redhat.rhn.frontend.xmlrpc.RhnXmlRpcServer;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.kickstart.tree.TreeCreateOperation;
 import com.redhat.rhn.manager.kickstart.tree.TreeDeleteOperation;
@@ -167,7 +167,7 @@ public class KickstartTreeHandler extends BaseHandler {
         create.setChannel(getChannel(channelLabel, loggedInUser));
         create.setInstallType(getInstallType(installType));
         create.setLabel(treeLabel);
-        create.setServerName(RhnXmlRpcServer.getServerName());
+        create.setServerName(ConfigDefaults.get().getJavaHostname());
         create.setKernelOptions(kernelOptions);
         create.setKernelOptionsPost(postKernelOptions);
 

--- a/java/spacewalk-java.changes.oholecek.fix_using_serverfqdn_for_distro_api
+++ b/java/spacewalk-java.changes.oholecek.fix_using_serverfqdn_for_distro_api
@@ -1,0 +1,2 @@
+- Use server FQDN instead of client used connection FQDN for
+  distro creation when using API


### PR DESCRIPTION
## What does this PR change?

Autoinstallation distro API uses host used by client as a host to access the distro files. This was probably done because of proxies, but for proxy we have postprocessing translations in place, which assumes server fqdn used there. Also using client's host means using spacecmd on container would use 'localhost'.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24508
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
