### PR TITLE
BV 5.0 GMC - Minions bootstrapping issues

### DIFF
--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -132,4 +132,4 @@ Feature: Create bootstrap repositories
 
 @sle15sp5s390_minion
   Scenario: Create the bootstrap repository for a SLES 15 SP5 s390x minion
-    When I create the bootstrap repository for "sle15sp5s390_minion" on the server
+    When I create the bootstrap repository for "sle15sp5s390_minion" on the server without flushing

--- a/testsuite/features/build_validation/init_clients/slmicro60_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slmicro60_minion.feature
@@ -28,7 +28,7 @@ Feature: Bootstrap a SL Micro 6.0 Salt minion
   # Following the bootstrapping process, automatic rebooting is disabled.
   # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
   Scenario: Reboot the SL Micro 6.0 minion through SSH
-    When I reboot the "slmicro60_minion" minion through SSH
+    When I reboot the "slmicro60_minion" host through SSH, waiting until it comes back
 
   Scenario: Check the new bootstrapped SL Micro 6.0 minion in System Overview page
     When I wait until onboarding is completed for "slmicro60_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1048,18 +1048,22 @@ When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |p
   end
 end
 
-When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host|
+When(/^I create the bootstrap repository for "([^"]*)" on the server((?: without flushing)?)$/) do |host, without_flushing|
   base_channel = BASE_CHANNEL_BY_CLIENT[product][host]
   channel = CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL[product][base_channel]
   parent_channel = PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL[product][base_channel]
   get_target('server').wait_while_process_running('mgr-create-bootstrap-repo')
+
   cmd =
     if parent_channel.nil?
-      "mgr-create-bootstrap-repo --create #{channel} --with-custom-channels --flush"
+      "mgr-create-bootstrap-repo --create #{channel} --with-custom-channels"
     else
-      "mgr-create-bootstrap-repo --create #{channel} --with-parent-channel #{parent_channel} --with-custom-channels --flush"
+      "mgr-create-bootstrap-repo --create #{channel} --with-parent-channel #{parent_channel} --with-custom-channels"
     end
-  log 'Creating the boostrap repository on the server:'
+
+  cmd += ' --flush' unless without_flushing
+
+  log 'Creating the bootstrap repository on the server:'
   log "  #{cmd}"
   get_target('server').run(cmd)
 end


### PR DESCRIPTION
## What does this PR change?

* Fixing a typo in `Scenario: Reboot the SL Micro 6.0 minion through SSH`
* Specify whether to `--flush` when creating bootstrap repositories

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24593
Port(s): <s>https://github.com/SUSE/spacewalk/pull/24602</s> does not apply to 4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
