### PR TITLE
QE: Use correct kernel image for SLES 15 SP4

### DIFF
--- a/testsuite/features/build_validation/init_clients/sle15sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp4_minion.feature
@@ -42,6 +42,13 @@ Feature: Bootstrap a SLES 15 SP4 Salt minion
     And I follow "Proxy" in the content area
     Then I should see "sle15sp4_minion" hostname
 
+  Scenario: Use correct kernel image on the SLES 15 SP4 minion
+    When I remove package "kernel-default-base" from this "sle15sp4_minion"
+    And I install package "kernel-default" on this "sle15sp4_minion"
+
+  Scenario: Reboot the SLES 15 SP4 minion to use the new kernel
+    When I reboot the "sle15sp4_minion" host through SSH, waiting until it comes back
+
   Scenario: Check events history for failures on SLES 15 SP4 minion
     Given I am on the Systems overview page of this "sle15sp4_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/sle15sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp4_ssh_minion.feature
@@ -37,6 +37,13 @@ Feature: Bootstrap a SLES 15 SP4 Salt SSH minion
     And I follow "Proxy" in the content area
     Then I should see "sle15sp4_ssh_minion" hostname
 
+  Scenario: Use correct kernel image on the SLES 15 SP4 SSH minion
+    When I remove package "kernel-default-base" from this "sle15sp4_ssh_minion"
+    And I install package "kernel-default" on this "sle15sp4_ssh_minion"
+
+  Scenario: Reboot the SLES 15 SP4 SSH minion to use the new kernel
+    When I reboot the "sle15sp4_ssh_minion" host through SSH, waiting until it comes back
+
   Scenario: Check events history for failures on SLES 15 SP4 SSH minion
     Given I am on the Systems overview page of this "sle15sp4_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -28,6 +28,15 @@ Feature: Bootstrap a Salt minion via the GUI
     And I wait until onboarding is completed for "sle_minion"
     Then the Salt master can reach "sle_minion"
 
+@susemanager
+  Scenario: Use correct kernel image on the SLES minion
+    When I remove package "kernel-default-base" from this "sle_minion"
+    And I install package "kernel-default" on this "sle_minion"
+
+@susemanager
+  Scenario: Reboot the SLES minion to use the new kernel
+    When I reboot the "sle_minion" host through SSH, waiting until it comes back
+
 @proxy
   Scenario: Check connection from minion to proxy
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -21,6 +21,15 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"
 
+@susemanager
+  Scenario: Use correct kernel image on the SSH minion
+    When I remove package "kernel-default-base" from this "ssh_minion"
+    And I install package "kernel-default" on this "ssh_minion"
+
+@susemanager
+  Scenario: Reboot the SSH minion to use the new kernel
+    When I reboot the "ssh_minion" host through SSH, waiting until it comes back
+
 @proxy
   Scenario: Check connection from SSH minion to proxy
     Given I am on the Systems overview page of this "ssh_minion"


### PR DESCRIPTION
## What does this PR change?

Forward port of https://github.com/SUSE/spacewalk/pull/24942. However, only HEAD is changed. Uyuni/Uyuni Podman is also affected, however, we do not fully sync openSUSE Leap 15.5 to be able to install the correct kernel.

See https://github.com/SUSE/spacewalk/issues/24903

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24903
Ports(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!