### PR TITLE
Allow group assignment for foreign servers (bsc#1222447)

### DIFF
--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -167,7 +167,7 @@
     </rhn-tab>
   </rhn-tab>
 
-  <rhn-tab name="Groups" acl="system_feature(ftr_system_grouping); user_role(org_admin) or user_role(system_group_admin);system_has_management_entitlement() or system_has_salt_entitlement() or system_is_bootstrap_minion_server()" url="/rhn/systems/details/groups/ListRemove.do">
+  <rhn-tab name="Groups" acl="system_feature(ftr_system_grouping); user_role(org_admin) or user_role(system_group_admin)" url="/rhn/systems/details/groups/ListRemove.do">
     <rhn-tab name="List / Leave" url="/rhn/systems/details/groups/ListRemove.do"/>
     <rhn-tab name="Join" url="/rhn/systems/details/groups/Add.do"/>
   </rhn-tab>

--- a/java/spacewalk-java.changes.nadvornik.foreign_group
+++ b/java/spacewalk-java.changes.nadvornik.foreign_group
@@ -1,0 +1,1 @@
+- Allow group assignment for foreign servers (bsc#1222447)

--- a/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
@@ -290,3 +290,8 @@ insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
                                        created, modified)
 values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_config'),
         current_timestamp,current_timestamp);
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+values (lookup_sg_type('foreign_entitled'), lookup_feature_type('ftr_system_grouping'),
+        current_timestamp,current_timestamp);

--- a/schema/spacewalk/susemanager-schema.changes.nadvornik.foreign_group
+++ b/schema/spacewalk/susemanager-schema.changes.nadvornik.foreign_group
@@ -1,0 +1,1 @@
+- Allow group assignment for foreign servers (bsc#1222447)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.0-to-susemanager-schema-5.1.1/010-foreign-groups.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.0-to-susemanager-schema-5.1.1/010-foreign-groups.sql
@@ -1,0 +1,7 @@
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+select lookup_sg_type('foreign_entitled'), lookup_feature_type('ftr_system_grouping'),
+       current_timestamp, current_timestamp from dual
+       where not exists ( select 1 from rhnServerGroupTypeFeature
+                              where server_group_type_id = lookup_sg_type('foreign_entitled')
+                              and feature_id = lookup_feature_type('ftr_system_grouping') );


### PR DESCRIPTION
## What does this PR change?

With this PR it is possible to assign foreign servers and proxies to system groups.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: expected behavior

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24096
https://bugzilla.suse.com/show_bug.cgi?id=1222447

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
