### PR TITLE
Add yum-utils package for redhat minions (bsc#1227133)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -28,6 +28,14 @@ mgr_install_flavor_check:
       - mgrcompat: sync_states
 {%- endif %}
 
+{%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] < 8 %}
+  pkg.installed:
+    - name: yum-utils
+    - require:
+      - file: mgrchannels_*
+      - mgrcompat: sync_states
+{%- endif %}
+
 mgr_refresh_grains:
 {%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
   saltutil.sync_grains:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.parlt.fix-yum-utils-missing
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.parlt.fix-yum-utils-missing
@@ -1,0 +1,1 @@
+- Fix yum-utils package missing on CentOS7 minions (bsc#1227133)


### PR DESCRIPTION
## What does this PR change?

CentOS7 and SLL7 systems would fail on `needs-restarting` because of missing `yum-utils` package.
Add the package to the `packages/init.sls` to ensure it is added during bootstrap or highstates execution.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24707 https://github.com/SUSE/spacewalk/issues/24862

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
