### PR TITLE
try to wait until the list of child channels are visible before clicking on "Save"

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -72,6 +72,7 @@ Feature: Content lifecycle
     And I follow "clp_name"
     And I click on "Attach/Detach Sources"
     And I select "openSUSE Leap 15.5 (x86_64)" from "selectedBaseChannel"
+    And I wait until I see "openSUSE Leap 15.5 Updates (x86_64)" text
     And I click on "Save"
     And I wait until I see "openSUSE Leap 15.5 (x86_64)" text
     Then I should see a "Version 1: (draft - not built) - Check the changes below" text


### PR DESCRIPTION
## What does this PR change?

I assume the failing CLM test in Uyuni is caused by clicking too fast on the "Save" button before the calculation of mandatory child channels is finished.
This PR try to wait until the list is visible by checking for the "Update" channel text

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests adapted

- [x] **DONE**

## Links

Port(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
