### PR TITLE
Prepare packages for SUSE Manager 5.1

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -226,7 +226,7 @@ java.mgr_sync_max_connections = 4
 java.max_changelog_entries = 20
 
 # Determins which product tree variation to use.
-java.product_tree_tag = SUMA5.0
+java.product_tree_tag = SUMA5.1
 
 # If true, login is enabled via Single Sign-On (SSO)
 java.sso = false

--- a/java/spacewalk-java.changes.mc.prepare51
+++ b/java/spacewalk-java.changes.mc.prepare51
@@ -1,0 +1,1 @@
+- prepare package for SUSE Manager 5.1

--- a/java/spacewalk-java.changes.mc.prepare51
+++ b/java/spacewalk-java.changes.mc.prepare51
@@ -1,1 +1,1 @@
-- prepare package for SUSE Manager 5.1
+- Prepare package for SUSE Multi-Linux Manager 5.1

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -550,6 +550,8 @@ install -m 644 conf/rhn_java_sso.conf %{buildroot}%{_datadir}/rhn/config-default
 # Adjust product tree tag
 %if 0%{?is_opensuse}
 sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Uyuni/' %{buildroot}%{_datadir}/rhn/config-defaults/rhn_java.conf
+%else
+sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Beta/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
 %endif
 # Adjust languages
 sed -i -e '/# NOTE: for the RPMs this is defined at the SPEC!/d' %{buildroot}%{_datadir}/rhn/config-defaults/rhn_java.conf

--- a/java/tito.props
+++ b/java/tito.props
@@ -5,5 +5,5 @@ salt-netapi-client=0.21
 salt-netapi-client=0.21
 
 [conf/rhn_java.conf]
-java.min_schema_version=5.0.8
-java.min_report_schema_version=5.0.5
+java.min_schema_version=5.1.2
+java.min_report_schema_version=5.1.2

--- a/python/spacewalk/spacewalk-backend.changes.mc.prepare51
+++ b/python/spacewalk/spacewalk-backend.changes.mc.prepare51
@@ -1,0 +1,1 @@
+- require 5.1 database schema

--- a/python/spacewalk/tito.props
+++ b/python/spacewalk/tito.props
@@ -1,2 +1,2 @@
 [rhn-conf/rhn_server_xmlrpc.conf]
-min_schema_version=5.0.8
+min_schema_version=5.1.2


### PR DESCRIPTION
## What does this PR change?

- enable beta client tools usage
- set product_tree_tag to SUMA5.1
- require 5.1 database schema versions

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24491

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
