### PR TITLE
QE: Add further validation for uptime flexibility

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -124,16 +124,19 @@ Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
     valid_uptime_messages << 'a day ago'
   elsif rounded_uptime_hours > 1 && rounded_uptime_hours <= 21
     valid_uptime_messages = diffs.map { |n| "#{rounded_uptime_hours + n} hours ago" }
+    valid_uptime_messages.map! { |time| time == '1 hours ago' ? 'an hour ago' : time }
   elsif rounded_uptime_minutes >= 45 && rounded_uptime_hours == 1 # shows "an hour ago" from 45 minutes onwards up to 1.5 hours
     valid_uptime_messages << 'an hour ago'
   elsif rounded_uptime_minutes > 1 && rounded_uptime_hours <= 1
     valid_uptime_messages += diffs.map { |n| "#{rounded_uptime_minutes + n} minutes ago" }
+    valid_uptime_messages.map! { |time| time == '1 minutes ago' ? 'a minute ago' : time }
   elsif uptime[:seconds] >= 45 && rounded_uptime_minutes == 1
     valid_uptime_messages << 'a minute ago'
   elsif uptime[:seconds] < 45
     valid_uptime_messages << 'a few seconds ago'
   elsif rounded_uptime_days < 25 # shows "a month ago" from 25 days onwards
     valid_uptime_messages += diffs.map { |n| "#{rounded_uptime_days + n} days ago" }
+    valid_uptime_messages.map! { |time| time == '1 days ago' ? 'a day ago' : time }
   else
     valid_uptime_messages << 'a month ago'
   end


### PR DESCRIPTION
## What does this PR change?
Changed "1 (minutes, hours, days) ago" to the proper grammatical equivalent expected in the valid uptime messages considered.

## Links

Port(s): # 4.3 https://github.com/SUSE/spacewalk/pull/25009

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
