### PR TITLE
Copy content of the dist directory and not the directory itself

### DIFF
--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -333,7 +333,7 @@
             description="Deploy css/js/img/font files in a running container">
         <echo message="Copying frontend files to container... "/>
         <copy-to-container
-                source="${frontend.dist.dir}"
+                source="${frontend.dist.dir}/."
                 target="/usr/share/susemanager/www/htdocs"
                 failonerror="true"
                 backend="${container.backend}"/>


### PR DESCRIPTION
## What does this PR change?

See https://docs.podman.io/en/latest/markdown/podman-cp.1.html

Podman cp requires source to be trailed by `/.` to copy the content of the directory and not the directory itself.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: development functionality

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
