### PR TITLE
Autoinstallation: prevent issues with duplicate IP address due to some networks (bsc#1226461)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
+++ b/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
@@ -318,7 +318,7 @@ Serializable {
      * @return true if the nic is a container network
      */
     public boolean isContainerNetwork() {
-        return ("bridge".equals(module) && (getName().startsWith("docker") || getName().startsWith("cni-podman")));
+        return ("bridge".equals(module) && (getName().startsWith("docker") || getName().startsWith("cni-podman") || getName().startsWith("podman")));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
+++ b/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
@@ -314,6 +314,14 @@ Serializable {
     }
 
     /**
+     * true if the nic is a container network
+     * @return true if the nic is a container network
+     */
+    public boolean isContainerNetwork() {
+        return ("bridge".equals(module) && (getName().startsWith("docker") || getName().startsWith("cni-podman")));
+    }
+
+    /**
      * isVirtBridge tells if nic is a virtual bridge
      * @return true if the nic is a virtual bridge, false otherwise
      */

--- a/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
+++ b/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
@@ -318,7 +318,13 @@ Serializable {
      * @return true if the nic is a container network
      */
     public boolean isContainerNetwork() {
-        return ("bridge".equals(module) && (getName().startsWith("docker") || getName().startsWith("cni-podman") || getName().startsWith("podman")));
+        return (
+            "bridge".equals(module) && (
+                    getName().startsWith("docker") ||
+                    getName().startsWith("cni-podman") ||
+                    getName().startsWith("podman") ||
+                    getName().startsWith("cni")
+            ) || getName().startsWith("flannel"));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/NetworkInterfaceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/NetworkInterfaceTest.java
@@ -75,6 +75,15 @@ public class NetworkInterfaceTest extends RhnBaseTestCase {
         netint1.setModule("bridge");
         netint1.setName("cni-podman0");
         assertTrue(netint1.isContainerNetwork());
+        netint1.setModule("bridge");
+        netint1.setName("cni0");
+        assertTrue(netint1.isContainerNetwork());
+        netint1.setModule("foobar");
+        netint1.setName("flannel.1");
+        assertTrue(netint1.isContainerNetwork());
+        netint1.setModule("foobar");
+        netint1.setName("eth0");
+        assertFalse(netint1.isContainerNetwork());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/NetworkInterfaceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/NetworkInterfaceTest.java
@@ -15,7 +15,9 @@
 package com.redhat.rhn.domain.server.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.NetworkInterface;
@@ -57,6 +59,22 @@ public class NetworkInterfaceTest extends RhnBaseTestCase {
                                             .uniqueResult();
 
         assertEquals(netint1, netint2);
+    }
+
+    /**
+     * Test NetworkInterface.isContainerNetwork
+     * @throws Exception something bad happened
+     */
+    @Test
+    public void testIsContainerNetwork() throws Exception {
+        NetworkInterface netint1 = createTestNetworkInterface();
+        assertFalse(netint1.isContainerNetwork());
+        netint1.setModule("bridge");
+        netint1.setName("docker0");
+        assertTrue(netint1.isContainerNetwork());
+        netint1.setModule("bridge");
+        netint1.setName("cni-podman0");
+        assertTrue(netint1.isContainerNetwork());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerSystemCreateCommand.java
@@ -280,7 +280,7 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
             }
             catch (XmlRpcException e) {
                 if (e.getCause() != null && e.getCause().getMessage() != null &&
-                        e.getCause().getMessage().contains("IP address duplicated")) {
+                        e.getCause().getMessage().contains("IP address duplicate")) {
                     return new ValidatorError(
                             "frontend.actions.systems.virt.duplicateipaddressvalue",
                             serverName);
@@ -302,7 +302,7 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
         }
         catch (XmlRpcException e) {
             if (e.getCause() != null && e.getCause().getMessage() != null &&
-                    e.getCause().getMessage().contains("IP address duplicated")) {
+                    e.getCause().getMessage().contains("IP address duplicate")) {
                 return new ValidatorError(
                         "frontend.actions.systems.virt.duplicateipaddressvalue",
                         serverName);
@@ -466,7 +466,8 @@ public class CobblerSystemCreateCommand extends CobblerCommand {
 
     private Optional<Network> processSingleNetworkInterface(NetworkInterface networkInterfaceIn) {
         // don't create a physical network device for a bond
-        if (!networkInterfaceIn.isVirtBridge() && !networkInterfaceIn.isBond()) {
+        if (!networkInterfaceIn.isVirtBridge() && !networkInterfaceIn.isBond() &&
+                !networkInterfaceIn.isContainerNetwork()) {
             if (networkInterfaceIn.isPublic()) {
                 return Optional.of(setupPublicInterface(networkInterfaceIn));
             }

--- a/java/spacewalk-java.changes.meaksh.Manager-4.3-prevent-issues-on-duplicate-ips-bsc1226461
+++ b/java/spacewalk-java.changes.meaksh.Manager-4.3-prevent-issues-on-duplicate-ips-bsc1226461
@@ -1,0 +1,1 @@
+- Autoinstallation: prevent "duplicate IP address" issues cause by container networks (bsc#1226461)

--- a/susemanager-utils/susemanager-sls/src/modules/sumautil.py
+++ b/susemanager-utils/susemanager-sls/src/modules/sumautil.py
@@ -115,11 +115,15 @@ def get_net_module(iface):
 
         salt '*' sumautil.get_net_module eth0
     """
-    sysfspath = os.path.join(SYSFS_NET_PATH, iface, "device/driver")
+    device_sysfspath = os.path.join(SYSFS_NET_PATH, iface, "device/driver")
+    bridge_sysfspath = os.path.join(SYSFS_NET_PATH, iface, "bridge")
 
-    return (
-        os.path.exists(sysfspath) and os.path.split(os.readlink(sysfspath))[-1] or None
-    )
+    if os.path.exists(device_sysfspath):
+        return os.path.split(os.readlink(device_sysfspath))[-1] or None
+    elif os.path.exists(bridge_sysfspath):
+        return "bridge"
+    else:
+        return None
 
 
 def get_net_modules():

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.Manager-4.3-prevent-issues-on-duplicate-ips-bsc1226461
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.Manager-4.3-prevent-issues-on-duplicate-ips-bsc1226461
@@ -1,0 +1,1 @@
+- sumautil: properly detect bridge interfaces (bsc#1226461)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue seen when dealing with Autoinstallation and some of your systems contain `docker*`, `virbr*` or `cni-podman*` interfaces with the same IP address.

Then, when triggering autoinstallation for those systems, an ISE is raised (due duplicate IP address on Cobbler) and autoinstallation is not triggered properly:

```
...
Caused by: org.cobbler.XmlRpcException: XmlRpcException calling cobbler.
        at org.cobbler.CobblerConnection.invokeMethod(CobblerConnection.java:160) ~[rhn.jar:?]
        at org.cobbler.CobblerConnection.invokeTokenMethod(CobblerConnection.java:190) ~[rhn.jar:?]
        at org.cobbler.SystemRecord.invokeModify(SystemRecord.java:310) ~[rhn.jar:?]
        at org.cobbler.CobblerObject.modify(CobblerObject.java:339) ~[rhn.jar:?]
        at org.cobbler.CobblerObject.modify(CobblerObject.java:322) ~[rhn.jar:?]
        at org.cobbler.SystemRecord.setNetworkInterfaces(SystemRecord.java:822) ~[rhn.jar:?]
...
Caused by: redstone.xmlrpc.XmlRpcFault: <class 'ValueError'>:IP address duplicate found "172.17.0.1". Object with the conflict has the name "my-system-host:1"
        at redstone.xmlrpc.XmlRpcClient.handleResponse(XmlRpcClient.java:444) ~[redstone-xmlrpc-client.jar:?]
        at redstone.xmlrpc.XmlRpcClient.endCall(XmlRpcClient.java:376) ~[redstone-xmlrpc-client.jar:?]
        at redstone.xmlrpc.XmlRpcClient.invoke(XmlRpcClient.java:165) ~[redstone-xmlrpc-client.jar:?]
```

The issue is caused as Java is not properly excluding these interfaces when preparing the Cobbler systems for autoinstallation, where some types of interfaces are being excluded to avoid this.

As a workaround, if we set `allow_duplicate_ips: true` on `/etc/cobbler/settings.yaml` then this issue is not happening.

So, to summarize, this PR does the following fixes:
- Fix string to parse when Cobbler raises IP address exception, to avoid a general ISE as it was expected in these cases.
- Make `sumautil` Salt module able to identify "bridge" network devices, as this is needed for Java for proper matching of network device types.
- Do not process container network devices: `docker*` and `cni-podman*`, when preparing an autoinstallation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24580
Port(s): https://github.com/SUSE/spacewalk/pull/24815

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
