### PR TITLE
Remove confusing notification message for recurring states

### DIFF
--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -34,7 +34,6 @@ Feature: Recurring Actions
     And I click on "Save Changes"
     And I wait until I see "Edit State Ranks" text
     And I click on "Confirm"
-    And I wait until I see "State assignments have been saved." text
     And I click on "Create Schedule"
     Then I wait until I see "Schedule successfully created" text
     And I should see a "IP forwarding custom state recurring action" text
@@ -56,7 +55,6 @@ Feature: Recurring Actions
     And I click on "Save Changes"
     And I wait until I see "Edit State Ranks" text
     And I click on "Confirm"
-    And I wait until I see "State assignments have been saved" text
     And I click on "Update Schedule"
     Then I wait until I see "Schedule successfully updated" text
     And I should see a "custom_state_schedule_name_changed" text

--- a/web/html/src/components/states-picker.tsx
+++ b/web/html/src/components/states-picker.tsx
@@ -149,7 +149,10 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
           }
         });
 
-        messages = messages.concat(MessagesUtils.info(t("State assignments have been saved.")));
+        messages =
+          this.props.type === "state"
+            ? messages
+            : messages.concat(MessagesUtils.info(t("State assignments have been saved.")));
         this.setState({
           changed: new Map(), // clear changed
           // Update the channels with the new data


### PR DESCRIPTION
## What does this PR change?

When updating state assignments a 'State assignments have been saved.' message would be shown that could confuse users that their changes are already persistet and clicking the 'Update Schedule' button is not needed.

Remove the above message to avoid this kind of confusion. The message will still be shown if the component is used from the 'Configuration Channels' UI where clicking the 'Confirm' button actually persists the changes in the database.

## GUI diff

- [x] **DONE**

## Documentation

- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were adjusted

- [x] **DONE**

## Links

Issue(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
