### PR TITLE
Explicitly handle timeouts when syncing channels

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -406,6 +406,9 @@ When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
       log "#{time_spent / 60.to_i} minutes out of #{timeout / 60.to_i} waiting for '#{channel}' channel to be synchronized" if ((time_spent += checking_rate) % 60).zero?
       sleep checking_rate
     end
+  rescue Timeout::Error => e
+    log e.message
+    raise ScriptError, "Timeout occured while syncing channel: #{channel}"
   rescue StandardError => e
     log e.message
     unless $build_validation
@@ -445,6 +448,9 @@ When(/^I wait until all synchronized channels for "([^"]*)" have finished$/) do 
       log "#{time_spent / 60.to_i} minutes out of #{timeout / 60.to_i} waiting for '#{os_product_version}' channels to be synchronized" if ((time_spent += checking_rate) % 60).zero?
       sleep checking_rate
     end
+  rescue Timeout::Error => e
+    log e.message
+    raise ScriptError, "Timeout occured while syncing channels for: #{os_product_version}"
   rescue StandardError => e
     log e.message
     unless $build_validation


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/25102

This PR forces failures in the case of an explicit Timeout Error when trying to sync existing repositories.
Cases in which a repository does not exist should still be handled by the StandardError branch

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/25102
Port(s): 

- 5.0
- 4.3 (?)

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
