### PR TITLE
yum_src: use proper name variable name for "subprocess.TimeoutExpired"

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -249,8 +249,7 @@ class ZyppoSync:
                 else:
                     # pylint: disable-next=consider-using-f-string
                     log(3, "CMD out: {}".format(outs.decode("utf-8")))
-            # pylint: disable-next=undefined-variable
-            except TimeoutExpired:
+            except subprocess.TimeoutExpired:
                 process.kill()
                 log(0, "Timeout exceeded while importing keys to rpm database")
             keycont = f.read()

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-fix-timeoutexpired
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-fix-timeoutexpired
@@ -1,0 +1,1 @@
+- yum_src: use proper name variable name for subprocess.TimeoutExpired


### PR DESCRIPTION
## What does this PR change?

This PR simply fixes an small issue detected in a reference to `subprocess.TimeoutExpired`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no tests around this feature**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
