### PR TITLE
Handle the different output depending the API protocol for event_details

### DIFF
--- a/testsuite/features/support/system_monitoring.rb
+++ b/testsuite/features/support/system_monitoring.rb
@@ -32,7 +32,10 @@ def last_onboarding_duration(host)
     onboarding_events = events.select { |event| event['summary'].include? 'certs, channels, packages' }
     last_event_id = onboarding_events.last['id']
     event_details = $api_test.system.get_event_details(system_id, last_event_id)
-    Time.parse(event_details['completed']) - Time.parse(event_details['picked_up'])
+    # Convert XMLRPC::DateTime to Ruby's Time if necessary
+    completed_time = event_details['completed'].is_a?(XMLRPC::DateTime) ? event_details['completed'].to_time : Time.parse(event_details['completed'])
+    picked_up_time = event_details['picked_up'].is_a?(XMLRPC::DateTime) ? event_details['picked_up'].to_time : Time.parse(event_details['picked_up'])
+    completed_time - picked_up_time
   rescue StandardError => e
     raise ScriptError, "Error extracting onboarding duration for #{host}.\n #{e.full_message}"
   end


### PR DESCRIPTION
## What does this PR change?

Handle the different output depending the API protocol for event_details

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
