### PR TITLE
Bump the WebUI version to 2024.07

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -63,7 +63,7 @@ web.version = 5.0.0
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni = 2024.06
+web.version.uyuni = 2024.07
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 

--- a/web/spacewalk-web.changes.raul.bump_uyuni_2024.07
+++ b/web/spacewalk-web.changes.raul.bump_uyuni_2024.07
@@ -1,0 +1,1 @@
+- Bump the WebUI version to 2024.07


### PR DESCRIPTION
# Warning
Do **NOT** merge till after the release of SUSE Manager 5.0 GMC.
Merge this when it is time to release Uyuni 2024.07

## What does this PR change?

Bump the WebUI version to 2024.07

## GUI diff

Before:
WebUI Showing version 2024.06 (which was not released)

After:
WebUI Showing version 2024.07

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23749

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!