### PR TITLE
Implement v2 for AWS instance detection

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.implement-v2-for-aws-instance-detection
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.implement-v2-for-aws-instance-detection
@@ -1,1 +1,1 @@
-- Implement IMDSv2 for AWS instance detection
+- Implement IMDSv2 for AWS instance detection (bsc#1226090)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.implement-v2-for-aws-instance-detection
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.implement-v2-for-aws-instance-detection
@@ -1,0 +1,1 @@
+- Implement IMDSv2 for AWS instance detection


### PR DESCRIPTION
## What does this PR change?

Implement `v2` with token to get AWS instance data according to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: No unit tests for this module

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24504

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
