### PR TITLE
adapt packages to check for modifications

### DIFF
--- a/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
@@ -230,7 +230,8 @@ def perform_compliants_checks():
             cloudProvider = "GCE"
 
         modifiedPackages = (
-            has_package_modifications("csp-billing-adapter-service")
+            has_package_modifications("python-instance-billing-flavor-check")
+            or has_package_modifications("csp-billing-adapter-service")
             or has_package_modifications("python3-csp-billing-adapter")
             or has_package_modifications("python3-csp-billing-adapter-local")
         )
@@ -239,10 +240,8 @@ def perform_compliants_checks():
                 "python3-csp-billing-adapter-amazon"
             )
         elif cloudProvider == "AZURE":
-            modifiedPackages = (
-                modifiedPackages
-                or has_package_modifications("python311-azure-mgmt-billing")
-                or has_package_modifications("python3-csp-billing-adapter-microsoft")
+            modifiedPackages = modifiedPackages or has_package_modifications(
+                "python3-csp-billing-adapter-microsoft"
             )
 
         billing_service_running = is_service_running("csp-billing-adapter.service")

--- a/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
@@ -218,13 +218,13 @@ def check_billing_adapter_status():
 def perform_compliants_checks():
     # defaults
     cloudProvider = "None"
-    modifiedPackages = False
+    modified_packages = False
     billing_service_running = False
     billing_status = False
     has_metering_access = False
-    isPaygInstance = is_payg_instance()
+    is_payg = is_payg_instance()
 
-    if isPaygInstance:
+    if is_payg:
         if os.path.isfile("/usr/bin/ec2metadata"):
             cloudProvider = "AWS"
         elif os.path.isfile("/usr/bin/azuremetadata"):
@@ -232,22 +232,17 @@ def perform_compliants_checks():
         elif os.path.isfile("/usr/bin/gcemetadata"):
             cloudProvider = "GCE"
 
-        modifiedPackages = any(
-            has_package_modifications(pkg)
-            for pkg in [
-                "python-instance-billing-flavor-check",
-                "csp-billing-adapter-service",
-                "python3-csp-billing-adapter-local",
-            ]
-        )
+        check_pkgs = [
+            "python-instance-billing-flavor-check",
+            "csp-billing-adapter-service",
+            "python3-csp-billing-adapter-local",
+        ]
         if cloudProvider == "AWS":
-            modifiedPackages = modifiedPackages or has_package_modifications(
-                "python3-csp-billing-adapter-amazon"
-            )
+            check_pkgs.append("python3-csp-billing-adapter-amazon")
         elif cloudProvider == "AZURE":
-            modifiedPackages = modifiedPackages or has_package_modifications(
-                "python3-csp-billing-adapter-microsoft"
-            )
+            check_pkgs.append("python3-csp-billing-adapter-microsoft")
+
+        modified_packages = any(has_package_modifications(pkg) for pkg in check_pkgs)
 
         billing_service_running = is_service_running("csp-billing-adapter.service")
 
@@ -260,14 +255,14 @@ def perform_compliants_checks():
         has_metering_access
         and billing_service_running
         and billing_status
-        and not modifiedPackages
+        and not modified_packages
     )
 
     return {
-        "isPaygInstance": isPaygInstance,
+        "isPaygInstance": is_payg,
         "compliant": compliant,
         "cloudProvider": cloudProvider,
-        "hasModifiedPackages": modifiedPackages,
+        "hasModifiedPackages": modified_packages,
         "billingServiceRunning": billing_service_running,
         "billingServiceStatus": billing_status,
         "hasMeteringAccess": has_metering_access,

--- a/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-extract-data.py
@@ -197,7 +197,10 @@ def check_billing_adapter_status():
         try:
             with open(cnf, encoding="utf-8") as f:
                 cspConfig = json.load(f)
-                if len(cspConfig["errors"]) > 0:
+                if (
+                    not cspConfig["billing_api_access_ok"]
+                    and len(cspConfig["errors"]) > 0
+                ):
                     errstr = "\n  ".join(cspConfig["errors"])
                     print(
                         f"CPS Billing Adapter reported errors:\n  {errstr}",
@@ -229,11 +232,13 @@ def perform_compliants_checks():
         elif os.path.isfile("/usr/bin/gcemetadata"):
             cloudProvider = "GCE"
 
-        modifiedPackages = (
-            has_package_modifications("python-instance-billing-flavor-check")
-            or has_package_modifications("csp-billing-adapter-service")
-            or has_package_modifications("python3-csp-billing-adapter")
-            or has_package_modifications("python3-csp-billing-adapter-local")
+        modifiedPackages = any(
+            has_package_modifications(pkg)
+            for pkg in [
+                "python-instance-billing-flavor-check",
+                "csp-billing-adapter-service",
+                "python3-csp-billing-adapter-local",
+            ]
         )
         if cloudProvider == "AWS":
             modifiedPackages = modifiedPackages or has_package_modifications(

--- a/uyuni/uyuni-payg-timer/uyuni-payg-timer.changes.mc.fix-pkglist-uyuni-payg-timer
+++ b/uyuni/uyuni-payg-timer/uyuni-payg-timer.changes.mc.fix-pkglist-uyuni-payg-timer
@@ -1,0 +1,1 @@
+- adapt packages to check for modifications


### PR DESCRIPTION
## What does this PR change?

The list of packages to check for compliance was wrong.
- python311-azure-mgmt-billing was removed as it is not on the image anymore
- python-instance-billing-flavor-check was added as it tells us if we are PAYG or not

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
