### PR TITLE
Check for the expected pillar data after enabling Git pillar stability

### DIFF
--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -13,8 +13,9 @@ Feature: Salt master integration with Git pillar
 
   Scenario: Check for the expected pillar data after enabling Git pillar
     When I refresh the pillar data
-    Then the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"
-    And the pillar data for "org_id" should be "1" on "sle_minion"
+    And I wait until there is no pillar refresh salt job active
+    Then the pillar data for "org_id" should be "1" on "sle_minion"
+    And the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"
     And the pillar data for "git_pillar_foobar" should be "12345" on the Salt master
 
   Scenario: Cleanup: Remove Git pillar configuration for Salt master


### PR DESCRIPTION
## What does this PR change?

With `And I wait until there is no pillar refresh salt job active` it takes a couple of minutes more, but hopefully may solve recurring:
```
Then the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"

Message:

    Output value wasn't found: uyuni-ci-master-podman-suse-minion.mgr.suse.de:
 (ScriptError)
./features/step_definitions/salt_steps.rb:378:in `/^the pillar data for "([^"]*)" should be "([^"]*)" on "([^"]*)"$/'
features/secondary/srv_salt_git_pillar.feature:18:in `the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"'
```

Full scenario run for conformity:

```
uyuni-ci-master-podman-controller:~/spacewalk/testsuite # cucumber features/secondary/srv_salt_git_pillar.feature
Using Ruby version: 3.3.6
QUALITY INTELLIGENCE MODE ENABLED.
Capybara APP Host: https://uyuni-ci-master-podman-server.mgr.suse.de:8888
Initializing a remote node for 'server'.
Host 'server' is alive with determined hostname uyuni-ci-master-podman-server and FQDN uyuni-ci-master-podman-server.mgr.suse.de
Node: uyuni-ci-master-podman-server, OS Version: 15-SP6, Family: sles
Activating HTTP API
Using the default profile...
# Copyright (c) 2024 SUSE LLC
# Licensed under the terms of the MIT license.
@skip_if_github_validation @sle_minion @scope_salt
Feature: Salt master integration with Git pillar

  Scenario: Preparing Git pillar configuration for Salt master                      # features/secondary/srv_salt_git_pillar.feature:9
      This scenario ran at: 2024-11-28 14:45:47 +0100
Initializing a remote node for 'localhost'.
Host 'localhost' is alive with determined hostname uyuni-ci-master-podman-controller and FQDN uyuni-ci-master-podman-controller.mgr.suse.de
Node: uyuni-ci-master-podman-controller, OS Version: 15.5, Family: opensuse-leap
mgrctl exec -i 'sh /tmp/salt_git_pillar_setup.sh setup' returned status code = 0.
Output:
'Setting up git_pillar environment and restarting Salt master and Salt API
Refreshing service 'container-suseconnect-zypp'.
Loading repository data...
Reading installed packages...
'git-core' is already installed.
No update candidate for 'git-core-2.43.0-150600.3.6.1.x86_64'. The highest available version is already installed.
Resolving package dependencies...
Nothing to do.
Initialized empty Git repository in /tmp/test_salt_git_pillar.git/.git/
[master (root-commit) 7bc58f9] initial commit
 Committer: root <root@uyuni-server.mgr.internal>
Your name and email address were configured automatically based
on your username and hostname. Please check that they are accurate.
You can suppress this message by setting them explicitly. Run the
following command and follow the instructions in your editor to edit
your configuration file:

    git config --global --edit

After doing this, you may fix the identity used for this commit with:

    git commit --amend --reset-author

 2 files changed, 4 insertions(+)
 create mode 100644 test_pillar.sls
 create mode 100644 top.sls
'
    When I setup a git_pillar environment on the Salt master                        # features/step_definitions/salt_steps.rb:75
Initializing a remote node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname uyuni-ci-master-podman-suse-minion and FQDN uyuni-ci-master-podman-suse-minion.mgr.suse.de
Node: uyuni-ci-master-podman-suse-minion, OS Version: 15.5, Family: opensuse-leap
    And I wait until Salt master can reach "sle_minion"                             # features/step_definitions/salt_steps.rb:110
    Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should exist on server # features/step_definitions/file_management_steps.rb:22
      This scenario took: 8 seconds

  Scenario: Check for the expected pillar data after enabling Git pillar             # features/secondary/srv_salt_git_pillar.feature:14
      This scenario ran at: 2024-11-28 14:45:55 +0100
    When I refresh the pillar data                                                   # features/step_definitions/salt_steps.rb:354
    And I wait until there is no pillar refresh salt job active                      # features/step_definitions/salt_steps.rb:358
    Then the pillar data for "org_id" should be "1" on "sle_minion"                  # features/step_definitions/salt_steps.rb:373
    And the pillar data for "git_pillar_foobar" should be "12345" on "sle_minion"    # features/step_definitions/salt_steps.rb:373
    And the pillar data for "git_pillar_foobar" should be "12345" on the Salt master # features/step_definitions/salt_steps.rb:408
      This scenario took: 247 seconds

  Scenario: Cleanup: Remove Git pillar configuration for Salt master                    # features/secondary/srv_salt_git_pillar.feature:21
      This scenario ran at: 2024-11-28 14:50:02 +0100
mgrctl exec -i 'sh /tmp/salt_git_pillar_setup.sh clean' returned status code = 0.
Output:
'Cleaning git_pillar environment and restarting Salt master and Salt API
'
    When I clean up the git_pillar environment on the Salt master                       # features/step_definitions/salt_steps.rb:86
    And I wait until Salt master can reach "sle_minion"                                 # features/step_definitions/salt_steps.rb:110
    Then file "/etc/salt/master.d/zz-testing-gitpillar.conf" should not exist on server # features/step_definitions/file_management_steps.rb:36
      This scenario took: 7 seconds

  Scenario: Cleanup: Check for the expected pillar data after disabling Git pillar # features/secondary/srv_salt_git_pillar.feature:26
      This scenario ran at: 2024-11-28 14:50:09 +0100
    When I refresh the pillar data                                                 # features/step_definitions/salt_steps.rb:354
    Then the pillar data for "git_pillar_foobar" should be empty on "sle_minion"   # features/step_definitions/salt_steps.rb:393
    And the pillar data for "org_id" should be "1" on "sle_minion"                 # features/step_definitions/salt_steps.rb:373
    And the pillar data for "git_pillar_foobar" should be empty on the Salt master # features/step_definitions/salt_steps.rb:403
      This scenario took: 4 seconds

4 scenarios (4 passed)
15 steps (15 passed)
4m25.901s
```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25657
Port(s): # **add downstream PR(s), if any** (Currently it appears only in uyuni)

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
