### PR TITLE
fix false positive ssh key generation error

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2164,8 +2164,10 @@ public class SystemManager extends BaseManager {
     }
 
     private Supplier<RhnRuntimeException> raiseAndLog(String message) {
-        log.error(message);
-        return () -> new RhnRuntimeException(message);
+        return () -> {
+            log.error(message);
+            return new RhnRuntimeException(message);
+        };
     }
 
     private Optional<Server> findByAnyFqdn(Set<String> fqdns) {

--- a/java/spacewalk-java.changes.oholecek.fix_false_positive_ssh_gen_error
+++ b/java/spacewalk-java.changes.oholecek.fix_false_positive_ssh_gen_error
@@ -1,0 +1,1 @@
+- fix false positive ssh key generation error (bsc#1226491)


### PR DESCRIPTION
## What does this PR change?

Fix false positive log of error. `orElseThrow` uses lambda, but logging was outside of it.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: only logging detail

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24645
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
