### PR TITLE
Add check after ssh reboot for venv-salt-minion service

### DIFF
--- a/testsuite/features/build_validation/init_clients/slemicro51_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro51_minion.feature
@@ -30,6 +30,7 @@ Feature: Bootstrap a SLE Micro 5.1 Salt minion
   # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
   Scenario: Reboot the SLE Micro 5.1 minion through SSH
     When I reboot the "slemicro51_minion" host through SSH, waiting until it comes back
+    Then service "venv-salt-minion" is active on "slemicro51_minion"
 
   Scenario: Check the new bootstrapped SLE Micro 5.1 minion in System Overview page
     When I wait until onboarding is completed for "slemicro51_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro52_minion.feature
@@ -30,6 +30,7 @@ Feature: Bootstrap a SLE Micro 5.2 Salt minion
   # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
   Scenario: Reboot the SLE Micro 5.2 minion through SSH
     When I reboot the "slemicro52_minion" host through SSH, waiting until it comes back
+    Then service "venv-salt-minion" is active on "slemicro52_minion"
 
   Scenario: Check the new bootstrapped SLE Micro 5.2 minion in System Overview page
     When I wait until onboarding is completed for "slemicro52_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro53_minion.feature
@@ -30,6 +30,7 @@ Feature: Bootstrap a SLE Micro 5.3 Salt minion
   # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
   Scenario: Reboot the SLE Micro 5.3 minion through SSH
     When I reboot the "slemicro53_minion" host through SSH, waiting until it comes back
+    Then service "venv-salt-minion" is active on "slemicro53_minion"
 
   Scenario: Check the new bootstrapped SLE Micro 5.3 minion in System Overview page
     When I wait until onboarding is completed for "slemicro53_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro54_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro54_minion.feature
@@ -30,6 +30,7 @@ Feature: Bootstrap a SLE Micro 5.4 Salt minion
   # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
   Scenario: Reboot the SLE Micro 5.4 minion through SSH
     When I reboot the "slemicro54_minion" host through SSH, waiting until it comes back
+    Then service "venv-salt-minion" is active on "slemicro54_minion"
 
   Scenario: Check the new bootstrapped SLE Micro 5.4 minion in System Overview page
     When I wait until onboarding is completed for "slemicro54_minion"

--- a/testsuite/features/build_validation/init_clients/slemicro55_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slemicro55_minion.feature
@@ -30,6 +30,7 @@ Feature: Bootstrap a SLE Micro 5.5 Salt minion
   # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
   Scenario: Reboot the SLE Micro 5.5 minion through SSH
     When I reboot the "slemicro55_minion" host through SSH, waiting until it comes back
+    Then service "venv-salt-minion" is active on "slemicro55_minion"
 
   Scenario: Check the new bootstrapped SLE Micro 5.5 minion in System Overview page
     When I wait until onboarding is completed for "slemicro55_minion"

--- a/testsuite/features/build_validation/init_clients/slmicro60_minion.feature
+++ b/testsuite/features/build_validation/init_clients/slmicro60_minion.feature
@@ -29,6 +29,7 @@ Feature: Bootstrap a SL Micro 6.0 Salt minion
   # This change was implemented due to intermittent errors with automatic reboots, which could occur before Salt could relay the results of applying the bootstrap salt state.
   Scenario: Reboot the SL Micro 6.0 minion through SSH
     When I reboot the "slmicro60_minion" host through SSH, waiting until it comes back
+    Then service "venv-salt-minion" is active on "slmicro60_minion"
 
   Scenario: Check the new bootstrapped SL Micro 6.0 minion in System Overview page
     When I wait until onboarding is completed for "slmicro60_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1597,6 +1597,7 @@ end
 When(/^I reboot the "([^"]*)" if it is a transactional system$/) do |host|
   if transactional_system?(host)
     step %(I reboot the "#{host}" minion through the web UI)
+    step %(I should not see a "There is a pending transaction for this system, please reboot it to activate the changes." text)
   end
 end
 


### PR DESCRIPTION
## Context

During 5.0.2, I can see that sometime I still have the Pending for reboot message when looking at the screenshot.
In the code, we are rebooting the slemicro after each actions so I added a step to detect this message after reboot.
Those changes are mainly for improving our test coverage.

## What does this PR change?

Add check after ssh reboot for venv-salt-minion service
Add check after reboot by web interface to see if pending message visible.

## GUI diff


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered


- [x] **DONE**

## Links

Port(s): 
 - 5.0 : https://github.com/SUSE/spacewalk/pull/25687
 - 4.3 : https://github.com/SUSE/spacewalk/pull/25688

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
