### PR TITLE
limit frontend-log message size (bsc#1231900)

### DIFF
--- a/java/spacewalk-java.changes.kwalter.bsc1231900
+++ b/java/spacewalk-java.changes.kwalter.bsc1231900
@@ -1,0 +1,1 @@
+- limit frontend-log message size (bsc#1231900)


### PR DESCRIPTION
## What does this PR change?

This limits the message size accepted by the frontend-log message endpoint.

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests:

- [x] **DONE**

## Links

Issue(s): #
Port(s):  https://github.com/SUSE/spacewalk/pull/25661 https://github.com/SUSE/spacewalk/pull/25660
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
