### PR TITLE
add SLE-Micro 5 to the list of systems which support monitoring

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -166,9 +166,12 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     @Override
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
-                isRedHat6() || isRedHat7() || isRedHat8() || isRedHat9() || isAlibaba2() || isAmazon2() ||
-                isAmazon2023() || isRocky8() || isRocky9() || isDebian12() || isDebian11() || isDebian10();
+        return isSLES12() || isSLES15() || isLeap15() || isLeapMicro() ||
+                isSLEMicro5() || // Micro 6 miss the node exporter
+                isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
+                isRedHat6() || isRedHat7() || isRedHat8() || isRedHat9() || // isRedHat catch also Rocky and Alma
+                isAlibaba2() || isAmazon2() || isAmazon2023() ||
+                isDebian12() || isDebian11() || isDebian10();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2417,9 +2417,12 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * @return <code>true</code> if OS supports monitoring
      */
     public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
-                isRedHat6() || isRedHat7() || isRedHat8() || isAlibaba2() || isAmazon2() || isAmazon2023() ||
-                isRocky8() || isRocky9() || isDebian12() || isDebian11() || isDebian10();
+        return isSLES12() || isSLES15() || isLeap15() || isLeapMicro() ||
+                isSLEMicro5() || // Micro 6 miss the node exporter
+                isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
+                isRedHat6() || isRedHat7() || isRedHat8() || isRedHat9() || // isRedHat catch also Rocky and Alma
+                isAlibaba2() || isAmazon2() || isAmazon2023() ||
+                isDebian12() || isDebian11() || isDebian10();
     }
 
     /**
@@ -2428,7 +2431,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * @return <code>true</code> if OS supports PTF uninstallation
      */
     public boolean doesOsSupportPtf() {
-        return ServerConstants.SLES.equals(getOs());
+        return ServerConstants.SLES.equals(getOs()) || isSLEMicro();
     }
 
     boolean isSLES() {
@@ -2470,10 +2473,24 @@ public class Server extends BaseDomainHelper implements Identifiable {
     }
 
     /**
-     * @return true if the installer type is of SLE Micro
+     * @return true if the installer type is of SLE Micro (version independent)
      */
     boolean isSLEMicro() {
         return ServerConstants.SLEMICRO.equals(getOs()) || ServerConstants.SLMICRO.equals(getOs());
+    }
+
+    /**
+     * @return true if the installer type is of SLE Micro 5
+     */
+    boolean isSLEMicro5() {
+        return ServerConstants.SLEMICRO.equals(getOs()) && getRelease().startsWith("5.");
+    }
+
+    /**
+     * @return true if the installer type is of SE Micro 6
+     */
+    boolean isSEMicro6() {
+        return ServerConstants.SLMICRO.equals(getOs()) && getRelease().startsWith("6.");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
@@ -216,6 +216,7 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
 
         MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
         minion1.setOs(ServerConstants.SLEMICRO);
+        minion1.setRelease("5.5");
         MinionSummary minionSummary1 = new MinionSummary(minion1);
 
         SystemManager.giveCapability(minion1.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
@@ -279,6 +280,7 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
 
         MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
         minion1.setOs(ServerConstants.SLEMICRO);
+        minion1.setRelease("6.0");
         MinionSummary minionSummary1 = new MinionSummary(minion1);
 
         SystemManager.giveCapability(minion1.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);

--- a/java/spacewalk-java.changes.mc.fix-add-monitoring-ent-to-slemicro
+++ b/java/spacewalk-java.changes.mc.fix-add-monitoring-ent-to-slemicro
@@ -1,0 +1,2 @@
+- add SLE-Micro 5 to the list of systems which support monitoring (bsc#1227334)
+- add all SLE-Micro systems to the list of systems which get PTF repositories

--- a/testsuite/features/init_clients/proxy_container.feature
+++ b/testsuite/features/init_clients/proxy_container.feature
@@ -60,3 +60,8 @@ Feature: Setup containerized proxy
   Scenario: The containerized proxy should be registered automatically
     When I follow the left menu "Systems"
     And I wait until I see the name of "proxy", refreshing the page
+
+  Scenario: Check if Monitoring can be enabled on the containerized proxy
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Properties" in the content area
+    Then the "monitoring_entitled" checkbox should be disabled


### PR DESCRIPTION
## What does this PR change?

The Monitoring System Type were not visible for SLE-Micro 5 systems incl. SUSE Manager Proxy 5 .
The same applied for support PTF repositories.

SL-Micro 6 still miss the node_exporter package and cannot be enabled yet.

## GUI diff

![image](https://github.com/user-attachments/assets/310c6811-5585-4810-bb49-126685233b42)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24710
Port(s): https://github.com/SUSE/spacewalk/pull/25082 https://github.com/SUSE/spacewalk/pull/25083

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
