### PR TITLE
Create a user for each client in BV

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -18,15 +18,18 @@ Feature: Smoke tests for <client>
   - Install spacecmd from client tools
   - Enable Prometheus and Prometheus Exporter
 
-  Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+  Scenario: Create <client> user
+    Given I create a user with name "<client>" and password "linux"
+
+  Scenario: Log in as <client> user
+    Given I am authorized as "<client>" with password "linux"
 
   Scenario: Check that Software package refresh works on a <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
     And I wait until I see "Upgrade Packages" text
     And I click on "Update Package List"
-    And I wait until event "Package List Refresh scheduled by admin" is completed
+    And I wait until event "Package List Refresh scheduled by <client>" is completed
 
   Scenario: Check that Hardware Refresh button works on a <client>
     Given I am on the Systems overview page of this "<client>"
@@ -36,7 +39,7 @@ Feature: Smoke tests for <client>
     And I wait until I see "Refresh Hardware List" text
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
-    And I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until event "Hardware List Refresh scheduled by <client>" is completed
     And I wait until there is no Salt job calling the module "hardware.profileupdate" on "<client>"
 
   Scenario: Client <client> grains are displayed correctly on the details page
@@ -79,12 +82,11 @@ Feature: Smoke tests for <client>
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    And I wait until event "Package Install/Upgrade scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
 
 @skip_for_sle_micro_ssh_minion
   Scenario: Remove package from <client>
-    Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
     And I wait until I see "Upgrade Packages" text
     And I follow "List / Remove"
@@ -94,7 +96,7 @@ Feature: Smoke tests for <client>
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
-    And I wait until event "Package Removal scheduled by admin" is completed
+    And I wait until event "Package Removal scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
 
   Scenario: Run a remote command on <client> minion
@@ -150,7 +152,7 @@ Feature: Smoke tests for <client>
     And I should see a "Reboot system" button
     When I click on "Reboot system"
     Then I should see a "Reboot scheduled for system" text
-    And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    And I wait at most 600 seconds until event "System reboot scheduled by <client>" is completed
     Then I should see a "This action's status is: Completed" text
 
 @skip_for_sle_micro
@@ -167,17 +169,19 @@ Feature: Smoke tests for <client>
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
-    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    And I wait until event "Package Install/Upgrade scheduled by <client>" is completed
 
 @skip_for_sle_micro_ssh_minion
   Scenario: Enable Prometheus Node exporter formula on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
+    And I wait until I see "Salt Formulas" text
     And I check the "prometheus-exporters" formula
     And I click on "Save"
     Then I wait until I see "Formula saved" text
     # Configure Prometheus exporter formula
     When I follow "Prometheus Exporters" in the content area
+    And I wait until I see "configure Prometheus exporters" text
     And I click on "Expand All Sections"
     And I should see a "Enable and configure Prometheus exporters for managed systems." text
     And I check "node" exporter
@@ -200,9 +204,10 @@ Feature: Smoke tests for <client>
   Scenario: Apply highstate for the Prometheus exporters on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "States" in the content area
+    And I wait until I see "Apply Highstate" text
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
-    And I wait until event "Apply highstate scheduled by admin" is completed
+    And I wait until event "Apply highstate scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
 
 @skip_for_sle_micro_ssh_minion

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -136,6 +136,21 @@ When(/^I call user\.remove_role\(\) on "([^"]*)" with the role "([^"]*)"$/) do |
   refute($api_test.user.remove_role(luser, rolename) != 1)
 end
 
+Given(/^I create a user with name "([^"]*)" and password "([^"]*)"/) do |user, password|
+  $current_user = user
+  $current_password = password
+  next if $api_test.user.list_users.to_s.include? user
+
+  $api_test.user.create(user, password, user, user, "#{user}@mail.com")
+  roles = %w[org_admin channel_admin config_admin system_group_admin activation_key_admin image_admin]
+  roles.each do |role|
+    $api_test.user.add_role(user, role)
+  end
+  add_context('user', user)
+  add_context('password', 'linux')
+  log "New user #{user} created"
+end
+
 # channel namespace
 
 When(/^I create a repo with label "([^"]*)" and url$/) do |label|


### PR DESCRIPTION
## What does this PR change?

The scenario `Deploy the configuration file to <client>` cannot run in parallel if using the same user. `Configuration > Channels` share the same context.
To prevent this issue, create a unique user for each client and use it during the smoke test.

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- No tests: already covered


- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24605

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
