### PR TITLE
Shutdown attestation service gracefully

### DIFF
--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/CoCoAttestation.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/CoCoAttestation.java
@@ -68,15 +68,19 @@ public class CoCoAttestation {
 
             LOGGER.debug("Initializing attestation queue processor");
             var attestationQueueProcessor = new AttestationQueueProcessor(sessionFactory, configuration, moduleLoader);
-            attestationQueueProcessor.run();
+            attestationQueueProcessor.start();
+            attestationQueueProcessor.awaitTermination();
 
-            LOGGER.debug("Execution completed");
+            LOGGER.info("Execution completed");
             System.exit(0);
         }
         catch (Exception ex) {
+            if (ex instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
             LOGGER.error("Unexpected exception", ex);
             System.exit(1);
         }
-
     }
 }

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/CoCoAttestation.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/CoCoAttestation.java
@@ -68,6 +68,24 @@ public class CoCoAttestation {
 
             LOGGER.debug("Initializing attestation queue processor");
             var attestationQueueProcessor = new AttestationQueueProcessor(sessionFactory, configuration, moduleLoader);
+
+            // Add shutdown hook to stop the processor and shutdown logging
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                try {
+                    LOGGER.debug("Received termination signal");
+                    if (attestationQueueProcessor.isRunning()) {
+                        attestationQueueProcessor.stop();
+                        attestationQueueProcessor.awaitTermination();
+                    }
+                }
+                catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+                finally {
+                    LogManager.shutdown();
+                }
+            }, "shutdown-hook"));
+
             attestationQueueProcessor.start();
             attestationQueueProcessor.awaitTermination();
 

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AbstractProcessorThread.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AbstractProcessorThread.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.coco.attestation;
+
+/**
+ * Base class for the threads used by the {@link AttestationQueueProcessor}.
+ */
+abstract class AbstractProcessorThread implements Runnable {
+
+    private final Thread thread;
+
+    private boolean running;
+
+    protected AbstractProcessorThread(String name) {
+        thread = new Thread(this, name);
+        running = false;
+    }
+
+    /**
+     * Starts the processing of the thread.
+     */
+    public void start() {
+        setRunning(true);
+        thread.start();
+    }
+
+    /**
+     * Stops the processing of the thread, if it is running.
+     */
+    public void stop() {
+        if (!isRunning()) {
+            return;
+        }
+
+        thread.interrupt();
+    }
+
+    /**
+     * Wait for this thread to complete its processing.
+     *
+     * @throws InterruptedException when the wait is interrupted
+     */
+    public void await() throws InterruptedException {
+        if (!isRunning()) {
+            return;
+        }
+
+        thread.join();
+    }
+
+    /**
+     * Check if this thread is currently running.
+     * @return true if the thread is running.
+     */
+    public synchronized boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Specify that this thread has already stopped it's processing and should not be considered as running.
+     * @param runningIn the new status
+     */
+    protected synchronized void setRunning(boolean runningIn) {
+        this.running = runningIn;
+    }
+}

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AttestationQueueProcessor.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AttestationQueueProcessor.java
@@ -17,230 +17,104 @@ package com.suse.coco.attestation;
 
 import com.suse.coco.configuration.Configuration;
 import com.suse.coco.module.AttestationModuleLoader;
-import com.suse.coco.module.AttestationWorker;
 import com.suse.common.concurrent.UnboundedGrowingThreadPoolExecutor;
 
 import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.postgresql.PGConnection;
-import org.postgresql.PGNotification;
 
-import java.sql.Connection;
-import java.sql.Statement;
 import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.IntStream;
 
 import javax.sql.DataSource;
 
 /**
  * Process entry in the table suseAttestationResult and executes the proper based on the result type.
  */
-public class AttestationQueueProcessor implements Runnable {
+public class AttestationQueueProcessor {
 
-    private static final Logger LOGGER = LogManager.getLogger(AttestationQueueProcessor.class);
+    private final ListeningThread listeningThread;
 
-    private final Object dataAvailable = new Object();
-
-    private final AtomicBoolean listenerRunning = new AtomicBoolean(false);
-
-    private final SqlSessionFactory sessionFactory;
-
-    private final AttestationModuleLoader moduleLoader;
-
-    private final AttestationResultService service;
-
-    private final ExecutorService executorService;
-
-    private final int batchSize;
+    private final ProcessingThread processingThread;
 
     /**
      * Create an attestation queue processor.
-     * @param sessionFactoryIn the session factory to access the database
-     * @param configurationIn the current application configuration
-     * @param moduleLoaderIn the attestation module loader
+     * @param sessionFactory the session factory to access the database
+     * @param configuration the current application configuration
+     * @param moduleLoader the attestation module loader
      */
     public AttestationQueueProcessor(
-        SqlSessionFactory sessionFactoryIn,
-        Configuration configurationIn,
-        AttestationModuleLoader moduleLoaderIn
+        SqlSessionFactory sessionFactory,
+        Configuration configuration,
+        AttestationModuleLoader moduleLoader
     ) {
-        sessionFactory = sessionFactoryIn;
-        service = new AttestationResultService(sessionFactoryIn);
-
-        executorService = new UnboundedGrowingThreadPoolExecutor(
-            configurationIn.getCorePoolSize(),
-            configurationIn.getMaximumPoolSize(),
-            Duration.ofSeconds(configurationIn.getThreadKeepAliveInSeconds()),
-            "attestation-processor-worker"
+        // Call the other constructor with the correct values
+        this(
+            sessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            new AttestationResultService(sessionFactory),
+            new UnboundedGrowingThreadPoolExecutor(
+                configuration.getCorePoolSize(),
+                configuration.getMaximumPoolSize(),
+                Duration.ofSeconds(configuration.getThreadKeepAliveInSeconds()),
+                "attestation-processor-worker"
+            ),
+            moduleLoader,
+            configuration.getBatchSize()
         );
-
-        moduleLoader = moduleLoaderIn;
-        batchSize = configurationIn.getBatchSize();
     }
 
     /**
      * Create an attestation queue processor.
-     * @param sessionFactoryIn the session factory
-     * @param serviceIn the attestation result service
-     * @param executorServiceIn the executor to perform the process
-     * @param moduleLoaderIn the attestation module loader
-     * @param batchSizeIn the batch size
+     * @param dataSource the datasource to be used to listen to the database notification
+     * @param service the attestation result service
+     * @param executorService the executor to perform the process
+     * @param moduleLoader the attestation module loader
+     * @param batchSize the batch size
      */
     protected AttestationQueueProcessor(
-            SqlSessionFactory sessionFactoryIn,
-            AttestationResultService serviceIn,
-            ExecutorService executorServiceIn,
-            AttestationModuleLoader moduleLoaderIn,
-            int batchSizeIn
+        DataSource dataSource,
+        AttestationResultService service,
+        ExecutorService executorService,
+        AttestationModuleLoader moduleLoader,
+        int batchSize
     ) {
-        sessionFactory = sessionFactoryIn;
-        service = serviceIn;
-        executorService = executorServiceIn;
-        moduleLoader = moduleLoaderIn;
-        batchSize = batchSizeIn;
+        listeningThread = new ListeningThread(dataSource);
+        processingThread = new ProcessingThread(service, executorService, moduleLoader, batchSize);
+
+        // Link the two threads
+        listeningThread.setProcessingThread(processingThread);
+        processingThread.setListeningThread(listeningThread);
     }
 
-    @Override
-    public void run() {
-        Thread listenerThread = createListenerThread();
-
-        try {
-            while (!Thread.currentThread().isInterrupted() && listenerRunning.get()) {
-                List<Long> results = service.getPendingResultByType(moduleLoader.getSupportedResultTypes(), batchSize);
-                if (results.isEmpty()) {
-                    LOGGER.info("No attestation result to process - Waiting");
-                    synchronized (dataAvailable) {
-                        dataAvailable.wait();
-                    }
-                    continue;
-                }
-
-                LOGGER.info("Processing attestation results {}", results);
-                CountDownLatch workersDone = new CountDownLatch(results.size());
-
-                results.forEach(resultId -> executorService.execute(() -> {
-                    try {
-                        service.processAttestationResult(resultId, (session, result) -> {
-                            AttestationWorker worker = moduleLoader.createWorker(result.getResultType());
-                            return worker.process(session, result);
-                        });
-                    }
-                    catch (Exception ex) {
-                        LOGGER.error("Unable to correctly process attestation result with id {}", resultId, ex);
-                    }
-                    finally {
-                        workersDone.countDown();
-                    }
-                }));
-
-                workersDone.await();
-            }
-        }
-        catch (InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-        catch (Exception ex) {
-            LOGGER.error("Unable to process", ex);
-        }
-
-        // Shut down the executor
-        shutdownExecutor();
-
-        // Interrupt the listener thread if still alive
-        stopListenerThread(listenerThread);
+    /**
+     * Start the execution of the queue processor. This method will start the processing asynchronously and exit
+     * immediately. Use {@link #awaitTermination()} to wait for the processor to complete.
+     */
+    public void start() {
+        listeningThread.start();
+        processingThread.start();
     }
 
-    private Thread createListenerThread() {
-        Thread listenerThread = new Thread(this::listenForAttestationResults, "attestation-processor-listener");
-
-        listenerRunning.set(true);
-        listenerThread.start();
-
-        return listenerThread;
+    /**
+     * Wait indefinitely for the processor to complete. This is the same as awaitTermination(0L)
+     * @throws InterruptedException if the wait for all the threads to stop is interrupted
+     */
+    public void awaitTermination() throws InterruptedException {
+        listeningThread.await();
+        processingThread.await();
     }
 
-    private static void stopListenerThread(Thread listenerThread) {
-        if (!listenerThread.isAlive() || listenerThread.isInterrupted()) {
-            return;
-        }
-
-        listenerThread.interrupt();
+    /**
+     * Interrupts the execution of this processor.
+     */
+    public void stop() {
+        listeningThread.stop();
+        processingThread.stop();
     }
 
-    private void shutdownExecutor() {
-        if (executorService.isShutdown()) {
-            return;
-        }
-
-        executorService.shutdown();
-
-        boolean isTerminated = executorService.isTerminated();
-        while (!isTerminated) {
-            try {
-                isTerminated = executorService.awaitTermination(1, TimeUnit.SECONDS);
-            }
-            catch (InterruptedException ex) {
-                Thread.currentThread().interrupt();
-            }
-        }
+    /**
+     * Check if this attestation processor is running
+     * @return true if at least one of the processor threads is still running
+     */
+    public boolean isRunning() {
+        return listeningThread.isRunning() || processingThread.isRunning();
     }
-
-    private void listenForAttestationResults() {
-        try {
-            // Retrieve the datasource from mybatis configuration and obtain a connection
-            DataSource dataSource = sessionFactory.getConfiguration().getEnvironment().getDataSource();
-            try (Connection connection = dataSource.getConnection()) {
-                // Ensure the connection is of the correct type
-                if (!connection.isWrapperFor(PGConnection.class)) {
-                    throw new IllegalStateException("Unexpected wrapped connection " +
-                        connection.unwrap(Object.class).getClass().getName());
-                }
-
-                try (Statement statement = connection.createStatement()) {
-                    statement.execute("LISTEN pendingAttestationResult");
-                }
-
-                while (!Thread.currentThread().isInterrupted()) {
-                    PGNotification[] notifications = connection.unwrap(PGConnection.class).getNotifications(60_000);
-                    if (notifications != null && notifications.length > 0) {
-                        LOGGER.info("Got {} notification(s) from pendingAttestationResult", notifications.length);
-
-                        if (LOGGER.isDebugEnabled()) {
-                            IntStream.range(0, notifications.length)
-                                .forEach(idx -> LOGGER.debug(
-                                    "\tNotification #{} -> {} {} {}",
-                                    idx,
-                                    notifications[idx].getPID(),
-                                    notifications[idx].getName(),
-                                    notifications[idx].getParameter()
-                                ));
-                        }
-
-                        // Notify the thread waiting
-                        synchronized (dataAvailable) {
-                            dataAvailable.notifyAll();
-                        }
-                    }
-                }
-            }
-        }
-        catch (Exception ex) {
-            LOGGER.error("Unexpected exception while listening to notifications", ex);
-        }
-
-        LOGGER.info("Stopping notification listener");
-        listenerRunning.set(false);
-
-        // Listener is stopping, better unblock the other thread.
-        synchronized (dataAvailable) {
-            dataAvailable.notifyAll();
-        }
-    }
-
 }

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ListeningThread.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ListeningThread.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.coco.attestation;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.postgresql.PGNotification;
+import org.postgresql.jdbc.PgConnection;
+
+import java.net.SocketException;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.stream.IntStream;
+
+import javax.sql.DataSource;
+
+/**
+ * Listener thread of the {@link AttestationQueueProcessor}. Waits for the PostgreSQL notifications and notifies
+ * the {@link ProcessingThread} when there is data to process.
+ */
+class ListeningThread extends AbstractProcessorThread {
+
+    private static final Logger LOGGER = LogManager.getLogger(ListeningThread.class);
+
+    private final Object connectionLock = new Object();
+
+    private final DataSource dataSource;
+
+    private boolean forceShutdown;
+
+    private PgConnection pgConnection;
+
+    private ProcessingThread processingThread;
+
+    /**
+     * Builds a listener thread
+     * @param dataSourceIn the datasource to be used to connect to the database
+     */
+    ListeningThread(DataSource dataSourceIn) {
+        super("attestation-processor-listener");
+
+        dataSource = dataSourceIn;
+
+        forceShutdown = false;
+
+        processingThread = null;
+        pgConnection = null;
+    }
+
+    public void setProcessingThread(ProcessingThread processingThreadIn) {
+        this.processingThread = processingThreadIn;
+    }
+
+    @Override
+    public void start() {
+        if (processingThread == null) {
+            throw new IllegalStateException("Set the processing thread before starting the listener");
+        }
+
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        if (!isRunning()) {
+            return;
+        }
+
+        // Force the closure of the database connection
+        forceShutdown = true;
+        abortConnection();
+
+        super.stop();
+    }
+
+    @Override
+    public void run() {
+        // Obtain a connection from the datasource
+        try (Connection connection = dataSource.getConnection()) {
+            // Ensure the connection is of the correct type
+            if (!connection.isWrapperFor(PgConnection.class)) {
+                throw new IllegalStateException("Unexpected wrapped connection " +
+                    connection.unwrap(Object.class).getClass().getName());
+            }
+
+            updateConnection(connection.unwrap(PgConnection.class));
+
+            try (Statement statement = pgConnection.createStatement()) {
+                statement.execute("LISTEN pendingAttestationResult");
+            }
+
+            while (!Thread.currentThread().isInterrupted() && processingThread.isRunning()) {
+                PGNotification[] notifications = pgConnection.getNotifications(60_000);
+                if (notifications != null && notifications.length > 0) {
+                    LOGGER.info("Got {} notification(s) from pendingAttestationResult", notifications.length);
+
+                    if (LOGGER.isDebugEnabled()) {
+                        IntStream.range(0, notifications.length)
+                            .forEach(idx -> LOGGER.debug(
+                                "\tNotification #{} -> {} {} {}",
+                                idx,
+                                notifications[idx].getPID(),
+                                notifications[idx].getName(),
+                                notifications[idx].getParameter()
+                            ));
+                    }
+
+                    // Notify the thread waiting
+                    processingThread.notifyDataAvailable();
+                }
+            }
+        }
+        catch (Exception ex) {
+            // A socket closed exception is expected when we are shutting down the listener
+            if (!(forceShutdown && ex.getCause() instanceof SocketException)) {
+                LOGGER.error("Unexpected exception while listening to notifications", ex);
+            }
+        }
+        finally {
+            // Cleanup the state
+            updateConnection(null);
+            setRunning(false);
+
+            // We are shutting down the listener. Notify the main thread to unblock it, if it is waiting.
+            processingThread.notifyDataAvailable();
+        }
+
+        LOGGER.debug("Notification listener thread is stopped");
+    }
+
+    private void abortConnection() {
+        synchronized (connectionLock) {
+            if (pgConnection != null) {
+                pgConnection.getQueryExecutor().abort();
+            }
+        }
+    }
+
+    private void updateConnection(PgConnection pgConnectionIn) {
+        synchronized (connectionLock) {
+            this.pgConnection = pgConnectionIn;
+        }
+    }
+}

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ProcessingThread.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ProcessingThread.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.coco.attestation;
+
+import com.suse.coco.module.AttestationModuleLoader;
+import com.suse.coco.module.AttestationWorker;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Main processing thread of the {@link AttestationQueueProcessor}. Extracts the attestation result of the supported
+ * types and uses the correct {@link com.suse.coco.module.AttestationModule} to process them.
+ */
+class ProcessingThread extends AbstractProcessorThread {
+
+    private static final Logger LOGGER = LogManager.getLogger(ProcessingThread.class);
+
+    private final Object dataAvailableLock = new Object();
+
+    private final AttestationModuleLoader moduleLoader;
+
+    private final AttestationResultService service;
+
+    private final ExecutorService executorService;
+
+    private final int batchSize;
+
+    private ListeningThread listeningThread;
+
+    ProcessingThread(AttestationResultService serviceIn, ExecutorService executorServiceIn,
+                     AttestationModuleLoader moduleLoaderIn, int batchSizeIn) {
+        super("attestation-processor-main");
+
+        moduleLoader = moduleLoaderIn;
+        service = serviceIn;
+        executorService = executorServiceIn;
+        batchSize = batchSizeIn;
+    }
+
+    public void setListeningThread(ListeningThread listeningThreadIn) {
+        this.listeningThread = listeningThreadIn;
+    }
+
+    /**
+     * Notifies the processor that some data is ready to be processed. Used by the {@link ListeningThread} to trigger
+     * the processing after receiving a notification.
+     */
+    public void notifyDataAvailable() {
+        if (isRunning()) {
+            synchronized (dataAvailableLock) {
+                dataAvailableLock.notifyAll();
+            }
+        }
+    }
+
+    @Override
+    public void start() {
+        if (listeningThread == null) {
+            throw new IllegalArgumentException("Set the listening thread before starting the processor");
+        }
+
+        super.start();
+    }
+
+    @Override
+    public void run() {
+        try {
+            while (!Thread.currentThread().isInterrupted() && listeningThread.isRunning()) {
+                // Load the pending attestation results of the supported types
+                List<Long> results = service.getPendingResultByType(moduleLoader.getSupportedResultTypes(), batchSize);
+                if (results.isEmpty()) {
+                    LOGGER.info("No attestation result to process - Waiting");
+                    synchronized (dataAvailableLock) {
+                        dataAvailableLock.wait();
+                    }
+                    continue;
+                }
+
+                LOGGER.info("Processing attestation results {}", results);
+                CountDownLatch workersDone = new CountDownLatch(results.size());
+
+                // Process each one of them in a separate worker thread
+                results.forEach(resultId -> executorService.execute(() -> {
+                    try {
+                        service.processAttestationResult(resultId, (session, result) -> {
+                            AttestationWorker worker = moduleLoader.createWorker(result.getResultType());
+                            return worker.process(session, result);
+                        });
+                    }
+                    catch (Exception ex) {
+                        LOGGER.error("Unable to correctly process attestation result with id {}", resultId, ex);
+                    }
+                    finally {
+                        workersDone.countDown();
+                    }
+                }));
+
+                // Wait for all workers to complete
+                workersDone.await();
+            }
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+        finally {
+            setRunning(false);
+
+            // Shut down the executor service
+            if (!executorService.isShutdown()) {
+                LOGGER.debug("Shutting down the worker executor service");
+                executorService.shutdown();
+
+                boolean isTerminated = executorService.isTerminated();
+                while (!isTerminated) {
+                    try {
+                        isTerminated = executorService.awaitTermination(1, TimeUnit.SECONDS);
+                    }
+                    catch (InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+        }
+
+        LOGGER.debug("Processor thread is stopped");
+    }
+}

--- a/microservices/coco-attestation/attestation-core/src/package/coco-attestation.sh
+++ b/microservices/coco-attestation/attestation-core/src/package/coco-attestation.sh
@@ -22,7 +22,7 @@ if [ -f /etc/coco-attestation.conf ]; then
     . /etc/coco-attestation.conf
 fi
 
-ATTESTATION_PARAMS="-Dfile.encoding=UTF-8 -Xms${ATTESTATION_INIT_MEMORY}m -Xmx${ATTESTATION_MAX_MEMORY}m ${ATTESTATION_CRASH_PARAMS} ${ATTESTATION_JAVA_OPTS}"
+ATTESTATION_PARAMS="-Dfile.encoding=UTF-8 -Dlog4j.shutdownHookEnabled=false -Xms${ATTESTATION_INIT_MEMORY}m -Xmx${ATTESTATION_MAX_MEMORY}m ${ATTESTATION_CRASH_PARAMS} ${ATTESTATION_JAVA_OPTS}"
 ATTESTATION_CLASSPATH="${ATTESTATION_CLASSES}:${ATTESTATION_JARS}"
 
 exec /usr/bin/java -Djava.library.path="${ATTESTATION_LIBRARY_PATH}" \

--- a/microservices/coco-attestation/attestation-core/src/package/log4j2.xml
+++ b/microservices/coco-attestation/attestation-core/src/package/log4j2.xml
@@ -15,7 +15,7 @@
   -->
 
 <!-- Confidential Computing Attestation Log4j2 configuration -->
-<Configuration name="CoCoAttestation" status="warn">
+<Configuration name="CoCoAttestation" status="warn" shutdownHook="disable">
 
     <Appenders>
         <RollingFile name="LogFile" fileName="/var/log/coco-attestation.log" filePattern="/var/log/coco-attestation-%i.log">

--- a/microservices/coco-attestation/uyuni-coco-attestation.changes.mackdk.shutdown-attestation-service-gracefully
+++ b/microservices/coco-attestation/uyuni-coco-attestation.changes.mackdk.shutdown-attestation-service-gracefully
@@ -1,0 +1,2 @@
+- Stop the attestation processing gracefully when receiving a 
+  termination signal


### PR DESCRIPTION
## What does this PR change?

This PR refactors the attestation queue processor to allow shutting it down after being started. It also handles the shutdown hook to properly close all connections and running threads when java receives a `SIGTERM` or `SIGINT` signal. It also disables the Log4j internal hook because it was interfering with the new one. The logging framework shutdown is called explicitly after the processing is terminated.

Note: this PR is currently built on top of https://github.com/uyuni-project/uyuni/pull/8678, which should be merged before this one. After that, this branch should be rebased.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24452

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
