### PR TITLE
Assign default reviewers for the workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,9 @@
 
 # Uyuni Code Owners
 
+# Workflows reviewers
+.github/workflows @uyuni-project/workflows-reviewers
+
 # Release Engineering
 rel-eng/ @uyuni-project/release-engineering
 tito.props @uyuni-project/release-engineering


### PR DESCRIPTION
## What does this PR change?

Assign default reviewers for the workflows.

We should probably add more contributors. If you have ideas, please ping me and I will add them to https://github.com/orgs/uyuni-project/teams/workflows-reviewers/members

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: `CODEOWNERS`changes

- [x] **DONE**

## Test coverage
- No tests:  `CODEOWNERS`changes

- [x] **DONE**

## Links

As agreed at https://github.com/SUSE/spacewalk/issues/25344

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
