### PR TITLE
Remove cobbler synchronization when adding system

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
@@ -28,7 +28,6 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.kickstart.KickstartFormatter;
 import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
-import com.redhat.rhn.manager.satellite.CobblerSyncCommand;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 
 import org.apache.commons.lang3.StringUtils;
@@ -324,7 +323,7 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
         if (saveCobblerId && server != null) {
             server.setCobblerId(rec.getId());
         }
-        return new CobblerSyncCommand(user).store();
+        return null;
     }
 
     private void processRedHatManagementKeys(SystemRecord rec, Profile profile) {

--- a/java/spacewalk-java.changes.mczernek.mczernek_1219450
+++ b/java/spacewalk-java.changes.mczernek.mczernek_1219450
@@ -1,0 +1,1 @@
+- Do not explicitly trigger Cobbler sync when adding a system via SUMA API

--- a/java/spacewalk-java.changes.mczernek.mczernek_1219450
+++ b/java/spacewalk-java.changes.mczernek.mczernek_1219450
@@ -1,1 +1,2 @@
 - Do not explicitly trigger Cobbler sync when adding a system via SUMA API
+  (bsc#1219450)

--- a/schema/spacewalk/common/data/rhnTaskoSchedule.sql
+++ b/schema/spacewalk/common/data/rhnTaskoSchedule.sql
@@ -22,7 +22,7 @@ INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
 INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
     VALUES(sequence_nextval('rhn_tasko_schedule_id_seq'), 'cobbler-sync-default',
         (SELECT id FROM rhnTaskoBunch WHERE name='cobbler-sync-bunch'),
-        current_timestamp, '0 * * * * ?');
+        current_timestamp, '0 0/5 * * * ?');
 
 INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
     VALUES(sequence_nextval('rhn_tasko_schedule_id_seq'), 'channel-repodata-default',

--- a/schema/spacewalk/susemanager-schema.changes.mczernek.mczernek_1219450
+++ b/schema/spacewalk/susemanager-schema.changes.mczernek.mczernek_1219450
@@ -1,0 +1,1 @@
+- Execute the cobbler-sync-default task once per 5 minutes by default

--- a/schema/spacewalk/susemanager-schema.changes.mczernek.mczernek_1219450
+++ b/schema/spacewalk/susemanager-schema.changes.mczernek.mczernek_1219450
@@ -1,1 +1,2 @@
 - Execute the cobbler-sync-default task once per 5 minutes by default
+  (bsc#1219450)


### PR DESCRIPTION
## What does this PR change?

When using the API to add a system, the API explicitly triggers a Cobbler synchronization. This should not be necessary because:

a) Cobbler shouldn't need a sync after adding a system
b) There is the `cobbler-sync-default` task in SUMA to schedule Cobbler sync periodically.

The default cadence of executing the `cobbler-sync-default` is every minute. This can be computationally expensive in large environments that add/remove a lot of systems in a short period of time, esp. because one `cobbler sync` can take longer than 5 minutes.

In this PR, I'm increasing the default schedule from 1 minute to every 5 minutes.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23775

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
