### PR TITLE
Make salt-broker reconnecting on master IP change

### DIFF
--- a/proxy/proxy/salt-broker/salt-broker
+++ b/proxy/proxy/salt-broker/salt-broker
@@ -85,7 +85,6 @@ class AbstractChannelProxy(multiprocessing.Process):
     def __init__(self, opts):
         self.opts = opts
         self.backend_connected = False
-        self.backend_ever_connected = False
         if "master" not in self.opts:
             raise self.ChannelException(
                 '[{}] No "master" opts is provided'.format(
@@ -126,6 +125,12 @@ class AbstractChannelProxy(multiprocessing.Process):
 
             if self.opts["wait_for_backend"]:
                 while not self.backend_connected:
+                    if self.backend.closed:
+                        log.warning(
+                            "Backend %s socket was closed while waiting for it. Terminating...",
+                            self.backend_type,
+                        )
+                        return
                     time.sleep(0.5)
 
             log.debug(
@@ -140,7 +145,16 @@ class AbstractChannelProxy(multiprocessing.Process):
             self.frontend.bind(self._frontend_uri)
 
             # Forward all messages
-            zmq.proxy(self.frontend, self.backend)
+            log.info("Staring ZMQ proxy on %s and %s sockets", self.frontend_type, self.backend_type)
+            try:
+                zmq.proxy(self.frontend, self.backend)
+            except Exception as e:
+                log.error(
+                    "Error while processing proxy with %s and %s sockets. Terminating...",
+                    self.frontend_type,
+                    self.backend_type
+                )
+                return
 
         except zmq.ZMQError as zmq_error:
             if self.reconnect_retries == 0:
@@ -172,14 +186,8 @@ class AbstractChannelProxy(multiprocessing.Process):
                 elif mon_evt["event"] == zmq.EVENT_CONNECTED:
                     log.info("{} socket connected".format(self.backend_type))
                     self.backend_connected = True
-                    self.backend_ever_connected = True
                     self.reconnect_retries = self.opts["drop_after_retries"]
                 elif mon_evt["event"] == zmq.EVENT_CONNECT_RETRIED:
-                    if (
-                        not self.backend_ever_connected
-                        and self.opts["wait_for_backend"]
-                    ):
-                        continue
                     if self.reconnect_retries == 0:
                         log.warning(
                             "Closing {} socket due to retry attempts reached!".format(

--- a/proxy/proxy/spacewalk-proxy.changes.vzhestkov.make-salt-broker-master-ip-change
+++ b/proxy/proxy/spacewalk-proxy.changes.vzhestkov.make-salt-broker-master-ip-change
@@ -1,0 +1,1 @@
+- Make salt-broker reconnecting if master IP has changed


### PR DESCRIPTION
## What does this PR change?

In some cases `salt-broker` could got stuck trying to connect to the `salt-master` with the old IP address of it, in case if IP address of the master has changed.

This fix is making `salt-broker` more agressive on re-resolving IP address.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/24752, https://github.com/SUSE/spacewalk/issues/24871
Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
