### PR TITLE
Fix payg race condition

### DIFF
--- a/java/code/src/com/suse/cloud/CloudPaygManager.java
+++ b/java/code/src/com/suse/cloud/CloudPaygManager.java
@@ -124,6 +124,12 @@ public class CloudPaygManager {
      * @return true when a refresh happened, otherwise false
      */
     public boolean checkRefreshCache(boolean force) {
+        if (complainceInfo != null &&
+                !complainceInfo.isPaygInstance() &&
+                complainceInfo.getCloudProvider() == CloudProvider.None &&
+                Files.isReadable(PAYG_COMPLIANCE_INFO_JSON)) {
+            force = true;
+        }
         // if isCompliant is false, we re-detect
         if (force || !isCompliant || Duration.between(cacheTime, Instant.now()).toHours() >= 1) {
             // cached values older than 1 hour - time to refresh

--- a/java/code/src/com/suse/cloud/CloudPaygManager.java
+++ b/java/code/src/com/suse/cloud/CloudPaygManager.java
@@ -143,7 +143,7 @@ public class CloudPaygManager {
 
     private boolean detectHasSCCCredentials() {
         return CredentialsFactory.listSCCCredentials().stream()
-                .anyMatch(c -> mgr.isSCCCredentials(c));
+                .anyMatch(mgr::isSCCCredentials);
     }
 
     private boolean detectIsCompliant() {

--- a/java/spacewalk-java.changes.mc.fix-payg-race-condition
+++ b/java/spacewalk-java.changes.mc.fix-payg-race-condition
@@ -1,0 +1,2 @@
+- fix a race condition during PAYG setup by re-detecting compliance
+  when the instance report BYOS but payg_compliance.json is available


### PR DESCRIPTION
## What does this PR change?

During setup we first setup the container which start without the payg*.json files.
It will think it is a BYOS setup.
After the container is running, we call `uyuni-payg-extract-data` from mgradm to perform the detection and create the files.
But the container is running and the next detection will be done just 1 hour later.

This PR check if the complianceInfo report BYOS and no Cloud Provider, but the payg_compliance.json file exits and is readable.
In this case it force a re-detection.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24677

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
