### PR TITLE
add bootstrap repository data for Liberty Linux 7 LTSS

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -814,6 +814,18 @@ DATA = {
         "PKGLIST": RES7 + RES7_X86,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
     },
+    "SLL7-LTSS-x86_64": {
+        "PDID": [2702, 1683],
+        "BETAPDID": [2065],
+        "PKGLIST": RES7 + RES7_X86,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
+    },
+    "SLL7-OL-LTSS-x86_64": {
+        "PDID": [2778, 1683],
+        "BETAPDID": [2065],
+        "PKGLIST": RES7 + RES7_X86,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
+    },
     "SLE-12-SP2-aarch64": {
         "PDID": 1375,
         "BETAPDID": [1744],

--- a/susemanager/susemanager.changes.mc.sll-7-ltss-bootstrap-repo
+++ b/susemanager/susemanager.changes.mc.sll-7-ltss-bootstrap-repo
@@ -1,0 +1,1 @@
+- add bootstrap repository data for Liberty Linux 7 LTSS (bsc#1226958)


### PR DESCRIPTION
## What does this PR change?

Bootstrap repo data for Linerty Linux 7 LTSS is missing

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/24652

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
