### PR TITLE
Do not throw exception if the nonce/report are not available

### DIFF
--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
@@ -85,9 +85,19 @@ public class SNPGuestWorker implements AttestationWorker {
 
              LOGGER.debug("Loaded report {}", report);
              if (report.getCpuGeneration() == EpycGeneration.UNKNOWN) {
-                 appendError("Unable to identify Epyc processor generation for attestation report");
+                appendError("Unable to identify Epyc processor generation for attestation report");
                 return false;
             }
+
+            if (report.getRandomNonce() == null || report.getRandomNonce().length == 0) {
+                appendError("Unable to verify: randomized nonce not found");
+                return false;
+            }
+
+             if (report.getReport() == null || report.getReport().length == 0) {
+                 appendError("Unable to verify: attestation report not found");
+                 return false;
+             }
 
             try (var workingDir = directoryProvider.createDirectoryFor(result.getId(), report)) {
                 // Ensure the nonce is present in the report

--- a/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/SNPGuestWorkerTest.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/SNPGuestWorkerTest.java
@@ -138,6 +138,7 @@ class SNPGuestWorkerTest {
         verifyNoInteractions(sequenceFinder);
         verifyNoInteractions(snpWrapper);
     }
+
     @Test
     @DisplayName("Rejects report if processor model is unknown")
     void rejectsWithUnknownProcessorModel() {
@@ -148,6 +149,102 @@ class SNPGuestWorkerTest {
         assertEquals(
             String.join(System.lineSeparator(),
                 "- Unable to identify Epyc processor generation for attestation report",
+                ""
+            ),
+            result.getProcessOutput()
+        );
+
+        // Verify no files have been created
+        verifyNoInteractions(directoryProvider);
+
+        // Verify no checks have been performed
+        verifyNoInteractions(sequenceFinder);
+        verifyNoInteractions(snpWrapper);
+    }
+
+    @Test
+    @DisplayName("Rejects report if nonce is null")
+    void rejectsWithNullNonce() {
+        // Set the model as UNKNOWN
+        report.setRandomNonce(null);
+        report.setReport("REPORT".getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(worker.process(session, result));
+        assertEquals(
+            String.join(System.lineSeparator(),
+                "- Unable to verify: randomized nonce not found",
+                ""
+            ),
+            result.getProcessOutput()
+        );
+
+        // Verify no files have been created
+        verifyNoInteractions(directoryProvider);
+
+        // Verify no checks have been performed
+        verifyNoInteractions(sequenceFinder);
+        verifyNoInteractions(snpWrapper);
+    }
+
+    @Test
+    @DisplayName("Rejects report if nonce is empty")
+    void rejectsWithEmptyNonce() {
+        // Set the model as UNKNOWN
+        report.setRandomNonce(new byte[0]);
+        report.setReport("REPORT".getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(worker.process(session, result));
+        assertEquals(
+            String.join(System.lineSeparator(),
+                "- Unable to verify: randomized nonce not found",
+                ""
+            ),
+            result.getProcessOutput()
+        );
+
+        // Verify no files have been created
+        verifyNoInteractions(directoryProvider);
+
+        // Verify no checks have been performed
+        verifyNoInteractions(sequenceFinder);
+        verifyNoInteractions(snpWrapper);
+    }
+
+    @Test
+    @DisplayName("Rejects report if data is null")
+    void rejectsWithNullReport() {
+        // Set the model as UNKNOWN
+        report.setReport(null);
+        report.setRandomNonce("NONCE".getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(worker.process(session, result));
+        assertEquals(
+            String.join(System.lineSeparator(),
+                "- Unable to verify: attestation report not found",
+                ""
+            ),
+            result.getProcessOutput()
+        );
+
+        // Verify no files have been created
+        verifyNoInteractions(directoryProvider);
+
+        // Verify no checks have been performed
+        verifyNoInteractions(sequenceFinder);
+        verifyNoInteractions(snpWrapper);
+    }
+
+    @Test
+    @DisplayName("Rejects report if data is empty")
+    void rejectsWithEmptyReport() {
+        // Set the model as UNKNOWN
+        report.setReport(new byte[0]);
+        report.setRandomNonce("NONCE".getBytes(StandardCharsets.UTF_8));
+
+        assertFalse(worker.process(session, result));
+        assertEquals(
+            String.join(System.lineSeparator(),
+                "- Unable to verify: attestation report not found",
                 ""
             ),
             result.getProcessOutput()

--- a/microservices/coco-attestation/uyuni-coco-attestation.changes.mackdk.attestation-fix-report-missing
+++ b/microservices/coco-attestation/uyuni-coco-attestation.changes.mackdk.attestation-fix-report-missing
@@ -1,0 +1,2 @@
+- Ensure the report and the nonce are not empty before attempting 
+  to validate


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with the snpguest attestation module. Currently, when the report is not present (because the attestation action failed) a `NullPointerException` is thrown. This change handles this edge case and notifies of the problem in the log.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
