### PR TITLE
Add support for Hub XML-RPC container to server-helm

### DIFF
--- a/containers/server-helm/server-helm.changes.nadvornik.hub-helm
+++ b/containers/server-helm/server-helm.changes.nadvornik.hub-helm
@@ -1,0 +1,1 @@
+- Add support for Hub XML-RPC container

--- a/containers/server-helm/templates/deployment.yaml
+++ b/containers/server-helm/templates/deployment.yaml
@@ -444,6 +444,7 @@ spec:
           - name: SSH_AUTH_SOCK
             value: /tmp/ssh_auth_sock
 {{- end }}
+{{- if not .Values.migration }}
         livenessProbe:
           exec:
             command:
@@ -460,6 +461,7 @@ spec:
               - multi-user.target
           periodSeconds: 10
           timeoutSeconds: 10
+{{- end }}
         volumeMounts:
           - mountPath: /run
             name: tmp

--- a/containers/server-helm/templates/deployment.yaml
+++ b/containers/server-helm/templates/deployment.yaml
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   name: uyuni
   namespace: "{{ .Release.Namespace }}"
-labels:
-  app: uyuni
+  labels:
+    app: uyuni
 spec:
   replicas: 1
   selector:

--- a/containers/server-helm/templates/hub-xmlrpc-api.yaml
+++ b/containers/server-helm/templates/hub-xmlrpc-api.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: uyuni-hub-xmlrpc-api
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app: uyuni-hub-xmlrpc-api
+spec:
+{{- if .Values.migration }}
+  replicas: 0
+{{- else }}
+  replicas: {{ ((.Values.hub).api).replicas | default 0 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: uyuni-hub-xmlrpc-api
+  template:
+    metadata:
+      labels:
+        app: uyuni-hub-xmlrpc-api
+    spec:
+      containers:
+      - name: uyuni-hub-xmlrpc-api
+        image: {{- include "deployment.container.image" (dict "name" "hub-xmlrpc-api" "global" .) | indent 1}}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        ports:
+          - containerPort: 2830
+        env:
+          - name: HUB_API_URL
+            value: http://uyuni-tcp:80/rpc/api
+          - name: HUB_CONNECT_TIMEOUT
+            value: "{{ ((.Values.hub).api).connectTimeout | default 10 }}"
+          - name: HUB_REQUEST_TIMEOUT
+            value: "{{ ((.Values.hub).api).requestTimeout | default 10 }}"
+          - name: HUB_CONNECT_USING_SSL
+            value: "true"
+        volumeMounts:
+          - name: ca-cert
+            mountPath: /etc/pki/trust/anchors/LOCAL-RHN-ORG-TRUSTED-SSL-CERT
+            readOnly: true
+            subPath: ca.crt
+      volumes:
+      - name: ca-cert
+        configMap:
+          name: uyuni-ca
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: uyuni-hub-xmlrpc-api
+  name: uyuni-hub-xmlrpc-api
+  namespace: "{{ .Release.Namespace }}"
+{{- if .Values.servicesAnnotations }}
+  annotations:
+{{ toYaml .Values.servicesAnnotations | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: hub-xmlrpc-api
+    port: 2830
+    protocol: TCP
+    targetPort: 2830
+  selector:
+    app: uyuni-hub-xmlrpc-api
+  type: ClusterIP

--- a/containers/server-helm/templates/k3s-ingress-routes.yaml
+++ b/containers/server-helm/templates/k3s-ingress-routes.yaml
@@ -152,6 +152,22 @@ spec:
       - name: uyuni-tcp
         port: 8001
 {{- end }}
+{{- if and .Values.hub (and .Values.hub.api .Values.hub.api.replicas) }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: hub-xmlrpc-router
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  entryPoints:
+    - hub-xmlrpc
+  routes:
+    - match: HostSNI(`*`)
+      services:
+      - name: uyuni-hub-xmlrpc-api
+        port: 2830
+{{- end }}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRouteUDP

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -76,3 +76,13 @@ timezone: "Etc/UTC"
 #     configPath: /home/mine/.ssh/config
 #     knownHostsPath: /home/mine/.ssh/known_hosts
 #   dataPath: /tmp/uyuni-migration
+
+# Hub XML-RPC API cnfiguration
+# Enable the hub XML-RPC API by setting the replicas to 1.
+# If migration values are set, the Hub API will be kept disabled
+# whatever the replicas value is.
+# hub:
+#   api:
+#     replicas: 1
+#     connectTimeout: 10
+#     requestTimeout: 10


### PR DESCRIPTION
## What does this PR change?

Add support for Hub XML-RPC container to server-helm

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: handled via mgradm

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni-tools/issues/292

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
