### PR TITLE
support multiple certificates for root-ca-file and server-cert-file

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -643,12 +643,12 @@ def checks(server_key_content, server_cert_content, certData):
     """
     Perform different checks on the input data
     """
+    checkCompleteCAChain(server_cert_content, certData)
+
     if not getPrivateKey(server_key_content):
         raise CertCheckError("Unable to read the server key. Is it maybe encrypted?")
 
     checkKeyBelongToCert(server_key_content, server_cert_content)
-
-    checkCompleteCAChain(server_cert_content, certData)
 
 
 # pylint: disable-next=invalid-name

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.expect-ca-in-servercert
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.expect-ca-in-servercert
@@ -1,0 +1,1 @@
+- support multiple certificates for root-ca-file and server-cert-file


### PR DESCRIPTION
## What does this PR change?

Support multiple certificates for root-ca-file and server-cert-file.
First split all files files into single certificates. If multiple certificates are found in root-ca-file or server-cert-file,
use all additional as intermediate CAs.

This means especially for server-cert-file: it must contain the server certificate a 1st certificate. Additional certificates in the same file are added to intermediate CAs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8983
Port(s): TBD

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
