### PR TITLE
QE : use current user instead of admin during after step authentification

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1584,7 +1584,7 @@ When(/^I reboot the "([^"]*)" minion through the web UI$/) do |host|
     And I should see a "Reboot system" button
     When I click on "Reboot system"
     Then I should see a "Reboot scheduled for system" text
-    And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    And I wait at most 600 seconds until event "System reboot scheduled by #{$current_user}" is completed
     Then I should see a "This action's status is: Completed" text
   )
 end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -45,6 +45,8 @@ $server_http_proxy = ENV.fetch('SERVER_HTTP_PROXY', nil) if ENV['SERVER_HTTP_PRO
 $custom_download_endpoint = ENV.fetch('CUSTOM_DOWNLOAD_ENDPOINT', nil) if ENV['CUSTOM_DOWNLOAD_ENDPOINT']
 $no_auth_registry = ENV.fetch('NO_AUTH_REGISTRY', nil) if ENV['NO_AUTH_REGISTRY']
 $auth_registry = ENV.fetch('AUTH_REGISTRY', nil) if ENV['AUTH_REGISTRY']
+$current_user = 'admin'
+$current_password = 'admin'
 
 # maximal wait before giving up
 # the tests return much before that delay in case of success
@@ -144,7 +146,7 @@ After do |scenario|
     ensure
       print_server_logs
       previous_url = current_url
-      step 'I am authorized for the "Admin" section'
+      step %(I am authorized as "#{$current_user}" with password "#{$current_password}")
       visit previous_url
     end
   end


### PR DESCRIPTION
## What does this PR change?

### Context After step scenario
During the BV smoke test, we are using client user to execute the test.
If a scenario is failing, in `After do |scenario|`, the code block inside `if scenario.failed?` is going to be executed.
A step of this rescue scenario is to log back to susemanager with admin.
Unfortunately, this scenario switch back to admin user and doesn't use our client user.

### Context I reboot the "([^"]*)" minion through the web UI
During BV, we have a user for each smote tests scenario. Currently, `I reboot the "([^"]*)" minion through the web UI` is looking at reboot event triggered by admin ( only during bootstrap ) and not reboot event from the current user. Because the testsuite was not looking at the correct event, we were not waiting for the slemicro to correctly reboot and starting new test during the slemicro reboot.

### Changes
This change will correctly log with the client user when a scenario is failing.
This change will make sure we are looking for the correct reboot event.

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to 
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24894

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
