### PR TITLE
update last sync refresh timestamp only when products were synced

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/common/ManagerInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/common/ManagerInfoFactory.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.common.db.datasource.Row;
 import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.product.SUSEProductFactory;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -61,10 +62,13 @@ public class ManagerInfoFactory extends HibernateFactory {
     }
 
     /**
-     * set last mgr-sync refresh to now
+     * set last mgr-sync refresh to now.
+     * It will be executed only when also products were at least one time synced.
      */
     public static void setLastMgrSyncRefresh() {
-        setLastMgrSyncRefresh(System.currentTimeMillis());
+        if (SUSEProductFactory.hasProducts()) {
+            setLastMgrSyncRefresh(System.currentTimeMillis());
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -109,8 +109,8 @@ public class SUSEProductFactory extends HibernateFactory {
      * @return return true if any products are available, otherwise false
      */
     public static boolean hasProducts() {
-        return getSession().createQuery("SELECT productId FROM SUSEProduct")
-                .stream().findAny().isPresent();
+        return getSession().createQuery("SELECT count(p) > 0 FROM SUSEProduct p", Boolean.class)
+            .uniqueResult();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -106,6 +106,14 @@ public class SUSEProductFactory extends HibernateFactory {
     }
 
     /**
+     * @return return true if any products are available, otherwise false
+     */
+    public static boolean hasProducts() {
+        return getSession().createQuery("SELECT productId FROM SUSEProduct")
+                .stream().findAny().isPresent();
+    }
+
+    /**
      * @return map of all {@link SUSEProductSCCRepository} by ID triple
      */
     public static Map<Tuple3<Long, Long, Long>, SUSEProductSCCRepository> allProductReposByIds() {

--- a/java/code/src/com/redhat/rhn/domain/scc/test/SCCCachingFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/scc/test/SCCCachingFactoryTest.java
@@ -92,6 +92,14 @@ public class SCCCachingFactoryTest extends BaseTestCaseWithUser {
         ManagerInfoFactory.setLastMgrSyncRefresh();
         Optional<Date> lastRefreshDate = ManagerInfoFactory.getLastMgrSyncRefresh();
 
+        // no products synced - this should prevent setting the date
+        assertTrue(lastRefreshDate.isEmpty(), "Last refresh date is unexpectedly set");
+
+        SUSEProductTestUtils.createVendorSUSEProducts();
+        ManagerInfoFactory.setLastMgrSyncRefresh();
+        lastRefreshDate = ManagerInfoFactory.getLastMgrSyncRefresh();
+        assertTrue(lastRefreshDate.isPresent(), "Last refresh date is unexpectedly empty");
+
         // Repos are newer than credentials -> no refresh
         assertFalse(SCCCachingFactory.refreshNeeded(lastRefreshDate));
 

--- a/java/spacewalk-java.changes.mc.fix-product-refresh-in-cloud
+++ b/java/spacewalk-java.changes.mc.fix-product-refresh-in-cloud
@@ -1,0 +1,2 @@
+- update last sync refresh timestamp only when at least one time
+  products were synced before


### PR DESCRIPTION
## What does this PR change?

update last sync refresh timestamp only when at least one time products were synced before.
This happens when PAYG Update Task only refreshing repositories, but never products were synchronized

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were updated

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24717

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
