### PR TITLE
QE: refresh packages list before CVE audit

### DIFF
--- a/testsuite/features/secondary/min_cve_audit.feature
+++ b/testsuite/features/secondary/min_cve_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2024 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion
@@ -13,9 +13,13 @@ Feature: CVE Audit on SLE Salt Minions
 
   Scenario: Pre-requisite: downgrade milkyway-dummy to lower version
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
-    And I install old package "milkyway-dummy-1.0" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
-    And I follow the left menu "Admin > Task Schedules"
+    And I install old package "milkyway-dummy-1.0" on this "sle_minion"
+    And I refresh packages list via spacecmd on "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
+
+  Scenario: Schedule errata cache refresh
+    When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
     And I click on "Single Run Schedule"


### PR DESCRIPTION
## What does this PR change?

This PR adds a packages list refresh after installing the old package otherwise the system is not aware of its presence on the minion and does not suggest the patch for it after a CVE audit.

It also move the errata cache refresh to its own scenario, as I think that should not be considered strictly part of the pre-requisite one.


## GUI diff

- None

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- Cucumber tests were modified

- [ ] **DONE**

## Links

Port(s): 

- 4.3:
- 5.0:

- [ ] **DONE**

## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
