### PR TITLE
Hub authentication examples

### DIFF
--- a/testsuite/ext-tools/hub-examples/README
+++ b/testsuite/ext-tools/hub-examples/README
@@ -1,0 +1,4 @@
+The HUB XMLRPC API port use to be blocked by our internal firewall.
+If you want to run these scripts from your local machine, use a SSH tunnel:
+
+ssh -L 2830:<server_fqdn>:2830 root@<server_fqdn>

--- a/testsuite/ext-tools/hub-examples/auto-authentication.py
+++ b/testsuite/ext-tools/hub-examples/auto-authentication.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+import xmlrpc.client
+import argparse
+
+# Parsing arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('hub_fqdn', type=str, help='The Hub FQDN')
+parser.add_argument('user', type=str, help='The username for the Hub')
+parser.add_argument('password', type=str, help='The password for the Hub')
+args = parser.parse_args()
+
+api = f"http://{args.hub_fqdn}:2830/hub/rpc/api"
+client = xmlrpc.client.ServerProxy(api)
+
+print("Login with autoconnect mode...")
+loginResponse = client.hub.loginWithAutoconnectMode(args.user, args.password)
+hubSessionKey = loginResponse["SessionKey"]
+print(f"hubSessionKey: {hubSessionKey}\n")
+
+print("Get the server IDs...")
+serverIds = client.hub.listServerIds(hubSessionKey)
+print(f"serverIds: {serverIds}\n")
+
+print("Get the list of systems per server IDs...")
+systemsPerServer = client.multicast.system.list_systems(hubSessionKey, serverIds)
+successfulResponses = systemsPerServer["Successful"]
+failedResponses = systemsPerServer["Failed"]
+
+if successfulResponses["Responses"]:
+  print(f"Systems responding successfully through a multicast api call:\n{successfulResponses}\n")
+
+if failedResponses["Responses"]:
+  print(f"Systems failing to reply through a multicast api call:\n{failedResponses}\n")
+
+# Log out
+client.hub.logout(hubSessionKey)

--- a/testsuite/ext-tools/hub-examples/install-pkg-all-systems.py
+++ b/testsuite/ext-tools/hub-examples/install-pkg-all-systems.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+import xmlrpc.client
+import argparse
+from datetime import datetime, timezone
+
+# Parsing arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('hub_fqdn', type=str, help='The Hub FQDN')
+parser.add_argument('user', type=str, help='The username for the Hub')
+parser.add_argument('password', type=str, help='The password for the Hub')
+parser.add_argument('packageId', type=int, help='Package ID')
+args = parser.parse_args()
+
+api = f"http://{args.hub_fqdn}:2830/hub/rpc/api"
+client = xmlrpc.client.ServerProxy(api)
+
+print("Login with autoconnect mode...")
+loginResponse = client.hub.loginWithAutoconnectMode(args.user, args.password)
+hubSessionKey = loginResponse["SessionKey"]
+print(f"hubSessionKey: {hubSessionKey}\n")
+
+print("Get the server IDs...")
+serverIds = client.hub.listServerIds(hubSessionKey)
+print(f"serverIds: {serverIds}\n")
+
+print("Multicast call to get the list of systems per server IDs...")
+systemsPerServer = client.multicast.system.list_systems(hubSessionKey, serverIds)
+successfulResponses = systemsPerServer["Successful"]
+failedResponses = systemsPerServer["Failed"]
+
+if successfulResponses["Responses"]:
+    systemsPerServer = {server_id: [item['id'] for item in response] for server_id, response in zip(successfulResponses['ServerIds'], successfulResponses['Responses'])}
+    for serverId, systemIds in systemsPerServer.items():
+        print(f"Unicast call to {serverId} server, to schedule a install of package ID {args.packageId} into {systemIds} system")
+        result = client.unicast.system.schedulePackageInstall(hubSessionKey, serverId, systemIds, [args.packageId], datetime.now())
+        print(f"ActionIds: {result}")
+
+if failedResponses["Responses"]:
+    print(f"Systems failing to reply through a multicast api call:\n{failedResponses}\n")
+
+print("Multicast call to get the list of systems per server IDs...")
+result = client.multicast.system.list_systems(hubSessionKey, serverIds)
+print(f"ActionIds: {result}")
+
+# Log out
+client.hub.logout(hubSessionKey)

--- a/testsuite/ext-tools/hub-examples/manual-authentication.py
+++ b/testsuite/ext-tools/hub-examples/manual-authentication.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+import xmlrpc.client
+import argparse
+
+# Parsing arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('hub_fqdn', type=str, help='The Hub FQDN')
+parser.add_argument('user', type=str, help='The username for the Hub')
+parser.add_argument('password', type=str, help='The password for the Hub')
+args = parser.parse_args()
+
+api = f"http://{args.hub_fqdn}:2830/hub/rpc/api"
+client = xmlrpc.client.ServerProxy(api)
+
+print("Manual login...")
+hubSessionKey = client.hub.login(args.user, args.password)
+print(f"hubSessionKey: {hubSessionKey}\n")
+
+print("Get the server IDs...")
+serverIds = client.hub.listServerIds(hubSessionKey)
+print(f"serverIds: {serverIds}\n")
+
+# For simplicity, this example assumes you are using the same username and password here, as on the hub server.
+# However, in most cases, every server has its own individual credentials.
+usernames = [args.user for s in serverIds]
+passwords = [args.password for s in serverIds]
+
+# Each server uses the credentials set above, client.hub.attachToServers needs
+# them passed as lists with as many elements as there are servers.
+client.hub.attachToServers(hubSessionKey, serverIds, usernames, passwords)
+
+print("Get the list of systems by server IDs...")
+systemsPerServer = client.multicast.system.list_systems(hubSessionKey, serverIds)
+successfulResponses = systemsPerServer["Successful"]
+failedResponses = systemsPerServer["Failed"]
+
+if successfulResponses["Responses"]:
+  print(f"Systems responding successfully through a multicast api call:\n{successfulResponses}\n")
+
+if failedResponses["Responses"]:
+  print(f"Systems failing to reply through a multicast api call:\n{failedResponses}\n")
+
+# Log out
+client.hub.logout(hubSessionKey)

--- a/testsuite/ext-tools/hub-examples/relay-authentication.py
+++ b/testsuite/ext-tools/hub-examples/relay-authentication.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+import xmlrpc.client
+import argparse
+
+# Parsing arguments
+parser = argparse.ArgumentParser()
+parser.add_argument('hub_fqdn', type=str, help='The Hub FQDN')
+parser.add_argument('user', type=str, help='The username for the Hub')
+parser.add_argument('password', type=str, help='The password for the Hub')
+args = parser.parse_args()
+
+api = f"http://{args.hub_fqdn}:2830/hub/rpc/api"
+client = xmlrpc.client.ServerProxy(api)
+
+print("Login with authrelay mode...")
+hubSessionKey = client.hub.loginWithAuthRelayMode(args.user, args.password)
+print(f"hubSessionKey: {hubSessionKey}\n")
+
+print("Get the server IDs...")
+serverIds = client.hub.listServerIds(hubSessionKey)
+print(f"serverIds: {serverIds}\n")
+
+# Authenticate those servers(same credentials will be used as of hub to authenticate)
+client.hub.attachToServers(hubSessionKey, serverIds)
+
+print("Get the list of systems by server IDs...")
+systemsPerServer = client.multicast.system.list_systems(hubSessionKey, serverIds)
+successfulResponses = systemsPerServer["Successful"]
+failedResponses = systemsPerServer["Failed"]
+
+if successfulResponses["Responses"]:
+  print(f"Systems responding successfully through a multicast api call:\n{successfulResponses}\n")
+
+if failedResponses["Responses"]:
+  print(f"Systems failing to reply through a multicast api call:\n{failedResponses}\n")
+
+# Log out
+client.hub.logout(hubSessionKey)


### PR DESCRIPTION
## What does this PR change?

I added some useful snippets to test a Hub environment.
Setting up a Hub environment it's quite resource and time consuming, so I don't consider to automate this for now. These scripts will help to run some basic tests in that kind of environment, if you prepare one manually.

Related to the testing card: https://github.com/SUSE/spacewalk/issues/24175

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Ports:
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
