### PR TITLE
Bump WebUI version for SUMA 5.0.1 and Uyuni 2024.08

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -58,12 +58,12 @@ web.config_delim_start = {|
 web.config_delim_end = |}
 
 # the version of SUSE Manager to show at the WebUI
-web.version = 5.0.0
+web.version = 5.0.1
 
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni = 2024.07
+web.version.uyuni = 2024.08
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 

--- a/web/spacewalk-web.changes.deneb-alpha.webui501-202408
+++ b/web/spacewalk-web.changes.deneb-alpha.webui501-202408
@@ -1,0 +1,1 @@
+- Update the WebUI version


### PR DESCRIPTION
## What does this PR change?

- Update the WebUI version fo r SUMA 5.0.1  and Uyuni 2024.08
- migration schema and reportdb are fine

## GUI diff

Before: WebUI version  `5.0.0` and `2024.07`

After: WebUI version  `5.0.1` and `2024.08`

- [x] **DONE**

## Documentation
- No documentation needed: **No additional documentation needed**

- [x] **DONE**

## Test coverage

- No tests: no  additional tests needed

- [x] **DONE**

## Links

related: https://github.com/SUSE/spacewalk/issues/24610 and https://github.com/SUSE/spacewalk/issues/23751

- [x] **DONE**

## Changelogs

A changelog entry  is  needed for tagging the  change with tito.

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
