### PR TITLE
Filter package lock failures from salt event parser

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -516,10 +516,10 @@ Then(/^the salt event log on server should contain no failures$/) do
   # ignore the error if there is only the expected hoag-dummy package lock installation failure from min_salt_lock_packages.feature
   output, _code = get_target('server').run("python3 /tmp/#{file}")
   filtered_output = output
-    .split(/(?=# Failure \d+)/)
-    .reject { 
-      |block| block.include?('remove lock to allow installation of hoag-dummy')
-    }
+                    .split(/(?=# Failure \d+)/)
+                    .reject do |block|
+                      block.include?('remove lock to allow installation of hoag-dummy')
+                    end
   count_failures = filtered_output.to_s.scan(/false/).length
   filtered_output = filtered_output.join.to_s if filtered_output.respond_to?(:join)
   raise ScriptError, "\nFound #{count_failures} failures in salt event log:\n#{filtered_output}\n" if count_failures.nonzero?

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -515,11 +515,12 @@ Then(/^the salt event log on server should contain no failures$/) do
   # print failures from salt event log
   # ignore the error if there is only the expected hoag-dummy package lock installation failure from min_salt_lock_packages.feature
   output, _code = get_target('server').run("python3 /tmp/#{file}")
-  filtered_output = output
-                    .split(/(?=# Failure \d+)/)
-                    .reject do |block|
-                      block.include?('remove lock to allow installation of hoag-dummy')
-                    end
+  filtered_output = 
+    output
+      .split(/(?=# Failure \d+)/)
+      .reject do |block|
+        block.include?('remove lock to allow installation of hoag-dummy')
+      end
   count_failures = filtered_output.to_s.scan(/false/).length
   filtered_output = filtered_output.join.to_s if filtered_output.respond_to?(:join)
   raise ScriptError, "\nFound #{count_failures} failures in salt event log:\n#{filtered_output}\n" if count_failures.nonzero?

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -515,12 +515,12 @@ Then(/^the salt event log on server should contain no failures$/) do
   # print failures from salt event log
   # ignore the error if there is only the expected hoag-dummy package lock installation failure from min_salt_lock_packages.feature
   output, _code = get_target('server').run("python3 /tmp/#{file}")
-  filtered_output = 
-    output
-      .split(/(?=# Failure \d+)/)
-      .reject do |block|
-        block.include?('remove lock to allow installation of hoag-dummy')
-      end
+  filtered_output =
+  output
+    .split(/(?=# Failure \d+)/)
+    .reject do |block|
+      block.include?('remove lock to allow installation of hoag-dummy')
+    end
   count_failures = filtered_output.to_s.scan(/false/).length
   filtered_output = filtered_output.join.to_s if filtered_output.respond_to?(:join)
   raise ScriptError, "\nFound #{count_failures} failures in salt event log:\n#{filtered_output}\n" if count_failures.nonzero?

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -516,7 +516,7 @@ Then(/^the salt event log on server should contain no failures$/) do
   # ignore the error if there is only the expected hoag-dummy package lock installation failure from min_salt_lock_packages.feature
   output, _code = get_target('server').run("python3 /tmp/#{file}")
   filtered_output =
-  output
+    output
     .split(/(?=# Failure \d+)/)
     .reject do |block|
       block.include?('remove lock to allow installation of hoag-dummy')


### PR DESCRIPTION
## What does this PR change?

We filter out the package lock failure from https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/secondary/min_salt_lock_packages.feature. However, the error still appears alongside non-ignored errors if there is more than 1 error in the salt event log.

The goal of this PR is to filter the output so that intentionally triggered errors do not appear, avoiding confusion.

How it looks now:

```
    Then the salt event log on server should contain no failures # features/step_definitions/salt_steps.rb:507
      
      Found 3 failures in salt event log:
      
      # Failure 2 , _stamp: 2024-11-26T07:48:35.920140 {
          "__id__": "mgr_buildimage",
          "__run_num__": 1,
          "__sls__": "images.docker",
          "changes": {},
          "comment": "Module function docker.build threw an exception. Exception: invalid tag 'registry.mgr.suse.de:5000/cucutest/auth_registry_profile:latest': invalid reference format",
          "duration": 3.036,
          "name": "docker.build",
          "result": false,
          "start_time": "08:48:35.894366"
      }
      
      # Failure 3 , _stamp: 2024-11-26T07:48:35.920140 {
          "__id__": "mgr_pushimage",
          "__run_num__": 2,
          "__sls__": "images.docker",
          "changes": {},
          "comment": "One or more requisite failed: images.docker.mgr_buildimage",
          "duration": 0.003,
          "name": "docker.push",
          "result": false,
          "start_time": "08:48:35.897643"
      }
      
      # Failure 4 , _stamp: 2024-11-26T07:48:35.920140 {
          "__id__": "mgr_registries_logout",
          "__run_num__": 3,
          "__sls__": "images.docker",
          "changes": {},
          "comment": "One or more requisite failed: images.docker.mgr_pushimage",
          "duration": 0.003,
          "name": "docker.logout",
          "result": false,
          "start_time": "08:48:35.897814"
      }
      
       (ScriptError)
      ./features/step_definitions/salt_steps.rb:526:in `/^the salt event log on server should contain no failures$/'
      features/finishing/srv_debug.feature:13:in `the salt event log on server should contain no failures'

```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25872
Port(s): https://github.com/SUSE/spacewalk/pull/25883

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
