### PR TITLE
Changing OS Image build via kiwi to running via podman and adding eib pre-processing

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/kiwi-image-server.sls
@@ -20,6 +20,8 @@
 mgr_install_kiwi:
   pkg.installed:
     - pkgs:
+      - podman
+      - xorriso
 {%- if use_kiwi_ng %}
       - python3-kiwi
 {%- else %}


### PR DESCRIPTION
## What does this PR change?

We worked on this as part of https://hackweek.opensuse.org/projects/build-edge-image-builder-iso-with-suse-manager

In this PR we have several changes:

1. switch from local installed kiwi to running kiwi via image
2. run eib pre-processing in case eib/eib.yaml exists

We hope someone else can take this forward as this is just an initial "PoC" even though it is working well for us.
Limitations that might need to be addressed as well:

- did not remove the installation of kiwi-ng
- did not test on SLES 12 build host
- did not add "air-gapped" - so the build-hosts need to be able to pull these images from the internet:

```
docker.io/dgiebert/edge-image-builder:1.2.7
registry.suse.com/bci/kiwi:10.1.10

```
- the edge-image-builder used is based on a new PR against edge-image-builder and we might need a final merge and new version of the image https://github.com/suse-edge/edge-image-builder/pull/618
- the kiwi image might not be available "officially", yet
 
We have been testing with https://github.com/Martin-Weiss/kiwi-image-micro-gpu-60 

## GUI diff

No difference.

## Documentation
- We need to explain the git repo eib/eib.yaml and point to the official EIB docs...
- We need to explain Podman requirements

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- We did not add test-cases so far - but build on x86, aarch64 and with repos having eib/eib.yaml and without need to be added.
