### PR TITLE
Set default rpm package summary value if it's missing

### DIFF
--- a/python/spacewalk/server/importlib/packageImport.py
+++ b/python/spacewalk/server/importlib/packageImport.py
@@ -367,7 +367,8 @@ class PackageImport(ChannelPackageSubscription):
 
         # fix encoding issues in package summary and description
         package["description"] = self._fix_encoding(package["description"])
-        package["summary"] = self._fix_encoding(package["summary"]).rstrip()
+        package["summary"] = self._fix_encoding(package["summary"])
+        package["summary"] = package["summary"].rstrip() if package["summary"] else ""
 
         if package["product_files"] is not None:
             for prodFile in package["product_files"]:

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.rpmimport-fix
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.rpmimport-fix
@@ -1,0 +1,1 @@
+- Set default rpm package summary if it's missing (bsc#1232530)


### PR DESCRIPTION
## What does this PR change?

An RPM package may not set any summary in the RPM header. Technically, this is an invalid RPM package, but reposync can handle this case.

- [ ] **DONE**

## Documentation
- No documentation needed: **Internal bugfix**


- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **Internal bugfix**


- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25668
Port(s): 

- 4.3: https://github.com/SUSE/spacewalk/pull/25801
- 5.0: https://github.com/SUSE/spacewalk/pull/25995

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
