### PR TITLE
show Confidential Compute Attestation tab also for salt ssh managed clients

### DIFF
--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -181,8 +181,8 @@
     <rhn-tab name="Deployment" url="/rhn/systems/details/virtualization/Deployment.do" acl="not system_is_virtual(); system_has_management_entitlement()"/>
   </rhn-tab>
 
-  <rhn-tab name="Audit" acl="system_has_management_entitlement() or system_has_salt_entitlement_and_contact_method(default)" url="/rhn/systems/details/audit/ListScap.do">
-    <rhn-tab name="OpenSCAP" url="/rhn/systems/details/audit/ListScap.do">
+  <rhn-tab name="Audit" url="/rhn/manager/systems/details/coco/settings">
+    <rhn-tab name="OpenSCAP" acl="system_has_salt_entitlement_and_contact_method(default)" url="/rhn/systems/details/audit/ListScap.do">
       <rhn-tab-url>/rhn/systems/details/audit/ListScap.do</rhn-tab-url>
       <rhn-tab name="nav.system.audit.list_scans">
         <rhn-tab-url>/rhn/systems/details/audit/ListScap.do</rhn-tab-url>

--- a/java/spacewalk-java.changes.mc.Manager-5.0-coco-attestation-salt-ssh
+++ b/java/spacewalk-java.changes.mc.Manager-5.0-coco-attestation-salt-ssh
@@ -1,0 +1,1 @@
+- show Confidential Compute Attestation tab also for salt ssh managed clients

--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -29,6 +29,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
   Scenario: Schedule an OpenSCAP audit job on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
@@ -40,6 +41,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "xccdf_org.open-scap_testresult"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Ubuntu" text
@@ -60,6 +62,7 @@ Feature: OpenSCAP audit of Debian-like Salt minion
   Scenario: Cleanup: delete audit results from Debian-like minion
     Given I am on the Systems overview page of this "deblike_minion"
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "List Scans" in the content area
     And I click on "Select All"
     And I click on "Remove Selected Scans"

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -29,6 +29,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
   Scenario: Schedule an OpenSCAP audit job on the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary" as "params"
@@ -40,6 +41,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "xccdf_org.open-scap_testresult"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "RHEL-8" text
@@ -61,6 +63,7 @@ Feature: OpenSCAP audit of Red Hat-like Salt minion
   Scenario: Cleanup: delete audit results from Red Hat-like minion
     Given I am on the Systems overview page of this "rhlike_minion"
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "List Scans" in the content area
     And I click on "Select All"
     And I click on "Remove Selected Scans"

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -26,6 +26,7 @@ Feature: OpenSCAP audit of Salt minion
 @susemanager
   Scenario: Schedule an OpenSCAP audit job on the SLE minion
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
@@ -37,6 +38,7 @@ Feature: OpenSCAP audit of Salt minion
 @uyuni
   Scenario: Schedule an OpenSCAP audit job on the SLE minion
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
@@ -48,6 +50,7 @@ Feature: OpenSCAP audit of Salt minion
 @susemanager
   Scenario: Check results of the audit job on the minion
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "xccdf_org.open-scap_testresult"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "profile standard" text
@@ -59,6 +62,7 @@ Feature: OpenSCAP audit of Salt minion
 @uyuni
   Scenario: Check results of the audit job on the minion
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "xccdf_org.open-scap_testresult"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "profile standard" text
@@ -70,6 +74,7 @@ Feature: OpenSCAP audit of Salt minion
 @susemanager
   Scenario: Create a second, almost identical, audit job
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
@@ -81,6 +86,7 @@ Feature: OpenSCAP audit of Salt minion
 @uyuni
   Scenario: Create a second, almost identical, audit job
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
@@ -91,6 +97,7 @@ Feature: OpenSCAP audit of Salt minion
 
   Scenario: Compare audit results
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "List Scans" in the content area
     And I click on "Select All"
     And I click on "Compare Selected Scans"
@@ -108,6 +115,7 @@ Feature: OpenSCAP audit of Salt minion
   Scenario: Cleanup: delete audit results
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Audit" in the content area
+    And I follow "OpenSCAP" in the content area
     And I follow "List Scans" in the content area
     And I click on "Select All"
     And I click on "Remove Selected Scans"


### PR DESCRIPTION
## What does this PR change?

The Audit Tab with the Confidential Compute Attestation pages are only visible for salt managed clients with default contact method. This was done as OpenSCAP scans can only be done with a minion installed.

But CoCo attestation works also with salt-ssh managed systems. Show this also for these kind of clients.

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25389

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
