### PR TITLE
Fix appstreams newest package definitions

### DIFF
--- a/python/spacewalk/satellite_tools/appstreams.py
+++ b/python/spacewalk/satellite_tools/appstreams.py
@@ -143,6 +143,9 @@ class ModuleMdImporter:
                     f"{no_stream_added} new package(s) imported for module {stream.get_NSVCA()}.",
                 )
 
+        refresh_newest_package = rhnSQL.Procedure("rhn_channel.refresh_newest_package")
+        refresh_newest_package(self.channel_id, "backend.appstreams.import_modules")
+
         rhnSQL.commit()
         log(2, f"{no_total_added} of {no_total_pkgs} packages matched.")
 

--- a/python/spacewalk/spacewalk-backend.changes.welder.appstreams-refresh-newest-package
+++ b/python/spacewalk/spacewalk-backend.changes.welder.appstreams-refresh-newest-package
@@ -1,0 +1,1 @@
+- Refresh channel newest packages after importing appstreams metadata

--- a/schema/spacewalk/common/views/suseServerAppStreamHiddenPackagesView.sql
+++ b/schema/spacewalk/common/views/suseServerAppStreamHiddenPackagesView.sql
@@ -23,7 +23,8 @@ FROM rhnserverchannel sc
     INNER JOIN suseappstreampackage sasp ON sasp.module_id = sas.id
     LEFT JOIN suseserverappstream ssa ON ssa.name = sas.name
         AND ssa.stream = sas.stream
-        AND sas.arch = ssa.arch
+        AND ssa.arch = sas.arch
+        AND ssa.server_id = sc.server_id
 WHERE ssa.id IS NULL
 
 UNION

--- a/schema/spacewalk/susemanager-schema.changes.welder.fix-appstreams-related-views
+++ b/schema/spacewalk/susemanager-schema.changes.welder.fix-appstreams-related-views
@@ -1,0 +1,1 @@
+- Fix queries related to appstreams to avoid inconsistencies when listing packages

--- a/schema/spacewalk/upgrade/susemanager-schema-5.0.10-to-susemanager-schema-5.0.11/200-fix-appstreams-related-views.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.0.10-to-susemanager-schema-5.0.11/200-fix-appstreams-related-views.sql
@@ -1,21 +1,31 @@
---
--- Copyright (c) 2008--2012 Red Hat, Inc.
---
--- This software is licensed to you under the GNU General Public License,
--- version 2 (GPLv2). There is NO WARRANTY for this software, express or
--- implied, including the implied warranties of MERCHANTABILITY or FITNESS
--- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
--- along with this software; if not, see
--- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
---
--- Red Hat trademarks are not licensed under GPLv2. No permission is
--- granted to use or replicate Red Hat trademarks that are incorporated
--- in this software or its documentation.
---
---
---
---
--- this is much more readable with ts=4, enjoy!
+CREATE OR REPLACE VIEW suseServerAppStreamHiddenPackagesView AS
+
+SELECT DISTINCT sasp.package_id AS pid, sc.server_id AS sid
+FROM rhnserverchannel sc
+    INNER JOIN suseappstream sas ON sas.channel_id = sc.channel_id
+    INNER JOIN suseappstreampackage sasp ON sasp.module_id = sas.id
+    LEFT JOIN suseserverappstream ssa ON ssa.name = sas.name
+        AND ssa.stream = sas.stream
+        AND ssa.arch = sas.arch
+        AND ssa.server_id = sc.server_id
+WHERE ssa.id IS NULL
+
+UNION
+
+SELECT DISTINCT p.id AS pid, server_stream.server_id AS sid
+FROM suseServerAppstream server_stream
+    INNER JOIN suseAppstream appstream ON appstream.name = server_stream.name
+        AND appstream.stream = server_stream.stream
+        AND appstream.arch = server_stream.arch
+    INNER JOIN suseAppstreamApi api ON api.module_id = appstream.id
+    inner join rhnPackageName pn ON pn.name = api.rpm
+    inner join rhnPackage p ON p.name_id = pn.id
+WHERE NOT EXISTS (
+    SELECT package_id
+    FROM suseServerAppStreamPackageView
+    WHERE server_id = server_stream.server_id
+        AND package_id = p.id
+);
 
 create or replace view
 rhnChannelNewestPackageView


### PR DESCRIPTION
## What does this PR change?

It adds a call to refresh newest package after import modules metadata for a channel and fix the views using appstreams data to calculate the newest package correctly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
