### PR TITLE
KRB cannot use KEYRING ccache type in container

### DIFF
--- a/containers/server-image/krb5.conf
+++ b/containers/server-image/krb5.conf
@@ -15,8 +15,8 @@ includedir  /etc/rhn/krb5.conf.d
     # fail if "verify_ap_req_nofail" is set to true. If it is set to false and the client machine
     # does not have a keytab, the verification is skipped.
     verify_ap_req_nofail = true
-#   default_realm = EXAMPLE.COM
-    default_ccache_name = KEYRING:persistent:%{uid}
+    # KEYRING type cannot be used inside container, explicitely set krb 1.20 default
+    default_ccache_name = FILE:/tmp/krb5cc_%{uid}
     # move default keytab to the persistent /etc/rhn/krb5.conf.d directory
     default_keytab_name = FILE:/etc/rhn/krb5.conf.d/krb5.keytab
 

--- a/containers/server-image/server-image.changes.oholecek.fix-krb-ccache
+++ b/containers/server-image/server-image.changes.oholecek.fix-krb-ccache
@@ -1,0 +1,1 @@
+- use FILE: type for krb5 ccache


### PR DESCRIPTION
## What does this PR change?

Use FILE type which is ccache default anyway.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
