### PR TITLE
mgr-push package is not available on sle_minion during push package feature tests

### DIFF
--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -18,6 +18,7 @@ Feature: Push a package with unset vendor
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check radio button "openSUSE Leap Micro 5.5 (x86_64)"
+    And I wait until I do not see "Loading..." text
     And I check "Uyuni Client Tools for openSUSE Leap Micro 5.5 (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -11,6 +11,21 @@ Feature: Push a package with unset vendor
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  @uyuni
+  Scenario: Pre-requisite: SLES minion must be subscribed to the openSUSE Leap Micro 5.5 channel
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap Micro 5.5 (x86_64)"
+    And I check "Uyuni Client Tools for openSUSE Leap Micro 5.5 (x86_64)"
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    When I follow "scheduled" in the content area
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+
   Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -12,8 +12,6 @@ Feature: Push a package with unset vendor
     Given I am authorized for the "Admin" section
 
   @uyuni
-  @sle_minion
-  @scc_credentials
   Scenario: Pre-requisite: SLES minion must be subscribed to the openSUSE Leap Micro 5.5 channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -12,6 +12,8 @@ Feature: Push a package with unset vendor
     Given I am authorized for the "Admin" section
 
   @uyuni
+  @sle_minion
+  @scc_credentials
   Scenario: Pre-requisite: SLES minion must be subscribed to the openSUSE Leap Micro 5.5 channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -23,8 +25,7 @@ Feature: Push a package with unset vendor
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    When I follow "scheduled" in the content area
-    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+    And I wait until event "Subscribe channels scheduled by admin" is completed
 
   Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion
     Given I am on the Systems overview page of this "sle_minion"


### PR DESCRIPTION
## What does this PR change?

Pipeline: https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-dev-acceptance-tests-podman/

Before:

<details>

```

uyuni-master-podman-ctl:~/spacewalk/testsuite # cucumber features/secondary/srv_push_package.feature 
Capybara APP Host: https://uyuni-master-podman-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.5, Family: opensuse-leap
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.5, Family: opensuse-leap
Activating HTTP API
Using the default profile...
# Copyright (c) 2015-2024 SUSE LLC
# Licensed under the terms of the MIT license.
@sle_minion @scc_credentials @flaky
Feature: Push a package with unset vendor
  In order to distribute software to the clients
  As an authorized user
  I want to push a package with unset vendor

  Scenario: Log in as admin user                  # features/secondary/srv_push_package.feature:12
      This scenario ran at: 2024-08-01 13:00:17 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:401
      This scenario took: 13 seconds

  Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion     # features/secondary/srv_push_package.feature:15
      This scenario ran at: 2024-08-01 13:00:30 +0200
Initializing a twopence node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname uyuni-master-podman-min-suse and FQDN uyuni-master-podman-min-suse.mgr.suse.de
Node: uyuni-master-podman-min-suse, OS Version: 15.5, Family: opensuse-leap
    Given I am on the Systems overview page of this "sle_minion"                     # features/step_definitions/navigation_steps.rb:413
    When I follow "Software" in the content area                                     # features/step_definitions/navigation_steps.rb:299
    And I wait until I see "Upgrade Packages" text                                   # features/step_definitions/navigation_steps.rb:39
    And I follow "Install"                                                           # features/step_definitions/navigation_steps.rb:284
    And I wait until I see "Installable Packages" text                               # features/step_definitions/navigation_steps.rb:39
    And I enter "mgr-push" as the filtered package name                              # features/step_definitions/navigation_steps.rb:846
    And I click on the filter button                                                 # features/step_definitions/navigation_steps.rb:818
    And I check "mgr-push" in the list                                               # features/step_definitions/navigation_steps.rb:924
      Unable to find xpath "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'mgr-push')]]//input[@type='checkbox']" (Capybara::ElementNotFound)
      ./features/step_definitions/navigation_steps.rb:926:in `/^I (check|uncheck) "([^"]*)" in the list$/'
      features/secondary/srv_push_package.feature:23:in `I check "mgr-push" in the list'
    And I click on "Install Selected Packages"                                       # features/step_definitions/navigation_steps.rb:256
    And I click on "Confirm"                                                         # features/step_definitions/navigation_steps.rb:256
    Then I should see a "1 package install has been scheduled for" text              # features/step_definitions/navigation_steps.rb:591
    And I wait until event "Package Install/Upgrade scheduled by admin" is completed # features/step_definitions/common_steps.rb:161
=> /var/log/rhn/rhn_web_ui.log
2024-08-01 12:57:11,687 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:57:11,718 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-10] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:57:16,687 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:57:16,727 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:57:35,174 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:10,303 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:10,330 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:11,730 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:11,757 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:13,305 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:13,338 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:38,845 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-10] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:38,874 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 13:00:29,583 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-9] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:00:30,959 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-2] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:00:30,989 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-1] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]

=> /var/log/rhn/rhn_web_api.log
[2024-08-01 12:58:06,094] INFO  - REQUESTED FROM: 10.100.219.102 CALL: systems.list.all(p=1, sc=server_name, ps=100, s=1) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:58:06,116] INFO  - REQUESTED FROM: 10.100.219.102 CALL: sets.system_list(1000010025=true) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:58:09,711] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: systems.list.all(p=1, sc=server_name, ps=100, s=1) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:58:09,723] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: sets.system_list(1000010025=true) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:59:10,305] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.013 seconds
[2024-08-01 12:59:10,319] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:10,331] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:11,732] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.013 seconds
[2024-08-01 12:59:11,745] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-pxy.mgr.suse.de") CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:11,758] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:13,308] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.016 seconds
[2024-08-01 12:59:13,325] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.003 seconds
[2024-08-01 12:59:13,339] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:15,144] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: systems.proxy(proxy="0", ids=[1000010026]) CALLER: (admin) TIME: 0.087 seconds
[2024-08-01 12:59:38,847] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.014 seconds
[2024-08-01 12:59:38,862] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:59:38,875] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 13:00:30,961] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.014 seconds
[2024-08-01 13:00:30,978] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-min-suse.mgr.suse.de") CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 13:00:30,991] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds

      This scenario took: 13 seconds

  @flaky
  Scenario: Push a package with unset vendor through the SLES minion                                                               # features/secondary/srv_push_package.feature:30
      This scenario ran at: 2024-08-01 13:01:06 +0200
    When I copy unset package file on "sle_minion"                                                                                 # features/step_definitions/command_steps.rb:1315
    And I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "fake-base-channel-suse-like" channel through "sle_minion" # features/step_definitions/common_steps.rb:513
      FAIL: mgrpush -u admin -p admin --server=uyuni-master-podman-srv.mgr.suse.de --nosig -c fake-base-channel-suse-like /root/subscription-tools-1.0-0.noarch.rpm returned status code = 127.
      Output:
      bash: mgrpush: command not found
       (ScriptError)
      ./features/support/lavanda.rb:189:in `run_local'
      ./features/support/lavanda.rb:168:in `run'
      ./features/step_definitions/common_steps.rb:515:in `/^I push package "([^"]*)" into "([^"]*)" channel through "([^"]*)"$/'
      features/secondary/srv_push_package.feature:32:in `I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "fake-base-channel-suse-like" channel through "sle_minion"'
    Then I should see package "subscription-tools-1.0-0.noarch" in channel "Fake-Base-Channel-SUSE-like"                           # features/step_definitions/common_steps.rb:519
=> /var/log/rhn/rhn_web_ui.log
2024-08-01 12:57:11,687 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:57:11,718 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-10] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:57:16,687 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:57:16,727 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:57:35,174 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:10,303 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:10,330 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:11,730 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:11,757 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:13,305 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:13,338 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:38,845 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-10] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:38,874 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 13:00:29,583 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-9] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:00:30,959 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-2] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:00:30,989 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-1] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 13:01:05,163 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]

=> /var/log/rhn/rhn_web_api.log
[2024-08-01 12:58:06,094] INFO  - REQUESTED FROM: 10.100.219.102 CALL: systems.list.all(p=1, sc=server_name, ps=100, s=1) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:58:06,116] INFO  - REQUESTED FROM: 10.100.219.102 CALL: sets.system_list(1000010025=true) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:58:09,711] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: systems.list.all(p=1, sc=server_name, ps=100, s=1) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:58:09,723] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: sets.system_list(1000010025=true) CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:59:10,305] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.013 seconds
[2024-08-01 12:59:10,319] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:10,331] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:11,732] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.013 seconds
[2024-08-01 12:59:11,745] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-pxy.mgr.suse.de") CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:11,758] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:13,308] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.016 seconds
[2024-08-01 12:59:13,325] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.003 seconds
[2024-08-01 12:59:13,339] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:15,144] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: systems.proxy(proxy="0", ids=[1000010026]) CALLER: (admin) TIME: 0.087 seconds
[2024-08-01 12:59:38,847] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.014 seconds
[2024-08-01 12:59:38,862] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:59:38,875] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 13:00:30,961] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.014 seconds
[2024-08-01 13:00:30,978] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-min-suse.mgr.suse.de") CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 13:00:30,991] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds

      This scenario took: 0 seconds

  Scenario: Check vendor of package displayed in web UI         # features/secondary/srv_push_package.feature:35
      This scenario ran at: 2024-08-01 13:01:29 +0200
    When I follow the left menu "Software > Channel List > All" # features/step_definitions/navigation_steps.rb:339
    And I follow "Fake-Base-Channel-SUSE-like"                  # features/step_definitions/navigation_steps.rb:284
    And I follow "Packages"                                     # features/step_definitions/navigation_steps.rb:284
    And I follow "subscription-tools-1.0-0.noarch"              # features/step_definitions/navigation_steps.rb:284
      Unable to find link "subscription-tools-1.0-0.noarch" (Capybara::ElementNotFound)
      ./features/support/commonlib.rb:200:in `click_link_and_wait'
      ./features/step_definitions/navigation_steps.rb:285:in `/^I follow "([^"]*)"$/'
      features/secondary/srv_push_package.feature:39:in `I follow "subscription-tools-1.0-0.noarch"'
    Then I should see a "Vendor:" text                          # features/step_definitions/navigation_steps.rb:591
    And I should see a "Not defined" text                       # features/step_definitions/navigation_steps.rb:591
=> /var/log/rhn/rhn_web_ui.log
2024-08-01 12:57:11,687 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:57:11,718 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-10] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:57:16,687 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-8] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:57:16,727 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:57:35,174 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:10,303 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:10,330 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:11,730 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:11,757 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:13,305 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:13,338 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-7] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 12:59:38,845 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-10] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 12:59:38,874 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 13:00:29,583 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-9] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:00:30,959 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-2] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:00:30,989 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-1] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]
2024-08-01 13:01:05,163 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-5] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:01:28,264 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-4] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:01:40,139 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-6] INFO  com.suse.manager.webui.controllers.login.LoginController - LOCAL AUTH SUCCESS: [admin]
2024-08-01 13:01:40,178 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-1] INFO  com.suse.manager.webui.controllers.login.LoginController - WEB LOGOUT: [admin]

=> /var/log/rhn/rhn_web_api.log
[2024-08-01 12:59:10,305] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.013 seconds
[2024-08-01 12:59:10,319] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:10,331] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:11,732] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.013 seconds
[2024-08-01 12:59:11,745] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-pxy.mgr.suse.de") CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:11,758] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:13,308] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.016 seconds
[2024-08-01 12:59:13,325] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.003 seconds
[2024-08-01 12:59:13,339] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 12:59:15,144] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: systems.proxy(proxy="0", ids=[1000010026]) CALLER: (admin) TIME: 0.087 seconds
[2024-08-01 12:59:38,847] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.014 seconds
[2024-08-01 12:59:38,862] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 12:59:38,875] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 13:00:30,961] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.014 seconds
[2024-08-01 13:00:30,978] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-min-suse.mgr.suse.de") CALLER: (admin) TIME: 0.002 seconds
[2024-08-01 13:00:30,991] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 13:01:40,142] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.login(password=******, login="admin") CALLER: (none) TIME: 0.015 seconds
[2024-08-01 13:01:40,161] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: system.searchByName(regexp="uyuni-master-podman-minssh-suse.mgr.suse.de") CALLER: (admin) TIME: 0.003 seconds
[2024-08-01 13:01:40,179] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: auth.logout() CALLER: (admin) TIME: 0.001 seconds
[2024-08-01 13:01:43,066] INFO  - REQUESTED FROM: 2a07:de40:b208:1:a8b2:93ff:fe01:20 CALL: systems.proxy(proxy="1000010000", ids=[1000010026]) CALLER: (admin) TIME: 0.054 seconds

^C
Exiting... Interrupt again to exit immediately.
      This scenario took: 11 seconds
      exit (SystemExit)
      ./features/step_definitions/navigation_steps.rb:529:in `/^I am authorized as "([^"]*)" with password "([^"]*)"$/'
      ./features/support/env.rb:150:in `After'

Failing Scenarios:
cucumber features/secondary/srv_push_package.feature:15 # Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion
cucumber features/secondary/srv_push_package.feature:30 # Scenario: Push a package with unset vendor through the SLES minion
cucumber features/secondary/srv_push_package.feature:35 # Scenario: Check vendor of package displayed in web UI

4 scenarios (3 failed, 1 passed)
22 steps (3 failed, 7 skipped, 12 passed)
1m39.805s

```

</details>

After:

<details>

```

uyuni-master-podman-ctl:~/spacewalk/testsuite # cucumber features/secondary/srv_push_package.feature 
Capybara APP Host: https://uyuni-master-podman-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.5, Family: opensuse-leap
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.5, Family: opensuse-leap
Activating HTTP API
Using the default profile...
# Copyright (c) 2015-2024 SUSE LLC
# Licensed under the terms of the MIT license.
@sle_minion @scc_credentials @flaky
Feature: Push a package with unset vendor
  In order to distribute software to the clients
  As an authorized user
  I want to push a package with unset vendor

  Scenario: Log in as admin user                  # features/secondary/srv_push_package.feature:12
      This scenario ran at: 2024-08-01 13:34:24 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:401
      This scenario took: 13 seconds

  @uyuni
  Scenario: Pre-requisite: SLES minion must be subscribed to the openSUSE Leap Micro 5.5 channel    # features/secondary/srv_push_package.feature:16
      This scenario ran at: 2024-08-01 13:34:37 +0200
Initializing a twopence node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname uyuni-master-podman-min-suse and FQDN uyuni-master-podman-min-suse.mgr.suse.de
Node: uyuni-master-podman-min-suse, OS Version: 15.5, Family: opensuse-leap
    Given I am on the Systems overview page of this "sle_minion"                                    # features/step_definitions/navigation_steps.rb:413
    When I follow "Software" in the content area                                                    # features/step_definitions/navigation_steps.rb:299
    And I follow "Software Channels" in the content area                                            # features/step_definitions/navigation_steps.rb:299
    And I wait until I do not see "Loading..." text                                                 # features/step_definitions/navigation_steps.rb:43
    And I check radio button "openSUSE Leap Micro 5.5 (x86_64)"                                     # features/step_definitions/common_steps.rb:220
    And I check "Uyuni Client Tools for openSUSE Leap Micro 5.5 (x86_64)"                           # features/step_definitions/navigation_steps.rb:154
    And I click on "Next"                                                                           # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Confirm Software Channel Change" text                                      # features/step_definitions/navigation_steps.rb:591
    When I click on "Confirm"                                                                       # features/step_definitions/navigation_steps.rb:256
    Then I should see a "Changing the channels has been scheduled." text                            # features/step_definitions/navigation_steps.rb:591
    When I follow "scheduled" in the content area                                                   # features/step_definitions/navigation_steps.rb:299
    And I wait until I see "1 system successfully completed this action." text, refreshing the page # features/step_definitions/navigation_steps.rb:55
      This scenario took: 20 seconds

  Scenario: Pre-requisite: mgr-push package must be installed on the SLES minion     # features/secondary/srv_push_package.feature:30
      This scenario ran at: 2024-08-01 13:34:57 +0200
    Given I am on the Systems overview page of this "sle_minion"                     # features/step_definitions/navigation_steps.rb:413
    When I follow "Software" in the content area                                     # features/step_definitions/navigation_steps.rb:299
    And I wait until I see "Upgrade Packages" text                                   # features/step_definitions/navigation_steps.rb:39
    And I follow "Install"                                                           # features/step_definitions/navigation_steps.rb:284
    And I wait until I see "Installable Packages" text                               # features/step_definitions/navigation_steps.rb:39
    And I enter "mgr-push" as the filtered package name                              # features/step_definitions/navigation_steps.rb:846
    And I click on the filter button                                                 # features/step_definitions/navigation_steps.rb:818
    And I check "mgr-push" in the list                                               # features/step_definitions/navigation_steps.rb:924
    And I click on "Install Selected Packages"                                       # features/step_definitions/navigation_steps.rb:256
    And I click on "Confirm"                                                         # features/step_definitions/navigation_steps.rb:256
    Then I should see a "1 package install has been scheduled for" text              # features/step_definitions/navigation_steps.rb:591
    And I wait until event "Package Install/Upgrade scheduled by admin" is completed # features/step_definitions/common_steps.rb:161
      This scenario took: 26 seconds

  @flaky
  Scenario: Push a package with unset vendor through the SLES minion                                                               # features/secondary/srv_push_package.feature:45
      This scenario ran at: 2024-08-01 13:35:23 +0200
    When I copy unset package file on "sle_minion"                                                                                 # features/step_definitions/command_steps.rb:1315
    And I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "fake-base-channel-suse-like" channel through "sle_minion" # features/step_definitions/common_steps.rb:513
    Then I should see package "subscription-tools-1.0-0.noarch" in channel "Fake-Base-Channel-SUSE-like"                           # features/step_definitions/common_steps.rb:519
      This scenario took: 255 seconds

  Scenario: Check vendor of package displayed in web UI         # features/secondary/srv_push_package.feature:50
      This scenario ran at: 2024-08-01 13:39:38 +0200
    When I follow the left menu "Software > Channel List > All" # features/step_definitions/navigation_steps.rb:339
    And I follow "Fake-Base-Channel-SUSE-like"                  # features/step_definitions/navigation_steps.rb:284
    And I follow "Packages"                                     # features/step_definitions/navigation_steps.rb:284
    And I follow "subscription-tools-1.0-0.noarch"              # features/step_definitions/navigation_steps.rb:284
    Then I should see a "Vendor:" text                          # features/step_definitions/navigation_steps.rb:591
    And I should see a "Not defined" text                       # features/step_definitions/navigation_steps.rb:591
      This scenario took: 3 seconds

5 scenarios (5 passed)
34 steps (34 passed)
5m16.386s

```

</details>

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes
- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24979
Port(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
