### PR TITLE
Add custom krb5.conf which moved keytab under krb5.conf.d

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -122,6 +122,11 @@ RUN uyuni-configfiles-sync init /srv/tftpboot/
 RUN uyuni-configfiles-sync init /srv/www/
 RUN uyuni-configfiles-sync init /var/lib/cobbler/
 
+# Set /etc/krb5.conf.d/ as a link to krb5
+COPY krb5.conf /etc/krb5.conf
+COPY krb5-conf-setup.sh /usr/bin/krb5-conf-setup.sh
+RUN /bin/bash krb5-conf-setup.sh
+
 # LABELs
 ARG PRODUCT=Uyuni
 ARG VENDOR="Uyuni project"

--- a/containers/server-image/krb5-conf-setup.sh
+++ b/containers/server-image/krb5-conf-setup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+KRB5CONFD="krb5.conf.d"
+
+rmdir "/etc/$KRB5CONFD"
+mkdir "/etc/rhn/$KRB5CONFD"
+ln -s "/etc/rhn/$KRB5CONFD" "/etc/$KRB5CONFD"

--- a/containers/server-image/krb5.conf
+++ b/containers/server-image/krb5.conf
@@ -1,0 +1,32 @@
+includedir  /etc/rhn/krb5.conf.d
+
+[libdefaults]
+    # "dns_canonicalize_hostname" and "rdns" are better set to false for improved security.
+    # If set to true, the canonicalization mechanism performed by Kerberos client may
+    # allow service impersonification, the consequence is similar to conducting TLS certificate
+    # verification without checking host name.
+    # If left unspecified, the two parameters will have default value true, which is less secure.
+    dns_canonicalize_hostname = false
+    rdns = false
+    # "verify_ap_req_nofail" is enabled to protect against KDC spoofing. After obtaining the
+    # initial credentials the client library will attempt to verify if the KDC that issued them
+    # is the same that issued the keys stored in the local keytab. If the client machine does
+    # not have a keytab, it cannot be read or there is no host key in it, the verification will
+    # fail if "verify_ap_req_nofail" is set to true. If it is set to false and the client machine
+    # does not have a keytab, the verification is skipped.
+    verify_ap_req_nofail = true
+#   default_realm = EXAMPLE.COM
+    default_ccache_name = KEYRING:persistent:%{uid}
+    # move default keytab to the persistent /etc/rhn/krb5.conf.d directory
+    default_keytab_name = FILE:/etc/rhn/krb5.conf.d/krb5.keytab
+
+[realms]
+#       EXAMPLE.COM = {
+#                kdc = kerberos.example.com
+#               admin_server = kerberos.example.com
+#       }
+
+[logging]
+    kdc = FILE:/var/log/krb5/krb5kdc.log
+    admin_server = FILE:/var/log/krb5/kadmind.log
+    default = SYSLOG:NOTICE:DAEMON

--- a/containers/server-image/server-image.changes.oholecek.krb5-persistent-fix
+++ b/containers/server-image/server-image.changes.oholecek.krb5-persistent-fix
@@ -1,0 +1,2 @@
+- use /etc/krb5.conf.d for all kerberos related configurations
+  (bsc#1229077)


### PR DESCRIPTION
## What does this PR change?

See title.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/25033

- [X] **DONE**

## Test coverage
- No tests: not testing kerberos integration

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25033
Port(s): # **add downstream PR(s), if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
