### PR TITLE
UpdateAvailable notification parsing fix

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/NotificationMessage.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.domain.notification;
 
+import com.redhat.rhn.common.RhnRuntimeException;
 import com.redhat.rhn.domain.notification.types.ChannelSyncFailed;
 import com.redhat.rhn.domain.notification.types.ChannelSyncFinished;
 import com.redhat.rhn.domain.notification.types.CreateBootstrapRepoFailed;
@@ -140,7 +141,7 @@ public class NotificationMessage implements Serializable {
                 return new Gson().fromJson(getData(), UpdateAvailable.class);
             case PaygNotCompliantWarning:
                 return new Gson().fromJson(getData(), PaygNotCompliantWarning.class);
-            default: throw new RuntimeException("Notification type not found");
+            default: throw new RhnRuntimeException("Notification type not found");
         }
     }
 
@@ -249,6 +250,6 @@ public class NotificationMessage implements Serializable {
      * The enum type for a {@link NotificationMessage}
      */
     public enum NotificationMessageSeverity {
-        info, warning, error
+        INFO, WARNING, ERROR
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/ChannelSyncFailed.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/ChannelSyncFailed.java
@@ -59,7 +59,7 @@ public class ChannelSyncFailed implements NotificationData {
      */
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.error;
+        return NotificationMessage.NotificationMessageSeverity.ERROR;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/notification/types/ChannelSyncFinished.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/ChannelSyncFinished.java
@@ -54,7 +54,7 @@ public class ChannelSyncFinished implements NotificationData {
      */
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.info;
+        return NotificationMessage.NotificationMessageSeverity.INFO;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/notification/types/CreateBootstrapRepoFailed.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/CreateBootstrapRepoFailed.java
@@ -49,7 +49,7 @@ public class CreateBootstrapRepoFailed implements NotificationData {
      */
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.error;
+        return NotificationMessage.NotificationMessageSeverity.ERROR;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/notification/types/EndOfLifePeriod.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/EndOfLifePeriod.java
@@ -48,10 +48,10 @@ public class EndOfLifePeriod implements NotificationData {
         // Mark the notification as error 1 month before the actual expiration
         final LocalDate localEolDate = LocalDate.ofInstant(endOfLifeDate.toInstant(), ZoneId.systemDefault());
         if (ChronoUnit.MONTHS.between(localEolDate, LocalDate.now()) > -1) {
-            return NotificationMessage.NotificationMessageSeverity.error;
+            return NotificationMessage.NotificationMessageSeverity.ERROR;
         }
 
-        return NotificationMessage.NotificationMessageSeverity.warning;
+        return NotificationMessage.NotificationMessageSeverity.WARNING;
     }
 
     private boolean isExpired() {

--- a/java/code/src/com/redhat/rhn/domain/notification/types/OnboardingFailed.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/OnboardingFailed.java
@@ -57,7 +57,7 @@ public class OnboardingFailed implements NotificationData {
      */
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.error;
+        return NotificationMessage.NotificationMessageSeverity.ERROR;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/notification/types/PaygAuthenticationUpdateFailed.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/PaygAuthenticationUpdateFailed.java
@@ -42,7 +42,7 @@ public class PaygAuthenticationUpdateFailed implements NotificationData {
 
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.error;
+        return NotificationMessage.NotificationMessageSeverity.ERROR;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/types/PaygNotCompliantWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/PaygNotCompliantWarning.java
@@ -23,7 +23,7 @@ public class PaygNotCompliantWarning implements NotificationData {
 
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.warning;
+        return NotificationMessage.NotificationMessageSeverity.WARNING;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/types/StateApplyFailed.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/StateApplyFailed.java
@@ -64,7 +64,7 @@ public class StateApplyFailed implements NotificationData {
      */
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.error;
+        return NotificationMessage.NotificationMessageSeverity.ERROR;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
@@ -42,7 +42,7 @@ public class SubscriptionWarning implements NotificationData {
 
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.warning;
+        return NotificationMessage.NotificationMessageSeverity.WARNING;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
@@ -82,7 +82,7 @@ public class UpdateAvailable implements NotificationData {
 
     @Override
     public NotificationMessage.NotificationMessageSeverity getSeverity() {
-        return NotificationMessage.NotificationMessageSeverity.warning;
+        return NotificationMessage.NotificationMessageSeverity.WARNING;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
@@ -23,11 +23,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * Notification data for an update being available for the server.
  */
-public class UpdateAvailable implements NotificationData {
+public class UpdateAvailable implements NotificationData, Serializable {
 
     private static final LocalizationService LOCALIZATION_SERVICE = LocalizationService.getInstance();
     private static final Logger LOG = LogManager.getLogger(UpdateAvailable.class);
@@ -36,7 +37,7 @@ public class UpdateAvailable implements NotificationData {
 
     private final boolean mgr = !ConfigDefaults.get().isUyuni();
     private final String version = StringUtils.substringBeforeLast(ConfigDefaults.get().getProductVersion(), ".");
-    private final Runtime runtime;
+    private final transient Runtime runtime;
 
     /**
      * Constructor allowing to pass the runtime as argument.

--- a/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
@@ -45,7 +45,7 @@ class UpdateAvailableTest extends MockObjectTestCase {
     public void testPropertiesAndStrings() {
         UpdateAvailable notification = new UpdateAvailable(runtimeMock);
         assertEquals(NotificationType.UpdateAvailable, notification.getType());
-        assertEquals(NotificationMessage.NotificationMessageSeverity.warning, notification.getSeverity());
+        assertEquals(NotificationMessage.NotificationMessageSeverity.WARNING, notification.getSeverity());
         assertEquals("Updates are available.", notification.getSummary());
         if (ConfigDefaults.get().isUyuni()) {
             assertEquals("A new update for Uyuni is now available. For further details, please refer to the " +

--- a/java/spacewalk-java.changes.cbosdo.notification-fix
+++ b/java/spacewalk-java.changes.cbosdo.notification-fix
@@ -1,0 +1,1 @@
+- Fix parsing UpdateAvailable notifications (bsc#1228261)


### PR DESCRIPTION
## What does this PR change?
    
After the Java 17 update the Gson introspection raises an error when
parsing the runtime field. Since this field is only for testing, mark it
as transient to skip it during serialization and deserialization.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: For some reason the unit test I could come up with didn't trigger the error, only a real environment did.

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24905
Port(s): https://github.com/SUSE/spacewalk/pull/25471

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
