### PR TITLE
Make the list for package actions unique so it can be passed to salt (bsc#1232042)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -2009,10 +2009,36 @@ public class ActionManager extends BaseManager {
     public static void addPackageActionDetails(Collection<Action> actions,
             List<Map<String, Long>> packageMaps) {
         if (packageMaps != null) {
+            List<Map<String, Long>> pkgMaps;
+
+            if (actions.iterator().next().getActionType().equals(ActionFactory.TYPE_PACKAGES_REMOVE)) {
+                // our packages.pkgremove state is handling duplicates
+                pkgMaps = packageMaps;
+            }
+            else {
+                long noarch = PackageFactory.lookupPackageArchByLabel("noarch").getId();
+                long all = PackageFactory.lookupPackageArchByLabel("all-deb").getId();
+                Map<String, Map<String, Long>> uPkgMap = new HashMap<>();
+                // For other salt pkg states (pkg.installed), name + arch must be unique.
+                for (Map<String, Long> p : packageMaps) {
+                    long archId = p.getOrDefault("arch_id", noarch);
+                    String name = String.valueOf(p.get("name_id"));
+                    if (archId == noarch || archId == all) {
+                        if (uPkgMap.keySet().stream().noneMatch(k -> k.startsWith(name + "."))) {
+                            uPkgMap.put(name, p);
+                        }
+                    }
+                    else if (!uPkgMap.containsKey(name)) {
+                        String key = name + "." + p.get("arch_id");
+                        uPkgMap.put(key, p);
+                    }
+                }
+                pkgMaps = new ArrayList<>(uPkgMap.values());
+            }
             List<Map<String, Object>> paramList =
                 actions.stream().flatMap(action -> {
                     String packageParameter = getPackageParameter(action);
-                    return packageMaps.stream().map(packageMap -> {
+                    return pkgMaps.stream().map(packageMap -> {
                         Map<String, Object> params = new HashMap<>();
                         params.put("action_id", action.getId());
                         params.put("name_id", packageMap.get("name_id"));

--- a/java/spacewalk-java.changes.mcalmer.Manager-4.3-unique-pkglist-in-action
+++ b/java/spacewalk-java.changes.mcalmer.Manager-4.3-unique-pkglist-in-action
@@ -1,0 +1,2 @@
+- Make the list for package actions unique so it can be passed
+  to salt (bsc#1232042)


### PR DESCRIPTION
## What does this PR change?

The package name+arch must be unique for salt pkg states.
Take care that this is correctly set in the Action Details

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual tested**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/8121
Fixes https://github.com/uyuni-project/uyuni/issues/8998
Port(s): https://github.com/SUSE/spacewalk/pull/25985

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
