### PR TITLE
QE: Add dummy AppStream repository and channel

### DIFF
--- a/testsuite/features/reposync/srv_create_fake_channels.feature
+++ b/testsuite/features/reposync/srv_create_fake_channels.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in:
@@ -158,3 +158,16 @@ Feature: Create fake channels
     And I enter "No more description for base channel." as "Channel Description"
     And I click on "Create Channel"
     Then I should see a "Channel Fake-Base-Channel-RH-like created." text
+
+@rhlike_minion
+  Scenario: Add a fake AppStream base channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "Fake-Base-Channel-AppStream" as "Channel Name"
+    And I enter "fake-base-channel-appstream" as "Channel Label"
+    And I select "None" from "Parent Channel"
+    And I select "x86_64" from "Architecture:"
+    And I enter "Fake-Base-Channel-AppStream for testing" as "Channel Summary"
+    And I enter "Description for Fake-Base-Channel-AppStream." as "Channel Description"
+    And I click on "Create Channel"
+    Then I should see a "Channel Fake-Base-Channel-AppStream created." text

--- a/testsuite/features/reposync/srv_create_fake_repositories.feature
+++ b/testsuite/features/reposync/srv_create_fake_repositories.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in:
@@ -25,6 +25,25 @@ Feature: Create fake repositories for each fake child channel
   Scenario: Disable metadata check for the fake RPM repository
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "fake-rpm-repo"
+    And I uncheck "metadataSigned"
+    And I click on "Update Repository"
+    Then I should see a "Repository updated successfully" text
+    And I should see "metadataSigned" as unchecked
+
+@rhlike_minion
+  Scenario: Create a fake AppStream repository
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "Create Repository"
+    And I enter "fake-appstream-repo" as "label"
+    And I enter "http://localhost/pub/TestRepoAppStream/" as "url"
+    And I click on "Create Repository"
+    Then I should see a "Repository created successfully" text
+    And I should see "metadataSigned" as checked
+
+@rhlike_minion
+  Scenario: Disable metadata check for the fake AppStream repository
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "fake-appstream-repo"
     And I uncheck "metadataSigned"
     And I click on "Update Repository"
     Then I should see a "Repository updated successfully" text
@@ -64,6 +83,18 @@ Feature: Create fake repositories for each fake child channel
     And I select the "fake-rpm-repo" repo
     And I click on "Save Repositories"
     Then I should see a "Fake-Base-Channel-RH-like repository information was successfully updated" text
+
+@rhlike_minion
+  Scenario: Add the fake AppStream repository to the AppStream base channel
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-Base-Channel-AppStream"
+    And I enter "file:///etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key" as "GPG key URL"
+    And I click on "Update Channel"
+    Then I should see a "Channel Fake-Base-Channel-AppStream updated" text
+    When I follow "Repositories" in the content area
+    And I select the "fake-appstream-repo" repo
+    And I click on "Save Repositories"
+    Then I should see a "Fake-Base-Channel-AppStream repository information was successfully updated" text
 
   Scenario: Create a fake repository for i586
     When I follow the left menu "Software > Manage > Repositories"

--- a/testsuite/features/reposync/srv_sync_fake_channels.feature
+++ b/testsuite/features/reposync/srv_sync_fake_channels.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2023 SUSE LLC
+# Copyright (c) 2022-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in:
@@ -92,6 +92,18 @@ Feature: Synchronize fake channels
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Fake-Base-Channel-RH-like." text
     And I wait until the channel "fake-base-channel-rh-like" has been synced
+
+@rhlike_minion
+  Scenario: Synchronize Fake-Base-Channel-AppStream channel
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Fake-Base-Channel-AppStream"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled for Fake-Base-Channel-AppStream." text
+    And I wait until the channel "fake-base-channel-appstream" has been synced
 
 @pxeboot_minion
 @uyuni

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1398,6 +1398,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'el9-pool-x86_64' => 60,
   'fake-base-channel-debian-like' => 120,
   'fake-base-channel-rh-like' => 120,
+  'fake-base-channel-appstream' => 120,
   'fake-child-channel-i586' => 120,
   'fake-child-channel-suse-like' => 120,
   'fake-rpm-suse-channel' => 120,


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/23765

Depends on:

- [x] infra entries for the mirrors 
- [x] https://github.com/uyuni-project/sumaform/pull/1675 
- [x] https://github.com/uyuni-project/uyuni/pull/9246
- [x] https://github.com/uyuni-project/uyuni/pull/9249 + build new CI server image


Add a custom dummy modular repository and the corresponding base channel for it.
They'll later be used to test AppStream features.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23765
Port(s): SUMA 5.0 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
