### PR TITLE
Align changelog entries and add missing bsc#1222731

### DIFF
--- a/python/rhn/rhnlib.changes
+++ b/python/rhn/rhnlib.changes
@@ -20,7 +20,7 @@ Fri Dec 15 16:54:45 CET 2023 - rosuna@suse.com
 Wed Nov 01 20:56:07 CET 2023 - marina.latini@suse.com
 
 - version 4.4.5-1
-  *  Use bundle CA certificate in rhnpush
+  *  Use bundle CA certificate in rhnpush (bsc#1222731)
 
 -------------------------------------------------------------------
 Mon Sep 18 14:13:24 CEST 2023 - rosuna@suse.com

--- a/python/rhn/rhnlib.changes.deneb-alpha.add_missing_bsc1222731
+++ b/python/rhn/rhnlib.changes.deneb-alpha.add_missing_bsc1222731
@@ -1,0 +1,1 @@
+- Align changelog entries


### PR DESCRIPTION
## What does this PR change?

Align changelogs between SUMA 4.3 and SUMA 5.0 and add missing bsc#1222731 reference 
https://github.com/SUSE/spacewalk/issues/24543

**Please note that I also edited the main .changes for adding the missing bsc reference. the changelog test is expected to fail**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: just changelog fix

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24543

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
