### PR TITLE
use external hostname in email subject

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
@@ -16,15 +16,14 @@
 package com.redhat.rhn.frontend.events;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.messaging.MessageAction;
-import com.redhat.rhn.common.messaging.MessageExecuteException;
 import com.redhat.rhn.domain.user.User;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.net.InetAddress;
 import java.util.Date;
 
 /**
@@ -37,31 +36,21 @@ public class TraceBackAction extends BaseMailAction implements MessageAction {
     @Override
     protected String getSubject(BaseEvent evtIn) {
         // setup subject
-        StringBuilder subject = new StringBuilder();
-        subject.append(LocalizationService.getInstance().
-                getMessage("web traceback subject", evtIn.getUserLocale()));
-        // Not sure if getting the local hostname is the correct thing to do
-        // here.  But the traceback emails that I've received seem to do this
-        try {
-            subject.append(InetAddress.getLocalHost().getHostName());
-        }
-        catch (java.net.UnknownHostException uhe) {
-            String message = "TraceBackAction can't find localhost!";
-            getLogger().warn(message);
-            throw new MessageExecuteException(message);
-        }
-        subject.append(" (");
-        subject.append(LocalizationService.getInstance().formatDate(new Date(),
-                evtIn.getUserLocale()));
-        subject.append(")");
-        return subject.toString();
+        return LocalizationService.getInstance().
+                getMessage("web traceback subject", evtIn.getUserLocale()) +
+                // Not sure if getting the local hostname is the correct thing to do
+                // here.  But the traceback emails that I've received seem to do this
+                ConfigDefaults.get().getJavaHostname() +
+                " (" +
+                LocalizationService.getInstance().formatDate(new Date(), evtIn.getUserLocale()) +
+                ")";
     }
 
     @Override
     protected String[] getRecipients(User userIn) {
         Config c = Config.get();
         String[] retval = null;
-        if (c.getString("web.traceback_mail").equals("")) {
+        if (c.getString("web.traceback_mail").isEmpty()) {
 
             retval = new String[1];
             retval[0] = "root@localhost";

--- a/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TraceBackAction.java
@@ -38,8 +38,6 @@ public class TraceBackAction extends BaseMailAction implements MessageAction {
         // setup subject
         return LocalizationService.getInstance().
                 getMessage("web traceback subject", evtIn.getUserLocale()) +
-                // Not sure if getting the local hostname is the correct thing to do
-                // here.  But the traceback emails that I've received seem to do this
                 ConfigDefaults.get().getJavaHostname() +
                 " (" +
                 LocalizationService.getInstance().formatDate(new Date(), evtIn.getUserLocale()) +

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TaskHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TaskHelper.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
-import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.Row;
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.quartz.SchedulerException;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,15 +61,9 @@ public class TaskHelper {
         LocalizationService ls = LocalizationService.getInstance();
         String[] recipients = MailHelper.getAdminRecipientsFromConfig();
 
-        StringBuilder subject = new StringBuilder();
-        subject.append(ls.getMessage("web traceback subject", Locale.getDefault()));
-        try {
-            subject.append(InetAddress.getLocalHost().getHostName());
-        }
-        catch (Throwable t) {
-            subject.append("Taskomatic");
-        }
-        MailHelper.withSmtp().sendEmail(recipients, subject.toString(), messageBody);
+        String subject = ls.getMessage("web traceback subject", Locale.getDefault()) +
+                ConfigDefaults.get().getJavaHostname();
+        MailHelper.withSmtp().sendEmail(recipients, subject, messageBody);
 
     }
 
@@ -80,24 +73,17 @@ public class TaskHelper {
      * @param messageBody to send.
      */
     public static void sendTaskoEmail(Integer orgId, String messageBody) {
-        Config c = Config.get();
         LocalizationService ls = LocalizationService.getInstance();
         String[] recipients = MailHelper.getAdminRecipientsFromConfig();
         if (orgId != null) {
             List<String> emails = getActiveOrgAdminEmails(orgId);
             recipients = !emails.isEmpty() ?
-                    emails.toArray(new String[emails.size()]) :
+                    emails.toArray(new String[0]) :
                     MailHelper.getAdminRecipientsFromConfig();
         }
-        StringBuilder subject = new StringBuilder();
-        subject.append(ls.getMessage("taskomatic notif subject", Locale.getDefault()));
-        try {
-            subject.append(" from " + InetAddress.getLocalHost().getHostName());
-        }
-        catch (Throwable t) {
-            // nothing
-        }
-        MailHelper.withSmtp().sendEmail(recipients, subject.toString(), messageBody);
+        String subject = ls.getMessage("taskomatic notif subject", Locale.getDefault()) +
+                " from " + ConfigDefaults.get().getJavaHostname();
+        MailHelper.withSmtp().sendEmail(recipients, subject, messageBody);
     }
 
     /**

--- a/java/spacewalk-java.changes.mcalmer.fix-hostname-in-mail-title
+++ b/java/spacewalk-java.changes.mcalmer.fix-hostname-in-mail-title
@@ -1,0 +1,1 @@
+- use external hostname in title of traceback emails


### PR DESCRIPTION
## What does this PR change?

InetAddress.getLocalHost().getHostName() just get the internal container network FQDN name.
This is fix to `uyuni-server.mgr.internal ` and does not help to identify the origin of the error if you run multiple instances.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25405

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
