### PR TITLE
Enhance mechanism to cleanup old Salt Bundle environment (bsc#1228690)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -27,7 +27,7 @@ mgr_salt_minion_inst:
 {%- if salt_minion_name == 'venv-salt-minion' %}
 rm_old_venv_python_env:
   cmd.run:
-    - name: /usr/lib/venv-salt-minion/bin/post_start_cleanup.sh
+    - name: SALT_HIGHSTATE=1 /usr/lib/venv-salt-minion/bin/post_start_cleanup.sh
     - onlyif: test -f /usr/lib/venv-salt-minion/bin/post_start_cleanup.sh
 {%- endif %}
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-bsc1228690
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-bsc1228690
@@ -1,0 +1,1 @@
+- Enhance mechanism to cleanup old Salt Bundle environment (bsc#1228690)


### PR DESCRIPTION
## What does this PR change?

This PR passes `SALT_HIGHSTATE=1` when calling `post_start_cleanup.sh` as part of the highstate. This way, we allow `post_start_cleanup.sh` script to detect when it is triggered by `venv-salt-minion-postinstall.service` or highstate.

This way, together with the changes in the `post_start_cleanup.sh` script done here: https://build.opensuse.org/request/show/1206496, we prevent an early cleanup of the environment by the timer when there is still running Salt Bundle upgrade action.

This helps to prevent the following exception when triggering a patch upgrade containing Salt Bundle plus lot of other patches:

```
The minion function caused an exception: Traceback (most recent call last):
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/minion.py", line 1917, in _thread_return
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/minion.py", line 1876, in _execute_job_function
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1234, in run
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1249, in _run_as
File "/usr/lib/venv-salt-minion/lib/python3.10/site-packages/salt/executors/venv.py", line 24, in execute
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1234, in run
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1249, in _run_as
File "/usr/lib/venv-salt-minion/lib/python3.10/site-packages/salt/executors/direct_call.py", line 10, in execute
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1234, in run
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1249, in _run_as
File "/usr/lib/venv-salt-minion/lib/python3.10/site-packages/salt/modules/state.py", line 833, in apply_
File "/usr/lib/venv-salt-minion/lib/python3.10/site-packages/salt/modules/state.py", line 1479, in sls
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/state.py", line 3555, in call_high
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/state.py", line 2723, in call_chunks
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/state.py", line 3245, in call_chunk
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/utils/decorators/state.py", line 45, in _func
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/state.py", line 2463, in call
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/state.py", line 1368, in check_refresh
File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/state.py", line 1316, in module_refresh
File "/usr/lib/venv-salt-minion/lib64/python3.10/importlib/__init__.py", line 168, in reload
ModuleNotFoundError: spec not found for the module 'site'
(code 1)
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no acceptance tests yet Salt Bundle upgrade**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24978

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
