### PR TITLE
Ensure the context timezone is always non-null

### DIFF
--- a/java/code/src/com/redhat/rhn/common/localization/LocalizationService.java
+++ b/java/code/src/com/redhat/rhn/common/localization/LocalizationService.java
@@ -48,6 +48,7 @@ import java.util.StringTokenizer;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * Localization service class to simplify the job for producing localized
@@ -316,22 +317,19 @@ public class LocalizationService {
     // package (who calls this actually) - for debugging purposes
     private StackTraceElement getCallingMethod() {
         try {
-            throw new RuntimeException("Stacktrace Dummy Exception");
-        }
-        catch (RuntimeException e) {
-            try {
-                final String prefix = this.getClass().getPackage().getName();
-                for (StackTraceElement element : e.getStackTrace()) {
-                    if (!element.getClassName().startsWith(prefix)) {
-                        return element;
-                    }
+            String prefix = this.getClass().getPackage().getName();
+            StackTraceElement[] stackTrace = new RuntimeException().getStackTrace();
+            for (StackTraceElement element : stackTrace) {
+                if (!element.getClassName().startsWith(prefix)) {
+                    return element;
                 }
             }
-            catch (Exception err) {
-                // dont break - return nothing rather than stop
-                return null;
-            }
         }
+        catch (Exception err) {
+            // don't break - return nothing rather than stop
+            return null;
+        }
+
         return null;
     }
 
@@ -605,15 +603,11 @@ public class LocalizationService {
      * @return list of configured locales
      */
     public List<String> getConfiguredLocales() {
-        List<String> tmp = new LinkedList<>();
-        for (String key : this.supportedLocales.keySet()) {
-            LocaleInfo li = this.supportedLocales.get(key);
-            if (!li.isAlias()) {
-                tmp.add(key);
-            }
-        }
-        Collections.sort(tmp);
-        return Collections.unmodifiableList(tmp);
+        return supportedLocales.entrySet().stream()
+            .filter(entry -> !entry.getValue().isAlias())
+            .map(entry -> entry.getKey())
+            .sorted()
+            .collect(Collectors.toUnmodifiableList());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/localization/LocalizationService.java
+++ b/java/code/src/com/redhat/rhn/common/localization/LocalizationService.java
@@ -650,22 +650,12 @@ public class LocalizationService {
      * @return TimeZone from the Context
      */
     public  TimeZone determineTimeZone() {
-        TimeZone retval = null;
-        Context ctx = Context.getCurrentContext();
-
-        if (ctx != null) {
-            retval = ctx.getTimezone();
-        }
-        if (retval == null) {
-            log.debug("Context is null");
-            // Get the app server's default timezone
-            retval = TimeZone.getDefault();
-        }
+        TimeZone retval = Context.getCurrentContext().getTimezone();
         if (log.isDebugEnabled()) {
             log.debug("Determined timeZone to be: {}", retval);
         }
-        return retval;
 
+        return retval;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateGuestAction.java
@@ -22,7 +22,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.TimeZone;
 
 /**
  * CreateAction - Class representing TYPE_VIRTUALIZATION_CREATE
@@ -48,8 +47,7 @@ public class VirtualizationCreateGuestAction extends BaseVirtualizationGuestActi
     public String getDetailsAsString() {
         if (details != null) {
             if (details.getEarliest().isEmpty()) {
-                ZoneId zoneId = Optional.ofNullable(Context.getCurrentContext().getTimezone())
-                        .orElse(TimeZone.getDefault()).toZoneId();
+                ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
                 details.setEarliest(Optional.of(LocalDateTime.ofInstant(getEarliestAction().toInstant(), zoneId)));
             }
             return details.toJson();

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DateRangePicker.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DateRangePicker.java
@@ -32,13 +32,13 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class DateRangePicker {
 
-    private DynaActionForm form;
-    private HttpServletRequest req;
-    private Date defaultStartOffset;
-    private Date defaultEndOffset;
-    private int yearRangeDirection;
-    private String startKey;
-    private String endKey;
+    private final DynaActionForm form;
+    private final HttpServletRequest req;
+    private final Date defaultStartOffset;
+    private final Date defaultEndOffset;
+    private final int yearRangeDirection;
+    private final String startKey;
+    private final String endKey;
 
     /**
      * Construct a new DateRangePicker
@@ -48,7 +48,7 @@ public class DateRangePicker {
      * @param defaultStartDateIn number of days to offset the start from today
      * @param defaultEndOffsetIn number of days to offset the end from today
      * @param yearRangeDirectionIn If you want the year range selector to show years
-     * in the future or in the past. See DatePicker.YEAR_RANGE_POSATIVE, and
+     * in the future or in the past. See DatePicker.YEAR_RANGE_POSITIVE, and
      * DatePicker.YEAR_RANGE_NEGATIVE
      * @param startKeyIn the l10n key for the name of the start date
      * @param endKeyIn the l10n key for the name of the end date
@@ -78,10 +78,10 @@ public class DateRangePicker {
      */
     public DatePickerResults processDatePickers(boolean isSubmitted,
             boolean justDateRelevant) {
-        // Setup the date pickers
+        // Set up the date pickers
         Context ctx = Context.getCurrentContext();
-        DatePicker start = null;
-        DatePicker end = null;
+        DatePicker start;
+        DatePicker end;
         if (justDateRelevant) {
             start = new DatePicker("start", ctx.getLocale(), yearRangeDirection);
             end = new DatePicker("end", ctx.getLocale(), yearRangeDirection);
@@ -152,7 +152,7 @@ public class DateRangePicker {
      * DatePickerResults class to encapsulate the results of processing the DatePickers
      * in the form.
      */
-    public class DatePickerResults {
+    public static class DatePickerResults {
         private DatePicker start;
         private DatePicker end;
         private ActionMessages errors;

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DateRangePicker.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DateRangePicker.java
@@ -87,10 +87,8 @@ public class DateRangePicker {
             end = new DatePicker("end", ctx.getLocale(), yearRangeDirection);
         }
         else {
-            start = new DatePicker("start", ctx.getTimezone(), ctx.getLocale(),
-                    yearRangeDirection);
-            end = new DatePicker("end", ctx.getTimezone(), ctx.getLocale(),
-                    yearRangeDirection);
+            start = new DatePicker("start", ctx.getTimezone(), ctx.getLocale(), yearRangeDirection);
+            end = new DatePicker("end", ctx.getTimezone(), ctx.getLocale(), yearRangeDirection);
         }
         ActionMessages errors = new ActionMessages();
         DatePickerResults retval = new DatePickerResults();

--- a/java/code/src/com/redhat/rhn/frontend/context/Context.java
+++ b/java/code/src/com/redhat/rhn/frontend/context/Context.java
@@ -34,7 +34,7 @@ public class Context {
     private String activeLocaleLabel;
     private TimeZone timezone;
 
-    private static ThreadLocal currentContext = new ThreadLocal();
+    private static final ThreadLocal<Context> CURRENT_CONTEXT = new ThreadLocal<>();
 
     private Context() {
     }
@@ -48,8 +48,7 @@ public class Context {
         LocalizationService ls = LocalizationService.getInstance();
 
         if (ls.hasMessage("preferences.jsp.lang." + localeIn.toString())) {
-            activeLocaleLabel = ls.getMessage("preferences.jsp.lang." +
-                    localeIn.toString(), localeIn);
+            activeLocaleLabel = ls.getMessage("preferences.jsp.lang." + localeIn, localeIn);
         }
         else {
             // default to en_US
@@ -124,12 +123,12 @@ public class Context {
      * @return Current context.
      */
     public static Context getCurrentContext() {
-
-        Context retval = (Context) currentContext.get();
+        Context retval = CURRENT_CONTEXT.get();
         if (retval == null) {
-            currentContext.set(new Context());
-            retval = (Context) currentContext.get();
+            CURRENT_CONTEXT.set(new Context());
+            retval = CURRENT_CONTEXT.get();
         }
+
         return retval;
     }
 
@@ -138,7 +137,7 @@ public class Context {
      * executing thread
      */
     public static void freeCurrentContext() {
-        currentContext.set(null);
+        CURRENT_CONTEXT.remove();
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/context/Context.java
+++ b/java/code/src/com/redhat/rhn/frontend/context/Context.java
@@ -104,6 +104,10 @@ public class Context {
      * @return Returns the timezone.
      */
     public TimeZone getTimezone() {
+        if (timezone == null) {
+            return TimeZone.getDefault();
+        }
+
         return timezone;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6560,8 +6560,7 @@ public class SystemHandler extends BaseHandler {
             data.setForce(false);
             data.setEarliest(
                 Optional.ofNullable(date).map((localDate) -> {
-                    ZoneId zoneId = Optional.ofNullable(Context.getCurrentContext().getTimezone())
-                            .orElse(TimeZone.getDefault()).toZoneId();
+                    ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
                     return LocalDateTime.ofInstant(localDate.toInstant(), zoneId);
                 })
             );

--- a/java/code/src/com/suse/manager/reactor/utils/LocalDateTimeISOAdapter.java
+++ b/java/code/src/com/suse/manager/reactor/utils/LocalDateTimeISOAdapter.java
@@ -29,8 +29,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.Optional;
-import java.util.TimeZone;
 
 /**
  * Parses a ISO 8601 DateTime String into a LocalDateTime
@@ -64,8 +62,7 @@ public class LocalDateTimeISOAdapter extends TypeAdapter<LocalDateTime> {
         String dateStr = jsonReader.nextString();
         try {
             ZonedDateTime p = ZonedDateTime.parse(dateStr);
-            ZoneId zoneId = Optional.ofNullable(Context.getCurrentContext().getTimezone())
-                    .orElse(TimeZone.getDefault()).toZoneId();
+            ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
             return LocalDateTime.ofInstant(p.toInstant(), zoneId);
         }
         catch (DateTimeParseException e) {

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -62,9 +62,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import spark.ModelAndView;
@@ -328,8 +326,7 @@ public class AnsibleController {
     }
 
     private static Date getScheduleDate(LocalDateTime dateTime) {
-        ZoneId zoneId = Optional.ofNullable(Context.getCurrentContext().getTimezone())
-                .orElse(TimeZone.getDefault()).toZoneId();
+        ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
         return Date.from(dateTime.atZone(zoneId).toInstant());
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -107,7 +107,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -536,8 +535,7 @@ public class StatesAPI {
     }
 
     private Date getScheduleDate(ServerApplyStatesJson json) {
-        ZoneId zoneId = Optional.ofNullable(Context.getCurrentContext().getTimezone())
-                .orElse(TimeZone.getDefault()).toZoneId();
+        ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
         return Date.from(
             json.getEarliest().map(t -> t.atZone(zoneId).toInstant())
                 .orElseGet(Instant::now)
@@ -545,8 +543,7 @@ public class StatesAPI {
     }
 
     private Date getScheduleDate(ServerApplyHighstateJson json) {
-        ZoneId zoneId = Optional.ofNullable(Context.getCurrentContext().getTimezone())
-                .orElse(TimeZone.getDefault()).toZoneId();
+        ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
         return Date.from(
             json.getEarliest().orElseGet(LocalDateTime::now).atZone(zoneId).toInstant()
         );

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -53,7 +53,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -205,8 +204,7 @@ public class MinionActionUtils {
      * @return the date to run the action
      */
     public static Date getScheduleDate(Optional<LocalDateTime> earliest) {
-        ZoneId zoneId = Optional.ofNullable(Context.getCurrentContext().getTimezone())
-                .orElse(TimeZone.getDefault()).toZoneId();
+        ZoneId zoneId = Context.getCurrentContext().getTimezone().toZoneId();
         return Date.from(earliest.orElseGet(LocalDateTime::now).atZone(zoneId).toInstant());
     }
 

--- a/java/code/src/com/suse/manager/webui/utils/UserPreferenceUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/UserPreferenceUtils.java
@@ -156,8 +156,8 @@ public class UserPreferenceUtils {
         }
 
         Context ctx = Context.getCurrentContext();
-        Locale locale = ctx != null ? ctx.getLocale() : Locale.getDefault();
-        TimeZone timezone = ctx != null ? ctx.getTimezone() : TimeZone.getDefault();
+        Locale locale = ctx.getLocale();
+        TimeZone timezone = ctx.getTimezone();
         DateFormat tzFormat = new SimpleDateFormat("z", locale);
         tzFormat.setTimeZone(new GregorianCalendar(timezone, locale).getTimeZone());
         return tzFormat.format(new Date());
@@ -183,10 +183,7 @@ public class UserPreferenceUtils {
             }
         }
 
-        Context ctx = Context.getCurrentContext();
-        Locale locale = ctx != null ? ctx.getLocale() : Locale.getDefault();
-        TimeZone timezone = ctx != null ? ctx.getTimezone() : TimeZone.getDefault();
-        return timezone.getID();
+        return Context.getCurrentContext().getTimezone().getID();
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -171,8 +171,8 @@ public enum ViewHelper {
     @Deprecated
     public String renderTimezone() {
         Context ctx = Context.getCurrentContext();
-        Locale locale = ctx != null ? ctx.getLocale() : Locale.getDefault();
-        TimeZone timezone = ctx != null ? ctx.getTimezone() : TimeZone.getDefault();
+        Locale locale = ctx.getLocale();
+        TimeZone timezone = ctx.getTimezone();
         DateFormat tzFormat = new SimpleDateFormat("z", locale);
         tzFormat.setTimeZone(new GregorianCalendar(timezone, locale).getTimeZone());
         return tzFormat.format(new Date());
@@ -204,8 +204,8 @@ public enum ViewHelper {
     @Deprecated
     public String renderDate(Date date) {
         Context ctx = Context.getCurrentContext();
-        Locale locale = ctx != null ? ctx.getLocale() : Locale.getDefault();
-        TimeZone timezone = ctx != null ? ctx.getTimezone() : TimeZone.getDefault();
+        Locale locale = ctx.getLocale();
+        TimeZone timezone = ctx.getTimezone();
         DateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mmXXX", locale);
         isoFormat.setTimeZone(new GregorianCalendar(timezone, locale).getTimeZone());
         return isoFormat.format(date);

--- a/java/spacewalk-java.changes.mackdk.ensure-timezone-nonnull
+++ b/java/spacewalk-java.changes.mackdk.ensure-timezone-nonnull
@@ -1,0 +1,1 @@
+- Ensure the context timezone is never null


### PR DESCRIPTION
## What does this PR change?

This PR refactors the `Context` code to ensure the timezone field is always non-null and the code consuming it does not to worry about null checking.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
