### PR TITLE
Fix rebootifneeded state which miss definition of a variable (bsc#1233426)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
+++ b/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
@@ -13,6 +13,6 @@ mgr_reboot_if_needed:
     - onlyif:
       - test -e /boot/do_purge_kernels
 {%- else %}
-    - onlyif: 'zypper ps -s; [ $? -eq 102 ] || [ {{ patch_need_reboot }} -eq 0 ]'
+    - onlyif: 'zypper ps -s; [ $? -eq 102 ]'
 {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -45,3 +45,15 @@ mgr_keep_system_up2date_pkgs:
     - require:
       - sls: channels
       - mgr_keep_system_up2date_updatestack
+
+{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease'] >= 15 %}
+
+# zypper up does not evaluate reboot_suggested flags in patches. We need to do it manual
+mgr_flag_reboot_needed:
+  file.touch:
+    - name: /run/reboot-needed
+    - onlyif: '[ {{ patch_need_reboot|default(1) }} -eq 0 ]'
+    - require:
+      - pkg: mgr_keep_system_up2date_pkgs
+
+{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.Manager-5.0-fix-undef-var-in-rebootifneeded
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.Manager-5.0-fix-undef-var-in-rebootifneeded
@@ -1,0 +1,2 @@
+- Fix rebootifneeded state which miss definition of a variable
+  (bsc#1233426)


### PR DESCRIPTION
## What does this PR change?

After splitting the "reboot if needed" part from the `uptodate` state, we got an undefined variable.
This PR add a trick to keep the functionality by touching /run/reboot-needed file when patches
request restart. This cause zypper ps report 102 exit code which is used in the new `rebootifneeded` state.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manual

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25901

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
