### PR TITLE
Force the generation of bootstrap repositories in CT

### DIFF
--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -4,6 +4,9 @@
 @buildhost
 Feature: Bootstrap a build host via the GUI
 
+  Scenario: Clean up sumaform leftovers on build host
+    When I perform a full salt minion cleanup on "build_host"
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/min_virthost.feature
+++ b/testsuite/features/init_clients/min_virthost.feature
@@ -7,6 +7,9 @@
 @virthost_kvm
 Feature: Bootstrap a virtualization host minion and set it up for virtualization
 
+  Scenario: Clean up sumaform leftovers on KVM virtual host
+    When I perform a full salt minion cleanup on "kvm_server"
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -4,6 +4,9 @@
 @sle_minion
 Feature: Bootstrap a Salt minion via the GUI
 
+  Scenario: Clean up sumaform leftovers on SLES minion
+    When I perform a full salt minion cleanup on "sle_minion"
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -4,6 +4,9 @@
 @ssh_minion
 Feature: Bootstrap a Salt host managed via salt-ssh
 
+  Scenario: Clean up sumaform leftovers on SLES SSH minion
+    When I perform a full salt minion cleanup on "ssh_minion"
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 

--- a/testsuite/features/reposync/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/reposync/srv_create_bootstrap_repositories.feature
@@ -1,0 +1,10 @@
+# Copyright (c) 2021-2024 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Create bootstrap repositories
+  In order to be able to enroll clients with MU repositories
+  As the system administrator
+  I create all bootstrap repos with --with-custom-channels option
+
+  Scenario: Create the bootstrap repositories including custom channels
+    When I create the bootstrap repositories including custom channels

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1076,6 +1076,11 @@ When(/^I create the bootstrap repository for "([^"]*)" on the server((?: without
   get_target('server').run(cmd)
 end
 
+When(/^I create the bootstrap repositories including custom channels$/) do
+  get_target('server').wait_while_process_running('mgr-create-bootstrap-repo')
+  get_target('server').run('mgr-create-bootstrap-repo --auto --force --with-custom-channels', check_errors: false, verbose: true)
+end
+
 When(/^I install "([^"]*)" product on the proxy$/) do |product|
   out, = get_target('proxy').run("zypper ref && zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product #{product}")
   log "Installed #{product} product: #{out}"

--- a/testsuite/run_sets/reference_reposync.yml
+++ b/testsuite/run_sets/reference_reposync.yml
@@ -23,6 +23,7 @@
 
 # Special reference repo sync
 - features/reposync/reference_srv_sync_products_extra.feature
+- features/reposync/srv_create_bootstrap_repositories.feature
 #- features/reposync/reference_srv_check_reposync.feature
 
 ## Channels and Product synchronization features END ###

--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -19,4 +19,5 @@
 # Activation keys can only be created after products and channels are synced
 - features/reposync/srv_create_activationkey.feature
 - features/reposync/allcli_update_activationkeys.feature
+- features/reposync/srv_create_bootstrap_repositories.feature
 ## Channels and Product synchronization features END ###


### PR DESCRIPTION
## What does this PR change?

This PR aims to have back the proper onboarding of salt bundle on Continuous Testing for at least those minions that have a product synchronized, or at least the Client Tools.
For that, we are force to regenerate the bootstrap repository, so the venv-enabled-x86_64.txt is generated.

Until now, we live without it, because we were installing salt-bundle manually through sumaform, in particular we do it at cloud-init or combustion stage, we do like that so sumaform can run the salt states to configure all the system after the VM is deployed.
But what it happen now is that our server detects a salt-bundle package already installed and don't do a proper onboarding of the minion, installing the package on the custom client tools repo, instead it's using the one previously installed, that's why we need to run a pre-condition scenario that clean the salt-bundle used during the deployment.

That's easy to observe when we look on the metrics of the time it takes the onboard in Uyuni compared with MLM 5.0 https://grafana.mgr.suse.de/d/ae3c5r75ow8owb/fitness-functions?from=now-7d&to=now&timezone=browser

This is a continuation of this revert: https://github.com/uyuni-project/uyuni/pull/9532

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-5.0
- Manager-4.3

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
