### PR TITLE
QE: do not unregister the Salt migration minion

### DIFF
--- a/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
@@ -111,11 +111,3 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     And I click on "Confirm"
     When I wait until event "Package Removal scheduled by admin" is completed
     Then "adobe-sourcecodepro-fonts" should not be installed on "salt_migration_minion"
-
-  Scenario: Cleanup: remove the minion in the Salt migration context
-    Given I am on the Systems overview page of this "salt_migration_minion"
-    And I follow "Delete System"
-    Then I should see a "Confirm System Profile Deletion" text
-    When I click on "Delete Profile"
-    And I wait until I see "has been deleted" text
-    Then "salt_migration_minion" should not be registered


### PR DESCRIPTION
## What does this PR change?

Do not remove the Salt migration minion from SUMA server at the end of  feature.

It makes debugging harder and has no real advantage:

1) The VM still exists and uses resources

2) The minion has its packages upgraded and is no more in the starting state --> the feature is not idempotent

The only point would be to verify that the removal itself works, but that can eventually be done manually.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified (removed scenario)

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24233
Port(s): 4.3 https://github.com/SUSE/spacewalk/pull/24723

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
