### PR TITLE
Feature: Coexistence with user-defined states | Scenario: Create a user-defined state | Scenario: Trigger highstate from API | Scenario: Cleanup: remove user-defined state and the file it created

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -639,6 +639,7 @@ When(/^I install a user-defined state for "([^"]*)" on the server$/) do |host|
 
   # make both files readeable by salt
   get_target('server').run('chgrp salt /srv/salt/*')
+  get_target('server').run('chmod 644 /srv/salt/*')
 end
 
 When(/^I uninstall the user-defined state from the server$/) do

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -961,10 +961,6 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-micro-5.5-updates-x86_64
         sle-manager-tools-for-micro5-pool-x86_64-5.5
         sle-manager-tools-for-micro5-updates-x86_64-5.5
-        suse-manager-retail-branch-server-5.0-pool-x86_64
-        suse-manager-retail-branch-server-5.0-updates-x86_64
-        suse-manager-proxy-5.0-pool-x86_64
-        suse-manager-proxy-5.0-updates-x86_64
       ],
     'sl-micro-6.0' =>
       %w[

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -961,6 +961,10 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-micro-5.5-updates-x86_64
         sle-manager-tools-for-micro5-pool-x86_64-5.5
         sle-manager-tools-for-micro5-updates-x86_64-5.5
+        suse-manager-retail-branch-server-5.0-pool-x86_64
+        suse-manager-retail-branch-server-5.0-updates-x86_64
+        suse-manager-proxy-5.0-pool-x86_64
+        suse-manager-proxy-5.0-updates-x86_64
       ],
     'sl-micro-6.0' =>
       %w[


### PR DESCRIPTION
## What does this PR change?

It has too little privileges to be applied in the following scenarios. This state were omitted:

```
uyuni-server:/srv/salt # tail -f /var/log/salt/master
    return callable(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/fileserver/roots.py", line 305, in file_hash
    ret["hsum"] = salt.utils.hashutils.get_hash(path, __opts__["hash_type"])
  File "/usr/lib/python3.6/site-packages/salt/utils/hashutils.py", line 165, in get_hash
    with salt.utils.files.fopen(path, "rb") as ifile:
  File "/usr/lib/python3.6/site-packages/salt/utils/files.py", line 393, in fopen
    f_handle = open(*args, **kwargs)  # pylint: disable=resource-leakage
PermissionError: [Errno 13] Permission denied: '/srv/salt/top.sls'
...
uyuni-server:/srv/salt # ls -la
total 8
drwxr-xr-x. 1 root salt  58 Oct 17 12:21 .
drwxr-xr-x. 1 root root 172 Oct 15 16:23 ..
-rw-------. 1 root salt  77 Oct 17 12:21 top.sls
-rw-r--r--. 1 root salt 148 Oct 17 12:21 user_defined_state.sls
```

The following changes makes `features/secondary/min_salt_user_states.feature` passing:
```
uyuni-master-podman-ctl:~/spacewalk/testsuite # cucumber features/secondary/min_salt_user_states.feature 
Using Ruby version: 3.3.5
Capybara APP Host: https://uyuni-master-podman-srv.mgr.suse.de:8888
Initializing a remote node for 'server'.
Host 'server' is alive with determined hostname uyuni-master-podman-srv and FQDN uyuni-master-podman-srv.mgr.suse.de
Node: uyuni-master-podman-srv, OS Version: 15.6, Family: opensuse-leap
Activating HTTP API
Using the default profile...
# Copyright (c) 2018-2024 SUSE LLC
# Licensed under the terms of the MIT license.
@skip_if_github_validation @scope_salt
Feature: Coexistence with user-defined states

  Scenario: Log in as org admin user # features/secondary/min_salt_user_states.feature:8
      This scenario ran at: 2024-10-17 12:54:19 +0200
    Given I am authorized            # features/step_definitions/navigation_steps.rb:562
      This scenario took: 13 seconds

  Scenario: Create a user-defined state                                                      # features/secondary/min_salt_user_states.feature:11
      This scenario ran at: 2024-10-17 12:54:32 +0200
Initializing a remote node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname uyuni-master-podman-min-suse and FQDN uyuni-master-podman-min-suse.mgr.suse.de
Node: uyuni-master-podman-min-suse, OS Version: 15.5, Family: opensuse-leap
    Given I am on the Systems overview page of this "sle_minion"                             # features/step_definitions/navigation_steps.rb:432
    When I follow "States" in the content area                                               # features/step_definitions/navigation_steps.rb:314
Initializing a remote node for 'localhost'.
Host 'localhost' is alive with determined hostname uyuni-master-podman-ctl and FQDN uyuni-master-podman-ctl.mgr.suse.de
Node: uyuni-master-podman-ctl, OS Version: 15.5, Family: opensuse-leap
    And I install a user-defined state for "sle_minion" on the server                        # features/step_definitions/command_steps.rb:621
    And I follow "Highstate" in the content area                                             # features/step_definitions/navigation_steps.rb:314
    And I click on "Show full highstate output"                                              # features/step_definitions/navigation_steps.rb:260
    And I wait for "6" seconds                                                               # features/step_definitions/common_steps.rb:19
    Then I should see a "user_defined_state" or "running as PID" text in element "highstate" # features/step_definitions/navigation_steps.rb:710
      This scenario took: 11 seconds

  Scenario: Trigger highstate from API                                    # features/secondary/min_salt_user_states.feature:20
      This scenario ran at: 2024-10-17 12:54:43 +0200
    When I schedule a highstate for "sle_minion" via API                  # features/step_definitions/api_common.rb:46
    And I wait until event "Apply highstate scheduled" is completed       # features/step_definitions/common_steps.rb:164
    Then file "/tmp/test_user_defined_state" should exist on "sle_minion" # features/step_definitions/file_management_steps.rb:26
      This scenario took: 22 seconds

  Scenario: Cleanup: remove user-defined state and the file it created       # features/secondary/min_salt_user_states.feature:25
      This scenario ran at: 2024-10-17 12:55:05 +0200
    When I follow "States" in the content area                               # features/step_definitions/navigation_steps.rb:314
    And I uninstall the user-defined state from the server                   # features/step_definitions/command_steps.rb:645
    And I uninstall the managed file from "sle_minion"                       # features/step_definitions/command_steps.rb:649
    And I follow "Highstate" in the content area                             # features/step_definitions/navigation_steps.rb:314
    And I click on "Show full highstate output"                              # features/step_definitions/navigation_steps.rb:260
    And I wait for "6" seconds                                               # features/step_definitions/common_steps.rb:19
    Then I should not see a "user_defined_state" text in element "highstate" # features/step_definitions/navigation_steps.rb:704
      This scenario took: 18 seconds

4 scenarios (4 passed)
18 steps (18 passed)
1m3.943s
```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25559
Port(s): https://github.com/SUSE/spacewalk/pull/25560

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
