### PR TITLE
Revert supportutils-plugin-susemanager-client changes from uyuni-project/uyuni#9232 due to SUSE/spacewalk#25211

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes.deneb-alpha.drop_proxy-systemd-services
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes.deneb-alpha.drop_proxy-systemd-services
@@ -1,1 +1,0 @@
-- uyuni-proxy-systemd-services has been deprecated and removed

--- a/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
@@ -30,6 +30,7 @@ zypp-plugin-spacewalk
 salt-minion
 salt
 podman
+uyuni-proxy-systemd-services
 "
 
 for THISRPM in $RPMLIST; do
@@ -53,7 +54,8 @@ conf_files $OF \
     /etc/salt/minion \
     /etc/salt/minion.d/susemanager.conf \
     /etc/salt/minion.d/_schedule.conf \
-    /etc/uyuni/proxy/config.yaml
+    /etc/uyuni/proxy/config.yaml  \
+    /etc/sysconfig/uyuni-proxy-systemd-services
 
 
 log_entry $OF note "SUSE Manager Client Log Files"
@@ -80,4 +82,47 @@ log_entry $OF note "Cloud / PAYG"
 log_cmd $OF "test -e /usr/bin/instance-flavor-check && /usr/bin/instance-flavor-check"
 rpm_verify $OF "python-instance-billing-flavor-check"
 
+####################################################################
+#### The instance where a proxy is running, is just a managed client
+####################################################################
 
+log_entry $OF note "Proxy Containers Configuration Files"
+
+log_cmd $OF "ls -l /etc/uyuni/proxy/"
+
+log_entry $OF note "Proxy Containers Systems Status"
+
+SERVICES="
+    uyuni-proxy-pod
+    uyuni-proxy-httpd
+    uyuni-proxy-salt-broker
+    uyuni-proxy-squid
+    uyuni-proxy-ssh
+    uyuni-proxy-tftpd
+"
+
+for SERVICE in $SERVICES; do
+    check_service $OF $SERVICE
+done
+
+CONTAINERS="
+    uyuni-proxy-httpd
+    uyuni-proxy-ssh
+    uyuni-proxy-squid
+    uyuni-proxy-tftpd
+    uyuni-proxy-salt-broker
+"
+
+if which podman >/dev/null 2>&1; then
+    log_entry $OF note "Proxy Containers Inspects"
+
+    for CONTAINER in $CONTAINERS; do
+        log_cmd $OF "podman inspect $CONTAINER"
+    done
+
+    log_entry $OF note "Proxy Containers Logs"
+
+    for CONTAINER in $CONTAINERS; do
+        log_cmd $OF "podman logs $CONTAINER"
+    done
+fi

--- a/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient-scplugin
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient-scplugin
@@ -43,6 +43,7 @@ zypp-plugin-spacewalk
 salt-minion
 salt
 podman
+uyuni-proxy-systemd-services
 "
 
 for THISRPM in $RPMLIST; do
@@ -66,7 +67,8 @@ pconf_files \
     /etc/salt/minion \
     /etc/salt/minion.d/susemanager.conf \
     /etc/salt/minion.d/_schedule.conf \
-    /etc/uyuni/proxy/config.yaml
+    /etc/uyuni/proxy/config.yaml \
+    /etc/sysconfig/uyuni-proxy-systemd-services
 
 
 section_header "SUSE Manager Client Capabilities"
@@ -97,6 +99,53 @@ elif [ $(cat /proc/sys/crypto/fips_enabled) -ne 0 ]; then
         plugin_message "FIPS"
 else
         plugin_command "grep -v '#' /usr/share/crypto-policies/default-config"
+fi
+
+section_header "Proxy Containers Configuration Files"
+
+plugin_command "ls -l /etc/uyuni/proxy/"
+
+section_header "Proxy Containers Systems Status"
+
+systemd_status() {
+    if systemctl list-unit-files $1 >/dev/null; then
+        plugin_command "systemctl status $1"
+    fi
+}
+
+SERVICES="
+    uyuni-proxy-pod
+    uyuni-proxy-httpd
+    uyuni-proxy-salt-broker
+    uyuni-proxy-squid
+    uyuni-proxy-ssh
+    uyuni-proxy-tftpd
+"
+
+for SERVICE in $SERVICES; do
+    systemd_status "$SERVICE.service"
+done
+
+CONTAINERS="
+    uyuni-proxy-httpd
+    uyuni-proxy-ssh
+    uyuni-proxy-squid
+    uyuni-proxy-tftpd
+    uyuni-proxy-salt-broker
+"
+
+if which podman >/dev/null 2>&1; then
+    section_header "Proxy Containers Inspects"
+
+    for CONTAINER in $CONTAINERS; do
+        plugin_command "podman inspect $CONTAINER"
+    done
+
+    section_header "Proxy Containers Logs"
+
+    for CONTAINER in $CONTAINERS; do
+        plugin_command "podman logs $CONTAINER"
+    done
 fi
 
 section_header "Cloud / PAYG"


### PR DESCRIPTION
## What does this PR change?

Revert supportutils-plugin-susemanager-client changes from uyuni-project/uyuni#9232 due to SUSE/spacewalk#25211

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: reverting a previously merged change

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25211
Port(s): No backports needed. Only the drop of `uyuni-proxy-systemd-services` will have to be ported to `Manager-5.0`

- [x] **DONE**

## Changelogs

No need to add an additional changelog entry for this. 

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
