### PR TITLE
Improve starting ipmi_sim program

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -579,16 +579,16 @@ When(/^the server starts mocking an IPMI host$/) do
   end
   server.run('chmod +x /etc/ipmi/fake_ipmi_host.sh', verbose: true, check_errors: true)
   # Check if ipmi_sim is already running
-  if server.run('pgrep -f ipmi_sim', verbose: false, check_errors: false).empty?
+  if server.run('pgrep -f ipmi_sim', verbose: false, check_errors: false)[1] != 0
     server.run('ipmi_sim -n < /dev/null > /dev/null &', verbose: true, check_errors: true)
   else
-    puts 'ipmi_sim is already running; skipping startup.'
+    log 'ipmi_sim is already running; skipping startup.'
   end
 end
 
 When(/^the server stops mocking an IPMI host$/) do
   get_target('server').run('pkill ipmi_sim')
-  get_target('server').run('pkill --full fake_ipmi_host.sh || :')
+  get_target('server').run('pkill --full fake_ipmi_host.sh || :', verbose: false, check_errors: false)
 end
 
 When(/^the controller starts mocking a Redfish host$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -578,12 +578,12 @@ When(/^the server starts mocking an IPMI host$/) do
     raise ScriptError, 'File injection failed' unless success
   end
   server.run('chmod +x /etc/ipmi/fake_ipmi_host.sh', verbose: true, check_errors: true)
-  server.run('ipmi_sim -n < /dev/null > /dev/null &', verbose: true, check_errors: true)
+  server.run('nohup ipmi_sim -n > /var/log/ipmi_sim.log 2>&1 &', verbose: true, check_errors: true)
 end
 
 When(/^the server stops mocking an IPMI host$/) do
   get_target('server').run('pkill ipmi_sim')
-  get_target('server').run('pkill fake_ipmi_host.sh || :')
+  get_target('server').run("ps aux | grep [f]ake_ipmi_host.sh | awk '{print $2}' | xargs kill")
 end
 
 When(/^the controller starts mocking a Redfish host$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -579,10 +579,10 @@ When(/^the server starts mocking an IPMI host$/) do
   end
   server.run('chmod +x /etc/ipmi/fake_ipmi_host.sh', verbose: true, check_errors: true)
   # Check if ipmi_sim is already running
-  if server.run('pgrep -f ipmi_sim', verbose: false, check_errors: false)[1] != 0
-    server.run('ipmi_sim -n < /dev/null > /dev/null &', verbose: true, check_errors: true)
-  else
+  if server.run('pgrep -f ipmi_sim', verbose: false, check_errors: false)[1].zero?
     log 'ipmi_sim is already running; skipping startup.'
+  else
+    server.run('ipmi_sim -n < /dev/null > /dev/null &', verbose: true, check_errors: true)
   end
 end
 


### PR DESCRIPTION
## Update

I have this issue:
```hcl
uyuni-ci-master-podman-server:~ # mgrctl exec -i 'pkill --full fake_ipmi_host.sh || :'
uyuni-ci-master-podman-server:~ # echo $?
143
```
So I ignore the errors for `get_target('server').run('pkill --full fake_ipmi_host.sh')`

## Context

If one of the IPMI Power management features is failing, it will keep `ipmi_sim` process running. The next feature will try to start again this `ipmi_sim` process. In this situation, the command `ipmi_sim -n < /dev/null > /dev/null &` will be executed and wait for the previous process to stop ( nothing will stop the process ). The command will not return any code and the ssh connection will die. This situation will not be detected by the ssh timeout and the testsuite will stay stuck forever at this stage.

## What does this PR change?

Use nohup command to start the service. This command will return immediately a result even if the process is already running.
Improve the IPMI mocking cleanup. From my test, `pkill fake_ipmi_host.sh || :` was not killing successfully `fake_ipmi_host`. ( detected by rerunning several time the same features. )

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port: 
 - 5.0: https://github.com/SUSE/spacewalk/pull/25807
 - 4.3: https://github.com/SUSE/spacewalk/pull/25808
Issue: 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
