### PR TITLE
Changelog action: Fixes after test runs

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -50,6 +50,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
+        # Checkout only workflow code
+        sparse-checkout: '.github/workflows'
     - id: master
       name: Get modified master changelog files
       uses: Ana06/get-changed-files@v2.3.0

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -89,7 +89,7 @@ jobs:
       run: |
         pip install python-bugzilla~=3.2.0
 
-        CHANGED_FILES=$(gh pr diff -R $GIT_REPO $PR_NUM --name-only)
+        CHANGED_FILES=$(gh api --paginate repos/$GIT_REPO/pulls/$PR_NUM/files | jq -r '.[].filename')
         python .github/workflows/changelogs/changelogs.py \
             --tracker-file $TRACKER_FILE --git-repo $GIT_REPO --uyuni-dir .head --pr-number $PR_NUM $CHANGED_FILES
 

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -50,7 +50,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
-        ref: ${{ github.event.pull_request.head.sha }}
     - id: master
       name: Get modified master changelog files
       uses: Ana06/get-changed-files@v2.3.0
@@ -68,8 +67,17 @@ jobs:
         echo
         echo "See https://github.com/uyuni-project/uyuni/wiki/Contributing for a guide to writing changelogs."
         exit 1
-    - name: Test changelog entries
+    - name: Checkout the HEAD branch
+      id: checkout
       if: "!contains(github.event.pull_request.body, '[x] No changelog needed')"
+      # Check out the PR HEAD in a subdirectory to read the updated changelog files
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: .head
+    - name: Test changelog entries
+      if: steps.checkout.outcome == 'success'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BZ_TOKEN: ${{ secrets.BUGZILLA_TOKEN }}
@@ -83,7 +91,7 @@ jobs:
 
         CHANGED_FILES=$(gh pr diff -R $GIT_REPO $PR_NUM --name-only)
         python .github/workflows/changelogs/changelogs.py \
-            --tracker-file $TRACKER_FILE --git-repo $GIT_REPO --pr-number $PR_NUM $CHANGED_FILES
+            --tracker-file $TRACKER_FILE --git-repo $GIT_REPO --uyuni-dir .head --pr-number $PR_NUM $CHANGED_FILES
 
   # Warns the user if they merged the PR, but the changelog test failed
   warn_user_if_merged:

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -69,6 +69,7 @@ jobs:
         echo "See https://github.com/uyuni-project/uyuni/wiki/Contributing for a guide to writing changelogs."
         exit 1
     - name: Test changelog entries
+      if: "!contains(github.event.pull_request.body, '[x] No changelog needed')"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BZ_TOKEN: ${{ secrets.BUGZILLA_TOKEN }}

--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -90,7 +90,7 @@ jobs:
         pip install python-bugzilla~=3.2.0
 
         CHANGED_FILES=$(gh api --paginate repos/$GIT_REPO/pulls/$PR_NUM/files | jq -r '.[].filename')
-        python .github/workflows/changelogs/changelogs.py \
+        python .github/workflows/changelogs/changelogs.py ${RUNNER_DEBUG:+--verbose} \
             --tracker-file $TRACKER_FILE --git-repo $GIT_REPO --uyuni-dir .head --pr-number $PR_NUM $CHANGED_FILES
 
   # Warns the user if they merged the PR, but the changelog test failed

--- a/.github/workflows/changelogs/changelogs.py
+++ b/.github/workflows/changelogs/changelogs.py
@@ -248,13 +248,19 @@ class ChangelogValidator:
         pkg_chlogs = []
         for f in files:
             # Check if the file exists in a subdirectory of the base path of the package
-            if os.path.normpath(os.path.dirname(f)).startswith(os.path.normpath(pkg_path)):
+            if (f.startswith(pkg_path)):
                 if os.path.basename(f).startswith(pkg_name + ".changes."):
                     # Ignore if the change is a removal
                     if os.path.isfile(os.path.join(self.uyuni_root, f)):
                         pkg_chlogs.append(f)
                 else:
                     pkg_files.append(f)
+
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            if len(pkg_files):
+                logging.debug(f"Found {len(pkg_files)} file(s) in package {pkg_name}:\n  " + "\n  ".join(pkg_files))
+            if len(pkg_chlogs):
+                logging.debug(f"Found {len(pkg_chlogs)} changelog(s) in package {pkg_name}:\n  " + "\n  ".join(pkg_chlogs))
 
         return { "files": pkg_files, "changes": pkg_chlogs }
 
@@ -292,7 +298,7 @@ class ChangelogValidator:
             # Each file contains the package version and the
             # package path, separated by a space character
             pkg_path = linecache.getline(os.path.join(packages_dir, pkg_name), 1).rstrip().split(maxsplit=1)[1]
-            logging.debug(f"Package {pkg_name} is in path {pkg_path}")
+            logging.debug(f"Indexing package {pkg_name} in path {pkg_path}")
 
             # Get the list of modified files and changelog files for the package
             modified_files = self.get_modified_files_for_pkg(pkg_path, pkg_name, files)

--- a/.github/workflows/changelogs/changelogs.py
+++ b/.github/workflows/changelogs/changelogs.py
@@ -206,8 +206,7 @@ class ChangelogValidator:
         self.pr_number = pr_number
         self.max_line_length = max_line_length
         self.regex = regex_rules
-        if regex_rules.trackers:
-            self.bzapi = self.get_bugzilla_api()
+        self.bzapi = self.get_bugzilla_api() if regex_rules.trackers else None
 
     def get_bugzilla_api(self) -> bugzilla.Bugzilla:
         """Initialize and authenticate the Bugzilla API

--- a/.github/workflows/changelogs/test_changelogs.py
+++ b/.github/workflows/changelogs/test_changelogs.py
@@ -88,7 +88,7 @@ def validator_with_trackers(monkeypatch, tracker_filename, base_path):
 First commit message (tckr#99)
 Second commit message
 """
-        if re.search(r"^gh pr view -R [^ ]+ 999 .*", api_cmd):
+        if re.search(r"^gh api repos/[^/]*/[^/]*/pulls/999 .*", api_cmd):
             return io.StringIO(pr_data)
         else:
             raise Exception("An error occurred when getting the PR information from the GitHub API.")

--- a/.github/workflows/changelogs/test_changelogs.py
+++ b/.github/workflows/changelogs/test_changelogs.py
@@ -204,8 +204,13 @@ def test_get_entry_obj_with_multiple_trackers(validator_with_trackers):
     assert ("tckr#01", "01") in entry.trackers["tckr"]
     assert ("tckr#02", "02") in entry.trackers["tckr"]
 
-def test_validate_chlog_file_valid(validator, chlog_file):
-    chlog_file.write_text("- This is a valid\n  multiline changelog entry\n")
+@pytest.mark.parametrize("entry_text", [
+    "- This is a valid changelog entry\n",
+    "- This is a valid\n  multiline changelog entry\n",
+    "- This is an entry with a version-1.2.3 string\n"
+])
+def test_validate_chlog_file_valid(validator, chlog_file, entry_text):
+    chlog_file.write_text(entry_text)
     issues, entries = validator.validate_chlog_file(str(chlog_file))
     assert not issues, issues_to_str(issues, 0)
     assert len(entries) == 1
@@ -259,6 +264,7 @@ def test_validate_chlog_file_multiple_issues_and_entries(validator, chlog_file):
     ("- This entry has wrong capitalization.\n  right here.\n", IssueType.WRONG_CAP),
     ("- This entry does not have a space.After a full stop\n", IssueType.WRONG_SPACING),
     ("- This entry does not have a space:After a colon\n", IssueType.WRONG_SPACING),
+    ("- Entry with version string 2.0 with.Wrong spacing.\n", IssueType.WRONG_SPACING),
     ("- This entry is" + " very" * 10 + " long\n", IssueType.LINE_TOO_LONG.format(DEFAULT_LINE_LENGTH)),
 ])
 def test_validate_chlog_file_rules(validator, chlog_file, entry_text, issue_msg):

--- a/.github/workflows/changelogs/test_changelogs.py
+++ b/.github/workflows/changelogs/test_changelogs.py
@@ -34,7 +34,9 @@ def file_list():
         "pkg/path/myfile.txt",
         "pkg/path/mypkg.changes.my.feature",
         "pkg/other/path/file.txt",
-        "pkg/other/otherpkg.changes.my.feature"
+        "pkg/other/otherpkg.changes.my.feature",
+        "pkg/path-extra/myfile-extra.txt",
+        "pkg/path-extra/mypkg-extra.changes.my.feature"
     ]
 
 @pytest.fixture
@@ -53,11 +55,17 @@ def base_path(tmp_path, file_list):
     pkg_dir = base_path / "rel-eng/packages"
     pkg_dir.mkdir(parents=True)
 
+    #'mypkg' package
     pkg_file = pkg_dir / "mypkg"
     pkg_file.write_text("1.0.0 pkg/path/")
 
+    #'otherpkg' package
     pkg_file = pkg_dir / "otherpkg"
     pkg_file.write_text("1.0.0 pkg/other/")
+
+    #'mypkg-extra' package
+    pkg_file = pkg_dir / "mypkg-extra"
+    pkg_file.write_text("1.0.0 pkg/path-extra/")
     return base_path
 
 @pytest.fixture
@@ -124,9 +132,24 @@ def test_issue_gh_action_string(monkeypatch):
 
 def test_get_pkg_index(validator, file_list):
     pkg_idx = validator.get_pkg_index(file_list)
+
     assert "mypkg" in pkg_idx
+    assert 1 == len(pkg_idx["mypkg"]["files"])
+    assert 1 == len(pkg_idx["mypkg"]["changes"])
     assert "pkg/path/myfile.txt" in pkg_idx["mypkg"]["files"]
     assert "pkg/path/mypkg.changes.my.feature" in pkg_idx["mypkg"]["changes"]
+
+    assert "mypkg-extra" in pkg_idx
+    assert 1 == len(pkg_idx["mypkg-extra"]["files"])
+    assert 1 == len(pkg_idx["mypkg-extra"]["changes"])
+    assert "pkg/path-extra/myfile-extra.txt" in pkg_idx["mypkg-extra"]["files"]
+    assert "pkg/path-extra/mypkg-extra.changes.my.feature" in pkg_idx["mypkg-extra"]["changes"]
+
+    assert "otherpkg" in pkg_idx
+    assert 1 == len(pkg_idx["otherpkg"]["files"])
+    assert 1 == len(pkg_idx["otherpkg"]["changes"])
+    assert "pkg/other/path/file.txt" in pkg_idx["otherpkg"]["files"]
+    assert "pkg/other/otherpkg.changes.my.feature" in pkg_idx["otherpkg"]["changes"]
 
 def test_extract_trackers(validator_with_trackers):
     trackers = validator_with_trackers.extract_trackers("""


### PR DESCRIPTION
This PR adds some fixes to the changelogs action after the first test runs upstream:

- Add back the "checkbox" condition in Changelog tests action
- Run the workflow code from the `base` branch instead of PR `head`:
    This makes it impossible to inject malicious code to the workflow code
- Fix the error when testing PRs with >300 files
- Propagate the GH action `debug` flag to print verbose messages on debug runs
- Fix indexing when one package name is a substring of another
- Ignore spacing issues in version strings
- Retrieve extended (untruncated) commit messages from GH API

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
