### PR TITLE
Rubocop Rakefile fixes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,4 +7,3 @@ Uyuni follows a rolling release model, so it is always the next upcoming version
 ## Reporting a Vulnerability
 
 Please report any security vulnerabilities by creating a [security advisory](https://github.com/uyuni-project/uyuni/security/advisories/new). We will be reviewing your report, get back to you after evaluation and happily give you credits for your help with making Uyuni more secure.
-ASD

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,4 @@ Uyuni follows a rolling release model, so it is always the next upcoming version
 ## Reporting a Vulnerability
 
 Please report any security vulnerabilities by creating a [security advisory](https://github.com/uyuni-project/uyuni/security/advisories/new). We will be reviewing your report, get back to you after evaluation and happily give you credits for your help with making Uyuni more secure.
+ASD

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -219,6 +219,7 @@ namespace :jenkins do
     minions = args[:instances]
     minions.each do |minion|
       next if minion.include?('proxy') or minion.include?('monitoring')
+
       # WORKAROUND: renaming should be removed once this issue is done https://github.com/SUSE/spacewalk/issues/25591
       modified_client = minion.gsub(/ssh_minion$/, 'sshminion')
       Rake::Task['jenkins:generate_rake_run_step'].invoke(
@@ -268,10 +269,10 @@ namespace :jenkins do
     minions = args[:instances]
     minions.each do |minion|
       next if minion.include?('proxy') || minion.include?('monitoring')
+
       # WORKAROUND: renaming should be removed once this issue is done https://github.com/SUSE/spacewalk/issues/25591
       modified_client = minion.gsub(/ssh_minion$/, 'sshminion')
 
-      
       Rake::Task['jenkins:generate_rake_run_step'].invoke(
         '_smoke_tests',
         File.basename(minion, '.feature'),

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -271,6 +271,7 @@ namespace :jenkins do
       # WORKAROUND: renaming should be removed once this issue is done https://github.com/SUSE/spacewalk/issues/25591
       modified_client = minion.gsub(/ssh_minion$/, 'sshminion')
 
+      
       Rake::Task['jenkins:generate_rake_run_step'].invoke(
         '_smoke_tests',
         File.basename(minion, '.feature'),


### PR DESCRIPTION
## What does this PR change?

Solves the issue with the following result from rubocop running pipeline result:
```
+ export PRODUCT=SUSE-Manager
+ PRODUCT=SUSE-Manager
+ gitarro.ruby2.5 -r SUSE/spacewalk -c ruby_rubocop -d rubocop checkstyle -f testsuite/ -t /var/lib/jenkins/workspace/manager-prs-ruby_rubocop-pipeline/jenkins_pipelines/manager_prs/tests_files/rubocop.sh -g /var/lib/jenkins/workspace/manager-prs-ruby_rubocop-pipeline -u https://ci.suse.de/job/manager-prs-ruby_rubocop-pipeline/58493/ -P 25633
Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
/usr/lib64/ruby/gems/2.5.0/gems/faraday-0.17.3/lib/faraday/upload_io.rb:65: warning: constant ::UploadIO is deprecated
/usr/lib64/ruby/gems/2.5.0/gems/faraday-0.17.3/lib/faraday/upload_io.rb:66: warning: constant ::Parts is deprecated
==============================
TITLE_PR: Rubocop Rakefile fixes 4.3, NR: 25633
DESCRIPTION:
Backport of https://github.com/uyuni-project/uyuni/pull/9404
==============================
success
[TESTREQUIRED=true] PR requires test
Cloning into '/var/lib/jenkins/workspace/manager-prs-ruby_rubocop-pipeline/spacewalk1729758688_5'...
Updating files:  54% (7973/14719)
Updating files:  55% (8096/14719)
Updating files:  56% (8243/14719)
Updating files:  57% (8390/14719)
Updating files:  58% (8538/14719)
Updating files:  59% (8685/14719)
Updating files:  60% (8832/14719)
Updating files:  61% (8979/14719)
Updating files:  62% (9126/14719)
Updating files:  63% (9273/14719)
Updating files:  64% (9421/14719)
Updating files:  65% (9568/14719)
Updating files:  66% (9715/14719)
Updating files:  67% (9862/14719)
Updating files:  68% (10009/14719)
Updating files:  69% (10157/14719)
Updating files:  70% (10304/14719)
Updating files:  71% (10451/14719)
Updating files:  72% (10598/14719)
Updating files:  73% (10745/14719)
Updating files:  74% (10893/14719)
Updating files:  75% (11040/14719)
Updating files:  76% (11187/14719)
Updating files:  77% (11334/14719)
Updating files:  78% (11481/14719)
Updating files:  79% (11629/14719)
Updating files:  80% (11776/14719)
Updating files:  81% (11923/14719)
Updating files:  82% (12070/14719)
Updating files:  83% (12217/14719)
Updating files:  84% (12364/14719)
Updating files:  85% (12512/14719)
Updating files:  86% (12659/14719)
Updating files:  87% (12806/14719)
Updating files:  88% (12953/14719)
Updating files:  89% (13100/14719)
Updating files:  90% (13248/14719)
Updating files:  91% (13395/14719)
Updating files:  92% (13542/14719)
Updating files:  93% (13689/14719)
Updating files:  94% (13836/14719)
Updating files:  95% (13984/14719)
Updating files:  96% (14131/14719)
Updating files:  97% (14278/14719)
Updating files:  98% (14425/14719)
Updating files:  99% (14572/14719)
Updating files: 100% (14719/14719)
Updating files: 100% (14719/14719), done.

running rubocop on step files
Inspecting 46 files
..............................................

46 files inspected, no offenses detected
```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25634
Port(s):
* 4.3 https://github.com/SUSE/spacewalk/pull/25633
* 5.0 https://github.com/SUSE/spacewalk/pull/25632

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
