### PR TITLE
Support '^' in RPM version string when importing appstreams

### DIFF
--- a/python/spacewalk/satellite_tools/appstreams.py
+++ b/python/spacewalk/satellite_tools/appstreams.py
@@ -310,7 +310,7 @@ class ModuleMdImporter:
         pattern = re.compile(
             r"(?P<name>[a-zA-Z0-9._+-]+)-"
             r"(?P<epoch>\d+:)?"
-            r"(?P<version>[a-zA-Z0-9._-~]+)-"
+            r"(?P<version>[a-zA-Z0-9._-~^]+)-"
             r"(?P<release>[a-zA-Z0-9._+-]+)\."
             r"(?P<arch>[a-zA-Z0-9._-]+)"
         )

--- a/python/spacewalk/spacewalk-backend.changes.cbbayburt.appstream-ver-fix
+++ b/python/spacewalk/spacewalk-backend.changes.cbbayburt.appstream-ver-fix
@@ -1,0 +1,1 @@
+- Support '^' in RPM version string when importing appstreams

--- a/python/test/unit/spacewalk/satellite_tools/test_appstreams.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_appstreams.py
@@ -186,6 +186,14 @@ def test_get_modules(importer):
             "4.el8.remi.7.2",
             "x86_64",
         ),
+        (
+            "toolbox-0:0.0.99.2^1.git660b6970e998-1.module_el8.5.0+874+6db8bee3.noarch",
+            "toolbox",
+            "0",
+            "0.0.99.2^1.git660b6970e998",
+            "1.module_el8.5.0+874+6db8bee3",
+            "noarch",
+        ),
     ],
 )
 def test_parse_rpm_name(nevra_input, name, epoch, version, release, arch):


### PR DESCRIPTION
Support '^' in RPM version string when importing appstreams during reposync.

## Documentation
- No documentation needed: bugfix

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/9211

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
