### PR TITLE
Remove wrong changelog from spacewalk-search into spacewalk-java

### DIFF
--- a/java/spacewalk-search.changes.rjpmestre.switch_used_java_to_java-17-openjdk
+++ b/java/spacewalk-search.changes.rjpmestre.switch_used_java_to_java-17-openjdk
@@ -1,1 +1,0 @@
-- Replace java 11 with java 17


### PR DESCRIPTION
## What does this PR change?

There was a changelog file that did not belong where it was. As we're tagging and resubmitting, we're taking the chance to remove it to avoid confusions.

I'm not adding a changelog for this, as this is actually about removing one (that never got into the tagging anyway because it was for the wrong package).

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
