### PR TITLE
Create SLE15SP7 bootstrap repo definitions for SUSE Multi Linux Manager

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -651,6 +651,30 @@ DATA = {
         "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/6/bootstrap/",
     },
+    "SLE-15-SP7-aarch64": {
+        "PDID": [2797, 1709],
+        "BETAPDID": [1925],
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/7/bootstrap/",
+    },
+    "SLE-15-SP7-ppc64le": {
+        "PDID": [2798, 1710],
+        "BETAPDID": [1926],
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_PPC,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/7/bootstrap/",
+    },
+    "SLE-15-SP7-s390x": {
+        "PDID": [2799, 1711],
+        "BETAPDID": [1927],
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_Z,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/7/bootstrap/",
+    },
+    "SLE-15-SP7-x86_64": {
+        "PDID": [2800, 1712],
+        "BETAPDID": [1928],
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/7/bootstrap/",
+    },
     # When adding new SLE15 Service packs, keep in mind the first PDID is for the BaseSystem product (not the base product)!
     "SUMA-43-PROXY-x86_64": {
         "PDID": [2299, 2384, 2379],

--- a/susemanager/susemanager.changes.carlo.uyuni-mlm-bootstrap-repo-sle15sp7
+++ b/susemanager/susemanager.changes.carlo.uyuni-mlm-bootstrap-repo-sle15sp7
@@ -1,0 +1,1 @@
+- Create SLE15SP7 bootstrap repo definitions


### PR DESCRIPTION
## What does this PR change?
Creates SLE15SP7 bootstrap repo definitions for Multi-Linux Manager

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Port(s): https://github.com/SUSE/spacewalk/pull/26195, https://github.com/SUSE/spacewalk/pull/26196
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

## Re-run a test
- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
