### PR TITLE
Removes Python 2 compatibility code for spacecmd

### DIFF
--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -33,10 +33,9 @@
 import re
 import shlex
 import gettext
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -27,10 +27,9 @@
 import logging
 import sys
 import gettext
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -34,10 +34,9 @@ from datetime import datetime
 import base64
 import codecs
 import gettext
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/cryptokey.py
+++ b/spacecmd/src/spacecmd/cryptokey.py
@@ -27,10 +27,9 @@
 # pylint: disable=W0613
 
 import gettext
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -31,10 +31,9 @@
 # pylint: disable=C0103
 
 import gettext
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 
 from spacecmd.i18n import _N
 from spacecmd.utils import *

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -33,10 +33,9 @@ import gettext
 import os
 import re
 import shlex
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 
 from spacecmd.i18n import _N
 from spacecmd.utils import *

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -34,16 +34,12 @@ import gettext
 import os
 from getpass import getpass
 from operator import itemgetter
-try:
-    from urllib2 import urlopen, HTTPError
-except ImportError:
-    from urllib.request import urlopen
-    from urllib.error import HTTPError
+
+from urllib.request import urlopen
+from urllib.error import HTTPError
 import re
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
 
 from spacecmd.i18n import _N
 from spacecmd.utils import *

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -30,10 +30,9 @@
 # pylint: disable=C0103
 
 import gettext
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/repo.py
+++ b/spacecmd/src/spacecmd/repo.py
@@ -31,10 +31,9 @@
 
 import gettext
 import shlex
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -32,10 +32,9 @@
 import base64
 import gettext
 from operator import itemgetter
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -52,7 +52,7 @@ except AttributeError:
 class UnknownCallException(Exception):
 
     def __init__(self):
-        Exception.__init__(self)
+        super().__init__(self)
 
 
 class SpacewalkShell(Cmd):

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -31,18 +31,12 @@
 # pylint: disable=C0103
 
 import gettext
-try:
-    from urllib import ContentTooShortError
-except ImportError:
-    from urllib.error import ContentTooShortError
-try:
-    from urllib import urlretrieve
-except ImportError:
-    from urllib.request import urlretrieve
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from urllib.error import ContentTooShortError
+from urllib.request import urlretrieve
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -33,10 +33,8 @@
 import gettext
 import shlex
 from datetime import datetime
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+from xmlrpc import client as xmlrpclib
+
 from getpass import getpass
 from operator import itemgetter
 from xml.parsers.expat import ExpatError

--- a/spacecmd/src/spacecmd/user.py
+++ b/spacecmd/src/spacecmd/user.py
@@ -33,10 +33,9 @@
 import gettext
 import shlex
 from getpass import getpass
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
+
+from xmlrpc import client as xmlrpclib
+
 from spacecmd.i18n import _N
 from spacecmd.utils import *
 

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -40,11 +40,8 @@ import shlex
 import sys
 import time
 import argparse
+from xmlrpc import client as xmlrpclib
 
-try:
-    from xmlrpc import client as xmlrpclib
-except ImportError:
-    import xmlrpclib
 from collections import deque
 from datetime import datetime, timedelta
 from difflib import unified_diff
@@ -53,10 +50,7 @@ from textwrap import wrap
 from subprocess import Popen, PIPE
 from dateutil.parser import isoparse
 
-try:
-    import json
-except ImportError:
-    import simplejson as json  # python < 2.6
+import json
 
 import rpm
 


### PR DESCRIPTION
## What does this PR change?

This PR removes Python 2 compatibility code and replaces it with modern Python 3 code. This aligns with the project's decision to deprecate Python 2 support.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
No documentation needed: only internal and user-invisible changes.

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #6005


- [x] **DONE**

## Changelogs

- [x] No changelog needed




