### PR TITLE
QE: correct names for paramaters in kickstart API calls

### DIFF
--- a/testsuite/features/support/namespaces/kickstart.rb
+++ b/testsuite/features/support/namespaces/kickstart.rb
@@ -21,7 +21,7 @@ class NamespaceKickstart
   # @param kshost [String] The Kickstart hostname (of a server or proxy) used to construct the default download URL.
   # @return [Object] The result of the 'kickstart.profile.createProfile' API call.
   def create_profile(name, kstreelabel, kshost)
-    @test.call('kickstart.profile.createProfile', sessionKey: @test.token, profileLabel: name, vmType: 'none', kickstartableTreeLabel: kstreelabel, kickstartHost: kshost, rootPassword: 'linux', updateType: 'all')
+    @test.call('kickstart.profile.createProfile', sessionKey: @test.token, profileLabel: name, virtualizationType: 'none', kickstartableTreeLabel: kstreelabel, kickstartHost: kshost, rootPassword: 'linux', updateType: 'all')
   end
 
   #  Import a raw kickstart file into #product().
@@ -31,7 +31,7 @@ class NamespaceKickstart
   # @param filename [String] Contents of the kickstart file to import.
   def create_profile_using_import_file(name, kstreelabel, filename)
     file_content = File.read(filename)
-    @test.call('kickstart.importRawFile', sessionKey: @test.token, profileLabel: name, vmType: 'none', kickstartableTreeLabel: kstreelabel, kickstartFileContents: file_content)
+    @test.call('kickstart.importRawFile', sessionKey: @test.token, profileLabel: name, virtualizationType: 'none', kickstartableTreeLabel: kstreelabel, kickstartFileContents: file_content)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Uyuni testuite relies on an HTTP client sending/receiving JSON to test REST API endpoints.

The parameters' names we use in our testsuite wrapper for such API calls are turned into keys for the JSON sent in POST calls and must therefore perfectly match the endpoint's parameter names.

The XMLRPC API, tested with SUMA,  likely  relies on positional parameters instead.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests definitions were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24572

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
