### PR TITLE
Add wait channel sync for monitoring MU channels ( sle15sp4 MU )

### DIFF
--- a/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
+++ b/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
@@ -41,3 +41,7 @@ Feature: Add a Maintenance Update custom channel and the custom repositories for
     And I wait until button "Sync Now" becomes enabled
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled" text or "No repositories are currently associated with this channel" text
+
+  Scenario: Wait for running reposyncs to finish after adding custom channel for <client>
+    When I wait until the channel "sle15sp4_minion" has been synced
+    Then the "sle15sp4_minion" reposync logs should not report errors


### PR DESCRIPTION
## What does this PR change?

During monitoring add MU stage, we need sle15sp4 channels ( maybe also monitoring specific channels ? ).
Add the wait for reposync step to this stage so make sure we have the last packages. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port:
Issue: 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
