### PR TITLE
Update hamcrest-library to 3.0 due to SUSE:Maintenance:35494:343927

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -125,7 +125,7 @@
           <artifact name="all" type="jar" url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.12.7/checkstyle-10.12.7-all.jar"/>
         </dependency>
         <dependency org="suse" name="hamcrest-core" rev="1.3" transitive="false"/>
-        <dependency org="suse" name="hamcrest-library" rev="2.2" transitive="false"/>
+        <dependency org="suse" name="hamcrest-library" rev="3.0" transitive="false"/>
         <dependency org="suse" name="junit" rev="4.13.2" transitive="false"/>
         <dependency org="org.junit.jupiter" name="junit-jupiter-api" rev="5.8.2" transitive="false"/>
         <dependency org="org.junit.platform" name="junit-platform-commons" rev="1.8.2" transitive="false" />


### PR DESCRIPTION
## What does this PR change?

Update `hamcrest-library` ~and `hamcrest-core`~ to 3.0 due to `SUSE:Maintenance:35494:343927`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **for development**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
