### PR TITLE
Do not install spacewalk-utils-extra on server image

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -27,7 +27,6 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     ${PRODUCT_PATTERN_PREFIX}_server \
     ${PRODUCT_PATTERN_PREFIX}_retail \
     billing-data-service \
-    spacewalk-utils-extras \
     grub2-x86_64-efi \
     ed \
     susemanager-tftpsync \

--- a/containers/server-image/server-image.changes.rmateus.uyuni-not-install-spacewalk-utils-extra
+++ b/containers/server-image/server-image.changes.rmateus.uyuni-not-install-spacewalk-utils-extra
@@ -1,0 +1,1 @@
+- Do not install outdated package "spacewalk-utils-extras" on server image 

--- a/utils/spacewalk-utils.changes.rmateus.Manager-4.3
+++ b/utils/spacewalk-utils.changes.rmateus.Manager-4.3
@@ -1,0 +1,1 @@
+- move takotop tool to spacewalk-utils package

--- a/utils/spacewalk-utils.changes.rmateus.Manager-4.3
+++ b/utils/spacewalk-utils.changes.rmateus.Manager-4.3
@@ -1,1 +1,1 @@
-- move takotop tool to spacewalk-utils package
+- move taskotop tool to spacewalk-utils package

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -76,6 +76,10 @@ Requires:       spacewalk-setup
 Requires:       susemanager-schema
 # Required by cloneByDate.py, depsolver.py,spacewalk-clone-by-date
 Requires(pre):  uyuni-base-common
+# Required by taskotop
+Requires:       python3-curses
+# Required by taskotop
+Requires:       spacewalk-backend-sql
 
 %description
 Utilities that may be run against a SUSE Manager server (supported) or an Uyuni server
@@ -85,8 +89,6 @@ Summary:        Extra utilities that may run against a SUSE Manager/Uyuni server
 # Required by spacewalk-watch-channel-sync.sh
 Group:          Productivity/Other
 Requires:       bash
-# Required by taskotop
-Requires:       python3-curses
 # Required by sw-ldap-user-sync
 Requires:       python3-ldap
 # Required by sw-ldap-user-sync
@@ -97,8 +99,6 @@ Requires:       python3-rhnlib >= 2.5.20
 Requires:       python3-uyuni-common-libs
 # Required by spacewalk-manage-snapshots, systemSnapshot.py
 Requires:       spacewalk-backend
-# Required by taskotop
-Requires:       spacewalk-backend-sql
 # Required by spacewalk-final-archive, spacewalk-watch-channel-sync.sh
 Requires:       spacewalk-backend-tools >= 2.2.27
 # As spacewalk-utils owns {python3_sitelib}/utils
@@ -137,6 +137,7 @@ popd
 %attr(755,root,root) %{_bindir}/spacewalk-hostname-rename
 %attr(755,root,root) %{_bindir}/spacewalk-manage-channel-lifecycle
 %attr(755,root,root) %{_bindir}/spacewalk-sync-setup
+%attr(755,root,root) %{_bindir}/taskotop
 %config %{_sysconfdir}/rhn/spacewalk-common-channels.ini
 %dir %{python3_sitelib}/utils
 %{python3_sitelib}/utils/__init__.py*
@@ -151,6 +152,7 @@ popd
 %{_mandir}/man8/spacewalk-clone-by-date.8.gz
 %{_mandir}/man8/spacewalk-hostname-rename.8.gz
 %{_mandir}/man8/spacewalk-sync-setup.8.gz
+%{_mandir}/man8/taskotop.8.gz
 
 %files extras
 %defattr(-,root,root)
@@ -165,7 +167,6 @@ popd
 %attr(755,root,root) %{_bindir}/spacewalk-watch-channel-sync.sh
 %attr(755,root,root) %{_bindir}/sw-ldap-user-sync
 %attr(755,root,root) %{_bindir}/sw-system-snapshot
-%attr(755,root,root) %{_bindir}/taskotop
 %{python3_sitelib}/utils/migrateSystemProfile.py*
 %{python3_sitelib}/utils/__pycache__/migrateSystemProfile.*
 %config(noreplace) %{_sysconfdir}/rhn/sw-ldap-user-sync.conf
@@ -177,6 +178,5 @@ popd
 %{_mandir}/man8/spacewalk-final-archive.8.gz
 %{_mandir}/man8/spacewalk-manage-snapshots.8.gz
 %{_mandir}/man8/sw-system-snapshot.8.gz
-%{_mandir}/man8/taskotop.8.gz
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

Do not install the spacewalk-utils-extra on the server image. At the same time move the taskotop tool to the spacewalk-utils package.

Next step would be remove the package `spacewalk-utils-extra`

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

Need port to 5.0 branch when it's ready.

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
