### PR TITLE
Add productname api

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -668,7 +668,7 @@ public class ConfigDefaults {
      * @return the java hostname
      */
     public String getJavaHostname() {
-        return Config.get().getString("java.hostname", "localhost");
+        return Config.get().getString(SERVER_HOSTNAME, "localhost");
     }
 
     /**
@@ -693,7 +693,7 @@ public class ConfigDefaults {
      * @return true is this is an Uyuni or Spacewalk instance.
      */
     public boolean isSpacewalk() {
-        return SPACEWALK.contains(Config.get().getString(PRODUCT_NAME));
+        return SPACEWALK.contains(getProductName());
     }
 
     /**
@@ -702,6 +702,13 @@ public class ConfigDefaults {
      */
     public boolean isUyuni() {
         return isSpacewalk();
+    }
+
+    /**
+     * @return return the product name
+     */
+    public String getProductName() {
+        return Config.get().getString(PRODUCT_NAME, "");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/ApiHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/ApiHandler.java
@@ -68,6 +68,18 @@ public class ApiHandler extends BaseHandler {
     }
 
     /**
+     * Returns the server product name.
+     * @return Returns the server product name.
+     *
+     * @apidoc.doc Returns the server product name.
+     * @apidoc.returntype #param("string", "product name")
+     */
+    @ReadOnly
+    public String productName() {
+        return ConfigDefaults.get().getProductName();
+    }
+
+    /**
      * Returns the api version. Called as: api.get_version
      * @return the api version.
      *

--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -126,6 +126,7 @@ public class HttpApiRegistry {
         return Set.of(
             "/rhn/manager/api/api/getVersion",
             "/rhn/manager/api/api/systemVersion",
+            "/rhn/manager/api/api/productName",
             "/rhn/manager/api/org/createFirst"
         );
     }

--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -122,11 +122,11 @@ public class LoginController {
             model.put("request_method", reqMethod);
         }
         model.put("isUyuni", ConfigDefaults.get().isUyuni());
-        model.put("title", Config.get().getString(ConfigDefaults.PRODUCT_NAME) + " - Sign In");
+        model.put("title", ConfigDefaults.get().getProductName() + " - Sign In");
         model.put("validationErrors", Json.GSON.toJson(LoginHelper.validateDBVersion()));
         model.put("schemaUpgradeRequired", Json.GSON.toJson(LoginHelper.isSchemaUpgradeRequired()));
         model.put("webVersion", ConfigDefaults.get().getProductVersion());
-        model.put("productName", Config.get().getString(ConfigDefaults.PRODUCT_NAME));
+        model.put("productName", ConfigDefaults.get().getProductName());
         model.put("customHeader", Config.get().getString("java.custom_header"));
         model.put("customFooter", Config.get().getString("java.custom_footer"));
         model.put("legalNote", Config.get().getString("java.legal_note"));

--- a/java/code/src/com/suse/scc/client/SCCRequestFactory.java
+++ b/java/code/src/com/suse/scc/client/SCCRequestFactory.java
@@ -14,7 +14,6 @@
  */
 package com.suse.scc.client;
 
-import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 
 import org.apache.http.client.methods.HttpGet;
@@ -72,7 +71,7 @@ public class SCCRequestFactory {
         request.addHeader("SMS", uuid != null ? uuid : "undefined");
 
         // overwrite the default
-        request.addHeader("User-Agent", Config.get().getString(ConfigDefaults.PRODUCT_NAME) + "/" +
+        request.addHeader("User-Agent", ConfigDefaults.get().getProductName() + "/" +
                 ConfigDefaults.get().getProductVersion());
 
         // add additional headers from the config

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -14,7 +14,6 @@
  */
 package com.suse.scc.client;
 
-import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.http.HttpClientAdapter;
 import com.redhat.rhn.manager.content.ProductTreeEntry;
@@ -211,7 +210,7 @@ public class SCCWebClient implements SCCClient {
         request.addHeader("SMS", uuid != null ? uuid : "undefined");
 
         // overwrite the default
-        request.addHeader("User-Agent", Config.get().getString(ConfigDefaults.PRODUCT_NAME) + "/" +
+        request.addHeader("User-Agent", ConfigDefaults.get().getProductName() + "/" +
                 ConfigDefaults.get().getProductVersion());
         if (LOG.isDebugEnabled()) {
             Arrays.stream(request.getAllHeaders()).forEach(h -> LOG.debug(h.toString()));

--- a/java/spacewalk-java.changes.mc.Manager-5.0-fix-reportdb-update-with-container
+++ b/java/spacewalk-java.changes.mc.Manager-5.0-fix-reportdb-update-with-container
@@ -1,0 +1,1 @@
+- introduce API endpoint to get the product name

--- a/schema/spacewalk/common/tables/rhnActionApplyStates.sql
+++ b/schema/spacewalk/common/tables/rhnActionApplyStates.sql
@@ -27,6 +27,10 @@ CREATE TABLE rhnActionApplyStates
                          DEFAULT ('N') NOT NULL
                          CONSTRAINT rhn_act_apply_states_test_ck
                              CHECK (test in ('Y','N')),
+    direct           CHAR(1)
+                         DEFAULT ('N') NOT NULL
+                         CONSTRAINT rhn_act_apply_states_direct_ck
+                             CHECK (test in ('Y','N')),
     created          TIMESTAMPTZ
                          DEFAULT (current_timestamp) NOT NULL,
     modified         TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes.mc.Manager-5.0-fix-reportdb-update-with-container
+++ b/schema/spacewalk/susemanager-schema.changes.mc.Manager-5.0-fix-reportdb-update-with-container
@@ -1,0 +1,1 @@
+- store direct call request in action details

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/002-rhnActionApplyStates.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/002-rhnActionApplyStates.sql
@@ -1,0 +1,1 @@
+ALTER TABLE rhnActionApplyStates ADD COLUMN IF NOT EXISTS direct CHAR(1) DEFAULT ('N') NOT NULL CONSTRAINT rhn_act_apply_states_direct_ck CHECK (test in ('Y', 'N'));

--- a/susemanager-utils/susemanager-sls/Makefile.python
+++ b/susemanager-utils/susemanager-sls/Makefile.python
@@ -17,6 +17,11 @@ __pytest ::
 	$(call install_pytest)
 	cd src/tests; pytest --disable-warnings --tb=native --color=yes -v
 
+junit_pytest ::
+	$(call update_pip_env)
+	$(call install_pytest)
+	cd src/tests; pytest -v --junit-xml /manager/susemanager-utils/susemanager-sls/reports/susemanager-sls.xml
+
 docker_pylint ::
 	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_BASE)-pgsql /bin/sh -c "cd /manager/susemanager-utils/susemanager-sls/; make -f Makefile.python __pylint"
 

--- a/susemanager-utils/testing/automation/susemanager-sls-tests.sh
+++ b/susemanager-utils/testing/automation/susemanager-sls-tests.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+SCRIPT=$(basename ${0})
+
+if [ -z ${PRODUCT+x} ];then
+    VPRODUCT="VERSION.Uyuni"
+else
+    VPRODUCT="VERSION.${PRODUCT}"
+fi
+
+while getopts 'P:h' option
+do
+    case ${option} in
+        P) VPRODUCT="VERSION.${OPTARG}" ;;
+        h) echo "Usage ${SCRIPT} [-P PRODUCT]";exit 2;;
+    esac
+done
+
+HERE=`dirname $0`
+
+if [ ! -f ${HERE}/${VPRODUCT} ];then
+   echo "${VPRODUCT} does not exist"
+   exit 3
+fi
+
+echo "Loading ${VPRODUCT}"
+. ${HERE}/${VPRODUCT}
+GITROOT=`readlink -f ${HERE}/../../../`
+
+INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CMD="cd /manager/susemanager-utils/susemanager-sls/; make -f Makefile.python junit_pytest"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
+
+docker pull $REGISTRY/$PGSQL_CONTAINER
+echo docker run --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
+docker run --rm=true -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
+if [ $? -ne 0 ]; then
+   EXIT=1
+fi
+
+exit $EXIT


### PR DESCRIPTION
## What does this PR change?

Forward porting parts of https://github.com/SUSE/spacewalk/pull/25586 which should stay in master.
The reportdb handling will be handled in a different PR.

This introduce only the new API endpoint for the product name and the database column for direct call
as it is specified in 5.0

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Partial Port(s) of : https://github.com/SUSE/spacewalk/pull/25586

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
