### PR TITLE
Removed usages of deprecated SnakeYAML `SafeConstructor()`

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -38,6 +38,7 @@ import com.suse.utils.Opt;
 import org.apache.commons.collections.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -327,7 +328,7 @@ public class FormulaFactory {
         File layoutFileManager = new File(metadataDirManager + layoutFilePath);
         File layoutFileCustom = new File(METADATA_DIR_CUSTOM + layoutFilePath);
 
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         try {
             if (layoutFileStandalone.exists()) {
                 return Optional.of((Map<String, Object>) yaml.load(new FileInputStream(layoutFileStandalone)));
@@ -613,7 +614,7 @@ public class FormulaFactory {
         File metadataFileManager = new File(metadataDirManager + metadataFilePath);
         File metadataFileCustom = new File(METADATA_DIR_CUSTOM + metadataFilePath);
 
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         try {
             if (metadataFileStandalone.isFile()) {
                 return (Map<String, Object>) yaml.load(new FileInputStream(metadataFileStandalone));
@@ -666,7 +667,7 @@ public class FormulaFactory {
         File pillarExampleFileManager = new File(metadataDirManager + pillarExamplePath);
         File pillarExampleFileCustom = new File(METADATA_DIR_CUSTOM + pillarExamplePath);
 
-        Yaml yaml = new Yaml(new SafeConstructor());
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
         try {
             if (pillarExampleFileStandalone.isFile()) {
                 return (Map<String, Object>) yaml.load(new FileInputStream(pillarExampleFileStandalone));

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -415,8 +415,8 @@ public class FormulaManager {
 
         return minions.stream().flatMap(minion -> FormulaFactory.getCombinedFormulasByServer(minion)
                 .stream()
-                .flatMap(formulaName -> FormulaFactory.getEndpointsFromFormulaData(formulaName,
-                        getCombinedFormulaDataForSystemAndFormula(minion,
+                .flatMap(formulaName -> FormulaFactory.getEndpointsFromFormulaData(
+                    getCombinedFormulaDataForSystemAndFormula(minion,
                                 Optional.ofNullable(managedGroupsPerServer.get(minion.getId())),
                                 groupsFormulaData, formulaName)).stream())
         ).collect(Collectors.toList());

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -50,6 +50,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
@@ -76,7 +77,7 @@ public class AnsibleController {
 
     private static final Logger LOG = LogManager.getLogger(AnsibleController.class);
     private static final Gson GSON = Json.GSON;
-    private static final Yaml YAML = new Yaml(new SafeConstructor());
+    private static final Yaml YAML = new Yaml(new SafeConstructor(new LoaderOptions()));
 
     private static final LocalizationService LOCAL = LocalizationService.getInstance();
 

--- a/java/spacewalk-java.changes.mackdk.prepare-for-snakeyaml-upgrade
+++ b/java/spacewalk-java.changes.mackdk.prepare-for-snakeyaml-upgrade
@@ -1,0 +1,1 @@
+- Removed usage of deprecated constructor (bsc#1227306)


### PR DESCRIPTION
## What does this PR change?

This PR remove usages of the deprecated constructor `SafeConstructor()`. This will allow smooth migration to version 2.2

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24693
Port(s): https://github.com/SUSE/spacewalk/pull/24696

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
