### PR TITLE
Fix missing table renames

### DIFF
--- a/python/spacewalk/satellite_tools/exporter/exportLib.py
+++ b/python/spacewalk/satellite_tools/exporter/exportLib.py
@@ -919,16 +919,16 @@ class SuseProductChannelDumper(BaseQueryDumper):
     tag_name = "suse-product-channels"
     iterator_query = """
     SELECT p.product_id AS pdid,
-           pr.channel_label as clabel,
-           pr.parent_channel_label AS pclabel
-      FROM suseProductSCCRepository pr
-      JOIN suseProducts p ON pr.product_id = p.id
+           ct.channel_label as clabel,
+           ct.parent_channel_label AS pclabel
+      FROM suseChannelTemplate ct
+      JOIN suseProducts p ON ct.product_id = p.id
      WHERE EXISTS (select 1
                      FROM suseProductChannel pc
                      JOIN rhnChannel c ON c.id = pc.channel_id
                     WHERE p.id = pc.product_id
                       AND pc.mandatory = 'Y'
-                      AND c.label = pr.channel_label)
+                      AND c.label = ct.channel_label)
     """
 
     # pylint: disable-next=super-init-not-called
@@ -1031,15 +1031,15 @@ class SuseProductRepositoryDumper(BaseQueryDumper):
     SELECT p1.product_id AS pdid,
            p2.product_id AS rootid,
            r.scc_id AS repo_id,
-           pr.channel_label,
-           pr.parent_channel_label,
-           pr.channel_name,
-           pr.mandatory,
-           pr.update_tag
-      FROM suseProductSCCRepository pr
-      JOIN suseProducts p1 ON pr.product_id = p1.id
-      JOIN suseProducts p2 ON pr.root_product_id = p2.id
-      JOIN suseSCCRepository r ON pr.repo_id = r.id
+           ct.channel_label,
+           ct.parent_channel_label,
+           ct.channel_name,
+           ct.mandatory,
+           ct.update_tag
+      FROM suseChannelTemplate ct
+      JOIN suseProducts p1 ON ct.product_id = p1.id
+      JOIN suseProducts p2 ON ct.root_product_id = p2.id
+      JOIN suseSCCRepository r ON ct.repo_id = r.id
     """
 
     # pylint: disable-next=super-init-not-called

--- a/python/spacewalk/server/importlib/backend.py
+++ b/python/spacewalk/server/importlib/backend.py
@@ -1206,9 +1206,8 @@ class Backend:
         for op_type in ["insert", "update", "delete"]:
             op_values = getattr(dml, op_type)
             for table_name, values_hash in list(op_values.items()):
-                if table_name == "rhnErrata":
-                    field = "id"
-                elif "errata_id" in values_hash:
+                field = "id"
+                if "errata_id" in values_hash and table_name != "rhnErrata":
                     field = "errata_id"
 
                 # Now we know in which field to look for changes

--- a/python/spacewalk/server/importlib/backend.py
+++ b/python/spacewalk/server/importlib/backend.py
@@ -78,7 +78,6 @@ sequences = {
     "suseEula": "suse_eula_id_seq",
     "suseProducts": "suse_products_id_seq",
     "suseSCCRepository": "suse_sccrepository_id_seq",
-    "suseProductSCCRepository": "suse_prdrepo_id_seq",
 }
 
 
@@ -2021,16 +2020,16 @@ class Backend:
         """
         insert_pr = self.dbmodule.prepare(
             """
-            INSERT INTO suseProductSCCRepository
-                   (id, product_id, root_product_id, repo_id, channel_label, parent_channel_label,
+            INSERT INTO suseChannelTemplate
+                   (product_id, root_product_id, repo_id, channel_label, parent_channel_label,
                     channel_name, mandatory, update_tag)
-            VALUES (:id, :product_id, :root_id, :repo_id, :channel_label, :parent_channel_label,
+            VALUES (:product_id, :root_id, :repo_id, :channel_label, :parent_channel_label,
                     :channel_name, :mandatory, :update_tag)
             """
         )
         delete_pr = self.dbmodule.prepare(
             """
-            DELETE FROM suseProductSCCRepository
+            DELETE FROM suseChannelTemplate
              WHERE product_id = :product_id
                AND root_product_id = :root_id
                AND repo_id = :repo_id
@@ -2038,7 +2037,7 @@ class Backend:
         )
         update_pr = self.dbmodule.prepare(
             """
-            UPDATE suseProductSCCRepository
+            UPDATE suseChannelTemplate
                SET channel_label = :channel_label,
                    parent_channel_label = :parent_channel_label,
                    channel_name = :channel_name,
@@ -2052,7 +2051,7 @@ class Backend:
         # pylint: disable-next=invalid-name
         _query_pr = self.dbmodule.prepare(
             """
-            SELECT product_id, root_product_id, repo_id FROM suseProductSCCRepository
+            SELECT product_id, root_product_id, repo_id FROM suseChannelTemplate
             """
         )
         _query_pr.execute()
@@ -2082,15 +2081,14 @@ class Backend:
                 toupdate[6].append(int(item["root_pdid"]))
                 toupdate[7].append(int(item["repo_pdid"]))
                 continue
-            toinsert[0].append(self.sequences["suseProductSCCRepository"].next())
-            toinsert[1].append(int(item["product_pdid"]))
-            toinsert[2].append(int(item["root_pdid"]))
-            toinsert[3].append(int(item["repo_pdid"]))
-            toinsert[4].append(item["channel_label"])
-            toinsert[5].append(item["parent_channel_label"])
-            toinsert[6].append(item["channel_name"])
-            toinsert[7].append(item["mandatory"])
-            toinsert[8].append(item["update_tag"])
+            toinsert[0].append(int(item["product_pdid"]))
+            toinsert[1].append(int(item["root_pdid"]))
+            toinsert[2].append(int(item["repo_pdid"]))
+            toinsert[3].append(item["channel_label"])
+            toinsert[4].append(item["parent_channel_label"])
+            toinsert[5].append(item["channel_name"])
+            toinsert[6].append(item["mandatory"])
+            toinsert[7].append(item["update_tag"])
         for ident in existing_data:
             product_id, rootid, repo_id = ident.split("-", 2)
             todelete[0].append(int(product_id))

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.Manager-4.3
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.Manager-4.3
@@ -1,0 +1,2 @@
+- Rename table suseProductSCCRepository to the more meaningful
+  name suseChannelTemplate (bsc#1234994)

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -35,13 +35,13 @@ UYUNI = None
 
 _sql_synced_proucts = rhnSQL.Statement(
     """
-   SELECT sp.product_id id, spsr.root_product_id
+   SELECT sp.product_id id, ct.root_product_id
      FROM suseProducts sp
-     JOIN suseProductSCCRepository spsr ON spsr.product_id = sp.id
-LEFT JOIN rhnChannel c ON spsr.channel_label = c.label
-    WHERE spsr.mandatory = 'Y'
- GROUP BY sp.id, spsr.root_product_id
-   HAVING COUNT(c.label) = COUNT(spsr.mandatory)
+     JOIN suseChannelTemplate ct ON ct.product_id = sp.id
+LEFT JOIN rhnChannel c ON ct.channel_label = c.label
+    WHERE ct.mandatory = 'Y'
+ GROUP BY sp.id, ct.root_product_id
+   HAVING COUNT(c.label) = COUNT(ct.mandatory)
 """
 )
 
@@ -200,13 +200,13 @@ from rhnChannel c0
 join suseProductChannel spc ON spc.channel_id = c0.id
 join suseProducts p ON spc.product_id = p.id
 join (
-     select sp.product_id , spsr.root_product_id
+     select sp.product_id , ct.root_product_id
        from suseProducts sp
-       join suseProductSCCRepository spsr ON spsr.product_id = sp.id
-  left join rhnChannel c ON spsr.channel_label = c.label
-      where spsr.mandatory = 'Y'
-   group by sp.id, spsr.root_product_id
-     having COUNT(c.label) = COUNT(spsr.mandatory)
+       join suseChannelTemplate ct ON ct.product_id = sp.id
+  left join rhnChannel c ON ct.channel_label = c.label
+      where ct.mandatory = 'Y'
+   group by sp.id, ct.root_product_id
+     having COUNT(c.label) = COUNT(ct.mandatory)
    ) X on X.product_id = p.product_id
 where X.product_id in ( %s )
 """
@@ -267,7 +267,9 @@ def create_bootstrap_failure_notification(label, messages: List[str]):
     message = "\n".join(messages)
     # see TaskoXmlRpcHandler.java for available methods
     with xmlrpc.client.ServerProxy("http://localhost:2829/RPC2") as proxy:
-        log_debug(2, f"Calling createBootstrapRepoFailedNotification({label}, {message})")
+        log_debug(
+            2, f"Calling createBootstrapRepoFailedNotification({label}, {message})"
+        )
         return proxy.tasko.createBootstrapRepoFailedNotification(label, message)
 
 

--- a/susemanager/susemanager.changes.mcalmer.Manager-4.3
+++ b/susemanager/susemanager.changes.mcalmer.Manager-4.3
@@ -1,0 +1,2 @@
+- Rename table suseProductSCCRepository to the more meaningful
+  name suseChannelTemplate (bsc#1234994)


### PR DESCRIPTION
## What does this PR change?

We renamed the table suseProductSCCRepository into suseChannelTemplate.
Some queries still use the old table name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26127

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
