### PR TITLE
Use proxy FQDN from config file for auth token

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.store_proxy_fqdn
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.store_proxy_fqdn
@@ -1,0 +1,2 @@
+- store proxy FQDN in the rhn.conf for auth token use
+  (bsc#1230255)

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -167,6 +167,7 @@ with open(config_path + "httpd.yaml", encoding="utf-8") as httpdSource:
         
         # Hostname of Uyuni, SUSE Manager Server or another proxy
         proxy.rhn_parent = {config['server']}
+        proxy.proxy_fqdn = {config['proxy_fqdn']}
         
         # Destination of all tracebacks, etc.
         traceback_mail = {config['email']}

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -100,6 +100,10 @@ class BrokerHandler(SharedHandler):
                     socket.herror, socket.timeout):
                 # hostname probably didn't exist, fine
                 pass
+        if not hostname and CFG.has_key('PROXY_FQDN'):
+            # Not resolvable hostname, check container config
+            log_debug(2, "Using PROXY_FQDN config %s" % CFG.PROXY_FQDN)
+            hostname = CFG.PROXY_FQDN
         if not hostname:
             # okay, that didn't work, let's do a reverse dns lookup on my
             # ip address

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -126,11 +126,15 @@ class SharedHandler:
         # if this request is for an upstream server, use the original query string.
         # Otherwise, if it is for the local Squid instance, strip it so that
         # Squid will not keep multiple cached copies of the same resource
+        # Containers notes: when going for local proxy, use localhost as host to avoid
+        # hairpin problem.
         if self.httpProxy not in ['127.0.0.1:8080', 'localhost:8080']:
             if 'X-Suse-Auth-Token' in self.req.headers_in:
                 self.uri += '?%s' % self.req.headers_in['X-Suse-Auth-Token']
             elif query:
                 self.uri += '?%s' % query
+        else:
+            host = 'localhost'
 
         log_debug(3, 'Scheme:', scheme)
         log_debug(3, 'Host:', host)
@@ -172,6 +176,12 @@ class SharedHandler:
             'host':   host,
             'port':   port,
         }
+
+        # Containers notes: when going for local proxy, use localhost as host to avoid
+        # hairpin problem.
+        if self.httpProxy in ['127.0.0.1:8080', 'localhost:8080']:
+            params['host'] = 'localhost'
+
         if CFG.has_key('timeout'):
             params['timeout'] = CFG.TIMEOUT
         if self.httpProxy:

--- a/proxy/proxy/spacewalk-proxy.changes.oholecek.fix_authtoken_hostname
+++ b/proxy/proxy/spacewalk-proxy.changes.oholecek.fix_authtoken_hostname
@@ -1,0 +1,2 @@
+- set proxy authtoken FQDN based on config file
+  (bsc#1230255)


### PR DESCRIPTION
## What does this PR change?

AuthToken appended FQDN is used also for translating autoyast/ks server FQDN to proxy one. AuthToken thus has to use external FQDN and not internal pod hostname.

This commit introduce this change and also fix for hairpin problem as AuthToken hostname was used for internal connection, which must be localhost (or internal pod hosname) for container scenario.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added TBD

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25231
Port(s): https://github.com/SUSE/spacewalk/pull/25236

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
