### PR TITLE
fix system_upgradable_package_list query to not list duplicate names

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -1180,15 +1180,16 @@ SELECT  n.id AS id,
   join rhnPackageEvr spe
     on spe.id = sp.evr_id
   join (
-        select sop.package_name_id,
-               sop.package_arch_id,
-               sop.package_evr_id,
-               max(PE.evr) evr
-          from rhnServerOutdatedPackages sop
-          join rhnPackageEVR pe
-            on sop.package_evr_id = pe.id
-         where sop.server_id = :sid
-         group by sop.package_name_id, sop.package_arch_id, sop.package_evr_id) latest
+        SELECT X.package_name_id, X.package_arch_id, X.evr,
+               lookup_evr((X.evr).epoch, ((X.evr)).version, ((X.evr)).release, ((X.evr)).type) as package_evr_id
+        FROM ( select sop.package_name_id,
+                      sop.package_arch_id,
+                      max(PE.evr) evr
+                 from rhnServerOutdatedPackages sop
+                 join rhnPackageEVR pe on sop.package_evr_id = pe.id
+                where sop.server_id = :sid
+             group by sop.package_name_id, sop.package_arch_id) X
+       ) latest
     on latest.package_name_id = sp.name_id
   join rhnPackageArch latest_pa
     on latest_pa.id = latest.package_arch_id

--- a/java/spacewalk-java.changes.mc.fix-upgradable-package-query
+++ b/java/spacewalk-java.changes.mc.fix-upgradable-package-query
@@ -1,0 +1,1 @@
+- fix system_upgradable_package_list query to not return duplicate package names (bsc#1226037)


### PR DESCRIPTION
## What does this PR change?

The Package Upgrade page list duplicate package names. When all packages are selected, salt return an error like
`You are passing a list of packages that contains duplicated packages names`.

Adapt the query to return only the latest version of a package.

## GUI diff

No difference.

Before:

![image](https://github.com/uyuni-project/uyuni/assets/1038917/3701b703-5cae-44b9-afe1-ccdc84e104fd)

After:

![image](https://github.com/uyuni-project/uyuni/assets/1038917/e7fd7395-29cd-491c-8787-e7fab8b18285)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24509

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
