### PR TITLE
Update spacewalk-diskcheck (#25010)

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-diskcheck
+++ b/python/spacewalk/satellite_tools/spacewalk-diskcheck
@@ -174,6 +174,7 @@ done
 
 if [ "$CHECKONLY" = false ] && [ "$STOPCHECK" = "1" ] && [ "$SPACECHECKSHUTDOWN" = true ]; then
     spacewalk-service stop ; systemctl stop postgresql.service
+    logger "SPACECHECK CRITICAL: spacewalk shutted down"
 fi
 
 exit $CHECKSEVERITY

--- a/python/spacewalk/spacewalk-backend.changes.serpico.4.3-spacewalk#24283-missing-log-message-when-disk-check-shuts-down-the-system
+++ b/python/spacewalk/spacewalk-backend.changes.serpico.4.3-spacewalk#24283-missing-log-message-when-disk-check-shuts-down-the-system
@@ -1,0 +1,2 @@
+- added log string to the journal when services are stopped 
+  because of insufficent disk space


### PR DESCRIPTION

## What does this PR change?

Added a log string when shutting down the system as a result of the check disk script running
Port of: https://github.com/SUSE/spacewalk/pull/25010

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
