### PR TITLE
Create lzreposync subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,8 +67,6 @@ yarn-error.log
 # This should never be used since we use Yarn, but avoid anyone accidentally committing it
 package-lock.json
 
-rel-eng/custom/__pycache__
-
 # Intellij IDEA
 .idea/
 *.iml
@@ -86,6 +84,12 @@ python/.vscode
 # Python
 venv/
 .venv/
+*.egg-info/
+*.egg
+wheels/
+__pycache__/
+build/
+.pytest_cache/
 
 # Schema
 

--- a/python/lzreposync/README.md
+++ b/python/lzreposync/README.md
@@ -1,0 +1,24 @@
+# lzreposync
+
+TODO: project description
+
+## How to work in this project
+
+1. Create a new virtual environment
+```sh
+$ python3.11 -m venv .venv
+$ . .venv/bin/activate
+```
+2. Install `lzreposync` in *editable* mode
+``` sh
+$ pip install -e .
+```
+3. Try `lzreposync`
+``` sh
+$ lzreposync -u https://download.opensuse.org/update/leap/15.5/oss/repodata/
+```
+
+### How do I ...?
+
+- add new a dependency? Add the *pypi* name to the `dependencies` list in the `[project]` section in `pyproject.toml`.
+- run tests? After installing with `pip install .` (or `pip install -e .`), `pytest tests/` runs all tests. Sometimes a `rehash` is required to ensure `.venv/bin/pytest` is used by your shell.

--- a/python/lzreposync/pyproject.toml
+++ b/python/lzreposync/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+bild-backend = "setuptools.build_meta"
+
+[project]
+name = "lzreposync"
+version = "0.1"
+dependencies = [
+     "memory_profiler",
+     "pytest",
+     "requests"
+]
+
+[project.scripts]
+lzreposync = "lzreposync:main"

--- a/python/lzreposync/src/lzreposync/__init__.py
+++ b/python/lzreposync/src/lzreposync/__init__.py
@@ -1,0 +1,15 @@
+import argparse
+
+from lzreposync import parse
+
+
+def main():
+    args_parser = argparse.ArgumentParser(description="Lazy reposync service")
+    args_parser.add_argument(
+        "--url",
+        "-u",
+        help="The target url of the remote repository of which we'll "
+        "parse the metadata",
+    )
+    args = args_parser.parse_args()
+    parse.download_and_parse_metadata(args.url)

--- a/python/lzreposync/src/lzreposync/metadata_parser.py
+++ b/python/lzreposync/src/lzreposync/metadata_parser.py
@@ -1,0 +1,50 @@
+import xml.sax
+import re
+
+
+class PrimaryXmlHandler(xml.sax.ContentHandler):
+
+    def __init__(self):
+        self.current = ""  # current tag
+        self.currentParentTreeStack = []  # useful for nested tags
+        # self.count = 0  # only for testing, to limit the output
+
+    def startElement(self, name, attrs):
+        if name == "metadata":
+            return  # We can remove the tag from the file (or a copy of it) prior processing to avoid making this test
+        self.current = name
+        self.currentParentTreeStack.append(name)
+        # self.count += 1
+        # print(60 * "-")
+        print(
+            f"current: [{self.current}] | attrs: { {attr: attrs[attr] for attr in attrs.getNames()} }"
+        )
+        print(f"Tag tree: {'/'.join(self.currentParentTreeStack)}")
+        print(60 * "-")
+
+    def startElementNS(self, name, qname, attrs):
+        self.current = (
+            qname  # TODO should we keep the namespace prefix ('rpm' for eg) or just
+        )
+        self.currentParentTreeStack.append(qname)
+        # print(60 * "-")
+        print(
+            f"current: [{self.current}] | attrs: { {attr: attrs[attr] for attr in attrs.getNames()} }"
+        )
+        print(f"Tag tree: {'/'.join(self.currentParentTreeStack)}")
+
+    def characters(self, content):
+        if re.match("^[\w-]+$", content) is not None:  # alpha-num and dashes '-'
+            print(f"current: [{self.current}]")
+            print(f"Value: {content.strip()}")
+
+    def endElement(self, name):
+        # print(f"--End {self.current}")
+        # if self.count == 100:
+        #     exit(0)
+        self.currentParentTreeStack.pop()
+        print(60 * "-")
+
+    def endElementNS(self, name, qname):
+        self.currentParentTreeStack.pop()
+        print(60 * "-")

--- a/python/lzreposync/src/lzreposync/parse.py
+++ b/python/lzreposync/src/lzreposync/parse.py
@@ -1,0 +1,139 @@
+"""
+This is a minimal implementation of the lazy reposync parser.
+It downloads the target repository's metadata file(s) from the
+given url and parses it(them)
+"""
+
+# TODO Check for the signature
+# TODO Use SAX parser
+# TODO Define the best chunk size (consider calculating the current os's free memory and the file size and extract a formula)
+# TODO Evaluate the two versions of the download/ benchmark them/ write some tests about them
+# TODO After finishing, complete for all other files, normalize the sql code
+# TODO Should we parse the files at the time of download, or in a second step ?
+
+import argparse
+import xml.sax
+
+import requests
+import os
+import shutil
+from urllib.parse import urljoin
+import zipfile
+import tarfile
+import gzip
+
+from memory_profiler import profile
+
+from lzreposync.metadata_parser import PrimaryXmlHandler
+
+CACHE_DIR = "./cache/metadata/"  # TODO change it into /var/cache/...
+PRIMARY_XML = "00c99a7e67dac325f1cbeeedddea3e4001a8f803c9bf43d9f50b5f1c756b0887-primary.xml.gz"  # TODO can the name of this file change ?
+
+EMPTY_URL_ERROR = "ERROR: URL should not be empty."
+FILENAME_ERROR = "ERROR: Filename should not be empty."
+UNKNOWN_FORMAT = "ERROR: Unknown file format. Can't extract."
+
+# ARCHIVE EXTENSIONS
+ZIP_EXTENSION = ".zip"
+TAR_EXTENSION = ".tar"
+TAR_GZ_EXTENSION = ".tar.gz"
+TGZ_EXTENSION = ".tgz"
+GZ_EXTENSION = ".gz"
+
+
+def download_primary_xml_v1(url: str, primary_xml: str):
+    """Download the primary-xml file from the given repository url"""
+    try:
+        primary_xml_url = urljoin(url, primary_xml)
+        with requests.get(primary_xml_url, stream=True) as response:
+            response.raise_for_status()  # check for status code
+            with open(os.path.join(CACHE_DIR, primary_xml), "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    # chunk_size to be efficiently determined
+                    f.write(chunk)
+                print(f"file {primary_xml} was downloaded successfully!")
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading {primary_xml} file:", e)
+
+
+@profile
+def download_primary_xml_v2(url: str, primary_xml: str):
+    """Download the primary-xml file from the given repository url"""
+    try:
+        primary_xml_url = urljoin(url, primary_xml)
+        response = requests.get(primary_xml_url, stream=True)
+        with open(os.path.join(CACHE_DIR, primary_xml), "wb") as out_file:
+            shutil.copyfileobj(response.raw, out_file)
+        print(f"file {primary_xml} was downloaded successfully!")
+        response.close()
+    except requests.exceptions.RequestException as e:
+        print(f"Error downloading {primary_xml} file:", e)
+
+
+@profile
+def parse_primary_xml(file_path):
+    handler = PrimaryXmlHandler()
+    parser = xml.sax.make_parser()
+    # parser.setFeature(xml.sax.handler.feature_namespaces, True)  # TODO Fix problem (probably for the root tag)
+    parser.setContentHandler(handler)
+
+    try:
+        parser.parse(file_path)
+    except Exception as e:
+        print("Error parsing file: ", e)
+
+
+def get_filename(url):
+    """Extract filename from file url"""
+    filename = os.path.basename(url)
+    return filename
+
+
+def get_file_location(target_path, filename):
+    """Concatenate download directory and filename"""
+    return target_path + filename
+
+
+def extract_file(target_path, filename):
+    """Extract file based on file extension target_path: string, location where data will be extracted filename:
+    string, name of the file along with extension"""
+    if filename == "" or filename is None:
+        raise Exception(FILENAME_ERROR)
+
+    file_location = get_file_location(target_path, filename)
+
+    if filename.endswith(ZIP_EXTENSION):
+        print(f"Extracting {file_location} file")
+        zipf = zipfile.ZipFile(file_location, "r")
+        zipf.extractall(target_path)
+        zipf.close()
+    elif (
+        filename.endswith(TAR_EXTENSION)
+        or filename.endswith(TAR_GZ_EXTENSION)
+        or filename.endswith(TGZ_EXTENSION)
+    ):
+        print(f"Extracting {file_location} file")
+        tarf = tarfile.open(file_location, "r")
+        tarf.extractall(target_path)
+        tarf.close()
+    elif filename.endswith(GZ_EXTENSION):
+        print(f"Extracting {file_location} file")
+        out_file = file_location[:-3]
+        with gzip.open(file_location, "rt") as f_in:
+            with open(out_file, "w") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+    else:
+        raise ValueError(f"Unknown file format: {UNKNOWN_FORMAT}")
+    os.remove(file_location)
+    print(f"Removing file: {file_location}")
+
+
+@profile
+def download_and_parse_metadata(url):
+    if not url:
+        print("Error: target url not defined!")
+        raise ValueError("Repository URL missing")
+
+    download_primary_xml_v2(url, PRIMARY_XML)
+    extract_file(CACHE_DIR, PRIMARY_XML)
+    parse_primary_xml(os.path.join(CACHE_DIR, PRIMARY_XML.rstrip(".gz")))

--- a/python/lzreposync/tests/test_lzreposync.py
+++ b/python/lzreposync/tests/test_lzreposync.py
@@ -1,0 +1,7 @@
+import pytest
+from lzreposync import parse
+
+
+def test_download_and_parse_metadata():
+    with pytest.raises(ValueError, match="Repository URL missing"):
+        parse.download_and_parse_metadata("")


### PR DESCRIPTION
## What does this PR change?

lzreposync will be a spacewalk-repo-sync replacement written in Python. It uses a src layout and a pyproject.toml. The target Python version is 3.11, compatibility with older Python versions is explicitly not a goal.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: will come with the actual code PRs
- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
