### PR TITLE
suma_minion: prevent issues when calling Salt runners (bsc#1228232)

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -68,12 +68,12 @@ def __virtual__():
 
 
 def _is_salt_ssh_or_runner(opts):
-    """Check if this pillar is computed for Salt SSH or Salt Runner execution
+    """Check if this pillar is computed for Salt SSH or Salt runner execution
 
     Only in salt/client/ssh/__init__.py, the master_opts are moved into
     opts[__master_opts__], which we use to detect Salt SSH usage.
 
-    During a Salt Runner execution, the "_master" suffix is appended to the
+    During a Salt runner execution, the "_master" suffix is appended to the
     master_minion id.
     """
     return "__master_opts__" in opts or opts.get("id", "").endswith("_master")

--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -67,13 +67,16 @@ def __virtual__():
     return HAS_POSTGRES
 
 
-def _is_salt_ssh(opts):
-    """Check if this pillar is computed for Salt SSH.
+def _is_salt_ssh_or_runner(opts):
+    """Check if this pillar is computed for Salt SSH or Salt Runner execution
 
     Only in salt/client/ssh/__init__.py, the master_opts are moved into
     opts[__master_opts__], which we use to detect Salt SSH usage.
+
+    During a Salt Runner execution, the "_master" suffix is appended to the
+    master_minion id.
     """
-    return "__master_opts__" in opts
+    return "__master_opts__" in opts or opts.get("id", "").endswith("_master")
 
 
 def _get_cursor(func):
@@ -105,7 +108,7 @@ def _get_cursor(func):
             cnx = _connect_db()
             log.debug("Connected to the DB")
             # pylint: disable-next=undefined-variable
-            if not _is_salt_ssh(__opts__):
+            if not _is_salt_ssh_or_runner(__opts__):
                 # pylint: disable-next=undefined-variable
                 __context__["suma_minion_cnx"] = cnx
         except psycopg2.OperationalError as err:
@@ -119,7 +122,7 @@ def _get_cursor(func):
             cnx = _connect_db()
             log.debug("Reconnected to the DB")
             # pylint: disable-next=undefined-variable
-            if not _is_salt_ssh(__opts__):
+            if not _is_salt_ssh_or_runner(__opts__):
                 # pylint: disable-next=undefined-variable
                 __context__["suma_minion_cnx"] = cnx
             cursor = cnx.cursor()
@@ -134,7 +137,7 @@ def _get_cursor(func):
                 cnx = _connect_db()
                 log.debug("Reconnected to the DB")
                 # pylint: disable-next=undefined-variable
-                if not _is_salt_ssh(__opts__):
+                if not _is_salt_ssh_or_runner(__opts__):
                     # pylint: disable-next=undefined-variable
                     __context__["suma_minion_cnx"] = cnx
                 cursor = cnx.cursor()
@@ -152,7 +155,7 @@ def _get_cursor(func):
                 )
         finally:
             # pylint: disable-next=undefined-variable
-            if _is_salt_ssh(__opts__):
+            if _is_salt_ssh_or_runner(__opts__):
                 cnx.close()
 
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.Manager-4.3-bsc1228232
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.Manager-4.3-bsc1228232
@@ -1,0 +1,1 @@
+- suma_minion: prevent issues when calling Salt runners (bsc#1228232)

--- a/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
+++ b/susemanager-utils/susemanager-sls/test/test_pillar_suma_minion.py
@@ -144,6 +144,38 @@ def test_using_context_in__get_cursor():
             "port": 1234,
         }
     }
+    with patch.object(suma_minion, "__opts__", {"id": "foobar_master", **test_opts}), patch(
+        "suma_minion.psycopg2.connect", pg_connect_mock
+    ), patch.dict(suma_minion.__context__, {}):
+        # Check if it creates new connection if it's not in the context
+        # pylint: disable-next=protected-access
+        suma_minion._get_cursor(cursor_callback)
+
+        assert pg_connect_mock.call_args_list[0][1] == {
+            "host": "test_host",
+            "user": "test_user",
+            "password": "test_pass",
+            "dbname": "test_db",
+            "port": 1234,
+        }
+
+        pg_connect_mock.reset_mock()
+
+        # Check if it reuses the connection from the context
+        # pylint: disable-next=protected-access
+        suma_minion._get_cursor(cursor_callback)
+
+        assert pg_connect_mock.call_args_list[0][1] == {
+            "host": "test_host",
+            "user": "test_user",
+            "password": "test_pass",
+            "dbname": "test_db",
+            "port": 1234,
+        }
+        assert not "suma_minion_cnx" in suma_minion.__context__
+
+    pg_connect_mock.reset_mock()
+
     with patch.object(suma_minion, "__opts__", test_opts), patch(
         "suma_minion.psycopg2.connect", pg_connect_mock
     ), patch.dict(suma_minion.__context__, {}):

--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -4,26 +4,26 @@
 @skip_if_github_validation
 @sle_minion
 @scope_salt
-Feature: Salt Master integration with Git Pillar
+Feature: Salt master integration with Git pillar
 
-  Scenario: Preparing Git Pillar configuration for Salt Master
-    When I setup a git_pillar environment on the Salt Master
+  Scenario: Preparing Git pillar configuration for Salt master
+    When I setup a git_pillar environment on the Salt master
     And I wait for "30" seconds
     Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should exist on server
 
-  Scenario: Check for the expected pillar data after enabling Git Pillar
+  Scenario: Check for the expected pillar data after enabling Git pillar
     When I refresh the pillar data
     Then the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"
     And the pillar data for "org_id" should be "1" on "sle_minion"
-    And the pillar data for "git_pillar_foobar" should be "12345" on the Salt Master
+    And the pillar data for "git_pillar_foobar" should be "12345" on the Salt master
 
-  Scenario: Cleanup: Removing Git Pillar configuration for Salt Master
-    When I clean up the git_pillar environment on the Salt Master
+  Scenario: Cleanup: Remove Git pillar configuration for Salt master
+    When I clean up the git_pillar environment on the Salt master
     And I wait for "30" seconds
     Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should not exist on server
 
-  Scenario: Check for the expected pillar data after disabling Git Pillar
+Scenario: Cleanup: Check for the expected pillar data after disabling Git pillar
     When I refresh the pillar data
     Then the pillar data for "git_pillar_foobar" should be empty on "sle_minion"
     And the pillar data for "org_id" should be "1" on "sle_minion"
-    And the pillar data for "git_pillar_foobar" should be empty on the Salt Master
+    And the pillar data for "git_pillar_foobar" should be empty on the Salt master

--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -8,7 +8,7 @@ Feature: Salt master integration with Git pillar
 
   Scenario: Preparing Git pillar configuration for Salt master
     When I setup a git_pillar environment on the Salt master
-    And I wait for "30" seconds
+    And I wait until Salt master is active and ready
     Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should exist on server
 
   Scenario: Check for the expected pillar data after enabling Git pillar
@@ -19,7 +19,7 @@ Feature: Salt master integration with Git pillar
 
   Scenario: Cleanup: Remove Git pillar configuration for Salt master
     When I clean up the git_pillar environment on the Salt master
-    And I wait for "30" seconds
+    And I wait until Salt master is active and ready
     Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should not exist on server
 
 Scenario: Cleanup: Check for the expected pillar data after disabling Git pillar

--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -8,7 +8,7 @@ Feature: Salt master integration with Git pillar
 
   Scenario: Preparing Git pillar configuration for Salt master
     When I setup a git_pillar environment on the Salt master
-    And I wait until Salt master is active and ready
+    And I wait until Salt master can reach "sle_minion"
     Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should exist on server
 
   Scenario: Check for the expected pillar data after enabling Git pillar
@@ -19,7 +19,7 @@ Feature: Salt master integration with Git pillar
 
   Scenario: Cleanup: Remove Git pillar configuration for Salt master
     When I clean up the git_pillar environment on the Salt master
-    And I wait until Salt master is active and ready
+    And I wait until Salt master can reach "sle_minion"
     Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should not exist on server
 
 Scenario: Cleanup: Check for the expected pillar data after disabling Git pillar

--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@skip_if_github_validation
+@sle_minion
+@scope_salt
+Feature: Salt Master integration with Git Pillar
+
+  Scenario: Preparing Git Pillar configuration for Salt Master
+    When I setup a git_pillar environment on the Salt Master
+    And I wait for "30" seconds
+    Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should exist on server
+
+  Scenario: Check for the expected pillar data after enabling Git Pillar
+    When I refresh the pillar data
+    Then the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"
+    And the pillar data for "org_id" should be "1" on "sle_minion"
+    And the pillar data for "git_pillar_foobar" should be "12345" on the Salt Master
+
+  Scenario: Cleanup: Removing Git Pillar configuration for Salt Master
+    When I clean up the git_pillar environment on the Salt Master
+    And I wait for "30" seconds
+    Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should not exist on server
+
+  Scenario: Check for the expected pillar data after disabling Git Pillar
+    When I refresh the pillar data
+    Then the pillar data for "git_pillar_foobar" should be empty on "sle_minion"
+    And the pillar data for "org_id" should be "1" on "sle_minion"
+    And the pillar data for "git_pillar_foobar" should be empty on the Salt Master

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -107,8 +107,9 @@ When(/^I wait until Salt client is inactive on "([^"]*)"$/) do |minion|
   step %(I wait until "#{salt_minion}" service is inactive on "#{minion}")
 end
 
-When(/^I wait until Salt master is active and ready$/) do
-  get_target('server').run_until_ok('bash -c \'until timeout 5s salt-key; do :; done\'')
+When(/^I wait until Salt master can reach "([^"]*)"$/) do |minion|
+  system_name = get_system_name(minion)
+  get_target('server').run_until_ok("bash -c 'until timeout 5s salt #{system_name} test.ping; do :; done'")
 end
 
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -72,7 +72,7 @@ When(/^I refresh salt-minion grains on "(.*?)"$/) do |minion|
   node.run("#{salt_call} saltutil.refresh_grains")
 end
 
-When(/^I setup a git_pillar environment on the Salt Master$/) do
+When(/^I setup a git_pillar environment on the Salt master$/) do
   file = 'salt_git_pillar_setup.sh'
   source = "#{File.dirname(__FILE__)}/../upload_files/#{file}"
   dest = "/tmp/#{file}"
@@ -83,7 +83,7 @@ When(/^I setup a git_pillar environment on the Salt Master$/) do
   get_target('server').run("sh /tmp/#{file} setup", check_errors: true, verbose: true)
 end
 
-When(/^I clean up the git_pillar environment on the Salt Master$/) do
+When(/^I clean up the git_pillar environment on the Salt master$/) do
   file = 'salt_git_pillar_setup.sh'
 
   # Execute "salt_git_pillar_setup.sh setup" on the server
@@ -395,12 +395,12 @@ Then(/^the pillar data for "([^"]*)" should be empty on "([^"]*)"$/) do |key, mi
   end
 end
 
-Then(/^the pillar data for "([^"]*)" should be empty on the Salt Master$/) do |key|
+Then(/^the pillar data for "([^"]*)" should be empty on the Salt master$/) do |key|
   output = salt_master_pillar_get(key)
   raise "Output value is not empty: #{output}" unless output == ''
 end
 
-Then(/^the pillar data for "([^"]*)" should be "([^"]*)" on the Salt Master$/) do |key, value|
+Then(/^the pillar data for "([^"]*)" should be "([^"]*)" on the Salt master$/) do |key, value|
   output = salt_master_pillar_get(key)
   raise "Output value is different than #{value}: #{output}" unless output.to_s.strip == value
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -107,6 +107,10 @@ When(/^I wait until Salt client is inactive on "([^"]*)"$/) do |minion|
   step %(I wait until "#{salt_minion}" service is inactive on "#{minion}")
 end
 
+When(/^I wait until Salt master is active and ready$/) do
+  get_target('server').run_until_ok('bash -c \'until timeout 5s salt-key; do :; done\'')
+end
+
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|
   target = get_target(minion)
   salt_call = use_salt_bundle ? 'venv-salt-call' : 'salt-call'

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -691,6 +691,16 @@ def pillar_get(key, minion)
   get_target('server').run("#{cmd} #{system_name} pillar.get #{key}")
 end
 
+# Get a Salt pillar value from the master via Salt Runner
+#
+# @param key [String] The key of the pillar to retrieve.
+# @return [String] The value of the specified pillar key.
+def salt_master_pillar_get(key)
+  output, _code = get_target('server').run('salt-run --out=yaml salt.cmd pillar.items')
+  pillars = YAML.load(output)
+  pillars.key?(key) ? pillars[key] : ''
+end
+
 # Wait for an action to be completed, passing the action id and a timeout
 #
 # @param actionid [String] The ID of the action to wait for.

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -691,7 +691,7 @@ def pillar_get(key, minion)
   get_target('server').run("#{cmd} #{system_name} pillar.get #{key}")
 end
 
-# Get a Salt pillar value from the master via Salt Runner
+# Get a Salt pillar value from the master via Salt runner
 #
 # @param key [String] The key of the pillar to retrieve.
 # @return [String] The value of the specified pillar key.

--- a/testsuite/features/upload_files/salt_git_pillar_setup.sh
+++ b/testsuite/features/upload_files/salt_git_pillar_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This script create the necessary files to setup a "git_pillar" environment
-# together with SUSE Manager in order to provide some extra pillar data.
+# together with Uyuni in order to provide some extra pillar data.
 #
 # Use as:
 #   salt_git_pillar_setup.sh setup -> Prepare environment
@@ -18,7 +18,7 @@
 GIT_REPO="/tmp/test_salt_git_pillar.git"
 
 if [ "$1" == "setup" ]; then
-	echo "Setting up git_pillar environment and restarting Salt Master and Salt API"
+	echo "Setting up git_pillar environment and restarting Salt master and Salt API"
 	zypper in -y git-core
 	mkdir $GIT_REPO
 	cd $GIT_REPO
@@ -59,7 +59,7 @@ EOF
 fi
 
 if [ "$1" == "clean" ]; then
-	echo "Cleaning git_pillar environment and restarting Salt Master and Salt API"
+	echo "Cleaning git_pillar environment and restarting Salt master and Salt API"
 	rm -rf $GIT_REPO
 	rm /etc/salt/master.d/zz-testing-gitpillar.conf
 	cp /root/.ssh/authorized_keys_backup_gitpillar /root/.ssh/authorized_keys

--- a/testsuite/features/upload_files/salt_git_pillar_setup.sh
+++ b/testsuite/features/upload_files/salt_git_pillar_setup.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# This script create the necessary files to setup a "git_pillar" environment
+# together with SUSE Manager in order to provide some extra pillar data.
+#
+# Use as:
+#   salt_git_pillar_setup.sh setup -> Prepare environment
+#   salt_git_pillar_setup.sh clean -> Clean up environment
+#
+# It prepares a GIT repository containing the following files:
+#   top.sls
+#   test_pillar.sls
+#
+# This provides "git_pillar_foobar: 12345" as part of the pillar data
+# for all minions and master.
+#
+
+GIT_REPO="/tmp/test_salt_git_pillar.git"
+
+if [ "$1" == "setup" ]; then
+	echo "Setting up git_pillar environment and restarting Salt Master and Salt API"
+	zypper in -y git-core
+	mkdir $GIT_REPO
+	cd $GIT_REPO
+	git init
+
+	cat << 'EOF' > top.sls
+base:
+  '*':
+    - test_pillar
+EOF
+
+	cat << 'EOF' > test_pillar.sls
+git_pillar_foobar: 12345
+EOF
+
+	git add top.sls test_pillar.sls
+	git commit -m "initial commit"
+
+	# Store Salt SSH key as authorized for user root
+	cp /root/.ssh/authorized_keys /root/.ssh/authorized_keys_backup_gitpillar
+	cat /var/lib/salt/.ssh/mgr_ssh_id.pub >> /root/.ssh/authorized_keys
+
+	# Start SSHd service
+	ssh-keygen -A
+	/usr/sbin/sshd -D &
+
+	cat << 'EOF' > /etc/salt/master.d/zz-testing-gitpillar.conf
+ext_pillar:
+  - suma_minion: True
+  - git:
+    - __env__ ssh://root@localhost/tmp/test_salt_git_pillar.git:
+      - all_saltenvs: master
+      - pubkey: /var/lib/salt/.ssh/mgr_ssh_id.pub
+      - privkey: /var/lib/salt/.ssh/mgr_ssh_id
+EOF
+
+	systemctl restart salt-master salt-api
+fi
+
+if [ "$1" == "clean" ]; then
+	echo "Cleaning git_pillar environment and restarting Salt Master and Salt API"
+	rm -rf $GIT_REPO
+	rm /etc/salt/master.d/zz-testing-gitpillar.conf
+	cp /root/.ssh/authorized_keys_backup_gitpillar /root/.ssh/authorized_keys
+	rm /root/.ssh/authorized_keys_backup_gitpillar
+	pkill sshd
+	systemctl restart salt-master salt-api
+fi

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -21,6 +21,7 @@
 - features/secondary/srv_user_configuration_salt_states.feature
 - features/secondary/srv_handle_software_channels_with_ISS_v2.feature
 - features/secondary/srv_handle_config_channels_with_ISS_v2.feature
+- features/secondary/srv_salt_git_pillar.feature
 - features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature
 - features/secondary/min_rhlike_openscap_audit.feature


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with that can be seen in certain scenarios, where multiple `ext_pillar` modules are configured (particularly in combination with `git_pillar` module) and a pillar compilation is triggered via Salt Runner execution.

Under these circunstances, we see the following exception happening:

```
# salt-run salt.cmd pillar.items
[ERROR   ] Exception caught loading ext_pillar 'git':
  File "/usr/lib/python3.6/site-packages/salt/pillar/__init__.py", line 1200, in ext_pillar
    ext = self._external_pillar_data(pillar, val, key)
  File "/usr/lib/python3.6/site-packages/salt/pillar/__init__.py", line 1130, in _external_pillar_data
    ext = self.ext_pillars[key](self.minion_id, pillar, *val)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/pillar/git_pillar.py", line 506, in ext_pillar
    local_pillar.compile_pillar(ext=False),
  File "/usr/lib/python3.6/site-packages/salt/pillar/__init__.py", line 1247, in compile_pillar
    matches = self.top_matches(top)
  File "/usr/lib/python3.6/site-packages/salt/pillar/__init__.py", line 869, in top_matches
    self.opts.get("nodegroups", {}),
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/contextvars/__init__.py", line 38, in run
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/matchers/confirm_top.py", line 29, in confirm_top
    matchers = salt.loader.matchers(__opts__)
  File "/usr/lib/python3.6/site-packages/salt/loader/__init__.py", line 433, in matchers
    loaded_base_name=loaded_base_name,
  File "/usr/lib/python3.6/site-packages/salt/loader/__init__.py", line 93, in LazyLoader
    return _LazyLoader(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 249, in __init__
    opts = copy.deepcopy(opts)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 161, in deepcopy
    y = copier(memo)
  File "/usr/lib/python3.6/site-packages/salt/utils/context.py", line 236, in __deepcopy__
    copy.deepcopy(self.__dict, memo), copy.deepcopy(self.pre_keys, memo)
  File "/usr/lib64/python3.6/copy.py", line 161, in deepcopy
    y = copier(memo)
  File "/usr/lib/python3.6/site-packages/salt/utils/context.py", line 141, in __deepcopy__
    new_obj.global_data = copy.deepcopy(self.global_data, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 150, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.6/copy.py", line 240, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.6/copy.py", line 169, in deepcopy
    rv = reductor(4)

[CRITICAL] Pillar render error: Failed to load ext_pillar git: can't pickle psycopg2.extensions.connection objects
_errors:
    - Failed to load ext_pillar git: can't pickle psycopg2.extensions.connection objects
```

The issue is caused as `suma_minion` is storing the DB connection object in the Salt `__context__` in order to be able to reuse it later if needed, but this creates a conflict with the `git_pillar` engine when running in the context of a Salt Runner execution, i.a. `salt-run state.orch` or some other commands like `salt-run salt.cmd pillar.items`.

This PR simply prevent the `suma_minion` ext_pillar module to store the DB object into the Salt `__context__` when the execution is driven by a Salt runner, as we already with Salt SSH executions (presumably due similar reasons)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit and acceptance tests added.

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24913

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
