### PR TITLE
Revert change on preview button for salt commands.

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -167,31 +167,8 @@ end
 
 # user salt steps
 
-# WORKAROUND : Click preview button retry to fix https://github.com/SUSE/spacewalk/issues/24893
 When(/^I click on preview$/) do
-  # Define the maximum number of attempts
-  max_attempts = 2
-
-  (1..max_attempts).each do |attempt|
-    if page.has_button?('stop', visible: true)
-      puts 'Stop button visible, searching request ongoing.'
-    else
-      # Click the preview button
-      find('button#preview').click
-    end
-    # Wait for up to 3 seconds for the run button to be visible
-    if page.has_button?('run', visible: true, wait: 5)
-      puts 'The run button is visible.'
-      break
-    else
-      puts "The run button is not visible after clicking preview (attempt #{attempt})."
-    end
-  end
-
-  # After the loop, check if the run button is still not visible
-  unless page.has_button?('run', visible: true)
-    raise "Preview button not working: the run button is not visible after #{max_attempts} attempts."
-  end
+  find('button#preview').click
 end
 
 When(/^I click on stop waiting$/) do


### PR DESCRIPTION
## What does this PR change?

Revert retry method for preview button

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
