### PR TITLE
Ensure the reporting database username is lowercase

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -4092,7 +4092,10 @@ public class SystemManager extends BaseManager {
                 return existingCredentials;
             })
             .orElseGet(() -> {
-                String username = "hermes_" + RandomStringUtils.random(8, 0, 0, true, false, null, new SecureRandom());
+                String randomSuffix = RandomStringUtils.random(8, 0, 0, true, false, null, new SecureRandom());
+                // Ensure the username is stored lowercase in the database, since the script uyuni-setup-reportdb-user
+                // will convert it to lowercase anyway
+                String username = "hermes_" + randomSuffix.toLowerCase();
 
                 ReportDBCredentials reportCredentials = CredentialsFactory.createReportCredentials(username, password);
                 CredentialsFactory.storeCredentials(reportCredentials);

--- a/java/spacewalk-java.changes.mackdk.reportdb-ensure-lowercase-username
+++ b/java/spacewalk-java.changes.mackdk.reportdb-ensure-lowercase-username
@@ -1,0 +1,1 @@
+- Ensure the reporting db uses a lowercase username (bsc#1220494)

--- a/schema/spacewalk/susemanager-schema.changes.mackdk.reportdb-ensure-lowercase-username
+++ b/schema/spacewalk/susemanager-schema.changes.mackdk.reportdb-ensure-lowercase-username
@@ -1,0 +1,1 @@
+- Ensure the reporting db uses a lowercase username (bsc#1220494)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/000-convert-reportdb-users-to-lowercase.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.1-to-susemanager-schema-5.1.2/000-convert-reportdb-users-to-lowercase.sql
@@ -1,0 +1,13 @@
+--
+-- Copyright (c) 2024 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+UPDATE susecredentials
+   SET username = LOWER(username)
+ WHERE type = 'reportcreds';


### PR DESCRIPTION
## What does this PR change?

This PR make sure the username we generate for the reporting database is always lowercase. This prevents a mismatch between java, bash and salt.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/23817
Ports(s): https://github.com/SUSE/spacewalk/pull/25617 https://github.com/SUSE/spacewalk/pull/25449

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
