### PR TITLE
fix NullPointerException when generating subscription matcher input

### DIFF
--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -182,7 +182,9 @@ public class MatcherJsonIO {
                 boolean virtualHost = entitlements.contains(EntitlementManager.VIRTUALIZATION_ENTITLED) ||
                         !system.getGuests().isEmpty();
                 boolean countVCores = !virtualHost && system.getInstalledProductSet()
-                        .map(s -> s.getBaseProduct().getChannelFamily()).stream()
+                        .map(productSet -> productSet.getBaseProduct())
+                        .map(baseProduct -> baseProduct.getChannelFamily())
+                        .stream()
                         .anyMatch(cf -> vCoreCountedChannelFamilies.contains(cf.getLabel()));
                 if (countVCores) {
                     // HACK: better would be to introduce a field in SystemJson and adapt subscription-matcher

--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -184,8 +184,8 @@ public class MatcherJsonIO {
                 boolean countVCores = !virtualHost && system.getInstalledProductSet()
                         .map(productSet -> productSet.getBaseProduct())
                         .map(baseProduct -> baseProduct.getChannelFamily())
-                        .stream()
-                        .anyMatch(cf -> vCoreCountedChannelFamilies.contains(cf.getLabel()));
+                        .map(cf -> vCoreCountedChannelFamilies.contains(cf.getLabel()))
+                        .orElse(false); // Case when any of the mappings above return empty.
                 if (countVCores) {
                     // HACK: better would be to introduce a field in SystemJson and adapt subscription-matcher
                     // For now it is not worth the effort

--- a/java/spacewalk-java.changes.mc.Manager-4.3-fix-npe-matcher-io
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-fix-npe-matcher-io
@@ -1,0 +1,1 @@
+- fix NullPointerException when generating subscription matcher input (bsc#1228638)


### PR DESCRIPTION
## What does this PR change?

When a system has no base product a NPE can happen when generating the input for the subscription matcher.

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/24980

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
