### PR TITLE
Adapt channel change

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/AccessTokenFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/AccessTokenFactory.java
@@ -25,7 +25,6 @@ import com.suse.utils.Opt;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hibernate.criterion.Restrictions;
 import org.jose4j.lang.JoseException;
 
 import java.time.Duration;
@@ -58,12 +57,10 @@ public class AccessTokenFactory extends HibernateFactory {
      * @return optional of AccessToken
      */
     public static Optional<AccessToken> lookupById(long id) {
-        return Optional.ofNullable(
-                (AccessToken)HibernateFactory.getSession()
-                .createCriteria(AccessToken.class)
-                .add(Restrictions.eq("id", id))
-                .uniqueResult()
-        );
+        return getSession()
+                .createQuery("FROM AccessToken WHERE id = :id", AccessToken.class)
+                .setParameter("id", id)
+                .uniqueResultOptional();
     }
 
     /**
@@ -71,8 +68,21 @@ public class AccessTokenFactory extends HibernateFactory {
      * @return list of AccessTokens
      */
     public static List<AccessToken> all() {
-        return (List<AccessToken>) HibernateFactory.getSession()
-                .createCriteria(AccessToken.class)
+        return getSession()
+                .createQuery("FROM AccessToken", AccessToken.class)
+                .list();
+    }
+
+
+    /**
+     * Queries all AccessTokens for a specific minion
+     * @param minion the minion
+     * @return list of AccessTokens
+     */
+    public static List<AccessToken> listByMinion(MinionServer minion) {
+        return getSession()
+                .createQuery("FROM AccessToken WHERE minion = :minion", AccessToken.class)
+                .setParameter("minion", minion)
                 .list();
     }
 
@@ -82,12 +92,10 @@ public class AccessTokenFactory extends HibernateFactory {
      * @return optional of AccessToken
      */
     public static Optional<AccessToken> lookupByToken(String token) {
-        return Optional.ofNullable(
-            (AccessToken)HibernateFactory.getSession()
-            .createCriteria(AccessToken.class)
-            .add(Restrictions.eq("token", token))
-            .uniqueResult()
-        );
+        return getSession()
+                .createQuery("FROM AccessToken WHERE token = :token", AccessToken.class)
+                .setParameter("token", token)
+                .uniqueResultOptional();
     }
 
     /**
@@ -210,6 +218,8 @@ public class AccessTokenFactory extends HibernateFactory {
             minion.getAccessTokens().add(toActivate);
         });
 
+        LOG.debug("Token refresh finished. Got Unneeded {} Got Updated {} Got New {}",
+                !unneededTokens.isEmpty(), !update.isEmpty(), !newTokens.isEmpty());
         return !unneededTokens.isEmpty() || !update.isEmpty() || !newTokens.isEmpty();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -15,6 +15,8 @@
 package com.redhat.rhn.domain.server;
 
 import com.redhat.rhn.domain.channel.AccessToken;
+import com.redhat.rhn.domain.channel.AccessTokenFactory;
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.configuration.SaltConfigSubscriptionService;
@@ -29,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * MinionServer
@@ -219,6 +222,20 @@ public class MinionServer extends Server implements SaltConfigurable {
                 .append(getMachineId(), otherMinion.getMachineId())
                 .append(getMinionId(), otherMinion.getMinionId())
                 .isEquals();
+    }
+
+
+    /**
+     * @return Return true when all assigned software channels have valid access tokens.
+     */
+    public boolean hasValidTokensForAllChannels() {
+
+        Set<Channel> tokenChannels = AccessTokenFactory.listByMinion(this)
+                .stream()
+                .flatMap(t -> t.getChannels().stream())
+                .collect(Collectors.toSet());
+
+        return tokenChannels.containsAll(getChannels()) && getChannels().containsAll(tokenChannels);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -232,6 +233,8 @@ public class MinionServer extends Server implements SaltConfigurable {
 
         Set<Channel> tokenChannels = AccessTokenFactory.listByMinion(this)
                 .stream()
+                .filter(AccessToken::getValid)
+                .filter(t -> t.getExpiration().toInstant().isAfter(Instant.now()))
                 .flatMap(t -> t.getChannels().stream())
                 .collect(Collectors.toSet());
 

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -53,7 +53,7 @@ import javax.persistence.criteria.Root;
  */
 public class MinionServerFactory extends HibernateFactory {
 
-    private static Logger log = LogManager.getLogger(MinionServerFactory.class);
+    private static final Logger LOG = LogManager.getLogger(MinionServerFactory.class);
 
     /**
      * Lookup all Servers that belong to an org
@@ -75,13 +75,13 @@ public class MinionServerFactory extends HibernateFactory {
      */
     public static Stream<MinionServer> lookupVisibleToUser(User user) {
         return user.getServers().stream().flatMap(
-                s -> s.asMinionServer().map(Stream::of).orElseGet(Stream::empty)
+                s -> s.asMinionServer().stream()
         );
     }
 
     @Override
     protected Logger getLogger() {
-        return log;
+        return LOG;
     }
 
     /**
@@ -153,7 +153,7 @@ public class MinionServerFactory extends HibernateFactory {
      */
     public static Stream<MinionServer> lookupByIds(List<Long> ids) {
         return ServerFactory.lookupByIds(ids).stream().flatMap(server ->
-           server.asMinionServer().map(Stream::of).orElseGet(Stream::empty)
+                server.asMinionServer().stream()
         );
     }
 
@@ -324,7 +324,7 @@ public class MinionServerFactory extends HibernateFactory {
         List<MinionSummary> allMinions = MinionServerFactory.findQueuedMinionSummaries(action.getId());
         return allMinions.stream().filter(
                 minionSummary -> MinionServerFactory.findByMinionId(minionSummary.getMinionId())
-                .map(server -> server.isDeniedOnPayg())
+                .map(Server::isDeniedOnPayg)
                 .orElse(false)).toList();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -472,44 +472,6 @@ public class SystemHandler extends BaseHandler {
      * Sets the base channel for the given server to the given channel
      * @param loggedInUser The current user
      * @param sid The id for the server
-     * @param cid The id for the channel
-     * @return Returns 1 if successful, exception otherwise
-     * @throws FaultException A FaultException is thrown if:
-     *   - the server corresponding to sid cannot be found.
-     *   - the channel corresponding to cid is not a base channel.
-     *   - the user doesn't have subscribe access to either the current or
-     *     the new base channel.
-     * @deprecated being replaced by system.setBaseChannel(string sessionKey,
-     * int serverId, string channelLabel)
-     *
-     * @apidoc.doc Assigns the server to a new baseChannel.
-     * @apidoc.param #session_key()
-     * @apidoc.param #param("int", "sid")
-     * @apidoc.param #param_desc("int", "cid", "channel ID")
-     * @apidoc.returntype #return_int_success()
-     */
-    @Deprecated
-    public int setBaseChannel(User loggedInUser, Integer sid, Integer cid)
-            throws FaultException {
-        //Get the logged in user and server
-        Server server = lookupServer(loggedInUser, sid);
-        UpdateBaseChannelCommand cmd =
-                new UpdateBaseChannelCommand(
-                        loggedInUser, server, cid.longValue());
-        cmd.setScheduleApplyChannelsState(true);
-        ValidatorError ve = cmd.store();
-        if (ve != null) {
-            throw new InvalidChannelException(
-                    LocalizationService.getInstance()
-                    .getMessage(ve.getKey(), ve.getValues()));
-        }
-        return 1;
-    }
-
-    /**
-     * Sets the base channel for the given server to the given channel
-     * @param loggedInUser The current user
-     * @param sid The id for the server
      * @param channelLabel The id for the channel
      * @return Returns 1 if successful, exception otherwise
      * @throws FaultException A FaultException is thrown if:

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.system;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -118,7 +119,6 @@ import com.redhat.rhn.frontend.events.SsmDeleteServersEvent;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidActionTypeException;
-import com.redhat.rhn.frontend.xmlrpc.InvalidChannelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelListException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidEntitlementException;
@@ -181,8 +181,6 @@ import com.redhat.rhn.manager.system.DuplicateSystemGrouping;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.SystemsExistException;
-import com.redhat.rhn.manager.system.UpdateBaseChannelCommand;
-import com.redhat.rhn.manager.system.UpdateChildChannelsCommand;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
@@ -405,7 +403,7 @@ public class SystemHandler extends BaseHandler {
      * @throws FaultException A FaultException is thrown if:
      *   - the server corresponding to sid cannot be found.
      *   - the channel corresponding to cid is not a valid child channel.
-     *   - the user doesn't have subscribe access to any one of the current or
+     *   - the user doesn't have subscribed access to any one of the current or
      *     new child channels.
      * @deprecated being replaced by system.scheduleChangeChannels(string sessionKey,
      * int serverId, String baseChannelLabel, array_single channelLabels, date earliestOccurrence).
@@ -424,12 +422,12 @@ public class SystemHandler extends BaseHandler {
      * @apidoc.returntype #return_int_success()
      */
     @Deprecated
-    public int setChildChannels(User loggedInUser, Integer sid,
-            List channelIdsOrLabels)
-                    throws FaultException {
+    public int setChildChannels(User loggedInUser, Integer sid, List channelIdsOrLabels) throws FaultException {
 
         //Get the logged in user and server
         Server server = lookupServer(loggedInUser, sid);
+        List<String> channelLabels = new ArrayList<>();
+        String baseChannel = "";
 
         // Determine if user passed in a list of channel ids or labels... note: the list
         // must contain all ids or labels (i.e. not a combination of both)
@@ -437,6 +435,12 @@ public class SystemHandler extends BaseHandler {
         if (!channelIdsOrLabels.isEmpty()) {
             if (channelIdsOrLabels.get(0) instanceof String) {
                 receivedLabels = true;
+                Channel channel = ChannelFactory.lookupByLabel((String) channelIdsOrLabels.get(0));
+                baseChannel = channel.getParentChannel().getLabel();
+            }
+            else {
+                Channel channel = ChannelFactory.lookupById(Long.valueOf((Integer) channelIdsOrLabels.get(0)));
+                baseChannel = channel.getParentChannel().getLabel();
             }
 
             // check to make sure that the objects are all the same type
@@ -445,38 +449,18 @@ public class SystemHandler extends BaseHandler {
                     if (!(object instanceof String)) {
                         throw new InvalidChannelListException();
                     }
+                    channelLabels.add((String) object);
                 }
                 else {
                     if (!(object instanceof Integer)) {
                         throw new InvalidChannelListException();
                     }
+                    channelLabels.add(ChannelFactory.lookupById(Long.valueOf((Integer) object)).getLabel());
                 }
             }
         }
 
-        List<Long> channelIds = new ArrayList<>();
-        if (receivedLabels) {
-            channelIds = ChannelFactory.getChannelIds(channelIdsOrLabels);
-
-            // if we weren't able to retrieve channel ids for all labels provided,
-            // one or more of the labels must be invalid...
-            if (channelIds.size() != channelIdsOrLabels.size()) {
-                throw new InvalidChannelLabelException();
-            }
-        }
-        else {
-            // unfortunately, the interface only allows Integer input (not Long);
-            // therefore, convert the input to Long, since channel ids are
-            // internally represented as Long
-            for (Object channelId : channelIdsOrLabels) {
-                channelIds.add(Long.valueOf((Integer) channelId));
-            }
-        }
-
-        UpdateChildChannelsCommand cmd = new UpdateChildChannelsCommand(loggedInUser,
-                server, channelIds);
-        cmd.setScheduleApplyChannelsState(true);
-        cmd.store();
+        scheduleChangeChannels(loggedInUser, sid, baseChannel, channelLabels, new Date());
 
         SystemManager.snapshotServer(server, LocalizationService
                 .getInstance().getMessage("snapshots.childchannel"));
@@ -531,10 +515,11 @@ public class SystemHandler extends BaseHandler {
      * @throws FaultException A FaultException is thrown if:
      *   - the server corresponding to sid cannot be found.
      *   - the channel corresponding to cid is not a base channel.
-     *   - the user doesn't have subscribe access to either the current or
+     *   - the user doesn't have subscribed access to either the current or
      *     the new base channel.
      * @deprecated being replaced by system.scheduleChangeChannels(string sessionKey,
      * int serverId, String baseChannelLabel, array_single channelLabels, date earliestOccurrence).
+     * Internally it is already implemented using scheduleChangeChannels
      *
      *
      * @apidoc.doc Assigns the server to a new base channel.  If the user provides an empty
@@ -550,31 +535,8 @@ public class SystemHandler extends BaseHandler {
             throws FaultException {
         Server server = lookupServer(loggedInUser, sid);
 
-        UpdateBaseChannelCommand cmd = null;
-        if (StringUtils.isEmpty(channelLabel)) {
-            // if user provides an empty string for the channel label, they are requesting
-            // to remove the base channel
-            cmd = new UpdateBaseChannelCommand(loggedInUser, server, -1L);
-        }
-        else {
-            List<String> channelLabels = new ArrayList<>();
-            channelLabels.add(channelLabel);
+        scheduleChangeChannels(loggedInUser, sid, channelLabel, emptyList(), new Date());
 
-            List<Long> channelIds = ChannelFactory.getChannelIds(channelLabels);
-
-            if (!channelIds.isEmpty()) {
-                cmd = new UpdateBaseChannelCommand(loggedInUser, server, channelIds.get(0));
-                cmd.setScheduleApplyChannelsState(true);
-            }
-            else {
-                throw new InvalidChannelLabelException();
-            }
-        }
-        ValidatorError ve = cmd.store();
-        if (ve != null) {
-            throw new InvalidChannelException(LocalizationService.getInstance()
-                    .getMessage(ve.getKey(), ve.getValues()));
-        }
         SystemManager.snapshotServer(server, LocalizationService
                 .getInstance().getMessage("snapshots.basechannel"));
         return 1;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -119,6 +119,7 @@ import com.redhat.rhn.frontend.events.SsmDeleteServersEvent;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidActionTypeException;
+import com.redhat.rhn.frontend.xmlrpc.InvalidChannelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidChannelListException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidEntitlementException;
@@ -436,10 +437,19 @@ public class SystemHandler extends BaseHandler {
             if (channelIdsOrLabels.get(0) instanceof String) {
                 receivedLabels = true;
                 Channel channel = ChannelFactory.lookupByLabel((String) channelIdsOrLabels.get(0));
+                if (channel == null) {
+                    throw new InvalidChannelLabelException();
+                }
+                if (channel.getParentChannel() == null) {
+                    throw new InvalidChannelException();
+                }
                 baseChannel = channel.getParentChannel().getLabel();
             }
             else {
                 Channel channel = ChannelFactory.lookupById(Long.valueOf((Integer) channelIdsOrLabels.get(0)));
+                if (channel == null || channel.getParentChannel() == null) {
+                    throw new InvalidChannelException();
+                }
                 baseChannel = channel.getParentChannel().getLabel();
             }
 
@@ -565,11 +575,6 @@ public class SystemHandler extends BaseHandler {
      */
     public List<Long> scheduleChangeChannels(User loggedInUser, List<Integer> sids, String baseChannelLabel,
                                              List childLabels, Date earliestOccurrence) {
-        //Get the logged in user and server
-        Set<Long> servers = sids.stream()
-                .map(sid -> lookupServer(loggedInUser, sid))
-                .map(Server::getId)
-                .collect(toSet());
         Optional<Channel> baseChannel = Optional.empty();
 
         // base channel
@@ -577,9 +582,29 @@ public class SystemHandler extends BaseHandler {
             List<Long> channelIds = ChannelFactory.getChannelIds(singletonList(baseChannelLabel));
             long baseChannelId = channelIds.stream().findFirst().orElseThrow(InvalidChannelLabelException::new);
             baseChannel = Optional.of(ChannelManager.lookupByIdAndUser(baseChannelId, loggedInUser));
+            if (baseChannel.filter(Channel::isBaseChannel).isEmpty()) {
+                throw new InvalidChannelException();
+            }
         }
         // else if the user provides an empty string for the channel label, they are requesting
         // to remove the base channel
+
+        //Get the logged in user and server
+        Set<Server> servers = sids.stream()
+                .map(sid -> lookupServer(loggedInUser, sid))
+                .collect(toSet());
+
+        for (Server s : servers) {
+            if (baseChannel.map(Channel::getChannelArch)
+                    .filter(arch -> arch.isCompatible(s.getServerArch()))
+                    .isEmpty()) {
+                throw new InvalidChannelException();
+            }
+        }
+
+        Set<Long> serverIds = servers.stream()
+                .map(Server::getId)
+                .collect(toSet());
 
         // check if user passed a list of labels for the child channels
         if (childLabels.stream().anyMatch(e -> !(e instanceof String))) {
@@ -601,7 +626,7 @@ public class SystemHandler extends BaseHandler {
 
         try {
             Set<Action> action = ActionChainManager.scheduleSubscribeChannelsAction(loggedInUser,
-                    servers,
+                    serverIds,
                     baseChannel,
                     childChannels,
                     earliestOccurrence, null);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -170,6 +171,7 @@ import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.bootstrap.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.bootstrap.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
@@ -348,8 +350,13 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     public void testSetChildChannelsDeprecated() throws Exception {
         // the usage of setChildChannels API as tested by this junit where
         // channel ids are passed as arguments is being deprecated...
+        SystemHandler mockedHandler = getMockedHandler();
+        ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
+        SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
+        sa.setCommitTransaction(false);
+        List<Long> finishedActions = new ArrayList<>();
 
-        Server server = ServerFactoryTest.createTestServer(admin, true);
+        Server server = MinionServerFactoryTest.createTestMinionServer(admin);
         assertNull(server.getBaseChannel());
         Integer sid = server.getId().intValue();
 
@@ -364,6 +371,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
         //subscribe to base channel.
         SystemManager.subscribeServerToChannel(admin, server, base);
+        TestUtils.flushAndEvict(server);
         server = reload(server);
         assertNotNull(server.getBaseChannel());
 
@@ -372,6 +380,14 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         cids.add(child2.getId().intValue());
 
         int result = handler.setChildChannels(admin, sid, cids);
+        Optional<Action> first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+        finishedActions.add(first.get().getId());
+
+        TestUtils.flushAndEvict(server);
         server = TestUtils.reload(server);
         assertEquals(1, result);
         assertEquals(3, server.getChannels().size());
@@ -382,6 +398,15 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertEquals(1, cids.size());
 
         result = handler.setChildChannels(admin, sid, cids);
+        first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> !finishedActions.contains(a.getId()))
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+        finishedActions.add(first.get().getId());
+
+        TestUtils.flushAndEvict(server);
         server = TestUtils.reload(server);
         assertEquals(1, result);
         assertEquals(2, server.getChannels().size());
@@ -414,6 +439,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             //success
         }
 
+        TestUtils.flushAndEvict(server);
         server = reload(server);
         assertEquals(2, server.getChannels().size());
 
@@ -440,7 +466,13 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     @Test
     public void testSetChildChannels() throws Exception {
-        Server server = ServerFactoryTest.createTestServer(admin, true);
+        SystemHandler mockedHandler = getMockedHandler();
+        ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
+        SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
+        sa.setCommitTransaction(false);
+        List<Long> finishedActions = new ArrayList<>();
+
+        Server server = MinionServerFactoryTest.createTestMinionServer(admin);
         assertNull(server.getBaseChannel());
         Integer sid = server.getId().intValue();
 
@@ -449,37 +481,60 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
         Channel child1 = ChannelFactoryTest.createTestChannel(admin);
         child1.setParentChannel(base);
+        String child1Label = child1.getLabel();
 
         Channel child2 = ChannelFactoryTest.createTestChannel(admin);
         child2.setParentChannel(base);
+        String child2Label = child2.getLabel();
+
+        TestUtils.flushAndEvict(child1);
+        TestUtils.flushAndEvict(child2);
 
         //subscribe to base channel.
         SystemManager.subscribeServerToChannel(admin, server, base);
+        TestUtils.saveAndFlush(server);
         server = reload(server);
         assertNotNull(server.getBaseChannel());
 
-        List channelLabels = new ArrayList<>();
-        channelLabels.add(new String(child1.getLabel()));
-        channelLabels.add(new String(child2.getLabel()));
+        List<String> channelLabels = new ArrayList<>();
+        channelLabels.add(child1Label);
+        channelLabels.add(child2Label);
 
         int result = handler.setChildChannels(admin, sid, channelLabels);
+        Optional<Action> first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+        finishedActions.add(first.get().getId());
+
+        TestUtils.flushAndEvict(server);
         server = TestUtils.reload(server);
         assertEquals(1, result);
         assertEquals(3, server.getChannels().size());
 
         //Try 'unsubscribing' from child1...
         channelLabels = new ArrayList<>();
-        channelLabels.add(new String(child2.getLabel()));
+        channelLabels.add(child2Label);
         assertEquals(1, channelLabels.size());
 
         result = handler.setChildChannels(admin, sid, channelLabels);
+        first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> !finishedActions.contains(a.getId()))
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+        finishedActions.add(first.get().getId());
+
+        TestUtils.flushAndEvict(server);
         server = TestUtils.reload(server);
         assertEquals(1, result);
         assertEquals(2, server.getChannels().size());
 
         //Try putting an invalid channel in there
         channelLabels = new ArrayList<>();
-        channelLabels.add(new String("invalid-unknown-channel-label"));
+        channelLabels.add("invalid-unknown-channel-label");
         assertEquals(1, channelLabels.size());
 
         try {
@@ -491,10 +546,13 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         }
         assertEquals(2, server.getChannels().size());
 
+        TestUtils.flushAndEvict(server);
+        server = TestUtils.reload(server);
+
         Channel base2 = ChannelFactoryTest.createTestChannel(admin);
         base2.setParentChannel(null);
         channelLabels = new ArrayList<>();
-        channelLabels.add(new String(base2.getLabel()));
+        channelLabels.add(base2.getLabel());
         assertEquals(1, channelLabels.size());
 
         try {
@@ -505,6 +563,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             //success
         }
 
+        TestUtils.flushAndEvict(server);
         server = reload(server);
         assertEquals(2, server.getChannels().size());
 
@@ -532,8 +591,13 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     @Test
     public void testSetBaseChannelDeprecated() throws Exception {
         // the setBaseChannel API tested by this junit is being deprecated
+        SystemHandler mockedHandler = getMockedHandler();
+        ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
+        SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
+        sa.setCommitTransaction(false);
+        List<Long> finishedActions = new ArrayList<>();
 
-        Server server = ServerFactoryTest.createTestServer(admin, true);
+        MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
         assertNull(server.getBaseChannel());
         Integer sid = server.getId().intValue();
 
@@ -547,16 +611,28 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         child1.setParentChannel(base1);
 
         // Set base channel to base1
-        int result = handler.setBaseChannel(admin, sid,
-                base1.getId().intValue());
+        int result = handler.setBaseChannel(admin, sid, base1.getLabel());
+        Optional<Action> first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+        finishedActions.add(first.get().getId());
+
         server = reload(server);
         assertEquals(1, result);
         assertNotNull(server.getBaseChannel());
         assertEquals(server.getBaseChannel().getLabel(), base1.getLabel());
 
         // Set base channel to base2
-        result = handler.setBaseChannel(admin, sid,
-                base2.getId().intValue());
+        result = handler.setBaseChannel(admin, sid, base2.getLabel());
+        first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> !finishedActions.contains(a.getId()))
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+
         server = TestUtils.reload(server);
         assertEquals(1, result);
         assertNotNull(server.getBaseChannel());
@@ -564,8 +640,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
         // Try setting base channel to child
         try {
-            result = handler.setBaseChannel(admin, sid,
-                    child1.getId().intValue());
+            result = handler.setBaseChannel(admin, sid, child1.getLabel());
             fail("SystemHandler.setBaseChannel allowed invalid base channel to be set.");
         }
         catch (InvalidChannelException e) {
@@ -582,8 +657,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             ServerFactory.save(server);
 
 
-            result = handler.setBaseChannel(admin, sid,
-                    base1.getId().intValue());
+            result = handler.setBaseChannel(admin, sid, base1.getLabel());
             fail("allowed channel with incompatible arch to be set");
         }
         catch (InvalidChannelException e) {
@@ -593,7 +667,13 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     @Test
     public void testSetBaseChannel() throws Exception {
-        Server server = ServerFactoryTest.createTestServer(admin, true);
+        SystemHandler mockedHandler = getMockedHandler();
+        ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
+        SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
+        sa.setCommitTransaction(false);
+        List<Long> finishedActions = new ArrayList<>();
+
+        MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
         assertNull(server.getBaseChannel());
         Integer sid = server.getId().intValue();
 
@@ -608,6 +688,13 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
         // Set base channel to base1
         int result = handler.setBaseChannel(admin, sid, base1.getLabel());
+        Optional<Action> first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+        finishedActions.add(first.get().getId());
+
         server = reload(server);
         assertEquals(1, result);
         assertNotNull(server.getBaseChannel());
@@ -615,6 +702,14 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
         // Set base channel to base2
         result = handler.setBaseChannel(admin, sid, base2.getLabel());
+        first = ActionFactory.listActionsForServer(admin, server).stream()
+                .filter(a -> !finishedActions.contains(a.getId()))
+                .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
+                .findFirst();
+        assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        sa.execute(first.get(), false, false, Optional.empty());
+        finishedActions.add(first.get().getId());
+
         server = TestUtils.reload(server);
         assertEquals(1, result);
         assertNotNull(server.getBaseChannel());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -354,6 +354,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
         SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
         sa.setCommitTransaction(false);
+        sa.setSaltApi(saltApi);
         List<Long> finishedActions = new ArrayList<>();
 
         Server server = MinionServerFactoryTest.createTestMinionServer(admin);
@@ -470,6 +471,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
         SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
         sa.setCommitTransaction(false);
+        sa.setSaltApi(saltApi);
         List<Long> finishedActions = new ArrayList<>();
 
         Server server = MinionServerFactoryTest.createTestMinionServer(admin);
@@ -595,6 +597,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
         SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
         sa.setCommitTransaction(false);
+        sa.setSaltApi(saltApi);
         List<Long> finishedActions = new ArrayList<>();
 
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
@@ -619,6 +622,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
         server = reload(server);
         assertEquals(1, result);
         assertNotNull(server.getBaseChannel());
@@ -632,6 +638,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
         sa.execute(first.get(), false, false, Optional.empty());
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
 
         server = TestUtils.reload(server);
         assertEquals(1, result);
@@ -671,6 +680,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         ActionChainManager.setTaskomaticApi(mockedHandler.getTaskomaticApi());
         SaltServerActionService sa = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
         sa.setCommitTransaction(false);
+        sa.setSaltApi(saltApi);
         List<Long> finishedActions = new ArrayList<>();
 
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
@@ -695,6 +705,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
         server = reload(server);
         assertEquals(1, result);
         assertNotNull(server.getBaseChannel());
@@ -709,6 +722,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
 
         server = TestUtils.reload(server);
         assertEquals(1, result);

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -167,6 +167,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
@@ -3644,7 +3645,7 @@ public class SystemManager extends BaseManager {
 
         // if there's no base channel present the there are no child channels to set
         List<Long> childChannelIds = baseChannel.isPresent() ?
-                childChannels.stream().map(Channel::getId).toList() :
+                childChannels.stream().map(Channel::getId).collect(Collectors.toList()) :
                 emptyList();
 
         UpdateBaseChannelCommand baseChannelCommand =

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1353,7 +1353,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         HibernateFactory.getSession().flush();
 
-        SystemManager.updateServerChannels(user, server, of(base2), Arrays.asList(ch21, ch22));
+        systemManager.updateServerChannels(user, server, of(base2), Arrays.asList(ch21, ch22));
 
         assertEquals(base2.getId(), server.getBaseChannel().getId());
         assertEquals(2, server.getChildChannels().size());
@@ -1383,7 +1383,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         HibernateFactory.getSession().flush();
 
-        SystemManager.updateServerChannels(user, server, of(base2), Collections.emptyList());
+        systemManager.updateServerChannels(user, server, of(base2), Collections.emptyList());
 
         assertEquals(base2.getId(), server.getBaseChannel().getId());
         assertEquals(0, server.getChildChannels().size());
@@ -1411,7 +1411,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         HibernateFactory.getSession().flush();
 
-        SystemManager.updateServerChannels(user, server, empty(), Arrays.asList(ch21, ch22));
+        systemManager.updateServerChannels(user, server, empty(), Arrays.asList(ch21, ch22));
 
         assertNull(server.getBaseChannel());
         assertEquals(0, server.getChildChannels().size());

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -79,6 +79,8 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
+import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
+import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
 import com.suse.manager.reactor.messaging.JobReturnEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
 import com.suse.manager.reactor.utils.test.RhelUtilsTest;
@@ -2054,6 +2056,20 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             allowing(taskomaticMock).scheduleSubscribeChannels(
                     with(any(User.class)), with(any(SubscribeChannelsAction.class)));
         } });
+        saltServerActionService.setCommitTransaction(false);
+
+        SaltService saltService = new SaltService() {
+            @Override
+            public void refreshPillar(MinionList minionList) {
+            }
+        };
+        ChannelsChangedEventMessageAction ccema = new ChannelsChangedEventMessageAction(saltService);
+
+        /* remove comment when testing with real message queue
+        saltServerActionService.setCommitTransaction(true);
+        MessageQueue.registerAction(ccema, ChannelsChangedEventMessage.class);
+        MessageQueue.startMessaging();
+        */
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -2081,10 +2097,15 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ServerAction sa = ActionFactoryTest.createServerAction(minion, action);
         action.addServerAction(sa);
 
-        saltServerActionService.setCommitTransaction(false);
-        Map<LocalCall<?>, List<MinionSummary>> calls = saltServerActionService.callsForAction(action);
+        saltServerActionService.callsForAction(action);
 
-        HibernateFactory.getSession().flush();
+
+        // callsForAction would fire ChannelChangedEventMessage asynchronous to generate tokens.
+        // We emulate this here only
+        // comment this block when testing with real message queue
+        assertFalse(minion.hasValidTokensForAllChannels(), "Unexpected minion has tokens for all channels");
+        ccema.execute(new ChannelsChangedEventMessage(minion.getId(), user.getId()));
+        assertTrue(minion.hasValidTokensForAllChannels(), "Unexpected minion miss tokens for some channels");
 
         // Setup an event message from file contents
         Optional<JobReturnEvent> event = JobReturnEvent.parse(
@@ -2094,6 +2115,11 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
+
+        /* remove comment when testing with real message queue
+        MessageQueue.stopMessaging();
+        MessageQueue.deRegisterAction(ccema, ChannelsChangedEventMessage.class);
+        */
 
         assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
         assertEquals(0L, (long)sa.getResultCode());

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -27,7 +27,6 @@ import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.ActionType;
-import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
 import com.redhat.rhn.domain.action.config.ConfigRevisionActionResult;
 import com.redhat.rhn.domain.action.config.ConfigVerifyAction;
 import com.redhat.rhn.domain.action.dup.DistUpgradeAction;
@@ -46,7 +45,6 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationNetworkAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
-import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.image.ImageFile;
@@ -837,24 +835,8 @@ public class SaltUtils {
     private void handleSubscribeChannels(ServerAction serverAction, JsonElement jsonResult, Action action) {
         if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
             serverAction.setResultMsg("Successfully applied state: " + ApplyStatesEventMessage.CHANNELS);
-            SubscribeChannelsAction sca = (SubscribeChannelsAction)action;
-
-            // if successful update channels in db and trigger pillar refresh
-            SystemManager.updateServerChannels(
-                    action.getSchedulerUser(),
-                    serverAction.getServer(),
-                    Optional.ofNullable(sca.getDetails().getBaseChannel()),
-                    sca.getDetails().getChannels());
         }
         else {
-            //set the token as invalid
-            SubscribeChannelsAction sca = (SubscribeChannelsAction)action;
-            sca.getDetails().getAccessTokens().forEach(token -> {
-                token.setValid(false);
-                token.setMinion(null);
-                AccessTokenFactory.save(token);
-            });
-
             serverAction.setResultMsg("Failed to apply state: " + ApplyStatesEventMessage.CHANNELS + ".\n" +
                     getJsonResultWithPrettyPrint(jsonResult));
         }

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectSourcesApiController.java
@@ -29,6 +29,7 @@ import com.suse.manager.webui.controllers.contentmanagement.request.ProjectSourc
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import spark.Request;
 import spark.Response;
@@ -78,7 +79,7 @@ public class ProjectSourcesApiController {
         List<String> sourceLabelsToAttach = createSourceRequest.getSoftwareSources()
                 .stream()
                 .map(ProjectSoftwareSourceRequest::getLabel)
-                .toList();
+                .collect(Collectors.toList());
         Collections.reverse(sourceLabelsToAttach);
         sourceLabelsToAttach.forEach(sourceLabel -> CONTENT_MGR.attachSource(
                 projectLabel,

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -114,6 +114,7 @@ import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
@@ -211,7 +212,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1431,40 +1431,20 @@ public class SaltServerActionService {
     private Map<LocalCall<?>, List<MinionSummary>> subscribeChanelsAction(
             List<MinionSummary> minionSummaries, SubscribeChannelsActionDetails actionDetails) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        SystemManager sysMgr = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
 
         List<MinionServer> minions = MinionServerFactory.lookupByMinionIds(
                 minionSummaries.stream().map(MinionSummary::getMinionId).collect(Collectors.toSet()));
 
         minions.forEach(minion ->
-            // change channels in DB and fire a ChannelsChangedEventMessage
-            // the ChannelsChangedEventMessageAction regenerate pillar and refresh Tokens
-            // but does not execute a "state.apply channels"
-            SystemManager.updateServerChannels(
+            // change channels in DB and execult the ChannelsChangedEventMessageAction
+            // which regenerate pillar and refresh Tokens but does not execute a "state.apply channels"
+            sysMgr.updateServerChannels(
                     actionDetails.getParentAction().getSchedulerUser(),
                     minion,
                     Optional.ofNullable(actionDetails.getBaseChannel()),
                     actionDetails.getChannels())
         );
-        if (commitTransaction) {
-            // we must be sure that new channel assignments and action Details are in the database
-            // before we return and send the salt calls to update the minions.
-            HibernateFactory.commitTransaction();
-
-            try {
-                for (int k = 0; k < 10; k = k + 1) {
-                    // check, if all channels got valid tokens before we send the update to the minions.
-                    // can only work, if we commit the transaction. In unit tests this just cause 10 seconds wait
-                    if (minions.stream().allMatch(MinionServer::hasValidTokensForAllChannels)) {
-                        break;
-                    }
-                    LOG.error("Waiting for all channel tokens being refreshed");
-                    TimeUnit.SECONDS.sleep(1);
-                }
-            }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
         ret.put(State.apply(List.of(ApplyStatesEventMessage.CHANNELS), Optional.empty()),
                 minionSummaries);
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -90,8 +90,6 @@ import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAc
 import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationStartGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendGuestAction;
-import com.redhat.rhn.domain.channel.AccessToken;
-import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.errata.Errata;
@@ -141,7 +139,6 @@ import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestsUpdat
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.DownloadTokenBuilder;
 import com.suse.manager.webui.utils.SaltModuleRun;
@@ -208,13 +205,13 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1435,55 +1432,41 @@ public class SaltServerActionService {
             List<MinionSummary> minionSummaries, SubscribeChannelsActionDetails actionDetails) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
 
-        Stream<MinionServer> minions = MinionServerFactory.lookupByIds(
-                minionSummaries.stream().map(MinionSummary::getServerId).toList());
+        List<MinionServer> minions = MinionServerFactory.lookupByMinionIds(
+                minionSummaries.stream().map(MinionSummary::getMinionId).collect(Collectors.toSet()));
 
-        minions.forEach(minion -> {
-            // generate access tokens
-            Set<Channel> allChannels = new HashSet<>(actionDetails.getChannels());
-            if (actionDetails.getBaseChannel() != null) {
-                allChannels.add(actionDetails.getBaseChannel());
-            }
-
-            List<AccessToken> newTokens = allChannels.stream()
-                    .map(channel ->
-                            AccessTokenFactory.generate(minion, Collections.singleton(channel))
-                                    .orElseThrow(() ->
-                                            new RuntimeException(
-                                                    "Could not generate new channel access token for minion " +
-                                                            minion.getMinionId() + " and channel " +
-                                                            channel.getName())))
-                    .toList();
-
-            newTokens.forEach(newToken -> {
-                // set the token as valid, then if something is wrong, the state chanel will disable it
-                newToken.setValid(true);
-                actionDetails.getAccessTokens().add(newToken);
-            });
-
-            MinionGeneralPillarGenerator minionGeneralPillarGenerator = new MinionGeneralPillarGenerator();
-            Map<String, Object> chanPillar = new HashMap<>();
-            newTokens.forEach(accessToken ->
-                accessToken.getChannels().forEach(chan -> {
-                    Map<String, Object> chanProps =
-                            minionGeneralPillarGenerator.getChannelPillarData(minion, accessToken, chan);
-                    chanPillar.put(chan.getLabel(), chanProps);
-                })
-            );
-
-            Map<String, Object> pillar = new HashMap<>();
-            pillar.put("_mgr_channels_items_name", "mgr_channels_new");
-            pillar.put("mgr_channels_new", chanPillar);
-
-            ret.put(State.apply(List.of(ApplyStatesEventMessage.CHANNELS),
-                    Optional.of(pillar)), Collections.singletonList(new MinionSummary(minion)));
-
-        });
+        minions.forEach(minion ->
+            // change channels in DB and fire a ChannelsChangedEventMessage
+            // the ChannelsChangedEventMessageAction regenerate pillar and refresh Tokens
+            // but does not execute a "state.apply channels"
+            SystemManager.updateServerChannels(
+                    actionDetails.getParentAction().getSchedulerUser(),
+                    minion,
+                    Optional.ofNullable(actionDetails.getBaseChannel()),
+                    actionDetails.getChannels())
+        );
         if (commitTransaction) {
-            // we must be sure that tokens and action Details are in the database
+            // we must be sure that new channel assignments and action Details are in the database
             // before we return and send the salt calls to update the minions.
             HibernateFactory.commitTransaction();
+
+            try {
+                for (int k = 0; k < 10; k = k + 1) {
+                    // check, if all channels got valid tokens before we send the update to the minions.
+                    // can only work, if we commit the transaction. In unit tests this just cause 10 seconds wait
+                    if (minions.stream().allMatch(MinionServer::hasValidTokensForAllChannels)) {
+                        break;
+                    }
+                    LOG.error("Waiting for all channel tokens being refreshed");
+                    TimeUnit.SECONDS.sleep(1);
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
+        ret.put(State.apply(List.of(ApplyStatesEventMessage.CHANNELS), Optional.empty()),
+                minionSummaries);
 
         return ret;
     }

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -42,7 +42,6 @@ import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
-import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.config.ConfigRevision;
@@ -74,6 +73,8 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
+import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
@@ -109,7 +110,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -690,6 +690,15 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testSubscribeChannels() throws Exception {
+        saltServerActionService.setCommitTransaction(false);
+
+        SaltService saltService = new SaltService() {
+            @Override
+            public void refreshPillar(MinionList minionList) {
+            }
+        };
+        ChannelsChangedEventMessageAction ccema = new ChannelsChangedEventMessageAction(saltService);
+
         Channel base = ChannelFactoryTest.createBaseChannel(user);
         Channel ch1 = ChannelFactoryTest.createTestChannel(user.getOrg());
         ch1.setParentChannel(base);
@@ -701,7 +710,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
 
         final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
-        SubscribeChannelsAction action = (SubscribeChannelsAction)ActionManager.createAction(
+        SubscribeChannelsAction action = (SubscribeChannelsAction) ActionManager.createAction(
                 user, ActionFactory.TYPE_SUBSCRIBE_CHANNELS, "Subscribe to channels", Date.from(now.toInstant()));
 
         SubscribeChannelsActionDetails details = new SubscribeChannelsActionDetails();
@@ -713,50 +722,38 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         ActionFactory.addServerToAction(minion1, action);
 
-        saltServerActionService.setCommitTransaction(false);
         Map<LocalCall<?>, List<MinionSummary>> calls = saltServerActionService.callsForAction(action);
+        ccema.execute(new ChannelsChangedEventMessage(minion1.getId(), user.getId()));
 
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
         assertEquals(1, calls.size());
 
-        Map<String, Object> pillar = (Map<String, Object>)((Map<String, Object>)calls.keySet().stream()
+        Map<String, Object> payload = calls.keySet().stream()
                 .findFirst()
-                .get().getPayload().get("kwarg")).get("pillar");
-        assertEquals("mgr_channels_new", pillar.get("_mgr_channels_items_name"));
-        Map<String, Object> channels = (Map<String, Object>)pillar.get("mgr_channels_new");
-        assertEquals(3, channels.size());
-        assertTrue(channels.keySet().contains(base.getLabel()));
-        assertTrue(channels.keySet().contains(ch1.getLabel()));
-        assertTrue(channels.keySet().contains(ch2.getLabel()));
+                .get().getPayload();
 
-        assertTokenPillarValue(base, action, channels);
-        assertTokenPillarValue(ch1, action, channels);
-        assertTokenPillarValue(ch2, action, channels);
+        assertEquals("state.apply", payload.get("fun"));
+        assertEquals("channels", ((List<String>) ((Map<String, Object>) payload.get("kwarg")).get("mods")).get(0));
 
-        action = (SubscribeChannelsAction)ActionFactory.lookupById(action.getId());
+        minion1 = TestUtils.reload(minion1);
+        assertEquals(3, minion1.getChannels().size());
+        assertEquals(base.getId(), minion1.getBaseChannel().getId());
+        assertEquals(2, minion1.getChildChannels().size());
+        assertTrue(minion1.getChildChannels().stream().anyMatch(cc -> cc.getId().equals(ch1.getId())));
+        assertTrue(minion1.getChildChannels().stream().anyMatch(cc -> cc.getId().equals(ch2.getId())));
 
-        assertEquals(3,  action.getDetails().getAccessTokens().size());
-        assertTrue(action.getDetails().getAccessTokens().stream()
-                .allMatch(token ->
-                        token.getStart().toInstant().isAfter(now.toInstant()) &&
-                        token.getStart().toInstant().isBefore(now.toInstant().plus(10, ChronoUnit.SECONDS))));
-        assertTrue(action.getDetails().getAccessTokens().stream().allMatch(AccessToken::getValid));
-        assertTokenExists(base, action);
-        assertTokenExists(ch1, action);
-        assertTokenExists(ch2, action);
+        assertEquals(3, minion1.getAccessTokens().size());
+        assertTokenChannel(minion1, base);
+        assertTokenChannel(minion1, ch1);
+        assertTokenChannel(minion1, ch2);
     }
 
-    private void assertTokenExists(Channel channel, SubscribeChannelsAction action) {
-        assertEquals(1, action.getDetails().getAccessTokens().stream()
-                .filter(token -> token.getChannels().size() == 1 && token.getChannels().contains(channel)).count());
-    }
-
-    private void assertTokenPillarValue(Channel channel, SubscribeChannelsAction action, Map<String, Object> channels) {
-        AccessToken tokenForChannel = action.getDetails().getAccessTokens().stream()
-                .filter(token -> token.getChannels().contains(channel)).findFirst().get();
-        assertEquals(tokenForChannel.getToken(), ((Map<String, Object>)channels.get(channel.getLabel())).get("token"));
+    private void assertTokenChannel(MinionServer minionIn, Channel channel) {
+        assertTrue(minionIn.getAccessTokens().stream()
+                .anyMatch(token -> token.getChannels().size() == 1 && token.getChannels().contains(channel)),
+                channel.getLabel());
     }
 
     private SaltServerActionService countSaltActionCalls(AtomicInteger counter) {

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -73,8 +73,6 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
-import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
-import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
@@ -690,15 +688,6 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testSubscribeChannels() throws Exception {
-        saltServerActionService.setCommitTransaction(false);
-
-        SaltService saltService = new SaltService() {
-            @Override
-            public void refreshPillar(MinionList minionList) {
-            }
-        };
-        ChannelsChangedEventMessageAction ccema = new ChannelsChangedEventMessageAction(saltService);
-
         Channel base = ChannelFactoryTest.createBaseChannel(user);
         Channel ch1 = ChannelFactoryTest.createTestChannel(user.getOrg());
         ch1.setParentChannel(base);
@@ -723,7 +712,6 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         ActionFactory.addServerToAction(minion1, action);
 
         Map<LocalCall<?>, List<MinionSummary>> calls = saltServerActionService.callsForAction(action);
-        ccema.execute(new ChannelsChangedEventMessage(minion1.getId(), user.getId()));
 
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();

--- a/java/spacewalk-java.changes.mc.adapt-channel-change
+++ b/java/spacewalk-java.changes.mc.adapt-channel-change
@@ -1,0 +1,3 @@
+- adapt changing software channels to first perform the changes in
+  the database and apply the channel state later to. This allow better
+  handling of offline minions (bsc#1216683)


### PR DESCRIPTION
## What does this PR change?

Currently we have 2 ways in the code how channels are changed.
1. One is changing the channels first in the Database and send it out to the client after it was changed.
2. The other way (new) we send the new channels out to the client first and only when the change was performed on the client successfully, we adapt the channels in the database.

The first (old) way has the benefit, that also offline clients change the channels and it can be changed on the client also later by just applying the channel state. 

The 2nd way is complicated as new access tokens needs to be generated, but the channel pillar data needs to be manually compiled and send via the state.apply instead of using the standard way by reading the database.
Offline minions will not change the channels at all which is a requirement of some users.

This PR try to go back to the 1st (old) way to just perform the changes in the Database and send out the result to the client.
If that fail, we do not invalidate the tokens anymore as a new state.apply can fix the situation later.

For this we have to remove asynchronous handling of of things which were done in ChannelsChangeEventMessageAction as the following state.apply for the channels require to have the data in the database and this event is waiting on the main event to be finished.
In this one case we execute now this Action Syncronous, while on Distupgrade and other cases we still use it via the message queue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23251
Port(s): ???

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
