### PR TITLE
MinionServer is now standard Server type

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -59,16 +59,16 @@
         <dependency org="suse" name="jose4j" rev="0.9.5" />
         <dependency org="suse" name="log4j-api" rev="2.17.2" />
         <dependency org="suse" name="log4j-core" rev="2.17.2" />
-        <dependency org="suse" name="jsch" rev="0.2.9" />
+        <dependency org="suse" name="jsch" rev="0.2.15" />
         <dependency org="suse" name="jctools-core" rev="3.3.0" />
         <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
-        <dependency org="suse" name="netty-buffer" rev="4.1.94" />
-        <dependency org="suse" name="netty-codec" rev="4.1.94" />
-        <dependency org="suse" name="netty-common" rev="4.1.94" />
-        <dependency org="suse" name="netty-handler" rev="4.1.94" />
-        <dependency org="suse" name="netty-resolver" rev="4.1.94" />
-        <dependency org="suse" name="netty-transport" rev="4.1.94" />
-        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.94" />
+        <dependency org="suse" name="netty-buffer" rev="4.1.108" />
+        <dependency org="suse" name="netty-codec" rev="4.1.108" />
+        <dependency org="suse" name="netty-common" rev="4.1.108" />
+        <dependency org="suse" name="netty-handler" rev="4.1.108" />
+        <dependency org="suse" name="netty-resolver" rev="4.1.108" />
+        <dependency org="suse" name="netty-transport" rev="4.1.108" />
+        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.108" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.7" />
         <dependency org="suse" name="postgresql-jdbc" rev="42.2.25" />

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -50,6 +50,7 @@ import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.salt.netapi.calls.LocalCall;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -67,7 +69,12 @@ import java.util.Set;
 public class AccessTest extends BaseTestCaseWithUser {
 
     private Acl acl;
-    private final SaltApi saltApi = new TestSaltApi();
+    private final SaltApi saltApi = new TestSaltApi() {
+        @Override
+        public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+            return Optional.empty();
+        }
+    };
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionChainFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionChainFactoryTest.java
@@ -417,6 +417,13 @@ public class ActionChainFactoryTest extends BaseTestCaseWithUser {
             }
         }
 
+        TaskomaticApi taskomaticTestApi = new TaskomaticApi() {
+            @Override
+            public void scheduleActionChainExecution(ActionChain actionchain) {
+            }
+        };
+
+        ActionChainFactory.setTaskomaticApi(taskomaticTestApi);
         ActionChainFactory.schedule(actionChain, new Date());
 
         // check actions are scheduled in correct order

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -169,8 +169,8 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
     }
 
     public static Channel createTestChannel(Org org, ChannelFamily cfam) throws Exception {
-        String query = "ChannelArch.findById";
-        ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheById(500L, query);
+        String query = "ChannelArch.findByLabel";
+        ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheByLabel("channel-x86_64", query);
         return createTestChannel(org, arch, cfam);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelTest.java
@@ -191,7 +191,7 @@ public class ChannelTest extends BaseTestCaseWithUser {
         Channel c = ChannelFactoryTest.createTestChannel(user);
         Package p = PackageTest.createTestPackage(user.getOrg());
         assertNotNull(c);
-        assertEquals("channel-ia32", c.getChannelArch().getLabel());
+        assertEquals("channel-x86_64", c.getChannelArch().getLabel());
         assertNotNull(p);
         assertEquals("noarch", p.getPackageArch().getLabel());
 
@@ -199,16 +199,16 @@ public class ChannelTest extends BaseTestCaseWithUser {
             c.addPackage(p);
         }
         catch (Exception e) {
-            fail("noarch should be acceptible in an ia32 channel");
+            fail("noarch should be acceptible in an x86_64 channel");
         }
 
 
         try {
-            PackageArch pa = PackageFactory.lookupPackageArchByLabel("x86_64");
+            PackageArch pa = PackageFactory.lookupPackageArchByLabel("aarch64");
             assertNotNull(pa);
             p.setPackageArch(pa);
             c.addPackage(p);
-            fail("x86_64 is not acceptible in an ia32 channel");
+            fail("aarch64 is not acceptible in an x86_64 channel");
         }
         catch (Exception e) {
             // expected.

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -130,7 +130,7 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertFalse(filter.test(pack));
 
         criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevra",
-                packageName + evrGreater + ".x86_64");
+                packageName + evrGreater + ".i386");
         filter = contentManager.createFilter(packageName + "nevra-lower-filter2", DENY, PACKAGE, criteria, user);
         assertFalse(filter.test(pack));
 
@@ -223,7 +223,7 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertFalse(filter.test(pack));
 
         criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevra",
-                packageName + evrGreater + ".x86_64");
+                packageName + evrGreater + ".i386");
         filter = contentManager.createFilter(packageName + "nevra-lower-filter2", DENY, PACKAGE, criteria, user);
         assertFalse(filter.test(pack));
 

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/AnsibleControlNodeEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/AnsibleControlNodeEntitlementTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.redhat.rhn.domain.entitlement.AnsibleControlNodeEntitlement;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -56,7 +57,7 @@ public class AnsibleControlNodeEntitlementTest extends BaseEntitlementTestCase {
      */
     @Test
     public void testIsForbiddenOnTraditionalClients() throws Exception {
-        Server server = ServerTestUtils.createTestSystem(user);
+        Server server = ServerTestUtils.createTestSystem(user, ServerConstants.getServerGroupTypeEnterpriseEntitled());
         assertFalse(EntitlementManager.ANSIBLE_CONTROL_NODE.isAllowedOnServer(server));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
@@ -72,7 +73,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
 
     @Test
     public void testIsAllowedOnServer() throws Exception {
-        Server traditional = ServerTestUtils.createTestSystem(user);
+        Server traditional = ServerTestUtils.createTestSystem(user,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
         systemEntitlementManager.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
@@ -84,7 +86,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
 
     @Test
     public void testIsAllowedOnServerWithGrains() throws Exception {
-        Server traditional = ServerTestUtils.createTestSystem(user);
+        Server traditional = ServerTestUtils.createTestSystem(user,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
         systemEntitlementManager.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -37,16 +37,22 @@ import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
+import com.suse.salt.netapi.calls.LocalCall;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
 
     private final SystemQuery systemQuery = new TestSystemQuery();
-    private final SaltApi saltApi = new TestSaltApi();
+    private final SaltApi saltApi = new TestSaltApi() {
+        public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+            return Optional.empty();
+        }
+    };
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -96,6 +96,14 @@ public class FormulaFactory {
     }
 
     /**
+     * Setter for {@link SystemEntitlementManager} required for testing
+     * @param mgr the entitlement manager
+     */
+    public static void setSystemEntitlementManager(SystemEntitlementManager mgr) {
+        systemEntitlementManager = mgr;
+    }
+
+    /**
      * Return a warning message in case some folder doesn't exist or have wrong access level.
      * @return a warning message if cannot access one folder. NULL if all folder are ok.
      */

--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/test/PackageTest.java
@@ -181,12 +181,12 @@ public class PackageTest extends BaseTestCaseWithUser {
     }
 
     public static Package populateTestPackage(Package p, Org org) {
-        PackageArch parch = (PackageArch) TestUtils.lookupFromCacheById(100L, "PackageArch.findById");
+        PackageArch parch = (PackageArch) TestUtils.lookupFromCacheByLabel("noarch", "PackageArch.findByLabel");
         return populateTestPackage(p, org, parch);
     }
 
     public static Package populateTestPackage(Package p, String packageName, Org org) {
-        PackageArch parch = (PackageArch) TestUtils.lookupFromCacheById(100L, "PackageArch.findById");
+        PackageArch parch = (PackageArch) TestUtils.lookupFromCacheByLabel("noarch", "PackageArch.findByLabel");
         return populateTestPackage(p, org, parch, PackageNameTest.createTestPackageName(packageName));
     }
     public static PackageSource createTestPackageSource(SourceRpm rpm, Org org) {

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -39,7 +39,7 @@ public class MinionServer extends Server implements SaltConfigurable {
     private String kernelLiveVersion;
     private Integer sshPushPort;
     private Set<AccessToken> accessTokens = new HashSet<>();
-    private Set<Pillar> pillars = new HashSet<>();
+    private final Set<Pillar> pillars = new HashSet<>();
     private Date rebootRequiredAfter;
 
     /**
@@ -125,50 +125,6 @@ public class MinionServer extends Server implements SaltConfigurable {
     public void setConfigChannels(List<ConfigChannel> configChannelList, User user) {
         super.setConfigChannels(configChannelList, user);
         SaltConfigSubscriptionService.setConfigChannels(this, configChannelList, user);
-    }
-
-    /**
-     * Return <code>true</code> if OS on this system supports OS Image building,
-     * <code>false</code> otherwise.
-     *
-     * @return <code>true</code> if OS supports OS Image building
-     */
-    @Override
-    public boolean doesOsSupportsOSImageBuilding() {
-        return isSLES11() || isSLES12() || isSLES15() || isLeap15();
-    }
-
-    /**
-     * Return <code>true</code> if OS on this system supports Containerization,
-     * <code>false</code> otherwise.
-     * <p>
-     * Note: For SLES, we are only checking if it's not 10 nor 11.
-     * Older than SLES 10 are not being checked.
-     * </p>
-     *
-     * @return <code>true</code> if OS supports Containerization
-     */
-    @Override
-    public boolean doesOsSupportsContainerization() {
-        return !isSLES10() && !isSLES11();
-    }
-
-    /**
-     * Return <code>true</code> if OS on this system supports Transactional Update,
-     * <code>false</code> otherwise.
-     *
-     * @return <code>true</code> if OS supports Transactional Update
-     */
-    @Override
-    public boolean doesOsSupportsTransactionalUpdate() {
-        return isSLEMicro() || isLeapMicro() || isopenSUSEMicroOS();
-    }
-
-    @Override
-    public boolean doesOsSupportsMonitoring() {
-        return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
-                isRedHat6() || isRedHat7() || isRedHat8() || isRedHat9() || isAlibaba2() || isAmazon2() ||
-                isAmazon2023() || isRocky8() || isRocky9() || isDebian12() || isDebian11() || isDebian10();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2418,8 +2418,8 @@ public class Server extends BaseDomainHelper implements Identifiable {
      */
     public boolean doesOsSupportsMonitoring() {
         return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isUbuntu2204() ||
-                isRedHat6() || isRedHat7() || isRedHat8() || isAlibaba2() || isAmazon2() || isAmazon2023() ||
-                isRocky8() || isRocky9() || isDebian12() || isDebian11() || isDebian10();
+                isRedHat6() || isRedHat7() || isRedHat8() || isRedHat9() || isAlibaba2() || isAmazon2() ||
+                isAmazon2023() || isRocky8() || isRocky9() || isDebian12() || isDebian11() || isDebian10();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerPathId.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerPathId.java
@@ -93,9 +93,9 @@ public class ServerPathId implements Serializable {
             return false;
         }
         ServerPathId castOther = (ServerPathId) other;
-        return new EqualsBuilder().append(getServer(), castOther.getServer())
-                .append(getProxyServer(), castOther.getProxyServer())
-                .isEquals();
+        boolean equals1 = new EqualsBuilder().append(getServer(), castOther.getServer()).isEquals();
+        boolean equals2 = new EqualsBuilder().append(getProxyServer(), castOther.getProxyServer()).isEquals();
+        return equals1 && equals2;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -139,7 +139,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private Server server;
     public static final int TYPE_SERVER_MGR = 0;
     public static final int TYPE_SERVER_PROXY = 1;
-    public static final int TYPE_SERVER_NORMAL = 2;
+    public static final int TYPE_SERVER_NORMAL = 2; // bootstrap or foreign
     public static final int TYPE_SERVER_VIRTUAL = 3;
     public static final int TYPE_SERVER_MINION = 4;
     public static final String RUNNING_KERNEL = "2.6.9-55.EL";
@@ -594,6 +594,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
 
     /**
      * Create a test Server and commit it to the DB.
+     * Create a x86_64 Minion Server
      * @param owner the owner of this Server
      * @return Server that was created
      */
@@ -601,17 +602,13 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         return createTestServer(owner, false);
     }
 
-    public static Server createTestServer(User owner, boolean ensureOwnerAccess,
-            ServerGroupType type) {
-        return createTestServer(owner, ensureOwnerAccess, type, TYPE_SERVER_NORMAL,
-                                new Date());
+    public static Server createTestServer(User owner, boolean ensureOwnerAccess, ServerGroupType type) {
+        return createTestServer(owner, ensureOwnerAccess, type, TYPE_SERVER_MINION, new Date());
     }
-
 
     public static Server createTestServer(User owner, boolean ensureOwnerAccess, ServerGroupType type, int stype) {
         return createTestServer(owner, ensureOwnerAccess, type, stype, new Date());
     }
-
 
     private static Server createTestServer(User owner, boolean ensureOwnerAccess,
             ServerGroupType type, int stype, Date dateCreated) {
@@ -621,11 +618,11 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
 
         if (!type.getAssociatedEntitlement().isBase()) {
             EntitlementServerGroup mgmt = ServerGroupFactory.lookupEntitled(
-                    EntitlementManager.MANAGEMENT, owner.getOrg());
+                    EntitlementManager.SALT, owner.getOrg());
             if (mgmt == null) {
                 newS = TestUtils.saveAndReload(newS);
                 mgmt = ServerGroupFactory.lookupEntitled(
-                        EntitlementManager.MANAGEMENT,
+                        EntitlementManager.SALT,
                         owner.getOrg());
                 newS = ServerFactory.lookupById(newS.getId());
             }
@@ -634,9 +631,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             SYSTEM_ENTITLEMENT_MANAGER.addEntitlementToServer(newS, mgmt.getGroupType().getAssociatedEntitlement());
         }
 
-
-        EntitlementServerGroup sg = ServerGroupTestUtils.createEntitled(owner.getOrg(),
-                                                                        type);
+        EntitlementServerGroup sg = ServerGroupTestUtils.createEntitled(owner.getOrg(), type);
 
         SYSTEM_ENTITLEMENT_MANAGER.addEntitlementToServer(newS, sg.getGroupType().getAssociatedEntitlement());
         return TestUtils.saveAndReload(newS);
@@ -722,14 +717,14 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         s.setCreator(owner);
         s.setOrg(owner.getOrg());
         s.setDigitalServerId("ID-" + TestUtils.randomString());
-        s.setOs("Red Hat Linux");
+        s.setOs("SUSE Linux");
         s.setRunningKernel(RUNNING_KERNEL);
-        s.setName("serverfactorytest" + TestUtils.randomString() + ".rhn.redhat.com");
-        s.setRelease("9");
+        s.setName("serverfactorytest" + TestUtils.randomString() + ".example.com");
+        s.setRelease("15");
         s.setSecret("1234567890123456789012345678901234567890123456789012345678901234");
         s.setAutoUpdate("N");
         s.setLastBoot(System.currentTimeMillis() / 1000);
-        s.setServerArch(ServerFactory.lookupServerArchByLabel("i386-redhat-linux"));
+        s.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         s.setCreated(new Date());
         s.setModified(new Date());
         s.setRam(1024);
@@ -739,7 +734,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             // a Mgr Server is also a Minion
             MinionServer minionServer = (MinionServer) s;
             minionServer.setMinionId(s.getName());
-            minionServer.setOsFamily("RedHat");
+            minionServer.setOsFamily("Suse");
             minionServer.setMachineId(TestUtils.randomString());
 
             ReportDBCredentials reportCredentials = CredentialsFactory.createReportCredentials("pythia", "secret");
@@ -755,6 +750,12 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             minionServer.setMgrServerInfo(info);
         }
         else if (type == TYPE_SERVER_PROXY) {
+            // a Proxy Server is also a Minion
+            MinionServer minionServer = (MinionServer) s;
+            minionServer.setMinionId(s.getName());
+            minionServer.setOsFamily("Suse");
+            minionServer.setMachineId(TestUtils.randomString());
+
             ProxyInfo info = new ProxyInfo();
             info.setVersion(PackageEvrFactory.lookupOrCreatePackageEvr("10", "10", "10", s.getPackageType()));
             info.setServer(s);
@@ -763,7 +764,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         else if (type == TYPE_SERVER_MINION) {
             MinionServer minionServer = (MinionServer) s;
             minionServer.setMinionId(s.getName());
-            minionServer.setOsFamily("RedHat");
+            minionServer.setOsFamily("Suse");
             minionServer.setMachineId(TestUtils.randomString());
         }
     }
@@ -795,11 +796,9 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
 
     private static Server createServer(int type) {
         switch(type) {
-            case TYPE_SERVER_PROXY:
             case TYPE_SERVER_NORMAL:
                 return ServerFactory.createServer();
-            case TYPE_SERVER_MGR:
-            case TYPE_SERVER_MINION:
+            case TYPE_SERVER_PROXY, TYPE_SERVER_MGR, TYPE_SERVER_MINION:
                 return new MinionServer();
 
             default:

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -46,10 +46,13 @@ import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
+import com.suse.salt.netapi.calls.LocalCall;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
 
 /**
  * SystemEntitlementsSubmitActionTest
@@ -62,7 +65,12 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
                                     "system_entitlements.unentitle";
 
     private final SystemQuery systemQuery = new TestSystemQuery();
-    private final SaltApi saltApi = new TestSaltApi();
+    private final SaltApi saltApi = new TestSaltApi() {
+        @Override
+        public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+            return Optional.empty();
+        }
+    };
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -102,6 +102,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
+import com.suse.manager.utils.MinionServerUtils;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
@@ -417,6 +418,13 @@ public class ActionManager extends BaseManager {
                     )
                 )
                 .filter(p -> !p.getRight().isEmpty())
+                // select Actions that have no minions besides those in the specified set
+                // (those that have any other minion should NOT be unscheduled!)
+                .filter(e -> e.getKey().getServerActions().stream()
+                        .map(ServerAction::getServer)
+                        .filter(MinionServerUtils::isMinionServer)
+                        .allMatch(s -> e.getValue().contains(s))
+                )
                 .collect(toMap(
                     Pair::getLeft,
                     Pair::getRight

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
@@ -39,6 +39,7 @@ import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.errata.cache.test.ErrataCacheManagerTest;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
@@ -57,6 +58,15 @@ import java.util.Map;
  */
 public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
 
+    private static final TaskomaticApi TASKO_TEST_API = new TaskomaticApi() {
+        @Override
+        public void scheduleActionChainExecution(ActionChain actionchain) {
+        }
+        @Override
+        public void scheduleActionExecution(Action action) {
+        }
+    };
+
     /**
      * {@inheritDoc}
      */
@@ -65,6 +75,7 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
     public void setUp() throws Exception {
         super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        ActionChainManager.setTaskomaticApi(TASKO_TEST_API);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
@@ -39,6 +39,7 @@ import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
@@ -132,7 +133,8 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
         UserTestUtils.addUserRole(user, RoleFactory.CONFIG_ADMIN);
 
         // Create a system
-        Server srv1 = ServerFactoryTest.createTestServer(user, true);
+        Server srv1 = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
         Server minion = MinionServerFactoryTest.createTestMinionServer(user);
 
         // Create a local for that system

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
@@ -52,6 +52,7 @@ import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.scc.SCCRepository;
 import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.frontend.dto.EssentialChannelDto;
 import com.redhat.rhn.manager.action.ActionManager;
@@ -473,7 +474,8 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
      */
     @Test
     public void testCapabilityMissing() {
-        Server server = ServerFactoryTest.createTestServer(user, true);
+        Server server = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
         try {
             DistUpgradeManager.performServerChecks(server.getId(), user);
             fail("Missing capability should make the server checks fail!");
@@ -490,7 +492,8 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
      */
     @Test
     public void testZyppPluginNotInstalled() throws Exception {
-        Server server = ServerFactoryTest.createTestServer(user, true);
+        Server server = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
         SystemManagerTest.giveCapability(server.getId(), "distupgrade.upgrade", 1L);
         try {
             DistUpgradeManager.performServerChecks(server.getId(), user);
@@ -508,7 +511,8 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
      */
     @Test
     public void testDistUpgradeScheduled() throws Exception {
-        Server server = ServerFactoryTest.createTestServer(user, true);
+        Server server = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
         SystemManagerTest.giveCapability(server.getId(), "distupgrade.upgrade", 1L);
 
         // Install the zypp-plugin-spacewalk package

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -108,7 +108,7 @@ import java.util.Set;
 public class KickstartScheduleCommand extends BaseSystemOperation {
 
     private static Logger log = LogManager.getLogger(KickstartScheduleCommand.class);
-    private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
+    private static TaskomaticApi taskomaticApi = new TaskomaticApi();
     public  static final String DHCP_NETWORK_TYPE = "dhcp";
     public  static final String LINK_NETWORK_TYPE = "link";
 
@@ -635,7 +635,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         }
 
         ActionFactory.save(kickstartAction);
-        TASKOMATIC_API.scheduleActionExecution(kickstartAction);
+        taskomaticApi.scheduleActionExecution(kickstartAction);
         log.debug("** Created ksaction: {}", kickstartAction.getId());
 
         this.scheduledAction = kickstartAction;
@@ -815,7 +815,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         rebootAction.setName(rebootAction.getActionType().getName());
         log.debug("** saving reboot action: {}", rebootAction.getName());
         ActionFactory.save(rebootAction);
-        TASKOMATIC_API.scheduleActionExecution(rebootAction);
+        taskomaticApi.scheduleActionExecution(rebootAction);
         log.debug("** Saved rebootAction: {}", rebootAction.getId());
 
         return rebootAction;
@@ -1501,5 +1501,9 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
             }
         }
         return null;
+    }
+
+    public void setTaskomaticApi(TaskomaticApi testApiIn) {
+        taskomaticApi = testApiIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartScheduleCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartScheduleCommandTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.kickstart.KickstartAction;
 import com.redhat.rhn.domain.channel.Channel;
@@ -56,6 +57,7 @@ import com.redhat.rhn.manager.kickstart.KickstartScheduleCommand;
 import com.redhat.rhn.manager.profile.ProfileManager;
 import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.TestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -308,6 +310,12 @@ public class KickstartScheduleCommandTest extends BaseKickstartCommandTestCase {
         KickstartScheduleCommand cmd = new
                 KickstartScheduleCommand(server.getId(), ksdata.getId(),
                         user, new Date(), "rhn.webdev.redhat.com");
+        TaskomaticApi testApi = new TaskomaticApi() {
+            @Override
+            public void scheduleActionExecution(Action action) {
+            }
+        };
+        cmd.setTaskomaticApi(testApi);
 
         PackageManagerTest.addPackageToSystemAndChannel(
                 ConfigDefaults.get().getKickstartPackageNames().get(0), server, c);

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -52,6 +52,7 @@ import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.salt.netapi.calls.LocalCall;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -73,7 +75,12 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     private Server server;  // virt host w/guests
     private Server server2; // server w/provisioning ent
 
-    private final SaltApi saltApi = new TestSaltApi();
+    private final SaltApi saltApi = new TestSaltApi() {
+         @Override
+        public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+            return Optional.empty();
+        }
+    };
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
@@ -43,6 +44,7 @@ import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 
 import org.jmock.Expectations;
@@ -70,6 +72,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         );
         context().checking(new Expectations() {{
             allowing(saltServiceMock).refreshPillar(with(any(MinionList.class)));
+            allowing(saltServiceMock).callSync(with(any(LocalCall.class)), with(any(String.class)));
         }});
     }
 
@@ -82,7 +85,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
-        Server server = ServerTestUtils.createTestSystem(user);
+        Server server = ServerTestUtils.createTestSystem(user, ServerConstants.getServerGroupTypeEnterpriseEntitled());
         ChannelTestUtils.setupBaseChannelForVirtualization(user,
                 server.getBaseChannel());
         UserTestUtils.addVirtualization(user.getOrg());
@@ -156,7 +159,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
-        Server server = ServerTestUtils.createTestSystem(user);
+        Server server = ServerTestUtils.createTestSystem(user, ServerConstants.getServerGroupTypeEnterpriseEntitled());
         Channel[] children = ChannelTestUtils.setupBaseChannelForVirtualization(user,
                 server.getBaseChannel());
 
@@ -205,7 +208,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
-        Server server = ServerTestUtils.createTestSystem(user);
+        Server server = ServerTestUtils.createTestSystem(user, ServerConstants.getServerGroupTypeEnterpriseEntitled());
         server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         server = HibernateFactory.reload(server);
 

--- a/java/code/src/com/redhat/rhn/testing/ConfigTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ConfigTestUtils.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.config.ConfigurationFactory;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -355,7 +356,8 @@ public class ConfigTestUtils  {
             throw new IllegalArgumentException("User and channel " +
                     "must be from the same org!");
         }
-        Server srv = ServerFactoryTest.createTestServer(user, true);
+        Server srv = ServerFactoryTest.createTestServer(user, true,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled());
         if (channel.isGlobalChannel()) {
             srv.subscribeConfigChannel(channel, user);
         }

--- a/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
@@ -70,8 +70,7 @@ public class ServerTestUtils {
      * @throws Exception if error
      */
     public static Server createTestSystem(User creator) throws Exception {
-        return createTestSystem(creator,
-            ServerConstants.getServerGroupTypeEnterpriseEntitled());
+        return createTestSystem(creator, ServerConstants.getServerGroupTypeSaltEntitled());
     }
 
     /**
@@ -150,7 +149,7 @@ public class ServerTestUtils {
     public static Server createVirtHostWithGuests(User user, int numberOfGuests,
                                                   SystemEntitlementManager systemEntitlementManager)
         throws Exception {
-        return createVirtHostWithGuests(user, numberOfGuests, false, systemEntitlementManager);
+        return createVirtHostWithGuests(user, numberOfGuests, true, systemEntitlementManager);
     }
 
     /**
@@ -315,7 +314,8 @@ public class ServerTestUtils {
      */
     public static Server createForeignSystem(User user, String digitalServerId)
             throws Exception {
-        Server existingHost = ServerTestUtils.createTestSystem(user);
+        Server existingHost = ServerTestUtils.createTestSystem(user,
+                ServerConstants.getServerGroupTypeForeignEntitled());
         existingHost.setName(TestUtils.randomString());
         existingHost.setDigitalServerId(digitalServerId);
         GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(existingHost,


### PR DESCRIPTION
## What does this PR change?

The traditional Server is only used now for corner cases like Bootstrap entitled and Foreign systems.
The default now is a MinionServer. Change everything in the java code to reflect this

- move support check methods to super class as we only support minions
- make unit tests "createTestServer" a minion my default


## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
