### PR TITLE
add missing package python3-ply to bootstrap repo definition

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -205,6 +205,7 @@ PKGLIST15_SALT_NO_BUNDLE = [
     "python3-iniconfig*",
     "python3-looseversion",
     "python3-jmespath",
+    "python3-ply",
     "xz",
 ]
 

--- a/susemanager/susemanager.changes.mc.Manager-4.3-adapt-bsrepo-15sp6
+++ b/susemanager/susemanager.changes.mc.Manager-4.3-adapt-bsrepo-15sp6
@@ -1,0 +1,1 @@
+- add missing package python3-ply to bootstrap repo definition (bsc#1228130)


### PR DESCRIPTION
## What does this PR change?

Package python3-ply seems to be missing in the bootstrap repo when the classic salt-minion package is installed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: corner case

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24931 https://github.com/SUSE/spacewalk/pull/25004

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
