### PR TITLE
Make salt-broker less dependant on spacewalk libs

### DIFF
--- a/proxy/proxy/salt-broker/salt-broker
+++ b/proxy/proxy/salt-broker/salt-broker
@@ -40,8 +40,11 @@ import time
 import traceback
 import yaml
 
-# Import RHN libs
-from spacewalk.common.rhnConfig import RHNOptions
+try:
+    # Import RHN libs
+    from spacewalk.common.rhnConfig import RHNOptions
+except ImportError:
+    RHNOptions = None
 
 # Import pyzmq lib
 import zmq
@@ -362,11 +365,12 @@ class SaltBroker(object):
 if __name__ == "__main__":
     # Try to get config from /etc/rhn/rhn.conf
     rhn_parent = None
-    rhn_proxy_conf = RHNOptions(component="proxy")
-    rhn_proxy_conf.parse()
-    if rhn_proxy_conf.get("rhn_parent"):
-        log.debug("Using 'rhn_parent' from /etc/rhn/rhn.conf as 'master'")
-        rhn_parent = rhn_proxy_conf["rhn_parent"]
+    if RHNOptions is not None:
+        rhn_proxy_conf = RHNOptions(component="proxy")
+        rhn_proxy_conf.parse()
+        if rhn_proxy_conf.get("rhn_parent"):
+            log.debug("Using 'rhn_parent' from /etc/rhn/rhn.conf as 'master'")
+            rhn_parent = rhn_proxy_conf["rhn_parent"]
 
     # Check for the config file
     if not os.path.isfile(SALT_BROKER_CONF_FILE):

--- a/proxy/proxy/spacewalk-proxy.changes.vzhestkov.salt-broker-no-strict-spacewalk-req
+++ b/proxy/proxy/spacewalk-proxy.changes.vzhestkov.salt-broker-no-strict-spacewalk-req
@@ -1,0 +1,1 @@
+- Make salt-broker less dependant on spacewalk libs


### PR DESCRIPTION
## What does this PR change?

`salt-broker` is using `spacewalk` lib just to read 1 config parameter (`rhn_parent`) from `rhn.conf` which is filled with extra script in the containerised deployment. It would be way easier to put `master` config to the broker config instead and the container with the `salt-broker` could become bit lighter due to unneeded `spacewalk` libraries in it.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
