### PR TITLE
Improve channel change

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -625,6 +625,19 @@ public class SystemHandler extends BaseHandler {
                 .map(cid -> ChannelFactory.lookupByIdAndUser(cid, loggedInUser))
                 .toList();
 
+        // consistent check
+        long bid = baseChannel.map(Channel::getId).orElse(-1L);
+        for (Server s : servers) {
+            if (bid == -1L) {
+                bid = s.getBaseChannel().getId();
+            }
+            for (Channel cch : childChannels) {
+                if (!cch.getParentChannel().getId().equals(bid)) {
+                    throw new InvalidParentChannelException();
+                }
+            }
+        }
+
         try {
             Set<Action> action = ActionChainManager.scheduleSubscribeChannelsAction(loggedInUser,
                     serverIds,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -127,6 +127,7 @@ import com.redhat.rhn.frontend.xmlrpc.InvalidEntitlementException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidPackageArchException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidPackageException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
+import com.redhat.rhn.frontend.xmlrpc.InvalidParentChannelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidProfileLabelException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidSystemException;
 import com.redhat.rhn.frontend.xmlrpc.MethodInvalidParamException;
@@ -564,8 +565,15 @@ public class SystemHandler extends BaseHandler {
      * @apidoc.doc Schedule an action to change the channels of the given system. Works for both traditional
      * and Salt systems.
      * This method accepts labels for the base and child channels.
-     * If the user provides an empty string for the channelLabel, the current base channel and
-     * all child channels will be removed from the system.
+     * If the user provides an empty string for the baseChannelLabel and an empty list for the childLabels,
+     * the current base channel and all child channels will be removed from the system.
+     * If the user provides only a different baseChannelLabel and an empty list for childLabels,
+     * the new base channel is assigned to the system and we search for compatible child channels for the assigned one.
+     * If the base channel stay empty, all the child channels from the list should be compatible with the currently
+     * assigned base channel. The currently assigned child channels are exchanged with the channels provided in
+     * the childLabels list.
+     * When both baseChannelLabel and childLabels are provided, the compatibility is checked, and the system
+     * gets these new set of channels assigned.
      *
      * @apidoc.param #session_key()
      * @apidoc.param #array_single("int", "sids")
@@ -596,7 +604,7 @@ public class SystemHandler extends BaseHandler {
                 .collect(toSet());
 
         for (Server s : servers) {
-            if (baseChannel.map(Channel::getChannelArch)
+            if (baseChannel.isPresent() && baseChannel.map(Channel::getChannelArch)
                     .filter(arch -> arch.isCompatible(s.getServerArch()))
                     .isEmpty()) {
                 throw new InvalidChannelException();

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -538,8 +538,26 @@ public class SaltServerActionService {
 
     private void executeForRegularMinions(Action actionIn, boolean forcePackageListRefresh,
             boolean isStagingJob, Optional<Long> stagingJobMinionServerId, List<MinionSummary> minionSummaries) {
-        for (Map.Entry<LocalCall<?>, List<MinionSummary>> entry : callsForAction(actionIn, minionSummaries)
-                .entrySet()) {
+        Map<LocalCall<?>, List<MinionSummary>> localCalls = new HashMap<>();
+        try {
+             localCalls = callsForAction(actionIn, minionSummaries);
+        }
+        catch (RuntimeException e) {
+            LOG.error("Failed to prepare salt calls: ", e);
+            List<Long> failedServerIds  = minionSummaries.stream()
+                    .map(MinionSummary::getServerId).toList();
+            if (!failedServerIds.isEmpty()) {
+                actionIn.getServerActions().stream()
+                        .filter(sa -> failedServerIds.contains(sa.getServer().getId()))
+                        .forEach(sa -> {
+                            sa.setStatus(STATUS_FAILED);
+                            sa.setResultMsg("Error preparing salt call: " + e.getMessage());
+                            sa.setCompletionTime(new Date());
+                        });
+            }
+            return;
+        }
+        for (Map.Entry<LocalCall<?>, List<MinionSummary>> entry : localCalls.entrySet()) {
             LocalCall<?> call = entry.getKey();
             final List<MinionSummary> targetMinions;
             Map<Boolean, List<MinionSummary>> results;
@@ -2481,7 +2499,16 @@ public class SaltServerActionService {
 
             sa.setRemainingTries(sa.getRemainingTries() - 1);
 
-            Map<LocalCall<?>, List<MinionSummary>> calls = callsForAction(action, List.of(new MinionSummary(minion)));
+            Map<LocalCall<?>, List<MinionSummary>> calls = new HashMap<>();
+            try {
+                calls = callsForAction(action, List.of(new MinionSummary(minion)));
+            }
+            catch (RuntimeException e) {
+                sa.setStatus(STATUS_FAILED);
+                sa.setResultMsg("Error preparing salt call: " + e.getMessage());
+                sa.setCompletionTime(new Date());
+                return;
+            }
 
             for (LocalCall<?> call : calls.keySet()) {
                 Optional<Result<JsonElement>> result;

--- a/java/spacewalk-java.changes.mcalmer.improve-channel-change
+++ b/java/spacewalk-java.changes.mcalmer.improve-channel-change
@@ -1,1 +1,4 @@
+- Support removing all channels with scheduleChangeChannels()
+- Support finding compatible child channels when changing the
+  base channels with scheduleChangeChannels()
 - Check consistence of base and child channels (bsc#1232713)

--- a/java/spacewalk-java.changes.mcalmer.improve-channel-change
+++ b/java/spacewalk-java.changes.mcalmer.improve-channel-change
@@ -1,0 +1,1 @@
+- Check consistence of base and child channels (bsc#1232713)


### PR DESCRIPTION
## What does this PR change?

This PR handle 3 issues
- when child channels do not match the base channel, raise early an excpeption
- when an exception happens late, cancel the server action if it exists
- support 2 special cases which were possible with the deprecated setBaseChannel() call
  - when baseChannelLabel and childLabels are both empty, unassign all channels from the system
  - when only a new baseChannelLabel is provided, look for compatible child channels to the assigned once and add them

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port(s): Added on top of https://github.com/SUSE/spacewalk/pull/25923

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
