### PR TITLE
spacecmd: speedup softwarechannel_removepackages

### DIFF
--- a/spacecmd/spacecmd.changes.agraul.speedup-softwarechannel_removepackages
+++ b/spacecmd/spacecmd.changes.agraul.speedup-softwarechannel_removepackages
@@ -1,0 +1,1 @@
+- Speed up softwarechannel_removepackages (bsc#1227606)

--- a/spacecmd/tests/test_softwarechannel.py
+++ b/spacecmd/tests/test_softwarechannel.py
@@ -3,7 +3,7 @@
 Test software channel module.
 """
 
-from mock import Mock, MagicMock, patch
+from mock import Mock, MagicMock, patch, call
 import spacecmd.softwarechannel
 from helpers import shell, assert_expect, assert_list_args_expect
 import pytest
@@ -700,3 +700,44 @@ def test_softwarechannel_errata_diff(shell):
         ],
     )
 
+
+def test_softwarechannel_removepackages(shell):
+    packages_list = [
+        {
+            "id": 21708,
+            "name": "emacs",
+            "version": "42.0",
+            "release": "9",
+            "epoch": "",
+            "arch": "x86_64",
+        },
+        {
+            "id": 21742,
+            "name": "emacs-nox",
+            "version": "42.0",
+            "release": "10",
+            "epoch": "",
+            "arch_label": "x86_64",
+        },
+        {
+            "id": 12969,
+            "name": "tiff",
+            "version": "1.0",
+            "release": "11",
+            "epoch": "3",
+            "arch": "amd64",
+        },
+    ]
+
+    mprint = MagicMock()
+    shell.client.channel.software.listAllPackages = MagicMock(
+        return_value=packages_list
+    )
+    with patch("spacecmd.softwarechannel.print", mprint):
+        out = spacecmd.softwarechannel.do_softwarechannel_removepackages(
+            shell, "some_channel emacs-42.0-9.x86_64"
+        )
+    assert out == 0
+    # It's not good to check output, but the actual call includes so many mocked
+    # functions that it's close to meaningless to check those
+    assert call("emacs-42.0-9.x86_64") in mprint.call_args_list


### PR DESCRIPTION
## What does this PR change?

Speedup softwarechannel_removepackages

Instead of converting the list of dictionaries to strings and later find each package db id from the local cache (which needs to be built first), we can build ourselves a dictionary with the same package name string as the key and the id as the value. This approach bypasses building the cache. A request to list all packages for the requested channel takes place either way and did not use the cache.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24775
Port(s): https://github.com/SUSE/spacewalk/pull/24973, https://github.com/SUSE/spacewalk/pull/25203

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
