### PR TITLE
Add deb reposync timeouts (bsc#1225960)

### DIFF
--- a/python/spacewalk/common/repo.py
+++ b/python/spacewalk/common/repo.py
@@ -84,7 +84,13 @@ class DpkgRepo:
                 )
             return self[key]
 
-    def __init__(self, url: str, proxies: dict = None, gpg_verify: bool = True):
+    def __init__(
+        self,
+        url: str,
+        proxies: dict = None,
+        gpg_verify: bool = True,
+        timeout: typing.Optional[int] = None,
+    ):
         self._url = url
         self._flat_checked: typing.Optional[int] = None
         self._flat: bool = False
@@ -95,6 +101,7 @@ class DpkgRepo:
         self._release = DpkgRepo.EntryDict(self)
         self.proxies = proxies
         self.gpg_verify = gpg_verify
+        self.timeout = timeout
 
     def append_index_file(self, index_file: str) -> str:
         """
@@ -156,7 +163,11 @@ class DpkgRepo:
                             exc_info=True,
                         )
                 else:
-                    resp = requests.get(packages_url, proxies=self.proxies)
+                    resp = requests.get(
+                        packages_url,
+                        proxies=self.proxies,
+                        timeout=self.timeout,
+                    )
                     if resp.status_code == http.HTTPStatus.OK:
                         self._pkg_index = cnt_fname, resp.content
                         break
@@ -326,6 +337,7 @@ class DpkgRepo:
                 signature_response = requests.get(
                     self._get_parent_url(response.url, 1, "Release.gpg"),
                     proxies=self.proxies,
+                    timeout=self.timeout,
                 )
                 if signature_response.status_code != http.HTTPStatus.OK:
                     return False
@@ -487,11 +499,15 @@ class DpkgRepo:
         # pylint: disable-next=logging-format-interpolation,consider-using-f-string
         logging.debug("Fetching release file from local http: {}".format(self._url))
         resp = requests.get(
-            self._get_parent_url(self._url, 2, "InRelease"), proxies=self.proxies
+            self._get_parent_url(self._url, 2, "InRelease"),
+            proxies=self.proxies,
+            timeout=self.timeout,
         )
         if resp.status_code != http.HTTPStatus.OK:
             resp = requests.get(
-                self._get_parent_url(self._url, 2, "Release"), proxies=self.proxies
+                self._get_parent_url(self._url, 2, "Release"),
+                proxies=self.proxies,
+                timeout=self.timeout,
             )
 
         try:
@@ -539,11 +555,13 @@ class DpkgRepo:
                 resp = requests.get(
                     self._get_parent_url(self._url, 0, "InRelease"),
                     proxies=self.proxies,
+                    timeout=self.timeout,
                 )
                 if resp.status_code != http.HTTPStatus.OK:
                     resp = requests.get(
                         self._get_parent_url(self._url, 0, "Release"),
                         proxies=self.proxies,
+                        timeout=self.timeout,
                     )
 
                 if resp.status_code == http.HTTPStatus.OK:

--- a/python/spacewalk/spacewalk-backend.changes.vzhestkov.add-deb-reposync-timeouts
+++ b/python/spacewalk/spacewalk-backend.changes.vzhestkov.add-deb-reposync-timeouts
@@ -1,0 +1,1 @@
+- Set timeout values for connections on deb repositories synchronization


### PR DESCRIPTION
## What does this PR change?

In some cases `spacewalk-repo-sync` could get stuck on `deb` repos synchronization as there is no `timeout` set for the connections.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
