### PR TITLE
7427 cleanup truncata errata

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.frontend.dto;
 
+import com.redhat.rhn.domain.errata.Errata;
+
 import java.util.Date;
 
 /**
@@ -24,6 +26,23 @@ public class OwnedErrata extends ErrataOverview {
     private Date created;
     private String locallyModified;
     private Integer published;
+
+    /**
+     * Empty default Constructor
+     */
+    public OwnedErrata() {
+        super();
+    }
+
+    /**
+     * Constructor from errata
+     * @param errataIn the errata
+     */
+    public OwnedErrata(Errata errataIn) {
+        super();
+        setId(errataIn.getId());
+        setAdvisory(errataIn.getAdvisory());
+    }
 
     /**
      * @param locallyModifiedIn The locallyModified to set.

--- a/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
@@ -25,6 +25,16 @@ public class OwnedErrata extends ErrataOverview {
     private String locallyModified;
     private Integer published;
 
+    public OwnedErrata(){
+        super();
+    }
+    
+    public OwnedErrata(Long id, String advisory) {
+        super();
+        setId(id);
+        setAdvisory(advisory);
+    }
+
     /**
      * @param locallyModifiedIn The locallyModified to set.
      */

--- a/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
@@ -25,10 +25,11 @@ public class OwnedErrata extends ErrataOverview {
     private String locallyModified;
     private Integer published;
 
-    public OwnedErrata(){
-        super();
-    }
-    
+    /**
+     * Constructor for OwnedErrata
+     * @param id the id
+     * @param advisory the advisory string
+     */
     public OwnedErrata(Long id, String advisory) {
         super();
         setId(id);

--- a/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/OwnedErrata.java
@@ -26,17 +26,6 @@ public class OwnedErrata extends ErrataOverview {
     private Integer published;
 
     /**
-     * Constructor for OwnedErrata
-     * @param id the id
-     * @param advisory the advisory string
-     */
-    public OwnedErrata(Long id, String advisory) {
-        super();
-        setId(id);
-        setAdvisory(advisory);
-    }
-
-    /**
      * @param locallyModifiedIn The locallyModified to set.
      */
     public void setLocallyModified(String locallyModifiedIn) {

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -650,7 +650,7 @@ public class ErrataManager extends BaseManager {
         OwnedErrata oErrata = new OwnedErrata();
         oErrata.setId(errata.getId());
         oErrata.setAdvisory(errata.getAdvisory());
-        return oErrata;        
+        return oErrata;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -307,10 +307,11 @@ public class ErrataManager extends BaseManager {
         Set<Errata> filteredErrata = tgtErrata.stream().filter(e -> !(srcErrata.contains(e) || asCloned(e)
                 .map(er -> srcErrata.contains(er.getOriginal())).orElse(false)))
                 .collect(Collectors.toUnmodifiableSet());
-
         removeErratumAndPackagesFromChannel(filteredErrata, srcErrata, tgtChannel, user);
-
-        List<OwnedErrata> emptyChannelErrata = srcErrata.stream().filter(t -> t.getChannels().isEmpty()).map(e -> new OwnedErrata(e.getId(), e.getAdvisory())).collect(Collectors.toList());
+        List<OwnedErrata> emptyChannelErrata = srcErrata.stream()
+            .filter(t -> t.getChannels().isEmpty())
+            .map(e -> new OwnedErrata(e.getId(), e.getAdvisory()))
+            .collect(Collectors.toList());
         ErrataManager.deleteErrata(user, emptyChannelErrata);
     }
 

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -310,7 +310,7 @@ public class ErrataManager extends BaseManager {
         removeErratumAndPackagesFromChannel(filteredErrata, srcErrata, tgtChannel, user);
         List<OwnedErrata> emptyChannelErrata = srcErrata.stream()
             .filter(t -> t.getChannels().isEmpty())
-            .map(e -> new OwnedErrata(e.getId(), e.getAdvisory()))
+            .map(ErrataManager::buildOwnedErrataFromErrata)
             .collect(Collectors.toList());
         ErrataManager.deleteErrata(user, emptyChannelErrata);
     }
@@ -641,9 +641,16 @@ public class ErrataManager extends BaseManager {
      */
     public static void deleteErratum(User user, Errata errata) {
         List<OwnedErrata> eids = new ArrayList<>();
-        OwnedErrata oErrata = new OwnedErrata(errata.getId(), errata.getAdvisory());
+        OwnedErrata oErrata = buildOwnedErrataFromErrata(errata);
         eids.add(oErrata);
         deleteErrata(user, eids);
+    }
+
+    private static OwnedErrata buildOwnedErrataFromErrata(Errata errata) {
+        OwnedErrata oErrata = new OwnedErrata();
+        oErrata.setId(errata.getId());
+        oErrata.setAdvisory(errata.getAdvisory());
+        return oErrata;        
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -308,7 +308,7 @@ public class ErrataManager extends BaseManager {
                 .map(er -> srcErrata.contains(er.getOriginal())).orElse(false)))
                 .collect(Collectors.toUnmodifiableSet());
         removeErratumAndPackagesFromChannel(filteredErrata, srcErrata, tgtChannel, user);
-        List<OwnedErrata> emptyChannelErrata = srcErrata.stream()
+        List<OwnedErrata> emptyChannelErrata = filteredErrata.stream()
             .filter(t -> t.getChannels().isEmpty())
             .map(ErrataManager::buildOwnedErrataFromErrata)
             .collect(Collectors.toList());

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -310,7 +310,7 @@ public class ErrataManager extends BaseManager {
         removeErratumAndPackagesFromChannel(filteredErrata, srcErrata, tgtChannel, user);
         List<OwnedErrata> emptyChannelErrata = filteredErrata.stream()
             .filter(t -> t.getChannels().isEmpty())
-            .map(ErrataManager::buildOwnedErrataFromErrata)
+            .map(OwnedErrata::new)
             .collect(Collectors.toList());
         ErrataManager.deleteErrata(user, emptyChannelErrata);
     }
@@ -641,16 +641,9 @@ public class ErrataManager extends BaseManager {
      */
     public static void deleteErratum(User user, Errata errata) {
         List<OwnedErrata> eids = new ArrayList<>();
-        OwnedErrata oErrata = buildOwnedErrataFromErrata(errata);
+        OwnedErrata oErrata = new OwnedErrata(errata);
         eids.add(oErrata);
         deleteErrata(user, eids);
-    }
-
-    private static OwnedErrata buildOwnedErrataFromErrata(Errata errata) {
-        OwnedErrata oErrata = new OwnedErrata();
-        oErrata.setId(errata.getId());
-        oErrata.setAdvisory(errata.getAdvisory());
-        return oErrata;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -309,6 +309,14 @@ public class ErrataManager extends BaseManager {
                 .collect(Collectors.toUnmodifiableSet());
 
         removeErratumAndPackagesFromChannel(filteredErrata, srcErrata, tgtChannel, user);
+
+        List<OwnedErrata> emptyChannelErrata = srcErrata.stream().filter(t -> t.getChannels().isEmpty()).map(e -> {
+            OwnedErrata oErrata = new OwnedErrata();
+            oErrata.setId(e.getId());
+            oErrata.setAdvisory(e.getAdvisory());
+            return oErrata;
+            }).collect(Collectors.toList());
+        ErrataManager.deleteErrata(user, emptyChannelErrata);
     }
 
     private static Optional<ClonedErrata> asCloned(Errata e) {

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -641,9 +641,7 @@ public class ErrataManager extends BaseManager {
      */
     public static void deleteErratum(User user, Errata errata) {
         List<OwnedErrata> eids = new ArrayList<>();
-        OwnedErrata oErrata = new OwnedErrata();
-        oErrata.setId(errata.getId());
-        oErrata.setAdvisory(errata.getAdvisory());
+        OwnedErrata oErrata = new OwnedErrata(errata.getId(), errata.getAdvisory());
         eids.add(oErrata);
         deleteErrata(user, eids);
     }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -310,12 +310,7 @@ public class ErrataManager extends BaseManager {
 
         removeErratumAndPackagesFromChannel(filteredErrata, srcErrata, tgtChannel, user);
 
-        List<OwnedErrata> emptyChannelErrata = srcErrata.stream().filter(t -> t.getChannels().isEmpty()).map(e -> {
-            OwnedErrata oErrata = new OwnedErrata();
-            oErrata.setId(e.getId());
-            oErrata.setAdvisory(e.getAdvisory());
-            return oErrata;
-            }).collect(Collectors.toList());
+        List<OwnedErrata> emptyChannelErrata = srcErrata.stream().filter(t -> t.getChannels().isEmpty()).map(e -> new OwnedErrata(e.getId(), e.getAdvisory())).collect(Collectors.toList());
         ErrataManager.deleteErrata(user, emptyChannelErrata);
     }
 

--- a/java/spacewalk-java.changes.serpico.7427-cleanup-truncata-errata
+++ b/java/spacewalk-java.changes.serpico.7427-cleanup-truncata-errata
@@ -1,0 +1,2 @@
+- ErrataManager.truncateErrata now tries to clean orphan erratas 
+  at the end (erratas with no channel)


### PR DESCRIPTION
## What does this PR change?

ErrataManager.truncateErrata now tries to clean orphan erratas at the end (erratas with no channel)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/7427
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
