### PR TITLE
Fix parsing authoritykeyident

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -14,6 +14,7 @@
 
 ## language imports
 import os
+import re
 import sys
 import argparse
 import traceback
@@ -321,7 +322,9 @@ def getCertData(cert):
                 data["subjectKeyIdentifier"] = line.strip().upper()
             elif nextval == "authorityKeyIdentifier" and line.startswith("    keyid:"):
                 data["authorityKeyIdentifier"] = line[10:].strip().upper()
-            elif nextval == "authorityKeyIdentifier" and re.match("^\s+[0-9A-Fa-f]{2}:.+$", line):
+            elif nextval == "authorityKeyIdentifier" and re.match(
+                r"^\s+[0-9A-Fa-f]{2}:.+$", line
+            ):
                 data["authorityKeyIdentifier"] = line.strip().upper()
         elif "subject_hash" not in data:
             # subject_hash comes first without key to identify it

--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -325,6 +325,7 @@ def getCertData(cert):
             elif nextval == "authorityKeyIdentifier" and re.match(
                 r"^\s+[0-9A-Fa-f]{2}:.+$", line
             ):
+                # the regex check, if the line contain the hex value directly without identifier
                 data["authorityKeyIdentifier"] = line.strip().upper()
         elif "subject_hash" not in data:
             # subject_hash comes first without key to identify it

--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -321,6 +321,8 @@ def getCertData(cert):
                 data["subjectKeyIdentifier"] = line.strip().upper()
             elif nextval == "authorityKeyIdentifier" and line.startswith("    keyid:"):
                 data["authorityKeyIdentifier"] = line[10:].strip().upper()
+            elif nextval == "authorityKeyIdentifier" and re.match("^\s+[0-9A-Fa-f]{2}:.+$", line):
+                data["authorityKeyIdentifier"] = line.strip().upper()
         elif "subject_hash" not in data:
             # subject_hash comes first without key to identify it
             data["subject_hash"] = line.strip()

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.Manager-4.3-fix-parsing-authoritykeyident
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mc.Manager-4.3-fix-parsing-authoritykeyident
@@ -1,0 +1,1 @@
+- fix parsing Authority Key Identifier when keyid is not prefixed (bsc#1229079)


### PR DESCRIPTION
## What does this PR change?

When openssl output Authority Key Identifier, the format can differ and it does not prefix it with `keyid:`.
Change the parser to find the keyid also in this case.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25028

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
