### PR TITLE
Fix monitoring ent detection

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2566,19 +2566,23 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * This is supposed to cover all RedHat flavors (incl. RHEL, RES and CentOS Linux)
      */
     boolean isRedHat6() {
-        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("6");
+        return ServerConstants.REDHAT.equals(getOsFamily()) &&
+                (getRelease().equals("6") || getRelease().startsWith("6."));
     }
 
     boolean isRedHat7() {
-        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("7");
+        return ServerConstants.REDHAT.equals(getOsFamily()) &&
+                (getRelease().equals("7") || getRelease().startsWith("7."));
     }
 
     boolean isRedHat8() {
-        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("8");
+        return ServerConstants.REDHAT.equals(getOsFamily()) &&
+                (getRelease().equals("8") || getRelease().startsWith("8."));
     }
 
     boolean isRedHat9() {
-        return ServerConstants.REDHAT.equals(getOsFamily()) && getRelease().equals("9");
+        return ServerConstants.REDHAT.equals(getOsFamily()) &&
+                (getRelease().equals("9") || getRelease().startsWith("9."));
     }
 
     public boolean isRedHat() {
@@ -2590,19 +2594,13 @@ public class Server extends BaseDomainHelper implements Identifiable {
     }
 
     boolean isAmazon2() {
-        return ServerConstants.AMAZON.equals(getOsFamily()) && getRelease().equals("2");
+        return ServerConstants.AMAZON.equals(getOsFamily()) &&
+                (getRelease().equals("2") || getRelease().startsWith("2."));
     }
 
     boolean isAmazon2023() {
-        return ServerConstants.AMAZON.equals(getOsFamily()) && getRelease().equals("2023");
-    }
-
-    boolean isRocky8() {
-        return ServerConstants.ROCKY.equals(getOs()) && getRelease().startsWith("8.");
-    }
-
-    boolean isRocky9() {
-        return ServerConstants.ROCKY.equals(getOs()) && getRelease().startsWith("9.");
+        return ServerConstants.AMAZON.equals(getOsFamily()) &&
+                (getRelease().equals("2023") || getRelease().startsWith("2023."));
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -24,17 +24,12 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.common.messaging.MessageQueue;
-import com.redhat.rhn.common.util.RpmVersionComparator;
 import com.redhat.rhn.common.util.StringUtil;
-import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.channel.ChannelArch;
-import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
-import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ContactMethod;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
@@ -50,9 +45,7 @@ import com.redhat.rhn.domain.state.StateFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.dto.EssentialChannelDto;
 import com.redhat.rhn.manager.action.ActionManager;
-import com.redhat.rhn.manager.distupgrade.DistUpgradeManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
@@ -82,15 +75,12 @@ import com.suse.manager.webui.utils.salt.custom.MinionStartupGrains;
 import com.suse.manager.webui.utils.salt.custom.SumaUtil.PublicCloudInstanceFlavor;
 import com.suse.manager.webui.utils.salt.custom.SystemInfo;
 import com.suse.salt.netapi.datatypes.target.MinionList;
-import com.suse.salt.netapi.errors.SaltError;
 import com.suse.salt.netapi.exception.SaltException;
-import com.suse.salt.netapi.results.Result;
 import com.suse.utils.Opt;
 
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -98,9 +88,7 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -569,7 +557,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
             String osfullname = grains.getValueAsString("osfullname");
             String osfamily = grains.getValueAsString("os_family");
-            String osrelease = getOsRelease(minionId, grains);
+            String osrelease = grains.getOptionalAsString("osrelease").orElse("unknown");
 
             String kernelrelease = grains.getValueAsString("kernelrelease");
             String osarch = grains.getValueAsString("osarch");
@@ -697,18 +685,6 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 .getMap("susemanager")
                 .flatMap(suma -> suma.getOptionalAsString("activation_key"));
         return activationKeyOverride.isPresent() ? activationKeyOverride : activationKeyFromGrains;
-    }
-
-    /**
-     * Extract management key label from grains
-     *
-     * @param grains
-     * @return
-     */
-    private Optional<String> getManagementKeyLabelFromGrains(ValueMap grains) {
-        //apply management key properties that can be set before saving the server
-        return grains.getMap("susemanager")
-                .flatMap(suma -> suma.getOptionalAsString("management_key"));
     }
 
     /**
@@ -968,159 +944,6 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                     return ak.getContactMethod();
                 }
         );
-    }
-
-    private static Optional<Channel> lookupBaseChannel(SUSEProduct sp, ChannelArch arch) {
-        Optional<EssentialChannelDto> productBaseChannelDto =
-                ofNullable(DistUpgradeManager.getProductBaseChannelDto(sp.getId(), arch));
-        Optional<Channel> baseChannel = productBaseChannelDto
-                .flatMap(base -> ofNullable(ChannelFactory.lookupById(base.getId())).map(c -> {
-                    LOG.info("Base channel {} found for OS: {}, version: {}, arch: {}", c.getName(), sp.getName(),
-                            sp.getVersion(), arch.getName());
-            return c;
-        }));
-        if (!baseChannel.isPresent()) {
-            LOG.warn("Product Base channel not found - refresh SCC sync?");
-            return empty();
-        }
-        return baseChannel;
-    }
-
-    private Optional<String> rpmErrQueryRHELProvidesRelease(String minionId) {
-        LOG.error("No package providing 'redhat-release' found on RHEL minion {}", minionId);
-        return empty();
-    }
-
-    private Optional<String> rpmErrQueryRHELRelease(SaltError err, String minionId) {
-        LOG.error("Error querying 'redhat-release' package on RHEL minion {}: {}", minionId, err);
-        return empty();
-    }
-
-    private String unknownRHELVersion(String minionId) {
-        LOG.error("Could not determine OS release version for RHEL minion {}", minionId);
-        return "unknown";
-    }
-
-    private Map<String, List<String>> parseRHELReleseQuery(String result) {
-        // Split the result into 3-line chunks per installed package version
-        String[] resultLines = result.split("\\r?\\n");
-        List<List<String>> resultItems = new ArrayList<>();
-        for (int i = 0; i < resultLines.length;) {
-            List<String> resultItem = new ArrayList<>();
-            for (int j = 0; j < 3; j++) {
-                resultItem.add(resultLines[i++]);
-            }
-            resultItems.add(resultItem);
-        }
-
-        // Create a map for each 3-line chunk from key-value pairs in each line
-        return resultItems.stream()
-                .map(list -> list.stream().map(line -> line.split("="))
-                        .collect(Collectors.toMap(linetoks -> linetoks[0],
-                                linetoks -> Arrays.asList(StringUtils
-                                        .splitPreserveAllTokens(linetoks[1], ",")))))
-                // Get the result map with the biggest rpm version
-                .max(Comparator.comparing(pkgInfoMap -> pkgInfoMap.get("VERSION").get(0),
-                        new RpmVersionComparator()))
-                .get();
-    }
-
-    private String getOsRelease(String minionId, ValueMap grains) {
-        // java port of up2dataUtils._getOSVersionAndRelease()
-        String osRelease = grains.getValueAsString("osrelease");
-
-        if ("redhat".equalsIgnoreCase(grains.getValueAsString("os")) ||
-                "centos".equalsIgnoreCase(grains.getValueAsString("os")) ||
-                "oel".equalsIgnoreCase(grains.getValueAsString("os")) ||
-                "alibaba cloud (aliyun)".equalsIgnoreCase(grains.getValueAsString("os")) ||
-                "almalinux".equalsIgnoreCase(grains.getValueAsString("os")) ||
-                ("amazon".equalsIgnoreCase(grains.getValueAsString("os")) &&
-                 "2".equalsIgnoreCase(grains.getValueAsString("osmajorrelease"))) ||
-                "rocky".equalsIgnoreCase(grains.getValueAsString("os"))) {
-            MinionList target = new MinionList(Arrays.asList(minionId));
-            Optional<Result<String>> whatprovidesRes = saltApi.runRemoteCommand(target,
-                    "rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release")
-                    .entrySet()
-                    .stream()
-                    .findFirst()
-                    .map(e -> of(e.getValue()))
-                    .orElse(empty());
-
-            osRelease = whatprovidesRes.flatMap(res -> res.fold(
-                    err -> err.fold(err1 -> rpmErrQueryRHELProvidesRelease(minionId),
-                            err2 -> rpmErrQueryRHELProvidesRelease(minionId),
-                            err3 -> rpmErrQueryRHELProvidesRelease(minionId),
-                            err4 -> rpmErrQueryRHELProvidesRelease(minionId),
-                            err5 -> rpmErrQueryRHELProvidesRelease(minionId)),
-                    r -> of(r.split("\\r?\\n")[0]) // Take the first line if multiple results return
-            ))
-            .flatMap(pkgStr -> {
-                String[] pkgs = StringUtils.split(pkgStr);
-                if (pkgs.length > 1) {
-                    LOG.warn("Multiple release packages are installed on minion: {}", minionId);
-                    // Pick the package with the biggest precedence:
-                    // sles_es > redhat > others (centos etc.)
-                    return Arrays.stream(pkgs).max(Comparator.comparingInt(s -> {
-                        switch (s) {
-                        case "sles_es-release-server":
-                            return 2;
-                        case "redhat-release-server":
-                            return 1;
-                        default:
-                            return 0;
-                        }
-                    }));
-                }
-                else {
-                    return of(pkgs[0]);
-                }
-            })
-            .flatMap(pkg ->
-                saltApi.runRemoteCommand(target,
-                        "rpm -q --queryformat \"" +
-                            "VERSION=%{VERSION}\\n" +
-                            "PROVIDENAME=[%{PROVIDENAME},]\\n" +
-                            "PROVIDEVERSION=[%{PROVIDEVERSION},]\\n\" " + pkg)
-                        .entrySet().stream().findFirst().map(Map.Entry::getValue)
-                        .flatMap(res -> res.fold(
-                                err -> err.fold(
-                                        err1 -> rpmErrQueryRHELRelease(err1, minionId),
-                                        err2 -> rpmErrQueryRHELRelease(err2, minionId),
-                                        err3 -> rpmErrQueryRHELRelease(err3, minionId),
-                                        err4 -> rpmErrQueryRHELRelease(err4, minionId),
-                                        err5 -> rpmErrQueryRHELRelease(err5, minionId)),
-                                Optional::of
-                        ))
-                        .map(result -> {
-                            if (result.split("\\r?\\n").length > 3) {
-                                // Output should be 3 lines per installed package version
-                                LOG.warn(String.format(
-                                        "Multiple versions of release package '%s' is installed on minion: %s",
-                                        pkg, minionId));
-                            }
-                            return this.parseRHELReleseQuery(result);
-                        })
-                        .map(pkgtags -> {
-                            Optional<String> version = Optional
-                                    .ofNullable(pkgtags.get("VERSION"))
-                                    .map(v -> v.stream().findFirst())
-                                    .orElse(empty());
-                            List<String> provideName = pkgtags.get("PROVIDENAME");
-                            List<String> provideVersion = pkgtags.get("PROVIDEVERSION");
-                            int idxReleasever = provideName
-                                    .indexOf("system-release(releasever)");
-                            if (idxReleasever > -1) {
-                                version = provideVersion.size() > idxReleasever ?
-                                        of(provideVersion.get(idxReleasever)) :
-                                        empty();
-                            }
-                            return version;
-                        })
-                        .orElse(empty())
-            )
-            .orElseGet(() -> unknownRHELVersion(minionId));
-        }
-        return osRelease;
     }
 
     private void mapHardwareGrains(MinionServer server, ValueMap grains) {

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -99,8 +99,6 @@ import com.suse.salt.netapi.calls.modules.Grains;
 import com.suse.salt.netapi.calls.modules.Zypper.ProductInfo;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.parser.JsonParser;
-import com.suse.salt.netapi.results.Result;
-import com.suse.salt.netapi.utils.Xor;
 import com.suse.utils.Json;
 
 import com.google.gson.Gson;
@@ -1054,18 +1052,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         will(returnValue(getSystemInfo(MINION_ID, testCase.productName.toLowerCase(),
                                 baseChannel != null ? key : null)));
-
-                        allowing(saltServiceMock).runRemoteCommand(
-                                with(any(MinionList.class)),
-                                with("rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release"));
-                        will(returnValue(singletonMap(MINION_ID,
-                                new Result<>(Xor.right(testCase.availableReleasePackages + "\n")))));
-
-                        allowing(saltServiceMock).runRemoteCommand(
-                                with(any(MinionList.class)),
-                                with("rpm -q --queryformat \"VERSION=%{VERSION}\\nPROVIDENAME=[%{PROVIDENAME},]\\n" +
-                                        "PROVIDEVERSION=[%{PROVIDEVERSION},]\\n\" " + testCase.releasePackage));
-                        will(returnValue(singletonMap(MINION_ID, new Result<>(Xor.right(testCase.packageInfo)))));
 
                         allowing(saltServiceMock).redhatProductInfo(MINION_ID);
                         will(returnValue(Optional.of(new RedhatProductInfo(

--- a/java/code/src/com/suse/manager/reactor/test/dummy_systeminfo_rhel9.json
+++ b/java/code/src/com/suse/manager/reactor/test/dummy_systeminfo_rhel9.json
@@ -69,96 +69,43 @@
       "__sls__": "util.systeminfo",
       "changes": {
         "ret": {
-          "biosversion": "rel-1.7.5-0-ge51488c-20150524_160643-cloud127",
           "kernel": "Linux",
-          "domain": "vagrant.local",
-          "biosreleasedate": "04/01/2014",
-          "zmqversion": "4.0.4",
-          "kernelrelease": "3.12.48-52.27-default",
+          "domain": "",
+          "zmqversion": "4.0.8",
+          "kernelrelease": "4.1.27-27-default",
           "pythonpath": [
             "/usr/bin",
-            "/usr/lib/python27.zip",
-            "/usr/lib64/python2.7",
-            "/usr/lib64/python2.7/plat-linux2",
-            "/usr/lib64/python2.7/lib-tk",
-            "/usr/lib64/python2.7/lib-old",
-            "/usr/lib64/python2.7/lib-dynload",
-            "/usr/lib64/python2.7/site-packages",
-            "/usr/local/lib64/python2.7/site-packages",
-            "/usr/local/lib/python2.7/site-packages",
-            "/usr/lib/python2.7/site-packages"
+            "/usr/lib64/python39.zip",
+            "/usr/lib64/python3.9",
+            "/usr/lib64/python3.9/lib-dynload",
+            "/usr/lib64/python3.9/site-packages",
+            "/usr/lib/python3.9/site-packages"
           ],
-          "ip_interfaces": {
-            "lo": [
-              "127.0.0.1",
-              "::1"
-            ],
-            "eth1": [
-              "172.16.37.5",
-              "fe80::5054:ff:feb0:1da2"
-            ],
-            "eth0": [
-              "192.168.121.35",
-              "fe80::5054:ff:fe4f:7102"
-            ]
-          },
-          "shell": "/bin/bash",
-          "mem_total": 489,
+          "ip_interfaces": {},
+          "shell": "/bin/sh",
+          "mem_total": 7684,
           "saltversioninfo": [
-            2015,
-            8,
-            2,
-            0
+            3004,
+            1
           ],
-          "SSDs": [],
-          "server": "suma3pg.vagrant.local",
-          "id": "clisles12-suma3pg.vagrant.local",
-          "osrelease": "7.2",
+          "host": "sll9host",
+          "SSDs": [
+            "sda",
+            "dm-0"
+          ],
+          "id": "sll9host",
+          "osrelease": "9",
           "ps": "ps -efH",
-          "server_id": 1617825398,
-          "uuid": "75299898-533c-ff48-8b5c-be026df56f74",
-          "ip6_interfaces": {
-            "lo": [
-              "::1"
-            ],
-            "eth1": [
-              "fe80::5054:ff:feb0:1da2"
-            ],
-            "eth0": [
-              "fe80::5054:ff:fe4f:7102"
-            ]
-          },
-          "num_cpus": 1,
-          "hwaddr_interfaces": {
-            "lo": "00:00:00:00:00:00",
-            "eth1": "52:54:00:b0:1d:a2",
-            "eth0": "52:54:00:4f:71:02"
-          },
-          "init": "systemd",
-          "ip4_interfaces": {
-            "lo": [
-              "127.0.0.1"
-            ],
-            "eth1": [
-              "172.16.37.5"
-            ],
-            "eth0": [
-              "192.168.121.35"
-            ]
-          },
-          "osfullname": "Red Hat Enterprise Linux Server",
-          "master": "suma3pg",
-          "ipv4": [
-            "127.0.0.1",
-            "172.16.37.5",
-            "192.168.121.35"
-          ],
-          "ipv6": [
-            "::1",
-            "fe80::5054:ff:fe4f:7102",
-            "fe80::5054:ff:feb0:1da2"
-          ],
-          "role": "client",
+          "server_id": 823542642,
+          "ip6_interfaces": {},
+          "num_cpus": 4,
+          "hwaddr_interfaces": {},
+          "osfullname": "Red Hat Enterprise Linux",
+          "ip4_interfaces": {},
+          "init": "unknown",
+          "master": "suma.server.local",
+          "lsb_distrib_id": "Red Hat Enterprise Linux",
+          "ipv6": [],
           "cpusockets": 1,
           "cpu_flags": [
             "fpu",
@@ -179,26 +126,45 @@
             "pat",
             "pse36",
             "clflush",
+            "dts",
+            "acpi",
             "mmx",
             "fxsr",
             "sse",
             "sse2",
             "ss",
+            "ht",
+            "tm",
+            "pbe",
             "syscall",
             "nx",
             "pdpe1gb",
             "rdtscp",
             "lm",
             "constant_tsc",
+            "arch_perfmon",
+            "pebs",
+            "bts",
             "rep_good",
             "nopl",
+            "xtopology",
+            "nonstop_tsc",
+            "aperfmperf",
             "eagerfpu",
             "pni",
             "pclmulqdq",
+            "dtes64",
+            "monitor",
+            "ds_cpl",
             "vmx",
+            "smx",
+            "est",
+            "tm2",
             "ssse3",
             "fma",
             "cx16",
+            "xtpr",
+            "pdcm",
             "pcid",
             "sse4_1",
             "sse4_2",
@@ -211,66 +177,81 @@
             "avx",
             "f16c",
             "rdrand",
-            "hypervisor",
             "lahf_lm",
             "abm",
-            "xsaveopt",
+            "3dnowprefetch",
+            "ida",
+            "arat",
+            "epb",
+            "pln",
+            "pts",
+            "dtherm",
+            "intel_pt",
+            "tpr_shadow",
             "vnmi",
+            "flexpriority",
             "ept",
+            "vpid",
             "fsgsbase",
+            "tsc_adjust",
             "bmi1",
+            "hle",
             "avx2",
             "smep",
             "bmi2",
             "erms",
-            "invpcid"
+            "invpcid",
+            "rtm",
+            "rdseed",
+            "adx",
+            "smap",
+            "xsaveopt"
           ],
-          "localhost": "clisles12-suma3pg",
-          "lsb_distrib_id": "Red Hat Enterprise Linux Server",
+          "ipv4": [],
+          "localhost": "sll9host",
+          "virtual_subtype": "Docker",
           "fqdn_ip4": [
-            "127.0.0.1"
+            "172.17.0.2"
           ],
-          "fqdn_ip6": [],
-          "nodename": "clisles12-suma3pg",
-          "saltversion": "2015.8.2",
-          "lsb_distrib_release": "12",
+          "fqdn_ip6": [
+            "fe80::42:acff:fe11:2"
+          ],
+          "nodename": "sll9host",
+          "saltversion": "3004.1",
+          "lsb_distrib_release": "9",
           "systemd": {
-            "version": "210",
-            "features": "+PAM +LIBWRAP +AUDIT +SELINUX -IMA +SYSVINIT +LIBCRYPTSETUP +GCRYPT +ACL +XZ +SECCOMP +APPARMOR"
+            "version": "219",
+            "features": "+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ -LZ4 -SECCOMP +BLKID +ELFUTILS +KMOD +IDN"
           },
-          "saltpath": "/usr/lib/python2.7/site-packages/salt",
-          "host": "clisles12-suma3pg",
+          "saltpath": "/usr/bin/salt",
+          "osmajorrelease": "9",
           "os_family": "RedHat",
-          "oscodename": "Red Hat Enterprise Linux Server 7.2",
-          "gpus": [],
+          "oscodename": "Red Hat Enterprise Linux release 9.0 (Plow)",
           "pythonversion": [
-            2,
-            7,
+            3,
             9,
-            "final",
-            0
+            10
           ],
-          "manufacturer": "QEMU",
+          "total_num_cpus": 4,
           "num_gpus": 0,
-          "virtual": "kvm",
-          "cpu_model": "Intel Xeon E312xx (Sandy Bridge)",
-          "fqdn": "clisles12-suma3pg.vagrant.local",
-          "pythonexecutable": "/usr/bin/python",
-          "productname": "Standard PC (i440FX + PIIX, 1996)",
+          "virtual": "physical",
+          "cpu_model": "Intel(R) Core(TM) i7-5600U CPU @ 2.60GHz",
+          "fqdn": "sll9host",
+          "pythonexecutable": "/bin/python",
           "osarch": "x86_64",
           "cpuarch": "x86_64",
-          "lsb_distrib_codename": "Red Hat Enterprise Linux Server 7.2",
+          "lsb_distrib_codename": "Red Hat Enterprise Linux release 9.0 (Plow)",
           "osrelease_info": [
-            7,
-            2
+            7
           ],
           "locale_info": {
-            "detectedencoding": "UTF-8",
-            "defaultlanguage": "en_US",
-            "defaultencoding": "UTF-8"
+            "detectedencoding": "ANSI_X3.4-1968",
+            "defaultlanguage": null,
+            "defaultencoding": null
           },
-          "path": "/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin:/usr/games:/usr/lib/mit/bin:/usr/lib/mit/sbin",
-          "machine_id": "44da3fc9b97b6552cc668bcd56498fe5",
+          "gpus": [],
+          "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "machine_id": "73fdc9b544754e8896989f6219b62af8",
           "os": "RedHat"
         }
       },

--- a/java/code/src/com/suse/manager/reactor/test/rhel_minion_test_data.json
+++ b/java/code/src/com/suse/manager/reactor/test/rhel_minion_test_data.json
@@ -2,24 +2,20 @@
   {
     "description": "Register RHEL Minion With Multiple Release Packages",
     "productName": "RHEL",
-    "availableReleasePackages": "redhat-release-server\nsles_es-release-server\nsles_es-release-server\nredhat-release-server",
     "releasePackage": "redhat-release-server",
-    "packageInfo": "VERSION\u003d7.2\nPROVIDENAME\u003dcentos-release,config(sles_es-release-server),redhat-release,redhat-release-server,sles_es-release-server,sles_es-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7Server,\nVERSION\u003d7.3\nPROVIDENAME\u003dcentos-release,config(sles_es-release-server),redhat-release,redhat-release-server,sles_es-release-server,sles_es-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d,7.3-7.el7,7.3-7.el7,7.3-7.el7,7.3-7.el7,7.3-7.el7,7.3-7.el7,7Server,\nVERSION\u003d7.2\nPROVIDENAME\u003dcentos-release,config(sles_es-release-server),redhat-release,redhat-release-server,sles_es-release-server,sles_es-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7Server,\nVERSION\u003d7.3\nPROVIDENAME\u003dcentos-release,config(sles_es-release-server),redhat-release,redhat-release-server,sles_es-release-server,sles_es-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d,7.3-7.el7,7.3-7.el7,7.3-7.el7,7.3-7.el7,7.3-7.el7,7.3-7.el7,7Server,\n",
     "releaseFileContent": "Red Hat Enterprise Linux Server release 7.2 (Maipo)",
     "resProvider": "",
     "sllProvider": "",
-    "osVersion": "7Server"
+    "osVersion": "7.2"
   },
   {
     "description": "Register RHEL Minion Without Activation Key",
     "productName": "RHEL",
-    "availableReleasePackages": "redhat-release-server",
     "releasePackage": "redhat-release-server",
-    "packageInfo": "VERSION\u003d7.2\nPROVIDENAME\u003dconfig(redhat-release-server),redhat-release,redhat-release-server,redhat-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7Server,\n",
     "releaseFileContent": "Red Hat Enterprise Linux Server release 7.2 (Maipo)",
     "resProvider": "",
     "sllProvider": "",
-    "osVersion": "7Server"
+    "osVersion": "7.2"
   },
   {
     "description": "Register RHEL Minion With RES Activation Key and One Base Channel",
@@ -31,13 +27,11 @@
       }
     ],
     "productName": "RHEL",
-    "availableReleasePackages": "redhat-release-server",
     "releasePackage": "redhat-release-server",
-    "packageInfo": "VERSION\u003d7.2\nPROVIDENAME\u003dconfig(redhat-release-server),redhat-release,redhat-release-server,redhat-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7Server,\n",
     "releaseFileContent": "Red Hat Enterprise Linux Server release 7.2 (Maipo)",
     "resProvider": "",
     "sllProvider": "",
-    "osVersion": "7Server"
+    "osVersion": "7.2"
   },
   {
     "description": "Register RHEL Minion With RES Activation Key and Two Base Channels",
@@ -54,13 +48,11 @@
       }
     ],
     "productName": "RHEL",
-    "availableReleasePackages": "redhat-release-server",
     "releasePackage": "redhat-release-server",
-    "packageInfo": "VERSION\u003d7.2\nPROVIDENAME\u003dconfig(redhat-release-server),redhat-release,redhat-release-server,redhat-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7.2-9.el7,7Server,\n",
     "releaseFileContent": "Red Hat Enterprise Linux Server release 7.2 (Maipo)",
     "resProvider": "",
     "sllProvider": "",
-    "osVersion": "7Server"
+    "osVersion": "7.2"
   },
   {
     "description": "Register RHEL Minion With SLL Activation Key and One Base Channel",
@@ -71,10 +63,8 @@
         "version": "9"
       }
     ],
-    "productName": "RHEL",
+    "productName": "RHEL9",
     "availableReleasePackages": "redhat-release-server",
-    "releasePackage": "redhat-release-server",
-    "packageInfo": "VERSION\u003d9.0\nPROVIDENAME\u003dconfig(redhat-release-server),redhat-release,redhat-release-server,redhat-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d9.0-9.el9,9.0-9.el9,9.0-9.el9,9.0-9.el9,9.0-9.el9,9,\n",
     "releaseFileContent": "Red Hat Enterprise Linux release 9.0 (Plow)",
     "resProvider": "",
     "sllProvider": "",
@@ -94,10 +84,8 @@
         "version": "9"
       }
     ],
-    "productName": "RHEL",
-    "availableReleasePackages": "redhat-release-server",
+    "productName": "RHEL9",
     "releasePackage": "redhat-release-server",
-    "packageInfo": "VERSION\u003d9.0\nPROVIDENAME\u003dconfig(redhat-release-server),redhat-release,redhat-release-server,redhat-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d9.0-9.el9,9.0-9.el9,9.0-9.el9,9.0-9.el9,9.0-9.el9,9,\n",
     "releaseFileContent": "Red Hat Enterprise Linux release 9.0 (Plow)",
     "resProvider": "",
     "sllProvider": "",
@@ -115,11 +103,10 @@
     "productName": "RES",
     "availableReleasePackages": "sles_es-release-server",
     "releasePackage": "sles_es-release-server",
-    "packageInfo": "VERSION\u003d7.2\nPROVIDENAME\u003dcentos-release,config(sles_es-release-server),redhat-release,redhat-release-server,sles_es-release-server,sles_es-release-server(x86-64),system-release,system-release(releasever),\nPROVIDEVERSION\u003d,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7.2-9.el7.2.1,7Server,\n",
     "releaseFileContent": "Red Hat Enterprise Linux Server release 7.2 (Maipo)\n# This is a \"SLES Expanded Support platform Server release 7.2\"\n# The above \"Red Hat Enterprise Linux \" string is only used to \n# keep software compatibility.",
     "resProvider": "sles_es-release-server-7.2-9.el7.2.1.x86_64",
     "sllProvider": "",
-    "osVersion": "7Server"
+    "osVersion": "7"
   },
   {
     "description": "Register SLL Minion Without Activation Key",
@@ -133,7 +120,6 @@
     "productName": "SLL",
     "availableReleasePackages": "sll-release",
     "releasePackage": "sll-release",
-    "packageInfo": "VERSION\u003d9.0\nPROVIDENAME\u003dbase-module(platform:el9),centos-release,centos-release,centos-release-eula,centos-release-eula,centos-release-server,config(sll-release),redhat-release,redhat-release-client,redhat-release-computenode,redhat-release-eula,redhat-release-eula,redhat-release-server,redhat-release-workstation,sll-release,sll-release(x86-64),sll-release-client,sll-release-computenode,sll-release-eula,sll-release-eula,sll-release-server,sll-release-workstation,system-release,system-release(releasever),\nPROVIDEVERSION\u003d,,9.0-2.17.el9,,9.0-2.17.el9,,9.0-2.17.el9,9.0-2.17.el9,,,,9.0-2.17.el9,,,9.0-2.17.el9,9.0-2.17.el9,,,,9.0-2.17.el9,,,9.0-2.17.el9,9,\n",
     "releaseFileContent": "Red Hat Enterprise Linux release 9.0 (Plow)\n# This is a \"SUSE Liberty Linux 9.0\"\n# The above \"Red Hat Enterprise Linux Server\" string is only used to\n# keep software compatibility.",
     "resProvider": "",
     "sllProvider": "sll-release-9.0-2.17.el9.x86_64",

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-monitoring-ent-detection
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-monitoring-ent-detection
@@ -1,0 +1,1 @@
+- Fix Monitoring detection on Oracle Linux (bsc#1234033)


### PR DESCRIPTION
## What does this PR change?

On Oracle Linux the OS Release is a 2 digit number. Our isRedHatX detection uses the family but expected only a single number.
Now we use a startsWith() to also detect sub releases.

This PR simplify also the OS release detection. We simply use what the grains will report to us instead of trying to stay compatible with the traditional stack.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26108

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
