### PR TITLE
Detect and update errata when not all repository packages are linked

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes.welder.fix-reposync-package-errata-link
+++ b/python/spacewalk/spacewalk-backend.changes.welder.fix-reposync-package-errata-link
@@ -1,0 +1,1 @@
+- Detect and update errata when not all repository packages are linked (bsc#1227644)


### PR DESCRIPTION
## What does this PR change?

This PR updates the logic for determining whether an errata requires an update. It introduces a new check that compares the packages associated with the errata in the repository against those in the database. If any package is found in the repository but is not yet reflected in the database, the errata is flagged for an update.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24793

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
