### PR TITLE
Ubuntu2404 set signedby

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -165,7 +165,15 @@ public class MinionGeneralPillarGenerator extends MinionPillarGeneratorBase {
             chanProps.put("repo_gpgcheck", "0");
             chanProps.put("pkg_gpgcheck", chan.isGPGCheck() ? "1" : "0");
         }
-        // For Type deb the packages are not signed. No need to set a GPG key here.
+        else {
+            // For Type deb the packages are not signed. But there are nasty warnings when none is given
+            if (minion.getOs().toLowerCase().contains("ubuntu")) {
+                chanProps.put("gpgkeyurl", "file:///usr/share/keyrings/ubuntu-archive-keyring.gpg");
+            }
+            else if (minion.getOs().toLowerCase().contains("debian")) {
+                chanProps.put("gpgkeyurl", "file:///usr/share/keyrings/debian-archive-keyring.gpg");
+            }
+        }
 
         // Flag to override dnf modularity failsafe mechanism (module_hotfixes)
         chanProps.put("cloned_nonmodular", chan.isCloned() && !chan.isModular());

--- a/java/spacewalk-java.changes.mcalmer.Manager-4.3-ubuntu2404-set-signedby
+++ b/java/spacewalk-java.changes.mcalmer.Manager-4.3-ubuntu2404-set-signedby
@@ -1,0 +1,2 @@
+- Set Signed-by for debian repositories also for unsigned repos to
+  prevent warning messages (bsc#1234251)

--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -18,7 +18,9 @@ URIs: {{protocol}}://{{ args['token'] }}@{{hostname}}:{{port}}/rhn/manager/downl
 {%- endif %}
 Suites: {{ chan }}/
 Components:
+{%- if not salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
 Trusted: yes
+{%- endif %}
 {%- if args['gpgkeyurl'] is defined and args['gpgkeyurl'].startswith('file:///') %}
 Signed-By: {{ args['gpgkeyurl'][7:] }}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.ubuntu2404-set-signedby
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.ubuntu2404-set-signedby
@@ -1,0 +1,2 @@
+- Do not set "Trusted" for debian repositories when the repo
+  should be signed


### PR DESCRIPTION
## What does this PR change?

Improve handling of Debian repository configuration.
- Set "Signed-by" also for unsigned repos to prevent warning messages
- Do not set "Trusted" when the repo should be signed

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/25979

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
