### PR TITLE
QE: do not remove OS Salt during product migrations

### DIFF
--- a/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
@@ -7,17 +7,6 @@ Feature: Migrate a SLES 15 SP3 Salt minion to 15 SP4
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  # Having OS salt packages which are not up to date installed on the minion
-  # will not allow it to undergo a Product migration
-  Scenario: Remove OS salt leftovers from the SLE 15 SP3 minion
-    When I remove package "salt" from this "sle15sp3_minion" without error control
-
-  Scenario: Update Package List of this SLE 15 SP3 minion
-    Given I am on the Systems overview page of this "sle15sp3_minion"
-    And I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I wait until event "Package List Refresh" is completed
-
   Scenario: Migrate this minion to SLE 15 SP4
     Given I am on the Systems overview page of this "sle15sp3_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
@@ -7,17 +7,6 @@ Feature: Migrate a SLES 15 SP3 Salt SSH minion to 15 SP4
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  # Having OS salt packages which are not up to date installed on the minion
-  # will not allow it to undergo a Product migration
-  Scenario: Remove OS salt leftovers from this SLE 15 SP3 SSH minion
-    When I remove package "salt" from this "sle15sp3_ssh_minion" without error control
-
-  Scenario: Update Package List of this SLE 15 SP3 SSH minion
-    Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
-    And I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I wait until event "Package List Refresh" is completed
-
   Scenario: Migrate this SSH minion to SLE 15 SP4
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
@@ -7,27 +7,6 @@ Feature: Migrate a SLE Micro 5.4 Salt minion to SLE Micro 5.5
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  # Having OS salt packages which are not up to date installed on the minion
-  # will not allow it to undergo a Product migration
-  Scenario: Remove OS salt leftovers from this SLE Micro 5.4 minion
-    When I remove package "salt" from this "slemicro54_minion" without error control
-
-  Scenario: Reboot this SLE Micro 5.4 minion and wait until reboot is completed
-    Given I am on the Systems overview page of this "slemicro54_minion"
-    When I follow first "Schedule System Reboot"
-    Then I should see a "System Reboot Confirmation" text
-    And I should see a "Reboot system" button
-    When I click on "Reboot system"
-    Then I should see a "Reboot scheduled for system" text
-    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
-    Then I should see a "Reboot completed." text
-
-  Scenario: Update Package List of this SLE Micro 5.4 minion
-    Given I am on the Systems overview page of this "slemicro54_minion"
-    And I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I wait until event "Package List Refresh" is completed
-
   Scenario: Migrate this minion to SLE Micro 5.5
     Given I am on the Systems overview page of this "slemicro54_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
@@ -7,27 +7,6 @@ Feature: Migrate a SLE Micro 5.4 Salt SSH minion to SLE Micro 5.5
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  # Having OS salt packages which are not up to date installed on the minion
-  # will not allow it to undergo a Product migration
-  Scenario: Remove OS salt leftovers from this SLE Micro 5.4 SSH minion
-    When I remove package "salt" from this "slemicro54_ssh_minion" without error control
-  
-  Scenario: Reboot this SLE Micro 5.4 SSH minion and wait until reboot is completed
-    Given I am on the Systems overview page of this "slemicro54_minion"
-    When I follow first "Schedule System Reboot"
-    Then I should see a "System Reboot Confirmation" text
-    And I should see a "Reboot system" button
-    When I click on "Reboot system"
-    Then I should see a "Reboot scheduled for system" text
-    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
-    Then I should see a "Reboot completed." text
-
-  Scenario: Update Package List of this SLE Micro 5.4 SSH minion
-    Given I am on the Systems overview page of this "slemicro54_ssh_minion"
-    And I follow "Software" in the content area
-    And I click on "Update Package List"
-    And I wait until event "Package List Refresh" is completed
-
   Scenario: Migrate this SSH minion to SLE Micro 5.5
     Given I am on the Systems overview page of this "slemicro54_ssh_minion"
     When I follow "Software" in the content area


### PR DESCRIPTION
## What does this PR change?

PRs to fix https://bugzilla.suse.com/show_bug.cgi?id=1224209 have been merged and we should no longer need to remove OS Salt during product migrations.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24233
Port(s): 4.3 https://github.com/SUSE/spacewalk/pull/24897

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"