### PR TITLE
Make a deep copy of a map value and add more logs when processing and pushing metrics

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -162,8 +162,8 @@ When(/^I use spacewalk-common-channel to add channel "([^"]*)" with arch "([^"]*
 end
 
 When(/^I use spacewalk-common-channel to add all "([^"]*)" channels with arch "([^"]*)"$/) do |channel, architecture|
-  channels_to_synchronize = CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, channel) ||
-                            CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, "#{channel}-#{architecture}")
+  channels_to_synchronize = CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, channel).clone ||
+                            CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, "#{channel}-#{architecture}").clone
   channels_to_synchronize = filter_channels(channels_to_synchronize, ['beta']) unless $beta_enabled
   raise ScriptError, "Synchronization error, channel #{channel} or #{channel}-#{architecture} in #{product} product not found" if channels_to_synchronize.nil? || channels_to_synchronize.empty?
 
@@ -326,7 +326,7 @@ end
 When(/^I kill running spacewalk-repo-sync for "([^"]*)"$/) do |os_product_version|
   next if CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, os_product_version).nil?
 
-  channels_to_kill = CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION[product][os_product_version]
+  channels_to_kill = CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, os_product_version).clone
   channels_to_kill = filter_channels(channels_to_kill, ['beta']) unless $beta_enabled
   log "Killing channels:\n#{channels_to_kill}"
   time_spent = 0
@@ -416,7 +416,7 @@ When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
 end
 
 When(/^I wait until all synchronized channels for "([^"]*)" have finished$/) do |os_product_version|
-  channels_to_wait = CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, os_product_version)
+  channels_to_wait = CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION.dig(product, os_product_version).clone
   channels_to_wait = filter_channels(channels_to_wait, ['beta']) unless $beta_enabled
   raise ScriptError, "Synchronization error, channels for #{os_product_version} in #{product} not found" if channels_to_wait.nil?
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -731,10 +731,11 @@ end
 # @param channels [Array<String>] The list of channels to filter.
 # @param filters [Array<String>] The list of filters to apply.
 def filter_channels(channels, filters = [])
+  filtered_channels = channels.clone
   filters.each do |filter|
-    channels.delete_if { |channel| channel.include? filter }
+    filtered_channels.delete_if { |channel| channel.include? filter }
   end
-  channels
+  filtered_channels
 end
 
 # Mutex for processes accessing the API of the server via admin user

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -609,7 +609,8 @@ def channel_is_synced(channel)
   end
   if sync_status
     begin
-      channel_synchronization_duration(channel)
+      duration = channel_synchronization_duration(channel)
+      log "Channel #{channel} synchronized in #{duration} seconds"
     rescue ScriptError => e
       log "Error while checking synchronization duration: #{e.message}"
       sync_status = false

--- a/testsuite/features/support/metrics_collector_handler.rb
+++ b/testsuite/features/support/metrics_collector_handler.rb
@@ -26,8 +26,9 @@ class MetricsCollectorHandler
       gauge = @metrics_collector.get(metric_name.to_sym) || @metrics_collector.gauge(metric_name.to_sym, docstring: job_name, labels: labels.keys)
       gauge.set(metric_value, labels: labels)
       Prometheus::Client::Push.new(job: job_name, gateway: @metrics_collector_url).add(@metrics_collector)
+      $stdout.puts("Pushed the metric #{metric_name} with value #{metric_value} to #{@metrics_collector_url}")
     rescue StandardError => e
-      warn("Error pushing the metric #{metric_name} with value #{metric_value}:\n#{e.full_message}")
+      $stdout.puts("Error pushing the metric #{metric_name} with value #{metric_value}:\n#{e.full_message}")
       raise
     end
   end


### PR DESCRIPTION
## What does this PR change?

- Make a deep copy when we retrieve the value of a map
- Add more logs when processing and pushing metrics

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were improved

- [x] **DONE**

## Links

Ports:
- Manager-5.0 https://github.com/SUSE/spacewalk/pull/25785

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
