### PR TITLE
Added missing changelogs

### DIFF
--- a/microservices/uyuni-java-parent/uyuni-java-parent.changes.mackdk.add-missing-changelogs
+++ b/microservices/uyuni-java-parent/uyuni-java-parent.changes.mackdk.add-missing-changelogs
@@ -1,0 +1,1 @@
+- Added Awaitility to support asynchronous testing

--- a/search-server/spacewalk-search/spacewalk-search.changes.mackdk.add-missing-changelogs
+++ b/search-server/spacewalk-search/spacewalk-search.changes.mackdk.add-missing-changelogs
@@ -1,0 +1,1 @@
+- Updated the versions of the java build dependencies


### PR DESCRIPTION
## What does this PR change?

This PR adds missing changelog entries to `spacewalk-search` and `uyuni-java-parent`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no functional changes

- [X] **DONE**

## Test coverage
- No tests: No code changes

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
