### PR TITLE
Feature: Retracted patches | Scenario: Installed retracted package should show icon in the system packages list | Scenario: Retracted package should not be available for upgrade | Scenario: Retracted patch should not affect any system

### DIFF
--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -20,6 +20,7 @@ Feature: Retracted patches
     And I click on the filter button until page does contain "rute-dummy" text
     Then the table row for "rute-dummy-2.1-1.1" should contain "retracted" icon
     When I remove package "rute-dummy" from this "sle_minion"
+    And I refresh packages list via spacecmd on "sle_minion"
     And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
 
   Scenario: Retracted package should not be available for installation
@@ -40,6 +41,7 @@ Feature: Retracted patches
     And I follow "Upgrade"
     Then I should not see a "rute-dummy-2.1-1.1" text
     When I remove package "rute-dummy" from this "sle_minion"
+    And I refresh packages list via spacecmd on "sle_minion"
     And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
 
   Scenario: Retracted patch should not affect any system
@@ -54,6 +56,7 @@ Feature: Retracted patches
     And I follow "Affected Systems"
     Then I should see a "No systems." text
     When I remove package "rute-dummy" from this "sle_minion"
+    And I refresh packages list via spacecmd on "sle_minion"
     And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
 
   Scenario: Target systems for stable packages should not be empty

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -961,10 +961,6 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-micro-5.5-updates-x86_64
         sle-manager-tools-for-micro5-pool-x86_64-5.5
         sle-manager-tools-for-micro5-updates-x86_64-5.5
-        suse-manager-retail-branch-server-5.0-pool-x86_64
-        suse-manager-retail-branch-server-5.0-updates-x86_64
-        suse-manager-proxy-5.0-pool-x86_64
-        suse-manager-proxy-5.0-updates-x86_64
       ],
     'sl-micro-6.0' =>
       %w[

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -961,6 +961,10 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-micro-5.5-updates-x86_64
         sle-manager-tools-for-micro5-pool-x86_64-5.5
         sle-manager-tools-for-micro5-updates-x86_64-5.5
+        suse-manager-retail-branch-server-5.0-pool-x86_64
+        suse-manager-retail-branch-server-5.0-updates-x86_64
+        suse-manager-proxy-5.0-pool-x86_64
+        suse-manager-proxy-5.0-updates-x86_64
       ],
     'sl-micro-6.0' =>
       %w[


### PR DESCRIPTION
## What does this PR change?

It makes the `min_retracted_patches.feature` passing, checkout https://github.com/SUSE/spacewalk/issues/25529 for more info.
```
uyuni-master-podman-ctl:~/spacewalk/testsuite # cucumber features/secondary/min_retracted_patches.feature
Using Ruby version: 3.3.5
Capybara APP Host: https://uyuni-master-podman-srv.mgr.suse.de:8888
Initializing a remote node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.6, Family: opensuse-leap
Activating HTTP API
Using the default profile...
# Copyright (c) 2021-2024 SUSE LLC
# Licensed under the terms of the MIT license.
# skip failing test in master to give us time to fix
@skip_if_github_validation @scope_retracted_patches
Feature: Retracted patches

  Scenario: Log in as org admin user # features/secondary/min_retracted_patches.feature:9
      This scenario ran at: 2024-10-15 10:49:11 +0200
    Given I am authorized            # features/step_definitions/navigation_steps.rb:562
      This scenario took: 14 seconds

  Scenario: Installed retracted package should show icon in the system packages list # features/secondary/min_retracted_patches.feature:12
      This scenario ran at: 2024-10-15 10:49:25 +0200
Initializing a remote node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname uyuni-master-podman-min-suse and FQDN uyuni-master-podman-min-suse.mgr.suse.de
Node: uyuni-master-podman-min-suse, OS Version: 15.5, Family: opensuse-leap
    When I install package "rute-dummy=2.1-1.1" on this "sle_minion"                 # features/step_definitions/command_steps.rb:922
    And I refresh packages list via spacecmd on "sle_minion"                         # features/step_definitions/command_steps.rb:1213
    And I wait until refresh package list on "sle_minion" is finished                # features/step_definitions/command_steps.rb:1228
    And I am on the "Software" page of this "sle_minion"                             # features/step_definitions/navigation_steps.rb:449
    And I follow "Packages"                                                          # features/step_definitions/navigation_steps.rb:299
    And I follow "List / Remove"                                                     # features/step_definitions/navigation_steps.rb:299
    And I enter "rute-dummy" as the filtered package name                            # features/step_definitions/navigation_steps.rb:867
    And I click on the filter button until page does contain "rute-dummy" text       # features/step_definitions/navigation_steps.rb:853
    Then the table row for "rute-dummy-2.1-1.1" should contain "retracted" icon      # features/step_definitions/navigation_steps.rb:495
    When I remove package "rute-dummy" from this "sle_minion"                        # features/step_definitions/command_steps.rb:964
    And I refresh packages list via spacecmd on "sle_minion"                         # features/step_definitions/command_steps.rb:1213
    And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd  # features/step_definitions/command_steps.rb:1279
      This scenario took: 25 seconds

  Scenario: Retracted package should not be available for installation         # features/secondary/min_retracted_patches.feature:26
      This scenario ran at: 2024-10-15 10:49:50 +0200
    When I am on the "Software" page of this "sle_minion"                      # features/step_definitions/navigation_steps.rb:449
    And I follow "Packages"                                                    # features/step_definitions/navigation_steps.rb:299
    And I follow "Install"                                                     # features/step_definitions/navigation_steps.rb:299
    And I enter "rute-dummy" as the filtered package name                      # features/step_definitions/navigation_steps.rb:867
    And I click on the filter button until page does contain "rute-dummy" text # features/step_definitions/navigation_steps.rb:853
    Then I should see a "rute-dummy-2.0-1.2" text                              # features/step_definitions/navigation_steps.rb:610
    And I should not see a "rute-dummy-2.1-1.1" text                           # features/step_definitions/navigation_steps.rb:670
      This scenario took: 13 seconds

  Scenario: Retracted package should not be available for upgrade                   # features/secondary/min_retracted_patches.feature:35
      This scenario ran at: 2024-10-15 10:50:03 +0200
    When I install old package "rute-dummy=2.0-1.2" on this "sle_minion"            # features/step_definitions/command_steps.rb:945
    And I refresh packages list via spacecmd on "sle_minion"                        # features/step_definitions/command_steps.rb:1213
    And I wait until refresh package list on "sle_minion" is finished               # features/step_definitions/command_steps.rb:1228
    And I am on the "Software" page of this "sle_minion"                            # features/step_definitions/navigation_steps.rb:449
    And I follow "Packages"                                                         # features/step_definitions/navigation_steps.rb:299
    And I follow "Upgrade"                                                          # features/step_definitions/navigation_steps.rb:299
    Then I should not see a "rute-dummy-2.1-1.1" text                               # features/step_definitions/navigation_steps.rb:670
    When I remove package "rute-dummy" from this "sle_minion"                       # features/step_definitions/command_steps.rb:964
    And I refresh packages list via spacecmd on "sle_minion"                        # features/step_definitions/command_steps.rb:1213
    And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd # features/step_definitions/command_steps.rb:1279
      This scenario took: 14 seconds

  Scenario: Retracted patch should not affect any system                            # features/secondary/min_retracted_patches.feature:47
      This scenario ran at: 2024-10-15 10:50:17 +0200
    When I install package "rute-dummy=2.0-1.2" on this "sle_minion"                # features/step_definitions/command_steps.rb:922
    And I refresh packages list via spacecmd on "sle_minion"                        # features/step_definitions/command_steps.rb:1213
    And I wait until refresh package list on "sle_minion" is finished               # features/step_definitions/command_steps.rb:1228
    And I follow the left menu "Software > Channel List > All"                      # features/step_definitions/navigation_steps.rb:354
    And I follow "Show All Child Channels"                                          # features/step_definitions/navigation_steps.rb:299
    And I follow "Fake-RPM-SUSE-Channel"                                            # features/step_definitions/navigation_steps.rb:299
    And I follow "Patches" in the content area                                      # features/step_definitions/navigation_steps.rb:314
    And I follow "rute-dummy-0817"                                                  # features/step_definitions/navigation_steps.rb:299
    And I follow "Affected Systems"                                                 # features/step_definitions/navigation_steps.rb:299
    Then I should see a "No systems." text                                          # features/step_definitions/navigation_steps.rb:610
    When I remove package "rute-dummy" from this "sle_minion"                       # features/step_definitions/command_steps.rb:964
    And I refresh packages list via spacecmd on "sle_minion"                        # features/step_definitions/command_steps.rb:1213
    And I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd # features/step_definitions/command_steps.rb:1279
      This scenario took: 13 seconds

  Scenario: Target systems for stable packages should not be empty # features/secondary/min_retracted_patches.feature:62
      This scenario ran at: 2024-10-15 10:50:30 +0200
    When I follow the left menu "Software > Channel List > All"    # features/step_definitions/navigation_steps.rb:354
    And I follow "Show All Child Channels"                         # features/step_definitions/navigation_steps.rb:299
    And I follow "Fake-RPM-SUSE-Channel"                           # features/step_definitions/navigation_steps.rb:299
    And I follow "Packages" in the content area                    # features/step_definitions/navigation_steps.rb:314
    And I follow "rute-dummy-2.0-1.2.x86_64"                       # features/step_definitions/navigation_steps.rb:299
    And I follow "Target Systems"                                  # features/step_definitions/navigation_steps.rb:299
    And I refresh page until I see "sle_minion" hostname as text   # features/step_definitions/salt_steps.rb:433
      This scenario took: 3 seconds

  Scenario: Target systems for retracted packages should be empty # features/secondary/min_retracted_patches.feature:71
      This scenario ran at: 2024-10-15 10:50:33 +0200
    When I follow the left menu "Software > Channel List > All"   # features/step_definitions/navigation_steps.rb:354
    And I follow "Show All Child Channels"                        # features/step_definitions/navigation_steps.rb:299
    And I follow "Fake-RPM-SUSE-Channel"                          # features/step_definitions/navigation_steps.rb:299
    And I follow "Packages" in the content area                   # features/step_definitions/navigation_steps.rb:314
    And I follow "rute-dummy-2.1-1.1.x86_64"                      # features/step_definitions/navigation_steps.rb:299
    And I follow "Target Systems"                                 # features/step_definitions/navigation_steps.rb:299
    Then I should not see "sle_minion" hostname                   # features/step_definitions/navigation_steps.rb:628
      This scenario took: 12 seconds

  Scenario: Retracted packages in the patch detail           # features/secondary/min_retracted_patches.feature:80
      This scenario ran at: 2024-10-15 10:50:45 +0200
    When I follow the left menu "Patches > Patch List > All" # features/step_definitions/navigation_steps.rb:354
    And I enter "dummy" as the filtered synopsis             # features/step_definitions/navigation_steps.rb:873
    And I click on the filter button                         # features/step_definitions/navigation_steps.rb:839
    And I follow "rute-dummy-0815"                           # features/step_definitions/navigation_steps.rb:299
    Then I should see a "Status: Retracted" text             # features/step_definitions/navigation_steps.rb:610
    When I go back                                           # features/step_definitions/navigation_steps.rb:253
    And I enter "dummy" as the filtered synopsis             # features/step_definitions/navigation_steps.rb:873
    And I click on the filter button                         # features/step_definitions/navigation_steps.rb:839
    And I follow "rute-dummy-0816"                           # features/step_definitions/navigation_steps.rb:299
    Then I should see a "Status: Stable" text                # features/step_definitions/navigation_steps.rb:610
    When I go back                                           # features/step_definitions/navigation_steps.rb:253
    And I enter "dummy" as the filtered synopsis             # features/step_definitions/navigation_steps.rb:873
    And I click on the filter button                         # features/step_definitions/navigation_steps.rb:839
    And I follow "rute-dummy-0817"                           # features/step_definitions/navigation_steps.rb:299
    Then I should see a "Status: Retracted" text             # features/step_definitions/navigation_steps.rb:610
      This scenario took: 6 seconds

  Scenario: Retracted packages in the patches list                              # features/secondary/min_retracted_patches.feature:97
      This scenario ran at: 2024-10-15 10:50:51 +0200
    When I follow the left menu "Patches > Patch List > All"                    # features/step_definitions/navigation_steps.rb:354
    And I enter "dummy" as the filtered synopsis                                # features/step_definitions/navigation_steps.rb:873
    And I click on the filter button                                            # features/step_definitions/navigation_steps.rb:839
    Then the table row for "rute-dummy-0815" should contain "retracted" icon    # features/step_definitions/navigation_steps.rb:495
    And the table row for "rute-dummy-0816" should not contain "retracted" icon # features/step_definitions/navigation_steps.rb:495
    And the table row for "rute-dummy-0817" should contain "retracted" icon     # features/step_definitions/navigation_steps.rb:495
      This scenario took: 1 seconds

  Scenario: Retracted patches in the channel patches list                       # features/secondary/min_retracted_patches.feature:105
      This scenario ran at: 2024-10-15 10:50:52 +0200
    When I follow the left menu "Software > Channel List > All"                 # features/step_definitions/navigation_steps.rb:354
    And I follow "Show All Child Channels"                                      # features/step_definitions/navigation_steps.rb:299
    And I follow "Fake-RPM-SUSE-Channel"                                        # features/step_definitions/navigation_steps.rb:299
    And I follow "Patches" in the content area                                  # features/step_definitions/navigation_steps.rb:314
    Then the table row for "rute-dummy-0815" should contain "retracted" icon    # features/step_definitions/navigation_steps.rb:495
    And the table row for "rute-dummy-0816" should not contain "retracted" icon # features/step_definitions/navigation_steps.rb:495
    And the table row for "rute-dummy-0817" should contain "retracted" icon     # features/step_definitions/navigation_steps.rb:495
      This scenario took: 2 seconds

  Scenario: Retracted packages in the channel packages list                                # features/secondary/min_retracted_patches.feature:114
      This scenario ran at: 2024-10-15 10:50:54 +0200
    When I follow the left menu "Software > Channel List > All"                            # features/step_definitions/navigation_steps.rb:354
    And I follow "Show All Child Channels"                                                 # features/step_definitions/navigation_steps.rb:299
    And I follow "Fake-RPM-SUSE-Channel"                                                   # features/step_definitions/navigation_steps.rb:299
    And I follow "Packages" in the content area                                            # features/step_definitions/navigation_steps.rb:314
    Then the table row for "rute-dummy-2.0-1.1.x86_64" should contain "retracted" icon     # features/step_definitions/navigation_steps.rb:495
    Then the table row for "rute-dummy-2.0-1.2.x86_64" should not contain "retracted" icon # features/step_definitions/navigation_steps.rb:495
    Then the table row for "rute-dummy-2.1-1.1.x86_64" should contain "retracted" icon     # features/step_definitions/navigation_steps.rb:495
      This scenario took: 2 seconds

  Scenario: SSM: Retracted package should not be available for installation # features/secondary/min_retracted_patches.feature:123
      This scenario ran at: 2024-10-15 10:50:56 +0200
    When I follow the left menu "Systems > System List > All"               # features/step_definitions/navigation_steps.rb:354
    And I click on the clear SSM button                                     # features/step_definitions/navigation_steps.rb:835
    And I check the "sle_minion" client                                     # features/step_definitions/navigation_steps.rb:479
    And I follow the left menu "Systems > System Set Manager > Overview"    # features/step_definitions/navigation_steps.rb:354
    And I follow "Packages" in the content area                             # features/step_definitions/navigation_steps.rb:314
    And I follow "Install"                                                  # features/step_definitions/navigation_steps.rb:299
    And I follow "Fake-RPM-SUSE-Channel"                                    # features/step_definitions/navigation_steps.rb:299
    Then I should see a "rute-dummy-2.0-1.2" text                           # features/step_definitions/navigation_steps.rb:610
    And I should not see a "rute-dummy-2.1-1.1" text                        # features/step_definitions/navigation_steps.rb:670
    And I click on the clear SSM button                                     # features/step_definitions/navigation_steps.rb:835
      This scenario took: 2 seconds

12 scenarios (12 passed)
102 steps (102 passed)
1m46.694s
```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25529
Port(s): https://github.com/SUSE/spacewalk/pull/25530

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
