### PR TITLE
Fix action scheduler datetime selection if using maintenance windows

### DIFF
--- a/web/html/src/components/action-schedule.tsx
+++ b/web/html/src/components/action-schedule.tsx
@@ -14,7 +14,8 @@ export type MaintenanceWindow = {
   id: number;
   from: string;
   to: string;
-  fromLocalDate: string;
+  fromMilliseconds: number;
+  toMilliseconds: number;
 };
 
 export type ActionChain = {
@@ -136,7 +137,7 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
   };
 
   onMaintenanceWindowChanged = (selectedItem: MaintenanceWindow) => {
-    const startDateStr = selectedItem.fromLocalDate;
+    const startDateStr = selectedItem.fromMilliseconds;
     this.onDateTimeChanged(localizedMoment(startDateStr));
   };
 

--- a/web/spacewalk-web.changes.parlt.fix-MW-datetime-selection
+++ b/web/spacewalk-web.changes.parlt.fix-MW-datetime-selection
@@ -1,0 +1,1 @@
+- Fix datetime selection when using maintenance windows (bsc#1228036)


### PR DESCRIPTION
## What does this PR change?

Fix the datetime selection for the action scheduler component, when using maintenance windows.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **BUGFIX**

- [x] **DONE**

## Test coverage

- No tests: **BUGFIX**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24851

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
