### PR TITLE
Fixes: updated packages list when a SLE micro gets updated (bsc#1227118)

### DIFF
--- a/java/spacewalk-java.changes.carlo.Manager-5.0-sle-micro-update
+++ b/java/spacewalk-java.changes.carlo.Manager-5.0-sle-micro-update
@@ -1,0 +1,2 @@
+- Fixes: updated packages list when a SLE micro
+  gets updated (bsc#1227118)


### PR DESCRIPTION
## What does this PR change?

In the case of transactional systems, SUSE Manager should get a package list refresh right after the reboot, when the update is in place for real (the change in packages is only effective after the reboot. We may miss a triggering of that beacon, or of another beacon, in the case of a reboot.)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manual tests
- [x] **DONE**

## Links

Issue(s):
Port(s): https://github.com/SUSE/spacewalk/pull/26123, https://github.com/SUSE/spacewalk/pull/26179
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
