### PR TITLE
QE: use the correct virgo-dummy version

### DIFF
--- a/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_rhlike_salt_install_package_and_patch.feature
@@ -53,7 +53,7 @@ Feature: Install a patch on the Red Hat-like minion via Salt through the UI
     And I click on "Apply Patches"
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text
-    And I wait for "virgo-dummy-2.0-1.1" to be installed on "rhlike_minion"
+    And I wait for "virgo-dummy-2.0-1.2" to be installed on "rhlike_minion"
 
   Scenario: Install a package on the Red Hat-like minion
     When I follow "Software" in the content area


### PR DESCRIPTION
## What does this PR change?

Self-explanatory. We check for `virgo-dummy-2.0-1.1`, the package we actually install through the patch is `virgo-dummy-2.0-1.2
`
## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Port(s) - check if needed

- 4.3:
- 5.0:

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
