### PR TITLE
Fixed find target button bug

### DIFF
--- a/web/html/src/branding/css/base/theme.scss
+++ b/web/html/src/branding/css/base/theme.scss
@@ -1332,6 +1332,8 @@ tr.changed > td {
 
 .badge {
   font-size: 12px;
+  border-radius: 10px;
+  background: $eos-bc-gray-1000;
 }
 
 // We can reenable these after the theme migration is complete

--- a/web/html/src/branding/css/base/theme.scss
+++ b/web/html/src/branding/css/base/theme.scss
@@ -1333,7 +1333,7 @@ tr.changed > td {
 .badge {
   font-size: 12px;
   border-radius: 10px;
-  background: $eos-bc-gray-1000;
+  background: $badge-bg;
 }
 
 // We can reenable these after the theme migration is complete

--- a/web/html/src/manager/salt/cmd/remote-commands.tsx
+++ b/web/html/src/manager/salt/cmd/remote-commands.tsx
@@ -283,6 +283,7 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
       errors: [],
       warnings: [],
       previewed: deferred,
+      executing: jQuery.Deferred(),
       result: {
         minions: new Map(),
       },

--- a/web/spacewalk-web.changes.bisht-richa.fixed-find-targets-button-issue
+++ b/web/spacewalk-web.changes.bisht-richa.fixed-find-targets-button-issue
@@ -1,1 +1,2 @@
 - Fix Find targets button behavior for the feature salt > remote commands page
+- Fix the missing background color for the pending status badge and show/hide the response Badge component.

--- a/web/spacewalk-web.changes.bisht-richa.fixed-find-targets-button-issue
+++ b/web/spacewalk-web.changes.bisht-richa.fixed-find-targets-button-issue
@@ -1,0 +1,1 @@
+- Fix Find targets button behavior for the feature salt > remote commands page


### PR DESCRIPTION
## What does this PR change?
- Fix the `Find target` button behavior for the feature salt > remote commands
- Fix the missing background color for the pending status badge and show/hide the response labels. 

**add description**

## GUI diff

No difference.

Before:
<img width="1565" alt="Screenshot 2024-08-20 at 13 48 26" src="https://github.com/user-attachments/assets/47ee101b-8052-4f0a-82b8-8a8e59827b3a">

After:
<img width="1514" alt="Screenshot 2024-08-20 at 13 47 17" src="https://github.com/user-attachments/assets/f0c1dc66-a342-4410-86dc-7826acf4d0aa">

- [ ] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered


- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/25108

Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
