### PR TITLE
QE: use Rocky 8 specifig xml for OpenScap audit

### DIFF
--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2023 SUSE LLC
+# Copyright (c) 2017-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_openscap
@@ -32,7 +32,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos8-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds-1.2.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed


### PR DESCRIPTION
## What does this PR change?

A minor change,  the centos8 xml does work but I'd guess it is better to use a rhel-8 one with the change to Rocky 8 (?).

Available XML files:

```
[root@uyuni-master-podman-min-rocky8 content]# ls
ssg-centos7-ds-1.2.xml         ssg-fedora-ds.xml           ssg-ol8-cpe-oval.xml        ssg-ol9-xccdf.xml                     ssg-rhcos4-ocil.xml           ssg-rhel8-ds-1.2.xml          ssg-rhv4-cpe-dictionary.xml
ssg-centos7-ds.xml             ssg-fedora-ocil.xml         ssg-ol8-ds-1.2.xml          ssg-openeuler2203-cpe-dictionary.xml  ssg-rhcos4-oval.xml           ssg-rhel8-ds.xml              ssg-rhv4-cpe-oval.xml
ssg-centos7-xccdf.xml          ssg-fedora-oval.xml         ssg-ol8-ds.xml              ssg-openeuler2203-cpe-oval.xml        ssg-rhcos4-xccdf.xml          ssg-rhel8-ocil.xml            ssg-rhv4-ds-1.2.xml
ssg-centos8-ds-1.2.xml         ssg-fedora-xccdf.xml        ssg-ol8-ocil.xml            ssg-openeuler2203-ds-1.2.xml          ssg-rhel7-cpe-dictionary.xml  ssg-rhel8-oval.xml            ssg-rhv4-ds.xml
ssg-centos8-ds.xml             ssg-ol7-cpe-dictionary.xml  ssg-ol8-oval.xml            ssg-openeuler2203-ds.xml              ssg-rhel7-cpe-oval.xml        ssg-rhel8-xccdf.xml           ssg-rhv4-ocil.xml
ssg-centos8-xccdf.xml          ssg-ol7-cpe-oval.xml        ssg-ol8-xccdf.xml           ssg-openeuler2203-ocil.xml            ssg-rhel7-ds-1.2.xml          ssg-rhel9-cpe-dictionary.xml  ssg-rhv4-oval.xml
ssg-cs9-ds-1.2.xml             ssg-ol7-ds-1.2.xml          ssg-ol9-cpe-dictionary.xml  ssg-openeuler2203-oval.xml            ssg-rhel7-ds.xml              ssg-rhel9-cpe-oval.xml        ssg-rhv4-xccdf.xml
ssg-cs9-ds.xml                 ssg-ol7-ds.xml              ssg-ol9-cpe-oval.xml        ssg-openeuler2203-xccdf.xml           ssg-rhel7-ocil.xml            ssg-rhel9-ds-1.2.xml          ssg-sl7-ds-1.2.xml
ssg-cs9-xccdf.xml              ssg-ol7-ocil.xml            ssg-ol9-ds-1.2.xml          ssg-rhcos4-cpe-dictionary.xml         ssg-rhel7-oval.xml            ssg-rhel9-ds.xml              ssg-sl7-ds.xml
ssg-fedora-cpe-dictionary.xml  ssg-ol7-oval.xml            ssg-ol9-ds.xml              ssg-rhcos4-cpe-oval.xml               ssg-rhel7-xccdf.xml           ssg-rhel9-ocil.xml            ssg-sl7-xccdf.xml
ssg-fedora-cpe-oval.xml        ssg-ol7-xccdf.xml           ssg-ol9-ocil.xml            ssg-rhcos4-ds-1.2.xml                 ssg-rhel8-cpe-dictionary.xml  ssg-rhel9-oval.xml
ssg-fedora-ds-1.2.xml          ssg-ol8-cpe-dictionary.xml  ssg-ol9-oval.xml            ssg-rhcos4-ds.xml                     ssg-rhel8-cpe-oval.xml        ssg-rhel9-xccdf.xml
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24629

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
