### PR TITLE
BV 5.0 GMC - Add SLE 15 SP6 to the resposync testsuite

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -870,6 +870,21 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-module-devtools15-sp5-pool-x86_64
         sle-module-devtools15-sp5-updates-x86_64
       ],
+    'sles15-sp6' => # CHECKED
+      %w[
+        sle-product-sles15-sp6-pool-x86_64
+        sle-product-sles15-sp6-updates-x86_64
+        sle-module-basesystem15-sp6-pool-x86_64
+        sle-module-basesystem15-sp6-updates-x86_64
+        sle-manager-tools15-updates-x86_64-sp6
+        sle-manager-tools15-pool-x86_64-sp6
+        sle-module-server-applications15-sp6-pool-x86_64
+        sle-module-server-applications15-sp6-updates-x86_64
+        sle-module-desktop-applications15-sp6-pool-x86_64
+        sle-module-desktop-applications15-sp6-updates-x86_64
+        sle-module-devtools15-sp6-updates-x86_64
+        sle-module-devtools15-sp6-pool-x86_64
+      ],
     'slesforsap15-sp5' =>
       %w[
         sle-manager-tools15-pool-x86_64-sap-sp5
@@ -1198,6 +1213,20 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-module-server-applications15-sp5-updates-x86_64
         sles15-sp5-devel-uyuni-client-x86_64
       ],
+    'sles15-sp6' =>
+      %w[
+        sle-product-sles15-sp6-pool-x86_64
+        sle-product-sles15-sp6-updates-x86_64
+        sle-module-basesystem15-sp6-pool-x86_64
+        sle-module-basesystem15-sp6-updates-x86_64
+        sle-module-server-applications15-sp6-pool-x86_64
+        sle-module-server-applications15-sp6-updates-x86_64
+        sle-module-desktop-applications15-sp6-pool-x86_64
+        sle-module-desktop-applications15-sp6-updates-x86_64
+        sle-module-devtools15-sp6-updates-x86_64
+        sle-module-devtools15-sp6-pool-x86_64
+        sles15-sp6-devel-uyuni-client-x86_64
+      ],
     'slesforsap15-sp5' =>
       %w[
         sle-module-basesystem15-sp5-pool-x86_64-sap
@@ -1469,6 +1498,10 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'opensuse_leap15_6-x86_64-non-oss-updates' => 120,
   'opensuse_leap15_6-x86_64-sle-updates' => 5400,
   'opensuse_leap15_6-x86_64-updates' => 60,
+  'opensuse-leap-15.6-pool-aarch64' => 11_820,
+  'opensuse-leap-15.6-updates-aarch64' => 60,
+  'opensuse-backports-15.6-updates-aarch64' => 60,
+  'opensuse-sle-15.6-updates-aarch64' => 60,
   'opensuse_micro5_5-uyuni-client-x86_64' => 60,
   'opensuse_micro5_5-uyuni-client-devel-x86_64' => 60,
   'opensuse_micro5_5-x86_64' => 240,
@@ -1502,12 +1535,16 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-manager-tools15-pool-x86_64-sp3' => 60,
   'sle-manager-tools15-pool-x86_64-sp4' => 60,
   'sle-manager-tools15-pool-x86_64-sp5' => 60,
+  'sle-manager-tools15-pool-x86_64-sp6' => 60,
   'sle-manager-tools15-updates-s390x-sp5' => 120,
   'sle-manager-tools15-updates-x86_64-sp1' => 180,
   'sle-manager-tools15-updates-x86_64-sp2' => 90,
   'sle-manager-tools15-updates-x86_64-sp3' => 90,
   'sle-manager-tools15-updates-x86_64-sp4' => 90,
   'sle-manager-tools15-updates-x86_64-sp5' => 90,
+  'sle-manager-tools15-updates-x86_64-sp6' => 90,
+  'sle-manager-tools15-pool-aarch64-opensuse-15.6' => 60,
+  'sle-manager-tools15-updates-aarch64-opensuse-15.6' => 120,
   'sle-manager-tools-for-micro5-pool-x86_64-5.1' => 60,
   'sle-manager-tools-for-micro5-pool-x86_64-5.2' => 60,
   'sle-manager-tools-for-micro5-pool-x86_64-5.3' => 60,
@@ -1546,6 +1583,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-basesystem15-sp5-pool-x86_64' => 240,
   'sle-module-basesystem15-sp5-updates-s390x' => 600,
   'sle-module-basesystem15-sp5-updates-x86_64' => 540,
+  'sle-module-basesystem15-sp6-pool-x86_64' => 300,
+  'sle-module-basesystem15-sp6-updates-x86_64' => 60,
   'sle-module-containers15-sp4-pool-x86_64' => 60,
   'sle-module-containers15-sp4-pool-x86_64-proxy-4.3' => 60,
   'sle-module-containers15-sp4-pool-x86_64-smrbs-4.3' => 60,
@@ -1560,6 +1599,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-desktop-applications15-sp4-updates-x86_64' => 120,
   'sle-module-desktop-applications15-sp5-pool-x86_64' => 120,
   'sle-module-desktop-applications15-sp5-updates-x86_64' => 60,
+  'sle-module-desktop-applications15-sp6-pool-x86_64' => 240,
+  'sle-module-desktop-applications15-sp6-updates-x86_64' => 60,
   'sle-module-devtools15-sp2-pool-x86_64' => 120,
   'sle-module-devtools15-sp2-updates-x86_64' => 420,
   'sle-module-devtools15-sp3-pool-x86_64' => 120,
@@ -1568,6 +1609,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-devtools15-sp4-updates-x86_64' => 600,
   'sle-module-devtools15-sp5-pool-x86_64' => 120,
   'sle-module-devtools15-sp5-updates-x86_64' => 300,
+  'sle-module-devtools15-sp6-updates-x86_64' => 60,
+  'sle-module-devtools15-sp6-pool-x86_64' => 120,
   'sle-module-public-cloud15-sp4-pool-x86_64' => 840,
   'sle-module-public-cloud15-sp4-updates-x86_64' => 600,
   'sle-module-public-cloud15-sp5-pool-x86_64' => 600,
@@ -1589,6 +1632,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-server-applications15-sp5-pool-x86_64' => 60,
   'sle-module-server-applications15-sp5-updates-s390x' => 120,
   'sle-module-server-applications15-sp5-updates-x86_64' => 60,
+  'sle-module-server-applications15-sp6-pool-x86_64' => 60,
+  'sle-module-server-applications15-sp6-updates-x86_64' => 60,
   'sle-product-sles15-sp1-ltss-updates-x86_64' => 1500,
   'sle-product-sles15-sp1-pool-x86_64' => 60,
   'sle-product-sles15-sp1-updates-x86_64' => 60,
@@ -1605,6 +1650,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-product-sles15-sp5-pool-x86_64' => 60,
   'sle-product-sles15-sp5-updates-s390x' => 60,
   'sle-product-sles15-sp5-updates-x86_64' => 60,
+  'sle-product-sles15-sp6-pool-x86_64' => 60,
+  'sle-product-sles15-sp6-updates-x86_64' => 60,
   'sles12-sp5-installer-updates-x86_64' => 60,
   'sles12-sp5-pool-x86_64' => 180,
   'sles12-sp5-updates-x86_64' => 2280,


### PR DESCRIPTION
## What does this PR change?

SLE 15 SP6 constants and timeouts with Leap 15.6

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24568
Port(s): https://github.com/SUSE/spacewalk/pull/24577

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
