### PR TITLE
Lazy error report

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygAuthDataProcessor.java
@@ -306,6 +306,7 @@ public class PaygAuthDataProcessor {
         PaygSshDataFactory.savePaygSshData(instance);
         return credentials;
     }
+
     /**
      * Invalidate PAYG Instance credentials
      * @param instance the instance
@@ -318,5 +319,4 @@ public class PaygAuthDataProcessor {
                 CredentialsFactory.storeCredentials(credentials);
             });
     }
-
 }

--- a/java/spacewalk-java.changes.mcalmer.Manager-4.3-lazy-error-report
+++ b/java/spacewalk-java.changes.mcalmer.Manager-4.3-lazy-error-report
@@ -1,0 +1,2 @@
+- Show an error notification only when we invalidate the
+  payg credentials (bsc#1228956)


### PR DESCRIPTION
## What does this PR change?

For a PAYG Connection we check if the instance is PAYG. This test seems to be flaky and sometimes return BYOS.
We already invalidated the credentials only when the error happened the 2nd time in a row, but we showed the notification already on the first error.
This scares the user and produce questions especially as still everything works.

So with this PR we send the notification also on the second error when we also invalidate the credentials.
If the error happen only 1 time and is fixed with the next try, no visible error is reported.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26033

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
