### PR TITLE
do not build debuginfo package

### DIFF
--- a/uyuni/uyuni-storage-setup/uyuni-storage-setup.changes.mc.fix-debugpackage-build
+++ b/uyuni/uyuni-storage-setup/uyuni-storage-setup.changes.mc.fix-debugpackage-build
@@ -1,0 +1,1 @@
+- do not build debuginfo package

--- a/uyuni/uyuni-storage-setup/uyuni-storage-setup.spec
+++ b/uyuni/uyuni-storage-setup/uyuni-storage-setup.spec
@@ -15,6 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%global debug_package %{nil}
 
 Name:           uyuni-storage-setup
 Version:        5.0.1


### PR DESCRIPTION
## What does this PR change?

Disable building debuginfo packages as they will be empty anyway.
Important for other OSes which do not auto-detect this during building

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
