### PR TITLE
re-apply the filter after using the back button

### DIFF
--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -79,9 +79,13 @@ Feature: Retracted patches
     And I follow "rute-dummy-0815"
     Then I should see a "Status: Retracted" text
     When I go back
+    And I enter "dummy" as the filtered synopsis
+    And I click on the filter button
     And I follow "rute-dummy-0816"
     Then I should see a "Status: Stable" text
     When I go back
+    And I enter "dummy" as the filtered synopsis
+    And I click on the filter button
     And I follow "rute-dummy-0817"
     Then I should see a "Status: Retracted" text
 


### PR DESCRIPTION
## What does this PR change?

Follow up on https://github.com/uyuni-project/uyuni/pull/8856
When using the "back" button in a test, we need to re-apply the filter.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24526

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
