### PR TITLE
enforce directory permissions at repo-sync when creating directories

### DIFF
--- a/python/uyuni/common/fileutils.py
+++ b/python/uyuni/common/fileutils.py
@@ -312,6 +312,7 @@ def makedirs(path, mode=int("0755", 8), user=None, group=None):
         dirname = dirs_to_create.pop()
         try:
             os.mkdir(dirname, mode)
+            os.chmod(dirname, mode)
         except OSError:
             e = sys.exc_info()[1]
             if e.errno != 17:  # File exists

--- a/python/uyuni/uyuni-common-libs.changes.mc.Manager-4.3-reposync-mkdir-umask
+++ b/python/uyuni/uyuni-common-libs.changes.mc.Manager-4.3-reposync-mkdir-umask
@@ -1,0 +1,1 @@
+- enforce directory permissions at repo-sync when creating directories (bsc#1229260)


### PR DESCRIPTION
## What does this PR change?

When using umask 077, reposync create directories with 0700 permissions which prevent tomcat from reading these directories.
os.mkdir seems to apply the umask on the given mode. This require an extra os.chmod to enforce the permissions

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25109 https://github.com/SUSE/spacewalk/pull/25110

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
