### PR TITLE
Fix Extra Packages column in systems list

### DIFF
--- a/web/html/src/manager/systems/all-list.tsx
+++ b/web/html/src/manager/systems/all-list.tsx
@@ -116,7 +116,7 @@ export function AllSystems(props: Props) {
                 <a href={`/rhn/systems/details/packages/ExtraPackagesList.do?sid=${item.id}`}>{item.extraPkgCount}</a>
               );
             }
-            return item.outdatedPackages;
+            return item.extraPkgCount;
           }}
         />
 

--- a/web/spacewalk-web.changes.welder.fix-systems-list-extra-pkg
+++ b/web/spacewalk-web.changes.welder.fix-systems-list-extra-pkg
@@ -1,0 +1,1 @@
+- Fix Extra Packages column in systems list

--- a/web/spacewalk-web.changes.welder.fix-systems-list-extra-pkg
+++ b/web/spacewalk-web.changes.welder.fix-systems-list-extra-pkg
@@ -1,1 +1,1 @@
-- Fix Extra Packages column in systems list
+- Fix Extra Packages column in systems list (bsc#1228980)


### PR DESCRIPTION
## What does this PR change?

It was showing wrong value when extra packages count is zero.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
