### PR TITLE
Parse openssl3 authorityKeyIdentifier output line differently

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -17,6 +17,7 @@ import os
 import sys
 import argparse
 import traceback
+import re
 
 # pylint: disable-next=unused-import
 import shutil
@@ -319,8 +320,10 @@ def getCertData(cert):
         elif line.startswith("    "):
             if nextval == "subjectKeyIdentifier":
                 data["subjectKeyIdentifier"] = line.strip().upper()
-            elif nextval == "authorityKeyIdentifier" and line.startswith("    keyid:"):
-                data["authorityKeyIdentifier"] = line[10:].strip().upper()
+            elif nextval == "authorityKeyIdentifier" and re.match(
+                r"^\s+[0-9A-Fa-f]{2}:.+$", line
+            ):
+                data["authorityKeyIdentifier"] = line.strip().upper()
         elif "subject_hash" not in data:
             # subject_hash comes first without key to identify it
             data["subject_hash"] = line.strip()

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.dfaltum.master
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.dfaltum.master
@@ -1,0 +1,1 @@
+- fix parsing Authority Key Identifier when keyid is not prefixed (bsc#1229079)


### PR DESCRIPTION
## What does this PR change?

Modifies the parsing of the authorityKeyIdentifier line according to this issue: https://github.com/uyuni-project/uyuni/issues/9163

Port: https://github.com/SUSE/spacewalk/pull/25028
