### PR TITLE
Fix the enabled flag for users listed via API (bsc#1233431)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/UserSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/UserSerializer.java
@@ -47,7 +47,7 @@ public class UserSerializer extends ApiResponseSerializer<User> {
                 .add("id", src.getId())
                 .add("login", src.getLogin())
                 .add("login_uc", src.getLoginUc())
-                .add("enabled", src.isDisabled())
+                .add("enabled", !src.isDisabled())
                 .build();
     }
 }

--- a/java/spacewalk-java.changes.renner.fix-users-enabled-flag
+++ b/java/spacewalk-java.changes.renner.fix-users-enabled-flag
@@ -1,0 +1,1 @@
+- Fix enabled flag for users listed via API (bsc#1233431)


### PR DESCRIPTION
## What does this PR change?

This should fix the `enabled` flag for users when listed via the API, using for example the `user.listUsers()` call. Enabled obviously means not disabled, which seemed to be a small issue in the `UserSerializer` class.

## GUI diff

No difference.

## Documentation

- No documentation needed, this should work as expected now.

## Test coverage

- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1233431

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository.

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
