### PR TITLE
update ivy and obs-for-maven to get new jackson and asm

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -3,7 +3,7 @@
     <dependencies>
         <!-- Runtime dependencies -->
         <dependency org="suse" name="antlr" rev="2.7.7" />
-        <dependency org="suse" name="asm" rev="9.3" />
+        <dependency org="suse" name="asm" rev="9.7" />
         <dependency org="suse" name="bcel" rev="6.10.0" />
         <dependency org="suse" name="byte-buddy" rev="1.14.16" />
         <dependency org="suse" name="byte-buddy-dep" rev="1.14.16" />
@@ -44,9 +44,9 @@
         <dependency org="suse" name="httpcore" rev="4.4.14" />
         <dependency org="suse" name="httpcore-nio" rev="4.4.14" />
         <dependency org="suse" name="ical4j" rev="3.0.18" />
-        <dependency org="suse" name="jackson-annotations" rev="2.15.2" />
-        <dependency org="suse" name="jackson-core" rev="2.15.2" />
-        <dependency org="suse" name="jackson-databind" rev="2.15.2" />
+        <dependency org="suse" name="jackson-annotations" rev="2.17.3" />
+        <dependency org="suse" name="jackson-core" rev="2.17.3" />
+        <dependency org="suse" name="jackson-databind" rev="2.17.3" />
         <dependency org="suse" name="jade4j" rev="1.2.7" />
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="java-saml" rev="2.4.0" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -14,7 +14,7 @@ artifacts:
   - artifact: asm
     package: objectweb-asm
     jar: asm-all
-    repository: Uyuni_Other
+    repository: Leap_sle
   - artifact: antlr
     package: antlr-java
     repository: Leap
@@ -104,11 +104,11 @@ artifacts:
     package: hibernate-types
     repository: Uyuni_Other
   - artifact: jackson-annotations
-    repository: Leap
+    repository: Leap_sle
   - artifact: jackson-core
-    repository: Leap
+    repository: Leap_sle
   - artifact: jackson-databind
-    repository: Leap
+    repository: Leap_sle
   - artifact: hibernate-commons-annotations
     repository: Uyuni_Other
   - artifact: hibernate-core


### PR DESCRIPTION
## What does this PR change?

A jackson update was released. We need to update ivy.
Same for asm to use the latest one

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25880 https://github.com/SUSE/spacewalk/pull/25871

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
