### PR TITLE
QE: Use the same e-mail for all users created through the test framework

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -142,7 +142,7 @@ Given(/^I create a user with name "([^"]*)" and password "([^"]*)"/) do |user, p
   $current_password = password
   next if $api_test.user.list_users.to_s.include? user
 
-  $api_test.user.create(user, password, user, user, "#{user}@mail.com")
+  $api_test.user.create(user, password, user, user, 'galaxy-noise@suse.de')
   roles = %w[org_admin channel_admin config_admin system_group_admin activation_key_admin image_admin]
   roles.each do |role|
     $api_test.user.add_role(user, role)


### PR DESCRIPTION
## What does this PR change?

Having a different e-mail for each of the generated users per feature is causing a "Too many recipients" issue.

Therefore, we will re-use the same e-mail.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-5.0 https://github.com/SUSE/spacewalk/pull/25579
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/25580

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
