### PR TITLE
QE: Fix path for openscap

### DIFF
--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -32,7 +32,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds-1.2.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel8-ds.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed


### PR DESCRIPTION
## What does this PR change?
openSCAP tests are failing due to a filename change - this fixes that.