### PR TITLE
Disable transactional-update.timer on SLEM at bootstrap

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -341,4 +341,11 @@ transactional_update_set_reboot_method_systemd:
     - unless:
       - grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
 
+{# Cannot use the service module due to dbus, disable service manually #}
+{% set systemd_timer_file = '/etc/systemd/system/timers.target.wants/transactional-update.timer' %}
+{%- if salt['file.file_exists'](systemd_timer_file) %}
+disable_reboot_timer_transactional_minions:
+  file.absent:
+    - name: {{ systemd_timer_file }}
+{%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -341,11 +341,7 @@ transactional_update_set_reboot_method_systemd:
     - unless:
       - grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
 
-{# Cannot use the service module due to dbus, disable service manually #}
-{% set systemd_timer_file = '/etc/systemd/system/timers.target.wants/transactional-update.timer' %}
-{%- if salt['file.file_exists'](systemd_timer_file) %}
 disable_reboot_timer_transactional_minions:
-  file.absent:
-    - name: {{ systemd_timer_file }}
-{%- endif %}
+  cmd.run:
+    - name: systemctl disable transactional-update.timer
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.disable-slem-timer-on-bootstrap
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.disable-slem-timer-on-bootstrap
@@ -1,0 +1,1 @@
+- Disable transactional-update.timer on SLEM at bootstrap


### PR DESCRIPTION
## What does this PR change?

When bootstrapping SLEM, disable the SLEM's reboot timer so that it does not interfere with SUMA's timed work, e.g. reposyncing or other scheduled work.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation

- Documentation PR: https://github.com/uyuni-project/uyuni/pull/8981

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/24251

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
