### PR TITLE
Fix package profile update on CentOS 7 when yum-utils is not installed

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1536,8 +1536,10 @@ public class SaltUtils {
                 .orElse(null));
 
         result.getRebootRequired()
-                .map(flag -> (Boolean) flag.getChanges().getRet().get("reboot_required"))
-                .ifPresent(flag -> server.setRebootRequiredAfter(flag ? new Date() : null));
+            .map(rr -> rr.getChanges().getRet())
+            .filter(Objects::nonNull)
+            .map(ret -> (Boolean) ret.get("reboot_required"))
+            .ifPresent(flag -> server.setRebootRequiredAfter(flag ? new Date() : null));
 
         // Update live patching version
         server.setKernelLiveVersion(result.getKernelLiveVersionInfo()

--- a/java/spacewalk-java.changes.welder.fix-centos7-pkg-profile-update
+++ b/java/spacewalk-java.changes.welder.fix-centos7-pkg-profile-update
@@ -1,0 +1,1 @@
+- Fix package profile update on CentOS 7 when yum-utils is not installed (bsc#1227133)

--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -53,6 +53,10 @@ status_uptime:
 reboot_required:
   mgrcompat.module_run:
     - name: reboot_info.reboot_required
+    {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] < 8 %}
+    - onlyif:
+      - which needs-restarting
+    {%- endif %}
 {%- endif %}
 
 kernel_live_version:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.welder.fix-centos7-pkg-profile-update
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.welder.fix-centos7-pkg-profile-update
@@ -1,0 +1,1 @@
+- Fix package profile update on CentOS 7 when yum-utils is not installed (bsc#1227133)


### PR DESCRIPTION
## What does this PR change?

Bug fix, see title.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
