### PR TITLE
Fix sticky header scroll bug

### DIFF
--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -99,7 +99,8 @@ function sstScrollBehaviorSetup(sst) {
 // when the page scrolls down and the toolbar is going up and hidden,
 // the toolbar takes a fixed place right below the header bar
 function handleSst() {
-  var sst = jQuery('.spacewalk-section-toolbar');
+  // Some pages may have multiple instances of this element
+  var sst = jQuery('.spacewalk-section-toolbar').first();
 
   if (jQuery('.move-to-fixed-toolbar').length > 0) {
     // if there is no 'spacewalk-section-toolbar', then create it
@@ -143,7 +144,7 @@ function handleSst() {
 }
 
 function sstStyle() {
-  var sst = jQuery('.spacewalk-section-toolbar');
+  var sst = jQuery('.spacewalk-section-toolbar').first();
   if (sst.hasClass('fixed')) {
     sst.css({
       top: jQuery('header').outerHeight() - 1,

--- a/web/spacewalk-web.changes.eth.multi-sst
+++ b/web/spacewalk-web.changes.eth.multi-sst
@@ -1,1 +1,1 @@
-- Fix sticky header scroll bug
+- Fix sticky header infinite scroll

--- a/web/spacewalk-web.changes.eth.multi-sst
+++ b/web/spacewalk-web.changes.eth.multi-sst
@@ -1,0 +1,1 @@
+- Fix sticky header scroll bug


### PR DESCRIPTION
## What does this PR change?

The legacy script that handles sticky headers doesn't account for the fact that some pages may have multiple sections which are sticky header candidates. In the future we want to move this over to a purely CSS solution since [`position: sticky`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#sticky) is now widely supported, for the time being this PR fixes the infinite layout expansion bug.

## GUI diff

No more infinite scroll.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: UI bug

- [x] **DONE**

## Links

https://suse.slack.com/archives/C02D130RBA6/p1726915321046259

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
