### PR TITLE
Prevent a crash on Liberty 6 and RHEL 6 clones (bsc#1231404)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/reboot_info.py
+++ b/susemanager-utils/susemanager-sls/src/modules/reboot_info.py
@@ -51,7 +51,8 @@ def reboot_required():
     elif __grains__["os_family"] == "RedHat":
         cmd = (
             "dnf -q needs-restarting -r"
-            if __grains__["osmajorrelease"] >= 8
+            # In RHEL6 and clones 'osmajorrelease' is a string
+            if int(__grains__["osmajorrelease"]) >= 8
             else "needs-restarting -r"
         )
         result = _check_cmd_exit_code(cmd, 1)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-bsc1231404
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-bsc1231404
@@ -1,0 +1,1 @@
+- Prevent a crash on "reboot_info" module for Liberty 6, RHEL 6 & clones (bsc#1231404)


### PR DESCRIPTION
## What does this PR change?

This PR just prevent a crash when scheduling "Package List Refresh" action, as `reboot_info.reboot_required` function was raising an Exception:

```
Error running 'reboot_info.reboot_required': Unable to run command '['dnf', '-q', 'needs-restarting', '-r']' with the context '......', reason: command not found
```

The reason is that `osmajorrelease` grain in old Salt 2016.11.10 (used in this OS) is rendered as string instead of integer, making the current logic not to work.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no active testing on rhel6 and clones**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25460

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
