### PR TITLE
Fix mgr-sign-metadata-ctl check-channels when checking for signatures in repomd metadata (bsc#1233884)

### DIFF
--- a/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
+++ b/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
@@ -299,7 +299,7 @@ elif [[ $ACTION = "check-channels" ]]; then
            if [ ! -d "$REPODATA_DIR/$ch" ]; then
                 echo "ERROR. Channel $ch. Cached metadata not generated."
            else
-               if [[ -f "$REPODATA_DIR/$ch/Release.gpg" || -f "$REPODATA_DIR/$ch/Release.gpg" ]]; then
+               if [[ -f "$REPODATA_DIR/$ch/Release.gpg" || -f "$REPODATA_DIR/$ch/repomd.xml.asc" ]]; then
                     echo "OK. Channel $ch. Cached metadata is signed."
                else
                     echo "ERROR. Channel $ch. Cached metadata is not signed."

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.fix-signed-check
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.fix-signed-check
@@ -1,0 +1,2 @@
+- Fix mgr-sign-metadata-ctl check-channels when checking for
+  signatures in repomd metadata (bsc#1233884)


### PR DESCRIPTION
## What does this PR change?

The mgr-sign-metadata-ctl check-channels command is currently only checking for debian repos correctly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: cmd tool no tests

- [x] **DONE**

## Links

Port(s): TBD

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
