### PR TITLE
Fix importing module metadata from REMI's repositories

### DIFF
--- a/python/spacewalk/satellite_tools/appstreams.py
+++ b/python/spacewalk/satellite_tools/appstreams.py
@@ -286,7 +286,7 @@ class ModuleMdImporter:
         pattern = re.compile(
             r"(?P<name>[a-zA-Z0-9._+-]+)-"
             r"(?P<epoch>\d+:)?"
-            r"(?P<version>[a-zA-Z0-9._-]+)-"
+            r"(?P<version>[a-zA-Z0-9._-~]+)-"
             r"(?P<release>[a-zA-Z0-9._+-]+)\."
             r"(?P<arch>[a-zA-Z0-9._-]+)"
         )

--- a/python/spacewalk/spacewalk-backend.changes.cbbayburt.appstreams-reposync-8972
+++ b/python/spacewalk/spacewalk-backend.changes.cbbayburt.appstreams-reposync-8972
@@ -1,0 +1,1 @@
+- Support more NEVRA types when importing module metadata

--- a/python/test/unit/spacewalk/satellite_tools/test_appstreams.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_appstreams.py
@@ -178,6 +178,14 @@ def test_get_modules(importer):
             "396.module_el8.1.0+6019+b22674e1",
             "noarch",
         ),
+        (
+            "php-pecl-gmagick-0:2.0.5~RC1-4.el8.remi.7.2.x86_64",
+            "php-pecl-gmagick",
+            "0",
+            "2.0.5~RC1",
+            "4.el8.remi.7.2",
+            "x86_64",
+        ),
     ],
 )
 def test_parse_rpm_name(nevra_input, name, epoch, version, release, arch):


### PR DESCRIPTION
Some packages in REMI's 3rd party repositories include a '~' character as part of the version string. This patch fixes the module import during repo-sync to recognize this character.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/8972

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
