### PR TITLE
Fixed misleading error while waiting for SCC credentials synchronisation (bsc#1227374)

### DIFF
--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -147,7 +147,12 @@ class ProductsPageWrapper extends React.Component {
           noToolsChannelSubscription: metadata.noToolsChannelSubscription,
         });
 
-        if (currentObject.state.noToolsChannelSubscription && currentObject.state.issMaster) {
+        if (
+          currentObject.state.noToolsChannelSubscription &&
+          currentObject.state.issMaster &&
+          !currentObject.state.refreshNeeded &&
+          !currentObject.state.refreshRunning
+        ) {
           currentObject.setState({
             errors: MessagesUtils.warning(
               t(

--- a/web/spacewalk-web.changes.carlo.Manager-5.0-scc-credentials-message
+++ b/web/spacewalk-web.changes.carlo.Manager-5.0-scc-credentials-message
@@ -1,0 +1,2 @@
+- Fixed misleading error while waiting for SCC credentials
+  synchronisation (bsc#1227374)


### PR DESCRIPTION
## What does this PR change?
After adding SCC credentials, while SCC synchronisation is still ongoing, when you switch to the products tab, a misleading error appears: "No SUSE Manager Server Subscription available. Products requiring Client Tools Channel will not be shown.".
This error does not make sense since the synchronisation is still happening.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manual behaviour testing
- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26134, https://github.com/SUSE/spacewalk/pull/26169
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test
- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
