### PR TITLE
remove session timeout from webapp, in order to use the persisted one in /etc/tomcat/web.xml

### DIFF
--- a/java/code/webapp/WEB-INF/web.xml
+++ b/java/code/webapp/WEB-INF/web.xml
@@ -329,7 +329,6 @@
     configuration for HttpSession timeout
   -->
   <session-config>
-    <session-timeout>60</session-timeout>
     <tracking-mode>COOKIE</tracking-mode>
   </session-config>
 

--- a/java/spacewalk-java.changes.mbussolotto.remove_session_timeout
+++ b/java/spacewalk-java.changes.mbussolotto.remove_session_timeout
@@ -1,0 +1,1 @@
+- remove session timeout from webapp, in order to use the persisted one in /etc/tomcat/web.xml


### PR DESCRIPTION
## What does this PR change?

remove session timeout from webapp, in order to use the persisted one in `/etc/tomcat/web.xml`: this would allow to tune it as described https://www.uyuni-project.org/uyuni-docs/en/uyuni/administration/troubleshooting/tshoot-logintimeout.html

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- Doc needs to be changed from `/usr/share/susemanager/www/tomcat/webapps/rhn/WEB-INF/web.xml`  to `/etc/tomcat/web.xml`

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8030

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
