### PR TITLE
Pass the TZ variable to alignment service

### DIFF
--- a/containers/server-image/server-image.changes.cbosdo.timezone-fix
+++ b/containers/server-image/server-image.changes.cbosdo.timezone-fix
@@ -1,0 +1,1 @@
+- Fix timezone alignment on container restart (bsc#1235692)

--- a/containers/server-image/timezone_alignment.service
+++ b/containers/server-image/timezone_alignment.service
@@ -3,6 +3,7 @@ Description=Timezone alignment
 After=postgresql.service
 
 [Service]
+PassEnvironment=TZ
 ExecStart=timezone_alignment.sh
 Type=oneshot
 


### PR DESCRIPTION
## What does this PR change?

By default systemd doesn't pass manager environment variables to the services process, they need to be explicitely added with PassEnvironment. (bsc#1235692)

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: systemd service change.

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26188
Port(s): https://github.com/SUSE/spacewalk/pull/26189

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
