### PR TITLE
Revert "Clean up deployment salt minion leftovers on CT"

### DIFF
--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -4,9 +4,6 @@
 @buildhost
 Feature: Bootstrap a build host via the GUI
 
-  Scenario: Clean up sumaform leftovers on build host
-    When I perform a full salt minion cleanup on "build_host"
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/min_deblike_salt.feature
+++ b/testsuite/features/init_clients/min_deblike_salt.feature
@@ -7,9 +7,6 @@
 @deblike_minion
 Feature: Bootstrap a Debian-like minion and do some basic operations on it
 
-  Scenario: Clean up sumaform leftovers on Debian-like minion
-    When I perform a full salt minion cleanup on "deblike_minion"
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/min_rhlike_salt.feature
+++ b/testsuite/features/init_clients/min_rhlike_salt.feature
@@ -7,9 +7,6 @@
 @rhlike_minion
 Feature: Bootstrap a Red Hat-like minion and do some basic operations on it
 
-  Scenario: Clean up sumaform leftovers on Red Hat-like minion
-    When I perform a full salt minion cleanup on "rhlike_minion"
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/min_virthost.feature
+++ b/testsuite/features/init_clients/min_virthost.feature
@@ -7,9 +7,6 @@
 @virthost_kvm
 Feature: Bootstrap a virtualization host minion and set it up for virtualization
 
-  Scenario: Clean up sumaform leftovers on KVM virtual host
-    When I perform a full salt minion cleanup on "kvm_server"
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -4,9 +4,6 @@
 @sle_minion
 Feature: Bootstrap a Salt minion via the GUI
 
-  Scenario: Clean up sumaform leftovers on SLES minion
-    When I perform a full salt minion cleanup on "sle_minion"
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -4,9 +4,6 @@
 @ssh_minion
 Feature: Bootstrap a Salt host managed via salt-ssh
 
-  Scenario: Clean up sumaform leftovers on SLES SSH minion
-    When I perform a full salt minion cleanup on "ssh_minion"
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 


### PR DESCRIPTION
Reverts uyuni-project/uyuni#9530

Tt does not fly, as we actually don't have the repositories synchronized on CT, and therefore... we don't have the venv-enabled txt file, and so, we can't bootstrap the minions :disappointed:

It's a pity, I would like to at least think again about synchronizing Leap 15.5, to have a good comparison between onboardings on SUMA and Uyuni. But for now, reverting.