### PR TITLE
Fix susemanager-sync-data build

### DIFF
--- a/susemanager-sync-data/susemanager-sync-data.spec
+++ b/susemanager-sync-data/susemanager-sync-data.spec
@@ -37,6 +37,7 @@ This package contains data files with information used to channel syncing
 
 %install
 mkdir -p %{buildroot}%{_datadir}/susemanager/scc
+mkdir -p %{buildroot}%{_datadir}/susemanager/oval
 install -m 0644 channel_families.json %{buildroot}%{_datadir}/susemanager/scc/channel_families.json
 install -m 0644 additional_products.json    %{buildroot}%{_datadir}/susemanager/scc/additional_products.json
 install -m 0644 additional_repositories.json    %{buildroot}%{_datadir}/susemanager/scc/additional_repositories.json


### PR DESCRIPTION
## What does this PR change?

susemanager-sync-data fails to build after the merge of https://github.com/uyuni-project/uyuni/pull/7509, due to a missing directory.

Add the missing directory to the spec file

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Issue(s): #
Port(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
