### PR TITLE
QE: correctly upgrade Salt in product migrations

### DIFF
--- a/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_minion_migration.feature
@@ -30,12 +30,6 @@ Feature: Migrate a SLES 15 SP3 Salt minion to 15 SP4
     Then I wait until I see "SUSE Linux Enterprise Server 15 SP4" text, refreshing the page
     And vendor change should be enabled for product migration on "sle15sp3_minion"
 
-  Scenario: Install the latest Salt on this minion
-    When I migrate the non-SUMA repositories on "sle15sp3_minion"
-    And I enable repositories before installing Salt on this "sle15sp3_minion"
-    And I install Salt packages from "sle15sp3_minion"
-    And I disable repositories after installing Salt on this "sle15sp3_minion"
-
   Scenario: Subscribe the SLES minion to a SLES 15 SP4 child channel
     Given I am on the Systems overview page of this "sle15sp3_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
@@ -46,12 +46,6 @@ Feature: Migrate a SLES 15 SP3 Salt SSH minion to 15 SP4
     Then I should see a "SUSE Linux Enterprise Server 15 SP4" text
     And vendor change should be enabled for product migration on "sle15sp3_ssh_minion"
 
-  Scenario: Install the latest Salt on this SSH minion
-    When I migrate the non-SUMA repositories on "sle15sp3_ssh_minion"
-    And I enable repositories before installing Salt on this "sle15sp3_ssh_minion"
-    And I install Salt packages from "sle15sp3_ssh_minion"
-    And I disable repositories after installing Salt on this "sle15sp3_ssh_minion"
-
   Scenario: Subscribe the SSH-managed SLES minion to a SLES 15 SP4 child channel
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
@@ -7,6 +7,21 @@ Feature: Migrate a SLES 15 SP3 Salt SSH minion to 15 SP4
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
+  # pristine images for SSH minions use an old version of OS Salt
+  # Product Migration will be possible only if we update to latest
+  Scenario: Prerequisite: update OS Salt to the latest version
+    Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
+    When I follow "Software" in the content area
+    And I follow "Packages"
+    And I follow "Upgrade"
+    And I enter "salt" as the filtered package name
+    And I click on the filter button
+    And I click on "Select All"
+    And I click on "Upgrade Packages"
+    And I click on "Confirm"
+    Then I should see a "packages upgrades have been scheduled" text
+    And I wait until event "Package Install/Upgrade scheduled" is completed
+
   Scenario: Migrate this SSH minion to SLE 15 SP4
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
     When I follow "Software" in the content area


### PR DESCRIPTION
## What does this PR change?

It takes care of installing the latest OS Salt on the SLE 15 SP3 SSH minion we use to test product migration.
This is needed because we use a pristine image with an old version of it and the Product Migration feature requires the latest to be installed.

It also removes scenarios relying on a Salt file that is not present on the SLES 15 SP3 minions.
`/root/salt` and the `repos` Salt states are only found on the server 

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Port(s): 

- 4.3: https://github.com/SUSE/spacewalk/pull/25655
- 5.0: https://github.com/SUSE/spacewalk/pull/25656

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
