### PR TITLE
Trust the Content-Length header from ajp (bsc#1226439)

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -101,6 +101,9 @@ RewriteRule ^(/rhn/manager/download/.*)$ $1?%1
 # increase timeout on proxy requests
 ProxyTimeout 600
 
+# Trust the Content-Length header from ajp (bsc#1226439)
+SetEnv ap_trust_cgilike_cl
+
 <IfModule proxy_ajp_module>
 <Proxy ajp://localhost:8009>
   ProxySet min=1

--- a/spacewalk/config/spacewalk-config.changes.nadvornik.content_length
+++ b/spacewalk/config/spacewalk-config.changes.nadvornik.content_length
@@ -1,0 +1,1 @@
+- Trust the Content-Length header from ajp (bsc#1226439)


### PR DESCRIPTION
## What does this PR change?

Apache recently got a fix for CVE-2024-24795 - [bug 1222332](https://bugzilla.suse.com/show_bug.cgi?id=1222332). With this fix it no longer trusts the Content-Length from ajp and drops it. Then it switches to Transfer-Encoding: chunked which some clients, like grub, can't handle.

This PR restores the original behavior.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: bugfix

- [ ] **DONE**

## Test coverage
- No tests: already covered
- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24571
https://bugzilla.suse.com/show_bug.cgi?id=1226439
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
