### PR TITLE
fixes - ISE when removing systems from SSM (bsc#1222820)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/RebootSystemAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/RebootSystemAction.java
@@ -91,13 +91,15 @@ public class RebootSystemAction
         List<SystemOverview> systems = SystemManager.inSet(context.getCurrentUser(),
                 RhnSetDecl.SYSTEMS.getLabel());
 
-        List<Long> sids = ServerFactory.findSystemsPendingRebootActions(systems);
-        if (!sids.isEmpty()) {
-            getStrutsDelegate().saveMessage("ssm.misc.reboot.message.scheduled", context.getRequest());
-        }
+        if (!systems.isEmpty()) {
+            List<Long> sids = ServerFactory.findSystemsPendingRebootActions(systems);
+            if (!sids.isEmpty()) {
+                getStrutsDelegate().saveMessage("ssm.misc.reboot.message.scheduled", context.getRequest());
+            }
 
-        for (SystemOverview systemOverview : systems) {
-            systemOverview.setSelectable(1);
+            for (SystemOverview systemOverview : systems) {
+                systemOverview.setSelectable(1);
+            }
         }
 
         return systems;

--- a/java/spacewalk-java.changes.carlo.Manager-4.3-fix-ssm-page-reboot
+++ b/java/spacewalk-java.changes.carlo.Manager-4.3-fix-ssm-page-reboot
@@ -1,0 +1,2 @@
+- Fixes bug when accessing menu Systems | System Set Manager |
+  Misc | Reboot with no system selected (bsc#1222820)


### PR DESCRIPTION
## What does this PR change?

When accessing menu Systems > System Set Manager > Misc > Reboot with no system selected, an "Internal server error" page is shown. This is due to the fact that the query Server.findServersPendingRebootAction has a clause "IN (:systemIds)", hence an empty set of selected systems crashes the query.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: bug fix
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26105

- [x] **DONE**

## Changelogs

- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

