### PR TITLE
QE: improve BV smoke tests template

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -29,6 +29,7 @@ Feature: Smoke tests for <client>
     And I wait until event "Package List Refresh scheduled by admin" is completed
 
   Scenario: Check that Hardware Refresh button works on a <client>
+    Given I am on the Systems overview page of this "<client>"
     When I follow "Details" in the content area
     And I wait until I see "System Status" text
     And I follow "Hardware"
@@ -53,6 +54,7 @@ Feature: Smoke tests for <client>
 @skip_for_rocky9
 @skip_for_alma9
   Scenario: Install a patch on the <client>
+    Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
     And I wait until I see "Upgrade Packages" text
     And I follow "Patches" in the content area
@@ -66,6 +68,7 @@ Feature: Smoke tests for <client>
 
 @skip_for_sle_micro_ssh_minion
   Scenario: Install a package on the <client>
+    Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
     And I wait until I see "Upgrade Packages" text
     And I follow "Install"
@@ -81,6 +84,7 @@ Feature: Smoke tests for <client>
 
 @skip_for_sle_micro_ssh_minion
   Scenario: Remove package from <client>
+    Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
     And I wait until I see "Upgrade Packages" text
     And I follow "List / Remove"
@@ -107,6 +111,7 @@ Feature: Smoke tests for <client>
     Then I should see "My remote command output" in the command output for "<client>"
 
   Scenario: Subscribe a <client> to the configuration channel
+    Given I am on the Systems overview page of this "<client>"
     When I follow "Configuration" in the content area
     And I wait until I see "Configuration Overview" text
     And I follow "Manage Configuration Channels" in the content area


### PR DESCRIPTION
## What does this PR change?

We've experienced numerous failures in our smoke tests which are related to UI elements not being found.
This issue probably stems from the way skipped and failed test interact which each other, causing the webdriver to be on a different URL/web-page than the one the scenario expects.

Introducing a step in a few scenarios forcing navigation to a client's detail page should hopefully make the tests more robust and independent from each other's results.

NOTE: the final feature files are generated from a template using Rake, so the changes are applied there.

## GUI diff

 - No diff

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified (actually, the template to generate them)

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24518
Port(s): 4.3 https://github.com/SUSE/spacewalk/pull/24534

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

