### PR TITLE
Fix error in 'kickstart_delete' when using wildcards (bsc#1227578)

### DIFF
--- a/spacecmd/spacecmd.changes.cbbayburt.bsc1227578
+++ b/spacecmd/spacecmd.changes.cbbayburt.bsc1227578
@@ -1,0 +1,2 @@
+- Fix error in 'kickstart_delete' when using wildcards 
+  (bsc#1227578)

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -209,16 +209,10 @@ def do_kickstart_delete(self, args):
         self.help_kickstart_delete()
         return 1
 
-    mismatched = sorted(set(args).difference(set(all_labels)))
-    if mismatched:
-        logging.error(_N("The following kickstart labels are invalid:"),
-                      ", ".join(mismatched))
-        return 1
-    else:
-        for label in labels:
-            if self.options.yes or self.user_confirm(_("Delete profile %s [y/N]:") % label):
-                self.client.kickstart.deleteProfile(self.session, label)
-        return 0
+    for label in labels:
+        if self.options.yes or self.user_confirm(_("Delete profile %s [y/N]:") % label):
+            self.client.kickstart.deleteProfile(self.session, label)
+    return 0
 
 ####################
 

--- a/spacecmd/tests/test_kickstart.py
+++ b/spacecmd/tests/test_kickstart.py
@@ -374,9 +374,9 @@ echo 'some more hello'
         assert_args_expect(shell.do_kickstart_list.call_args_list,
                            [(('', True), {})])
 
-    def test_kickstart_delete_some_invalid_profile(self, shell):
+    def test_kickstart_delete_wildcard_arg(self, shell):
         """
-        Test do_kickstart_delete invalid profile (not found).
+        Test do_kickstart_delete with a wildcard argument
 
         :param shell:
         :return:
@@ -387,19 +387,18 @@ echo 'some more hello'
         logger = MagicMock()
         with patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_delete(
-                shell, "fourth_profile zero_profile first_profile second_profile")
+                shell, "*_profile")
 
-        assert not shell.client.kickstart.deleteProfile.called
         assert not shell.help_kickstart_delete.called
-        assert logger.error.called
+        assert not logger.error.called
+        assert shell.client.kickstart.deleteProfile.called
         assert shell.do_kickstart_list.called
         assert logger.debug.called
 
-        assert_expect(logger.debug.call_args_list,
-                      "Got labels to delete of ['first_profile', 'second_profile']")
-        assert_args_expect(logger.error.call_args_list,
-                           [(('The following kickstart labels are invalid:',
-                              'fourth_profile, zero_profile'), {})])
+        assert_args_expect(shell.client.kickstart.deleteProfile.call_args_list,
+                           [((shell.session, "first_profile"), {}),
+                            ((shell.session, "second_profile"), {}),
+                            ((shell.session, "third_profile"), {})])
 
     def test_kickstart_delete_profile_all_yes(self, shell):
         """


### PR DESCRIPTION
In `kickstart_delete`, the code first resolves wildcard arguments and returns matching labels. Then it tries to make sure if every arg actually matched a result. But since the original wildcard args don't literally match the resulting labels, the second check throws an error. This PR removes the second check (only exists in this method) to match the method with the rest of the system.

See bug: https://bugzilla.suse.com/show_bug.cgi?id=1227578

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/24761

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
