### PR TITLE
Fix ubuntu 2004 reposync issue and 2204 reposync issue

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -667,6 +667,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I use spacewalk-common-channel to add all "rockylinux9" channels with arch "x86_64"
     And I wait until all synchronized channels for "rockylinux9" have finished
 
+@susemanager
 @ubuntu2004_minion
   Scenario: Add Ubuntu 20.04
     Given I am authorized for the "Admin" section

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -65,7 +65,7 @@ end
 # @return [String, nil] The full product version if the command execution was successful and
 #   the output is not empty, otherwise nil.
 def product_version_full
-  cmd = 'salt-call --local grains.get product_version | tail -n 1'
+  cmd = 'venv-salt-call --local grains.get product_version | tail -n 1'
   out, code = get_target('server').run(cmd)
   out.strip if code.zero? && !out.nil?
 end

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -445,7 +445,7 @@ LABEL_BY_BASE_CHANNEL = {
     'Rocky Linux 9 (x86_64)' => 'rockylinux9-x86_64',
     'Ubuntu 20.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2004-pool-amd64-uyuni',
     'Ubuntu 22.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2204-pool-amd64-uyuni',
-    'Ubuntu 24.04 LTS AMD64 Base for Uyuni' => 'ubuntu-24.04-pool-amd64-uyuni',
+    'Ubuntu 24.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2404-pool-amd64-uyuni',
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian-11-pool-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian-12-pool-amd64-uyuni',
     'openSUSE Leap 15.5 (aarch64)' => 'opensuse_leap15_5-aarch64',
@@ -1643,7 +1643,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'ubuntu-2404-amd64-universe-updates-uyuni' => 240,
   'ubuntu-2404-amd64-universe-uyuni' => 24_000,
   'ubuntu-2404-amd64-uyuni-client-devel' => 60,
-  'ubuntu-24.04-pool-amd64-uyuni' => 60,
+  'ubuntu-2404-pool-amd64-uyuni' => 60,
   'ubuntu-24.04-suse-manager-tools-amd64' => 60,
   'uyuni-proxy-devel-leap-x86_64' => 60
 }.freeze

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -444,7 +444,7 @@ LABEL_BY_BASE_CHANNEL = {
     'Rocky Linux 8 (x86_64)' => 'rockylinux8-x86_64',
     'Rocky Linux 9 (x86_64)' => 'rockylinux9-x86_64',
     'Ubuntu 20.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2004-pool-amd64-uyuni',
-    'Ubuntu 22.04 LTS AMD64 Base for Uyuni' => 'ubuntu-22.04-pool-amd64-uyuni',
+    'Ubuntu 22.04 LTS AMD64 Base for Uyuni' => 'ubuntu-2204-pool-amd64-uyuni',
     'Ubuntu 24.04 LTS AMD64 Base for Uyuni' => 'ubuntu-24.04-pool-amd64-uyuni',
     'Debian 11 (bullseye) pool for amd64 for Uyuni' => 'debian-11-pool-amd64-uyuni',
     'Debian 12 (bookworm) pool for amd64 for Uyuni' => 'debian-12-pool-amd64-uyuni',
@@ -1314,7 +1314,7 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
       ],
     'ubuntu-2204' => # CHECKED
       %w[
-        ubuntu-22.04-pool-amd64-uyuni
+        ubuntu-2204-pool-amd64-uyuni
         ubuntu-2204-amd64-main-security-uyuni
         ubuntu-2204-amd64-main-updates-uyuni
         ubuntu-2204-amd64-main-uyuni
@@ -1326,7 +1326,7 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
       ],
     'ubuntu-2404' =>
       %w[
-        ubuntu-24.04-pool-amd64-uyuni
+        ubuntu-2404-pool-amd64-uyuni
         ubuntu-2404-amd64-main-security-uyuni
         ubuntu-2404-amd64-main-updates-uyuni
         ubuntu-2404-amd64-main-uyuni
@@ -1630,7 +1630,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'ubuntu-2204-amd64-universe-updates-uyuni' => 240,
   'ubuntu-2204-amd64-universe-uyuni' => 24_000,
   'ubuntu-2204-amd64-uyuni-client-devel' => 60,
-  'ubuntu-22.04-pool-amd64-uyuni' => 60,
+  'ubuntu-2204-pool-amd64-uyuni' => 60,
   'ubuntu-22.04-suse-manager-tools-amd64' => 60,
   'ubuntu-2404-amd64-main-amd64' => 780,
   'ubuntu-2404-amd64-main-security-amd64' => 2760,


### PR DESCRIPTION
## What does this PR change?

Fix ubuntu synchronization issues during BV uyuni reposync stage.

## Errors
```bash
uyuni-bv-master-server:~ # mgrctl exec -i 'spacewalk-common-channels -u admin -p admin --list' | grep ubuntu-2204-pool-amd64-uyuni
 ubuntu-2204-pool-amd64-uyuni: amd64-deb
```

![image](https://github.com/user-attachments/assets/bfe947f4-571a-4b56-8c0a-d1c0e0835e1a)
![image](https://github.com/user-attachments/assets/c426511e-2b82-4f4d-8b3a-c3381bb3d10c)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port :

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
