### PR TITLE
improve cleanup of reboot actions

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -126,6 +126,7 @@ public class ActionFactory extends HibernateFactory {
         setupActionArchTypes();
     }
 
+
     @SuppressWarnings("unchecked")
     private void setupActionArchTypes() {
         synchronized (this) {
@@ -766,6 +767,18 @@ public class ActionFactory extends HibernateFactory {
         params.put("date", date);
         return singleton.listObjectsByNamedQuery("ServerAction.findByServerAndActionTypeAndCreatedDate", params);
     }
+
+    /**
+     * Lookup a List of ServerAction objects for a given Server and Action Types.
+     * @param serverIn you want to limit the list of Actions to
+     * @param typesIn you want to limit the list of Actions to
+     * @return List of ServerAction objects
+     */
+    public static List<ServerAction> listServerActionsForServerAndTypes(Server serverIn, List<ActionType> typesIn) {
+        return singleton.listObjectsByNamedQuery("ServerAction.findServerActionsForServerAndTypes",
+                Map.of("server", serverIn, "typeList", typesIn));
+    }
+
     /**
      * Lookup a List of ServerAction objects in the given states for a given Server.
      * @param serverIn you want to limit the list of Actions to

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.hbm.xml
@@ -52,11 +52,18 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                     where sa.server = :server
                                 and (cast(:actionType as string) is null or sa.parentAction.actionType.name = :actionType)
                                 and (cast(:date as date) is null or sa.created >= :date)
-                        ]]>
+            ]]>
+        </query>
+
+        <query name="ServerAction.findServerActionsForServerAndTypes">
+            <![CDATA[from com.redhat.rhn.domain.action.server.ServerAction as sa
+                    where sa.server = :server
+                    and sa.parentAction.actionType in (:typeList)
+            ]]>
         </query>
 
         <query name="ServerAction.findByServerAndAction">
-           <![CDATA[from com.redhat.rhn.domain.action.server.ServerAction as sa
+            <![CDATA[from com.redhat.rhn.domain.action.server.ServerAction as sa
                     where sa.server = :server
                       and sa.parentAction = :action]]>
         </query>
@@ -64,12 +71,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <query name="ServerAction.findByServerAndStatus">
             <![CDATA[from com.redhat.rhn.domain.action.server.ServerAction as sa
              where sa.server = :server and sa.status in (:statusList)
-                            ]]>
+            ]]>
         </query>
         <query name="ServerAction.findByServerAndStatusAndCreatedDate">
             <![CDATA[from com.redhat.rhn.domain.action.server.ServerAction as sa
                  where sa.server = :server and sa.created >= :date and sa.status in (:statusList)
-                                ]]>
+            ]]>
         </query>
 
 </hibernate-mapping>

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -2144,8 +2144,8 @@ public class SaltUtils {
         minion.setLastBoot(bootTime.getTime() / 1000);
 
         // cleanup old reboot actions
-        List<ServerAction> serverActions = ActionFactory
-                .listServerActionsForServer(minion);
+        List<ServerAction> serverActions = ActionFactory.listServerActionsForServerAndTypes(minion,
+                List.of(ActionFactory.TYPE_REBOOT));
         int actionsChanged = 0;
         for (ServerAction sa : serverActions) {
             if (shouldCleanupAction(bootTime, sa)) {

--- a/java/spacewalk-java.changes.mc.improve-handling-of-job-returns
+++ b/java/spacewalk-java.changes.mc.improve-handling-of-job-returns
@@ -1,0 +1,1 @@
+- do not iterate over all actions when only reboot actions are handled


### PR DESCRIPTION
## What does this PR change?

When we handle uptime values, we check for reboot actions which needs to be marked as COMPLETED.
We load all actions for the system and iterate over them to look for type REBOOT.
This is inefficient, a all actions needs to be rendered.
This PR query the DB only for a list of action types which should really be checked.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25253

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
