### PR TITLE
Conditional fixes on running remote command on SSH tunnel minion

### DIFF
--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -74,8 +74,9 @@ Feature: Register a Salt system to be managed via SSH tunnel
     When I enter command "echo 'My remote command output'"
     And I enter the hostname of "ssh_minion" as "target"
     And I click on preview
-    Then I wait until I see "Target systems (1)" text
-    When I click on run
+    Then I should see a "Target systems (1)" text
+    When I wait until I do not see "pending" text
+    And I click on run
     And I wait until I see "show response" text
     And I expand the results for "ssh_minion"
     Then I should see "My remote command output" in the command output for "ssh_minion"

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -74,9 +74,8 @@ Feature: Register a Salt system to be managed via SSH tunnel
     When I enter command "echo 'My remote command output'"
     And I enter the hostname of "ssh_minion" as "target"
     And I click on preview
-    Then I wait until I do not see "Target systems (1)" text
-    When I wait until I do not see "pending" text
-    And I click on run
+    Then I wait until I see "Target systems (1)" text
+    When I click on run
     And I wait until I see "show response" text
     And I expand the results for "ssh_minion"
     Then I should see "My remote command output" in the command output for "ssh_minion"


### PR DESCRIPTION
## What does this PR change?


Before:

<details>

```

  Scenario: Run a remote command on this SSH tunnel minion                              # features/secondary/min_ssh_tunnel.feature:73
      This scenario ran at: 2024-08-07 13:17:36 +0200
    When I follow the left menu "Salt > Remote Commands"                                # features/step_definitions/navigation_steps.rb:339
    Then I should see a "Remote Commands" text in the content area                      # features/step_definitions/navigation_steps.rb:11
    When I enter command "echo 'My remote command output'"                              # features/step_definitions/salt_steps.rb:210
    And I enter the hostname of "ssh_minion" as "target"                                # features/step_definitions/navigation_steps.rb:437
      The hostname of ssh_minion is suma-head-minssh-sles15.mgr.suse.de
The run button is visible.
    And I click on preview                                                              # features/step_definitions/salt_steps.rb:171
    Then I wait until I do not see "Target systems (1)" text                            # features/step_definitions/navigation_steps.rb:43
      Text 'Target systems (1)' found (ScriptError)
      ./features/step_definitions/navigation_steps.rb:44:in `/^I wait until I do not see "([^"]*)" text$/'
      features/secondary/min_ssh_tunnel.feature:79:in `I wait until I do not see "Target systems (1)" text'
    When I wait until I do not see "pending" text                                       # features/step_definitions/navigation_steps.rb:43
    And I click on run                                                                  # features/step_definitions/salt_steps.rb:201
    And I wait until I see "show response" text                                         # features/step_definitions/navigation_steps.rb:39
    And I expand the results for "ssh_minion"                                           # features/step_definitions/salt_steps.rb:205
    Then I should see "My remote command output" in the command output for "ssh_minion" # features/step_definitions/salt_steps.rb:219

```

</details>

After

* For Uyuni master :warning: Big log:

<details>

```

uyuni-master-podman-ctl:~/uyuni/testsuite # cucumber features/secondary/min_ssh_tunnel.feature 
Capybara APP Host: https://uyuni-master-podman-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.5, Family: opensuse-leap
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.5, Family: opensuse-leap
Activating HTTP API
Using the default profile...
# Copyright (c) 2020-2024 SUSE LLC
# Licensed under the terms of the MIT license.
#
# This feature can cause failures in the following features:
# - features/secondary/min_activationkey.feature
# If the minion fails to bootstrap again.
@skip_if_github_validation @scope_salt_ssh @ssh_minion
Feature: Register a Salt system to be managed via SSH tunnel

  Scenario: Log in as admin user                  # features/secondary/min_ssh_tunnel.feature:13
      This scenario ran at: 2024-08-07 14:35:56 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:404
      This scenario took: 14 seconds

  Scenario: Pre-requisite: remove package before ssh tunnel test                        # features/secondary/min_ssh_tunnel.feature:16
      This scenario ran at: 2024-08-07 14:36:10 +0200
Initializing a twopence node for 'ssh_minion'.
Host 'ssh_minion' is alive with determined hostname uyuni-master-podman-minssh-suse and FQDN uyuni-master-podman-minssh-suse.mgr.suse.de
Node: uyuni-master-podman-minssh-suse, OS Version: 15.5, Family: opensuse-leap
    When I remove package "milkyway-dummy" from this "ssh_minion" without error control # features/step_definitions/command_steps.rb:964
      This scenario took: 1 seconds

  Scenario: Delete the Salt minion for SSH tunnel bootstrap      # features/secondary/min_ssh_tunnel.feature:19
      This scenario ran at: 2024-08-07 14:36:11 +0200
    Given I am on the Systems overview page of this "ssh_minion" # features/step_definitions/navigation_steps.rb:416
    When I follow "Delete System"                                # features/step_definitions/navigation_steps.rb:287
    Then I should see a "Confirm System Profile Deletion" text   # features/step_definitions/navigation_steps.rb:594
    When I click on "Delete Profile"                             # features/step_definitions/navigation_steps.rb:259
    And I wait until I see "has been deleted" text               # features/step_definitions/navigation_steps.rb:39
    Then "ssh_minion" should not be registered                   # features/step_definitions/salt_steps.rb:152
      This scenario took: 5 seconds

  Scenario: Register this minion for push via SSH tunnel                           # features/secondary/min_ssh_tunnel.feature:27
      This scenario ran at: 2024-08-07 14:36:16 +0200
    When I follow the left menu "Systems > Bootstrapping"                          # features/step_definitions/navigation_steps.rb:342
    Then I should see a "Bootstrap Minions" text                                   # features/step_definitions/navigation_steps.rb:594
    And I enter the hostname of "ssh_minion" as "hostname"                         # features/step_definitions/navigation_steps.rb:440
      The hostname of ssh_minion is uyuni-master-podman-minssh-suse.mgr.suse.de
    And I enter "22" as "port"                                                     # features/step_definitions/navigation_steps.rb:223
    And I enter "root" as "user"                                                   # features/step_definitions/navigation_steps.rb:223
    And I enter "linux" as "password"                                              # features/step_definitions/navigation_steps.rb:223
    And I select "1-SUSE-SSH-TUNNEL-KEY-x86_64" from "activationKeys"              # features/step_definitions/navigation_steps.rb:165
Initializing a twopence node for 'proxy'.
Host 'proxy' is alive with determined hostname uyuni-master-podman-pxy.mgr.suse.de and FQDN uyuni-master-podman-pxy.mgr.suse.de
Node: uyuni-master-podman-pxy.mgr.suse.de, OS Version: 5.5, Family: opensuse-leap-micro
    And I select the hostname of "proxy" from "proxies" if present                 # features/step_definitions/navigation_steps.rb:446
    And I check "manageWithSSH"                                                    # features/step_definitions/navigation_steps.rb:154
    And I click on "Bootstrap"                                                     # features/step_definitions/navigation_steps.rb:259
    # workaround for bsc#1222108
    And I wait at most 480 seconds until I see "Bootstrap process initiated." text # features/step_definitions/navigation_steps.rb:47
    And I wait until onboarding is completed for "ssh_minion"                      # features/step_definitions/setup_steps.rb:220
      This scenario took: 271 seconds

  Scenario: The contact method is SSH tunnel on this minion      # features/secondary/min_ssh_tunnel.feature:42
      This scenario ran at: 2024-08-07 14:40:47 +0200
    Given I am on the Systems overview page of this "ssh_minion" # features/step_definitions/navigation_steps.rb:416
    Then I should see a "Push via SSH tunnel" text               # features/step_definitions/navigation_steps.rb:594
      This scenario took: 1 seconds

  Scenario: Install a package from this SSH tunnel minion                             # features/secondary/min_ssh_tunnel.feature:46
      This scenario ran at: 2024-08-07 14:40:48 +0200
    Given I am on the Systems overview page of this "ssh_minion"                      # features/step_definitions/navigation_steps.rb:416
    When I follow "Software" in the content area                                      # features/step_definitions/navigation_steps.rb:302
    And I follow "Install"                                                            # features/step_definitions/navigation_steps.rb:287
    And I enter "milkyway-dummy" as the filtered package name                         # features/step_definitions/navigation_steps.rb:849
    And I click on the filter button                                                  # features/step_definitions/navigation_steps.rb:821
    And I check row with "milkyway-dummy" and arch of "ssh_minion"                    # features/step_definitions/navigation_steps.rb:887
    And I click on "Install Selected Packages"                                        # features/step_definitions/navigation_steps.rb:259
    And I click on "Confirm"                                                          # features/step_definitions/navigation_steps.rb:259
    Then I should see a "1 package install has been scheduled for" text               # features/step_definitions/navigation_steps.rb:594
    Then I wait until event "Package Install/Upgrade scheduled by admin" is completed # features/step_definitions/common_steps.rb:161
      This scenario took: 42 seconds

  Scenario: Remove a package from this SSH tunnel minion                      # features/secondary/min_ssh_tunnel.feature:58
      This scenario ran at: 2024-08-07 14:41:30 +0200
    Given I am on the Systems overview page of this "ssh_minion"              # features/step_definitions/navigation_steps.rb:416
    And I follow "Software" in the content area                               # features/step_definitions/navigation_steps.rb:302
    And I follow "List / Remove"                                              # features/step_definitions/navigation_steps.rb:287
    And I enter "milkyway-dummy" as the filtered package name                 # features/step_definitions/navigation_steps.rb:849
    And I click on the filter button                                          # features/step_definitions/navigation_steps.rb:821
    And I wait until I see "milkyway-dummy" text                              # features/step_definitions/navigation_steps.rb:39
    And I check "milkyway-dummy" in the list                                  # features/step_definitions/navigation_steps.rb:927
    And I click on "Remove Packages"                                          # features/step_definitions/navigation_steps.rb:259
    And I click on "Confirm"                                                  # features/step_definitions/navigation_steps.rb:259
    Then I should see a "1 package removal has been scheduled" text           # features/step_definitions/navigation_steps.rb:594
    Then I wait until event "Package Removal scheduled by admin" is completed # features/step_definitions/common_steps.rb:161
      This scenario took: 46 seconds

  Scenario: Run a remote command on this SSH tunnel minion                              # features/secondary/min_ssh_tunnel.feature:71
      This scenario ran at: 2024-08-07 14:42:16 +0200
    When I follow the left menu "Salt > Remote Commands"                                # features/step_definitions/navigation_steps.rb:342
    Then I should see a "Remote Commands" text in the content area                      # features/step_definitions/navigation_steps.rb:11
    When I enter command "echo 'My remote command output'"                              # features/step_definitions/salt_steps.rb:210
    And I enter the hostname of "ssh_minion" as "target"                                # features/step_definitions/navigation_steps.rb:440
      The hostname of ssh_minion is uyuni-master-podman-minssh-suse.mgr.suse.de
The run button is visible.
    And I click on preview                                                              # features/step_definitions/salt_steps.rb:171
    Then I wait until I see "Target systems (1)" text                                   # features/step_definitions/navigation_steps.rb:39
    When I click on run                                                                 # features/step_definitions/salt_steps.rb:201
    And I wait until I see "show response" text                                         # features/step_definitions/navigation_steps.rb:39
    And I expand the results for "ssh_minion"                                           # features/step_definitions/salt_steps.rb:205
    Then I should see "My remote command output" in the command output for "ssh_minion" # features/step_definitions/salt_steps.rb:219
      This scenario took: 20 seconds

  Scenario: Cleanup: delete the SSH tunnel minion                # features/secondary/min_ssh_tunnel.feature:83
      This scenario ran at: 2024-08-07 14:42:36 +0200
    Given I am on the Systems overview page of this "ssh_minion" # features/step_definitions/navigation_steps.rb:416
    When I follow "Delete System"                                # features/step_definitions/navigation_steps.rb:287
    Then I should see a "Confirm System Profile Deletion" text   # features/step_definitions/navigation_steps.rb:594
    When I click on "Delete Profile"                             # features/step_definitions/navigation_steps.rb:259
    And I wait until I see "has been deleted" text               # features/step_definitions/navigation_steps.rb:39
    Then "ssh_minion" should not be registered                   # features/step_definitions/salt_steps.rb:152
      This scenario took: 15 seconds

...
    Then I should see "ssh_minion" via spacecmd                                                                      # features/step_definitions/setup_steps.rb:224
    And I wait until onboarding is completed for "ssh_minion"                                                        # features/step_definitions/setup_steps.rb:220
      This scenario took: 88 seconds

10 scenarios (10 passed)
64 steps (64 passed)
8m22.951s

```

</details>


* For SUMA Head :warning: Big log:

<details>

```

suma-head-ctl:~/spacewalk/testsuite # cucumber features/secondary/min_ssh_tunnel.feature
Capybara APP Host: https://suma-head-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname suma-head-srv and FQDN suma-head-srv.mgr.suse.de
Node: suma-head-srv, OS Version: 15-SP6, Family: sles
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname suma-head-srv and FQDN suma-head-srv.mgr.suse.de
Node: suma-head-srv, OS Version: 15-SP6, Family: sles
Activating XML-RPC API
Using the default profile...
# Copyright (c) 2020-2024 SUSE LLC
# Licensed under the terms of the MIT license.
#
# This feature can cause failures in the following features:
# - features/secondary/min_activationkey.feature
# If the minion fails to bootstrap again.
@skip_if_github_validation @scope_salt_ssh @ssh_minion @flaky
Feature: Register a Salt system to be managed via SSH tunnel

  Scenario: Log in as admin user                  # features/secondary/min_ssh_tunnel.feature:14
      This scenario ran at: 2024-08-07 14:47:15 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:401
      This scenario took: 12 seconds

  Scenario: Pre-requisite: remove package before ssh tunnel test                        # features/secondary/min_ssh_tunnel.feature:17
      This scenario ran at: 2024-08-07 14:47:27 +0200
Initializing a twopence node for 'ssh_minion'.
Host 'ssh_minion' is alive with determined hostname suma-head-minssh-sles15 and FQDN suma-head-minssh-sles15.mgr.suse.de
Node: suma-head-minssh-sles15, OS Version: 15-SP4, Family: sles
    When I remove package "milkyway-dummy" from this "ssh_minion" without error control # features/step_definitions/command_steps.rb:964
      This scenario took: 1 seconds

  Scenario: Delete the Salt minion for SSH tunnel bootstrap      # features/secondary/min_ssh_tunnel.feature:20
      This scenario ran at: 2024-08-07 14:47:28 +0200
    Given I am on the Systems overview page of this "ssh_minion" # features/step_definitions/navigation_steps.rb:413
    When I follow "Delete System"                                # features/step_definitions/navigation_steps.rb:284
    Then I should see a "Confirm System Profile Deletion" text   # features/step_definitions/navigation_steps.rb:591
    When I click on "Delete Profile"                             # features/step_definitions/navigation_steps.rb:256
    And I wait until I see "has been deleted" text               # features/step_definitions/navigation_steps.rb:39
    Then "ssh_minion" should not be registered                   # features/step_definitions/salt_steps.rb:152
      This scenario took: 13 seconds

  Scenario: Register this minion for push via SSH tunnel                           # features/secondary/min_ssh_tunnel.feature:28
      This scenario ran at: 2024-08-07 14:47:41 +0200
    When I follow the left menu "Systems > Bootstrapping"                          # features/step_definitions/navigation_steps.rb:339
    Then I should see a "Bootstrap Minions" text                                   # features/step_definitions/navigation_steps.rb:591
    And I enter the hostname of "ssh_minion" as "hostname"                         # features/step_definitions/navigation_steps.rb:437
      The hostname of ssh_minion is suma-head-minssh-sles15.mgr.suse.de
    And I enter "22" as "port"                                                     # features/step_definitions/navigation_steps.rb:220
    And I enter "root" as "user"                                                   # features/step_definitions/navigation_steps.rb:220
    And I enter "linux" as "password"                                              # features/step_definitions/navigation_steps.rb:220
    And I select "1-SUSE-SSH-TUNNEL-KEY-x86_64" from "activationKeys"              # features/step_definitions/navigation_steps.rb:164
Initializing a twopence node for 'proxy'.
Host 'proxy' is alive with determined hostname suma-head-pxy and FQDN suma-head-pxy.mgr.suse.de
Node: suma-head-pxy, OS Version: 5.5, Family: sle-micro
    And I select the hostname of "proxy" from "proxies" if present                 # features/step_definitions/navigation_steps.rb:443
    And I check "manageWithSSH"                                                    # features/step_definitions/navigation_steps.rb:154
    And I click on "Bootstrap"                                                     # features/step_definitions/navigation_steps.rb:256
    # workaround for bsc#1222108
    And I wait at most 480 seconds until I see "Bootstrap process initiated." text # features/step_definitions/navigation_steps.rb:47
    And I wait until onboarding is completed for "ssh_minion"                      # features/step_definitions/setup_steps.rb:220
      This scenario took: 133 seconds

  Scenario: The contact method is SSH tunnel on this minion      # features/secondary/min_ssh_tunnel.feature:43
      This scenario ran at: 2024-08-07 14:49:54 +0200
    Given I am on the Systems overview page of this "ssh_minion" # features/step_definitions/navigation_steps.rb:413
    Then I should see a "Push via SSH tunnel" text               # features/step_definitions/navigation_steps.rb:591
      This scenario took: 1 seconds

  Scenario: Install a package from this SSH tunnel minion                             # features/secondary/min_ssh_tunnel.feature:47
      This scenario ran at: 2024-08-07 14:49:55 +0200
    Given I am on the Systems overview page of this "ssh_minion"                      # features/step_definitions/navigation_steps.rb:413
    When I follow "Software" in the content area                                      # features/step_definitions/navigation_steps.rb:299
    And I follow "Install"                                                            # features/step_definitions/navigation_steps.rb:284
    And I enter "milkyway-dummy" as the filtered package name                         # features/step_definitions/navigation_steps.rb:846
    And I click on the filter button                                                  # features/step_definitions/navigation_steps.rb:818
    And I check row with "milkyway-dummy" and arch of "ssh_minion"                    # features/step_definitions/navigation_steps.rb:884
    And I click on "Install Selected Packages"                                        # features/step_definitions/navigation_steps.rb:256
    And I click on "Confirm"                                                          # features/step_definitions/navigation_steps.rb:256
    Then I should see a "1 package install has been scheduled for" text               # features/step_definitions/navigation_steps.rb:591
    Then I wait until event "Package Install/Upgrade scheduled by admin" is completed # features/step_definitions/common_steps.rb:161
      This scenario took: 62 seconds

  @flaky
  Scenario: Remove a package from this SSH tunnel minion                      # features/secondary/min_ssh_tunnel.feature:60
      This scenario ran at: 2024-08-07 14:50:57 +0200
    Given I am on the Systems overview page of this "ssh_minion"              # features/step_definitions/navigation_steps.rb:413
    And I follow "Software" in the content area                               # features/step_definitions/navigation_steps.rb:299
    And I follow "List / Remove"                                              # features/step_definitions/navigation_steps.rb:284
    And I enter "milkyway-dummy" as the filtered package name                 # features/step_definitions/navigation_steps.rb:846
    And I click on the filter button                                          # features/step_definitions/navigation_steps.rb:818
    And I wait until I see "milkyway-dummy" text                              # features/step_definitions/navigation_steps.rb:39
    And I check "milkyway-dummy" in the list                                  # features/step_definitions/navigation_steps.rb:924
    And I click on "Remove Packages"                                          # features/step_definitions/navigation_steps.rb:256
    And I click on "Confirm"                                                  # features/step_definitions/navigation_steps.rb:256
    Then I should see a "1 package removal has been scheduled" text           # features/step_definitions/navigation_steps.rb:591
    Then I wait until event "Package Removal scheduled by admin" is completed # features/step_definitions/common_steps.rb:161
      This scenario took: 42 seconds

  Scenario: Run a remote command on this SSH tunnel minion                              # features/secondary/min_ssh_tunnel.feature:73
      This scenario ran at: 2024-08-07 14:51:39 +0200
    When I follow the left menu "Salt > Remote Commands"                                # features/step_definitions/navigation_steps.rb:339
    Then I should see a "Remote Commands" text in the content area                      # features/step_definitions/navigation_steps.rb:11
    When I enter command "echo 'My remote command output'"                              # features/step_definitions/salt_steps.rb:210
    And I enter the hostname of "ssh_minion" as "target"                                # features/step_definitions/navigation_steps.rb:437
      The hostname of ssh_minion is suma-head-minssh-sles15.mgr.suse.de
The run button is visible.
    And I click on preview                                                              # features/step_definitions/salt_steps.rb:171
    Then I wait until I see "Target systems (1)" text                                   # features/step_definitions/navigation_steps.rb:39
    When I click on run                                                                 # features/step_definitions/salt_steps.rb:201
    And I wait until I see "show response" text                                         # features/step_definitions/navigation_steps.rb:39
    And I expand the results for "ssh_minion"                                           # features/step_definitions/salt_steps.rb:205
    Then I should see "My remote command output" in the command output for "ssh_minion" # features/step_definitions/salt_steps.rb:219
      This scenario took: 19 seconds

  Scenario: Cleanup: delete the SSH tunnel minion                # features/secondary/min_ssh_tunnel.feature:85
      This scenario ran at: 2024-08-07 14:51:58 +0200
    Given I am on the Systems overview page of this "ssh_minion" # features/step_definitions/navigation_steps.rb:413
    When I follow "Delete System"                                # features/step_definitions/navigation_steps.rb:284
    Then I should see a "Confirm System Profile Deletion" text   # features/step_definitions/navigation_steps.rb:591
    When I click on "Delete Profile"                             # features/step_definitions/navigation_steps.rb:256
    And I wait until I see "has been deleted" text               # features/step_definitions/navigation_steps.rb:39
    Then "ssh_minion" should not be registered                   # features/step_definitions/salt_steps.rb:152
      This scenario took: 13 seconds

...
10 scenarios (10 passed)
64 steps (64 passed)
6m36.054s

```

</details>


## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered
- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24998
Port(s): https://github.com/SUSE/spacewalk/pull/25000

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
