### PR TITLE
Bump Web UI version to 2024.10 and schema db upgrades for spacewalk and reportdb

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -63,7 +63,7 @@ web.version = 5.1.0 Alpha1
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni = 2024.09
+web.version.uyuni = 2024.10
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 


### PR DESCRIPTION
## What does this PR change?

Bump Web UI version to 2024.10 and schema db upgrades for spacewalk and reportdb

For the main schema: migrations are there and are correct
For reportdb: the package didn't change, it's not in tito-wrapper report:
```
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (adjust-webui-version_check-migration-paths_2024.10 *$)$ grep ^Version schema/spacewalk/susemanager-schema.spec 
Version:        5.1.0
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (adjust-webui-version_check-migration-paths_2024.10 *$)$ ls -la schema/spacewalk/upgrade/susemanager-schema-5.1.0-to-susemanager-schema-5.1.1/
total 8
drwxr-xr-x 1 raul raul   110 oct 10 15:14 .
drwxr-xr-x 1 raul raul 27078 oct 10 15:14 ..
-rw-r--r-- 1 raul raul  2206 oct 10 15:14 001-oval-taskomatic.sql
-rw-r--r-- 1 raul raul   412 oct 10 15:14 002-errata-view-optimization.sql
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (adjust-webui-version_check-migration-paths_2024.10 *$)$ ls -la schema/spacewalk/upgrade/susemanager-schema-5.0.12-to-susemanager-schema-5.1.0/
total 0
drwxr-xr-x 1 raul raul    16 oct 10 15:14 .
drwxr-xr-x 1 raul raul 27078 oct 10 15:14 ..
-rw-r--r-- 1 raul raul     0 oct 10 15:14 .gitkeep
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (adjust-webui-version_check-migration-paths_2024.10 *$)$ grep ^Version schema/reportdb/uyuni-reportdb-schema.spec 
Version:        5.1.0
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (adjust-webui-version_check-migration-paths_2024.10 *$)$ ls -la schema/reportdb/upgrade/uyuni-reportdb-schema-5.0.12-to-uyuni-reportdb-schema-5.1.0/
total 0
drwxr-xr-x 1 raul raul    16 oct 10 15:14 .
drwxr-xr-x 1 raul raul 10348 oct 10 15:14 ..
-rw-r--r-- 1 raul raul     0 oct 10 15:14 .gitkeep
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (adjust-webui-version_check-migration-paths_2024.10 $)$ ls -la schema/reportdb/upgrade/uyuni-reportdb-schema-5.1.0*
ls: cannot access 'schema/reportdb/upgrade/uyuni-reportdb-schema-5.1.0*': No such file or directory
```
I assume the path to upgrade from 5.0.X would be to 5.1.0 first and then to go on, and this already exists (but maybe I'm wrong).

## GUI diff

No difference.

Before: Version 2024.09

After: Version 2024.10

- [X] **DONE**

## Documentation
- 2024.10 documentation provided separately, see: https://build.opensuse.org/request/show/1206640
- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24829
Port(s):

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
