### PR TITLE
Cleanup proxy known hosts

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -802,6 +802,9 @@ public class SystemManager extends BaseManager {
                         log.warn("Hostname {}:{} could not be removed from /var/lib/salt/.ssh/known_hosts: {}",
                                 hostname, port, result.map(r -> r.getComment()).orElse(""));
                     }
+                    else {
+                        SaltSSHService.cleanupKnownHostsFromProxy(server);
+                    }
                 },
                 () -> log.warn("Unable to remove SSH key for {} from /var/lib/salt/.ssh/known_hosts: unknown hostname",
                         server.getName()));

--- a/java/spacewalk-java.changes.mc.Manager-4.3-cleanup-proxy-known_hosts
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-cleanup-proxy-known_hosts
@@ -1,0 +1,1 @@
+- remove system also from proxy ssh known_hosts (bsc#1228345)

--- a/proxy/proxy/mgr-proxy-ssh-force-cmd
+++ b/proxy/proxy/mgr-proxy-ssh-force-cmd
@@ -3,6 +3,6 @@ set -- $SSH_ORIGINAL_COMMAND
 cmd="$1"
 shift
 case "$cmd" in
-  '/usr/bin/scp'|'/usr/bin/ssh'|'cat') exec "$cmd" "$@" ;;
-  *) echo "ERROR: command not allowed" ;;
+  '/usr/bin/scp'|'/usr/bin/ssh'|'cat'|'/usr/bin/ssh-keygen') exec "$cmd" "$@" ;;
+  *) echo "ERROR: command not allowed" >&2; exit 1 ;;
 esac

--- a/proxy/proxy/spacewalk-proxy.changes.mc.Manager-4.3-cleanup-proxy-known_hosts
+++ b/proxy/proxy/spacewalk-proxy.changes.mc.Manager-4.3-cleanup-proxy-known_hosts
@@ -1,0 +1,1 @@
+- allow execute of ssh-keygen command on the proxy to cleanup ssh known_hosts (bsc#1228345)


### PR DESCRIPTION
## What does this PR change?

When a system gets deleted, take care that it is also removed from proxy known_hosts

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25043

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
