### PR TITLE
Fixes related to RemoteNode implementation

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -10,7 +10,8 @@ require 'socket'
 
 Given(/^I want to operate on this "([^"]*)"$/) do |host|
   system_name = get_system_name(host)
-  $client_id = $api_test.system.search_by_name(system_name).first['id']
+  first_match = $api_test.system.search_by_name(system_name).first
+  $client_id = first_match['id'] unless first_match.nil?
   refute_nil($client_id, "Could not find system with hostname #{system_name}")
 end
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1752,29 +1752,6 @@ When(/^I check the cloud-init status on "([^"]*)"$/) do |host|
   end
 end
 
-When(/^I do a late hostname initialization of host "([^"]*)"$/) do |host|
-  # special handling for e.g. nested VMs that will only be crated later in the test suite
-  # this step is normally done in RemoteNode.rb
-  node = get_target(host)
-
-  hostname, local, remote, code = node.test_and_store_results_together('hostname', 'root', 500)
-  raise ScriptError, "Cannot connect to get hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
-  raise ScriptError, "No hostname for '#{$named_nodes[node.hash]}'. Response code: #{code}" if hostname.empty?
-
-  node.init_hostname(hostname)
-
-  fqdn, local, remote, code = node.test_and_store_results_together('hostname -f', 'root', 500)
-  raise ScriptError, "Cannot connect to get FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}, local: #{local}, remote: #{remote}" if code.nonzero? || remote.nonzero? || local.nonzero?
-  raise ScriptError, "No FQDN for '#{$named_nodes[node.hash]}'. Response code: #{code}" if fqdn.empty?
-
-  node.init_full_hostname(fqdn)
-
-  $stdout.puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{hostname.strip} and FQDN #{fqdn.strip}"
-  os_version, os_family = get_os_version(node)
-  node.init_os_family(os_family)
-  node.init_os_version(os_version)
-end
-
 When(/^I wait until I see "([^"]*)" in file "([^"]*)" on "([^"]*)"$/) do |text, file, host|
   node = get_target(host)
   repeat_until_timeout(message: "Entry #{text} in file #{file} on #{host} not found") do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1740,7 +1740,6 @@ end
 
 When(/^I check the cloud-init status on "([^"]*)"$/) do |host|
   node = get_target(host)
-  node.test_and_store_results_together('hostname', 'root', 500)
   node.run('cloud-init status --wait', check_errors: true, verbose: false)
 
   repeat_until_timeout(report_result: true) do

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -241,7 +241,7 @@ end
 When(/^I check the ram value of the "([^"]*)"$/) do |host|
   node = get_target(host)
   get_ram_value = 'grep MemTotal /proc/meminfo |awk \'{print $2}\''
-  ram_value, _local, _remote, _code = node.test_and_store_results_together(get_ram_value, 'root', 600)
+  ram_value, _err, _code = node.ssh(get_ram_value)
   ram_value = ram_value.gsub(/\s+/, '')
   ram_mb = ram_value.to_i / 1024
   step %(I should see a "#{ram_mb}" text)
@@ -250,7 +250,7 @@ end
 When(/^I check the MAC address value of the "([^"]*)"$/) do |host|
   node = get_target(host)
   get_mac_address = 'cat /sys/class/net/eth0/address'
-  mac_address, _local, _remote, _code = node.test_and_store_results_together(get_mac_address, 'root', 600)
+  mac_address, _err, _code = node.ssh(get_mac_address)
   mac_address = mac_address.gsub(/\s+/, '')
   mac_address.downcase!
   step %(I should see a "#{mac_address}" text)
@@ -259,7 +259,7 @@ end
 Then(/^I should see the CPU frequency of the "([^"]*)"$/) do |host|
   node = get_target(host)
   get_cpu_freq = 'cat /proc/cpuinfo  | grep -i \'CPU MHz\'' # | awk '{print $4}'"
-  cpu_freq, _local, _remote, _code = node.test_and_store_results_together(get_cpu_freq, 'root', 600)
+  cpu_freq, _err, _code = node.ssh(get_cpu_freq)
   get_cpu = cpu_freq.gsub(/\s+/, '')
   cpu = get_cpu.split('.')
   cpu = cpu[0].gsub(/[^\d]/, '')

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -616,11 +616,20 @@ end
 #
 # @return [ApiTestXmlrpc, ApiTestHttp] The created API client.
 def new_api_client
+  hostname = get_target('server').full_hostname
   ssl_verify = !$is_gh_validation
-  if product == 'SUSE Manager'
-    ApiTestXmlrpc.new(get_target('server').full_hostname)
+
+  case $api_protocol
+  when 'xmlrpc'
+    ApiTestXmlrpc.new(hostname)
+  when 'http'
+    ApiTestHttp.new(hostname, ssl_verify)
   else
-    ApiTestHttp.new(get_target('server').full_hostname, ssl_verify)
+    if product == 'SUSE Manager'
+      ApiTestXmlrpc.new(hostname)
+    else
+      ApiTestHttp.new(hostname, ssl_verify)
+    end
   end
 end
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -459,16 +459,16 @@ end
 #   Defaults to the server obtained from the `get_target` method.
 # @return [Array<String>] An array of GPG keys.
 def get_gpg_keys(node, target = get_target('server'))
-  os_version, os_family = get_os_version(node)
-  os_version_str = os_version.to_s
+  os_version = node.os_version
+  os_family = node.os_family
   case os_family
   when /^sles/
     # HACK: SLE 15 uses SLE 12 GPG key
-    if os_version_str.start_with?('15')
+    if os_version.start_with?('15')
       os_version = 12
-    elsif os_version_str.start_with?('12')
+    elsif os_version.start_with?('12')
       # SLE12 GPG keys don't contain service pack strings
-      os_version = os_version_str.slice(0, 2)
+      os_version = os_version.slice(0, 2)
     end
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", check_errors: false)
   when /^centos/

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -64,6 +64,7 @@ $is_using_build_image = ENV.fetch('IS_USING_BUILD_IMAGE', false)
 $is_using_scc_repositories = (ENV.fetch('IS_USING_SCC_REPOSITORIES', 'False') != 'False')
 $catch_timeout_message = (ENV.fetch('CATCH_TIMEOUT_MESSAGE', 'False') == 'True')
 $beta_enabled = (ENV.fetch('BETA_ENABLED', 'False') == 'True')
+$api_protocol = ENV.fetch('API_PROTOCOL', nil) if ENV['API_PROTOCOL'] # force the API protocol to be used. You can use 'http' or 'xmlrpc'
 
 # QAM and Build Validation pipelines will provide a json file including all custom (MI) repositories
 custom_repos_path = "#{File.dirname(__FILE__)}/../upload_files/custom_repositories.json"

--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -19,7 +19,7 @@ Net::SSH::KnownHosts::SUPPORTED_TYPE.reject! { |t| t.match(/^ecd(sa|h)-sha2/) }
 def ssh_command(command, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 65_536)
   stdout = ''
   stderr = ''
-  exit_code = nil
+  exit_code = -1
 
   begin
     Net::SSH.start(host, nil, port: port, verify_host_key: :never, timeout: timeout, keepalive: true, max_pkt_size: buffer_size, config: true) do |ssh|
@@ -73,7 +73,7 @@ private
 def ssh_exec!(ssh, command)
   stdout = ''
   stderr = ''
-  exit_code = nil
+  exit_code = -1
 
   ssh.open_channel do |channel|
     channel.exec(command) do |_ch, success|

--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -25,7 +25,7 @@ def ssh_command(command, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 
     Net::SSH.start(host, nil, port: port, verify_host_key: :never, timeout: timeout, keepalive: true, max_pkt_size: buffer_size, config: true) do |ssh|
       stdout, stderr, exit_code = ssh_exec!(ssh, command)
     end
-  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED
+  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
     # The connection times out or is refused
   end
 


### PR DESCRIPTION
## What does this PR change?

- Add the possibility to force the API protocol that we want to use during a test execution
- Add an extra exception to handle unreachable hosts
- Fix an issue handle the exit code of a ssh call.
- Refactor some remaining calls to Twopence methods
- Remove a not-used step definition

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports. It will be ported all together with qe-develop branch.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
