### PR TITLE
 Merge two steps of folder's removal into one

### DIFF
--- a/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
@@ -35,7 +35,6 @@ Feature: Export and import configuration channels with new ISS implementation
 
   Scenario: Export data with ISS v2
     When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"
     When I export config channels "testconfigchannel" with ISS v2 to "/tmp/export_iss_v2"
     Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory
 
@@ -66,4 +65,3 @@ Feature: Export and import configuration channels with new ISS implementation
 
   Scenario: Cleanup: remove ISS v2 export folder
     When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"

--- a/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_config_channels_with_ISS_v2.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 SUSE LLC
+# Copyright (c) 2021-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation

--- a/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_software_channels_with_ISS_v2.feature
@@ -36,7 +36,6 @@ Feature: Export and import software channels with new ISS implementation
 
   Scenario: Export data with ISS v2
     When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"
     When I export software channels "clone-fake-rpm-suse-channel" with ISS v2 to "/tmp/export_iss_v2"
     Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory
 
@@ -71,4 +70,3 @@ Feature: Export and import software channels with new ISS implementation
 
   Scenario: Cleanup: remove ISS v2 export folder
     When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"
-    Then export folder "/tmp/export_iss_v2" shouldn't exist on "server"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1342,8 +1342,10 @@ end
 
 When(/^I ensure folder "(.*?)" doesn't exist on "(.*?)"$/) do |folder, host|
   node = get_target(host)
-  return_code = folder_delete(node, folder) if folder_exists?(node, folder)
-  raise ScriptError, 'Folder exists and can not be removed' unless return_code.zero?
+  if folder_exists?(node, folder)
+    return_code = folder_delete(node, folder)
+    raise ScriptError, "Folder '#{folder}' exists and cannot be removed" unless return_code.zero?
+  end
 end
 
 # ReportDB

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1340,14 +1340,10 @@ Then(/^"(.*?)" folder on server is ISS v2 export directory$/) do |folder|
   raise ScriptError, "Folder #{folder} not found" unless file_exists?(get_target('server'), "#{folder}/sql_statements.sql.gz")
 end
 
-Then(/^export folder "(.*?)" shouldn't exist on "(.*?)"$/) do |folder, host|
-  node = get_target(host)
-  raise ScriptError, 'Folder exists' if folder_exists?(node, folder)
-end
-
 When(/^I ensure folder "(.*?)" doesn't exist on "(.*?)"$/) do |folder, host|
   node = get_target(host)
-  folder_delete(node, folder) if folder_exists?(node, folder)
+  return_code = folder_delete(node, folder) if folder_exists?(node, folder)
+  raise ScriptError, 'Folder exists and can not be removed' unless return_code.zero?
 end
 
 # ReportDB

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -35,6 +35,7 @@ end
 #
 # @param node [Node] The node on which the folder should be deleted.
 # @param folder [String] The name of the folder to be deleted.
+# @return [Integer] The exit code of the operation.
 def folder_delete(node, folder)
   node.folder_delete(folder)
 end


### PR DESCRIPTION
## What does this PR change?

Simplifies two folder removal operations into one.
Verification tests are passing:

```
uyuni-master-podman-ctl:~/uyuni/testsuite # cucumber features/secondary/srv_handle_config_channels_with_ISS_v2.feature
Capybara APP Host: https://uyuni-master-podman-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.6, Family: opensuse-leap
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.6, Family: opensuse-leap
Activating HTTP API
Using the default profile...
# Copyright (c) 2022 SUSE LLC
# Licensed under the terms of the MIT license.
@skip_if_github_validation
Feature: Export and import configuration channels with new ISS implementation
  Distribute configuration between servers
  Run export and import with ISS v2

  Scenario: Install inter server sync package                    # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:9
      This scenario ran at: 2024-07-30 11:18:46 +0200
    When I install packages "inter-server-sync" on this "server" # features/step_definitions/command_steps.rb:922
    Then "inter-server-sync" should be installed on "server"     # features/step_definitions/command_steps.rb:197
      This scenario took: 2 seconds

  Scenario: Log in as admin user                  # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:13
      This scenario ran at: 2024-07-30 11:18:48 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:401
      This scenario took: 12 seconds

  Scenario: Create a configuration channel                                 # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:16
      This scenario ran at: 2024-07-30 11:19:00 +0200
    When I follow the left menu "Configuration > Channels"                 # features/step_definitions/navigation_steps.rb:339
    And I follow "Create Config Channel"                                   # features/step_definitions/navigation_steps.rb:284
    And I enter "Test Config Channel" as "cofName"                         # features/step_definitions/navigation_steps.rb:220
    And I enter "testconfigchannel" as "cofLabel"                          # features/step_definitions/navigation_steps.rb:220
    And I enter "This is a test configuration channel" as "cofDescription" # features/step_definitions/navigation_steps.rb:220
    And I click on "Create Config Channel"                                 # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Test Config Channel" text                         # features/step_definitions/navigation_steps.rb:591
      This scenario took: 2 seconds

  Scenario: Add a configuration file to the test configuration channel                                       # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:25
      This scenario ran at: 2024-07-30 11:19:02 +0200
    When I follow the left menu "Configuration > Channels"                                                   # features/step_definitions/navigation_steps.rb:339
    And I follow "Test Config Channel"                                                                       # features/step_definitions/navigation_steps.rb:284
    And I follow "Create Configuration File or Directory"                                                    # features/step_definitions/navigation_steps.rb:284
    And I enter "/etc/s-mgr/config" as "cffPath"                                                             # features/step_definitions/navigation_steps.rb:220
    And I enter "COLOR=white" in the editor                                                                  # features/step_definitions/navigation_steps.rb:330
    And I click on "Create Configuration File"                                                               # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Revision 1 of /etc/s-mgr/config from channel Test Config Channel" text              # features/step_definitions/navigation_steps.rb:591
    And file "/srv/susemanager/salt/manager_org_1/testconfigchannel/init.sls" should exist on server         # features/step_definitions/file_management_steps.rb:22
    And file "/srv/susemanager/salt/manager_org_1/testconfigchannel/etc/s-mgr/config" should exist on server # features/step_definitions/file_management_steps.rb:22
      This scenario took: 3 seconds

  Scenario: Export data with ISS v2                                                       # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:36
      This scenario ran at: 2024-07-30 11:19:05 +0200
    When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server"                   # features/step_definitions/command_steps.rb:1343
    When I export config channels "testconfigchannel" with ISS v2 to "/tmp/export_iss_v2" # features/step_definitions/command_steps.rb:1331
    Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory                 # features/step_definitions/command_steps.rb:1339
      This scenario took: 12 seconds

  Scenario: Cleanup: remove the test configuration channel                                                # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:41
      This scenario ran at: 2024-07-30 11:19:17 +0200
    When I follow the left menu "Configuration > Channels"                                                # features/step_definitions/navigation_steps.rb:339
    And I follow "Test Config Channel"                                                                    # features/step_definitions/navigation_steps.rb:284
    And I follow "Delete Channel"                                                                         # features/step_definitions/navigation_steps.rb:284
    And I click on "Delete Config Channel"                                                                # features/step_definitions/navigation_steps.rb:256
    Then file "/srv/susemanager/salt/manager_org_1/testconfigchannel/init.sls" should not exist on server # features/step_definitions/file_management_steps.rb:36
    And I should not see a "Test Config Channel" link                                                     # features/step_definitions/navigation_steps.rb:665
      This scenario took: 2 seconds

  Scenario: Import data with ISS v2                          # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:49
      This scenario ran at: 2024-07-30 11:19:19 +0200
    When I import data with ISS v2 from "/tmp/export_iss_v2" # features/step_definitions/command_steps.rb:1335
      This scenario took: 0 seconds

  Scenario: Check that the config channel was imported                                                       # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:52
      This scenario ran at: 2024-07-30 11:19:19 +0200
    When I follow the left menu "Configuration > Channels"                                                   # features/step_definitions/navigation_steps.rb:339
    Then I should see a "Test Config Channel" link                                                           # features/step_definitions/navigation_steps.rb:658
    And file "/srv/susemanager/salt/manager_org_1/testconfigchannel/init.sls" should exist on server         # features/step_definitions/file_management_steps.rb:22
    And file "/srv/susemanager/salt/manager_org_1/testconfigchannel/etc/s-mgr/config" should exist on server # features/step_definitions/file_management_steps.rb:22
      This scenario took: 1 seconds

  Scenario: Cleanup: remove the test configuration channel                                                # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:58
      This scenario ran at: 2024-07-30 11:19:20 +0200
    When I follow the left menu "Configuration > Channels"                                                # features/step_definitions/navigation_steps.rb:339
    And I follow "Test Config Channel"                                                                    # features/step_definitions/navigation_steps.rb:284
    And I follow "Delete Channel"                                                                         # features/step_definitions/navigation_steps.rb:284
    And I click on "Delete Config Channel"                                                                # features/step_definitions/navigation_steps.rb:256
    Then file "/srv/susemanager/salt/manager_org_1/testconfigchannel/init.sls" should not exist on server # features/step_definitions/file_management_steps.rb:36
    And I should not see a "Test Config Channel" link                                                     # features/step_definitions/navigation_steps.rb:665
      This scenario took: 2 seconds

  Scenario: Cleanup: remove ISS v2 export folder                        # features/secondary/srv_handle_config_channels_with_ISS_v2.feature:66
      This scenario ran at: 2024-07-30 11:19:22 +0200
    When I ensure folder "/tmp/export_iss_v2" doesn't exist on "server" # features/step_definitions/command_steps.rb:1343
      This scenario took: 1 seconds

10 scenarios (10 passed)
40 steps (40 passed)
0m36.952s

```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24959
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
