### PR TITLE
Require correct scap packages for Ubuntu and Debian

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScapSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScapSetupAction.java
@@ -17,73 +17,95 @@ package com.redhat.rhn.frontend.action.systems.audit;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.systems.sdc.SdcHelper;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.manager.audit.ScapManager;
 
-import org.apache.commons.lang3.math.NumberUtils;
-
-import java.util.List;
-import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * ScapSetupAction
  */
 
 public abstract class ScapSetupAction extends RhnAction {
+    private static final Logger LOGGER = LogManager.getLogger(ScapSetupAction.class);
+
     public static final String SCAP_ENABLED = "scapEnabled";
     public static final String REQUIRED_PKG = "requiredPackage";
 
-    private static final List<String> OPENSCAP_SUSE_PKG = List.of("openscap-utils");
-    private static final List<String> OPENSCAP_REDHAT_PKG = List.of("openscap-scanner");
-    private static final List<String> OPENSCAP_DEBIAN_PKG = List.of("libopenscap25", "openscap-common");
-    private static final List<String> OPENSCAP_DEBIAN_LEGACY_PKG = List.of("libopenscap8");
+    private static final String OPENSCAP_SUSE_PKG = "openscap-utils";
+    private static final String OPENSCAP_REDHAT_PKG = "openscap-scanner";
+    private static final String OPENSCAP_DEBIAN_PKG = "openscap-utils";
+    private static final String OPENSCAP_DEBIAN_LEGACY_PKG = "libopenscap8";
 
     protected void setupScapEnablementInfo(RequestContext context) {
         Server server = context.lookupAndBindServer();
         User user = context.getCurrentUser();
 
         boolean enabled;
-        List<String> requiredPackages;
+        String requiredPackage;
 
         if (server.asMinionServer().isPresent()) {
             MinionServer minion = server.asMinionServer().get();
             switch (minion.getOsFamily()) {
                 case "Suse":
-                    requiredPackages = OPENSCAP_SUSE_PKG;
+                    requiredPackage = OPENSCAP_SUSE_PKG;
                     break;
 
                 case "Debian":
-                    requiredPackages = getPackagesForVersion(minion.getRelease());
+                    requiredPackage = getPackageForDebianFamily(minion.getOs(), minion.getRelease());
                     break;
 
                 default:
-                    requiredPackages = OPENSCAP_REDHAT_PKG;
+                    requiredPackage = OPENSCAP_REDHAT_PKG;
             }
 
-            // Verify all the packages are installed
-            enabled = requiredPackages.stream()
-                .map(pkg -> PackageFactory.lookupByNameAndServer(pkg, server))
-                .noneMatch(Objects::isNull);
+            // Verify the packages is installed
+            enabled = PackageFactory.lookupByNameAndServer(requiredPackage, server) != null;
         }
         else {
             enabled = ScapManager.isScapEnabled(server, user);
-            requiredPackages = List.of();
+            requiredPackage = "";
         }
 
         context.getRequest().setAttribute(SCAP_ENABLED, enabled);
-        context.getRequest().setAttribute(REQUIRED_PKG, String.join(" ", requiredPackages));
+        context.getRequest().setAttribute(REQUIRED_PKG, requiredPackage);
 
         SdcHelper.ssmCheck(context.getRequest(), server.getId(), user);
     }
 
-    private static List<String> getPackagesForVersion(String debianRelease) {
-        if (NumberUtils.isParsable(debianRelease) && Integer.parseInt(debianRelease) <= 11) {
-            return OPENSCAP_DEBIAN_LEGACY_PKG;
-        }
+    private static String getPackageForDebianFamily(String os, String release) {
+        try {
+            switch (os) {
+                case ServerConstants.UBUNTU:
+                    int ubuntuVersion = Integer.parseInt(StringUtils.substringBefore(release, "."));
+                    if (ubuntuVersion <= 22) {
+                        return OPENSCAP_DEBIAN_LEGACY_PKG;
+                    }
 
-        return OPENSCAP_DEBIAN_PKG;
+                    return OPENSCAP_DEBIAN_PKG;
+
+                case ServerConstants.DEBIAN:
+                    int debianVersion = Integer.parseInt(release);
+                    if (debianVersion <= 11) {
+                        return OPENSCAP_DEBIAN_LEGACY_PKG;
+                    }
+
+                    return OPENSCAP_DEBIAN_PKG;
+
+                default:
+                    LOGGER.warn("Unable to identify os {}. Assuming default Debian package.", os);
+                    return OPENSCAP_DEBIAN_PKG;
+            }
+        }
+        catch (NumberFormatException ex) {
+            LOGGER.warn("The release number {} of {} is not parseable. Assuming default Debian package.", release, os);
+            return OPENSCAP_DEBIAN_PKG;
+        }
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.action.systems.audit.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.frontend.action.systems.audit.ScapSetupAction;
+import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.testing.PackageTestUtils;
+import com.redhat.rhn.testing.RhnMockHttpServletRequest;
+import com.redhat.rhn.testing.RhnMockStrutsTestCase;
+import com.redhat.rhn.testing.TestUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ScapSetupActionTest extends RhnMockStrutsTestCase {
+
+    private TestScapSetupAction action;
+
+    private RequestContext mockContext;
+
+    private Server server;
+
+    @BeforeEach
+    public void setup() {
+        action = new TestScapSetupAction();
+
+        server = MinionServerFactoryTest.createTestMinionServer(user);
+
+        RhnMockHttpServletRequest request = TestUtils.getRequestWithSessionAndUser();
+        request.setAttribute(RequestContext.SYSTEM, server);
+
+        mockContext = new RequestContext(request);
+    }
+
+    @Test
+    public void canSearchForCorrectPackageForSUSE() {
+        server.setOsFamily("Suse");
+        server.setRelease("15.6");
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // The package is not installed. Scap should be disabled and the correct package should be requested
+        assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals("openscap-utils", mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG));
+    }
+
+    @Test
+    public void canSearchForCorrectPackageForRHEL() {
+        server.setOsFamily("RedHat");
+        server.setRelease("8");
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // The package is not installed. Scap should be disabled and the correct package should be requested
+        assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals("openscap-scanner", mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG));
+    }
+
+    @Test
+    public void canSearchForCorrectPackageForDebianLegacy() {
+        server.setOsFamily("Debian");
+        server.setRelease("10");
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // The package is not installed. Scap should be disabled and the correct package should be requested
+        assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals("libopenscap8", mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG));
+    }
+
+    @Test
+    public void canSearchForCorrectPackageForDebian() {
+        server.setOsFamily("Debian");
+        server.setRelease("12");
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // The package is not installed. Scap should be disabled and the correct package should be requested
+        assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals(
+            "libopenscap25 openscap-common",
+            mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG)
+        );
+    }
+
+    @Test
+    public void scapIsEnabledWhenCorrectPackageIsInstalled() {
+        server.setOsFamily("Suse");
+        server.setRelease("15.6");
+
+        Package scapPackage = PackageTest.createTestPackage(user.getOrg(), "openscap-utils");
+        PackageTestUtils.installPackageOnServer(scapPackage, server);
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // The package is installed. Scap should be enabled
+        assertEquals(true, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals("openscap-utils", mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG));
+    }
+
+    @Test
+    public void scapIsEnabledWhenAllRequiredPackagesAreInstalled() {
+        server.setOsFamily("Debian");
+        server.setRelease("12");
+
+        Package scapLibPackage = PackageTest.createTestPackage(user.getOrg(), "libopenscap25");
+        PackageTestUtils.installPackageOnServer(scapLibPackage, server);
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // One package is missing. Scap should be disabled and the correct package should be requested
+        assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals(
+            "libopenscap25 openscap-common",
+            mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG)
+        );
+
+        Package scapCommonPackage = PackageTest.createTestPackage(user.getOrg(), "openscap-common");
+        PackageTestUtils.installPackageOnServer(scapCommonPackage, server);
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // Now everything is installed and scap should be enabled
+        assertEquals(true, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals(
+            "libopenscap25 openscap-common",
+            mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG)
+        );
+    }
+
+    private static class TestScapSetupAction extends ScapSetupAction {
+        @Override
+        public void setupScapEnablementInfo(RequestContext context) {
+            super.setupScapEnablementInfo(context);
+        }
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.frontend.action.systems.audit.ScapSetupAction;
 import com.redhat.rhn.frontend.struts.RequestContext;
@@ -57,6 +58,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     @Test
     public void canSearchForCorrectPackageForSUSE() {
         server.setOsFamily("Suse");
+        server.setOs(ServerConstants.SLES);
         server.setRelease("15.6");
 
         action.setupScapEnablementInfo(mockContext);
@@ -69,6 +71,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     @Test
     public void canSearchForCorrectPackageForRHEL() {
         server.setOsFamily("RedHat");
+        server.setOs(ServerConstants.ROCKY);
         server.setRelease("8");
 
         action.setupScapEnablementInfo(mockContext);
@@ -81,6 +84,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     @Test
     public void canSearchForCorrectPackageForDebianLegacy() {
         server.setOsFamily("Debian");
+        server.setOs(ServerConstants.DEBIAN);
         server.setRelease("10");
 
         action.setupScapEnablementInfo(mockContext);
@@ -93,6 +97,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     @Test
     public void canSearchForCorrectPackageForDebian() {
         server.setOsFamily("Debian");
+        server.setOs(ServerConstants.DEBIAN);
         server.setRelease("12");
 
         action.setupScapEnablementInfo(mockContext);
@@ -100,7 +105,36 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
         // The package is not installed. Scap should be disabled and the correct package should be requested
         assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
         assertEquals(
-            "libopenscap25 openscap-common",
+            "openscap-utils",
+            mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG)
+        );
+    }
+
+    @Test
+    public void canSearchForCorrectPackageForUbuntuLegacy() {
+        server.setOsFamily("Debian");
+        server.setOs(ServerConstants.UBUNTU);
+        server.setRelease("22.04");
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // The package is not installed. Scap should be disabled and the correct package should be requested
+        assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals("libopenscap8", mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG));
+    }
+
+    @Test
+    public void canSearchForCorrectPackageForUbuntu() {
+        server.setOsFamily("Debian");
+        server.setOs(ServerConstants.UBUNTU);
+        server.setRelease("24.04");
+
+        action.setupScapEnablementInfo(mockContext);
+
+        // The package is not installed. Scap should be disabled and the correct package should be requested
+        assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
+        assertEquals(
+            "openscap-utils",
             mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG)
         );
     }
@@ -108,6 +142,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     @Test
     public void scapIsEnabledWhenCorrectPackageIsInstalled() {
         server.setOsFamily("Suse");
+        server.setOs(ServerConstants.SLES);
         server.setRelease("15.6");
 
         Package scapPackage = PackageTest.createTestPackage(user.getOrg(), "openscap-utils");
@@ -123,6 +158,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     @Test
     public void scapIsEnabledWhenAllRequiredPackagesAreInstalled() {
         server.setOsFamily("Debian");
+        server.setOs(ServerConstants.DEBIAN);
         server.setRelease("12");
 
         Package scapLibPackage = PackageTest.createTestPackage(user.getOrg(), "libopenscap25");
@@ -133,11 +169,11 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
         // One package is missing. Scap should be disabled and the correct package should be requested
         assertEquals(false, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
         assertEquals(
-            "libopenscap25 openscap-common",
+            "openscap-utils",
             mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG)
         );
 
-        Package scapCommonPackage = PackageTest.createTestPackage(user.getOrg(), "openscap-common");
+        Package scapCommonPackage = PackageTest.createTestPackage(user.getOrg(), "openscap-utils");
         PackageTestUtils.installPackageOnServer(scapCommonPackage, server);
 
         action.setupScapEnablementInfo(mockContext);
@@ -145,7 +181,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
         // Now everything is installed and scap should be enabled
         assertEquals(true, mockContext.getRequest().getAttribute(ScapSetupAction.SCAP_ENABLED));
         assertEquals(
-            "libopenscap25 openscap-common",
+            "openscap-utils",
             mockContext.getRequest().getAttribute(ScapSetupAction.REQUIRED_PKG)
         );
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
@@ -40,7 +40,10 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
     private Server server;
 
     @BeforeEach
-    public void setup() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
         action = new TestScapSetupAction();
 
         server = MinionServerFactoryTest.createTestMinionServer(user);

--- a/java/spacewalk-java.changes.mackdk.openscap-debian12
+++ b/java/spacewalk-java.changes.mackdk.openscap-debian12
@@ -1,1 +1,1 @@
-- Require correct scap packages for Debian 12 (bsc#1227746)
+- Require correct scap packages for Ubuntu and Debian (bsc#1227746)

--- a/java/spacewalk-java.changes.mackdk.openscap-debian12
+++ b/java/spacewalk-java.changes.mackdk.openscap-debian12
@@ -1,0 +1,1 @@
+- Require correct scap packages for Debian 12 (bsc#1227746)


### PR DESCRIPTION
## What does this PR change?

This PR fixes the package required to run OpenSCAP tests on a Debian 12  and Ubuntu 24.04 systems.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage

- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24821
Port(s): https://github.com/SUSE/spacewalk/pull/24996 https://github.com/SUSE/spacewalk/pull/25133

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
