### PR TITLE
Delay pkg refresh if needed

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -49,6 +49,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -145,7 +147,7 @@ public class JobReturnEventMessageAction implements MessageAction {
         Optional<Boolean> isActionChainResult = isActionChainResult(jobReturnEvent);
         boolean isActionChainInvolved = isActionChainResult.filter(isActionChain -> isActionChain).orElse(false);
         isActionChainResult.filter(isActionChain -> isActionChain).ifPresent(isActionChain -> {
-            if (!jobResult.isPresent()) {
+            if (jobResult.isEmpty()) {
                 return;
             }
             AtomicReference<Optional<User>> scheduler = new AtomicReference<>(Optional.empty());
@@ -199,36 +201,49 @@ public class JobReturnEventMessageAction implements MessageAction {
                     actionChainResult,
                     stateResult -> false);
 
-            boolean packageRefreshNeeded = !isFunctionTestMode && actionChainResult.entrySet().stream()
+            if (isFunctionTestMode) {
+                return;
+            }
+
+            Set<PackageChangeOutcome> packageRefreshNeeded = actionChainResult.entrySet().stream()
                     .map(entry -> SaltActionChainGeneratorService.parseActionChainStateId(entry.getKey())
                             .map(stateId -> handlePackageChanges(jobReturnEvent, entry.getValue().getName(),
                                     Optional.ofNullable(entry.getValue().getChanges().getRet())))
-                            .orElse(false))
-                    .collect(Collectors.toList())//This is needed to make sure we don't return early but execute
-                    .stream()                    // handlePackageChange for all the results in actions chain result.
-                    .anyMatch(Boolean.TRUE::equals);
-            if (packageRefreshNeeded) {
+                            .orElse(PackageChangeOutcome.DONE)
+                    ).collect(Collectors.toSet());
+
+            if (packageRefreshNeeded.contains(PackageChangeOutcome.NEEDS_DELAYED_REFRESHING)) {
+                schedulePackageRefresh(scheduler.get(), jobReturnEvent.getMinionId(),
+                                       Date.from(Instant.now().plusSeconds(60)));
+            }
+            else if (packageRefreshNeeded.contains(PackageChangeOutcome.NEEDS_REFRESHING)) {
                 schedulePackageRefresh(scheduler.get(), jobReturnEvent.getMinionId());
             }
         });
 
         //For all jobs except when action chains are involved or the action was in test mode
-        if (!isActionChainInvolved && !isFunctionTestMode && handlePackageChanges(jobReturnEvent,
-                Optional.ofNullable(function).map(Xor::right), jobResult)) {
+        if (!isActionChainInvolved && !isFunctionTestMode) {
             Date earliest = new Date();
-            Optional<User> scheduler = Optional.empty();
-            if (actionId.isPresent()) {
-                Optional<Action> action = Optional.ofNullable(ActionFactory.lookupById(actionId.get()));
-                if (action.isPresent()) {
-                    scheduler = Optional.ofNullable(action.get().getSchedulerUser());
-                    if (action.get().getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE)) {
-                        Calendar calendar = Calendar.getInstance();
-                        calendar.add(Calendar.SECOND, 30);
-                        earliest = calendar.getTime();
+            PackageChangeOutcome changeOutcome = handlePackageChanges(jobReturnEvent,
+                            Optional.ofNullable(function).map(Xor::right), jobResult);
+            if (changeOutcome != PackageChangeOutcome.DONE) {
+                if (changeOutcome == PackageChangeOutcome.NEEDS_DELAYED_REFRESHING) {
+                    earliest = Date.from(Instant.now().plusSeconds(60));
+                }
+                Optional<User> scheduler = Optional.empty();
+                if (actionId.isPresent()) {
+                    Optional<Action> action = Optional.ofNullable(ActionFactory.lookupById(actionId.get()));
+                    if (action.isPresent()) {
+                        scheduler = Optional.ofNullable(action.get().getSchedulerUser());
+                        if (action.get().getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE)) {
+                            Calendar calendar = Calendar.getInstance();
+                            calendar.add(Calendar.SECOND, 30);
+                            earliest = calendar.getTime();
+                        }
                     }
                 }
+                schedulePackageRefresh(scheduler, jobReturnEvent.getMinionId(), earliest);
             }
-            schedulePackageRefresh(scheduler, jobReturnEvent.getMinionId(), earliest);
         }
 
         // Check if event was triggered in response to state scheduled at minion start-up event
@@ -296,29 +311,30 @@ public class JobReturnEventMessageAction implements MessageAction {
      * @param jobReturnEvent jobReturnEvent
      * @param function salt module name
      * @param jobResult result
-     * @return return false If there is enough information to update database with new Package information(delta)
-     *         return true If information is not enough and a full package refresh is needed
+     * @return return a PackageChangeOutcome
+     *         DONE when there is enough information to update database with new Package information(delta)
+     *         NEEDS_REFRESHING when information is not enough and a full package refresh is needed.
+     *         If a refresh should happen with a delay, NEEDS_DELAYED_REFRESHING is returned
      */
-    private boolean handlePackageChanges(JobReturnEvent jobReturnEvent, Optional<Xor<String[], String>> function,
-                                                Optional<JsonElement> jobResult) {
+    private PackageChangeOutcome handlePackageChanges(JobReturnEvent jobReturnEvent,
+                    Optional<Xor<String[], String>> function, Optional<JsonElement> jobResult) {
 
         return MinionServerFactory.findByMinionId(jobReturnEvent.getMinionId()).flatMap(minionServer ->
                 jobResult.map(result -> {
-                    boolean fullPackageRefreshNeeded = false;
+                    PackageChangeOutcome refreshType = PackageChangeOutcome.DONE;
                     try {
-                        if (forcePackageListRefresh(jobReturnEvent) ||
-                                saltUtils.handlePackageChanges(function, result,
-                                        minionServer) ==  PackageChangeOutcome.NEEDS_REFRESHING) {
-                            fullPackageRefreshNeeded = true;
-                        }
+                        refreshType = saltUtils.handlePackageChanges(function, result, minionServer);
                     }
                      catch (JsonParseException e) {
                         LOG.warn("Could not determine if packages changed in call to {} because of a parse error",
                                  function, e);
                     }
-                    return fullPackageRefreshNeeded;
+                    if (refreshType == PackageChangeOutcome.DONE && forcePackageListRefresh(jobReturnEvent)) {
+                        refreshType = PackageChangeOutcome.NEEDS_REFRESHING;
+                    }
+                    return refreshType;
                 })
-        ).orElse(false);
+        ).orElse(PackageChangeOutcome.DONE);
     }
 
     /**

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -224,7 +224,11 @@ public class SaltUtils {
         /**
          * A separate full refresh is necessary.
          */
-        NEEDS_REFRESHING
+        NEEDS_REFRESHING,
+        /**
+         * A separate full refresh is necessary, but salt was updated and we need delay refreshing
+         */
+        NEEDS_DELAYED_REFRESHING
     }
 
     /**
@@ -353,6 +357,13 @@ public class SaltUtils {
         );
 
         if (fullRefreshNeeded) {
+            boolean needDelay = changes.entrySet()
+                    .stream().anyMatch(e ->
+                            e.getKey().startsWith("salt") ||
+                                    e.getKey().equals("venv-salt-minion"));
+            if (needDelay) {
+                return PackageChangeOutcome.NEEDS_DELAYED_REFRESHING;
+            }
             return PackageChangeOutcome.NEEDS_REFRESHING;
         }
         else {
@@ -461,12 +472,10 @@ public class SaltUtils {
                 .sorted(Comparator.comparingInt(StateApplyResult::getRunNum))
                 .collect(Collectors.toList());
         for (StateApplyResult<JsonElement> value : collect) {
-              Map<String, Change<Xor<String, List<Pkg.Info>>>> delta =
-                      extractPackageDelta(value.getChanges());
-
-            if (applyChangesFromStateModule(delta, server) ==
-                    PackageChangeOutcome.NEEDS_REFRESHING) {
-                return PackageChangeOutcome.NEEDS_REFRESHING;
+            Map<String, Change<Xor<String, List<Pkg.Info>>>> delta = extractPackageDelta(value.getChanges());
+            PackageChangeOutcome changeOutcome = applyChangesFromStateModule(delta, server);
+            if (changeOutcome != PackageChangeOutcome.DONE) {
+                return changeOutcome;
             }
         }
         return PackageChangeOutcome.DONE;

--- a/java/spacewalk-java.changes.mc.delay-pkg-refresh-if-needed
+++ b/java/spacewalk-java.changes.mc.delay-pkg-refresh-if-needed
@@ -1,0 +1,1 @@
+- delay package list refresh when salt was updated (bsc#1217978)


### PR DESCRIPTION
## What does this PR change?

Delay the package list refresh when salt was updated to give the daemon time to restart

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23193
Port(s): https://github.com/SUSE/spacewalk/pull/24955 https://github.com/SUSE/spacewalk/pull/25246

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
