### PR TITLE
Don't hardcode 127.0.0.1 in salt-api configuration

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -1,7 +1,7 @@
 # Setup cherrypy
 rest_cherrypy:
   port: 9080
-  host: 127.0.0.1
+  host: localhost
   collect_stats: false
   expire_responses: false
   ssl_crt: /etc/salt/pki/api/salt-api.crt

--- a/spacewalk/setup/spacewalk-setup.changes.cbosdo.salt-api-ip
+++ b/spacewalk/setup/spacewalk-setup.changes.cbosdo.salt-api-ip
@@ -1,0 +1,2 @@
+- Salt API should listen on localhost rather than 127.0.0.1
+  (bsc#1230865)


### PR DESCRIPTION
## What does this PR change?

Tomcat accesses the salt api using `localhost` but the salt-api is configured to listen on `127.0.0.1`. This works fine until IPv4 is disabled on the host or the `127.0.0.1` line is commented out in `/etc/hosts`.

In order to make sure both sides are on the same page, use localhost in the salt-api too (bsc#1230865).

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: requires test with disabled IPv4
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25318
Port(s): https://github.com/SUSE/spacewalk/pull/26042

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
