### PR TITLE
Add a test for the UserSerializer class

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/UserSerializerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/UserSerializerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.frontend.xmlrpc.serializer.UserSerializer;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+ * UserSerializer test
+ */
+public class UserSerializerTest extends BaseTestCaseWithUser {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    /**
+     * Minimal test
+     */
+    @Test
+    public void testSerializeUser() {
+        UserSerializer serializer = new UserSerializer();
+        Writer output = new StringWriter();
+        serializer.serialize(user, output, new XmlRpcSerializer());
+
+        String actual = output.toString();
+        assertTrue(actual.contains("<member><name>id</name><value><i4>" +
+                user.getId() + "</i4></value></member>"));
+        assertTrue(actual.contains("<member><name>login</name><value><string>" +
+                user.getLogin() + "</string></value></member>"));
+        assertTrue(actual.contains("<member><name>login_uc</name><value><string>" +
+                user.getLoginUc() + "</string></value></member>"));
+        assertTrue(actual.contains("<member><name>enabled</name><value><boolean>" +
+                String.valueOf(user.isDisabled() ? 0 : 1) + "</boolean></value></member>"));
+    }
+}


### PR DESCRIPTION
## What does this PR change?

After fixing a bug in there this week (see #9483), I'd like to add a small unit test to cover for the functionality in `UserSerializer`.

## GUI diff

No difference.

## Documentation

- No documentation needed, just test code in this PR.

## Test coverage

- This is adding a test for existing functionality.

## Links

Issue(s): This is an addon for https://github.com/uyuni-project/uyuni/pull/9483
Port(s):
- https://github.com/SUSE/spacewalk/pull/25822 (`Manager-5.0`)
- https://github.com/SUSE/spacewalk/pull/25824 (`Manager-4.3`)

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository.

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
