### PR TITLE
Allow the listing of already included patches when importing them into a custom channel

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -576,6 +576,49 @@ SELECT DISTINCT E.id, E.advisory_name AS advisory_name,
   <elaborator name="errata_flags"/>
 </mode>
 
+<mode name="in_sources_for_target_with_already_included" class="com.redhat.rhn.frontend.dto.ErrataOverview">
+    <query params="custom_cid, user_id">
+        SELECT DISTINCT E.id , E.advisory AS advisory,
+            E.update_date AS UPDATE_DATE,
+            E.synopsis as ADVISORY_SYNOPSIS,
+            E.advisory_type as ADVISORY_TYPE,
+            E.advisory_name AS advisory_name,
+            E.advisory_status
+        FROM rhnErrata E
+        INNER JOIN rhnChannelErrata CE ON E.id = CE.errata_id
+        LEFT JOIN
+            (SELECT errata_id from rhnChannelErrata where channel_id = :custom_cid) errata_exists
+            ON errata_exists.errata_id = E.id,
+        rhnSet S
+        WHERE CE.channel_id  = S.element
+        AND S.label =  'channels_for_errata'
+        AND errata_exists.errata_id is null
+        AND S.user_id = :user_id
+    </query>
+    <elaborator name="errata_flags"/>
+</mode>
+
+<mode name="in_sources_for_target_package_assoc_with_already_included" class="com.redhat.rhn.frontend.dto.ErrataOverview">
+    <query params="custom_cid, user_id">
+        SELECT DISTINCT E.id, E.advisory_name AS advisory_name,
+            E.update_date AS UPDATE_DATE,
+            E.synopsis as ADVISORY_SYNOPSIS,
+            E.advisory_type as ADVISORY_TYPE,
+            E.advisory_status
+        FROM rhnErrata E
+        INNER JOIN rhnChannelErrata CE ON CE.errata_id = E.id
+        INNER JOIN rhnSet S on S.element = CE.channel_id
+        INNER JOIN rhnErrataPackage EP ON EP.errata_id = E.id
+        INNER JOIN rhnPackage P ON p.id = EP.package_id
+        INNER JOIN rhnPackage P2 ON P.name_id = P2.name_id
+        INNER JOIN rhnChannelPackage CP ON P2.id = CP.package_id
+        WHERE CP.channel_id = :custom_cid
+        AND S.user_id = :user_id
+        AND S.label = 'channels_for_errata'
+        AND E.id not in (select errata_id from rhnChannelErrata where channel_id = :custom_cid)
+    </query>
+    <elaborator name="errata_flags"/>
+</mode>
 
 <mode name="for_target" class="com.redhat.rhn.frontend.dto.ErrataOverview">
   <query params="custom_cid">

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -602,6 +602,15 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[select cp.package_id from rhnChannelPackage cp where cp.channel_id = :cid]]>
     </sql-query>
 
+    <sql-query name="Channel.getClonedErrataOriginalIdList">
+        <return-scalar type="long" column="original_id"/>
+        <![CDATA[SELECT errataCloned.original_id
+                    FROM rhnChannelErrata channelErrata
+                    INNER JOIN rhnErrataCloned errataCloned ON errataCloned.id = channelErrata.errata_id
+                    WHERE channelErrata.channel_id = :cid
+        ]]>
+    </sql-query>
+
     <sql-query name="Channel.isAccessibleBy">
         <return-scalar type="int" column="result"/>
          <![CDATA[SELECT case when (EXISTS (

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -742,6 +742,18 @@ public class ChannelFactory extends HibernateFactory {
     }
 
     /**
+     * Get cloned errata ids for a channel
+     * @param cid the channel id
+     * @return List of errata ids
+     */
+    public static List<Long> getClonedErrataIds(Long cid) {
+        if (cid == null) {
+            return new ArrayList<>();
+        }
+        return singleton.listObjectsByNamedQuery("Channel.getClonedErrataOriginalIdList", Map.of("cid", cid));
+    }
+
+    /**
      * Looksup the number of Packages in a channel
      * @param channel the Channel who's package count you are interested in.
      * @return number of packages in this channel.

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddCustomErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddCustomErrataAction.java
@@ -221,7 +221,7 @@ public class AddCustomErrataAction extends RhnListAction {
             set.addElement(selectedChan.getId());
             RhnSetManager.store(set);
             return ChannelManager.findErrataFromRhnSetForTarget(currentChan,
-                    packageAssoc, user);
+                    packageAssoc, false, user);
         }
         else if (selChannelList != null) {
                 RhnSet set = RhnSetDecl.CHANNELS_FOR_ERRATA.get(user);
@@ -231,7 +231,7 @@ public class AddCustomErrataAction extends RhnListAction {
                 }
                 RhnSetManager.store(set);
                 return ChannelManager.findErrataFromRhnSetForTarget(currentChan,
-                        packageAssoc, user);
+                        packageAssoc, false, user);
         }
         else {
                 return ChannelManager.findCustomErrataForTarget(currentChan,

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddErrataToChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddErrataToChannelAction.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -82,6 +83,7 @@ public class AddErrataToChannelAction extends RhnListAction {
         }
 
         List<Long> channelPacks = ChannelFactory.getPackageIds(currentChan.getId());
+        List<Long> clonedErrataOriginalIds = ChannelFactory.getClonedErrataIds(currentChan.getId());
 
         for (Long pid : packageIds) {
             if (!channelPacks.contains(pid)) {
@@ -95,7 +97,10 @@ public class AddErrataToChannelAction extends RhnListAction {
         //        user).getElementValues();
         //ErrataManager.publishErrataToChannelAsync(currentChan, errataIds, user);
         List<ErrataOverview> errata = ErrataManager.errataInSet(user,
-                RhnSetDecl.setForChannelErrata(currentChan).get(user).getLabel());
+                RhnSetDecl.setForChannelErrata(currentChan).get(user).getLabel())
+                    .stream()
+                    .filter(it -> !clonedErrataOriginalIds.contains(it.getId()))
+                    .collect(Collectors.toList());
         Set<Long> eids = ErrataManager.cloneChannelErrata(errata, currentChan.getId(),
                 user);
 

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddRedHatErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/AddRedHatErrataAction.java
@@ -64,6 +64,7 @@ public class AddRedHatErrataAction extends RhnListAction {
     private static final String CHANNEL_SUBMIT = "frontend.actions.channels.manager." +
             "add.viewErrata";
     private static final String CHECKED = "assoc_checked";
+    private static final String LIST_ALREADY_INCLUDED_PATCH = "list_already_included";
 
     private static final String SUBMITTED = "frontend.actions.channels.manager." +
             "add.submit";
@@ -97,6 +98,7 @@ public class AddRedHatErrataAction extends RhnListAction {
         List<SelectableChannel> channelList;
         String selectedChannelStr;
         boolean checked = true;
+        boolean listAlreadyIncludedPatches = true;
 
 
         //Set initail strings
@@ -130,6 +132,10 @@ public class AddRedHatErrataAction extends RhnListAction {
             checked = false;
         }
 
+        if (requestContext.isSubmitted() && request.getParameter(LIST_ALREADY_INCLUDED_PATCH) == null)  {
+            listAlreadyIncludedPatches = false;
+        }
+
         request.setAttribute(CHECKED, checked);
         request.setAttribute(SELECTED_CHANNEL, selectedChannelStr);
 
@@ -157,7 +163,8 @@ public class AddRedHatErrataAction extends RhnListAction {
         RhnListSetHelper helper = new RhnListSetHelper(request);
         RhnSet set =  getSetDecl(currentChan).get(user);
 
-        DataResult<ErrataOverview> dr = getData(request, selectedChannel, currentChan, channelList, checked, user);
+        DataResult<ErrataOverview> dr = getData(request, selectedChannel, currentChan, channelList, checked,
+                listAlreadyIncludedPatches, user);
 
         request.setAttribute(RequestContext.PAGE_LIST, dr);
 
@@ -244,6 +251,7 @@ public class AddRedHatErrataAction extends RhnListAction {
                                                Channel currentChan,
                                                List<SelectableChannel> selChannelList,
                                                boolean packageAssoc,
+                                               boolean listAlreadyIncludedPatches,
                                                User user) {
 
         if (selectedChan != null) {
@@ -252,7 +260,7 @@ public class AddRedHatErrataAction extends RhnListAction {
             set.addElement(selectedChan.getId());
             RhnSetManager.store(set);
             return ChannelManager.findErrataFromRhnSetForTarget(currentChan,
-                    packageAssoc, user);
+                    packageAssoc, listAlreadyIncludedPatches, user);
         }
         else if (selChannelList != null) {
                 RhnSet set = RhnSetDecl.CHANNELS_FOR_ERRATA.get(user);
@@ -262,7 +270,7 @@ public class AddRedHatErrataAction extends RhnListAction {
                 }
                 RhnSetManager.store(set);
                 return ChannelManager.findErrataFromRhnSetForTarget(currentChan,
-                        packageAssoc, user);
+                        packageAssoc, listAlreadyIncludedPatches, user);
 
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -22447,6 +22447,12 @@ As a Channel Administrator, you may change the base channels your systems are su
       <trans-unit id="channel.manage.errata.packageassocmsg" xml:space="preserve">
         <source>&lt;em&gt;(Recommended)&lt;/em&gt; With this selected only patches that contain packages that apply to this channel are shown.  Also, package architecture will match what is currently in the channel.</source>
       </trans-unit>
+      <trans-unit id="channel.manage.errata.listalreadyincludedlabel" xml:space="preserve">
+        <source>List Already Included Patches:</source>
+      </trans-unit>
+      <trans-unit id="channel.manage.errata.listalreadyincludedmsg" xml:space="preserve">
+        <source>With this selected, patches that are already part of the channel are shown. This is useful when a patch is part of multiple channels, has been included from one of them, and it is necessary to associate its packages from another one.</source>
+      </trans-unit>
       <trans-unit id="toolbar.ssm.add" xml:space="preserve">
         <source>Add to SSM</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2138,18 +2138,13 @@ public class ChannelManager extends BaseManager {
      * @param user the user doing the query
      * @param packageAssoc whether to filter packages on what packages are already
      *                      in the channel
+     * @param listAlreadyIncluded whether to list erratas that are already in the channel
      * @return List of Errata
      */
     public static DataResult<ErrataOverview> findErrataFromRhnSetForTarget(
-            Channel targetChannel, boolean packageAssoc, User user) {
+            Channel targetChannel, boolean packageAssoc, boolean listAlreadyIncluded, User user) {
 
-        String mode;
-        if (packageAssoc) {
-             mode =  "in_sources_for_target_package_assoc";
-        }
-        else {
-             mode =  "in_sources_for_target";
-        }
+        String mode = getModeFindErrataFromRhnSet(packageAssoc, listAlreadyIncluded);
 
         Map<String, Long> params = new HashMap<>();
         params.put("custom_cid", targetChannel.getId());
@@ -2160,6 +2155,12 @@ public class ChannelManager extends BaseManager {
                 ERRATA_QUERIES, mode);
 
         return m.execute(params);
+    }
+
+    private static String getModeFindErrataFromRhnSet(boolean packageAssoc, boolean listAlreadyIncluded) {
+        return "in_sources_for_target" +
+                (packageAssoc ? "_package_assoc" : "") +
+                (listAlreadyIncluded ? "_with_already_included" : "");
     }
 
     /**

--- a/java/code/webapp/WEB-INF/pages/channel/manage/adderrataredhat.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/adderrataredhat.jsp
@@ -26,6 +26,16 @@
                 </div>
             </div>
 
+            <div class="form-group">
+                <label class="col-lg-3 control-label">
+                    <bean:message key="channel.manage.errata.listalreadyincludedlabel"/>
+                </label>
+                <div class="col-lg-6">
+                    <input type="checkbox" name="list_already_included" ${list_already_included ? 'checked' : ''}/>
+                    <bean:message key="channel.manage.errata.listalreadyincludedmsg"/>
+                </div>
+            </div>
+
             <c:if test="${selected_channel != null}">
                 <rhn:hidden name="selected_channel_old"  value="${selected_channel}"/>
             </c:if>

--- a/java/spacewalk-java.changes.welder.bsc1228856
+++ b/java/spacewalk-java.changes.welder.bsc1228856
@@ -1,0 +1,1 @@
+- Allow the listing of already included patches when importing them into a custom channel (bsc#1228856)


### PR DESCRIPTION
## What does this PR change?

When a patch exists in multiple origin channels, SUMA currently doesn’t allow importing from more than one channel. This PR adds a checkbox that allows the user to list the already included patches so that it is possible to import the related packages in case the patch was originally imported from a different channel.

## GUI diff

![image](https://github.com/user-attachments/assets/a550d383-521a-472a-80fa-1a87c7f6f41c)

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25002

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
