### PR TITLE
Fix the cobbler test pipeline scripts

### DIFF
--- a/susemanager-utils/testing/docker/scripts/Makefile
+++ b/susemanager-utils/testing/docker/scripts/Makefile
@@ -14,8 +14,9 @@ pull_container ::
 
 cobbler_tests :: pull_container
 	@echo "Running cobbler tests"
-	docker run --rm -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh $(DOCKER_CONTAINER) /test_cobbler.sh
+	docker run --rm --cap-add=NET_ADMIN -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh $(DOCKER_CONTAINER) /test_cobbler.sh
 
 cobbler_tests_shell ::
 	@echo "Spawning a shell inside of the cobbler tests container"
-	docker run --rm -ti -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh $(DOCKER_CONTAINER) /bin/bash
+	@echo "See /test_cobbler.sh for Cobbler env setup"
+	docker run --rm --cap-add=NET_ADMIN -ti -v $(CURDIR)/../../../../cobbler_reports:/reports -v $(CURDIR)/test_cobbler.sh:/test_cobbler.sh $(DOCKER_CONTAINER) /bin/bash


### PR DESCRIPTION
## What does this PR change?

This PR fixes the Cobbler Jenkins pipeline that is failing with the `127.0.0.1 != 192.168.1.1` errors.

### Related code

NOTE: This PR depends on the container modifications in OBS and IBS changes.

**Cobbler**:

- https://github.com/openSUSE/cobbler/pull/94
- https://github.com/openSUSE/cobbler/pull/95
- https://github.com/openSUSE/cobbler/pull/96
- https://github.com/openSUSE/cobbler/pull/97

**OBS**:

- 1181964

**IBS**:

- 336382
- 336383


## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/20850

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
