### PR TITLE
Fix spacecmd type issue during bootstrap

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.spacecmd-bootstrap-fix
+++ b/spacecmd/spacecmd.changes.mczernek.spacecmd-bootstrap-fix
@@ -1,0 +1,1 @@
+- Spacecmd bootstrap now works with specified port (bsc#1229437)

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -4563,6 +4563,9 @@ def do_system_bootstrap(self, args):
         if answer in ['y', 'Y']:
             options.saltssh = True
 
+    if isinstance(options.port, str) and options.port.isnumeric():
+        options.port = int(options.port)
+
     if not options.hostname:
         logging.error(_N("Hostname must be provided"))
         return 1

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -4563,7 +4563,10 @@ def do_system_bootstrap(self, args):
         if answer in ['y', 'Y']:
             options.saltssh = True
 
-    if isinstance(options.port, str) and options.port.isnumeric():
+    if isinstance(options.port, str):
+        if not options.port.isnumeric():
+            logging.error(_N("Provided port must be numeric"))
+            return 1
         options.port = int(options.port)
 
     if not options.hostname:


### PR DESCRIPTION
## What does this PR change?

When executing system bootstrap with specified port number, e.g. `system_bootstrap -H suma-new-minion -p 22 -u root -P linux -a 1-sles15-sp5-ssh`, the port number is a string. However, [SystemHandler](https://github.com/uyuni-project/uyuni/blob/master/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java#L8379) expects this to be an int.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25093
Port(s): 

- https://github.com/SUSE/spacewalk/pull/25176
- https://github.com/SUSE/spacewalk/pull/25178

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
