### PR TITLE
add SLES15-SP5-LTSS channel families

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -253,6 +253,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -265,6 +266,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -277,6 +279,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             }
         ]
@@ -1216,6 +1219,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1228,6 +1232,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1240,6 +1245,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1252,6 +1258,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1264,6 +1271,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1276,6 +1284,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1288,6 +1297,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -1501,6 +1511,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1513,6 +1524,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1525,6 +1537,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -1537,6 +1550,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -2438,11 +2452,11 @@
         "release_type" : null,
         "arch" : "amd64",
         "friendly_name" : "Ubuntu 22.04",
-        "product_class" : "SLE-M-T-BETA",
+        "product_class" : "SLE-M-T",
         "cpe" : null,
         "free" : true,
         "description" : null,
-        "release_stage" : "beta",
+        "release_stage" : "released",
         "eula_url" : "",
         "product_type" : "base",
         "offline_predecessor_ids" : [
@@ -2683,6 +2697,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -2695,6 +2710,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -2707,6 +2723,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             }
         ]
@@ -2746,6 +2763,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2758,6 +2776,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2770,6 +2789,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2782,6 +2802,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2794,6 +2815,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2806,6 +2828,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2818,6 +2841,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -2857,6 +2881,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2869,6 +2894,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2881,6 +2907,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2893,6 +2920,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2905,6 +2933,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2917,6 +2946,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2929,6 +2959,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2941,6 +2972,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -2980,6 +3012,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -2992,6 +3025,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3004,6 +3038,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3016,6 +3051,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3028,6 +3064,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3040,6 +3077,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -3079,6 +3117,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3091,6 +3130,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3103,6 +3143,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3115,6 +3156,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -3154,6 +3196,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3166,6 +3209,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3178,6 +3222,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3190,6 +3235,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3202,6 +3248,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -3328,6 +3375,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             },
             {
@@ -3340,6 +3388,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "aarch64"
                 ]
             }
         ]
@@ -4029,6 +4078,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4041,6 +4091,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4053,6 +4104,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             }
         ]
@@ -4092,6 +4144,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4104,6 +4157,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             }
         ]
@@ -4143,6 +4197,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4155,6 +4210,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4167,6 +4223,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4179,6 +4236,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4191,6 +4249,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4203,6 +4262,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4215,6 +4275,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4227,6 +4288,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4239,6 +4301,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4251,6 +4314,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4263,6 +4327,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4275,6 +4340,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4287,6 +4353,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4299,6 +4366,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4311,6 +4379,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             },
             {
@@ -4323,6 +4392,7 @@
                 "autorefresh" : true,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             }
         ]
@@ -6146,6 +6216,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             }
         ]
@@ -6185,6 +6256,7 @@
                 "autorefresh" : false,
                 "installer_updates" : false,
                 "arch" : [
+                    "amd64"
                 ]
             }
         ]

--- a/susemanager-sync-data/channel_families.json
+++ b/susemanager-sync-data/channel_families.json
@@ -96,6 +96,10 @@
     "name" : "MicroOS for ARM64"
   },
   {
+    "label" : "MICROOS-PPC",
+    "name" : "MicroOS for PPC"
+  },
+  {
     "label" : "MICROOS-X86",
     "name" : "MicroOS for x86_64"
   },
@@ -196,6 +200,10 @@
     "name" : "SUSE Linux Enterprise Workstation Extension"
   },
   {
+    "label" : "SLES-12-SP5-LTSS-Extended-Security",
+    "name" : "SUSE Linux Enterprise Server LTSS Extended Security 12 SP5 x86_64"
+  },
+  {
     "label" : "SLES-ARM64",
     "name" : "SUSE Linux Enterprise Server (ARM64)"
   },
@@ -288,10 +296,6 @@
     "name" : "SUSE Linux Enterprise Server LTSS CORE 12 SP5 x86_64"
   },
   {
-    "label" : "SLES-12-SP5-LTSS-Extended-Security",
-    "name" : "SUSE Linux Enterprise Server LTSS Extended Security 12 SP5 x86_64"
-  },
-  {
     "label" : "SLES12-SP5-LTSS-PPC",
     "name" : "SUSE Linux Enterprise Server LTSS 12 SP5 PPC"
   },
@@ -382,6 +386,22 @@
   {
     "label" : "SLES15-SP4-LTSS-Z",
     "name" : "SUSE Linux Enterprise Server LTSS 15 SP4 Z-Series"
+  },
+  {
+    "label" : "SLES15-SP5-LTSS-ARM64",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP5 ARM64"
+  },
+  {
+    "label" : "SLES15-SP5-LTSS-PPC",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP5 PPC"
+  },
+  {
+    "label" : "SLES15-SP5-LTSS-X86",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP5 x86_64"
+  },
+  {
+    "label" : "SLES15-SP5-LTSS-Z",
+    "name" : "SUSE Linux Enterprise Server LTSS 15 SP5 Z-Series"
   },
   {
     "label" : "SLESMT",

--- a/susemanager-sync-data/susemanager-sync-data.changes.mc.Manager-5.0-sles15-sp5-ltss
+++ b/susemanager-sync-data/susemanager-sync-data.changes.mc.Manager-5.0-sles15-sp5-ltss
@@ -1,0 +1,3 @@
+- add SLES15-SP5-LTSS channel families
+- add MicroOS PPC channel family
+- set Ubuntu 22.04 to released


### PR DESCRIPTION
## What does this PR change?

- add SLES15-SP5-LTSS channel families
- add MicroOS PPC channel family
- set Ubuntu 22.04 to released

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25463

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
