### PR TITLE
QE: Do not kill Uyuni Client Tools sync

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -107,6 +107,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Add openSUSE Leap 15.5 product, including Uyuni Client Tools
     When I use spacewalk-common-channel to add all "leap15.5" channels with arch "x86_64"
     And I kill running spacewalk-repo-sync for "leap15.5-x86_64"
+    And I use spacewalk-common-channel to add all "leap15.5-client-tools" channels with arch "x86_64"
+    And I wait until all synchronized channels for "leap15.5-client-tools-x86_64" have finished
 
 @containerized_server
 @proxy

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1287,9 +1287,13 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         opensuse_leap15_5-x86_64-non-oss-updates
         opensuse_leap15_5-x86_64-updates
         opensuse_leap15_5-x86_64-sle-updates
+        uyuni-proxy-devel-leap-x86_64
+      ],
+    # this on its own is needed due to the reposync killing in Uyuni
+    'leap15.5-client-tools-x86_64' => # CHECKED
+      %w[
         opensuse_leap15_5-uyuni-client-x86_64
         opensuse_leap15_5-uyuni-client-devel-x86_64
-        uyuni-proxy-devel-leap-x86_64
       ],
     'leap15.6-x86_64' => # CHECKED
       %w[


### PR DESCRIPTION
## What does this PR change?

If we do not let the Uyuni client tools being fully synchronized, we will e.g. not have `mgr-push` available which we need for further tests.
This only affects the CI and also only openSUSE Leap 15.5 X86 which we use in the CI.

Fixes https://github.com/SUSE/spacewalk/issues/24979

Test in the Uyuni CI

```bash
uyuni-master-ctl:~/spacewalk/testsuite # cucumber features/reposync/srv_sync_products.feature
Capybara APP Host: https://uyuni-master-srv.mgr.suse.de:8888
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-srv and FQDN uyuni-master-srv.mgr.suse.de
Node: uyuni-master-srv, OS Version: 15.5, Family: opensuse-leap
Initializing a twopence node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-srv and FQDN uyuni-master-srv.mgr.suse.de
Node: uyuni-master-srv, OS Version: 15.5, Family: opensuse-leap
Activating HTTP API
Using the default profile...
# Copyright (c) 2017-2024 SUSE LLC
# Licensed under the terms of the MIT license.
@test_issue
Feature: Synchronize products in the products page of the Setup Wizard

(...)
  @uyuni
  Scenario: Add openSUSE Leap 15.5 product, including Uyuni Client Tools                              # features/reposync/srv_sync_products.feature:109
      This scenario ran at: 2024-08-12 14:53:02 +0200
    When I use spacewalk-common-channel to add all "leap15.5" channels with arch "x86_64"             # features/step_definitions/command_steps.rb:164
      Channel opensuse_leap15_5 added
      Channel opensuse_leap15_5-backports-updates added
      Channel opensuse_leap15_5-non-oss added
      Channel opensuse_leap15_5-non-oss-updates added
      Channel opensuse_leap15_5-updates added
      Channel opensuse_leap15_5-sle-updates added
      Channel uyuni-proxy-devel-leap added
Timeout after 900 seconds (Timeout.timeout): Some reposync processes were not killed properly
    And I kill running spacewalk-repo-sync for "leap15.5-x86_64"                                      # features/step_definitions/command_steps.rb:326
      Killing channels:
      ["opensuse_leap15_5-x86_64", "opensuse_leap15_5-x86_64-backports-updates", "opensuse_leap15_5-x86_64-non-oss", "opensuse_leap15_5-x86_64-non-oss-updates", "opensuse_leap15_5-x86_64-updates", "opensuse_leap15_5-x86_64-sle-updates", "uyuni-proxy-devel-leap-x86_64"]
      Repo-sync process for channel 'opensuse_leap15_5-x86_64-backports-updates' running.
      Reposync of channel opensuse_leap15_5-x86_64-backports-updates killed
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/uyuni-proxy-devel-leap-x86_64/*primary.xml.gz contains 0 packages
      Repo-sync process for channel 'opensuse_leap15_5-x86_64-non-oss' running.
      Reposync of channel opensuse_leap15_5-x86_64-non-oss killed
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/uyuni-proxy-devel-leap-x86_64/*primary.xml.gz contains 0 packages
      1 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "opensuse_leap15_5-x86_64-non-oss-updates", "opensuse_leap15_5-x86_64-updates", "opensuse_leap15_5-x86_64-sle-updates", "uyuni-proxy-devel-leap-x86_64"]
      Repo-sync process for channel 'opensuse_leap15_5-x86_64-non-oss-updates' running.
      Reposync of channel opensuse_leap15_5-x86_64-non-oss-updates killed
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64-updates/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64-sle-updates/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/uyuni-proxy-devel-leap-x86_64/*primary.xml.gz contains 0 packages
      Repo-sync process for channel 'opensuse_leap15_5-x86_64-updates' running.
      Reposync of channel opensuse_leap15_5-x86_64-updates killed
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64-sle-updates/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/uyuni-proxy-devel-leap-x86_64/*primary.xml.gz contains 0 packages
      2 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "opensuse_leap15_5-x86_64-sle-updates", "uyuni-proxy-devel-leap-x86_64"]
      Repo-sync process for channel 'opensuse_leap15_5-x86_64-sle-updates' running.
      Reposync of channel opensuse_leap15_5-x86_64-sle-updates killed
      /var/cache/rhn/repodata/opensuse_leap15_5-x86_64/*primary.xml.gz contains 0 packages
      /var/cache/rhn/repodata/uyuni-proxy-devel-leap-x86_64/*primary.xml.gz contains 0 packages
      3 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      4 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      5 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      6 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      7 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      8 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      9 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      10 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      11 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      12 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      13 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
      14 minutes waiting for 'leap15.5-x86_64' remaining channels to start their repo-sync processes:
      ["opensuse_leap15_5-x86_64", "uyuni-proxy-devel-leap-x86_64"]
    And I use spacewalk-common-channel to add all "leap15.5-client-tools" channels with arch "x86_64" # features/step_definitions/command_steps.rb:164
      Channel opensuse_leap15_5-uyuni-client added
      Channel opensuse_leap15_5-uyuni-client-devel added
    And I wait until all synchronized channels for "leap15.5-client-tools-x86_64" have finished       # features/step_definitions/command_steps.rb:418
      Channel synced, no .new files exist and number of solvables is bigger than 0
      Channel opensuse_leap15_5-uyuni-client-devel-x86_64 finished syncing
      1 minutes out of 12 waiting for 'leap15.5-client-tools-x86_64' channels to be synchronized
      Channel synced, no .new files exist and number of solvables is bigger than 0
      Channel opensuse_leap15_5-uyuni-client-x86_64 finished syncing
      This scenario took: 972 seconds

(...)

1 scenario (1 passed)
4 steps (4 passed)
16m12.163s
```

![image](https://github.com/user-attachments/assets/74fee8c9-52f7-4a11-afac-632460546f89)



## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Cucumber tests were edited
- [x] **DONE**

## Links

Issue(s): #
Ports(s): # no ports
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:


- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!