### PR TITLE
Add Micro OS, SLE Micro and Leap Micro to metadata refresh step

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -295,7 +295,7 @@ When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   node = get_target(host)
   os_family = node.os_family
   case os_family
-  when /^opensuse/, /^sles/
+  when /^opensuse/, /^sles/, /micro/
     node.run_until_ok('zypper --non-interactive refresh -s')
   when /^centos/, /^rocky/
     node.run('yum clean all && yum makecache', timeout: 600)


### PR DESCRIPTION
## What does this PR change?

In order to avoid this error:
```
# bsc#1085436 - Apache returns 403 Forbidden after a zypper refresh on minion
Scenario: Check the new channel is working
When I refresh the metadata for "slemicro54_minion"
       The host slemicro54_minion has not yet a implementation for that step (ScriptError)
       ./features/step_definitions/common_steps.rb:305:in `/^I refresh the metadata for "([^"]*)"$/'
       features/build_validation/migration/slemicro54_minion_migration.feature:78:in
        `I refresh the metadata for "slemicro54_minion"'
```

add Micro OS, SLE Micro and Leap Micro to metadata refresh step.


## Links

Port(s):
* 4.3:  https://github.com/SUSE/spacewalk/pull/24662


## Changelogs

- [x] No changelog needed
