### PR TITLE
Add SLE 15 SP6 to the resposync on Uyuni

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1155,18 +1155,20 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-module-server-applications15-sp5-updates-x86_64
         sles15-sp5-devel-uyuni-client-x86_64
       ],
-    'sles15-sp6' =>
+    'sles15-sp6' => # CHECKED
       %w[
         sle-product-sles15-sp6-pool-x86_64
         sle-product-sles15-sp6-updates-x86_64
         sle-module-basesystem15-sp6-pool-x86_64
         sle-module-basesystem15-sp6-updates-x86_64
-        sle-module-server-applications15-sp6-pool-x86_64
-        sle-module-server-applications15-sp6-updates-x86_64
         sle-module-desktop-applications15-sp6-pool-x86_64
         sle-module-desktop-applications15-sp6-updates-x86_64
-        sle-module-devtools15-sp6-updates-x86_64
         sle-module-devtools15-sp6-pool-x86_64
+        sle-module-devtools15-sp6-updates-x86_64
+        sle-module-python3-15-sp6-pool-x86_64
+        sle-module-python3-15-sp6-updates-x86_64
+        sle-module-server-applications15-sp6-pool-x86_64
+        sle-module-server-applications15-sp6-updates-x86_64
         sles15-sp6-devel-uyuni-client-x86_64
       ],
     'slesforsap15-sp5' =>
@@ -1511,7 +1513,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-basesystem15-sp5-updates-s390x' => 600,
   'sle-module-basesystem15-sp5-updates-x86_64' => 540,
   'sle-module-basesystem15-sp6-pool-x86_64' => 300,
-  'sle-module-basesystem15-sp6-updates-x86_64' => 60,
+  'sle-module-basesystem15-sp6-updates-x86_64' => 400,
   'sle-module-containers15-sp4-pool-x86_64' => 60,
   'sle-module-containers15-sp4-pool-x86_64-proxy-4.3' => 60,
   'sle-module-containers15-sp4-pool-x86_64-smrbs-4.3' => 60,
@@ -1536,7 +1538,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-devtools15-sp4-updates-x86_64' => 600,
   'sle-module-devtools15-sp5-pool-x86_64' => 120,
   'sle-module-devtools15-sp5-updates-x86_64' => 300,
-  'sle-module-devtools15-sp6-updates-x86_64' => 60,
+  'sle-module-devtools15-sp6-updates-x86_64' => 240,
   'sle-module-devtools15-sp6-pool-x86_64' => 120,
   'sle-module-public-cloud15-sp4-pool-x86_64' => 840,
   'sle-module-public-cloud15-sp4-updates-x86_64' => 600,
@@ -1544,6 +1546,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-public-cloud15-sp5-updates-x86_64' => 420,
   'sle-module-python3-15-sp5-pool-x86_64' => 60,
   'sle-module-python3-15-sp5-updates-x86_64' => 60,
+  'sle-module-python3-15-sp6-pool-x86_64' => 60,
+  'sle-module-python3-15-sp6-updates-x86_64' => 60,
   'sle-module-server-applications15-sp2-pool-x86_64' => 60,
   'sle-module-server-applications15-sp2-updates-x86_64' => 120,
   'sle-module-server-applications15-sp3-pool-x86_64' => 60,
@@ -1582,6 +1586,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sles15-sp3-devel-uyuni-client-x86_64' => 60,
   'sles15-sp4-devel-uyuni-client-x86_64' => 60,
   'sles15-sp5-devel-uyuni-client-x86_64' => 60,
+  'sles15-sp6-devel-uyuni-client-x86_64' => 60,
   'sll-9-updates-x86_64' => 720,
   'sll-as-9-updates-x86_64' => 1620,
   'sll-cb-9-updates-x86_64' => 2640,


### PR DESCRIPTION
## What does this PR change?

Follow-up of #8932 which was for SUSE Manager.

Add SLE 15 SP6 to the resposync on Uyuni.


## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24573

Port(s):
  * 5.0: https://github.com/SUSE/spacewalk/pull/25911
  * 4.3: https://github.com/SUSE/spacewalk/pull/25910


## Changelogs

- [x] No changelog needed
