### PR TITLE
Add missing join in the count query for the packages list

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -1291,7 +1291,7 @@ public class PackageManager extends BaseManager {
                         "left join rhnPackageKeyAssociation assoc on assoc.package_id = P.id " +
                         "left join rhnPackageKey KEY on KEY.id = assoc.key_id " +
                         "left join rhnPackageProvider PP on KEY.provider_id = PP.id")
-                .countFrom("rhnPackage P")
+                .countFrom("rhnPackage P inner join rhnPackageName PN on P.name_id = PN.id")
                 .where("P.org_id = :org_id")
                 .run(Map.of("org_id", orgId), pc, PagedSqlQueryBuilder::parseFilterAsText, PackageOverview.class);
     }

--- a/java/spacewalk-java.changes.cbosdo.packages-list
+++ b/java/spacewalk-java.changes.cbosdo.packages-list
@@ -1,0 +1,2 @@
+- Fix missing FROM-clause entry for table 'pn' in managed software
+  list (bsc#1233450)


### PR DESCRIPTION
## What does this PR change?

This fixes the following error message when filtering all managed packages (bsc#1233450):

    ERROR: missing FROM-clause entry for table "pn"

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: hard to test

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25889
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
