### PR TITLE
QE: reboot and check server health after hostname change

### DIFF
--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT License.
 #
 # This feature can cause failures in the following features:
@@ -19,6 +19,7 @@ Feature: Reconfigure the server's hostname
 
   Scenario: Change hostname and reboot server
     When I change the server's short hostname from hosts and hostname files
+    And I reboot the server through SSH
     And I run spacewalk-hostname-rename command on the server
 
 @proxy

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1559,7 +1559,9 @@ When(/^I reboot the server through SSH$/) do
 
   repeat_until_timeout(timeout: default_timeout, message: 'Spacewalk didn\'t come up') do
     out, _code = temp_server.run('spacewalk-service status', check_errors: false, timeout: 10)
-    if !out.to_s.include?('dead') && out.to_s.include?('running')
+    # mgr-check-payg.service will be inactive (dead) for Uyuni, so we cannot check that all services are running
+    # we look for the status displayed by apache2.service, the webserver, when it is ready
+    if out.to_s.include? 'Processing requests...'
       log 'Server spacewalk service is up'
       break
     end
@@ -1629,7 +1631,9 @@ When(/^I run spacewalk-hostname-rename command on the server$/) do
   default_timeout = 300
   repeat_until_timeout(timeout: default_timeout, message: 'Spacewalk didn\'t come up') do
     out, _code = server_node.run('spacewalk-service status', check_errors: false, timeout: 10)
-    if !out.to_s.include?('dead') && out.to_s.include?('running')
+    # mgr-check-payg.service will be inactive (dead) for Uyuni, so we cannot check that all services are running
+    # we look for the status displayed by apache2.service, the webserver, when it is ready
+    if out.to_s.include? 'Processing requests...'
       log 'Server: spacewalk service is up'
       break
     end


### PR DESCRIPTION
## What does this PR change?

The Uyuni feature file is missing a reboot through SSH after the hostname changes.

Another thing worth noticing is that we're executing the following code to know whether the services are back up or not

```ruby
repeat_until_timeout(timeout: default_timeout, message: 'Spacewalk didn\'t come up') do
    out, _code = temp_server.run('spacewalk-service status', check_errors: false, timeout: 10)
    if !out.to_s.include?('dead') && out.to_s.include?('running')
      log 'Server spacewalk service is up'
      break
    end
    sleep 1
  end
 ```

this works fine in 4.3, but not on Uyuni where the following service doesn't run

```
○ mgr-check-payg.service - Check and install PAYG billing service.
     Loaded: loaded (/usr/lib/systemd/system/mgr-check-payg.service; static)
     Active: inactive (dead)
  Condition: start condition failed at Fri 2024-07-12 11:53:03 CEST; 3min 37s ago
             └─ ConditionEnvironment=ISPAYG=1 was not met
```

I propose a change of the check to

```ruby
repeat_until_timeout(timeout: default_timeout, message: 'Spacewalk didn\'t come up') do
    out, _code = temp_server.run('spacewalk-service status', check_errors: false, timeout: 10)
    if out.to_s.include?('Processing requests...')
      log 'Server spacewalk service is up'
      break
    end
    sleep 1
  end
 ```

Which is the status set by the Apache Webserver service when it's operative


## GUI diff

No changes

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24668

- [x] **DONE**

## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
