### PR TITLE
Enable deb for payg

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/cloudpayg/PaygProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/cloudpayg/PaygProductFactory.java
@@ -19,13 +19,11 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.util.RpmVersionComparator;
 import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
-import com.redhat.rhn.domain.common.ArchType;
 import com.redhat.rhn.domain.credentials.CloudCredentials;
 import com.redhat.rhn.domain.credentials.CloudRMTCredentials;
 import com.redhat.rhn.domain.credentials.RemoteCredentials;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
-import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.scc.SCCCachingFactory;
 import com.redhat.rhn.domain.scc.SCCRepository;
 import com.redhat.rhn.domain.scc.SCCRepositoryAuth;
@@ -174,11 +172,8 @@ public class PaygProductFactory extends HibernateFactory {
 
     private static boolean isSupportedToolsProduct(SUSEProduct product) {
         ChannelFamily family = product.getChannelFamily();
-        ArchType architecture = product.getArch().getArchType();
 
-        return ChannelFamilyFactory.TOOLS_CHANNEL_FAMILY_LABEL.equals(family.getLabel()) &&
-            // TODO: deb not yet available on RMT
-            PackageFactory.ARCH_TYPE_RPM.equals(architecture.getLabel());
+        return ChannelFamilyFactory.TOOLS_CHANNEL_FAMILY_LABEL.equals(family.getLabel());
     }
 
     private static boolean isSupportedProxyProduct(SUSEProduct product) {

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1620,15 +1620,7 @@ public class ContentSyncManager {
             return sources.stream().map(source -> {
                 try {
                     SCCClient scc = getSCCClient(source);
-                    var tree1 = scc.productTree();
-                    // Non rpm client tools are not available in cloud rmt so we remove these products.
-                    if (sources.stream().allMatch(c -> c instanceof RMTContentSyncSource)) {
-                        // Remove Ubuntu and Debian products until RMT supports them
-                        tree1.removeIf(product -> product.getChannelLabel().contains("amd64") ||
-                                product.getParentChannelLabel().filter(label -> label.contains("amd64")).isPresent()
-                        );
-                    }
-                    return tree1;
+                    return scc.productTree();
                 }
                 catch (SCCClientException e) {
                     throw new ContentSyncException(e);

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerPaygTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerPaygTest.java
@@ -229,9 +229,8 @@ public class ContentSyncManagerPaygTest extends RhnBaseTestCase {
                 () -> assertContains(noAuthRepos, "oraclelinux9"),
                 () -> assertContains(noAuthRepos, "almalinux8"),
                 () -> assertContains(noAuthRepos, "almalinux9"),
-                // Ubuntu and Debian should be excluded until RMT supports them
-                () -> assertNotContains(noAuthRepos, "debian-11-pool"),
-                () -> assertNotContains(noAuthRepos, "ubuntu-2204-amd64-main")
+                () -> assertContains(noAuthRepos, "debian-11-pool"),
+                () -> assertContains(noAuthRepos, "ubuntu-2204-amd64-main")
             );
         }
         finally {

--- a/java/spacewalk-java.changes.mc.Manager-4.3-enable-deb-for-payg
+++ b/java/spacewalk-java.changes.mc.Manager-4.3-enable-deb-for-payg
@@ -1,0 +1,1 @@
+- remove restrictions for debian repositories in public cloud

--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -259,6 +259,7 @@ class DebRepo:
                     cert=(self.sslclientcert, self.sslclientkey),
                     verify=self.sslcacert,
                     timeout=self.timeout,
+                    headers=self.http_headers,
                 )
                 if not data.ok:
                     return ""
@@ -425,6 +426,7 @@ class ContentSource:
                 channel_label=channel_label,
                 timeout=self.timeout,
             )
+            self.repo.http_headers = http_headers
             self.repo.verify()
 
             self.num_packages = 0

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.enable-deb-for-payg
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.enable-deb-for-payg
@@ -1,0 +1,1 @@
+- provide http_headers also to debian repository syncer


### PR DESCRIPTION
## What does this PR change?

The RMT Server in the Public Clouds can now provide also Ubuntu and Debian Tools Channels.
With this we can remove the restrictions we had for using Debian like repositories for SUMA PAYG.

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25169 https://github.com/SUSE/spacewalk/pull/24006

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
