### PR TITLE
Fix date input on HTTP API endpoints

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -1516,7 +1516,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
     @ReadOnly
     public List<ErrataOverview> listErrata(User loggedInUser, String channelLabel)
         throws NoSuchChannelException {
-        return listErrata(loggedInUser, channelLabel, (Date) null);
+        return listErrata(loggedInUser, channelLabel, null);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -295,24 +295,6 @@ public class ErrataHandler extends BaseHandler {
             }
         }
 
-        if (details.containsKey("issue_date")) {
-            try {
-                errata.setIssueDate((Date)details.get("issue_date"));
-            }
-            catch (ClassCastException e) {
-                throw new InvalidParameterException("Wrong 'issue_date' format.");
-            }
-        }
-
-        if (details.containsKey("update_date")) {
-            try {
-                errata.setUpdateDate((Date)details.get("update_date"));
-            }
-            catch (ClassCastException e) {
-                throw new InvalidParameterException("Wrong 'update_date' format.");
-            }
-        }
-
         if (details.containsKey("synopsis")) {
             if (StringUtils.isBlank((String)details.get("synopsis"))) {
                 throw new InvalidParameterException("Synopsis is required.");

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -279,19 +279,19 @@ public class ErrataHandler extends BaseHandler {
 
         if (details.containsKey("issue_date")) {
             try {
-                errata.setIssueDate((Date)details.get("issue_date"));
+                errata.setIssueDate(parseInputValue(details.get("issue_date"), Date.class));
             }
-            catch (ClassCastException e) {
-                throw new InvalidParameterException("Wrong 'issue_date' format.");
+            catch (InvalidParameterException e) {
+                throw new InvalidParameterException("Wrong 'issue_date' format.", e);
             }
         }
 
         if (details.containsKey("update_date")) {
             try {
-                errata.setUpdateDate((Date)details.get("update_date"));
+                errata.setUpdateDate(parseInputValue(details.get("update_date"), Date.class));
             }
-            catch (ClassCastException e) {
-                throw new InvalidParameterException("Wrong 'update_date' format.");
+            catch (InvalidParameterException e) {
+                throw new InvalidParameterException("Wrong 'update_date' format.", e);
             }
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -60,9 +60,12 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -289,6 +292,26 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         }
         assertTrue(foundKeyword1);
         assertTrue(foundKeyword2);
+    }
+
+    @Test
+    public void testSetDetailsDates() throws Exception {
+        Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+
+        Map<String, Object> details = new HashMap<>();
+        Date expectedDate = Date.from(LocalDate.of(1989, 4, 1).atStartOfDay().toInstant(ZoneOffset.UTC));
+        // Set using Date instance (XMLRPC)
+        details.put("issue_date", expectedDate);
+        // Set using ISO-8601 String (JSON over HTTP)
+        details.put("update_date", "1989-04-01T00:00:00Z");
+
+        int result = handler.setDetails(user, errata.getAdvisoryName(), details);
+
+        assertEquals(1, result);
+
+        Errata updatedErrata = ErrataManager.lookupErrata(errata.getId(), user);
+        assertEquals(expectedDate, updatedErrata.getIssueDate());
+        assertEquals(expectedDate, updatedErrata.getUpdateDate());
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/SnapshotHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/SnapshotHandler.java
@@ -290,10 +290,10 @@ public class SnapshotHandler extends BaseHandler {
         Date endDate = null;
 
         if (dateDetails.containsKey("startDate")) {
-            startDate = (Date)dateDetails.get("startDate");
+            startDate = parseInputValue(dateDetails.get("startDate"), Date.class);
         }
         if (dateDetails.containsKey("endDate")) {
-            endDate = (Date)dateDetails.get("endDate");
+            endDate = parseInputValue(dateDetails.get("endDate"), Date.class);
         }
         return deleteSnapshots(loggedInUser, startDate, endDate);
     }

--- a/java/code/src/com/suse/manager/api/ApiRequestParser.java
+++ b/java/code/src/com/suse/manager/api/ApiRequestParser.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
  */
 public class ApiRequestParser {
     private final Gson gson;
-    private final JsonParser parser = new JsonParser();
 
     /**
      * Constructs a parser with a {@link Gson} instance
@@ -49,7 +48,7 @@ public class ApiRequestParser {
      * @return the JSON object properties as key-value pairs
      */
     public Map<String, JsonElement> parseBody(String body) throws ParseException {
-        JsonElement bodyElement = parser.parse(body);
+        JsonElement bodyElement = JsonParser.parseString(body);
 
         if (bodyElement.isJsonNull()) {
             return Collections.emptyMap();
@@ -115,11 +114,11 @@ public class ApiRequestParser {
         JsonElement element;
         try {
             // Try to parse the literal value
-            element = parser.parse(value);
+            element = JsonParser.parseString(value);
         }
         catch (JsonSyntaxException e) {
             // Invalid syntax, try as string
-            element = parser.parse('"' + value + '"');
+            element = JsonParser.parseString('"' + value + '"');
         }
 
         if (element.isJsonPrimitive() || element.isJsonNull()) {

--- a/java/code/src/com/suse/manager/api/ListDeserializer.java
+++ b/java/code/src/com/suse/manager/api/ListDeserializer.java
@@ -28,9 +28,7 @@ import java.util.Map;
 
 /**
  * Custom {@link List} deserializer that handles arbitrary numbers properly
- * @deprecated the same behavior can be achieved using ToNumberPolicy.LONG_OR_DOUBLE with gson-2.8.9
  */
-@Deprecated
 public class ListDeserializer implements JsonDeserializer<List<Object>> {
     @Override
     public List<Object> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)

--- a/java/code/src/com/suse/manager/api/MapDeserializer.java
+++ b/java/code/src/com/suse/manager/api/MapDeserializer.java
@@ -28,9 +28,7 @@ import java.util.Map;
 
 /**
  * Custom {@link Map} deserializer that handles arbitrary numbers properly
- * @deprecated the same behavior can be achieved using ToNumberPolicy.LONG_OR_DOUBLE with gson-2.8.9
  */
-@Deprecated
 public class MapDeserializer implements JsonDeserializer<Map<String, Object>> {
     @Override
     public Map<String, Object> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)

--- a/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
+++ b/java/code/src/com/suse/manager/api/test/RouteFactoryTest.java
@@ -67,7 +67,6 @@ public class RouteFactoryTest extends BaseControllerTestCase {
             .registerTypeAdapter(Map.class, new MapDeserializer())
             .registerTypeAdapter(List.class, new ListDeserializer())
             .create();
-    private final JsonParser parser = new JsonParser();
     private RouteFactory routeFactory;
     private TestHandler handler;
 
@@ -718,7 +717,7 @@ public class RouteFactoryTest extends BaseControllerTestCase {
      * @return the result object
      */
     private <T> T getResult(String response, Type resultType) {
-        JsonObject obj = parser.parse(response).getAsJsonObject();
+        JsonObject obj = JsonParser.parseString(response).getAsJsonObject();
 
         boolean isSuccess = obj.getAsJsonPrimitive("success").getAsBoolean();
         assertTrue(isSuccess);

--- a/java/spacewalk-java.changes.cbbayburt.api-datetime-input
+++ b/java/spacewalk-java.changes.cbbayburt.api-datetime-input
@@ -1,0 +1,1 @@
+- Fix date input in 'errata.setDetails' endpoint in the HTTP API


### PR DESCRIPTION
Fix parsing of dates in HTTP API when the argument is a nested element in a struct.

Additionally, this PR refactors some deprecated bits around Gson.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/8269

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
