### PR TITLE
change to new and working repo urls

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -4036,7 +4036,7 @@
         "repositories" : [
             {
                 "id" : -129,
-                "url" : "http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os",
+                "url" : "https://vault.centos.org/centos/7/os/x86_64/",
                 "name" : "centos7",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7",
@@ -4046,7 +4046,7 @@
             },
             {
                 "id" : -130,
-                "url" : "http://mirror.centos.org/centos-7/7/atomic/x86_64",
+                "url" : "https://vault.centos.org/centos/7/atomic/x86_64/",
                 "name" : "centos7-atomic",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7 Atomic",
@@ -4056,7 +4056,7 @@
             },
             {
                 "id" : -131,
-                "url" : "http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=centosplus",
+                "url" : "https://vault.centos.org/centos/7/centosplus/x86_64/",
                 "name" : "centos7-centosplus",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7 Plus",
@@ -4066,7 +4066,7 @@
             },
             {
                 "id" : -133,
-                "url" : "http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=cr",
+                "url" : "https://vault.centos.org/centos/7/cr/x86_64/",
                 "name" : "centos7-cr",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7 CR",
@@ -4076,7 +4076,7 @@
             },
             {
                 "id" : -134,
-                "url" : "http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras",
+                "url" : "https://vault.centos.org/centos/7/extras/x86_64/",
                 "name" : "centos7-extras",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7 Extras",
@@ -4086,7 +4086,7 @@
             },
             {
                 "id" : -135,
-                "url" : "http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=fasttrack",
+                "url" : "https://vault.centos.org/centos/7/fasttrack/x86_64/",
                 "name" : "centos7-fasttrack",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7 FastTrack",
@@ -4096,7 +4096,7 @@
             },
             {
                 "id" : -138,
-                "url" : "http://mirror.centos.org/centos-7/7/rt/x86_64",
+                "url" : "https://vault.centos.org/centos/7/rt/x86_64/",
                 "name" : "centos7-rt",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7 RT",
@@ -4106,7 +4106,7 @@
             },
             {
                 "id" : -141,
-                "url" : "http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates",
+                "url" : "https://vault.centos.org/centos/7/updates/x86_64/",
                 "name" : "centos7-updates",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 7 Updates",

--- a/susemanager-sync-data/susemanager-sync-data.changes.kwalter.centos7
+++ b/susemanager-sync-data/susemanager-sync-data.changes.kwalter.centos7
@@ -1,0 +1,1 @@
+- fix centos 7 repo urls (bsc#1227526)


### PR DESCRIPTION
## What does this PR change?

the old centos 7 repo urls don't work anymore. this changes the urls to the currently working ones.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24768
Port(s): https://github.com/SUSE/spacewalk/pull/24783

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
