### PR TITLE
deb_src: introduce timeout when syncing DEB channels (bsc#1225960)

### DIFF
--- a/python/spacewalk/common/repo.py
+++ b/python/spacewalk/common/repo.py
@@ -84,7 +84,13 @@ class DpkgRepo:
                 )
             return self[key]
 
-    def __init__(self, url: str, proxies: dict = None, gpg_verify: bool = True):
+    def __init__(
+        self,
+        url: str,
+        proxies: dict = None,
+        gpg_verify: bool = True,
+        timeout: typing.Optional[int] = None,
+    ):
         self._url = url
         self._flat_checked: typing.Optional[int] = None
         self._flat: bool = False
@@ -95,6 +101,7 @@ class DpkgRepo:
         self._release = DpkgRepo.EntryDict(self)
         self.proxies = proxies
         self.gpg_verify = gpg_verify
+        self.timeout = timeout
 
     def append_index_file(self, index_file: str) -> str:
         """
@@ -156,7 +163,11 @@ class DpkgRepo:
                             exc_info=True,
                         )
                 else:
-                    resp = requests.get(packages_url, proxies=self.proxies)
+                    resp = requests.get(
+                        packages_url,
+                        proxies=self.proxies,
+                        timeout=self.timeout,
+                    )
                     if resp.status_code == http.HTTPStatus.OK:
                         self._pkg_index = cnt_fname, resp.content
                         break
@@ -326,6 +337,7 @@ class DpkgRepo:
                 signature_response = requests.get(
                     self._get_parent_url(response.url, 1, "Release.gpg"),
                     proxies=self.proxies,
+                    timeout=self.timeout,
                 )
                 if signature_response.status_code != http.HTTPStatus.OK:
                     return False
@@ -487,11 +499,15 @@ class DpkgRepo:
         # pylint: disable-next=logging-format-interpolation,consider-using-f-string
         logging.debug("Fetching release file from local http: {}".format(self._url))
         resp = requests.get(
-            self._get_parent_url(self._url, 2, "InRelease"), proxies=self.proxies
+            self._get_parent_url(self._url, 2, "InRelease"),
+            proxies=self.proxies,
+            timeout=self.timeout,
         )
         if resp.status_code != http.HTTPStatus.OK:
             resp = requests.get(
-                self._get_parent_url(self._url, 2, "Release"), proxies=self.proxies
+                self._get_parent_url(self._url, 2, "Release"),
+                proxies=self.proxies,
+                timeout=self.timeout,
             )
 
         try:
@@ -539,11 +555,13 @@ class DpkgRepo:
                 resp = requests.get(
                     self._get_parent_url(self._url, 0, "InRelease"),
                     proxies=self.proxies,
+                    timeout=self.timeout,
                 )
                 if resp.status_code != http.HTTPStatus.OK:
                     resp = requests.get(
                         self._get_parent_url(self._url, 0, "Release"),
                         proxies=self.proxies,
+                        timeout=self.timeout,
                     )
 
                 if resp.status_code == http.HTTPStatus.OK:

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-introduce-timeout-for-deb-reposync
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-introduce-timeout-for-deb-reposync
@@ -1,0 +1,1 @@
+- reposync: introduce timeout when syncing DEB channels (bsc#1225960)


### PR DESCRIPTION
## What does this PR change?

As mentioned in the title, this PR introduces a timeout when running "reposync" against DEB channels. This would prevent getting reposync stuck in case connections with the remote repositories gets stuck.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no tests for this corner case**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24459

Port(s): https://github.com/SUSE/spacewalk/pull/24755

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
