### PR TITLE
QE: Enable SLL 7 LTSS reposync in BV

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -584,6 +584,21 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Liberty Linux 7 x86_64" product has been added
     And I wait until all synchronized channels for "res7" have finished
 
+@susemanager
+@centos7_minion
+  Scenario: Add SUSE Liberty Linux 7 LTSS
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "currently running" text
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Liberty Linux LTSS 7" as the filtered product description
+    And I select "SUSE Liberty Linux LTSS 7 x86_64" as a product
+    Then I should see the "SUSE Liberty Linux LTSS 7 x86_64" selected
+    And I should see the "SUSE Manager Client Tools for RHEL, Liberty and Clones 7 x86_64" selected
+    When I click the Add Product button
+    And I wait until I see "SUSE Liberty Linux LTSS 7 x86_64" product has been added
+    And I wait until all synchronized channels for "sll-7-ltss" have finished
+
 @uyuni
 @centos7_minion
   Scenario: Add CentOS 7

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -750,6 +750,11 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         debian-12-main-updates-amd64
         debian-12-suse-manager-tools-amd64
       ],
+    'sll-7-ltss' => # CHECKED
+      %w[
+        res-7-ltss-updates-x86_64
+        res-7-suse-manager-tools-x86_64-lbt7
+      ],
     'sll-9' => # CHECKED
       %w[
         sll-cb-9-updates-x86_64
@@ -1515,6 +1520,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'oraclelinux9-appstream-x86_64' => 2100,
   'oraclelinux9-uyuni-client-devel-x86_64' => 60,
   'oraclelinux9-x86_64' => 840,
+  'res-7-ltss-updates-x86_64' => 960,
+  'res-7-suse-manager-tools-x86_64-lbt7' => 120,
   'res7-suse-manager-tools-x86_64' => 300,
   'res7-x86_64' => 21_000,
   'rhel-x86_64-server-7' => 60,


### PR DESCRIPTION
## What does this PR change?

This enables the sync of SUSE Liberty Linux 7 LTSS in our BV ~and switches the CentOS 7 Minion/SSH Minion to SLL 7 LTSS~. With https://github.com/SUSE/spacewalk/issues/24884 we will then migrate the CentOS 7 Minion to SLL 7 LTSS.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24438
Ports(s): Manager 4.3:

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!