### PR TITLE
Add missing changelog entries

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.deneb-alpha.fix-suma501-changelogs
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.deneb-alpha.fix-suma501-changelogs
@@ -1,0 +1,1 @@
+- Update translation strings

--- a/spacecmd/spacecmd.changes.deneb-alpha.fix-suma501-changelogs
+++ b/spacecmd/spacecmd.changes.deneb-alpha.fix-suma501-changelogs
@@ -1,0 +1,1 @@
+- Update translation strings

--- a/spacewalk/admin/spacewalk-admin.changes.deneb-alpha.fix-suma501-changelogs
+++ b/spacewalk/admin/spacewalk-admin.changes.deneb-alpha.fix-suma501-changelogs
@@ -1,0 +1,1 @@
+- Remove mgr-check-payg service


### PR DESCRIPTION
## What does this PR change?

Add missing changelog entries needed by Tito for tagging

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: no code changes

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/24610

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
