### PR TITLE
QE: Kiwi compressed images

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -19,7 +19,7 @@
 
         <rpm-excludedocs>true</rpm-excludedocs>
 
-        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="false" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
+        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
         <type boot="isoboot/suse-SLES12" image="iso"/>
         <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"/>
     </preferences>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -19,7 +19,7 @@
 
         <rpm-excludedocs>true</rpm-excludedocs>
 
-        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="false" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
+        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
         <type boot="isoboot/suse-SLES12" image="iso"/>
         <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"/>
     </preferences>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -19,7 +19,7 @@
 
         <rpm-excludedocs>true</rpm-excludedocs>
 
-        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="false" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
+        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
         <type boot="isoboot/suse-SLES12" image="iso"/>
         <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"/>
     </preferences>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -19,7 +19,7 @@
 
         <rpm-excludedocs>true</rpm-excludedocs>
 
-        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="false" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
+        <type boot="saltboot/suse-SLES12" bootloader="grub2" checkprebuilt="true" compressed="true" filesystem="ext3" fsmountoptions="acl" fsnocheck="true" image="pxe" kernelcmdline="quiet"/>
         <type boot="isoboot/suse-SLES12" image="iso"/>
         <type boot="oemboot/suse-SLES12" filesystem="ext3" image="oem" installiso="true"/>
     </preferences>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -18,7 +18,7 @@
         <hwclock>utc</hwclock>
 
         <rpm-excludedocs>true</rpm-excludedocs>
-        <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
+        <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
 
     <drivers>


### PR DESCRIPTION
## What does this PR change?

Card: https://github.com/SUSE/spacewalk/issues/25658

In our new MUs 5.0.2 and 4.3.14 we announce that the POS images will be compressed.
That's done just by a change in the kiwi profiles, there is no product code changed.
But the customers are using a set of kiwi profiles different than those that we use in our test framework, therefore we need to adapt our kiwi profiles too.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
