### PR TITLE
Avoid executing commands from path

### DIFF
--- a/client/tools/mgr-push/mgr-push.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/client/tools/mgr-push/mgr-push.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/client/tools/mgr-push/rhnpush_config.py
+++ b/client/tools/mgr-push/rhnpush_config.py
@@ -38,11 +38,11 @@ class rhnpushConfigParser:
     _instance = None
 
     def get_ca_bundle_path(self):
-        if os.system("grep -iq '^ID_LIKE=.*suse' /etc/os-release") == 0:
+        if os.system("/usr/bin/grep -iq '^ID_LIKE=.*suse' /etc/os-release") == 0:
             return '/etc/ssl/ca-bundle.pem'
-        if os.system("grep -iq '^ID_LIKE=.*rhel' /etc/os-release") == 0:
+        if os.system("/usr/bin/grep -iq '^ID_LIKE=.*rhel' /etc/os-release") == 0:
             return '/etc/pki/tls/certs/ca-bundle.crt'
-        if os.system("grep -iq '^ID_LIKE=.*debian' /etc/os-release") == 0:
+        if os.system("/usr/bin/grep -iq '^ID_LIKE=.*debian' /etc/os-release") == 0:
             return '/etc/ssl/certs/ca-certificates.crt'
 
     def __init__(self, filename=None, ensure_consistency=False):

--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -281,17 +281,17 @@ ProxyPassReverse /cobbler https://{config['server']}/cobbler
         f"ProxyPassMatch /proxyInternalLoop/(.*)$ https://{config['server']}/$1",
     )
 
-    os.system("chown root:www /etc/rhn/rhn.conf")
-    os.system("chmod 640 /etc/rhn/rhn.conf")
+    os.system("/usr/bin/chown root:www /etc/rhn/rhn.conf")
+    os.system("/usr/bin/chmod 640 /etc/rhn/rhn.conf")
 
 # Make sure permissions are set as desired
-os.system("chown -R wwwrun:www /var/spool/rhn-proxy")
-os.system("chmod -R 750 /var/spool/rhn-proxy")
+os.system("/usr/bin/chown -R wwwrun:www /var/spool/rhn-proxy")
+os.system("/usr/bin/chmod -R 750 /var/spool/rhn-proxy")
 if not os.path.exists("/var/cache/rhn/proxy-auth"):
     os.makedirs("/var/cache/rhn/proxy-auth")
-os.system("chown -R wwwrun:root /var/cache/rhn/proxy-auth")
-os.system("chown -R wwwrun:root /srv/tftpboot")
-os.system("chmod 755 /srv/tftpboot")
+os.system("/usr/bin/chown -R wwwrun:root /var/cache/rhn/proxy-auth")
+os.system("/usr/bin/chown -R wwwrun:root /srv/tftpboot")
+os.system("/usr/bin/chmod 755 /srv/tftpboot")
 
 # Invalidate (remove) possible old proxy auth cache files, based on sha1
 # after migration to sha256 proxy auth cache files.

--- a/containers/proxy-squid-image/proxy-squid-image.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/containers/proxy-squid-image/proxy-squid-image.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/containers/proxy-squid-image/uyuni-configure.py
+++ b/containers/proxy-squid-image/uyuni-configure.py
@@ -15,6 +15,7 @@ with open("/etc/uyuni/config.yaml", encoding="utf-8") as source:
         file_content = config_file.read()
         file_content = re.sub(
             r"cache_dir aufs .*",
+            # pylint: disable-next=inconsistent-quotes
             f"cache_dir aufs /var/cache/squid {str(config['max_cache_size_mb'])} 16 256",
             file_content,
         )
@@ -28,4 +29,4 @@ with open("/etc/uyuni/config.yaml", encoding="utf-8") as source:
         config_file.truncate()
 
 # make sure "squid" is the user and group owner of the cache squid path
-os.system("chown -R squid:squid /var/cache/squid")
+os.system("/usr/bin/chown -R squid:squid /var/cache/squid")

--- a/containers/proxy-ssh-image/proxy-ssh-image.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/containers/proxy-ssh-image/proxy-ssh-image.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/containers/proxy-ssh-image/uyuni-configure.py
+++ b/containers/proxy-ssh-image/uyuni-configure.py
@@ -21,15 +21,15 @@ with open(config_path + "ssh.yaml", encoding="utf-8") as sshSource:
     SSH_PUSH_KEY_DIR = f"{SSH_PUSH_USER_HOME}/.ssh"
 
     # create ssh push tunnel user
-    os.system(f"groupadd -r {SSH_PUSH_USER}")
+    os.system(f"/usr/sbin/groupadd -r {SSH_PUSH_USER}")
     os.system(
-        f'useradd -r -g {SSH_PUSH_USER} -m -d {SSH_PUSH_USER_HOME} -c "susemanager ssh push tunnel" {SSH_PUSH_USER}'
+        f'/usr/sbin/useradd -r -g {SSH_PUSH_USER} -m -d {SSH_PUSH_USER_HOME} -c "susemanager ssh push tunnel" {SSH_PUSH_USER}'
     )
 
     # create .ssh dir in home and set permissions
     os.makedirs(SSH_PUSH_KEY_DIR)
-    os.system(f"chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}")
-    os.system(f"chmod 700 {SSH_PUSH_KEY_DIR}")
+    os.system(f"/usr/bin/chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}")
+    os.system(f"/usr/bin/chmod 700 {SSH_PUSH_KEY_DIR}")
 
     # store the ssh push server/parent key files
     with open(f"{SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}", "w", encoding="utf-8") as file:
@@ -41,13 +41,13 @@ with open(config_path + "ssh.yaml", encoding="utf-8") as sshSource:
 
     # change owner to {SSH_PUSH_USER}
     os.system(
-        f"chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}"
+        f"/usr/bin/chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}"
     )
-    os.system(f"chmod 600 {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}")
+    os.system(f"/usr/bin/chmod 600 {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}")
     os.system(
-        f"chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub"
+        f"/usr/bin/chown {SSH_PUSH_USER}:{SSH_PUSH_USER} {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub"
     )
-    os.system(f"chmod 644 {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub")
+    os.system(f"/usr/bin/chmod 644 {SSH_PUSH_KEY_DIR}/{SSH_PUSH_KEY_FILE}.pub")
 
     # Authorize the server to ssh into this container
     with open(f"{SSH_PUSH_KEY_DIR}/authorized_keys", "w", encoding="utf-8") as file:

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/containers/proxy-tftpd-image/uyuni-configure.py
+++ b/containers/proxy-tftpd-image/uyuni-configure.py
@@ -28,11 +28,11 @@ with open(config_path + "config.yaml", encoding="utf-8") as source:
         file.write(
             f'''# Automatically generated Uyuni Proxy Server configuration file.
 TFTP_USER="tftp"
-TFTP_OPTIONS="{config.get('tftp_options', '')} "
+TFTP_OPTIONS="{config.get("tftp_options", "")} "
 TFTP_DIRECTORY="{tftp_root}"'''
         )
 
-    os.system(f"chmod 640 {tftp_config}")
+    os.system(f"/usr/bin/chmod 640 {tftp_config}")
 
 # Make sure we can read
 if not os.access(tftp_root, os.R_OK | os.X_OK):

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
@@ -195,7 +195,7 @@ public class SyncRepositoriesAction extends RhnAction implements Listable<Conten
         }
 
         // Is this PID running?
-        String[] cmd = {"ps", "-o", "args", "-p", pid};
+        String[] cmd = {"/usr/bin/ps", "-o", "args", "-p", pid};
         SystemCommandExecutor ce = new SystemCommandExecutor();
         ce.execute(cmd);
         return ce.getLastCommandOutput().contains(" " + chan.getLabel() + " ");

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6070,8 +6070,7 @@ public class SystemHandler extends BaseHandler {
                             map.put(csvUuid, record[uuidPos]);
                             map.put(csvSystemId, record[systemIdPos]);
                             map.put(csvStamp, fileStamp);
-                            String[] cmd = {"rpm", "--qf=%{NAME}",
-                                    "-qf", file.getAbsolutePath()};
+                            String[] cmd = {"/usr/bin/rpm", "--qf=%{NAME}", "-qf", file.getAbsolutePath()};
                             map.remove(csvHostname);
                             SystemCommandExecutor ce = new SystemCommandExecutor();
                             if (ce.execute(cmd) == 0) {

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -1809,7 +1809,7 @@ public class PackageManager extends BaseManager {
         }
 
         List<String> cmd = new ArrayList<>();
-        cmd.add(Config.get().getString("rpm.path", "/bin/rpm"));
+        cmd.add("/usr/bin/rpm");
         cmd.add("-qp");
         cmd.add("--changelog");
         cmd.add(f.getPath());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataExtractor.java
@@ -49,12 +49,12 @@ public class PaygAuthDataExtractor {
     private static final Path PAYG_INSTANCE_INFO_JSON = Path.of("/var/cache/rhn/payg.json");
     private static final int VALIDITY_MINUTES = 11;
 
-    private static final String CONNECTION_TIMEOUT_PROPEERRTY = "java.payg.connection_timeout";
-    private static final String WAIT_RESPONSE_TIMEOUT_PROPEERRTY = "java.payg.repsonse_timeout";
+    private static final String CONNECTION_TIMEOUT_PROPERTY = "java.payg.connection_timeout";
+    private static final String WAIT_RESPONSE_TIMEOUT_PROPERTY = "java.payg.repsonse_timeout";
 
     // time in milliseconds
-    private static final int CONNECTION_TIMEOUT = Config.get().getInt(CONNECTION_TIMEOUT_PROPEERRTY, 5000);
-    private static final int RESPONSE_TIMEOUT = Config.get().getInt(WAIT_RESPONSE_TIMEOUT_PROPEERRTY, 20000);
+    private static final int CONNECTION_TIMEOUT = Config.get().getInt(CONNECTION_TIMEOUT_PROPERTY, 5000);
+    private static final int RESPONSE_TIMEOUT = Config.get().getInt(WAIT_RESPONSE_TIMEOUT_PROPERTY, 20000);
 
     private static final Logger LOG = LogManager.getLogger(PaygAuthDataExtractor.class);
 
@@ -65,9 +65,9 @@ public class PaygAuthDataExtractor {
         .create();
 
     public enum OsSpecificExtractor {
-        SLES_EXTRACTOR("SLE", "sudo python3", "script/payg_extract_repo_data.py"),
-        RHEL_EXTRACTOR("RHEL", "sudo /usr/libexec/platform-python", "script/rhui_extract_repo_data.py"),
-        RHEL7_EXTRACTOR("RHEL7", "sudo python", "script/rhui7_extract_repo_data.py");
+        SLES_EXTRACTOR("SLE", "/usr/bin/sudo /usr/bin/python3", "script/payg_extract_repo_data.py"),
+        RHEL_EXTRACTOR("RHEL", "/usr/bin/sudo /usr/libexec/platform-python", "script/rhui_extract_repo_data.py"),
+        RHEL7_EXTRACTOR("RHEL7", "/usr/bin/sudo /usr/bin/python", "script/rhui7_extract_repo_data.py");
 
         private final String osLabel;
         private final String scriptExecutor;
@@ -75,7 +75,7 @@ public class PaygAuthDataExtractor {
 
         /**
          * Constructor
-         * @param osLabelIn the lable
+         * @param osLabelIn the label
          * @param scriptExecutorIn the script executor
          * @param extractorScriptIn the script path
          */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) 2018--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.redhat.rhn.taskomatic.task.repomd;
@@ -100,7 +96,7 @@ public class DebReleaseWriter {
 
     private String toArchString(ChannelArch channelArch) {
         return channelArch.getCompatiblePackageArches().stream().
-               map(a -> a.getLabel().replaceAll("-deb", "")).
+               map(a -> a.getLabel().replace("-deb", "")).
                filter(a -> !("all".equals(a) || "src".equals(a))).
                sorted().collect(Collectors.joining(" "));
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -423,7 +423,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
 
         if (ConfigDefaults.get().isMetadataSigningEnabled()) {
             String[] signCommand = new String[2];
-            signCommand[0] = "mgr-sign-metadata";
+            signCommand[0] = "/usr/bin/mgr-sign-metadata";
             signCommand[1] = prefix + "repomd.xml";
             cmdExecutor.execute(signCommand);
             createdFiles.add(new File(prefix, "repomd.xml.asc"));

--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -138,7 +138,7 @@ public abstract class AbstractMinionBootstrapper {
         }
 
         File knownHostsFile = new File(SALT_SSH_DIR_PATH + "/known_hosts");
-        String cmd = "sudo /usr/bin/ls -la " + knownHostsFile.getPath();
+        String cmd = "/usr/bin/sudo /usr/bin/ls -la " + knownHostsFile.getPath();
         Process prc = Runtime.getRuntime().exec(cmd);
 
         try {

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -414,7 +414,7 @@ public class LoginHelper {
 
     private static String getRpmSchemaVersion(String schemaName) {
         String[] rpmCommand = new String[4];
-        rpmCommand[0] = "rpm";
+        rpmCommand[0] = "/usr/bin/rpm";
         rpmCommand[1] = "-q";
         rpmCommand[2] = "--qf=%{VERSION}-%{RELEASE}";
         rpmCommand[3] = schemaName;

--- a/java/scripts/api/ks-setup.py
+++ b/java/scripts/api/ks-setup.py
@@ -53,7 +53,7 @@ def main():
     client.channel.software.create(key, channel,uniquify( options.prefix.lower() + "-channel"), options.prefix.title() + " channel","channel-ia32","")
 
     #upload the spacewalk koan rpm
-    execute("sudo /usr/bin/rhnpush -u %s -p %s -c %s  --nosig --server=http://%s/APP %s" % (SATELLITE_LOGIN, SATELLITE_PASSWORD, channel, SATELLITE_HOST, options.koan))
+    execute("/usr/bin/sudo /usr/bin/rhnpush -u %s -p %s -c %s  --nosig --server=http://%s/APP %s" % (SATELLITE_LOGIN, SATELLITE_PASSWORD, channel, SATELLITE_HOST, options.koan))
 
     #create activation key
 

--- a/java/spacewalk-java.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/java/spacewalk-java.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/python/spacewalk/common/repo.py
+++ b/python/spacewalk/common/repo.py
@@ -319,7 +319,7 @@ class DpkgRepo:
             # There is a response, so we are dealing with a URL.
             if parse.urlparse(response.url).path.endswith("InRelease"):
                 process = subprocess.Popen(
-                    ["gpg", "--verify", "--homedir", SPACEWALK_GPG_HOMEDIR],
+                    ["/usr/bin/gpg", "--verify", "--homedir", SPACEWALK_GPG_HOMEDIR],
                     stdin=subprocess.PIPE,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
@@ -342,7 +342,7 @@ class DpkgRepo:
                     temp_signature_file.seek(0)
                     process = subprocess.Popen(
                         [
-                            "gpg",
+                            "/usr/bin/gpg",
                             "--verify",
                             "--homedir",
                             SPACEWALK_GPG_HOMEDIR,

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -159,7 +159,7 @@ class ZyppoSync:
             # which are not needed and can cause issues when importing into the RPMDB
             all_keys_file = os.path.join(temp_dir, "_all_keys.gpg")
             args = [
-                "gpg",
+                "/usr/bin/gpg",
                 "-q",
                 "--batch",
                 "--no-options",
@@ -200,7 +200,13 @@ class ZyppoSync:
             )
 
             # Collect GPG keys from reposync Zypper RPM database
-            args = ["rpm", "-q", "gpg-pubkey", "--dbpath", REPOSYNC_ZYPPER_RPMDB_PATH]
+            args = [
+                "/usr/bin/rpm",
+                "-q",
+                "gpg-pubkey",
+                "--dbpath",
+                REPOSYNC_ZYPPER_RPMDB_PATH,
+            ]
             _log_command(args)
             process = subprocess.Popen(args, stdout=subprocess.PIPE)
             for line in process.stdout.readlines():
@@ -227,7 +233,7 @@ class ZyppoSync:
                     # This GPG key has a newer release on the Spacewalk GPG keyring that on the reposync Zypper RPM database.
                     # We delete this key from the RPM database to allow importing the newer version.
                     args = [
-                        "rpm",
+                        "/usr/bin/rpm",
                         "-q",
                         "--dbpath",
                         REPOSYNC_ZYPPER_RPMDB_PATH,
@@ -257,7 +263,7 @@ class ZyppoSync:
                 # pylint: disable-next=consider-using-f-string
                 key_file = os.path.join(temp_dir, "{}.gpg".format(key_id))
                 args = [
-                    "gpg",
+                    "/usr/bin/gpg",
                     "-q",
                     "--batch",
                     "--no-options",
@@ -277,7 +283,7 @@ class ZyppoSync:
                 _log_command(args)
                 subprocess.run(args, check=False)
                 args = [
-                    "rpmkeys",
+                    "/usr/bin/rpmkeys",
                     "-vv",
                     "--dbpath",
                     REPOSYNC_ZYPPER_RPMDB_PATH,
@@ -1005,12 +1011,12 @@ type=rpm-md
             sys.stdout.write(str(msg) + "\n")
             os.system(
                 # pylint: disable-next=consider-using-f-string
-                'awk \'BEGIN {{c=0;}} /BEGIN CERT/{{c++}} {{ print > "{0}/cert." c ".pem"}}\' < {1}'.format(
+                '/usr/bin/awk \'BEGIN {{c=0;}} /BEGIN CERT/{{c++}} {{ print > "{0}/cert." c ".pem"}}\' < {1}'.format(
                     _ssl_capath, self.sslcacert
                 )
             )
             # pylint: disable-next=consider-using-f-string
-            os.system("c_rehash {} 2&>1 /dev/null".format(_ssl_capath))
+            os.system("/usr/bin/c_rehash {} 2&>1 /dev/null".format(_ssl_capath))
             query_params["ssl_capath"] = _ssl_capath
         if self.sslclientcert:
             query_params["ssl_clientcert"] = self.sslclientcert

--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -521,7 +521,7 @@ class RepoSync(object):
             CFG.set("DEBUG", log_level)
             rhnLog.initLOG(log_path, log_level)
             # os.fchown isn't in 2.4 :/
-            os.system("chgrp " + CFG.httpd_group + " " + log_path)
+            os.system("/usr/bin/chgrp " + CFG.httpd_group + " " + log_path)
 
         # pylint: disable-next=consider-using-f-string
         log2disk(0, "Command: %s" % str(sys.argv))

--- a/python/spacewalk/spacewalk-backend.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/python/spacewalk/spacewalk-backend.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/python/test/unit/spacewalk/common/test_repo.py
+++ b/python/test/unit/spacewalk/common/test_repo.py
@@ -347,7 +347,7 @@ class TestCommonRepo:
             # pylint: disable-next=pointless-statement
             mock_popen.assert_called_once
             gpg_args = mock_popen.call_args[0][0]
-            assert gpg_args[0] == "gpg"
+            assert gpg_args[0] == "/usr/bin/gpg"
             assert gpg_args[1] == "--verify"
             assert gpg_args[2] == "--homedir"
             assert gpg_args[3] == "/var/lib/spacewalk/gpgdir"

--- a/spacewalk/admin/salt-secrets-config.py
+++ b/spacewalk/admin/salt-secrets-config.py
@@ -144,7 +144,7 @@ if not all(
     ]
 ):
     os.system(
-        "openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out /etc/salt/pki/api/salt-api.crt -keyout /etc/salt/pki/api/salt-api.key -subj '/CN=localhost'"
+        "/usr/bin/openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out /etc/salt/pki/api/salt-api.crt -keyout /etc/salt/pki/api/salt-api.key -subj '/CN=localhost'"
     )
     os.chown(
         "/etc/salt/pki/api/salt-api.crt",

--- a/spacewalk/admin/spacewalk-admin.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/spacewalk/admin/spacewalk-admin.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/susemanager-utils/susemanager-sls/salt/bootloader/autoinstall.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootloader/autoinstall.sls
@@ -11,10 +11,10 @@ mgr_copy_initrd:
 
 {% set loader_type = salt['cmd.run']('if [ -f /etc/sysconfig/bootloader ]; then source /etc/sysconfig/bootloader 2> /dev/null; fi;
 if [ -z "${LOADER_TYPE}" ]; then
-if [ $(which grubonce 2> /dev/null) ] && [ !$(which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="grub";
-elif [ $(which elilo 2> /dev/null) ] && [ !$(which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="elilo";
+if [ $(/usr/bin/which grubonce 2> /dev/null) ] && [ !$(/usr/bin/which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="grub";
+elif [ $(/usr/bin/which elilo 2> /dev/null) ] && [ !$(/usr/bin/which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="elilo";
 fi;
-fi; echo "${LOADER_TYPE}"', python_shell=True) %}
+fi; /usr/bin/echo "${LOADER_TYPE}"', python_shell=True) %}
 {% if loader_type == 'grub' %}
 mgr_create_grub_entry:
   file.append:
@@ -27,7 +27,7 @@ mgr_create_grub_entry:
 
 mgr_grub_boot_once:
   cmd.run:
-    - name: grubonce "{{ pillar.get('uyuni-reinstall-name') }}"
+    - name: /usr/sbin/grubonce "{{ pillar.get('uyuni-reinstall-name') }}"
     - onchanges:
       - file: mgr_create_grub_entry
 {% elif loader_type == 'elilo' %}
@@ -50,7 +50,7 @@ mgr_set_default_boot:
 
 mgr_elilo_copy_config:
   cmd.run:
-    - name: elilo
+    - name: /sbin/elilo
     - onchanges:
       - file: mgr_create_elilo_entry
       - file: mgr_set_default_boot
@@ -72,7 +72,7 @@ mgr_set_default_boot:
 
 mgr_generate_grubconf:
   cmd.run:
-    - name: grub2-mkconfig -o /boot/grub2/grub.cfg
+    - name: /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
     - onchanges:
       - file: mgr_copy_kernel
       - file: mgr_copy_initrd
@@ -82,7 +82,7 @@ mgr_generate_grubconf:
 
 mgr_autoinstall_start:
   cmd.run:
-    - name: shutdown -r +1
+    - name: /usr/sbin/shutdown -r +1
     - require:
 {% if loader_type == 'grub' %}
       - cmd: mgr_grub_boot_once

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -165,7 +165,7 @@ bootstrap_repo:
 {% set salt_minion_installed = (salt['pkg.info_installed']('venv-salt-minion', attr='version', failhard=False).get('venv-salt-minion', {}).get('version') != None) %}
 check_bootstrap_dbg:
   cmd.run:
-    - name: echo "{{ salt_minion_installed }}"
+    - name: /usr/bin/echo "{{ salt_minion_installed }}"
 {% set venv_available_request = salt_minion_installed or salt['http.query'](bootstrap_repo_url + 'venv-enabled-' + grains['osarch'] + '.txt', status=True, verify_ssl=False) %}
 {# Prefer venv-salt-minion if available and not disabled #}
 {%- set use_venv_salt = salt['pillar.get']('mgr_force_venv_salt_minion') or ((salt_minion_installed or (0 < venv_available_request.get('status', 404) < 300)) and not salt['pillar.get']('mgr_avoid_venv_salt_minion')) %}
@@ -189,10 +189,10 @@ salt-minion-package:
 {# hack until transactional_update.run is fixed to use venv-salt-call #}
 {# Writing  to the future - find latest etc overlay which was created for package installation and use that as etc root #}
 {# this only works here in bootstrap when we are not running in transaction #}
-{%- set pending_transaction_id = salt['cmd.run']('snapper --no-dbus list --columns=number | grep "+" | tr -d "+"', python_shell=True) %}
+{%- set pending_transaction_id = salt['cmd.run']('/usr/bin/snapper --no-dbus list --columns=number | /usr/bin/grep "+" | tr -d "+"', python_shell=True) %}
 {%- if not pending_transaction_id %}
 {#  if we did not get pending transaction id, write to current upperdir #}
-{%- set pending_transaction_id = salt['cmd.run']('snapper --no-dbus list --columns number | grep "*" | tr -d "*"', python_shell=True) %}
+{%- set pending_transaction_id = salt['cmd.run']('/usr/bin/snapper --no-dbus list --columns number | /usr/bin/grep "*" | tr -d "*"', python_shell=True) %}
 {%- endif %}
 {# increase transaction id by 1 since jinja is doing this before new transaction for package install is created #}
 {# this is working under assumption there will be only one transaction between jinja render and actual package installation #}
@@ -316,7 +316,7 @@ salt-minion-master-pub-wipe:
 {{ salt_minion_name }}:
   mgrcompat.module_run:
     - name: transactional_update.run
-    - command: systemctl enable {{ salt_minion_name }}
+    - command: /usr/bin/systemctl enable {{ salt_minion_name }}
     - snapshot: continue
     - require:
       - salt-minion-package
@@ -335,7 +335,7 @@ copy_transactional_conf_file_to_etc:
     - name: /etc/transactional-update.conf
     - source: /usr/etc/transactional-update.conf
     - unless:
-      - test -f /etc/transactional-update.conf
+      - /usr/bin/test -f /etc/transactional-update.conf
 
 transactional_update_set_reboot_method_systemd:
   file.keyvalue:
@@ -348,9 +348,9 @@ transactional_update_set_reboot_method_systemd:
     - require:
       - file: copy_transactional_conf_file_to_etc
     - unless:
-      - grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
+      - /usr/bin/grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
 
 disable_reboot_timer_transactional_minions:
   cmd.run:
-    - name: systemctl disable transactional-update.timer
+    - name: /usr/bin/systemctl disable transactional-update.timer
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -42,7 +42,7 @@ remove_traditional_stack:
 {%- if grains['os_family'] == 'Suse' %}
       - suseRegisterInfo
 {%- endif %}
-    - unless: rpm -q spacewalk-proxy-common || rpm -q spacewalk-common
+    - unless: /usr/bin/rpm -q spacewalk-proxy-common || /usr/bin/rpm -q spacewalk-common
 
 # only removing apt-transport-spacewalk above
 # causes apt-get update to 'freeze' if this

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
@@ -20,7 +20,7 @@
 restart:
   mgrcompat.module_run:
     - name: cmd.run_bg
-    - cmd: "sleep 2; service {{ salt_service }} restart"
+    - cmd: "/usr/bin/sleep 2; /usr/sbin/service {{ salt_service }} restart"
     - python_shell: true
 
 {% else -%}

--- a/susemanager-utils/susemanager-sls/salt/certs/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/init.sls
@@ -8,4 +8,4 @@ mgr_proxy_ca_cert_symlink:
   file.symlink:
     - name: /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
     - target: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
-    - onlyif: grep -Eq "^proxy.rhn_parent *= *[a-zA-Z0-9]+" /etc/rhn/rhn.conf && -e /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+    - onlyif: /usr/bin/grep -Eq "^proxy.rhn_parent *= *[a-zA-Z0-9]+" /etc/rhn/rhn.conf && -e /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT

--- a/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
@@ -3,7 +3,7 @@ enable_ca_store:
   cmd.run:
     - name: /usr/bin/update-ca-trust enable
     - runas: root
-    - unless: "/usr/bin/update-ca-trust check | grep \"PEM/JAVA Status: ENABLED\""
+    - unless: "/usr/bin/update-ca-trust check | /usr/bin/grep \"PEM/JAVA Status: ENABLED\""
 {%- endif %}
 
 mgr_ca_cert:

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -18,7 +18,7 @@ include:
 {%- set dnf_supports_params = is_dnf and salt['pkg.version_cmp'](is_dnf, "4.0.9") >= 0 %}
 
 {%- if is_dnf and not dnf_supports_params %}
-{%- set dnf_plugins = salt['cmd.run']("find /usr/lib -type d -name dnf-plugins -printf '%T@ %p\n' | sort -nr | cut -d ' ' -s -f 2- | head -n 1", python_shell=True) %}
+{%- set dnf_plugins = salt['cmd.run']("/usr/bin/find /usr/lib -type d -name dnf-plugins -printf '%T@ %p\n' | /usr/bin/sort -nr | /usr/bin/cut -d ' ' -s -f 2- | /usr/bin/head -n 1", python_shell=True) %}
 {%- if dnf_plugins %}
 mgrchannels_susemanagerplugin_dnf:
   file.managed:
@@ -44,7 +44,7 @@ mgrchannels_enable_dnf_plugins:
     - pattern: plugins=.*
     - repl: plugins=1
 {#- default is '1' when option is not specififed #}
-    - onlyif: grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
+    - onlyif: /usr/bin/grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
 {%- endif %}
 
 {# this break the susemanagerplugin as it overwrite HTTP headers (bsc#1214601) #}
@@ -53,7 +53,7 @@ mgrchannels_disable_dnf_rhui_plugin:
     - name: /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
     - pattern: enabled=.*
     - repl: enabled=0
-    - onlyif: grep -e 'enabled=1' -e 'enabled=True' -e 'enabled=yes' /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
+    - onlyif: /usr/bin/grep -e 'enabled=1' -e 'enabled=True' -e 'enabled=yes' /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
 
 {%- endif %}
 
@@ -81,7 +81,7 @@ mgrchannels_enable_yum_plugins:
     - name: /etc/yum.conf
     - pattern: plugins=.*
     - repl: plugins=1
-    - onlyif: grep plugins=0 /etc/yum.conf
+    - onlyif: /usr/bin/grep plugins=0 /etc/yum.conf
 
 {%- endif %}
 {%- endif %}
@@ -149,7 +149,7 @@ mgrchannels_dnf_clean_all:
     - runas: root
     - onchanges:
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
-    -  unless: "/usr/bin/dnf repolist | grep \"repolist: 0$\""
+    -  unless: "/usr/bin/dnf repolist | /usr/bin/grep \"repolist: 0$\""
 {%- endif %}
 {%- if is_yum %}
 mgrchannels_yum_clean_all:
@@ -158,7 +158,7 @@ mgrchannels_yum_clean_all:
     - runas: root
     - onchanges: 
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
-    -  unless: "/usr/bin/yum repolist | grep \"repolist: 0$\""
+    -  unless: "/usr/bin/yum repolist | /usr/bin/grep \"repolist: 0$\""
 {%- endif %}
 {%- elif grains['os_family'] == 'Debian' %}
 install_gnupg_debian:

--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -60,7 +60,7 @@ mgr_remove_salt_master_key:
 {%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
 mgr_disable_salt:
   cmd.run:
-    - name: systemctl disable {{ salt_minion_name }}
+    - name: /usr/bin/systemctl disable {{ salt_minion_name }}
     - require:
       - file: mgr_remove_salt_config
 
@@ -68,7 +68,7 @@ mgr_disable_salt:
 mgr_stop_salt:
   cmd.run:
     - bg: True
-    - name: sleep 9 && systemctl stop {{ salt_minion_name }}
+    - name: /usr/bin/sleep 9 && /usr/bin/systemctl stop {{ salt_minion_name }}
     - order: last
     - require:
       - file: mgr_remove_salt_config

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
@@ -18,28 +18,28 @@ mgr_inst_snpguest:
 
 mgr_write_request_data:
   cmd.run:
-    - name: echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | base64 -d > /tmp/cocoattest/request-data.txt
-    - onlyif: test -x /usr/bin/base64
+    - name: /usr/bin/echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | /usr/bin/base64 -d > /tmp/cocoattest/request-data.txt
+    - onlyif: /usr/bin/test -x /usr/bin/base64
     - require:
       - file: mgr_create_attestdir
 
 mgr_create_snpguest_report:
   cmd.run:
-    - name: snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
+    - name: /usr/bin/snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
     - require:
       - cmd: mgr_write_request_data
       - file: mgr_create_attestdir
 
 mgr_snpguest_report:
   cmd.run:
-    - name: cat /tmp/cocoattest/report.bin | base64
+    - name: /usr/bin/cat /tmp/cocoattest/report.bin | /usr/bin/base64
     - require:
       - cmd: mgr_create_snpguest_report
       - file: mgr_create_attestdir
 
 mgr_secureboot_enabled:
   cmd.run:
-    - name: mokutil --sb-state
+    - name: /usr/bin/mokutil --sb-state
     - success_retcodes:
       - 255
       - 0

--- a/susemanager-utils/susemanager-sls/salt/distupgrade/sap.sls
+++ b/susemanager-utils/susemanager-sls/salt/distupgrade/sap.sls
@@ -3,24 +3,24 @@
 
 mgr_remove_release_package:
   cmd.run:
-    - name: "rpm -e --nodeps sles-release"
+    - name: "/usr/bin/rpm -e --nodeps sles-release"
 
 mgr_remove_flavor_package_dvd:
   cmd.run:
-    - name: "rpm -e --nodeps sles-release-DVD"
-    - onlyif: rpm -q sles-release-DVD
+    - name: "/usr/bin/rpm -e --nodeps sles-release-DVD"
+    - onlyif: /usr/bin/rpm -q sles-release-DVD
 
 mgr_remove_flavor_package_pool:
   cmd.run:
-    - name: "rpm -e --nodeps sles-release-POOL"
-    - onlyif: rpm -q sles-release-POOL
+    - name: "/usr/bin/rpm -e --nodeps sles-release-POOL"
+    - onlyif: /usr/bin/rpm -q sles-release-POOL
 
 {% set default_modules = ['SLES_SAP', 'sle-module-basesystem', 'sle-module-desktop-applications', 'sle-module-server-applications', 'sle-ha', 'sle-module-sap-applications'] %}
 
 {% for module in default_modules %}
 mgr_install_product_{{ module }}:
   cmd.run:
-    - name: zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product {{ module }}
+    - name: /usr/bin/zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product {{ module }}
     - require:
       - cmd: mgr_remove_release_package
       - cmd: mgr_remove_flavor_package_dvd

--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -154,7 +154,7 @@ dns_fqdns:
       - mgrcompat: sync_states
 {%- endif %}
     - onlyif:
-        which host || which nslookup
+        /usr/bin/which host || /usr/bin/which nslookup
 {% endif%}
 {% if 'network.fqdns' in salt %}
 fqdns:
@@ -183,7 +183,7 @@ sap_workloads:
 
 uname:
   cmd.run:
-    - name: uname -r -v
+    - name: /usr/bin/uname -r -v
 
 container_runtime:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -42,7 +42,7 @@ mgr_buildimage_prepare_activation_key_in_source:
 {%- if use_kiwi_ng %}
 # KIWI NG
 #
-{%- set kiwi = 'kiwi-ng' %}
+{%- set kiwi = '/usr/bin/kiwi-ng' %}
 
 {%- set kiwi_options = pillar.get('kiwi_options', '') %}
 {%- set bootstrap_packages = ['findutils', 'rhn-org-trusted-ssl-cert-osimage'] %}
@@ -86,12 +86,12 @@ mgr_buildimage_kiwi_bundle:
 # KIWI Legacy
 #
 
-{%- set kiwi_help = salt['cmd.run']('kiwi --help') %}
+{%- set kiwi_help = salt['cmd.run']('/usr/bin/kiwi --help') %}
 {%- set have_bundle_build = kiwi_help.find('--bundle-build') > 0 %}
 
 # i586 build on x86_64 host must be called with linux32
 # let's consider the build i586 if there is no x86_64 repo specified
-{%- set kiwi = 'linux32 kiwi' if (pillar.get('kiwi_repositories')|join(' ')).find('x86_64') == -1 and grains.get('osarch') == 'x86_64' else 'kiwi' %}
+{%- set kiwi = '/usr/bin/linux32 /usr/bin/kiwi' if (pillar.get('kiwi_repositories')|join(' ')).find('x86_64') == -1 and grains.get('osarch') == 'x86_64' else '/usr/bin/kiwi' %}
 
 # in SLES11 Kiwi the --add-repotype is required
 {%- macro kiwi_params() -%}
@@ -141,13 +141,13 @@ mgr_buildimage_kiwi_bundle_dir:
 
 mgr_buildimage_kiwi_bundle_tarball:
   cmd.run:
-    - name: "cd '{{ dest_dir }}' && tar czf '{{ bundle_dir }}'`basename *.packages .packages`-{{ bundle_id }}.tgz --no-recursion `find . -maxdepth 1 -type f`"
+    - name: "cd '{{ dest_dir }}' && /usr/bin/tar czf '{{ bundle_dir }}'`basename *.packages .packages`-{{ bundle_id }}.tgz --no-recursion `/usr/bin/find . -maxdepth 1 -type f`"
     - require:
       - file: mgr_buildimage_kiwi_bundle_dir
 
 mgr_buildimage_kiwi_bundle:
   cmd.run:
-    - name: "cd '{{ bundle_dir }}' && sha256sum *.tgz > `echo *.tgz`.sha256"
+    - name: "cd '{{ bundle_dir }}' && /usr/bin/sha256sum *.tgz > `/usr/bin/echo *.tgz`.sha256"
     - require:
       - cmd: mgr_buildimage_kiwi_bundle_tarball
 

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
@@ -20,6 +20,6 @@ mgr_inspect_kiwi_image:
 
 mgr_kiwi_cleanup:
   cmd.run:
-    - name: "rm -rf '{{ root_dir }}'"
+    - name: "/usr/bin/rm -rf '{{ root_dir }}'"
     - require:
       - mgrcompat: mgr_inspect_kiwi_image

--- a/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
@@ -32,7 +32,7 @@ mgr_container_remove:
     - args: [ "{{ container_name }}" ]
     - force: False
     - onlyif:
-      - docker ps -a | grep "{{ container_name }}" >/dev/null
+      - /usr/bin/docker ps -a | /usr/bin/grep "{{ container_name }}" >/dev/null
 
 mgr_image_remove:
   mgrcompat.module_run:
@@ -85,7 +85,7 @@ mgr_container_remove:
     - args: [ "{{ container_name }}" ]
     - force: False
     - onlyif:
-      - docker ps -a | grep "{{ container_name }}" >/dev/null
+      - /usr/bin/docker ps -a | /usr/bin/grep "{{ container_name }}" >/dev/null
 
 mgr_image_remove:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -24,8 +24,8 @@ modules:
 {% elif grains['os_family'] == 'Debian' %}
 debianrelease:
   cmd.run:
-    - name: cat /etc/os-release
-    - onlyif: test -f /etc/os-release
+    - name: /usr/bin/cat /etc/os-release
+    - onlyif: /usr/bin/test -f /etc/os-release
 {% endif %}
 
 include:

--- a/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
@@ -1,38 +1,38 @@
 {% if grains['os_family'] == 'RedHat' %}
 rhelrelease:
   cmd.run:
-    - name: cat /etc/redhat-release
-    - onlyif: test -f /etc/redhat-release -a ! -L /etc/redhat-release
+    - name: /usr/bin/cat /etc/redhat-release
+    - onlyif: /usr/bin/test -f /etc/redhat-release -a ! -L /etc/redhat-release
 alibabarelease:
   cmd.run:
-    - name: cat /etc/alinux-release
-    - onlyif: test -f /etc/alinux-release
+    - name: /usr/bin/cat /etc/alinux-release
+    - onlyif: /usr/bin/test -f /etc/alinux-release
 centosrelease:
   cmd.run:
-    - name: cat /etc/centos-release
-    - onlyif: test -f /etc/centos-release
+    - name: /usr/bin/cat /etc/centos-release
+    - onlyif: /usr/bin/test -f /etc/centos-release
 oraclerelease:
   cmd.run:
-    - name: cat /etc/oracle-release
-    - onlyif: test -f /etc/oracle-release
+    - name: /usr/bin/cat /etc/oracle-release
+    - onlyif: /usr/bin/test -f /etc/oracle-release
 amazonrelease:
   cmd.run:
-    - name: cat /etc/system-release
-    - onlyif: test -f /etc/system-release && grep -qi Amazon /etc/system-release
+    - name: /usr/bin/cat /etc/system-release
+    - onlyif: /usr/bin/test -f /etc/system-release && /usr/bin/grep -qi Amazon /etc/system-release
 almarelease:
   cmd.run:
-    - name: cat /etc/almalinux-release
-    - onlyif: test -f /etc/almalinux-release
+    - name: /usr/bin/cat /etc/almalinux-release
+    - onlyif: /usr/bin/test -f /etc/almalinux-release
 rockyrelease:
   cmd.run:
-    - name: cat /etc/rocky-release
-    - onlyif: test -f /etc/rocky-release    
+    - name: /usr/bin/cat /etc/rocky-release
+    - onlyif: /usr/bin/test -f /etc/rocky-release
 respkgquery:
   cmd.run:
-    - name: rpm -q --whatprovides 'sles_es-release-server'
-    - onlyif: rpm -q --whatprovides 'sles_es-release-server'
+    - name: /usr/bin/rpm -q --whatprovides 'sles_es-release-server'
+    - onlyif: /usr/bin/rpm -q --whatprovides 'sles_es-release-server'
 sllpkgquery:
   cmd.run:
-    - name: rpm -q --whatprovides 'sll-release'
-    - onlyif: rpm -q --whatprovides 'sll-release'
+    - name: /usr/bin/rpm -q --whatprovides 'sll-release'
+    - onlyif: /usr/bin/rpm -q --whatprovides 'sll-release'
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
+++ b/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
@@ -101,15 +101,15 @@ mgrpxy_installed:
 
         [Service]
         Type=oneshot
-        ExecStart=/bin/bash -c 'mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 2>&1 | tee -a /var/log/mgrpxy_install.log'
+        ExecStart=/bin/bash -c '/usr/bin/mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 2>&1 | /usr/bin/tee -a /var/log/mgrpxy_install.log'
         
         ExecStartPost=/bin/bash -c 'STATUS_OUTPUT=$(mgrpxy status 2>&1); \
-            echo "$STATUS_OUTPUT" | tee -a /var/log/mgrpxy_install.log; \
-            if ! echo "$STATUS_OUTPUT" | grep -q "Error: no installed proxy detected"; then \
-                echo "mgrpxy was successfully {{ mgrpxy_operation }}ed. Removing apply mgrpxy service and configuration file." | tee -a /var/log/mgrpxy_install.log; \
-                rm -f /etc/systemd/system/apply_proxy_config.service; \
+            /usr/bin/echo "$STATUS_OUTPUT" | /usr/bin/tee -a /var/log/mgrpxy_install.log; \
+            if ! /usr/bin/echo "$STATUS_OUTPUT" | /usr/bin/grep -q "Error: no installed proxy detected"; then \
+                /usr/bin/echo "mgrpxy was successfully {{ mgrpxy_operation }}ed. Removing apply mgrpxy service and configuration file." | /usr/bin/tee -a /var/log/mgrpxy_install.log; \
+                /usr/bin/rm -f /etc/systemd/system/apply_proxy_config.service; \
             else \
-                echo "mgrpxy status check failed. Service file will remain for troubleshooting." | tee -a /var/log/mgrpxy_install.log; \
+                /usr/bin/echo "mgrpxy status check failed. Service file will remain for troubleshooting." | /usr/bin/tee -a /var/log/mgrpxy_install.log; \
             fi'
 
         [Install]
@@ -124,7 +124,7 @@ mgrpxy_installed:
 # The system will run this service to enable apply_proxy_config.service after reboot
 enable_apply_proxy_config_service:
   cmd.run:
-    - name: systemctl enable apply_proxy_config.service
+    - name: /usr/bin/systemctl enable apply_proxy_config.service
     - require:
       - file: /etc/systemd/system/apply_proxy_config.service
 
@@ -133,8 +133,8 @@ enable_apply_proxy_config_service:
 apply_proxy_configuration:
   cmd.run:
     - name: >
-        mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 
-        2>&1 | tee -a /var/log/mgrpxy_install.log
+        /usr/bin/mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 
+        2>&1 | /usr/bin/tee -a /var/log/mgrpxy_install.log
     - shell: /bin/bash
     - require:
       - file: /etc/uyuni/proxy/config.yaml

--- a/susemanager-utils/susemanager-sls/salt/reboot.sls
+++ b/susemanager-utils/susemanager-sls/salt/reboot.sls
@@ -1,3 +1,3 @@
 mgr_reboot:
   cmd.run:
-    - name: shutdown -r +5
+    - name: /usr/sbin/shutdown -r +5

--- a/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
+++ b/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
@@ -1,18 +1,18 @@
 {%- if salt['pillar.get']('mgr_reboot_if_needed', True) and salt['pillar.get']('custom_info:mgr_reboot_if_needed', 'true')|lower in ('true', '1', 'yes', 't') %}
 mgr_reboot_if_needed:
   cmd.run:
-    - name: shutdown -r +5
+    - name: /usr/sbin/shutdown -r +5
 {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 8 %}
-    - onlyif: 'dnf -q needs-restarting -r; [ $? -eq 1 ]'
+    - onlyif: '/usr/bin/dnf -q needs-restarting -r; /usr/bin/test $? -eq 1'
 {%- elif grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 7 %}
-    - onlyif: 'needs-restarting -r; [ $? -eq 1 ]'
+    - onlyif: '/usr/bin/needs-restarting -r; /usr/bin/test $? -eq 1'
 {%- elif grains['os_family'] == 'Debian' %}
     - onlyif:
-      - test -e /var/run/reboot-required
+      - /usr/bin/test -e /var/run/reboot-required
 {%- elif grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
     - onlyif:
-      - test -e /boot/do_purge_kernels
+      - /usr/bin/test -e /boot/do_purge_kernels
 {%- else %}
-    - onlyif: 'zypper ps -s; [ $? -eq 102 ]'
+    - onlyif: '/usr/bin/zypper ps -s; [ $? -eq 102 ]'
 {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
@@ -30,8 +30,8 @@ jmx_taskomatic_config:
 
 mgr_enable_prometheus_self_monitoring:
   cmd.run:
-    - name: grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 0/' /etc/rhn/rhn.conf || echo 'prometheus_monitoring_enabled = 0' >> /etc/rhn/rhn.conf
+    - name: /usr/bin/grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && /usr/bin/sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 0/' /etc/rhn/rhn.conf || /usr/bin/echo 'prometheus_monitoring_enabled = 0' >> /etc/rhn/rhn.conf
 
 mgr_is_prometheus_self_monitoring_disabled:
   cmd.run:
-    - name: grep -qF 'prometheus_monitoring_enabled = 0' /etc/rhn/rhn.conf
+    - name: /usr/bin/grep -qF 'prometheus_monitoring_enabled = 0' /etc/rhn/rhn.conf

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
@@ -141,8 +141,8 @@ jmx_exporter_taskomatic_service_cleanup:
 
 mgr_enable_prometheus_self_monitoring:
   cmd.run:
-    - name: grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 1/' /etc/rhn/rhn.conf || echo 'prometheus_monitoring_enabled = 1' >> /etc/rhn/rhn.conf
+    - name:  /usr/bin/grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && /usr/bin/sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 1/' /etc/rhn/rhn.conf || /usr/bin/echo 'prometheus_monitoring_enabled = 1' >> /etc/rhn/rhn.conf
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
-    - name: grep -qF 'prometheus_monitoring_enabled = 1' /etc/rhn/rhn.conf
+    - name: /usr/bin/grep -qF 'prometheus_monitoring_enabled = 1' /etc/rhn/rhn.conf

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
@@ -22,7 +22,7 @@ jmx_taskomatic_java_config:
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
-    - name: grep -q -E 'prometheus_monitoring_enabled\s*=\s*(1|y|true|yes|on)\s*$' /etc/rhn/rhn.conf
+    - name: /usr/bin/grep -q -E 'prometheus_monitoring_enabled\s*=\s*(1|y|true|yes|on)\s*$' /etc/rhn/rhn.conf
 
 include:
   - util.syncstates

--- a/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
@@ -37,7 +37,7 @@ proxy_ssh_identity:
 
 generate_own_ssh_key:
   cmd.run:
-    - name: ssh-keygen -N '' -C 'susemanager-own-ssh-push' -f {{ home }}/.ssh/mgr_own_id -t rsa -q
+    - name: /usr/bin/ssh-keygen -N '' -C 'susemanager-own-ssh-push' -f {{ home }}/.ssh/mgr_own_id -t rsa -q
     - creates: {{ home }}/.ssh/mgr_own_id.pub
 
 ownership_own_ssh_key:

--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -4,17 +4,17 @@ include:
 {%- if grains['os_family'] == 'Suse' %}
 mgr_keep_system_up2date_updatestack:
   cmd.run:
-    - name: zypper --non-interactive patch --updatestack-only
+    - name: /usr/bin/zypper --non-interactive patch --updatestack-only
     - success_retcodes:
       - 104
       - 103
       - 106
       - 0
-    - onlyif: 'zypper patch-check --updatestack-only; r=$?; test $r -eq 100 || test $r -eq 101'
+    - onlyif: '/usr/bin/zypper patch-check --updatestack-only; r=$?; /usr/bin/test $r -eq 100 || /usr/bin/test $r -eq 101'
     - require:
       - sls: channels
 
-{% set patch_need_reboot = salt['cmd.retcode']('zypper -x list-patches | grep \'restart="true"\' > /dev/null', python_shell=True) %}
+{% set patch_need_reboot = salt['cmd.retcode']('/usr/bin/zypper -x list-patches | /usr/bin/grep \'restart="true"\' > /dev/null', python_shell=True) %}
 
 {% else %}
 

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
@@ -9,7 +9,7 @@ mgr_disable_fqdns_grains:
   file.append:
     - name: {{ susemanager_minion_config }}
     - text: "enable_fqdns_grains: False"
-    - unless: grep 'enable_fqdns_grains:' {{ susemanager_minion_config }}
+    - unless: /usr/bin/grep 'enable_fqdns_grains:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
@@ -10,7 +10,7 @@ mgr_disable_mine:
   file.managed:
     - name: {{ susemanager_minion_config }}
     - contents: "mine_enabled: False"
-    - unless: grep 'mine_enabled:' {{ susemanager_minion_config }}
+    - unless: /usr/bin/grep 'mine_enabled:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_rotate_saltssh_key.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_rotate_saltssh_key.sls
@@ -12,7 +12,7 @@ proxy_new_mgr_ssh_identity:
   ssh_auth.present:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/new_mgr_ssh_id.pub
-    - onlyif: grep -q mgrsshtunnel /etc/passwd
+    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
 {% endif %}
 
 {% if salt['cp.list_master'](prefix='salt_ssh/disabled_mgr_ssh_id.pub') %}
@@ -33,12 +33,12 @@ proxy_old_mgr_ssh_identity:
   ssh_auth.absent:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/disabled_mgr_ssh_id.pub
-    - onlyif: grep -q mgrsshtunnel /etc/passwd
+    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
 
 # to prevent to lock out yourself
 proxy_current_mgr_ssh_identity:
   ssh_auth.present:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/mgr_ssh_id.pub
-    - onlyif: grep -q mgrsshtunnel /etc/passwd
+    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
@@ -8,4 +8,4 @@ mgr_start_event_grains:
     - name: {{ susemanager_minion_config }}
     - text: |
         start_event_grains: [machine_id, saltboot_initrd, susemanager]
-    - unless: grep 'start_event_grains:' {{ susemanager_minion_config }}
+    - unless: /usr/bin/grep 'start_event_grains:' {{ susemanager_minion_config }}

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
@@ -27,11 +27,11 @@ mgr_copy_salt_minion_id:
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
-      - test -f /etc/salt/minion_id
+      - /usr/bin/test -f /etc/salt/minion_id
 
 mgr_copy_salt_minion_configs:
   cmd.run:
-    - name: cp -r /etc/salt/minion.d /etc/venv-salt-minion/
+    - name: /usr/bin/cp -r /etc/salt/minion.d /etc/venv-salt-minion/
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
@@ -44,17 +44,17 @@ mgr_copy_salt_minion_grains:
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
-      - test -f /etc/salt/grains
+      - /usr/bin/test -f /etc/salt/grains
 
 mgr_copy_salt_minion_keys:
   cmd.run:
-    - name: cp -r /etc/salt/pki/minion/minion* /etc/venv-salt-minion/pki/minion/
+    - name: /usr/bin/cp -r /etc/salt/pki/minion/minion* /etc/venv-salt-minion/pki/minion/
     - require:
       - cmd: mgr_copy_salt_minion_configs
     - onlyif:
-      - test -f /etc/salt/pki/minion/minion_master.pub
+      - /usr/bin/test -f /etc/salt/pki/minion/minion_master.pub
     - unless:
-      - test -f /etc/venv-salt-minion/pki/minion/minion_master.pub
+      - /usr/bin/test -f /etc/venv-salt-minion/pki/minion/minion_master.pub
 
 mgr_enable_venv_salt_minion:
   service.running:
@@ -91,9 +91,9 @@ mgr_purge_non_venv_salt_packages:
 {%- if salt['pillar.get']('mgr_purge_non_venv_salt_files') %}
 mgr_purge_non_venv_salt_pki_dir:
   cmd.run:
-    - name: rm -rf /etc/salt/minion* /etc/salt/pki/minion
+    - name: /usr/bin/rm -rf /etc/salt/minion* /etc/salt/pki/minion
     - onlyif:
-      - test -d /etc/salt/pki/minion
+      - /usr/bin/test -d /etc/salt/pki/minion
     - require:
       - service: mgr_disable_salt_minion
 
@@ -101,7 +101,7 @@ mgr_purge_non_venv_salt_conf_dir:
   file.absent:
     - name: /etc/salt
     - unless:
-      - find /etc/salt -type f -print -quit | grep -q .
+      - /usr/bin/find /etc/salt -type f -print -quit | /usr/bin/grep -q .
     - require:
       - cmd: mgr_purge_non_venv_salt_pki_dir
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -798,7 +798,7 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
                 log(err, 2)
                 return 1
         else:
-            os.system("createrepo -s sha256 %s" % destdirtmp)
+            os.system("/usr/bin/createrepo -s sha256 %s" % destdirtmp)
         # ensure venv-enabled-{ARCH}.txt doesn't exist in repo with no salt bundle package
         # create venv-enabled-{ARCH}.txt for repos with salt bundle package
         for file_path in glob.glob(os.path.join(destdirtmp, "venv-enabled-*.txt")):

--- a/susemanager/susemanager.changes.mackdk.avoid-executing-commands-from-PATH
+++ b/susemanager/susemanager.changes.mackdk.avoid-executing-commands-from-PATH
@@ -1,0 +1,1 @@
+- Use absolute paths when invoking external commands


### PR DESCRIPTION
## What does this PR change?

This PR uses absolute paths when invoking commands to avoid using the `PATH` environment variable and thus avoid being subjected to possible environment injection attacks.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24387

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
