### PR TITLE
Allow refresh of all system pillar data via API and spacecmd

### DIFF
--- a/containers/proxy-squid-image/proxy-squid-image.changes.mcalmer.api-for-pillar-refresh-all-systems
+++ b/containers/proxy-squid-image/proxy-squid-image.changes.mcalmer.api-for-pillar-refresh-all-systems
@@ -1,0 +1,1 @@
+- Set maximal cache time for metadata to 5 minutes

--- a/containers/proxy-squid-image/squid.conf
+++ b/containers/proxy-squid-image/squid.conf
@@ -25,13 +25,13 @@ cache_replacement_policy heap LFUDA
 memory_replacement_policy heap GDSF
 
 # cache repodata only few minutes and then query parent whether it is fresh
-refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
-refresh_pattern /ks/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
+refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 5 reload-into-ims refresh-ims
+refresh_pattern /ks/.*/repodata/.*$ 0 1% 5 reload-into-ims refresh-ims
 # salt minions get the repodata via a different URL
-refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
+refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 5 reload-into-ims refresh-ims
 # bootstrap repos needs to be handled as well
-refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
-refresh_pattern /pub/repositories/.*/venv-enabled-.*.txt$ 0 1% 1440 reload-into-ims refresh-ims
+refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 5 reload-into-ims refresh-ims
+refresh_pattern /pub/repositories/.*/venv-enabled-.*.txt$ 0 1% 5 reload-into-ims refresh-ims
 # rpm will hardly ever change, force to cache it for very long time
 refresh_pattern  \.rpm$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
 refresh_pattern  \.deb$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims

--- a/java/spacewalk-java.changes.mcalmer.api-for-pillar-refresh-all-systems
+++ b/java/spacewalk-java.changes.mcalmer.api-for-pillar-refresh-all-systems
@@ -1,0 +1,2 @@
+- Modify systems refresh Pillar API to allow refresh pillar data
+  of all systems

--- a/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
+++ b/python/spacewalk/satellite_tools/mgr-sign-metadata-ctl
@@ -29,8 +29,10 @@ function regenerate_metadata {
     systemctl restart taskomatic
     echo "done."
     echo
-    echo "Scheduling repo metadata regeneration..."
     read_spacecmd_user_pass
+    echo "Refreshing pillar data..."
+    spacecmd -q -u $SPACECMD_USER -p $SPACECMD_PASS "system_refreshpillar"
+    echo "Scheduling repo metadata regeneration..."
     spacecmd -q -u $SPACECMD_USER -p $SPACECMD_PASS "softwarechannel_regenerateyumcache -f *"
     RETVAL=$?
     if [ $RETVAL -ne 0 ]; then
@@ -317,5 +319,7 @@ if [[ $ACTION = "enable" || $ACTION = "disable" ]]; then
     echo
     echo "NOTE. For the changes to become effective run:"
     echo "   mgr-sign-metadata-ctl regen-metadata"
+    echo "and schedule a highstate for all your systems to"
+    echo "apply the new repository configuration."
     echo
 fi

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.api-for-pillar-refresh-all-systems
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.api-for-pillar-refresh-all-systems
@@ -1,0 +1,1 @@
+- Refresh pillar data together with regenration of channel metadata

--- a/spacecmd/spacecmd.changes.mcalmer.api-for-pillar-refresh-all-systems
+++ b/spacecmd/spacecmd.changes.mcalmer.api-for-pillar-refresh-all-systems
@@ -1,0 +1,1 @@
+- Add command to refresh systems pillar data

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -2057,6 +2057,45 @@ def do_system_rename(self, args):
 ####################
 
 
+def help_system_refreshpillar(self):
+    print(_('system_refreshpillar: Refresh pillar data of system(s) '))
+    print(_('usage: system_refreshpillar [<SYSTEMS>]'))
+    print('')
+    print(self.HELP_SYSTEM_OPTS)
+
+def complete_system_refreshpillar(self, text, line, beg, end):
+    return self.tab_complete_systems(text)
+
+def do_system_refreshpillar(self, args):
+    arg_parser = get_argument_parser()
+
+    (args, _options) = parse_command_arguments(args, arg_parser)
+
+    sids = []
+    # use the systems listed in the SSM
+    if args:
+        if re.match('ssm', args[0], re.I):
+            systems = self.ssm.keys()
+        else:
+            systems = self.expand_systems(args)
+
+        for system in sorted(systems):
+            system_id = self.get_system_id(system)
+            if not system_id:
+                continue
+            sids.append(system_id)
+
+    self.client.system.refreshPillar(self.session, sids)
+
+    num = "%s" % len(sids)
+    if (num == "0"):
+        num = "all"
+    print('Refreshed Pillar data for "%s" systems' % (num))
+    return 0
+
+####################
+
+
 def help_system_listcustomvalues(self):
     print(_('system_listcustomvalues: List the custom values for a system'))
     print(_('usage: system_listcustomvalues <SYSTEMS>'))


### PR DESCRIPTION
## What does this PR change?

Allow via API and spacecmd to refresh pillar data of all systems.
When refreshing the metadata via mgr-sign-metadata-ctl generate also the pillar data new.
Finally reduce the maximal caching time in the proxy for metadata.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- not needed

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/8563 https://github.com/uyuni-project/uyuni/issues/8189
Port(s): ?

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
