### PR TITLE
Removing blue text and gaps in rhn/users/CreateUser

### DIFF
--- a/java/code/webapp/WEB-INF/pages/user/create/usercreate.jsp
+++ b/java/code/webapp/WEB-INF/pages/user/create/usercreate.jsp
@@ -163,8 +163,6 @@ function toggleAsterisk() {
                 checked="checked"
               </c:if>/>
               <c:out value="${defaultLocale.localizedName}" />
-              <br />
-              <br />
             </div>
           </div>
         <c:forEach var="item" items="${supportedLocales}">
@@ -176,7 +174,7 @@ function toggleAsterisk() {
               <c:if test="${item.key == currentLocale}">
                 checked="checked"
               </c:if>/>
-            <span class="text-info"><strong><c:out value="${item.value.localizedName}" /></strong></span>
+            <span><strong><c:out value="${item.value.localizedName}" /></strong></span>
           </div>
           <c:if test="${counter == 1}">
             </div>
@@ -210,8 +208,6 @@ function toggleAsterisk() {
                                     </c:if>/>
                             <c:out value="${defaultDocsLocale.localizedName}" />
                         </div>
-                        </br>
-                        </br>
                     </div>
                     <c:set var="counter" value="0"/>
                     <c:forEach var="item" items="${supportedDocsLocales}">
@@ -223,7 +219,7 @@ function toggleAsterisk() {
                                     <c:if test="${item.key == currentDocsLocale}">
                                         checked="checked"
                                     </c:if>/>
-                            <span class="text-info"><strong><c:out value="${item.value.localizedName}" /></strong></span>
+                            <span><strong><c:out value="${item.value.localizedName}" /></strong></span>
                         </div>
                         <c:if test="${counter == 1}">
                             </div>


### PR DESCRIPTION
## What does this PR change?
Removing blue text and gaps in rhn/users/CreateUser

## GUI diff
change the checkbox label color seen in issue #8763 to the default text-color instead of blue
also removes some <br> tags to remove gaps between elements

## Documentation
- No documentation needed: this only changes styling

## Test coverage
- No tests: already covered

## Links

Issue(s): #8763

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

