### PR TITLE
BV: use option fail fast during clients bootstrap stage

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -34,7 +34,7 @@ namespace :cucumber do
       include_tags =  tags.nil? ? [] : ['--tags', tags]
       cucumber_opts = %W[#{include_profiles} #{html_results} #{json_results} #{junit_results}] + %w[-f pretty -r features] + include_tags
       # Immediately fail core if any feature is failing
-      cucumber_opts << '--fail-fast' if filename.to_s.include?('core')
+      cucumber_opts << '--fail-fast' if filename.to_s.include?('core', 'build_validation_init_client')
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -33,8 +33,8 @@ namespace :cucumber do
       # not as an intersection of them (using 'and')
       include_tags =  tags.nil? ? [] : ['--tags', tags]
       cucumber_opts = %W[#{include_profiles} #{html_results} #{json_results} #{junit_results}] + %w[-f pretty -r features] + include_tags
-      # Immediately fail core if any feature is failing
-      cucumber_opts << '--fail-fast' if filename.to_s.include?('core', 'build_validation_init_client')
+      # Immediately fail a feature if a scenario on it fails
+      cucumber_opts << '--fail-fast' if filename.to_s.include?('core') || filename.to_s.include?('build_validation_init_client')
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -17,6 +17,7 @@ require 'set'
 require_relative 'code_coverage'
 require_relative 'twopence_env'
 require_relative 'commonlib'
+require 'timeout'
 
 # code coverage analysis
 # SimpleCov.start
@@ -130,17 +131,21 @@ After do |scenario|
   log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
   if scenario.failed?
     begin
-      Dir.mkdir('screenshots') unless File.directory?('screenshots')
-      path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
-      # only click on Details when we have errors during bootstrapping and more Details available
-      click_button('Details') if has_content?('Bootstrap Minions') && has_content?('Details')
-      # a TimeoutError may be raised while a page is still (re)loading
-      find('#page-body', wait: 3) if scenario.exception.is_a?(TimeoutError)
-      page.driver.browser.save_screenshot(path)
-      attach path, 'image/png'
-      attach "#{Time.at(@scenario_start_time).strftime('%H:%M:%S:%L')} - #{Time.at(current_epoch).strftime('%H:%M:%S:%L')} | Current URL: #{current_url}", 'text/plain'
+      Timeout.timeout(DEFAULT_TIMEOUT) do
+        Dir.mkdir('screenshots') unless File.directory?('screenshots')
+        path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
+        # only click on Details when we have errors during bootstrapping and more Details available
+        click_button('Details') if has_content?('Bootstrap Minions') && has_content?('Details')
+        # a TimeoutError may be raised while a page is still (re)loading
+        find('#page-body', wait: 3) if scenario.exception.is_a?(TimeoutError)
+        page.driver.browser.save_screenshot(path)
+        attach path, 'image/png'
+        attach "#{Time.at(@scenario_start_time).strftime('%H:%M:%S:%L')} - #{Time.at(current_epoch).strftime('%H:%M:%S:%L')} | Current URL: #{current_url}", 'text/plain'
+      end
+    rescue Timeout::Error
+      warn "Timeout occurred while saving screenshot for scenario: #{scenario.name}"
     rescue StandardError => e
-      warn e.message
+      warn "An error occurred while processing scenario: #{scenario.name}\nError message: #{e.message}"
     ensure
       print_server_logs
       previous_url = current_url

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -17,7 +17,6 @@ require 'set'
 require_relative 'code_coverage'
 require_relative 'twopence_env'
 require_relative 'commonlib'
-require 'timeout'
 
 # code coverage analysis
 # SimpleCov.start
@@ -131,21 +130,17 @@ After do |scenario|
   log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
   if scenario.failed?
     begin
-      Timeout.timeout(DEFAULT_TIMEOUT) do
-        Dir.mkdir('screenshots') unless File.directory?('screenshots')
-        path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
-        # only click on Details when we have errors during bootstrapping and more Details available
-        click_button('Details') if has_content?('Bootstrap Minions') && has_content?('Details')
-        # a TimeoutError may be raised while a page is still (re)loading
-        find('#page-body', wait: 3) if scenario.exception.is_a?(TimeoutError)
-        page.driver.browser.save_screenshot(path)
-        attach path, 'image/png'
-        attach "#{Time.at(@scenario_start_time).strftime('%H:%M:%S:%L')} - #{Time.at(current_epoch).strftime('%H:%M:%S:%L')} | Current URL: #{current_url}", 'text/plain'
-      end
-    rescue Timeout::Error
-      warn "Timeout occurred while saving screenshot for scenario: #{scenario.name}"
+      Dir.mkdir('screenshots') unless File.directory?('screenshots')
+      path = "screenshots/#{scenario.name.tr(' ./', '_')}.png"
+      # only click on Details when we have errors during bootstrapping and more Details available
+      click_button('Details') if has_content?('Bootstrap Minions') && has_content?('Details')
+      # a TimeoutError may be raised while a page is still (re)loading
+      find('#page-body', wait: 3) if scenario.exception.is_a?(TimeoutError)
+      page.driver.browser.save_screenshot(path)
+      attach path, 'image/png'
+      attach "#{Time.at(@scenario_start_time).strftime('%H:%M:%S:%L')} - #{Time.at(current_epoch).strftime('%H:%M:%S:%L')} | Current URL: #{current_url}", 'text/plain'
     rescue StandardError => e
-      warn "An error occurred while processing scenario: #{scenario.name}\nError message: #{e.message}"
+      warn e.message
     ensure
       print_server_logs
       previous_url = current_url


### PR DESCRIPTION
## What does this PR change?

During client bootstrap stage, when a client a failing to bootstrap, we are still trying to check if the client is correctly setup. This checks are adding 5-10 extra minutes to the test.
This PR will fail the client bootstrap feature if any scenario is failing. It will speed up the test when failing.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
