### PR TITLE
QI: Moving reporting of sync duration to the end of the feature and fixing a wrong type.

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -68,7 +68,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 SP4 x86_64" product has been added
     Then the SLE15 SP4 product should be added
     When I wait until all synchronized channels for "sles15-sp4" have finished
-    And I report the synchronization duration for "sles15-sp4"
 
 @scc_credentials
 @uyuni
@@ -101,7 +100,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then the SLE15 SP4 product should be added
     When I use spacewalk-common-channel to add channel "sles15-sp4-devel-uyuni-client" with arch "x86_64"
     And I wait until all synchronized channels for "sles15-sp4" have finished
-    And I report the synchronization duration for "sles15-sp4"
     # TODO: Refactor the scenarios in order to not require a full synchronization of SLES 15 SP4 product in Uyuni
     # When I kill running spacewalk-repo-sync for "sles15-sp4"
 
@@ -186,3 +184,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Trigger a refresh of the products synched from SCC
     When I execute mgr-sync refresh
+
+@scc_credentials
+  Scenario: Report the synchronization duration for SLES 15 SP4
+    When I report the synchronization duration for "sles15-sp4"

--- a/testsuite/features/support/quality_intelligence.rb
+++ b/testsuite/features/support/quality_intelligence.rb
@@ -20,7 +20,7 @@ class QualityIntelligence
   # @param time [Integer] the time to complete the bootstrap in seconds
   # @return [void]
   def push_bootstrap_duration(system, time)
-    @metrics_collector_handler.push_metrics(QI, 'system_bootstrap_duration_seconds', time, { 'system' => system, 'environment' => @environment })
+    @metrics_collector_handler.push_metrics(QI, 'system_bootstrap_duration_seconds', time, { :system => system, :environment => @environment })
   end
 
   # Report the time to complete the onboarding of a system passed as parameter,
@@ -30,7 +30,7 @@ class QualityIntelligence
   # @param time [Integer] the time to complete the onboarding in seconds
   # @return [void]
   def push_onboarding_duration(system, time)
-    @metrics_collector_handler.push_metrics(QI, 'system_onboarding_duration_seconds', time, { 'system' => system, 'environment' => @environment })
+    @metrics_collector_handler.push_metrics(QI, 'system_onboarding_duration_seconds', time, { :system => system, :environment => @environment })
   end
 
   # Report the time to complete a synchronization of a product passed as parameter,
@@ -40,6 +40,6 @@ class QualityIntelligence
   # @param time [Integer] the time to complete the synchronization in seconds
   # @return [void]
   def push_synchronization_duration(product, time)
-    @metrics_collector_handler.push_metrics(QI, 'product_synch_duration_seconds', time, { 'product' => product, 'environment' => @environment })
+    @metrics_collector_handler.push_metrics(QI, 'product_synch_duration_seconds', time, { :system => product, :environment => @environment })
   end
 end


### PR DESCRIPTION
## What does this PR change?

- Moving of sync duration to the end of the feature
- Fix an issue with the parameter type into Prometheus client

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-5.0 https://github.com/SUSE/spacewalk/pull/25757

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
