### PR TITLE
Fix custom state recurring actions being inserted into recurringHighstate table

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.parlt.master
+++ b/schema/spacewalk/susemanager-schema.changes.parlt.master
@@ -1,0 +1,1 @@
+- Fix custom state recurring actions being inserted into recurringHighstate table on migration if the table was empty (bsc#1227667)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/100-update-recurring-action.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.4.6-to-susemanager-schema-4.4.7/100-update-recurring-action.sql
@@ -73,15 +73,13 @@ CREATE TABLE IF NOT EXISTS suseRecurringHighstate
                     DEFAULT 'N'
 );
 
-ALTER TABLE suseRecurringAction ADD COLUMN IF NOT EXISTS test_mode CHAR(1) DEFAULT 'N' NOT NULL;
-INSERT INTO suseRecurringHighstate (rec_id, test_mode)
-         SELECT id, test_mode FROM suseRecurringAction
-         WHERE NOT EXISTS (SELECT id FROM suseRecurringHighstate);
-ALTER TABLE suseRecurringAction DROP COLUMN IF EXISTS test_mode;
-
 ALTER TABLE suseRecurringAction ADD COLUMN IF NOT EXISTS action_type VARCHAR(32) NULL;
 UPDATE suseRecurringAction SET action_type = 'HIGHSTATE' WHERE action_type IS NULL;
 ALTER TABLE suseRecurringAction ALTER COLUMN action_type SET NOT NULL;
+
+ALTER TABLE suseRecurringAction ADD COLUMN IF NOT EXISTS test_mode CHAR(1) DEFAULT 'N' NOT NULL;
+INSERT INTO suseRecurringHighstate (SELECT id, test_mode FROM suseRecurringAction WHERE action_type='HIGHSTATE') ON CONFLICT DO NOTHING;
+ALTER TABLE suseRecurringAction DROP COLUMN IF EXISTS test_mode;
 
 CREATE TABLE IF NOT EXISTS suseRecurringState
 (


### PR DESCRIPTION
## What does this PR change?

Fix a case where `custom state` type recurring actions would wrongly be inserted into `suseRecurringHighstate` if the table was empty during time of migration.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24794

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
