### PR TITLE
change Errata cve column to type text

### DIFF
--- a/schema/reportdb/common/tables/Errata.sql
+++ b/schema/reportdb/common/tables/Errata.sql
@@ -21,7 +21,7 @@ CREATE TABLE Errata
     severity                      VARCHAR(64),
     reboot_required               BOOLEAN NOT NULL DEFAULT FALSE,
     affects_package_manager       BOOLEAN NOT NULL DEFAULT FALSE,
-    cve                           VARCHAR(4000),
+    cve                           TEXT,
     synopsis                      VARCHAR(4000),
     organization                  VARCHAR(128),
     synced_date                   TIMESTAMPTZ DEFAULT (current_timestamp)

--- a/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.5-to-uyuni-reportdb-schema-5.0.6/001-alter-errata-cve-column.sql
+++ b/schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.5-to-uyuni-reportdb-schema-5.0.6/001-alter-errata-cve-column.sql
@@ -1,0 +1,37 @@
+DO $$
+  BEGIN
+    IF (SELECT data_type FROM information_schema.columns WHERE table_name = 'errata' AND column_name = 'cve') != 'text' THEN
+      DROP VIEW IF EXISTS ErrataListReport;
+
+      ALTER TABLE errata ALTER COLUMN cve TYPE text;
+
+      CREATE OR REPLACE VIEW ErrataListReport AS
+        SELECT Errata.mgm_id
+            , Errata.errata_id
+            , Errata.advisory_name
+            , Errata.advisory_type
+            , Errata.cve
+            , Errata.synopsis
+            , Errata.issue_date
+            , Errata.update_date
+            , COUNT(SystemErrata.system_id) AS affected_systems
+            , Errata.synced_date
+        FROM Errata
+            LEFT JOIN SystemErrata ON ( Errata.mgm_id = SystemErrata.mgm_id AND Errata.errata_id = SystemErrata.errata_id )
+        GROUP BY Errata.mgm_id
+            , Errata.errata_id
+            , Errata.advisory_name
+            , Errata.advisory_type
+            , Errata.cve
+            , Errata.synopsis
+            , Errata.issue_date
+            , Errata.update_date
+            , Errata.synced_date
+        ORDER BY Errata.mgm_id, Errata.advisory_name
+        ;
+    ELSE
+      RAISE NOTICE 'errata column cve is already of type text.';
+    END IF;
+  END;
+$$;
+

--- a/schema/reportdb/uyuni-reportdb-schema.changes.mc.master
+++ b/schema/reportdb/uyuni-reportdb-schema.changes.mc.master
@@ -1,0 +1,1 @@
+- change Errata cve column to type text as a varchar reaches the maximum (bsc#1226478)


### PR DESCRIPTION
## What does this PR change?

Errata table has a column defined as VARCHAR(4000) which is the maximum.
But new patches - especially kernel - have huge lists of CVE ids that we go over this maximum and updating the report DB
failed with:

```
ERROR: value too long for type character varying(4000)
```

This change the type to "TEXT" which should be able to take everything what is provided.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24607

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
