### PR TITLE
Revert "Look for proxy ssh port before look for host ssh port"

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
+++ b/susemanager-utils/susemanager-sls/modules/roster/uyuni.py
@@ -170,7 +170,7 @@ class UyuniRoster:
                 # pylint: disable-next=consider-using-f-string
                 "/usr/bin/ssh -p {ssh_port} -i {ssh_key_path} -o StrictHostKeyChecking=no "
                 "-o User={ssh_push_user} {in_out_forward} {proxy_host}".format(
-                    ssh_port=proxy.port or SSH_PUSH_PORT,
+                    ssh_port=proxy.port or 22,
                     ssh_key_path=SSH_KEY_PATH if i == 0 else PROXY_SSH_PUSH_KEY,
                     ssh_push_user=PROXY_SSH_PUSH_USER,
                     in_out_forward=(
@@ -336,7 +336,7 @@ class UyuniRoster:
                     minion_id=prow.minion_id,
                     proxies=proxies,
                     tunnel=prow.tunnel,
-                    ssh_push_port=int(prow.ssh_port or prow.ssh_push_port or SSH_PUSH_PORT),
+                    ssh_push_port=int(prow.ssh_push_port or SSH_PUSH_PORT),
                 )
             proxies = []
             if row is None:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.rmateus.uyuni_add_ssh_port_tunnel_creating_tunnel
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.rmateus.uyuni_add_ssh_port_tunnel_creating_tunnel
@@ -1,1 +1,0 @@
-- Look for proxy ssh port before look for host ssh port


### PR DESCRIPTION


## What does this PR change?

This reverts commit ef8b5d0052f42c4db8f61ddca22eeba06faa32e0.
from https://github.com/uyuni-project/uyuni/pull/8741

It connect to the client using the proxy port.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
