### PR TITLE
Fix package name search when sync volumes data (bsc#1229923)

### DIFF
--- a/containers/server-image/server-image.changes.rmateus.uyuni_1229923_syncfiles
+++ b/containers/server-image/server-image.changes.rmateus.uyuni_1229923_syncfiles
@@ -1,0 +1,1 @@
+- Fix package name search when sync volumes data (bsc#1229923)

--- a/containers/server-image/uyuni-configfiles-sync
+++ b/containers/server-image/uyuni-configfiles-sync
@@ -63,6 +63,7 @@ init() {
     echo "$PV" > $TARGET/.pv
     # Calculate the packages that are owning the files under this path
     PKGNAMES=$(LANG=C rpm -q -qf $(find $PV) | egrep -v "^file .+ is not owned by any package" | sort -u)
+    echo "$PKGNAMES" > $TARGET/.pk
     # Sync the package files (non-configuration and configuration files) to our storage
     for pkg in $PKGNAMES; do
         for cfgfile in $(rpm -ql $pkg | grep "^$PV"); do
@@ -104,7 +105,7 @@ sync() {
     for PV_DIR in $(ls $DEFAULTS_STORAGE | grep -v "^\.buildhash$"); do
         SOURCES=$(echo "$DEFAULTS_STORAGE/$PV_DIR/" | tr -s /)
         PV=$(cat $SOURCES/.pv)
-        PKGNAMES=$(LANG=C rpm -q -qf $(find $PV) | egrep -v "^file .+ is not owned by any package" | sort -u)
+        PKGNAMES=$(cat $SOURCES/.pk)
         PACKAGES_ALL=$(echo -e "$PACKAGES_ALL\n$PKGNAMES")
         echo "- Processing pv: $PV"
         echo -n "  * Getting information for files to synchronize ... "


### PR DESCRIPTION
## What does this PR change?

Fix the error when synchronizing configuration files on image start up. It tries to look for the packages with a find, and the file lists are too long.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1229923
Port(s): 
 - 5.0: https://github.com/uyuni-project/uyuni/pull/9233

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
