### PR TITLE
BV 5.0 GMC - salt migration minion testsuite errors

### DIFF
--- a/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
@@ -33,8 +33,8 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     And I wait until I do not see "Loading..." text
     And I check radio button "SLE-Product-SLES15-SP5-Pool for x86_64"
     And I wait until I see "SLE-Module-Basesystem15-SP5-Pool for x86_64" text
-    And I check "SLE-Manager-Tools15-Pool for x86_64 SP4"
-    And I check "SLE-Manager-Tools15-Updates for x86_64 SP4"
+    And I check "SLE-Manager-Tools15-Pool for x86_64 SP5"
+    And I check "SLE-Manager-Tools15-Updates for x86_64 SP5"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
@@ -70,6 +70,7 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "file /etc/salt/minion.d"
+    And I enter the hostname of "salt_migration_minion" as "target"
     And I click on preview
     Then I should see "salt_migration_minion" hostname
     And I wait until I do not see "pending" text
@@ -78,6 +79,7 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     And I expand the results for "salt_migration_minion"
     Then I should see "/etc/salt/minion.d: cannot open `/etc/salt/minion.d' (No such file or directory)" in the command output for "salt_migration_minion"
     When I enter command "file /etc/venv-salt-minion/minion.d"
+    And I enter the hostname of "salt_migration_minion" as "target"
     And I click on preview
     Then I should see "salt_migration_minion" hostname
     And I wait until I do not see "pending" text


### PR DESCRIPTION
## What does this PR change?

* Fixes typos in salt migration minion regarding channels selection.
* Shortens remote command list to only one required result.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24659
Port(s): https://github.com/SUSE/spacewalk/pull/24663

- [ ] **DONE**

## Changelogs

- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
