### PR TITLE
Update saltboot cobbler profile on image build

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -36,7 +36,6 @@ import com.suse.utils.Maps;
 import com.suse.utils.Opt;
 
 import org.apache.commons.collections.ListUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -70,6 +69,7 @@ public class FormulaFactory {
 
     /** Saltboot group deployment formula */
     public static final String SALTBOOT_GROUP = "saltboot-group";
+    public static final String SALTBOOT_PILLAR = PREFIX + SALTBOOT_GROUP;
 
     // Logger for this class
     private static final Logger LOG = LogManager.getLogger(FormulaFactory.class);
@@ -182,38 +182,12 @@ public class FormulaFactory {
         }
         // Handle Saltboot group - create Cobbler profile
         else if (SALTBOOT_GROUP.equals(formulaName)) {
-            saveGroupForSaltBoot(formData, group);
-        }
-    }
-
-    private static void saveGroupForSaltBoot(Map<String, Object> formData, ServerGroup group) {
-        Map<String, Object> saltboot = (Map<String, Object>) formData.get("saltboot");
-        String kernelOptions = "MINION_ID_PREFIX=" + group.getName();
-        kernelOptions += " MASTER=" + saltboot.get("download_server");
-        if (Boolean.TRUE.equals(saltboot.get("disable_id_prefix"))) {
-            kernelOptions += " DISABLE_ID_PREFIX=1";
-        }
-        if (Boolean.TRUE.equals(saltboot.get("disable_unique_suffix"))) {
-            kernelOptions += " DISABLE_UNIQUE_SUFFIX=1";
-        }
-        if ("FQDN".equals(saltboot.get("minion_id_naming"))) {
-            kernelOptions += " USE_FQDN_MINION_ID=1";
-        }
-        else if ("HWType".equals(saltboot.get("minion_id_naming"))) {
-            kernelOptions += " DISABLE_HOSTNAME_ID=1";
-        }
-        if (StringUtils.isNotEmpty((String) saltboot.get("default_kernel_parameters"))) {
-            kernelOptions += " " + saltboot.get("default_kernel_parameters");
-        }
-        String bootImage = (String)saltboot.get("default_boot_image");
-        String bootImageVersion = (String)saltboot.get("default_boot_image_version");
-
-        try {
-            SaltbootUtils.createSaltbootProfile(group.getName(), kernelOptions, group.getOrg(),
-                    bootImage, bootImageVersion);
-        }
-        catch (SaltbootException e) {
-            throw new ValidatorException(e.getMessage());
+            try {
+                SaltbootUtils.createSaltbootProfile(group);
+            }
+            catch (SaltbootException e) {
+                LOG.warn(e.getMessage());
+            }
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/Pillar.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Pillar.java
@@ -305,6 +305,27 @@ public class Pillar implements Identifiable {
     }
 
     /**
+     * Get a list of ServerGroups for a given category
+     *
+     * @param category the pillar category
+     * @return List of ServerGroups that have pillars with the given category
+     */
+    public static List<ServerGroup> getGroupsForCategory(String category) {
+        CriteriaBuilder criteriaBuilder = HibernateFactory.getSession().getCriteriaBuilder();
+        CriteriaQuery<ServerGroup> criteriaQuery = criteriaBuilder.createQuery(ServerGroup.class);
+        Root<Pillar> root = criteriaQuery.from(Pillar.class);
+
+        criteriaQuery.select(root.get("group"))
+                 .where(criteriaBuilder.and(
+                     criteriaBuilder.equal(root.get("category"), category),
+                     criteriaBuilder.isNotNull(root.get("group"))
+                 ))
+                 .distinct(true);
+
+        return HibernateFactory.getSession().createQuery(criteriaQuery).getResultList();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/ServerGroupFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerGroupFactory.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.common.hibernate.DuplicateObjectException;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.dto.SystemGroupID;
 import com.redhat.rhn.domain.entitlement.Entitlement;
+import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.user.User;
 
@@ -37,6 +38,7 @@ import org.apache.logging.log4j.Logger;
 import org.hibernate.Session;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -201,6 +203,9 @@ public class ServerGroupFactory extends HibernateFactory {
      */
     public static void remove(SaltApi saltApi, ServerGroup group) {
         if (group != null) {
+            // remove cobbler and monitoring configuration, which is connected with formulas
+            FormulaFactory.saveGroupFormulas(group, Collections.emptyList());
+
             List<String> minions = group.getServers().stream()
                     .map(Server::asMinionServer)
                     .flatMap(Opt::stream)

--- a/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
+++ b/java/code/src/com/suse/manager/saltboot/SaltbootUtils.java
@@ -16,6 +16,7 @@
 package com.suse.manager.saltboot;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.image.OSImageStoreUtils;
 import com.redhat.rhn.domain.org.CustomDataKey;
@@ -24,11 +25,14 @@ import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.CustomDataValue;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
+import com.redhat.rhn.domain.server.Pillar;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 
 import com.suse.manager.webui.utils.salt.custom.OSImageInspectSlsResult.BootImage;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cobbler.CobblerConnection;
@@ -36,6 +40,7 @@ import org.cobbler.Distro;
 import org.cobbler.Network;
 import org.cobbler.Profile;
 import org.cobbler.SystemRecord;
+import org.cobbler.XmlRpcException;
 
 import java.util.List;
 import java.util.Map;
@@ -44,6 +49,7 @@ import java.util.stream.Collectors;
 
 public class SaltbootUtils {
     private static final Logger LOG = LogManager.getLogger(SaltbootUtils.class);
+    private static final String DEFAULT_IMAGE = "DEFAULT_IMAGE";
     private SaltbootUtils() { }
 
     /**
@@ -59,25 +65,59 @@ public class SaltbootUtils {
         pathPrefix += imageInfo.getName() + "-" + imageInfo.getVersion() + "-" + imageInfo.getRevisionNumber() + "/";
         String initrd = pathPrefix + bootImage.getInitrd().getFilename();
         String kernel = pathPrefix + bootImage.getKernel().getFilename();
-        String name = imageInfo.getOrg().getId() + "-" + imageInfo.getName() + "-" + imageInfo.getVersion() + "-" +
+        String nameVR = imageInfo.getOrg().getId() + "-" + imageInfo.getName() + "-" + imageInfo.getVersion() + "-" +
                 imageInfo.getRevisionNumber();
+        String nameV = imageInfo.getOrg().getId() + "-" + imageInfo.getName() + "-" + imageInfo.getVersion();
+        String name = imageInfo.getOrg().getId() + "-" + imageInfo.getName();
         // Generic breed is required for cobbler not appending any autoyast or kickstart keywords
         Distro cd = new Distro.Builder<String>()
-                .setName(name)
+                .setName(nameVR)
                 .setInitrd(initrd)
                 .setKernel(kernel)
                 .setKernelOptions(Optional.of("panic=60 splash=silent"))
                 .setArch(imageInfo.getImageArch().getName()).setBreed("generic")
                 .build(con);
-        cd.setComment("Distro for image " + name + " belonging to organization " + imageInfo.getOrg().getName());
+        cd.setComment("Distro for image " + nameVR + " belonging to organization " + imageInfo.getOrg().getName());
         cd.save();
 
         // Each distro have its own private profile for individual system records
         // SystemRecords need to be decoupled from saltboot group default profiles
-        Profile profile = Profile.create(con, name, cd);
-        profile.setEnableMenu(false);
-        profile.setComment("Distro " + name + " private profile");
-        profile.save();
+        updateDistroProfile(con, nameVR, cd, "Distro " + nameVR + " private profile");
+
+        List<Distro> distros = Distro.list(con);
+        SaltbootVersionCompare saltbootCompare = new SaltbootVersionCompare();
+        String defaultImage = imageInfo.getOrg().getId() + "-" + DEFAULT_IMAGE;
+        if (nameVR.equals(selectDistro(distros, imageInfo.getOrg().getId() + "-"))) {
+            updateDistroProfile(con, defaultImage, cd, "Default image");
+        }
+
+        if (nameVR.equals(selectDistro(distros, name + "-"))) {
+            updateDistroProfile(con, name, cd, "Default image for " + name);
+        }
+
+        if (nameVR.equals(selectDistro(distros, nameV + "-"))) {
+            updateDistroProfile(con, nameV, cd, "Default image for " + nameV);
+        }
+
+
+        for (ServerGroup saltbootGroup : Pillar.getGroupsForCategory(FormulaFactory.SALTBOOT_PILLAR)) {
+            String parentProfile;
+            try {
+                parentProfile = getParent(saltbootGroup);
+            }
+            catch (SaltbootException e) {
+                LOG.warn("Can't get image for saltboot group {}-{}: {}",
+                         saltbootGroup.getOrg().getId(), saltbootGroup.getName(), e.getMessage());
+                continue;
+            }
+
+            if (parentProfile.equals(nameVR)) {
+                updateGroupProfile(con, saltbootGroup, false);
+            }
+            if (parentProfile.equals(nameV) || parentProfile.equals(name) || parentProfile.equals(defaultImage)) {
+                updateGroupProfile(con, saltbootGroup, true);
+            }
+        }
     }
 
     /**
@@ -87,78 +127,139 @@ public class SaltbootUtils {
      */
     public static void deleteSaltbootDistro(ImageInfo info) throws SaltbootException {
         CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-        String fullname = info.getName() + "-" + info.getVersion() + "-" + info.getRevisionNumber();
+        String nameVR = info.getOrg().getId() + "-" + info.getName() + "-" + info.getVersion() + "-" + info.getRevisionNumber();
+        String nameV = info.getOrg().getId() + "-" + info.getName() + "-" + info.getVersion();
+        String name = info.getOrg().getId() + "-" + info.getName();
 
         // First delete hidden distro profile
-        deleteSaltbootProfile(fullname, info.getOrg());
+        deleteSaltbootProfile(nameVR);
+
+        List<Distro> distros = Distro.list(con);
+        List<Distro> remainingDistros = distros.stream().filter(d -> !nameVR.equals(d.getName())).collect(Collectors.toList());
+
+        try {
+            Distro d = Distro.lookupByName(con, selectDistro(remainingDistros, info.getOrg().getId() + "-"));
+            updateDistroProfile(con, info.getOrg().getId() + "-" + DEFAULT_IMAGE, d, "Default image");
+
+            d = Distro.lookupByName(con, selectDistro(remainingDistros, name + '-'));
+            updateDistroProfile(con, name, d, "Default image for " + name);
+
+            d = Distro.lookupByName(con, selectDistro(remainingDistros, nameV + '-'));
+            updateDistroProfile(con, nameV, d, "Default image for " + nameV);
+        }
+        catch (SaltbootException e) {
+                LOG.error("Can't update the default: {}", e.getMessage());
+        }
         // then distro itself
-        Distro d = Distro.lookupByName(con, info.getOrg().getId() + "-" + fullname);
+        Distro d = Distro.lookupByName(con, nameVR);
         if (d != null) {
             d.remove();
         }
     }
 
+    private static String selectDistro(List<Distro> distros, String filter) {
+        SaltbootVersionCompare saltbootCompare = new SaltbootVersionCompare();
+        return distros
+               .stream()
+               .map(d -> d.getName())
+               .filter(s -> s.startsWith(filter))
+               .min(saltbootCompare)
+               .orElseThrow(() -> new SaltbootException("Specified image name is not found: " + filter));
+    }
+
+    private static void updateDistroProfile(CobblerConnection con, String name, Distro d, String comment) {
+        Profile p = Profile.lookupByName(con, name);
+        if (p == null) {
+            p = Profile.create(con, name, d);
+        }
+        else {
+            p.setDistro(d);
+        }
+        p.setEnableMenu(false);
+        p.setKickstart("");
+        p.setComment(comment);
+        p.save();
+    }
+
+    private static void updateGroupProfile(CobblerConnection con, ServerGroup saltbootGroup, boolean onlyMissing) {
+        String kernelOptions = getKernelOptions(saltbootGroup);
+        Org org = saltbootGroup.getOrg();
+
+        Profile gp = Profile.lookupByName(con, org.getId() + "-" + saltbootGroup.getName());
+        if (gp == null) {
+            gp = Profile.create(con, org.getId() + "-" + saltbootGroup.getName(), getParent(saltbootGroup));
+        }
+        else {
+            if (onlyMissing) {
+                return;
+            }
+            gp.setParent(getParent(saltbootGroup));
+        }
+        gp.<String>setKernelOptions(Optional.of(kernelOptions));
+        gp.setComment("Saltboot group " + saltbootGroup.getName() +
+              " of organization " + org.getName() + " default profile");
+        gp.save();
+    }
+
+    private static String getKernelOptions(ServerGroup group) {
+        Map<String, Object> formData = group.getPillarByCategory(FormulaFactory.SALTBOOT_PILLAR)
+                .orElseThrow(() -> new SaltbootException("Missing saltboot group pillar"))
+                .getPillar();
+        Map<String, Object> saltboot = (Map<String, Object>) formData.get("saltboot");
+        String kernelOptions = "MINION_ID_PREFIX=" + group.getName();
+        kernelOptions += " MASTER=" + saltboot.get("download_server");
+        if (Boolean.TRUE.equals(saltboot.get("disable_id_prefix"))) {
+            kernelOptions += " DISABLE_ID_PREFIX=1";
+        }
+        if (Boolean.TRUE.equals(saltboot.get("disable_unique_suffix"))) {
+            kernelOptions += " DISABLE_UNIQUE_SUFFIX=1";
+        }
+        if ("FQDN".equals(saltboot.get("minion_id_naming"))) {
+            kernelOptions += " USE_FQDN_MINION_ID=1";
+        }
+        else if ("HWType".equals(saltboot.get("minion_id_naming"))) {
+            kernelOptions += " DISABLE_HOSTNAME_ID=1";
+        }
+        if (StringUtils.isNotEmpty((String) saltboot.get("default_kernel_parameters"))) {
+            kernelOptions += " " + saltboot.get("default_kernel_parameters");
+        }
+        return kernelOptions;
+    }
+    private static String getParent(ServerGroup group) {
+        Org org = group.getOrg();
+        Map<String, Object> formData = group.getPillarByCategory(FormulaFactory.SALTBOOT_PILLAR)
+                .orElseThrow(() -> new SaltbootException("Missing saltboot group pillar"))
+                .getPillar();
+        Map<String, Object> saltboot = (Map<String, Object>) formData.get("saltboot");
+        String bootImage = (String)saltboot.get("default_boot_image");
+        String bootImageVersion = (String)saltboot.get("default_boot_image_version");
+        String parent;
+        if (bootImage == null || bootImage.isEmpty()) {
+            parent = org.getId() + "-" + DEFAULT_IMAGE;
+        }
+        else if (bootImageVersion == null || bootImageVersion.isEmpty()) {
+            parent = org.getId() + "-" + bootImage;
+        }
+        else {
+            parent = org.getId() + "-" + bootImage + "-" + bootImageVersion;
+        }
+        return parent;
+    }
+
     /**
      * Create saltboot profile
      * Saltboot profile is tied with particular saltboot group and contains default boot instructions for new terminals
-     * @param saltbootGroup Name of the group
-     * @param kernelOptions Compiled kernel options for the saltboot group
-     * @param org organization saltboot group belongs to
-     * @param bootImage Name of the image, used for saltboot distro lookup
-     * @param bootImageVersion Version of the image (including revision number), used for saltboot distro lookup
+     * @param saltbootGroup The group
      * @throws SaltbootException
      */
-    public static void createSaltbootProfile(String saltbootGroup, String kernelOptions, Org org,
-                                     String bootImage, String bootImageVersion) throws SaltbootException {
-        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-
-        String distroToUse;
-        if (bootImage == null || bootImage.isEmpty()) {
-            SaltbootVersionCompare saltbootCompare = new SaltbootVersionCompare();
-            distroToUse = Distro.list(con)
-                    .stream()
-                    .map(d -> d.getName())
-                    .filter(s -> s.startsWith(org.getId() + "-"))
-                    .min(saltbootCompare)
-                    .orElseThrow(() -> new SaltbootException("No registered image found"));
+    public static void createSaltbootProfile(ServerGroup saltbootGroup) throws SaltbootException {
+        try {
+            CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
+            updateGroupProfile(con, saltbootGroup, false);
         }
-        else if (bootImageVersion == null || bootImageVersion.isEmpty()) {
-            SaltbootVersionCompare saltbootCompare = new SaltbootVersionCompare();
-            distroToUse = Distro.list(con)
-                    .stream()
-                    .map(d -> d.getName())
-                    .filter(s -> s.startsWith(org.getId() + "-" + bootImage))
-                    .min(saltbootCompare)
-                    .orElseThrow(() -> new SaltbootException("Specified image name is not known"));
+        catch (XmlRpcException e) {
+            throw new SaltbootException(e);
         }
-        else if (!bootImageVersion.contains("-")) {
-            // bootImageVersion does not have revision
-            SaltbootVersionCompare saltbootCompare = new SaltbootVersionCompare();
-            distroToUse = Distro.list(con)
-                    .stream()
-                    .map(d -> d.getName())
-                    .filter(s -> s.startsWith(org.getId() + "-" + bootImage + "-" + bootImageVersion))
-                    .min(saltbootCompare)
-                    .orElseThrow(() -> new SaltbootException("Specified image name is not known"));
-        }
-        else {
-            distroToUse = org.getId() + "-" + bootImage + "-" + bootImageVersion;
-        }
-        Distro d = Distro.lookupByName(con, distroToUse);
-        if (d == null) {
-            throw new SaltbootException("Unable to find Cobbler distribution for specified image and version");
-        }
-
-        Profile gp = Profile.lookupByName(con, org.getId() + "-" + saltbootGroup);
-        if (gp == null) {
-            gp = Profile.create(con, org.getId() + "-" + saltbootGroup, d);
-        }
-        else {
-            gp.setDistro(d);
-        }
-        gp.<String>setKernelOptions(Optional.of(kernelOptions));
-        gp.setComment("Saltboot group " + saltbootGroup + " of organization " + org.getName() + " default profile");
-        gp.save();
     }
 
     /**
@@ -168,8 +269,18 @@ public class SaltbootUtils {
      * @param org
      */
     public static void deleteSaltbootProfile(String profileName, Org org) {
+        deleteSaltbootProfile(org.getId() + "-" + profileName);
+    }
+
+    /**
+     * Delete saltboot profile
+     * If profile is not found, does nothing
+     * @param profileName
+     * @param org
+     */
+    public static void deleteSaltbootProfile(String profileName) {
         CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-        Profile p = Profile.lookupByName(con, org.getId() + "-" + profileName);
+        Profile p = Profile.lookupByName(con, profileName);
 
         if (p != null) {
             List<SystemRecord> systems = SystemRecord.listByAssociatedProfile(con, p.getName());

--- a/java/code/src/org/cobbler/Profile.java
+++ b/java/code/src/org/cobbler/Profile.java
@@ -129,6 +129,25 @@ public class Profile extends CobblerObject {
     }
 
     /**
+     * Create a new child profile in cobbler
+     *
+     * @param client the xmlrpc client
+     * @param name   the profile name
+     * @param parent the parent profile name.
+     * @return the newly created profile
+     */
+    public static Profile create(CobblerConnection client,
+                                 String name, String parent) {
+        Profile profile = new Profile(client);
+        profile.handle = (String) client.invokeTokenMethod("new_profile");
+        profile.modify(NAME, name, false);
+        profile.modify(PARENT, parent, false);
+        profile.save();
+        profile = lookupByName(client, name);
+        return profile;
+    }
+
+    /**
      * Returns a kickstart profile matching the given name or null
      *
      * @param client the xmlrpc client
@@ -536,7 +555,12 @@ public class Profile extends CobblerObject {
      * @param kickstartIn the Kickstart
      */
     public void setKickstart(String kickstartIn) {
-        modify(KICKSTART, "/" + getRelativeAutoinstallPath(kickstartIn));
+        if (kickstartIn.isEmpty()) {
+            modify(KICKSTART, "");
+        }
+        else {
+            modify(KICKSTART, "/" + getRelativeAutoinstallPath(kickstartIn));
+        }
     }
 
     /**
@@ -756,6 +780,9 @@ public class Profile extends CobblerObject {
      * @return The absolute path on the server
      */
     private String getFullAutoinstallPath(String pathIn) {
+        if (pathIn.isEmpty()) {
+            return "";
+        }
         String cobblerPath = ConfigDefaults.get().getKickstartConfigDir();
         if (pathIn.startsWith(cobblerPath)) {
             return pathIn;

--- a/java/spacewalk-java.changes.nadvornik.saltboot-fix
+++ b/java/spacewalk-java.changes.nadvornik.saltboot-fix
@@ -1,0 +1,1 @@
+- Update saltboot cobbler profile on image build


### PR DESCRIPTION
## What does this PR change?

With this PR, the cobbler profiles for saltboot groups are updated when a new image is built. This keeps the profiles always up-to date.

Missing image when saving saltboot group formula is no longer fatal, the profile is updated later, when the image is built.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: bugfix
- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): related to https://github.com/SUSE/spacewalk/issues/24041

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
