### PR TITLE
Fix recurring custom state configs being deleted during migration 

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.parlt.fix-recurring-state-config-migration
+++ b/schema/spacewalk/susemanager-schema.changes.parlt.fix-recurring-state-config-migration
@@ -1,0 +1,1 @@
+- Fix recurring custom state configs being deleted during migration (bsc#1227491)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/100-update-recurring-action.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/100-update-recurring-action.sql
@@ -18,40 +18,49 @@ CREATE TABLE IF NOT EXISTS suseInternalState
   label             VARCHAR(128) NOT NULL
 );
 
-DELETE FROM suseInternalState;
+INSERT INTO suseInternalState (id, name, label)
+         VALUES (1, 'certs', 'Certificates')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (1, 'certs', 'Certificates');
+         VALUES (2, 'channels', 'Channels')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (2, 'channels', 'Channels');
+         VALUES (3, 'hardware.profileupdate', 'Hardware Profile Update')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (3, 'hardware.profileupdate', 'Hardware Profile Update');
+         VALUES (4, 'packages', 'Packages')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (4, 'packages', 'Packages');
+         VALUES (5, 'packages.profileupdate', 'Package Profile Update')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (5, 'packages.profileupdate', 'Package Profile Update');
+         VALUES (6, 'uptodate', 'Update System')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (6, 'uptodate', 'Update System');
+         VALUES (7, 'util.syncbeacons', 'Sync Beacons')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (7, 'util.syncbeacons', 'Sync Beacons');
+         VALUES (8, 'util.syncall', 'Sync All')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (8, 'util.syncall', 'Sync All');
+         VALUES (9, 'util.syncgrains', 'Sync Grains')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (9, 'util.syncgrains', 'Sync Grains');
+         VALUES (10, 'util.syncmodules', 'Sync Modules')
+         ON CONFLICT DO NOTHING;
 
 INSERT INTO suseInternalState (id, name, label)
-         VALUES (10, 'util.syncmodules', 'Sync Modules');
-
-INSERT INTO suseInternalState (id, name, label)
-         VALUES (11, 'util.syncstates', 'Sync States');
+         VALUES (11, 'util.syncstates', 'Sync States')
+         ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS suseRecurringHighstate
 (


### PR DESCRIPTION
## What does this PR change?

Fix a problem where the migration would delete existing `suseRecurringStateConfig` entries during migration due to delete cascading.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24743

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
