### PR TITLE
Use dots instead of underscores in the left menu

### DIFF
--- a/java/buildconf/apidoc/asciidoc/apiindex.txt
+++ b/java/buildconf/apidoc/asciidoc/apiindex.txt
@@ -1,3 +1,3 @@
 #foreach ($handler in $handlers)
-* <<${handler.name}.adoc#apidoc-$handler.name.replaceAll('\.', '_')>>
+* <<${handler.name}.adoc#apidoc-$handler.name>>
 #end

--- a/java/spacewalk-java.changes.cbosdo.apidoc
+++ b/java/spacewalk-java.changes.cbosdo.apidoc
@@ -1,0 +1,1 @@
+- Use dots instead of underscores in apidoc (bsc#1233761)


### PR DESCRIPTION
## What does this PR change?

Since users need to use dots to separate the API modules those should be showing up in the help to avoid confusion (bsc#1233761).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- API documentation changed: https://github.com/uyuni-project/uyuni-docs-api/pull/59

- [x] **DONE**

## Test coverage
- No tests: doc tooling

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25898
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
