### PR TITLE
Dedicated container for database

### DIFF
--- a/containers/server-postgresql-image/Dockerfile
+++ b/containers/server-postgresql-image/Dockerfile
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+#!BuildTag: uyuni/server-postgresql:latest
+
+ARG PG_BASE=registry.opensuse.org/opensuse/postgres:16
+# or ARG BASE=registry.suse.com/suse/postgres:16
+FROM $PG_BASE
+
+ADD --chown=root:root root.tar.gz /
+
+# LABELs
+ARG PRODUCT=Uyuni
+ARG VENDOR="Uyuni project"
+ARG URL="https://www.uyuni-project.org/"
+ARG REFERENCE_PREFIX="registry.opensuse.org/uyuni"
+
+# Build Service required labels
+# labelprefix=org.opensuse.uyuni.server-postgresql
+LABEL org.opencontainers.image.name=server-postgresql-image
+LABEL org.opencontainers.image.title="${PRODUCT} PostgreSQL container image"
+LABEL org.opencontainers.image.description="${PRODUCT} PostgreSQL container image"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opencontainers.image.vendor="${VENDOR}"
+LABEL org.opencontainers.image.url="${URL}"
+LABEL org.opencontainers.image.version=5.1.0
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opensuse.reference="${REFERENCE_PREFIX}/server-postgresql:${PRODUCT_VERSION}.%RELEASE%"
+# endlabelprefix
+LABEL org.uyuni.version="${PRODUCT_VERSION}"
+
+ENTRYPOINT ["/usr/local/bin/uyuni-entrypoint.sh"]
+CMD ["postgres"]

--- a/containers/server-postgresql-image/_service
+++ b/containers/server-postgresql-image/_service
@@ -1,0 +1,4 @@
+<services>
+  <service mode="buildtime" name="kiwi_metainfo_helper"/>
+  <service mode="buildtime" name="docker_label_helper"/>
+</services>

--- a/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/create-db.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/create-db.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+MANAGER_DB_NAME=susemanager
+
+run_sql() {
+    PGHOST= PGHOSTADDR= psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" --no-password --no-psqlrc "$@"
+}
+
+echo "CREATE DATABASE $MANAGER_DB_NAME ENCODING = UTF8 ;" | run_sql
+echo "CREATE EXTENSION IF NOT EXISTS plpgsql;"  | run_sql
+echo "CREATE ROLE $MANAGER_USER PASSWORD '$MANAGER_PASSWORD' SUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN;" | run_sql

--- a/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/create-reportdb.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/create-reportdb.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+REPORTDB_NAME=reportdb
+
+run_sql() {
+    PGHOST= PGHOSTADDR= psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" --no-password --no-psqlrc "$@"
+}
+
+echo "CREATE DATABASE $REPORTDB_NAME ENCODING = UTF8 ;" | run_sql
+echo "CREATE EXTENSION IF NOT EXISTS plpgsql;"  | run_sql
+echo "CREATE ROLE $REPORTDB_USER PASSWORD '$REPORTDB_PASSWORD' SUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN;" | run_sql

--- a/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/evr_t.sql
+++ b/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/evr_t.sql
@@ -1,0 +1,199 @@
+--
+-- Copyright (c) 2008--2013 Red Hat, Inc.
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+create type evr_t as (
+        epoch           varchar(16),
+        version         varchar(512),
+        release         varchar(512),
+        type            varchar(10)
+);
+
+create or replace function evr_t(e varchar, v varchar, r varchar, t varchar)
+returns evr_t as $$
+select row($1,$2,$3,$4)::evr_t
+$$ language sql;
+
+create or replace function evr_t_compare( a evr_t, b evr_t )
+returns int as $$
+begin
+  if a.type = b.type then
+      if a.type = 'rpm' then
+        return rpm.vercmp(a.epoch, a.version, a.release, b.epoch, b.version, b.release);
+      elsif a.type = 'deb' then
+        return deb.debvercmp(a.epoch, a.version, a.release, b.epoch, b.version, b.release);
+      else
+        raise EXCEPTION 'unknown evr type (using rpm) -> %', a.type;
+      end if;
+  else
+     raise NOTICE 'comparing incompatible evr types. Using %', a.type;
+     if a.type = 'deb' then
+       return -1;
+     else
+       return 1;
+     end if;
+  end if;
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_lt( a evr_t, b evr_t )
+returns boolean as $$
+begin
+  return evr_t_compare( a, b ) < 0;
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_le( a evr_t, b evr_t )
+returns boolean as $$
+begin
+  return evr_t_compare( a, b ) <= 0;
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_eq( a evr_t, b evr_t )
+returns boolean as $$
+begin
+  return evr_t_compare( a, b ) = 0;
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_ne( a evr_t, b evr_t )
+returns boolean as $$
+begin
+  return evr_t_compare( a, b ) != 0;
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_ge( a evr_t, b evr_t )
+returns boolean as $$
+begin
+  return evr_t_compare( a, b ) >= 0;
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_gt( a evr_t, b evr_t )
+returns boolean as $$
+begin
+  return evr_t_compare( a, b ) > 0;
+end;
+$$ language plpgsql immutable strict;
+
+create operator < (
+  leftarg = evr_t,
+  rightarg = evr_t,
+  procedure = evr_t_lt,
+  commutator = >,
+  negator = >=,
+  restrict = scalarltsel,
+  join = scalarltjoinsel
+);
+
+create operator <= (
+  leftarg = evr_t,
+  rightarg = evr_t,
+  procedure = evr_t_le,
+  commutator = >=,
+  negator = >,
+  restrict = scalarltsel,
+  join = scalarltjoinsel
+);
+
+create operator = (
+  leftarg = evr_t,
+  rightarg = evr_t,
+  procedure = evr_t_eq,
+  commutator = =,
+  negator = <>,
+  restrict = eqsel,
+  join = eqjoinsel
+);
+
+create operator >= (
+  leftarg = evr_t,
+  rightarg = evr_t,
+  procedure = evr_t_ge,
+  commutator = <=,
+  negator = <,
+  restrict = scalargtsel,
+  join = scalargtjoinsel
+);
+
+create operator > (
+  leftarg = evr_t,
+  rightarg = evr_t,
+  procedure = evr_t_gt,
+  commutator = <,
+  negator = <=,
+  restrict = scalargtsel,
+  join = scalargtjoinsel
+);
+
+create operator <> (
+  leftarg = evr_t,
+  rightarg = evr_t,
+  procedure = evr_t_ne,
+  commutator = <>,
+  negator = =,
+  restrict = eqsel,
+  join = eqjoinsel
+);
+
+
+create operator class evr_t_ops
+default for type evr_t using btree as
+  operator 1 <,
+  operator 2 <=,
+  operator 3 =,
+  operator 4 >=,
+  operator 5 >,
+  function 1 evr_t_compare( evr_t, evr_t )
+;
+
+create or replace function evr_t_as_vre( a evr_t ) returns varchar as $$
+begin
+  return a.version || '-' || a.release || ':' || coalesce(a.epoch, '');
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_as_vre_simple( a evr_t ) returns varchar as $$
+declare
+  vre_out VARCHAR(256);
+begin
+  vre_out := a.version || '-' || a.release;
+  if a.epoch is not null
+  then
+    vre_out := vre_out || ':' || a.epoch;
+  end if;
+  return vre_out;
+end;
+$$ language plpgsql immutable strict;
+
+create or replace function evr_t_larger(a evr_t, b evr_t)
+returns evr_t
+as $$
+begin
+  if a > b
+  then
+    return a;
+  else
+    return b;
+  end if;
+end;
+$$ language plpgsql immutable strict;
+
+create aggregate max (
+  sfunc=evr_t_larger,
+  basetype=evr_t,
+  stype=evr_t
+);

--- a/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Adjust postgresql.conf for Uyuni
+# This is run automatically at the first start of the container
+# or it can be run manually later.
+
+POSTGRESQL=/var/lib/pgsql/data/postgresql.conf
+SSL_CERT=/etc/pki/tls/certs/spacewalk.crt
+SSL_KEY=/etc/pki/tls/private/pg-spacewalk.key
+
+postgres_reconfig() {
+    echo "Setting $1 = $2"
+    if test $(sed -n "/^$1[[:space:]]*=/p" $POSTGRESQL | wc -l) -ne 0; then
+        sed -i "s|^$1[[:space:]]*=.*|$1 = $2|" $POSTGRESQL
+    else
+        echo "$1 = $2" >> $POSTGRESQL
+    fi
+}
+
+# Get total memory in KB
+TOTAL_MEM_KB=$(sed -n -e '/MemTotal:/{s|MemTotal:[[:space:]]*\([0-9]*\).*|\1| p}' /proc/meminfo)
+
+# Check minimum memory requirement (255KB)
+if [ "$TOTAL_MEM_KB" -lt $((0xff * 1024)) ]; then
+    echo "WARNING: low memory: $TOTAL_MEM_KB"
+    TOTAL_MEM_KB=$((0xff * 1024))
+fi
+
+# Binary rounding function
+bin_rnd() {
+    local value=$1
+    local mbt=1
+    while [ $value -gt 16 ]; do
+        value=$((value / 2))
+        mbt=$((mbt * 2))
+    done
+    echo $((mbt * value))
+}
+
+# Convert to MB
+to_mb() {
+    echo "$(($1 / 1024))MB"
+}
+
+# Get max_connections from current postgresql.conf
+MAX_CONNECTIONS=$(sed -n -e '/^max_connections[[:space:]]*=/{s/.*=[[:space:]]*\([0-9]*\).*/\1/ p}' $POSTGRESQL)
+[ -z "$MAX_CONNECTIONS" -o "$MAX_CONNECTIONS" -lt 400 ] && MAX_CONNECTIONS=500
+
+EFFECTIVE_IO_CONCURRENCY=$(sed -n -e '/^effective_io_concurrency[[:space:]]*=/{s/.*=[[:space:]]*\([0-9]*\).*/\1/ p}' $POSTGRESQL)
+
+if [ "$1" == "--hdd" ] ; then
+    echo "Configuring for rotational HDD"
+    IS_SSD=0
+elif [ "$1" == "--ssd" ] ; then
+    echo "Configuring for SSD"
+    IS_SSD=1
+elif [ "$EFFECTIVE_IO_CONCURRENCY" == 2 ] ; then
+    echo "Rotational HDD is already configured"
+    IS_SSD=0
+else
+    echo "Configuring for SSD"
+    IS_SSD=1
+fi
+
+# Calculate values
+SHARED_BUFFERS=$(bin_rnd $((TOTAL_MEM_KB / 4)))
+EFFECTIVE_CACHE_SIZE=$(bin_rnd $((TOTAL_MEM_KB * 3 / 4)))
+WORK_MEM=$(bin_rnd $(((TOTAL_MEM_KB - SHARED_BUFFERS) / (3 * MAX_CONNECTIONS))))
+MAINTENANCE_WORK_MEM=$(bin_rnd $(( TOTAL_MEM_KB / 16 < 1048576 ? TOTAL_MEM_KB / 16 : 1048576 ))) # 1GB
+
+# Apply configurations
+postgres_reconfig "shared_buffers" "$(to_mb $SHARED_BUFFERS)"
+postgres_reconfig "effective_cache_size" "$(to_mb $EFFECTIVE_CACHE_SIZE)"
+postgres_reconfig "work_mem" "$(to_mb $WORK_MEM)"
+postgres_reconfig "maintenance_work_mem" "$(to_mb $MAINTENANCE_WORK_MEM)"
+postgres_reconfig "max_wal_size" "4096MB"
+postgres_reconfig "min_wal_size" "1024MB"
+postgres_reconfig "checkpoint_completion_target" "0.9"
+postgres_reconfig "wal_buffers" "16MB"
+postgres_reconfig "constraint_exclusion" "off"
+postgres_reconfig "max_connections" "$MAX_CONNECTIONS"
+
+if [ "$IS_SSD" -eq 1 ]; then
+    postgres_reconfig "random_page_cost" "1.1"
+    postgres_reconfig "effective_io_concurrency" "200"
+else
+    postgres_reconfig "random_page_cost" "4"
+    postgres_reconfig "effective_io_concurrency" "2"
+fi
+
+postgres_reconfig jit off
+
+if [ -f $SSL_KEY ] ; then
+    chown postgres $SSL_KEY
+    chmod 400 $SSL_KEY
+    postgres_reconfig "ssl" "on"
+    postgres_reconfig "ssl_cert_file" "'$SSL_CERT'"
+    postgres_reconfig "ssl_key_file" "'$SSL_KEY'"
+fi
+
+echo "postgresql.conf updated"

--- a/containers/server-postgresql-image/root/usr/local/bin/uyuni-entrypoint.sh
+++ b/containers/server-postgresql-image/root/usr/local/bin/uyuni-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+chown postgres /etc/pki/tls/private/pg-spacewalk.key
+
+/usr/local/bin/docker-entrypoint.sh "$@"

--- a/containers/server-postgresql-image/server-postgresql-image.changes
+++ b/containers/server-postgresql-image/server-postgresql-image.changes
@@ -1,0 +1,1 @@
+- Initial release of PostgreSQL container image

--- a/containers/server-postgresql-image/tito.props
+++ b/containers/server-postgresql-image/tito.props
@@ -1,0 +1,3 @@
+[buildconfig]
+tagger = tito.tagger.SUSEContainerTagger
+builder = custom.ContainerBuilder

--- a/rel-eng/packages/server-postgresql-image
+++ b/rel-eng/packages/server-postgresql-image
@@ -1,0 +1,1 @@
+5.1.0 containers/server-postgresql-image/


### PR DESCRIPTION
## What does this PR change?

This PR adds a dedicated postgres container.
The script `uyuni-postgres-config.sh` replaces `smdba system-check autotuning` functionality.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
TBD

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/25363

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
