### PR TITLE
Issv3 info apis

### DIFF
--- a/java/buildconf/LICENSE.txt
+++ b/java/buildconf/LICENSE.txt
@@ -1,5 +1,5 @@
 ^/\*$
-(^ \* Copyright \(c\) (20([0123]\d|20)--)?20(1\d|2[012345]) (Red Hat, Inc.|SUSE LLC)$)+
+(^ \* Copyright \(c\) (20([01234]\d|20)--)?20(1\d|2[012345]) (Red Hat, Inc.|SUSE LLC)$)+
 ^ \*$
 ^ \* This software is licensed to you under the GNU General Public License,$
 ^ \* version 2 \(GPLv2\). There is NO WARRANTY for this software, express or$

--- a/java/code/src/com/redhat/rhn/domain/server/MgrServerInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MgrServerInfo.java
@@ -55,6 +55,7 @@ public class MgrServerInfo {
      */
     public MgrServerInfo() {
         super();
+        reportDbPort = 5432;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.java
@@ -106,6 +106,9 @@ public class ServerFQDN extends BaseDomainHelper implements Identifiable {
      */
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o instanceof ServerFQDN toCompare) {
             return new EqualsBuilder()
                     .append(name, toCompare.name)

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -1044,6 +1044,21 @@ public class ServerFactory extends HibernateFactory {
     }
 
     /**
+     * Find Server by a set of possible FQDNs
+     * @param fqdns the set of FQDNs
+     * @return return the first Server found if any
+     */
+    public static Optional<Server> findByAnyFqdn(Set<String> fqdns) {
+        for (String fqdn : fqdns) {
+            Optional<Server> server = findByFqdn(fqdn);
+            if (server.isPresent()) {
+                return server;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
      * Lookup a Server by their FQDN
      * @param name of the FQDN to search for
      * @return the Server found

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -1603,16 +1603,16 @@ public class ServerFactory extends HibernateFactory {
     /**
      * Remove MgrServerInfo from minion
      *
-     * @param minion the minion
+     * @param server the minion
      */
-    public static void dropMgrServerInfo(MinionServer minion) {
-        MgrServerInfo serverInfo = minion.getMgrServerInfo();
+    public static void dropMgrServerInfo(Server server) {
+        MgrServerInfo serverInfo = server.getMgrServerInfo();
         if (serverInfo == null) {
             return;
         }
         ReportDBCredentials credentials = serverInfo.getReportDbCredentials();
         CredentialsFactory.removeCredentials(credentials);
         SINGLETON.removeObject(serverInfo);
-        minion.setMgrServerInfo(null);
+        server.setMgrServerInfo(null);
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -34,7 +34,6 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
-import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.common.validator.ValidatorResult;
@@ -120,11 +119,10 @@ import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.task.systems.SystemsOverviewUpdateDriver;
 import com.redhat.rhn.taskomatic.task.systems.SystemsOverviewUpdateWorker;
 
+import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
-import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessageAction;
-import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.ssl.SSLCertData;
 import com.suse.manager.ssl.SSLCertGenerationException;
 import com.suse.manager.ssl.SSLCertManager;
@@ -3804,92 +3802,35 @@ public class SystemManager extends BaseManager {
     /**
      * Update MgrServerInfo with current grains data
      *
-     * @param minion the minion which is a Mgr Server
-     * @param grains grains from the minion
+     * @param server the server which is a Mgr Server
+     * @param info info from peripheral server
+     * @return return true when the report db infos where changed
      */
-    public static void updateMgrServerInfo(MinionServer minion, ValueMap grains) {
+    public static boolean updateMgrServerInfo(Server server, ManagerInfoJson info) {
         // Check for Uyuni Server and create basic info
-        if (grains.getOptionalAsBoolean("is_mgr_server").orElse(false)) {
-            MgrServerInfo serverInfo = Optional.ofNullable(minion.getMgrServerInfo()).orElse(new MgrServerInfo());
+        if (info != null) {
+            MgrServerInfo serverInfo = Optional.ofNullable(server.getMgrServerInfo()).orElse(new MgrServerInfo());
             String oldHost = serverInfo.getReportDbHost();
             String oldName = serverInfo.getReportDbName();
 
             serverInfo.setVersion(PackageEvrFactory.lookupOrCreatePackageEvr(null,
-                    grains.getOptionalAsString("version").orElse("0"),
-                    "1", minion.getPackageType()));
-            serverInfo.setReportDbName(grains.getValueAsString("report_db_name"));
-            serverInfo.setReportDbHost(grains.getValueAsString("report_db_host"));
-            serverInfo.setReportDbPort((grains.getValueAsLong("report_db_port").orElse(5432L)).intValue());
-            serverInfo.setServer(minion);
-            minion.setMgrServerInfo(serverInfo);
+                    info.getVersion(), "1", server.getPackageType()));
+            serverInfo.setReportDbName(info.getReportDbName());
+            serverInfo.setReportDbHost(info.getReportDbHost());
+            serverInfo.setReportDbPort(info.getReportDbPort());
+            serverInfo.setServer(server);
+            server.setMgrServerInfo(serverInfo);
 
-            if (!StringUtils.isAnyBlank(oldHost, oldName) &&
+            // something changed, we better reset the user
+            return StringUtils.isAnyBlank(oldHost, oldName) ||
                     !(oldHost.equals(serverInfo.getReportDbHost()) &&
-                            oldName.equals(serverInfo.getReportDbName()))) {
-                // something changed, we better reset the user
-                setReportDbUser(minion, false);
-            }
+                            oldName.equals(serverInfo.getReportDbName()));
         }
         else {
-            ServerFactory.dropMgrServerInfo(minion);
+            ServerFactory.dropMgrServerInfo(server);
             // Should we try to drop the credentials on the reportdb?
         }
-    }
-
-    /**
-     * Set the User and Password for the report database in MgrServerInfo.
-     * It trigger also a state apply to set this user in the report database.
-     *
-     * @param minion the Mgr Server
-     * @param forcePwChange force a password change
-     */
-    public static void setReportDbUser(MinionServer minion, boolean forcePwChange) {
-        // Create a report db user when system is a mgr server
-        if (!minion.isMgrServer()) {
-            return;
-        }
-        // create default user with random password
-        MgrServerInfo mgrServerInfo = minion.getMgrServerInfo();
-        if (StringUtils.isAnyBlank(mgrServerInfo.getReportDbName(), mgrServerInfo.getReportDbHost())) {
-            // no reportdb configured
-            return;
-        }
-
-        String password = RandomStringUtils.random(24, 0, 0, true, true, null, new SecureRandom());
-        ReportDBCredentials credentials = Optional.ofNullable(mgrServerInfo.getReportDbCredentials())
-            .map(existingCredentials -> {
-                if (forcePwChange) {
-                    existingCredentials.setPassword(password);
-                    CredentialsFactory.storeCredentials(existingCredentials);
-                }
-
-                return existingCredentials;
-            })
-            .orElseGet(() -> {
-                String randomSuffix = RandomStringUtils.random(8, 0, 0, true, false, null, new SecureRandom());
-                // Ensure the username is stored lowercase in the database, since the script uyuni-setup-reportdb-user
-                // will convert it to lowercase anyway
-                String username = "hermes_" + randomSuffix.toLowerCase();
-
-                ReportDBCredentials reportCredentials = CredentialsFactory.createReportCredentials(username, password);
-                CredentialsFactory.storeCredentials(reportCredentials);
-
-                return reportCredentials;
-            });
-
-        mgrServerInfo.setReportDbCredentials(credentials);
-
-        Map<String, Object> pillar = new HashMap<>();
-        pillar.put("report_db_user", credentials.getUsername());
-        pillar.put("report_db_password", credentials.getPassword());
-
-        MessageQueue.publish(new ApplyStatesEventMessage(
-                minion.getId(),
-                minion.getCreator() != null ? minion.getCreator().getId() : null,
-                        false,
-                        pillar,
-                        ApplyStatesEventMessage.REPORTDB_USER
-                ));
+        return false;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/code/src/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -134,7 +134,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
             SystemEntitlementManager systemEntitlementManager,
             User creator, String proxyName, Set<String> fqdns, Integer port, String sshPublicKey
     ) {
-        Optional<Server> existing = findByAnyFqdn(fqdns);
+        Optional<Server> existing = ServerFactory.findByAnyFqdn(fqdns);
         if (existing.isPresent()) {
             Server server = existing.get();
             if (!(server.hasEntitlement(EntitlementManager.FOREIGN) ||
@@ -229,15 +229,5 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
         }
 
         return new String(serverServer.getProxyInfo().getSshPublicKey());
-    }
-
-    private Optional<Server> findByAnyFqdn(Set<String> fqdns) {
-        for (String fqdn : fqdns) {
-            Optional<Server> server = ServerFactory.findByFqdn(fqdn);
-            if (server.isPresent()) {
-                return server;
-            }
-        }
-        return Optional.empty();
     }
 }

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -11,14 +11,27 @@
 
 package com.suse.manager.hub;
 
+import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.credentials.HubSCCCredentials;
+import com.redhat.rhn.domain.credentials.ReportDBCredentials;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.MgrServerInfo;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.SystemManagerUtils;
+import com.redhat.rhn.manager.system.SystemsExistException;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
@@ -28,6 +41,7 @@ import com.suse.manager.model.hub.IssHub;
 import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.IssServer;
+import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.SCCCredentialsJson;
 import com.suse.manager.model.hub.TokenType;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
@@ -38,11 +52,17 @@ import com.suse.manager.webui.utils.token.TokenParsingException;
 import com.suse.utils.CertificateUtils;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
+import java.text.MessageFormat;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Business logic to manage ISSv3 Sync
@@ -55,7 +75,11 @@ public class HubManager {
 
     private final IssClientFactory clientFactory;
 
+    private final SystemEntitlementManager systemEntitlementManager;
+
     private TaskomaticApi taskomaticApi;
+
+    private static final Logger LOG = LogManager.getLogger(HubManager.class);
 
     private static final String ROOT_CA_FILENAME_TEMPLATE = "%s_%s_root_ca.pem";
 
@@ -63,7 +87,8 @@ public class HubManager {
      * Default constructor
      */
     public HubManager() {
-        this(new HubFactory(), new IssClientFactory(), new MirrorCredentialsManager(), new TaskomaticApi());
+        this(new HubFactory(), new IssClientFactory(), new MirrorCredentialsManager(), new TaskomaticApi(),
+                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
     }
 
     /**
@@ -72,13 +97,16 @@ public class HubManager {
      * @param clientFactoryIn the ISS client factory
      * @param mirrorCredentialsManagerIn the mirror credentials manager
      * @param taskomaticApiIn the TaskomaticApi object
+     * @param systemEntitlementManagerIn the system entitlement manager
      */
     public HubManager(HubFactory hubFactoryIn, IssClientFactory clientFactoryIn,
-                      MirrorCredentialsManager mirrorCredentialsManagerIn, TaskomaticApi taskomaticApiIn) {
+                      MirrorCredentialsManager mirrorCredentialsManagerIn, TaskomaticApi taskomaticApiIn,
+                      SystemEntitlementManager systemEntitlementManagerIn) {
         this.hubFactory = hubFactoryIn;
         this.clientFactory = clientFactoryIn;
         this.mirrorCredentialsManager = mirrorCredentialsManagerIn;
         this.taskomaticApi = taskomaticApiIn;
+        this.systemEntitlementManager = systemEntitlementManagerIn;
     }
 
     /**
@@ -147,7 +175,7 @@ public class HubManager {
             throws TaskomaticApiException {
         ensureValidToken(accessToken);
 
-        return createServer(role, accessToken.getServerFqdn(), rootCA);
+        return createServer(role, accessToken.getServerFqdn(), rootCA, null);
     }
 
     /**
@@ -179,7 +207,7 @@ public class HubManager {
             remoteToken = externalClient.generateAccessToken(ConfigDefaults.get().getHostname());
         }
 
-        registerWithToken(remoteServer, role, rootCA, remoteToken);
+        registerWithToken(user, remoteServer, role, rootCA, remoteToken);
     }
 
     /**
@@ -204,7 +232,7 @@ public class HubManager {
         // Verify this server is not already registered as hub or peripheral
         ensureServerNotRegistered(remoteServer);
 
-        registerWithToken(remoteServer, role, rootCA, remoteToken);
+        registerWithToken(user, remoteServer, role, rootCA, remoteToken);
     }
 
     /**
@@ -237,16 +265,103 @@ public class HubManager {
         return saveCredentials(hub, username, password);
     }
 
-    private void registerWithToken(String remoteServer, IssRole role, String rootCA, String remoteToken)
+    /**
+     * Set the User and Password for the report database in MgrServerInfo.
+     * That trigger also a state apply to set this user in the report database.
+     *
+     * @param user the user
+     * @param server the Mgr Server
+     * @param forcePwChange force a password change
+     */
+    public void setReportDbUser(User user, Server server, boolean forcePwChange)
+            throws CertificateException, IOException {
+        ensureSatAdmin(user);
+        // Create a report db user when system is a mgr server
+        if (!server.isMgrServer()) {
+            return;
+        }
+        // create default user with random password
+        MgrServerInfo mgrServerInfo = server.getMgrServerInfo();
+        if (StringUtils.isAnyBlank(mgrServerInfo.getReportDbName(), mgrServerInfo.getReportDbHost())) {
+            // no reportdb configured
+            return;
+        }
+
+        String password = RandomStringUtils.random(24, 0, 0, true, true, null, new SecureRandom());
+        ReportDBCredentials credentials = Optional.ofNullable(mgrServerInfo.getReportDbCredentials())
+                .map(existingCredentials -> {
+                    if (forcePwChange) {
+                        existingCredentials.setPassword(password);
+                        CredentialsFactory.storeCredentials(existingCredentials);
+                    }
+
+                    return existingCredentials;
+                })
+                .orElseGet(() -> {
+                    String randomSuffix = RandomStringUtils.random(8, 0, 0, true, false, null, new SecureRandom());
+                    // Ensure the username is stored lowercase in the database, since the script
+                    // uyuni-setup-reportdb-user will convert it to lowercase anyway
+                    String username = "hermes_" + randomSuffix.toLowerCase();
+
+                    ReportDBCredentials reportCreds = CredentialsFactory.createReportCredentials(username, password);
+                    CredentialsFactory.storeCredentials(reportCreds);
+                    return reportCreds;
+                });
+
+        mgrServerInfo.setReportDbCredentials(credentials);
+
+        Optional<IssPeripheral> issPeripheral = server.getFqdns().stream()
+                .flatMap(fqdn -> hubFactory.lookupIssPeripheralByFqdn(fqdn.getName()).stream())
+                .findFirst();
+        if (issPeripheral.isPresent()) {
+            IssPeripheral remoteServer = issPeripheral.get();
+            IssAccessToken token = hubFactory.lookupAccessTokenFor(remoteServer.getFqdn());
+
+            IssInternalClient internalApi = clientFactory.newInternalClient(remoteServer.getFqdn(),
+                    token.getToken(), remoteServer.getRootCa());
+            internalApi.storeReportDbCredentials(credentials.getUsername(), credentials.getPassword());
+            String summary = "Report Database credentials changed by " + user.getLogin();
+            String details = MessageFormat.format("""
+            The Report Database credentials were changed by {0}.
+            Report Database User: {1}
+            """, user.getLogin(), credentials.getUsername());
+            SystemManager.addHistoryEvent(server, summary, details);
+        }
+    }
+
+    /**
+     * Collect data about a Manager Server
+     * @param accessToken the accesstoken
+     * @return return {@link ManagerInfoJson}
+     */
+    public ManagerInfoJson collectManagerInfo(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+        return collectManagerInfo();
+    }
+
+    private ManagerInfoJson collectManagerInfo() {
+        String reportDbName = Config.get().getString(ConfigDefaults.REPORT_DB_NAME, "");
+        // we need to provide the external hostname
+        String reportDbHost = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME, "");
+        int reportDbPort = Config.get().getInt(ConfigDefaults.REPORT_DB_PORT, 5432);
+        String version = ConfigDefaults.get().getProductVersion().split("\\s")[0];
+
+        return new ManagerInfoJson(
+                version,
+                StringUtils.isNoneBlank(reportDbName, reportDbHost),
+                reportDbName, reportDbHost, reportDbPort);
+    }
+
+    private void registerWithToken(User user, String remoteServer, IssRole role, String rootCA, String remoteToken)
         throws TokenParsingException, CertificateException, TokenBuildingException, IOException,
             TaskomaticApiException {
         parseAndSaveToken(remoteServer, remoteToken);
 
-        IssServer registeredServer = createServer(role, remoteServer, rootCA);
-        registerToRemote(registeredServer, remoteToken, rootCA);
+        IssServer registeredServer = createServer(role, remoteServer, rootCA, user);
+        registerToRemote(user, registeredServer, remoteToken, rootCA);
     }
 
-    private void registerToRemote(IssServer remoteServer, String remoteToken, String rootCA)
+    private void registerToRemote(User user, IssServer remoteServer, String remoteToken, String rootCA)
         throws CertificateException, TokenParsingException, TokenBuildingException, IOException {
 
         // Create a client to connect to the internal API of the remote server
@@ -265,11 +380,22 @@ public class HubManager {
             // if the remote server is a peripheral, generate the scc credentials for it
             HubSCCCredentials credentials = generateCredentials(peripheral);
             internalApi.storeCredentials(credentials.getUsername(), credentials.getPassword());
+
+            // Query Report DB connection values and set create a User
+            ManagerInfoJson managerInfo = internalApi.getManagerInfo();
+            Server peripheralServer = getOrCreateManagerSystem(systemEntitlementManager, user,
+                    remoteServer.getFqdn(), Set.of(remoteServer.getFqdn()));
+            boolean changed = SystemManager.updateMgrServerInfo(peripheralServer, managerInfo);
+            if (changed) {
+                setReportDbUser(user, peripheralServer, false);
+            }
         }
         else if (remoteServer instanceof IssHub hub) {
             // If remote server is a hub, ask for the credentials
             SCCCredentialsJson credentialsJson = internalApi.generateCredentials();
             saveCredentials(hub, credentialsJson.getUsername(), credentialsJson.getPassword());
+
+            internalApi.setManagerInfo(collectManagerInfo());
         }
         else {
             throw new IllegalStateException("Unknown IssServer class " + remoteServer.getClass());
@@ -352,7 +478,8 @@ public class HubManager {
         return String.format(ROOT_CA_FILENAME_TEMPLATE, role.getLabel(), serverFqdn);
     }
 
-    private IssServer createServer(IssRole role, String serverFqdn, String rootCA) throws TaskomaticApiException {
+    private IssServer createServer(IssRole role, String serverFqdn, String rootCA, User user)
+            throws TaskomaticApiException {
         taskomaticApi.scheduleSingleRootCaCertUpdate(computeRootCaFileName(role, serverFqdn), rootCA);
         return switch (role) {
             case HUB -> {
@@ -363,6 +490,7 @@ public class HubManager {
             case PERIPHERAL -> {
                 IssPeripheral peripheral = new IssPeripheral(serverFqdn, rootCA);
                 hubFactory.save(peripheral);
+                getOrCreateManagerSystem(systemEntitlementManager, user, serverFqdn, Set.of(serverFqdn));
                 yield peripheral;
             }
         };
@@ -396,4 +524,68 @@ public class HubManager {
         }
     }
 
+    /**
+     * Retrieves or create a server system
+     *
+     * @param systemEntitlementManagerIn the system entitlement manager
+     * @param creator                  the user creating the server system
+     * @param serverName               the FQDN of the proxy system
+     * @return the proxy system
+     */
+    private Server getOrCreateManagerSystem(
+            SystemEntitlementManager systemEntitlementManagerIn,
+            User creator, String serverName, Set<String> fqdns
+    ) {
+        Optional<Server> existing = ServerFactory.findByAnyFqdn(fqdns);
+        if (existing.isPresent()) {
+            Server server = existing.get();
+            if (!(server.hasEntitlement(EntitlementManager.SALT) ||
+                    server.hasEntitlement(EntitlementManager.FOREIGN))) {
+                throw new SystemsExistException(List.of(server.getId()));
+            }
+            // Add the FQDNs as some may not be already known
+            server.getFqdns().addAll(fqdns.stream()
+                    .filter(fqdn -> !fqdn.contains("*"))
+                    .map(fqdn -> new ServerFQDN(server, fqdn)).toList());
+
+            server.updateServerInfo();
+            SystemManager.updateSystemOverview(server.getId());
+            return server;
+        }
+        Server server = ServerFactory.createServer();
+        server.setName(serverName);
+        server.setHostname(serverName);
+        server.setOrg(Optional.ofNullable(creator).map(User::getOrg).orElse(OrgFactory.getSatelliteOrg()));
+        server.setCreator(creator);
+
+        String uniqueId = SystemManagerUtils.createUniqueId(List.of(serverName));
+        server.setDigitalServerId(uniqueId);
+        server.setMachineId(uniqueId);
+        server.setOs("(unknown)");
+        server.setRelease("(unknown)");
+        server.setSecret(RandomStringUtils.random(64, 0, 0, true, true,
+                null, new SecureRandom()));
+        server.setAutoUpdate("N");
+        server.setContactMethod(ServerFactory.findContactMethodByLabel("default"));
+        server.setLastBoot(System.currentTimeMillis() / 1000);
+        server.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
+        ServerFactory.save(server);
+
+        server.getFqdns().addAll(fqdns.stream()
+                .filter(fqdn -> !fqdn.contains("*"))
+                .map(fqdn -> new ServerFQDN(server, fqdn)).toList());
+
+        server.updateServerInfo();
+
+        MgrServerInfo serverInfo = new MgrServerInfo();
+        serverInfo.setServer(server);
+        server.setMgrServerInfo(serverInfo);
+
+        ServerFactory.save(server);
+
+        // No need to call `updateSystemOverview`
+        // It will be called inside the method setBaseEntitlement. If we remove this line we need to manually call it
+        systemEntitlementManagerIn.setBaseEntitlement(server, EntitlementManager.FOREIGN);
+        return server;
+    }
 }

--- a/java/code/src/com/suse/manager/hub/IssInternalClient.java
+++ b/java/code/src/com/suse/manager/hub/IssInternalClient.java
@@ -14,6 +14,7 @@ package com.suse.manager.hub;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
 
 import com.suse.manager.model.hub.IssRole;
+import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.SCCCredentialsJson;
 
 import java.io.IOException;
@@ -46,4 +47,26 @@ public interface IssInternalClient {
      * @throws IOException when the communication fails
      */
     SCCCredentialsJson generateCredentials() throws IOException;
+
+    /**
+     * Query Manager information from the peripheral server
+     * @return return {@link ManagerInfoJson} from peripheral server
+     * @throws IOException when communication fails
+     */
+    ManagerInfoJson getManagerInfo() throws IOException;
+
+    /**
+     * Send Manager information to a hub server
+     * @param managerInfo the {@link ManagerInfoJson} information
+     */
+    void setManagerInfo(ManagerInfoJson managerInfo) throws IOException;
+
+    /**
+     * Store Report DB credentials on the remote peripheral server
+     * @param username the username
+     * @param password the password
+     * @throws IOException when communication fails
+     */
+    void storeReportDbCredentials(String username, String password) throws IOException;
+
 }

--- a/java/code/src/com/suse/manager/model/hub/ManagerInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/ManagerInfoJson.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class ManagerInfoJson {
+
+    private final String version;
+
+    private final boolean reportDb;
+
+    private final String reportDbName;
+
+    private final String reportDbHost;
+
+    private final int reportDbPort;
+
+
+    /**
+     * Default constructor
+     */
+    public ManagerInfoJson() {
+        version = "0";
+        reportDb = false;
+        reportDbName = "";
+        reportDbHost = "";
+        reportDbPort = 5432;
+    }
+
+    /**
+     * Constructor
+     * @param versionIn the version
+     * @param reportDbIn has a report DB
+     * @param reportDbNameIn the report DB name
+     * @param reportDbHostIn the report DB hostname
+     * @param reportDbPortIn the report DB port number
+     */
+    public ManagerInfoJson(String versionIn, boolean reportDbIn, String reportDbNameIn,
+                           String reportDbHostIn, int reportDbPortIn) {
+        version = versionIn;
+        reportDb = reportDbIn;
+        reportDbName = reportDbNameIn;
+        reportDbHost = reportDbHostIn;
+        reportDbPort = reportDbPortIn;
+    }
+
+    /**
+     * @return return the version
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @return return true when a report DB is configured
+     */
+    public boolean hasReportDb() {
+        return reportDb;
+    }
+
+    /**
+     * @return return the report DB name
+     */
+    public String getReportDbName() {
+        return reportDbName;
+    }
+
+    /**
+     * @return return the report DB hostname
+     */
+    public String getReportDbHost() {
+        return reportDbHost;
+    }
+
+    /**
+     * @return return the report DB port number
+     */
+    public int getReportDbPort() {
+        return reportDbPort;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ManagerInfoJson that)) {
+            return false;
+        }
+        return Objects.equals(version, that.version) &&
+                Objects.equals(reportDb, that.reportDb) &&
+                Objects.equals(reportDbName, that.reportDbName) &&
+                Objects.equals(reportDbHost, that.reportDbHost) &&
+                Objects.equals(reportDbPort, that.reportDbPort);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, reportDb, reportDbName, reportDbHost, reportDbPort);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ManagerInfoJson.class.getSimpleName() + "[", "]")
+                .add("version='" + getVersion() + "'")
+                .add("reportDb='" + hasReportDb() + "'")
+                .add("reportDbHost='" + getReportDbHost() + "'")
+                .toString();
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -592,9 +592,6 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
             minion.updateServerInfo();
 
-            // Check for Uyuni Server and create basic info
-            SystemManager.updateMgrServerInfo(minion, grains);
-
             mapHardwareGrains(minion, grains);
 
             if (isSaltSSH) {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -158,7 +158,6 @@ public class RegistrationUtils {
                     true,
                     emptyList()));
         }
-        SystemManager.setReportDbUser(minion, false);
 
         // get hardware and network async
         // Hardware refresh depends on channels being assigned so as a temporary

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1568,7 +1568,6 @@ public class SaltUtils {
             if (server.getOsFamily().equals(OS_FAMILY_SUSE)) {
                 server.setRelease(grains.getValueAsString("osrelease"));
             }
-            SystemManager.updateMgrServerInfo(server, grains);
         }
 
         ServerFactory.save(server);

--- a/java/spacewalk-java.changes.mcalmer.issv3-info-apis
+++ b/java/spacewalk-java.changes.mcalmer.issv3-info-apis
@@ -1,0 +1,1 @@
+- Add API to configure report database access for the hub

--- a/web/html/src/manager/systems/details/mgr-server-info.tsx
+++ b/web/html/src/manager/systems/details/mgr-server-info.tsx
@@ -30,6 +30,7 @@ const messageMap = {
   invalid_systemid: t("Not a system id"),
   unknown_system: t("Unknown System"),
   system_not_mgr_server: t("System is not a peripheral server"),
+  set_reportdb_creds_failed: t("Setting new credentials for the report database failed"),
 };
 
 class MgrServer extends React.Component<Props, State> {
@@ -47,7 +48,7 @@ class MgrServer extends React.Component<Props, State> {
           this.setState({
             messages: MessagesUtils.success(
               <a href={"/rhn/systems/details/history/History.do?sid=" + this.props.serverId}>
-                {t("New password generated and action for peripheral server scheduled")}
+                {t("New password generated and changed on the peripheral server")}
               </a>
             ),
           });


### PR DESCRIPTION
## What does this PR change?

Add and use API functions to get information about the reportDB from a manager server and also create a user for the reportDB access.

This bring the Hub report DB feature back to master and is the successor for https://github.com/SUSE/spacewalk/pull/25586

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Part of the ISSv3 docs

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25474

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"   
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
