### PR TITLE
Revert "Fix error in 'kickstart_delete' when using wildcards (bsc#1227578)"

### DIFF
--- a/java/code/src/com/suse/utils/Exceptions.java
+++ b/java/code/src/com/suse/utils/Exceptions.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 package com.suse.utils;
-
+//TEST
 import java.util.Optional;
 
 public final class Exceptions {

--- a/spacecmd/spacecmd.changes.cbbayburt.bsc1227578
+++ b/spacecmd/spacecmd.changes.cbbayburt.bsc1227578
@@ -1,2 +1,0 @@
-- Fix error in 'kickstart_delete' when using wildcards 
-  (bsc#1227578)

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -209,10 +209,16 @@ def do_kickstart_delete(self, args):
         self.help_kickstart_delete()
         return 1
 
-    for label in labels:
-        if self.options.yes or self.user_confirm(_("Delete profile %s [y/N]:") % label):
-            self.client.kickstart.deleteProfile(self.session, label)
-    return 0
+    mismatched = sorted(set(args).difference(set(all_labels)))
+    if mismatched:
+        logging.error(_N("The following kickstart labels are invalid:"),
+                      ", ".join(mismatched))
+        return 1
+    else:
+        for label in labels:
+            if self.options.yes or self.user_confirm(_("Delete profile %s [y/N]:") % label):
+                self.client.kickstart.deleteProfile(self.session, label)
+        return 0
 
 ####################
 

--- a/spacecmd/tests/test_kickstart.py
+++ b/spacecmd/tests/test_kickstart.py
@@ -374,9 +374,9 @@ echo 'some more hello'
         assert_args_expect(shell.do_kickstart_list.call_args_list,
                            [(('', True), {})])
 
-    def test_kickstart_delete_wildcard_arg(self, shell):
+    def test_kickstart_delete_some_invalid_profile(self, shell):
         """
-        Test do_kickstart_delete with a wildcard argument
+        Test do_kickstart_delete invalid profile (not found).
 
         :param shell:
         :return:
@@ -387,18 +387,19 @@ echo 'some more hello'
         logger = MagicMock()
         with patch("spacecmd.kickstart.logging", logger) as lgr:
             spacecmd.kickstart.do_kickstart_delete(
-                shell, "*_profile")
+                shell, "fourth_profile zero_profile first_profile second_profile")
 
+        assert not shell.client.kickstart.deleteProfile.called
         assert not shell.help_kickstart_delete.called
-        assert not logger.error.called
-        assert shell.client.kickstart.deleteProfile.called
+        assert logger.error.called
         assert shell.do_kickstart_list.called
         assert logger.debug.called
 
-        assert_args_expect(shell.client.kickstart.deleteProfile.call_args_list,
-                           [((shell.session, "first_profile"), {}),
-                            ((shell.session, "second_profile"), {}),
-                            ((shell.session, "third_profile"), {})])
+        assert_expect(logger.debug.call_args_list,
+                      "Got labels to delete of ['first_profile', 'second_profile']")
+        assert_args_expect(logger.error.call_args_list,
+                           [(('The following kickstart labels are invalid:',
+                              'fourth_profile, zero_profile'), {})])
 
     def test_kickstart_delete_profile_all_yes(self, shell):
         """


### PR DESCRIPTION
Reverts uyuni-project/uyuni#9103

Test if that fixes the issue with 

```
WhenI remove package "rute-dummy" from this "sle_minion""
AndI wait until package "rute-dummy" is removed from "sle_minion" via spacecmd

execution expired (Timeout::Error)
./features/support/commonlib.rb:101:in `repeat_until_timeout'
./features/step_definitions/command_steps.rb:1283:in `/^I wait until package "([^"]*)" is removed from "([^"]*)" via spacecmd$/'
features/secondary/min_retracted_patches.feature:21:in `I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd'
```
