### PR TITLE
Update container image version of uyuni/server

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -38,7 +38,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE=registry.opensuse.org/uyuni/server
-            VERSION=2024.05
+            VERSION=2024.08
   build-and-push-ubuntu-minion-image:
     runs-on: ubuntu-latest
     permissions:

--- a/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
@@ -2,14 +2,14 @@ ARG BASE
 ARG VERSION
 FROM ${BASE}:${VERSION}
 
-RUN zypper ref && \
+RUN zypper -n --gpg-auto-import-keys ref && \
       zypper -n install \
       java-17-openjdk-devel \
       openssh \
       rsync \
       apache-ivy \
       ant \
-      ant-junit5 \
+      ant-junit \
       servletapi5 \
       cpio \
       spacecmd \
@@ -25,7 +25,7 @@ RUN mkdir /tmp/minima && \
     tar zxvf minima-linux-amd64.tar.gz && \
     cp minima /usr/bin/minima
 RUN /usr/bin/minima sync -c /etc/minima.yaml && \
-    mkdir /srv/www/htdocs/pub/TestRepoRpmUpdates /srv/www/htdocs/pub/TestRepoAppstream && \
+    mkdir /srv/www/htdocs/pub/TestRepoRpmUpdates /srv/www/htdocs/pub/TestRepoAppStream && \
     mv /srv/www/htdocs/pub/repositories/systemsmanagement\:/Uyuni\:/Test-Packages\:/Updates/rpm/* /srv/www/htdocs/pub/TestRepoRpmUpdates/ && \
     mv /srv/www/htdocs/pub/repositories/systemsmanagement\:/Uyuni\:/Test-Packages\:/Appstream/rhlike/* /srv/www/htdocs/pub/TestRepoAppStream/ && \
     rm -rf /srv/www/htdocs/pub/repositories/


### PR DESCRIPTION
## What does this PR change?

Bump the version of the container image we use as base for the CI containerized server

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: Just GH CI changes

- [x] **DONE**

## Links

Issues: https://github.com/SUSE/spacewalk/issues/23765

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
