### PR TITLE
spacecmd is not included on SL Micro

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -156,8 +156,9 @@ Feature: Smoke tests for <client>
     And I wait until file "/etc/s-mgr/config" exists on "<client>"
     Then file "/etc/s-mgr/config" should contain "COLOR=white" on "<client>"
 
+# The client tools of SLE Micro and SL Micro (intentionally) do not contain spacecmd
 @skip_for_sle_micro
-  # The client tools of SLE Micro (intentionally) do not contain spacecmd
+@skip_for_sl_micro
   Scenario: Install spacecmd from the client tools on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -506,13 +506,11 @@ Before('@skip_for_debianlike') do |scenario|
 end
 
 Before('@skip_for_rocky9') do |scenario|
-  filename = scenario.location.file
-  skip_this_scenario if filename.include? 'rocky9'
+  skip_this_scenario if scenario.location.file.include? 'rocky9'
 end
 
 Before('@skip_for_alma9') do |scenario|
-  filename = scenario.location.file
-  skip_this_scenario if filename.include? 'alma9'
+  skip_this_scenario if scenario.location.file.include? 'alma9'
 end
 
 Before('@skip_for_minion') do |scenario|
@@ -527,6 +525,10 @@ Before('@skip_for_sle_micro_ssh_minion') do |scenario|
   sle_micro_ssh_nodes = %w[slemicro51_ssh_minion slemicro52_ssh_minion slemicro53_ssh_minion slemicro54_ssh_minion slemicro55_ssh_minion slmicro60_ssh_minion]
   current_feature_node = scenario.location.file.split(%r{(_smoke_tests.feature|/)})[-2]
   skip_this_scenario if sle_micro_ssh_nodes.include? current_feature_node
+end
+
+Before('@skip_for_sl_micro') do |scenario|
+  skip_this_scenario if scenario.location.file.include? 'slmicro'
 end
 
 # do some tests only if we have SCC credentials


### PR DESCRIPTION
## What does this PR change?

This PR disables the test for spacecmd on SL Micro.


## Links

Ports:
 * 4.3: https://github.com/SUSE/spacewalk/pull/25118


## Changelogs

- [x] No changelog needed
