### PR TITLE
Update profile name (standart not available anymore)

### DIFF
--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -31,7 +31,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
-    And I enter "--profile standard" as "params"
+    And I enter "--profile xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary" as "params"
     And I enter "/usr/share/xml/scap/ssg/content/ssg-centos8-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text


### PR DESCRIPTION
## What does this PR change?

Profile standard is not available anymore for `openscap ssg-centos8-xccdf.xml`.
Switch to ANSSI-BP-028 (intermediary) profile. For more info see : https://github.com/SUSE/spacewalk/issues/24629 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24629

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
