### PR TITLE
Fix date format when using the HTTP API to use iso8601 date

### DIFF
--- a/java/code/src/com/suse/manager/api/DateSerializer.java
+++ b/java/code/src/com/suse/manager/api/DateSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.api;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Custom {@link Date} serializer to output Date objects in iso8601 format
+ */
+public class DateSerializer implements JsonSerializer<Date> {
+
+    private final DateFormat dateFormat;
+
+    /**
+     * Initialize dateFormat and set timezone to UTC
+     */
+    public DateSerializer() {
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Override
+    public JsonElement serialize(Date date, Type type, JsonSerializationContext context) {
+        return new JsonPrimitive(dateFormat.format(date));
+    }
+}

--- a/java/code/src/com/suse/manager/api/RouteFactory.java
+++ b/java/code/src/com/suse/manager/api/RouteFactory.java
@@ -46,6 +46,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -289,6 +290,7 @@ public class RouteFactory {
      */
     private Gson initGsonWithSerializers() {
         GsonBuilder builder = new GsonBuilder()
+                .registerTypeAdapter(Date.class, new DateSerializer())
                 .registerTypeAdapter(Map.class, new MapDeserializer())
                 .registerTypeAdapter(List.class, new ListDeserializer());
 

--- a/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
+++ b/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
@@ -244,11 +244,12 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Method basicDate = handler.getClass().getMethod("basicDate", Date.class);
         Route route = routeFactory.createRoute(basicDate, handler);
 
-        Request req = createRequest("/manager/api/test/basicDate", Collections.singletonMap("myDate", "2022-04-01"));
+        Request req = createRequest("/manager/api/test/basicDate",
+                Collections.singletonMap("myDate", "2022-04-01T00:00:00+02:00"));
         Response res = createResponse();
         String result = getResult((String) route.handle(req, res), String.class);
 
-        assertEquals("Apr 1, 2022, 12:00:00 AM", result);
+        assertEquals("2022-03-31T22:00:00Z", result);
     }
 
     /**
@@ -260,11 +261,11 @@ public class RouteFactoryTest extends BaseControllerTestCase {
         Route route = routeFactory.createRoute(basicDate, handler);
 
         Request req = createRequest("/manager/api/test/basicDate",
-                GSON.toJson(Collections.singletonMap("myDate", "2022-04-01")));
+                GSON.toJson(Collections.singletonMap("myDate", "2022-04-01T00:00:00+02:00")));
         Response res = createResponse();
         String result = getResult((String) route.handle(req, res), String.class);
 
-        assertEquals("Apr 1, 2022, 12:00:00 AM", result);
+        assertEquals("2022-03-31T22:00:00Z", result);
     }
 
     /**

--- a/java/spacewalk-java.changes.parlt.fix-http-api-date-format
+++ b/java/spacewalk-java.changes.parlt.fix-http-api-date-format
@@ -1,0 +1,1 @@
+- Fix the date format output when using the HTTP API to use iso8601 format (bsc#1227543)


### PR DESCRIPTION
## What does this PR change?

Change the ouput of `Date` object return values to be in iso8601 format.

There is an issue with the default gson `setDateFormat()` being locale specific, hence it's necessary to manually set the timezone to UTC in a custom serializer.

See here for more info: https://github.com/google/gson/issues/281

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24791
Fixes https://github.com/SUSE/spacewalk/issues/24093

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
