### PR TITLE
Fix typo on directories to cleanup when deleting a system (bsc#1228101)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -46,15 +46,16 @@ mgr_remove_salt_config_altname:
 
 mgr_remove_salt_priv_key:
   file.absent:
-     - name: {{ salt_config_dir }}/pki/minion.pem
+     - name: {{ salt_config_dir }}/pki/minion/minion.pem
 
 mgr_remove_salt_pub_key:
   file.absent:
-     - name: {{ salt_config_dir }}/pki/minion.pub
+     - name: {{ salt_config_dir }}/pki/minion/minion.pub
 
 mgr_remove_salt_master_key:
+
   file.absent:
-     - name: {{ salt_config_dir }}/pki/minion_master.pub
+     - name: {{ salt_config_dir }}/pki/minion/minion_master.pub
 
 {%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
 mgr_disable_salt:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-bsc1228101
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-bsc1228101
@@ -1,0 +1,1 @@
+- Fix typo on directories to cleanup when deleting a system (bsc#1228101)


### PR DESCRIPTION
## What does this PR change?

This PR fixes a typo on the paths to some minion files to cleanup when deleting a system in Uyuni. This was noticed as the `/etc/venv-salt-minion/pki/minion/minion_master.pub` and some other files were not cleaned up properly during system deletion as it was expected.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no tests for this**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24906
Port(s): https://github.com/SUSE/spacewalk/pull/24907

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
