### PR TITLE
Ensure the remote-container deploy mode uses an SSH tunnel

### DIFF
--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -67,46 +67,53 @@
         </and>
     </condition>
 
+    <!-- The command to execute to deploy, for each deployment mode -->
     <condition property="deploy.executor.command" value="sh">
         <equals arg1="${deploy.mode}" arg2="local"/>
     </condition>
 
-    <condition property="deploy.executor.parameters" value="-c">
-        <equals arg1="${deploy.mode}" arg2="local"/>
-    </condition>
-
     <condition property="deploy.executor.command" value="ssh">
-        <equals arg1="${deploy.mode}" arg2="remote"/>
-    </condition>
-
-    <condition property="deploy.executor.parameters" value="${ssh.command.args}">
-        <equals arg1="${deploy.mode}" arg2="remote"/>
+        <or>
+            <equals arg1="${deploy.mode}" arg2="remote"/>
+            <equals arg1="${deploy.mode}" arg2="remote-container"/>
+        </or>
     </condition>
 
     <condition property="deploy.executor.command" value="mgrctl">
         <equals arg1="${deploy.mode}" arg2="container"/>
     </condition>
 
-    <condition property="deploy.executor.parameters" value="exec ${mgrctl.backend.parameter} -i --">
-        <equals arg1="${deploy.mode}" arg2="container"/>
+    <!-- The parameters for the executor, for each deployment mode -->
+    <condition property="deploy.executor.parameters" value="-c">
+        <equals arg1="${deploy.mode}" arg2="local"/>
     </condition>
 
-    <condition property="deploy.executor.command" value="ssh">
-        <equals arg1="${deploy.mode}" arg2="remote-container"/>
+    <condition property="deploy.executor.parameters" value="${ssh.command.args}">
+        <equals arg1="${deploy.mode}" arg2="remote"/>
+    </condition>
+
+    <condition property="deploy.executor.parameters" value="exec ${mgrctl.backend.parameter} -i --">
+        <equals arg1="${deploy.mode}" arg2="container"/>
     </condition>
 
     <condition property="deploy.executor.parameters" value="${ssh.command.args} mgrctl exec ${mgrctl.backend.parameter} -i --">
         <equals arg1="${deploy.mode}" arg2="remote-container"/>
     </condition>
 
+    <!-- True if the deployment mode requires a SSH connection -->
     <condition property="deploy.requires.ssh" value="true">
-        <equals arg1="${deploy.mode}" arg2="remote"/>
+        <or>
+            <equals arg1="${deploy.mode}" arg2="remote"/>
+            <equals arg1="${deploy.mode}" arg2="remote-container"/>
+        </or>
     </condition>
 
+    <!-- True if the deployment mode requires mgrctl to be locally installed -->
     <condition property="deploy.requires.mgrctl" value="true">
         <equals arg1="${deploy.mode}" arg2="container"/>
     </condition>
 
+    <!-- True if the deployment mode requires mgrctl to be installed on the target server -->
     <condition property="deploy.requires.remote-mgrctl" value="true">
         <equals arg1="${deploy.mode}" arg2="remote-container"/>
     </condition>


### PR DESCRIPTION
## What does this PR change?

This PR enables the use of the SSH tunnel when selecting the `remote-container` deployment mode. This was previously not working because the flag `deploy.requires.ssh` was not set to `true` with `remote-container` mode.

This change also regroups the condition checks in order to improve readability. 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no code changes

- [X] **DONE**

## Test coverage
- No tests: no code changes

- [X] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26182

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
