### PR TITLE
Fixed place holder message text in Upgrade package page

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -3095,7 +3095,7 @@ button below, and &lt;b&gt;will be unable to log back in&lt;/b&gt;.</source>
         </context-group>
       </trans-unit>
       <trans-unit id="upgradable.jsp.latest" xml:space="preserve">
-        <source>Latest Package</source>
+        <source>Package Name</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/packages/UpgradableList</context>
         </context-group>

--- a/java/spacewalk-java.changes.bisht-richa.search-placeholder-text
+++ b/java/spacewalk-java.changes.bisht-richa.search-placeholder-text
@@ -1,0 +1,1 @@
+- Search input placeholder text change on the Upgrade package page

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -877,7 +877,7 @@ end
 When(/^I enter "([^"]*)" as the filtered latest package$/) do |input|
   raise ArgumentError, 'Package name is not set' if input.empty?
 
-  find('input[placeholder=\'Filter by Latest Package: \']').set(input)
+  find('input[placeholder=\'Filter by Package Name: \']').set(input)
 end
 
 When(/^I enter "([^"]*)" as the filtered synopsis$/) do |input|


### PR DESCRIPTION
## What does this PR change?
This PR fixes the bugzilla issue : https://bugzilla.suse.com/show_bug.cgi?id=1233082

Change search input placeholder text on the Upgrade package page


**add description**

## GUI diff

Before:
<img width="1534" alt="Screenshot 2024-11-13 at 16 13 14" src="https://github.com/user-attachments/assets/246d31c1-3419-4e7f-99e1-121984364e5b">

After:

<img width="1527" alt="Screenshot 2024-11-13 at 16 13 23" src="https://github.com/user-attachments/assets/fe7ee83a-62ad-4ce0-8442-08a5a00ee017">

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered


- [x] **DONE**

## Links

Issues: https://github.com/SUSE/spacewalk/issues/25108
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
