### PR TITLE
Always parse versions from rhn config as strings

### DIFF
--- a/python/spacewalk/common/rhnConfig.py
+++ b/python/spacewalk/common/rhnConfig.py
@@ -388,6 +388,8 @@ def parse_line(line):
             "db_host": str,
             "server.susemanager.mirrcred_user": str,
             "server.susemanager.mirrcred_pass": str,
+            "web.version": str,
+            "web.version.uyuni": str,
         }
         val = val.strip()
 

--- a/python/spacewalk/spacewalk-backend.changes.vzhestkov.fix-version-cfg-parse
+++ b/python/spacewalk/spacewalk-backend.changes.vzhestkov.fix-version-cfg-parse
@@ -1,0 +1,1 @@
+- Always parse versions from rhn config as strings


### PR DESCRIPTION
## What does this PR change?

`web.version.uyuni` config value is wrongly parsed as `float` and `2024.10` became `2024.1`.

`web.version` added as well even if it makes no much sense now, but anyway it should be always string as well.

## GUI diff

No difference.


## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: there are no unit tests for this legacy part of the code

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9414
Port(s): Not needed as Uyuni is the only having such values wrongly parsed as floats

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
