### PR TITLE
Retracted errata query optimizations

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/ErrataCache_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/ErrataCache_queries.xml
@@ -101,7 +101,16 @@ DELETE FROM rhnOrgErrataCacheQueue WHERE org_id = :org_id
   <!-- -->
   <query params="channel_id">
   INSERT INTO rhnServerNeededCache (server_id, package_id, channel_id)
-          ( SELECT DISTINCT
+          ( WITH retracted_packages AS (
+            SELECT DISTINCT ep.package_id AS pid, sc.server_id AS sid
+            FROM rhnserverchannel sc
+              JOIN rhnchannel c ON c.id = sc.channel_id
+              JOIN rhnchannelerrata ce ON ce.channel_id = c.id
+              JOIN rhnerrata e ON e.id = ce.errata_id
+              JOIN rhnerratapackage ep ON ep.errata_id = e.id
+            WHERE e.advisory_status::text = 'retracted'::text
+              AND ep.package_id in (%s))
+            SELECT DISTINCT
              S.id as server_id,
              P.id as package_id,
              :channel_id as channel_id
@@ -118,7 +127,7 @@ DELETE FROM rhnOrgErrataCacheQueue WHERE org_id = :org_id
                          SC.channel_id = :channel_id
                   AND    SC.server_id = S.id
                   AND    p.id in (%s)
-                  AND    NOT EXISTS (SELECT 1 FROM suseServerChannelsRetractedPackagesView WHERE sid = S.id AND pid = P.id)
+                  AND    NOT EXISTS (SELECT 1 FROM retracted_packages WHERE sid = S.id AND pid = P.id)
                   AND    NOT EXISTS (SELECT 1 FROM suseServerAppStreamHiddenPackagesView   WHERE sid = S.id AND pid = P.id)
                   AND    p.package_arch_id = spac.package_arch_id
                   AND    spac.server_arch_id = s.server_arch_id

--- a/java/spacewalk-java.changes.oholecek.replace-errata-view-by-select
+++ b/java/spacewalk-java.changes.oholecek.replace-errata-view-by-select
@@ -1,0 +1,2 @@
+- use custom select instead of errata view for better performance
+  (bsc#1225619)

--- a/schema/spacewalk/common/views/suseServerChannelsRetractedPackagesView.sql
+++ b/schema/spacewalk/common/views/suseServerChannelsRetractedPackagesView.sql
@@ -4,14 +4,12 @@
 --
 
 CREATE OR REPLACE VIEW suseServerChannelsRetractedPackagesView AS
- SELECT DISTINCT p.id AS pid,
-    s.id AS sid
-   FROM rhnserver s
-     JOIN rhnserverchannel sc ON s.id = sc.server_id
+ SELECT DISTINCT ep.package_id AS pid,
+    sc.server_id AS sid
+   FROM rhnserverchannel sc
      JOIN rhnchannel c ON c.id = sc.channel_id
      JOIN rhnchannelerrata ce ON ce.channel_id = c.id
      JOIN rhnerrata e ON e.id = ce.errata_id
      JOIN rhnerratapackage ep ON ep.errata_id = e.id
-     JOIN rhnpackage p ON p.id = ep.package_id
   WHERE e.advisory_status::text = 'retracted'::text;
 

--- a/schema/spacewalk/susemanager-schema.changes.oholecek.errata-optimizations
+++ b/schema/spacewalk/susemanager-schema.changes.oholecek.errata-optimizations
@@ -1,0 +1,1 @@
+- remove superfluous joins from errata view

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.0-to-susemanager-schema-5.1.1/002-errata-view-optimization.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.0-to-susemanager-schema-5.1.1/002-errata-view-optimization.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE VIEW suseServerChannelsRetractedPackagesView AS
+SELECT DISTINCT ep.package_id AS pid,
+   sc.server_id AS sid
+   FROM rhnserverchannel sc
+      JOIN rhnchannel c ON c.id = sc.channel_id
+      JOIN rhnchannelerrata ce ON ce.channel_id = c.id
+      JOIN rhnerrata e ON e.id = ce.errata_id
+      JOIN rhnerratapackage ep ON ep.errata_id = e.id
+   WHERE e.advisory_status::text = 'retracted'::text;


### PR DESCRIPTION
## What does this PR change?

Optimize errata view computation by dropping superfluous table joins.
Remove errata usage view completely from computationally intensive errata server cache update.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24426
Port(s): https://github.com/SUSE/spacewalk/pull/25167

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
