### PR TITLE
Fix dangling old theme reference

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
@@ -13,8 +13,7 @@ html(lang=window.preferredLocale.replace("_", "-"))
         // import custom fonts/icons styles
         link(rel='stylesheet', href='/fonts/font-spacewalk/css/spacewalk-font.css?cb=#{webBuildtimestamp}')
         // import styles
-        link(rel='stylesheet', href='/css/#{webTheme}.css?cb=#{webBuildtimestamp}', id='web-theme')
-        link(rel='stylesheet', href='/css/updated-#{webTheme}.css?cb=#{webBuildtimestamp}', id='updated-web-theme')
+        link(rel='stylesheet', href='/css/updated-#{webTheme}.css?cb=#{webBuildtimestamp}')
         script(type='text/javascript').
             window.preferredLocale = "#{preferredLocale}";
             window.docsLocale = "#{docsLocale}";
@@ -28,7 +27,7 @@ html(lang=window.preferredLocale.replace("_", "-"))
 
         include /templates/common.jade
 
-        body(class='#{webTheme}' == "uyuni" ? "theme-#{webTheme} old-theme login-page" : "theme-#{webTheme} old-theme")
+        body(class='#{webTheme}' == "uyuni" ? "theme-#{webTheme} new-theme login-page" : "theme-#{webTheme} new-theme")
             #login
 
         +csrfToken

--- a/java/code/webapp/WEB-INF/decorators/layout_error.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_error.jsp
@@ -33,8 +33,7 @@
 
     <c:set var="webTheme" value="${ConfigDefaults.get().getDefaultWebTheme()}"/>
     <!-- import styles -->
-    <link rel="stylesheet" href="/css/${webTheme}.css?cb=${cb_version}" id="web-theme" />
-    <link rel="stylesheet" href="/css/updated-${webTheme}.css?cb=${cb_version}" id="updated-web-theme" />
+    <link rel="stylesheet" href="/css/updated-${webTheme}.css?cb=${cb_version}" />
 
     <!-- expose user preferred language to the application -->
     <c:set var="currentLocale" value="${ConfigDefaults.get().getDefaultLocale()}"/>

--- a/java/code/webapp/WEB-INF/decorators/layout_head.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_head.jsp
@@ -32,8 +32,7 @@
 
     <!-- import styles -->
     <c:set var="webTheme" value="${GlobalInstanceHolder.USER_PREFERENCE_UTILS.getCurrentWebTheme(pageContext)}"/>
-    <link rel="stylesheet" href="/css/${webTheme}.css?cb=${cb_version}" id="web-theme" />
-    <link rel="stylesheet" href="/css/updated-${webTheme}.css?cb=${cb_version}" id="updated-web-theme" />
+    <link rel="stylesheet" href="/css/updated-${webTheme}.css?cb=${cb_version}" />
     
     <!-- expose user preferred language to the application -->
     <c:set var="currentLocale" value="${GlobalInstanceHolder.USER_PREFERENCE_UTILS.getCurrentLocale(pageContext)}"/>

--- a/java/spacewalk-java.changes.eth.login
+++ b/java/spacewalk-java.changes.eth.login
@@ -1,0 +1,1 @@
+- Update login page layout

--- a/web/spacewalk-web.changes.eth.login
+++ b/web/spacewalk-web.changes.eth.login
@@ -1,0 +1,1 @@
+- Update login page layout

--- a/web/spacewalk-web.changes.eth.login
+++ b/web/spacewalk-web.changes.eth.login
@@ -1,1 +1,0 @@
-- Update login page layout


### PR DESCRIPTION
## What does this PR change?

See title, no pages should use the old theme anymore, but the login page was still looking for it.

## GUI diff

Fixes login page.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: UI bugfix

- [x] **DONE**

## Links

Slack thread: https://suse.slack.com/archives/C02D134507M/p1732619812848779

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
