### PR TITLE
Refactor Remote Node

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -562,9 +562,10 @@ When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on t
   files.split(/, */).each do |file|
     script += "    - '#{file}'\n"
   end
-  path = generate_temp_file('top.sls', script)
-  inject_salt_pillar_file(path, 'top.sls')
-  `rm #{path}`
+  temp_file = generate_temp_file('top.sls', script)
+  inject_salt_pillar_file(temp_file.path, 'top.sls')
+  temp_file.close
+  temp_file.unlink
 end
 
 When(/^I install the package download endpoint pillar file on the server$/) do

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -618,9 +618,9 @@ end
 def new_api_client
   ssl_verify = !$is_gh_validation
   if product == 'SUSE Manager'
-    ApiTestXmlrpc.new(get_target('server', refresh: true).full_hostname)
+    ApiTestXmlrpc.new(get_target('server').full_hostname)
   else
-    ApiTestHttp.new(get_target('server', refresh: true).full_hostname, ssl_verify)
+    ApiTestHttp.new(get_target('server').full_hostname, ssl_verify)
   end
 end
 

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -64,12 +64,11 @@ end
 #
 # @param name [String] The name of the temporary file.
 # @param content [String] The content to be written to the temporary file.
-# @return [String] The path of the generated temporary file.
+# @return [File] The Tempfile instance.
 def generate_temp_file(name, content)
-  Tempfile.open(name) do |file|
-    file.write(content)
-    return file.path
-  end
+  file = Tempfile.new(name)
+  file.write(content)
+  file
 end
 
 # Create salt pillar file in the default pillar_roots location
@@ -84,7 +83,7 @@ def inject_salt_pillar_file(source, file)
 
   # make file readable by salt
   get_target('server').run("chgrp salt #{dest}")
-  return_code
+  success
 end
 
 # Reads the value of a variable from a given file on a given host

--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -13,25 +13,16 @@ Net::SSH::KnownHosts::SUPPORTED_TYPE.reject! { |t| t.match(/^ecd(sa|h)-sha2/) }
 # @param [String] command The command to execute on the remote host.
 # @param [String] host The hostname or IP address of the remote host.
 # @param [Integer] port The port to connect to on the remote host.
-# @param [String] user The username to use when connecting to the remote host.
-# @param [String] password The password to use when connecting to the remote host.
 # @param [Integer] timeout The timeout to use when connecting to the remote host.
 # @param [Integer] buffer_size The buffer size to use when connecting to the remote host.
 # @return [Array] An array containing the stdout, stderr, and exit code of the command.
-def ssh_command(command, host, port: 22, user: 'root', password: nil, timeout: DEFAULT_TIMEOUT, buffer_size: 65_536)
+def ssh_command(command, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 65_536)
   stdout = ''
   stderr = ''
   exit_code = nil
 
-  if password.nil?
-    # Not passing :password uses systems ssh keys to authenticate
-    Net::SSH.start(host, user, port: port, verify_host_key: :never, timeout: timeout, max_pkt_size: buffer_size) do |ssh|
-      stdout, stderr, exit_code = ssh_exec!(ssh, command)
-    end
-  else
-    Net::SSH.start(host, user, port: port, password: password, verify_host_key: :never, timeout: timeout, max_pkt_size: buffer_size) do |ssh|
-      stdout, stderr, exit_code = ssh_exec!(ssh, command)
-    end
+  Net::SSH.start(host, nil, port: port, verify_host_key: :never, timeout: timeout, max_pkt_size: buffer_size, config: true) do |ssh|
+    stdout, stderr, exit_code = ssh_exec!(ssh, command)
   end
 
   [stdout, stderr, exit_code]
@@ -43,20 +34,11 @@ end
 # @param [String] remote_path The path to the destination file.
 # @param [String] host The hostname or IP address of the remote host.
 # @param [Integer] port The port to connect to on the remote host.
-# @param [String] user The username to use when connecting to the remote host.
-# @param [String] password The password to use when connecting to the remote host.
 # @param [Integer] timeout The timeout to use when connecting to the remote host.
 # @param [Integer] buffer_size The buffer size to use when connecting to the remote host.
-def scp_command(local_path, remote_path, host, port: 22, user: 'root', password: nil, timeout: DEFAULT_TIMEOUT, buffer_size: 65_536)
-  if password.nil?
-    # Not passing :password uses systems ssh keys to authenticate
-    Net::SSH.start(host, user, port: port, verify_host_key: :never, timeout: timeout, max_pkt_size: buffer_size) do |ssh|
-      ssh.scp.upload! local_path, remote_path
-    end
-  else
-    Net::SSH.start(host, user, port: port, password: password, verify_host_key: :never, timeout: timeout, max_pkt_size: buffer_size) do |ssh|
-      ssh.scp.upload! local_path, remote_path
-    end
+def scp_command(local_path, remote_path, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 65_536)
+  Net::SSH.start(host, nil, port: port, verify_host_key: :never, timeout: timeout, max_pkt_size: buffer_size, config: true) do |ssh|
+    ssh.scp.upload! local_path, remote_path
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This refactor:
- simplifies the connection with remote nodes
- adds the possibility to run the testsuite from an IDE running in a MacOS
- fixes an issue with temporary files being copied to remote nodes
- Remove a duplicate initialization of the server node

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were refactored

- [x] **DONE**

## Links

No ports, as this goes to qe-develop

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
