### PR TITLE
search: more robust parsing of max memory config

### DIFF
--- a/java/scripts/taskomatic
+++ b/java/scripts/taskomatic
@@ -2,7 +2,7 @@
 # TaskomaticDaemon start script
 . /etc/rhn/taskomatic.conf
 
-RHN_MEM=`grep ^[[:blank:]]*taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
+RHN_MEM=`grep ^[[:blank:]]*taskomatic.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*\([0-9]\+\)[[:blank:]]*/\1/"`
 if [ "x$RHN_MEM" != "x" ]; then
     TASKO_MAX_MEMORY=$RHN_MEM
 fi

--- a/java/spacewalk-java.changes.cbosdo.4.3-rhn-search-mem
+++ b/java/spacewalk-java.changes.cbosdo.4.3-rhn-search-mem
@@ -1,0 +1,1 @@
+- More robust parsing of max memory configuration (bsc#1229000)

--- a/search-server/spacewalk-search/spacewalk-search.changes.cbosdo.4.3-rhn-search-mem
+++ b/search-server/spacewalk-search/spacewalk-search.changes.cbosdo.4.3-rhn-search-mem
@@ -1,0 +1,1 @@
+- More robust parsing of max memory configuration (bsc#1229000)

--- a/search-server/spacewalk-search/src/config/rhn-search
+++ b/search-server/spacewalk-search/src/config/rhn-search
@@ -2,7 +2,7 @@
 echo "Sourcing config file..."
  . /usr/share/rhn/config-defaults/rhn_search_daemon.conf
 
-RHN_MEM=`grep ^[[:blank:]]*rhn-search.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
+RHN_MEM=`grep ^[[:blank:]]*rhn-search.java.maxmemory /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*\([0-9]\+\)[[:blank:]]*/\1/"`
 if [ "x$RHN_MEM" != "x" ]; then
         SEARCH_MAX_MEMORY=$RHN_MEM
 fi


### PR DESCRIPTION
## What does this PR change?

Strip all spaces around the numeric value to not break the generated command line parameter (bsc#1229000)

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: config loading change in shell scripts

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26094
Port(s): https://github.com/SUSE/spacewalk/pull/26104 https://github.com/SUSE/spacewalk/pull/26103

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
