### PR TITLE
Ignore 'buildorder' parsing errors when parsing module metadata entries (bsc#1230274)

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes.cbbayburt.bsc1230274
+++ b/python/spacewalk/spacewalk-backend.changes.cbbayburt.bsc1230274
@@ -1,0 +1,1 @@
+- Ignore 'buildorder' parsing errors when parsing entries in module metadata (bsc#1230274)


### PR DESCRIPTION
Build systems of some RH-like distributions sometimes wrongly output `-1` as an unsigned integer for the `buildorder` property. This causes the upstream library `libmodulemd2-2.13.0` to fail to parse those values.

Since we don't use the `buildorder` property in Uyuni, we can safely ignore these failures. This PR introduces the change to ignore these parsing errors and continue operation without any real side-effect.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: Already covered

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/9123
Fixes https://github.com/SUSE/spacewalk/issues/25209

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
