### PR TITLE
Safer cobbler get_profile cast

### DIFF
--- a/java/spacewalk-java.changes.cbosdo.cobbler-cast-fix
+++ b/java/spacewalk-java.changes.cbosdo.cobbler-cast-fix
@@ -1,0 +1,2 @@
+- Prevent class cast exceptions when getting cobbler profiles
+  (bsc#1227759)


### PR DESCRIPTION
## What does this PR change?

Getting the list of cobbler profiles happens in two steps:

* calling cobbler's `get_profiles` API to list all the profiles
* calling cobbler's `get_profile` API to get more info on each profile

In between those two calls, some of the profiles could be gone due to concurrent deletion. In such a case `get_profile` will return `"~"` which means `null`.

Filter out the `"~"` returns to avoid the class cast exception and better reflect reality.

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24846
Port(s): https://github.com/SUSE/spacewalk/pull/24916

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
