### PR TITLE
Change path to store the code coverage report

### DIFF
--- a/testsuite/features/support/code_coverage.rb
+++ b/testsuite/features/support/code_coverage.rb
@@ -21,6 +21,7 @@ class CodeCoverage
   #
   # @param feature_name [String] The name of the feature.
   def push_feature_coverage(feature_name)
+    $stdout.puts("Pushing coverage for #{feature_name} into Redis")
     filename = "/tmp/jacoco-#{feature_name}.xml"
     begin
       xml = File.read(filename, mode: 'r')
@@ -62,9 +63,9 @@ class CodeCoverage
     xml_report = xml ? "--xml /srv/www/htdocs/pub/jacoco-#{feature_name}.xml" : ''
     sourcefiles = source ? '--sourcefiles /tmp/uyuni-master/java/code/src' : ''
     classfiles = '--classfiles /srv/tomcat/webapps/rhn/WEB-INF/lib/rhn.jar'
-    dump_path = "/tmp/jacoco-#{feature_name}.exec"
-    get_target('server').run("#{cli} dump --address localhost --destfile #{dump_path} --port 6300 --reset")
-    get_target('server').run("#{cli} report #{dump_path} #{html_report} #{xml_report} #{sourcefiles} #{classfiles}")
-    file_extract(get_target('server'), "/srv/www/htdocs/pub/jacoco-#{feature_name}.xml", "/tmp/jacoco-#{feature_name}.xml")
+    dump_path = "/var/cache/jacoco-#{feature_name}.exec"
+    get_target('server').run("#{cli} dump --address localhost --destfile #{dump_path} --port 6300 --reset", verbose: true)
+    get_target('server').run("#{cli} report #{dump_path} #{html_report} #{xml_report} #{sourcefiles} #{classfiles}", verbose: true)
+    get_target('server').extract("/srv/www/htdocs/pub/jacoco-#{feature_name}.xml", "/tmp/jacoco-#{feature_name}.xml")
   end
 end

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -199,7 +199,7 @@ class RemoteNode
   def extract(remote_node_file, test_runner_file)
     if @has_mgrctl
       tmp_file = File.join('/tmp/', File.basename(remote_node_file))
-      _out, code = run_local("mgrctl cp server:#{remote_node_file} #{tmp_file}")
+      _out, code = run_local("mgrctl cp server:#{remote_node_file} #{tmp_file}", verbose: true)
       raise ScriptError, "Failed to extract #{remote_node_file} from container" unless code.zero?
 
       success = get_target('localhost').scp_download(tmp_file, test_runner_file, host: @full_hostname)


### PR DESCRIPTION
## What does this PR change?

Change path to store the code coverage report, to be aligned with the pipeline code.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
