### PR TITLE
include proxy products for aarch64

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFamilyFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFamilyFactory.java
@@ -44,6 +44,7 @@ public class ChannelFamilyFactory extends HibernateFactory {
     public static final String TOOLS_CHANNEL_FAMILY_LABEL = "SLE-M-T";
     public static final String SATELLITE_CHANNEL_FAMILY_LABEL = "SMS";
     public static final String PROXY_CHANNEL_FAMILY_LABEL = "SMP";
+    public static final String PROXY_ARM_CHANNEL_FAMILY_LABEL = "SMP-ARM64";
     public static final String MODULE_CHANNEL_FAMILY_LABEL = "MODULE";
     public static final String OPENSUSE_CHANNEL_FAMILY_LABEL = "OPENSUSE";
 

--- a/java/code/src/com/redhat/rhn/domain/cloudpayg/PaygProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/cloudpayg/PaygProductFactory.java
@@ -185,7 +185,9 @@ public class PaygProductFactory extends HibernateFactory {
         ChannelFamily family = product.getChannelFamily();
         String version = product.getVersion();
 
-        return ChannelFamilyFactory.PROXY_CHANNEL_FAMILY_LABEL.equals(family.getLabel()) &&
+        // This exclude ALPHA and BETA versions
+        return List.of(ChannelFamilyFactory.PROXY_CHANNEL_FAMILY_LABEL,
+                        ChannelFamilyFactory.PROXY_ARM_CHANNEL_FAMILY_LABEL).contains(family.getLabel()) &&
             RPM_VERSION_COMPARATOR.compare(version, "4.3") >= 0;
     }
 

--- a/java/spacewalk-java.changes.mc.payg-proxy-product-for-aarch64
+++ b/java/spacewalk-java.changes.mc.payg-proxy-product-for-aarch64
@@ -1,0 +1,2 @@
+- show SUSE Manager Proxy for different architectures when using
+  SUSE Manager Server PAYG


### PR DESCRIPTION
## What does this PR change?

The Proxy product exist now also for aarch64. This got a different Channel Family.
To show this correctly, we need to check for "startwith()".
This will also allow to see "BETA" versions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24672

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
