### PR TITLE
Add aarch64 and ppc64 grub loaders

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -28,6 +28,8 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     ${PRODUCT_PATTERN_PREFIX}_retail \
     billing-data-service \
     grub2-x86_64-efi \
+    grub2-arm64-efi \
+    grub2-powerpc-ieee1275 \
     ed \
     susemanager-tftpsync \
     golang-github-prometheus-node_exporter \

--- a/containers/server-image/server-image.changes.oholecek.add_missing_grub_efis
+++ b/containers/server-image/server-image.changes.oholecek.add_missing_grub_efis
@@ -1,0 +1,1 @@
+- add aarch64 and ppc64 grub loaders (bsc#1231762)


### PR DESCRIPTION
## What does this PR change?

Grub was missing loaders for other architectures then AMD64. This PR adds loaders for AArch64 and PPC64le.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25562
Port(s): https://github.com/SUSE/spacewalk/pull/25561

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
