### PR TITLE
Find the text of the event, instead of an event completed during last minute

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -27,7 +27,7 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     And I follow this "sle12sp5_terminal" link
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "added system entitlement" completed during last minute, refreshing the page
+    And I wait until I see "added system entitlement" text, refreshing the page
     And I wait until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area

--- a/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
@@ -27,7 +27,7 @@ Feature: PXE boot a SLES 15 SP4 retail terminal
     And I follow this "sle15sp4_terminal" link
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "added system entitlement" completed during last minute, refreshing the page
+    And I wait until I see "added system entitlement" text, refreshing the page
     And I wait until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area

--- a/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
@@ -136,7 +136,7 @@ Feature: PXE boot a Retail terminal behind a containerized proxy
     And I follow this "pxeboot_minion" link
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "added system entitlement" completed during last minute, refreshing the page
+    And I wait until I see "added system entitlement" text, refreshing the page
     And I wait until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area

--- a/testsuite/features/secondary/proxy_traditional_retail_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_traditional_retail_pxeboot.feature
@@ -198,7 +198,7 @@ Feature: PXE boot a Retail terminal behind a traditional proxy
     And I follow this "pxeboot_minion" link
     And I follow "Events"
     And I follow "History"
-    And I wait until I see the event "added system entitlement" completed during last minute, refreshing the page
+    And I wait until I see "added system entitlement" text, refreshing the page
     And I wait until event "Apply states [saltboot]" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area


### PR DESCRIPTION
## What does this PR change?

This change aims to remove a flaky test:
![image](https://github.com/user-attachments/assets/f577d04b-6037-4186-9103-003169af36e0)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were changed

- [x] **DONE**

## Links

No ports, part of qe-develop

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
