### PR TITLE
fix accessing 'has_metering_access' on BYOS systems

### DIFF
--- a/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
@@ -218,6 +218,7 @@ def perform_compliants_checks():
     modifiedPackages = False
     billing_service_running = False
     billing_status = False
+    has_metering_access = False
     isPaygInstance = is_payg_instance()
 
     if isPaygInstance:

--- a/uyuni/uyuni-payg-timer/uyuni-payg-timer.changes.mc.fix-uninitialized-var-access
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-timer.changes.mc.fix-uninitialized-var-access
@@ -1,0 +1,1 @@
+- fix accessing 'has_metering_access' on BYOS systems (bsc#1226483)


### PR DESCRIPTION
## What does this PR change?

On BYOS systems the variable 'has_metering_access' is not initialized before it is accessed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manual

- [x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1226483

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
