### PR TITLE
Filter away Debian12 boostrap extra log messages (bsc#1216553)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -265,6 +265,19 @@ public class DownloadController {
     }
 
     /**
+     * Predicate telling if a file is a key or a signature file,
+     * also filters Debian files InRelease and Release.gpg in order to avoid extra log messages
+     *
+     * @param filename name of the file
+     */
+    private boolean isKeyOrSignatureFile(String filename) {
+        return filename.endsWith(".asc") ||
+                filename.endsWith(".key") ||
+                filename.equals("InRelease") ||
+                filename.equals("Release.gpg");
+    }
+
+    /**
      * Download metadata taking the channel and filename from the request path.
      *
      * @param request the request object
@@ -279,7 +292,7 @@ public class DownloadController {
 
         File file = Path.of(mountPoint, prefix, channelLabel, filename).toAbsolutePath().toFile();
 
-        if (!file.exists() && (filename.endsWith(".asc") || filename.endsWith(".key"))) {
+        if (!file.exists() && isKeyOrSignatureFile(filename)) {
             halt(HttpStatus.SC_NOT_FOUND,
                     String.format("Key or signature file not provided: %s", filename));
         }

--- a/java/spacewalk-java.changes.carlo.Manager-4.3-fix-debian12-log
+++ b/java/spacewalk-java.changes.carlo.Manager-4.3-fix-debian12-log
@@ -1,0 +1,1 @@
+- Filter away Debian12 boostrap extra log messages (bsc#1216553)


### PR DESCRIPTION
## What does this PR change?
When synchronising Debian 12 product, a lot of log messages appear all the time in /var/log/rhn_web_ui.log on the server, like these:
INFO: ... - 404 - File not found: /var/cache/rhn/repodata/debian-12-suse-manager-tools-amd64/InRelease
INFO: ... - 404 - File not found: /var/cache/rhn/repodata/debian-12-pool-amd64/Release.gpg
Debian has alternative files as metadata "Release" vs "InRelease".
Seems that Debian12 is trying first the "InRelease" which we do not generate by default.
Hence the extra log messages are not needed and should be filtered out.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26177, https://github.com/SUSE/spacewalk/pull/26178
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

## Re-run a test
- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

