### PR TITLE
Menu entry on the left changed with 5.0

### DIFF
--- a/testsuite/features/secondary/minssh_tunnel.feature
+++ b/testsuite/features/secondary/minssh_tunnel.feature
@@ -91,6 +91,6 @@ Feature: Register a Salt system to be managed via SSH tunnel
 
   Scenario: Cleanup: register a SSH minion after SSH tunnel tests
     When I call system.bootstrap() on host "ssh_minion" and salt-ssh "enabled"
-    And I follow the left menu "Systems > Overview"
+    And I follow the left menu "Systems > System List > All"
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"


### PR DESCRIPTION
## What does this PR change?

This PR fixes a faulty upstream port


## Links

Port(s):
* no 4.3, menu entry is correct
* 5.0: change merged together with https://github.com/SUSE/spacewalk/pull/25150


## Changelogs

- [x] No changelog needed
