### PR TITLE
Only show versions for 'kernel-default' in CLM Live Patching template (bsc#1233400)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -752,7 +752,7 @@ public class SUSEProductFactory extends HibernateFactory {
                 "JOIN SUSEProduct ext ON x.extensionProduct = ext " +
                 "JOIN SUSEProductChannel pc ON pc.product = ext " +
                 "JOIN pc.channel.packages pkg " +
-                "WHERE pkg.packageName.name LIKE 'kernel-default%' " +
+                "WHERE pkg.packageName.name = 'kernel-default' " +
                 "AND x.rootProduct = :product", PackageEvr.class)
                 .setParameter("product", product)
                 .getResultStream();

--- a/java/spacewalk-java.changes.cbbayburt.bsc1233400
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1233400
@@ -1,0 +1,2 @@
+- Only show versions for 'kernel-default' in CLM Live Patching
+  template (bsc#1233400)


### PR DESCRIPTION
"Live patching for a product" filter in CLM shows versions of all the available kernels in a dropdown, including `kernel-default-base` and any other flavours. Since live patching is only available for `kernel-default`, this change excludes the versions from other kernel packages from the dropdown list.

Port of [#25987 (Manager-4.3)](https://github.com/SUSE/spacewalk/pull/25987)

## Links

Issue: https://github.com/SUSE/spacewalk/issues/25813

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
