### PR TITLE
Use the correct input field when upgrading OS Salt during product migration

### DIFF
--- a/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/sle15sp3_ssh_minion_migration.feature
@@ -14,12 +14,12 @@ Feature: Migrate a SLES 15 SP3 Salt SSH minion to 15 SP4
     When I follow "Software" in the content area
     And I follow "Packages"
     And I follow "Upgrade"
-    And I enter "salt" as the filtered package name
+    And I enter "salt" as the filtered latest package
     And I click on the filter button
     And I click on "Select All"
     And I click on "Upgrade Packages"
     And I click on "Confirm"
-    Then I should see a "packages upgrades have been scheduled" text
+    Then I should see a "package upgrades have been scheduled" text
     And I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Migrate this SSH minion to SLE 15 SP4

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -874,6 +874,12 @@ When(/^I enter "([^"]*)" as the filtered package name$/) do |input|
   find('input[placeholder=\'Filter by Package Name: \']').set(input)
 end
 
+When(/^I enter "([^"]*)" as the filtered latest package$/) do |input|
+  raise 'Package name is not set' if input.empty?
+
+  find('input[placeholder=\'Filter by Latest Package: \']').set(input)
+end
+
 When(/^I enter "([^"]*)" as the filtered synopsis$/) do |input|
   find('input[placeholder=\'Filter by Synopsis: \']').set(input)
 end


### PR DESCRIPTION
## What does this PR change?

As the title implies, the placeholder text for the input to be used when selecting pkgs to upgrade is slightly different and we need a step for it.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- Cucumber tests were modified

- [ ] **DONE**

## Links

Port(s): 

- 4.3:
- 5.0:

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
