### PR TITLE
Qe bv change reboot order

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -126,6 +126,17 @@ Feature: Smoke tests for <client>
     Then I should see a "Channel Subscriptions successfully changed for" text
     And I reboot the "<client>" if it is a transactional system
 
+@skip_for_sle_micro
+  Scenario: Reboot the <client> and wait until reboot is completed
+    Given I am on the Systems overview page of this "<client>"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    And I wait at most 600 seconds until event "System reboot scheduled by <client>" is completed
+    Then I should see a "This action's status is: Completed" text
+
   Scenario: Deploy the configuration file to <client>
     When I follow the left menu "Configuration > Channels"
     And I wait until I see "Centrally Managed Configuration Channel" text
@@ -144,16 +155,6 @@ Feature: Smoke tests for <client>
     And I should see a "0 revision-deploys overridden." text
     And I wait until file "/etc/s-mgr/config" exists on "<client>"
     Then file "/etc/s-mgr/config" should contain "COLOR=white" on "<client>"
-
-  Scenario: Reboot the <client> and wait until reboot is completed
-    Given I am on the Systems overview page of this "<client>"
-    When I follow first "Schedule System Reboot"
-    Then I should see a "System Reboot Confirmation" text
-    And I should see a "Reboot system" button
-    When I click on "Reboot system"
-    Then I should see a "Reboot scheduled for system" text
-    And I wait at most 600 seconds until event "System reboot scheduled by <client>" is completed
-    Then I should see a "This action's status is: Completed" text
 
 @skip_for_sle_micro
   # The client tools of SLE Micro (intentionally) do not contain spacecmd

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -126,7 +126,6 @@ Feature: Smoke tests for <client>
     Then I should see a "Channel Subscriptions successfully changed for" text
     And I reboot the "<client>" if it is a transactional system
 
-@skip_for_sle_micro
   Scenario: Reboot the <client> and wait until reboot is completed
     Given I am on the Systems overview page of this "<client>"
     When I follow first "Schedule System Reboot"


### PR DESCRIPTION
## What does this PR change?

### Context :  
During BV smoke tests, all slemicro reboot scenarios are failing with this message.
My theory is `Deploy the configuration file to <client>` scenario is not completely finish before we start rebooting.
The deploy configuration is in the events but doesn't have a status that we can check.

![Image](https://github.com/user-attachments/assets/b98ada2f-00d7-4af2-b242-dcb28814cae7)

### Solution: 
Change scenarios order to get reboot scenario after a wait for event step.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24939

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
