### PR TITLE
Mark Secure Boot as succeeded only if the correct message is present in the output

### DIFF
--- a/microservices/coco-attestation/attestation-module-secureboot/src/main/java/com/suse/coco/module/secureboot/SecureBootWorker.java
+++ b/microservices/coco-attestation/attestation-module-secureboot/src/main/java/com/suse/coco/module/secureboot/SecureBootWorker.java
@@ -38,10 +38,12 @@ public class SecureBootWorker implements AttestationWorker {
             result.setDetails(secureBootMsg);
             String bootMsgLowerCase = secureBootMsg.toLowerCase();
             // got these messages from mokutil source code
-            return !bootMsgLowerCase.contains("secureboot disabled") &&
+            return bootMsgLowerCase.contains("secureboot enabled") &&
+                    !bootMsgLowerCase.contains("secureboot disabled") &&
                     !bootMsgLowerCase.contains("is disabled in shim") &&
                     !bootMsgLowerCase.contains("cannot determine secure boot state") &&
-                    !bootMsgLowerCase.contains("failed to read");
+                    !bootMsgLowerCase.contains("failed to read") &&
+                    !bootMsgLowerCase.contains("efi variables are not supported on this system");
         }
         catch (Exception ex) {
             LOGGER.error("Unable to process attestation result {}", result.getId(), ex);

--- a/microservices/coco-attestation/attestation-module-secureboot/src/test/java/com/suse/coco/module/secureboot/SecureBootWorkerTest.java
+++ b/microservices/coco-attestation/attestation-module-secureboot/src/test/java/com/suse/coco/module/secureboot/SecureBootWorkerTest.java
@@ -52,14 +52,20 @@ class SecureBootWorkerTest {
         result.setStatus(AttestationStatus.PENDING);
         result.setReportId(5L);
 
-        reportMessages = Map.of(1L, "SecureBoot enabled\n",
-                2L, "SecureBoot enabled\nSecureBoot validation is disabled in shim\n",
-                3L, "SecureBoot disabled\n",
-                4L, "SecureBoot disabled\nPlatform is in Setup Mode\n",
-                5L, "Cannot determine secure boot state.\n",
-                6L, "Failed to read \"SetupMode\" variable: XYZ\n",
-                7L, "Failed to read \"SecureBoot\" variable: ABC\n"
-                );
+        reportMessages = Map.ofEntries(
+            Map.entry(1L, "SecureBoot enabled\n"),
+            Map.entry(2L, "SecureBoot enabled\nSecureBoot validation is disabled in shim\n"),
+            Map.entry(3L, "SecureBoot disabled\n"),
+            Map.entry(4L, "SecureBoot disabled\nPlatform is in Setup Mode\n"),
+            Map.entry(5L, "Cannot determine secure boot state.\n"),
+            Map.entry(6L, "Failed to read \"SetupMode\" variable: XYZ\n"),
+            Map.entry(7L, "Failed to read \"SecureBoot\" variable: ABC\n"),
+            Map.entry(8L, "EFI variables are not supported on this system\n"),
+            Map.entry(9L, "This system doesn't support Secure Boot\n"),
+            Map.entry(10L, "Could not allocate space: reasons\n"),
+            Map.entry(11L, "Totally unexpected error message\n")
+        );
+
         // Common mocking
         when(session.selectOne(eq("SecureBootModule.retrieveReport"), anyLong()))
                 .thenAnswer(invocation -> reportMessages.get(invocation.getArgument(1, Long.class)));

--- a/microservices/coco-attestation/attestation-module-secureboot/src/test/java/com/suse/coco/module/secureboot/SecureBootWorkerTest.java
+++ b/microservices/coco-attestation/attestation-module-secureboot/src/test/java/com/suse/coco/module/secureboot/SecureBootWorkerTest.java
@@ -14,10 +14,7 @@
  */
 package com.suse.coco.module.secureboot;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.suse.coco.model.AttestationResult;
@@ -26,12 +23,14 @@ import com.suse.coco.model.AttestationStatus;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
+import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
 class SecureBootWorkerTest {
@@ -43,8 +42,6 @@ class SecureBootWorkerTest {
 
     private SecureBootWorker worker;
 
-    private Map<Long, String> reportMessages;
-
     @BeforeEach
     public void setup() {
         result = new AttestationResult();
@@ -52,41 +49,37 @@ class SecureBootWorkerTest {
         result.setStatus(AttestationStatus.PENDING);
         result.setReportId(5L);
 
-        reportMessages = Map.ofEntries(
-            Map.entry(1L, "SecureBoot enabled\n"),
-            Map.entry(2L, "SecureBoot enabled\nSecureBoot validation is disabled in shim\n"),
-            Map.entry(3L, "SecureBoot disabled\n"),
-            Map.entry(4L, "SecureBoot disabled\nPlatform is in Setup Mode\n"),
-            Map.entry(5L, "Cannot determine secure boot state.\n"),
-            Map.entry(6L, "Failed to read \"SetupMode\" variable: XYZ\n"),
-            Map.entry(7L, "Failed to read \"SecureBoot\" variable: ABC\n"),
-            Map.entry(8L, "EFI variables are not supported on this system\n"),
-            Map.entry(9L, "This system doesn't support Secure Boot\n"),
-            Map.entry(10L, "Could not allocate space: reasons\n"),
-            Map.entry(11L, "Totally unexpected error message\n")
-        );
-
-        // Common mocking
-        when(session.selectOne(eq("SecureBootModule.retrieveReport"), anyLong()))
-                .thenAnswer(invocation -> reportMessages.get(invocation.getArgument(1, Long.class)));
-
         worker = new SecureBootWorker();
     }
 
-    @Test
+    @ParameterizedTest(name = "Expecting {1} with message {2}")
     @DisplayName("Test secure boot messages")
-    void testSecureBootMessages() {
+    @MethodSource("messagesProvider")
+    void testSecureBootMessages(long reportId, boolean expectedOutcome, String message) {
+        // Setting the report id we're retrieving
+        result.setReportId(reportId);
 
-        reportMessages.forEach((k, v) -> {
-            result.setReportId(k);
-            if (k.equals(1L)) {
-                // success
-                assertTrue(worker.process(session, result));
-            }
-            else {
-                // errors
-                assertFalse(worker.process(session, result));
-            }
-        });
+        // Mock the report retrieval
+        when(session.selectOne("SecureBootModule.retrieveReport", reportId))
+            .thenReturn(message);
+
+        // Ensure the result is correct
+        assertEquals(expectedOutcome, worker.process(session, result));
+    }
+
+    static Stream<Arguments> messagesProvider() {
+        return Stream.of(
+            Arguments.of(1L, true, "SecureBoot enabled\n"),
+            Arguments.of(2L, false, "SecureBoot enabled\nSecureBoot validation is disabled in shim\n"),
+            Arguments.of(3L, false, "SecureBoot disabled\n"),
+            Arguments.of(4L, false, "SecureBoot disabled\nPlatform is in Setup Mode\n"),
+            Arguments.of(5L, false, "Cannot determine secure boot state.\n"),
+            Arguments.of(6L, false, "Failed to read \"SetupMode\" variable: XYZ\n"),
+            Arguments.of(7L, false, "Failed to read \"SecureBoot\" variable: ABC\n"),
+            Arguments.of(8L, false, "EFI variables are not supported on this system\n"),
+            Arguments.of(9L, false, "This system doesn't support Secure Boot\n"),
+            Arguments.of(10L, false, "Could not allocate space: reasons\n"),
+            Arguments.of(11L, false, "Totally unexpected error message\n")
+        );
     }
 }

--- a/microservices/coco-attestation/uyuni-coco-attestation.changes.mackdk.attestation-fix-secureboot
+++ b/microservices/coco-attestation/uyuni-coco-attestation.changes.mackdk.attestation-fix-secureboot
@@ -1,0 +1,2 @@
+- Mark Secure Boot as succeeded only if the correct message is 
+  present


### PR DESCRIPTION
## What does this PR change?

This PR changes the behaviour of the Secure Boot validation to ensure the text `SecureBoot enabled` is present in the output from mokutil in order to mark the result as `SUCCEEDED`. Currently if we get a different errors from the expected one, we could potentailly mark a failed test as correct.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
