### PR TITLE
Fix wrong master key on rebootstrap

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -295,6 +295,12 @@ salt-minion-key-pem:
       - salt-minion-package
 {%- endif %}
 
+# On bootstapping the minion which was registered to the other master before,
+# the master public key must be removed from the minion to prevent key verification fails.
+salt-minion-master-pub-wipe:
+  file.absent:
+    - name: {{ salt_config_dir }}/pki/minion/minion_master.pub
+
 {%- if not transactional %}
 {{ salt_minion_name }}:
   service.running:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-wrong-master-key-on-rebootstrap
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.vzhestkov.fix-wrong-master-key-on-rebootstrap
@@ -1,0 +1,1 @@
+- Remove master public key on bootstrapping to prevent possible issues.


### PR DESCRIPTION
## What does this PR change?

In case if the minion was registered before for the other master on bootstrapping it will not be able to connect to the master due to key verification fail.

Bootstrapping with the script was already fixed with https://github.com/uyuni-project/uyuni/pull/8967

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
