### PR TITLE
Use dash instead of underscore in uyuni-configfiles-sync generated paths

### DIFF
--- a/containers/server-image/server-image.changes.cbosdo.configfiles-sync-dash
+++ b/containers/server-image/server-image.changes.cbosdo.configfiles-sync-dash
@@ -1,0 +1,1 @@
+- Use underscore instead of dash in uyuni-configfiles-sync paths

--- a/containers/server-image/uyuni-configfiles-sync
+++ b/containers/server-image/uyuni-configfiles-sync
@@ -58,7 +58,7 @@ init() {
         echo $RANDOM | sha256sum | head -c 64 > $DEFAULTS_STORAGE/.buildhash
     fi
     echo -n "Initializing environment for persistent volume $PV ... "
-    TARGET="$DEFAULTS_STORAGE/$(echo $PV | sed 's/\//-/g')"
+    TARGET="$DEFAULTS_STORAGE/$(echo $PV | sed 's/\//_/g')"
     mkdir -p $TARGET
     echo "$PV" > $TARGET/.pv
     # Calculate the packages that are owning the files under this path


### PR DESCRIPTION
## What does this PR change?

Replacing slashes by dashes in paths makes it hard to work with. Using underscores is more user friendly.

## GUI diff

No difference.
- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
