### PR TITLE
Fix salt minion PKI directory cleanup with bootstrap script

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -934,14 +934,14 @@ if [ -n "$SNAPSHOT_ID" ]; then
 fi
 
 MINION_ID_FILE="${{SNAPSHOT_PREFIX}}/etc/salt/minion_id"
-MINION_PKI_CONF="${{SNAPSHOT_PREFIX}}/etc/salt/pki"
+MINION_PKI_CONF="${{SNAPSHOT_PREFIX}}/etc/salt/pki/minion"
 MINION_CONFIG_DIR="${{SNAPSHOT_PREFIX}}/etc/salt/minion.d"
 SUSEMANAGER_MASTER_FILE="${{MINION_CONFIG_DIR}}/susemanager.conf"
 MINION_SERVICE="salt-minion"
 
 if [ $VENV_ENABLED -eq 1 ]; then
     MINION_ID_FILE="${{SNAPSHOT_PREFIX}}/etc/venv-salt-minion/minion_id"
-    MINION_PKI_CONF="${{SNAPSHOT_PREFIX}}/etc/venv-salt-minion/pki"
+    MINION_PKI_CONF="${{SNAPSHOT_PREFIX}}/etc/venv-salt-minion/pki/minion"
     MINION_CONFIG_DIR="${{SNAPSHOT_PREFIX}}/etc/venv-salt-minion/minion.d"
     SUSEMANAGER_MASTER_FILE="${{MINION_CONFIG_DIR}}/susemanager.conf"
     MINION_SERVICE="venv-salt-minion"

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -950,6 +950,14 @@ fi
 if [ $REGISTER_THIS_BOX -eq 1 ]; then
     echo "* registering"
 
+    PREV_MASTER="$(sed -n 's/^master: //p' $SUSEMANAGER_MASTER_FILE 2> /dev/null)"
+    # Remove old minion keys so reregistration do different master works
+    # Delete the pki config only in case of changing the master
+    if [ -d "$MINION_PKI_CONF" -a "$HOSTNAME" != "$PREV_MASTER" ]; then
+        echo "* removing old Salt PKI files"
+        rm -r "$MINION_PKI_CONF"
+    fi
+
     echo "$MYNAME" > "$MINION_ID_FILE"
     cat <<EOF > "$SUSEMANAGER_MASTER_FILE"
 master: $HOSTNAME
@@ -990,11 +998,6 @@ system-environment:
       _:
         SALT_RUNNING: 1
 EOF
-
-# Remove old minion keys so reregistration do different master works
-if [ -d "$MINION_PKI_CONF" ]; then
-    rm -r "$MINION_PKI_CONF"
-fi
 
 if [ -n "$SNAPSHOT_ID" ]; then
     cat <<EOF >> "${{MINION_CONFIG_DIR}}/transactional_update.conf"

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.vzhestkov.fix-pki-dir-deletion
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.vzhestkov.fix-pki-dir-deletion
@@ -1,0 +1,1 @@
+- Remove PKI of salt minion only in case of changing the master with the bootstrap script


### PR DESCRIPTION
## What does this PR change?

In case of second run of bootstrap script when the minion is already tried to authenticate to the master it's possible that PKI directory will be removed and the minion key regenerated, so that the master will get two (or even more) keys with the same minion ID.

Additionally: set PKI config directory to be more precise to prevent possible deletion of master PKI directory in case if bootstrap script will try to bootstrap the salt master host with classic `salt-minion` package.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: in some test it was already causing errors, so it seems that some of the tests are covering it already.

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
