### PR TITLE
mark dmidecode and logrotate as optional for Liberty 7 LTSS

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -102,12 +102,13 @@ RES6 = [
     "openssh-clients",
 ]
 
-RES7 = [
-    "logrotate",
-    "venv-salt-minion",
-]
+RES7 = ["venv-salt-minion"]
 
-RES7_X86 = ["dmidecode"]
+RES7REQ = ["logrotate"]
+
+RES7OPT = ["logrotate*"]
+
+RES7_X86 = ["dmidecode*"]
 
 RES8 = [
     "redhat-rpm-config",
@@ -816,19 +817,19 @@ DATA = {
     "RES7-x86_64": {
         "PDID": [1251],
         "BETAPDID": [2065],
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
     },
     "SLL7-LTSS-x86_64": {
         "PDID": [2702, 1683],
         "BETAPDID": [2065],
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
     },
     "SLL7-OL-LTSS-x86_64": {
         "PDID": [2778, 1683],
         "BETAPDID": [2065],
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7OPT,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
     },
     "SLE-12-SP2-aarch64": {
@@ -1607,13 +1608,13 @@ DATA = {
     "centos-7-x86_64": {
         "PDID": [-12, 1683],
         "BETAPDID": [2065],
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/centos/7/bootstrap/",
     },
     "centos-7-aarch64": {
         "PDID": [-31, 2361],
         "BETAPDID": [2363],
-        "PKGLIST": RES7,
+        "PKGLIST": RES7 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/centos/7/bootstrap/",
     },
     "centos-8-x86_64": {
@@ -1635,17 +1636,17 @@ DATA = {
     },
     "centos-7-x86_64-uyuni": {
         "BASECHANNEL": "centos7-x86_64",
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/centos/7/bootstrap/",
     },
     "centos-7-ppc64le-uyuni": {
         "BASECHANNEL": "centos7-ppc64le",
-        "PKGLIST": RES7,
+        "PKGLIST": RES7 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/centos/7/bootstrap/",
     },
     "centos-7-aarch64-uyuni": {
         "BASECHANNEL": "centos7-aarch64",
-        "PKGLIST": RES7,
+        "PKGLIST": RES7 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/centos/7/bootstrap/",
     },
     "centos-8-x86_64-uyuni": {
@@ -1672,13 +1673,13 @@ DATA = {
     "oracle-7-x86_64": {
         "PDID": [-14, 1683],
         "BETAPDID": [2065],
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/oracle/7/bootstrap/",
     },
     "oracle-7-aarch64": {
         "PDID": [-28, 2361],
         "BETAPDID": [2363],
-        "PKGLIST": RES7,
+        "PKGLIST": RES7 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/oracle/7/bootstrap/",
     },
     "oracle-8-x86_64": {
@@ -1700,12 +1701,12 @@ DATA = {
     },
     "oracle-7-x86_64-uyuni": {
         "BASECHANNEL": "oraclelinux7-x86_64",
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/oracle/7/bootstrap/",
     },
     "oracle-7-aarch64-uyuni": {
         "BASECHANNEL": "oraclelinux7-aarch64",
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/oracle/7/bootstrap/",
     },
     "oracle-8-x86_64-uyuni": {
@@ -1743,23 +1744,23 @@ DATA = {
     "amazonlinux-2-x86_64": {
         "PDID": [-22, 1683],
         "BETAPDID": [2065],
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/amzn/2/bootstrap/",
     },
     "amazonlinux-2-aarch64": {
         "PDID": [-28, 2361],
         "BETAPDID": [2363],
-        "PKGLIST": RES7,
+        "PKGLIST": RES7 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/amzn/2/bootstrap/",
     },
     "amazonlinux-2-x86_64-uyuni": {
         "BASECHANNEL": "amazonlinux2-core-x86_64",
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/amzn/2/bootstrap/",
     },
     "amazonlinux-2-aarch64-uyuni": {
         "BASECHANNEL": "amazonlinux2-core-aarch64",
-        "PKGLIST": RES7,
+        "PKGLIST": RES7 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/amzn/2/bootstrap/",
     },
     "amazonlinux-2023-x86_64-uyuni": {
@@ -1787,12 +1788,12 @@ DATA = {
     "RHEL7-x86_64": {
         "PDID": [-7, 1683],
         "BETAPDID": [2065],
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
     },
     "RHEL7-x86_64-uyuni": {
         "BASECHANNEL": "rhel7-pool-uyuni-x86_64",
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/res/7/bootstrap/",
     },
     "SLE-ES8-x86_64": {
@@ -1831,12 +1832,12 @@ DATA = {
     },
     "alibaba-2-x86_64-uyuni": {
         "BASECHANNEL": "alibaba-2-x86_64",
-        "PKGLIST": RES7 + RES7_X86,
+        "PKGLIST": RES7 + RES7_X86 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/alibaba/2/bootstrap/",
     },
     "alibaba-2-aarch64-uyuni": {
         "BASECHANNEL": "alibaba-2-aarch64",
-        "PKGLIST": RES7,
+        "PKGLIST": RES7 + RES7REQ,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/alibaba/2/bootstrap/",
     },
     "almalinux-8-x86_64": {

--- a/susemanager/susemanager.changes.mc.Manager-5.0-res7ltss-optional-dmidecode
+++ b/susemanager/susemanager.changes.mc.Manager-5.0-res7ltss-optional-dmidecode
@@ -1,0 +1,1 @@
+- mark dmidecode and logrotate as optional for Liberty 7 LTSS (bsc#1226958)


### PR DESCRIPTION
## What does this PR change?

Mark additional packages as optional.
Liberty 7 LTSS for OL do not have all the packages in the repo and generating the bootstrap repo fails for this.
With marking them optional they can be ignored without producing error messages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25485

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
