### PR TITLE
Expose salt event publisher for Saline

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -17,6 +17,9 @@ RUN chmod a+x /usr/bin/healthcheck.sh
 # Copy timezone link update service
 COPY timezone_alignment.service /usr/lib/systemd/system/
 
+# Copy Salt Event Publisher service used by Saline
+COPY salt-event-publisher.service /usr/lib/systemd/system/
+
 COPY remove_unused.sh .
 RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf
 
@@ -71,7 +74,8 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     sssd-ad \
     sssd-ipa \
     sssd-krb5 \
-    sssd-tools
+    sssd-tools \
+    socat
 
 RUN sed -i 's/sysctl kernel.shmmax/#sysctl kernel.shmmax/g' /usr/bin/uyuni-setup-reportdb
 
@@ -106,7 +110,8 @@ RUN echo "cat /etc/motd" >/etc/sh.shrc.local
 RUN systemctl enable prometheus-node_exporter; \
     systemctl enable uyuni-setup; \
     systemctl enable timezone_alignment; \
-    systemctl enable sssd;
+    systemctl enable sssd; \
+    systemctl enable salt-event-publisher;
 
 # Provide tool to synchronize package and configuration files to persistent volumes
 COPY uyuni-configfiles-sync /usr/bin

--- a/containers/server-image/salt-event-publisher.service
+++ b/containers/server-image/salt-event-publisher.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Salt Event Publisher
+After=network.target salt-master.service
+
+[Service]
+Type=simple
+User=salt
+SyslogIdentifier=salt-event-publisher
+# Check if salt master event publisher IPC socket is availabe.
+# `socat` can start if the unix socket is not present,
+# but will not be able to read the events once salt-master get started
+ExecStartPre=test -S /run/salt/master/master_event_pub.ipc
+ExecStart=/usr/bin/socat TCP4-LISTEN:4512,reuseaddr,fork UNIX-CONNECT:/run/salt/master/master_event_pub.ipc
+Restart=always
+RestartSec=5s
+SuccessExitStatus=0 143
+RestartForceExitStatus=143
+
+[Install]
+WantedBy=multi-user.target

--- a/containers/server-image/server-image.changes.vzhestkov.expose-salt-event-publisher
+++ b/containers/server-image/server-image.changes.vzhestkov.expose-salt-event-publisher
@@ -1,0 +1,1 @@
+- Expose salt event bus with salt-event-publisher.service


### PR DESCRIPTION
## What does this PR change?

To include `Saline` with the separate container to the server it's required to expose salt event publisher socket.
Originally it's published with unix socket, but in case of changing the transport to `tcp` it's listening on `127.0.0.1` and it's hardcoded, so `socat` is used here to expose the socket as `tcp`.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: TBD once Saline will be included to the server deployment.

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/24751

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
