### PR TITLE
Remove RPM options and feature in rhn-ssl-tool --gen-server

### DIFF
--- a/java/code/src/com/suse/manager/ssl/SSLCertManager.java
+++ b/java/code/src/com/suse/manager/ssl/SSLCertManager.java
@@ -86,7 +86,7 @@ public class SSLCertManager {
             FileUtils.writeStringToFile(caPair.getKey(), tempCaKeyFile.getAbsolutePath());
 
             List<String> command = new ArrayList<>();
-            command.addAll(List.of("rhn-ssl-tool", "--gen-server", "-q", "--no-rpm"));
+            command.addAll(List.of("rhn-ssl-tool", "--gen-server", "-q"));
             command.addAll(List.of("-d", sslBuildDir.getAbsolutePath()));
             command.addAll(List.of("--ca-cert", tempCaCertFile.getName()));
             command.addAll(List.of("--ca-key", tempCaKeyFile.getName()));

--- a/java/code/src/com/suse/manager/ssl/test/SSLCertManagerTest.java
+++ b/java/code/src/com/suse/manager/ssl/test/SSLCertManagerTest.java
@@ -68,7 +68,7 @@ public class SSLCertManagerTest extends RhnJmockBaseTestCase {
         ByteArrayOutputStream outStream = new ByteArrayOutputStream();
         context().checking(new Expectations() {{
             allowing(runtime).exec(with(IsArrayContainingInAnyOrder.arrayContainingInAnyOrder(
-                    "rhn-ssl-tool", "--gen-server", "-q", "--no-rpm", "-d", tempDir.getAbsolutePath(),
+                    "rhn-ssl-tool", "--gen-server", "-q", "-d", tempDir.getAbsolutePath(),
                     "--ca-cert", "ca.crt", "--ca-key", "ca.key", "--set-hostname", "server.acme.lab",
                     "--set-cname", "srv1.acme.lab", "--set-cname", "srv2.acme.lab", "--set-country", "DE",
                     "--set-state", "Bayern", "--set-city", "Nurnberg", "--set-org", "SUSE",

--- a/java/spacewalk-java.changes.cbosdo.no-rpm
+++ b/java/spacewalk-java.changes.cbosdo.no-rpm
@@ -1,0 +1,2 @@
+- Remove rhn-ssl-tool --gen-server RPM feature and options
+  (bsc#1235696)

--- a/spacewalk/certs-tools/mgr-ssl-tool.sgml
+++ b/spacewalk/certs-tools/mgr-ssl-tool.sgml
@@ -47,7 +47,6 @@ Generate and maintain SSL keys, certificates and deployment RPMs.
     <member>(advanced) <command>mgr-ssl-tool --gen-server --key-only --help</command></member>
     <member>(advanced) <command>mgr-ssl-tool --gen-server --cert-req-only --help</command></member>
     <member>(advanced) <command>mgr-ssl-tool --gen-server --cert-only --help</command></member>
-    <member>(advanced) <command>mgr-ssl-tool --gen-server --rpm-only --help</command></member>
 </simplelist>
 </RefSect1>
 
@@ -191,53 +190,11 @@ Generate and maintain SSL keys, certificates and deployment RPMs.
             <para>generate a web server's SSL private key: <command>--gen-server --key-only <replaceable>...</replaceable></command></para>
             <para>generate a web server's SSL certificate request: <command>--gen-server --cert-req-only <replaceable>...</replaceable></command></para>
             <para>generate/sign a web server's SSL certificate: <command>--gen-server --cert-only <replaceable>...</replaceable></command></para>
-            <para>generate a web server's private RPM (and tar archive used for SUSE Manager Proxy installations): <command>--gen-server --rpm-only <replaceable>...</replaceable></command></para>
-            <para>generate a web server's private RPM using a custom SSL key and certificate: <command>--gen-server --rpm-only --from-server-key=<replaceable>FILE</replaceable> --from-server-cert=<replaceable>FILE</replaceable></command></para>
 
             </listitem>
         </varlistentry></variablelist>
         </msgtext></member>
 
-        <member><msgtext>
-        <variablelist><varlistentry>
-
-            <term>Using a 3rd party CA (rarely done in the SUSE Manager context):</term>
-
-            <listitem>
-            <para><emphasis>DEPRECATED:</emphasis> Use
-            <command>--from-ca-cert</command>,
-            <command>--from-server-key</command> and
-            <command>--from-server-cert</command> parameters instead as
-            described in Advanced options section.
-            </para>
-
-            <listitem>
-            <para></para>
-
-            <para><emphasis>CA public certificate:</emphasis> In the "3rd party
-            CA" case, simply copy the certificate authorities public
-            certificate to the SSL build directory; renaming it to
-            <emphasis>RHN-ORG-TRUSTED-SSL-CERT</emphasis>; and then run
-            <command>--gen-ca --dir BUILD_DIR --rpm-only</command> to package
-            that certificate in an expected manner ready for client deployment.
-            See further instructions in <emphasis>step 2</emphasis>.</para>
-
-            <para><emphasis>Web server's SSL key pair(set):</emphasis> Usually,
-            one creates the web server's SSL private key, certificate-request
-            and certificate in one step. If using a 3rd party CA though, create
-            a web server's SSL private key and certificate-request via
-            <command>--gen-server --key-only --dir BUILD_DIR</command> and
-            <command>--gen-server --cert-req-only --dir BUILD_DIR</command>.
-            Have the 3rd party sign server.csr which will generate a server.crt
-            file. Copy that server.crt file into the
-            <emphasis>BUILD_DIR/MACHINE_NAME</emphasis> directory (where the
-            server.key file was generated). And then create your deployable RPM
-            with <command>--gen-server --rpm-only --dir BUILD_DIR</command>.
-            </para>
-
-            </listitem>
-        </varlistentry></variablelist>
-        </msgtext></member>
     </simplelist></para>
 
     <para>NOTE: each step (<command>--gen-*</command> or <command>--gen-*
@@ -557,49 +514,12 @@ Generate and maintain SSL keys, certificates and deployment RPMs.
                 </listitem>
                 </varlistentry>
                 <varlistentry>
-                <term>--server-rpm</term>
-                <listitem>
-                    <para>(rarely changed) RPM name that houses the web
-                    server's SSL key set (the base filename, not
-                    filename-version-release.noarch.rpm).</para>
-                </listitem>
-                </varlistentry>
-                <varlistentry>
                 <term>--server-tar</term>
                 <listitem>
                     <para>(rarely changed) name of archive (tarball) of the web
                     server's SSL key set and CA SSL public certificate that is
                     used solely by the hosted SUSE Manager installation
                     routines (the base filename, not filename-version-release.tar).</para>
-                </listitem>
-                </varlistentry>
-                <varlistentry>
-                <term>--rpm-packager</term>
-                <listitem>
-                    <para>(rarely used) packager of the generated RPM, such as
-                    "SUSE Manager Admin &lt;rhn-admin@example.com&gt;".</para>
-                </listitem>
-                </varlistentry>
-                <varlistentry>
-                <term>--rpm-vendor</term>
-                <listitem>
-                    <para>(rarely used) vendor of the generated RPM, such as
-                    "IS/IT Example Corp.".</para>
-                </listitem>
-                </varlistentry>
-                <varlistentry>
-                <term>--rpm-only</term>
-                <listitem>
-                    <para>(rarely used) only generate a deployable RPM.
-                    Try <command>--gen-server --rpm-only --help</command> for
-                    more information.</para>
-                </listitem>
-                </varlistentry>
-                <varlistentry>
-                <term>--no-rpm</term>
-                <listitem>
-                    <para>(rarely used) do everything *except* generate an
-                    RPM.</para>
                 </listitem>
                 </varlistentry>
                 <varlistentry>
@@ -645,8 +565,6 @@ Generate and maintain SSL keys, certificates and deployment RPMs.
     <member>BUILD_DIR/MACHINE_NAME/server.key</member>
     <member>BUILD_DIR/MACHINE_NAME/server.csr</member>
     <member>BUILD_DIR/MACHINE_NAME/server.crt</member>
-    <member>BUILD_DIR/MACHINE_NAME/rhn-org-httpd-ssl-key-pair-MACHINE_NAME-VER-REL.src.rpm</member>
-    <member>BUILD_DIR/MACHINE_NAME/rhn-org-httpd-ssl-key-pair-MACHINE_NAME-VER-REL.noarch.rpm</member>
     <member>BUILD_DIR/MACHINE_NAME/rhn-org-httpd-ssl-archive-MACHINE_NAME-VER-REL.tar</member>
 </simplelist>
 </RefSect1>

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.cbosdo.no-rpm
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.cbosdo.no-rpm
@@ -1,0 +1,2 @@
+- Remove rhn-ssl-tool --gen-server RPM feature and options
+  (bsc#1235696)

--- a/spacewalk/certs-tools/sslToolCli.py
+++ b/spacewalk/certs-tools/sslToolCli.py
@@ -167,13 +167,6 @@ def _getOptionsTree(defs):
         help="(rarely changed) RPM name that houses the CA SSL public certificate (the base filename, not filename-version-release.noarch.rpm).",
     )
     # pylint: disable-next=invalid-name
-    _optServerRpm = make_option(
-        "--server-rpm",
-        action="store",
-        type="string",
-        help="(rarely changed) RPM name that houses the web server's SSL key set (the base filename, not filename-version-release.noarch.rpm).",
-    )
-    # pylint: disable-next=invalid-name
     _optServerTar = make_option(
         "--server-tar",
         action="store",
@@ -214,20 +207,6 @@ def _getOptionsTree(defs):
         action="store",
         type="string",
         help="(for usage with --gen-ca and --rpm-only) Use a custom CA certificate from the given file. Note this doesn't affect the output CA certificate filename (for this use --ca-cert option).",
-    )
-    # pylint: disable-next=invalid-name
-    _optFromServerKey = make_option(
-        "--from-server-key",
-        action="store",
-        type="string",
-        help="(for usage with --gen-server and --rpm-only) Use a server private SSL key from the given file. Note this doesn't affect the output server key filename (for this use --server-key option).",
-    )
-    # pylint: disable-next=invalid-name
-    _optFromServerCert = make_option(
-        "--from-server-cert",
-        action="store",
-        type="string",
-        help="(for usage with --gen-server and --rpm-only) Use server public SSL certificate from the given file. Note this doesn't affect the output server certificate filename (for this use --server-cert option).",
     )
 
     # pylint: disable-next=invalid-name
@@ -456,8 +435,7 @@ def _getOptionsTree(defs):
         + _serverConfOptions
         + _genOptions
         + [_optServerKeyOnly, _optServerCertReqOnly, _optServerCertOnly]
-        + _buildRpmOptions
-        + [_optServerRpm, _optServerTar, _optNoRpm]
+        + [_optServerTar]
     )
     # pylint: disable-next=invalid-name
     _serverKeyOnlySet = (
@@ -475,21 +453,6 @@ def _getOptionsTree(defs):
     # pylint: disable-next=invalid-name
     _serverCertOnlySet = (
         [_optGenServer] + _serverCertOptions + _genOptions + [_optServerCertOnly]
-    )
-    # pylint: disable-next=invalid-name
-    _serverRpmOnlySet = (
-        [
-            _optGenServer,
-            _optServerKey,
-            _optServerCertReq,
-            _optServerCert,
-            _optSetHostname,
-            _optSetCname,
-        ]
-        + _buildRpmOptions
-        + [_optFromServerKey, _optFromServerCert]
-        + [_optServerRpm, _optServerTar]
-        + _genOptions
     )
 
     # CA key check set possibilities
@@ -544,7 +507,6 @@ ERROR: cannot use these options in combination:
         optionsTree["--gen-server"] = _serverCertReqOnlySet
     elif "--rpm-only" in sys.argv:
         optionsTree["--gen-ca"] = _caRpmOnlySet
-        optionsTree["--gen-server"] = _serverRpmOnlySet
 
     # pylint: disable-next=invalid-name
     baseOptions = [_optGenCa, _optGenServer, _optCheckKey, _optCheckCert]

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -37,7 +37,7 @@ from uyuni.common.fileutils import (
 )
 
 # pylint: disable-next=unused-import
-from .sslToolLib import getMachineName, daysTil18Jan2038, incSerial, fixSerial
+from .sslToolLib import getMachineName, daysTil18Jan2038, fixSerial
 from rhn.stringutils import sstr
 
 # defaults where we can see them (NOTE: directory is figured at write time)
@@ -113,7 +113,6 @@ _defs = {
     "--server-key": "server.key",
     "--server-cert-req": "server.csr",
     "--server-cert": "server.crt",
-    "--jabberd-ssl-cert": "server.pem",
     "--set-country": "US",
     "--set-common-name": "",  # these two will never appear
     "--set-hostname": HOSTNAME,  # at the same time on the CLI
@@ -839,33 +838,6 @@ serial                  = $dir/serial
 ## generated RPM "configuration" dumping ground:
 ##
 
-POST_UNINSTALL_SCRIPT = """\
-if [ \$1 = 0 ]; then
-    # The following steps are copied from mod_ssl's postinstall scriptlet
-    # Make sure the permissions are okay
-    umask 077
-
-    if [ ! -f /etc/httpd/conf/ssl.key/server.key ] ; then
-        /usr/bin/openssl genrsa -rand /proc/apm:/proc/cpuinfo:/proc/dma:/proc/filesystems:/proc/interrupts:/proc/ioports:/proc/pci:/proc/rtc:/proc/uptime 1024 > /etc/httpd/conf/ssl.key/server.key 2> /dev/null
-    fi
-
-    if [ ! -f /etc/httpd/conf/ssl.crt/server.crt ] ; then
-        cat << EOF | /usr/bin/openssl req -new -key /etc/httpd/conf/ssl.key/server.key -x509 -days 365 -out /etc/httpd/conf/ssl.crt/server.crt 2>/dev/null
---
-SomeState
-SomeCity
-SomeOrganization
-SomeOrganizationalUnit
-localhost.localdomain
-root@localhost.localdomain
-EOF
-    fi
-    /sbin/service httpd graceful || /sbin/service httpd try-restart
-    exit 0
-fi
-"""
-
-SERVER_RPM_SUMMARY = "Organizational server (httpd) SSL key-pair/key-set."
 CA_CERT_RPM_SUMMARY = "Organizational public SSL CA certificate " "(client-side)."
 
 

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -367,7 +367,7 @@ function re-generate_server_ssl_certificate {
             else
                 echo " No need to generate a new SSL CA Certificate" | tee -a $LOG
             fi
-            echo "rhn-ssl-tool --gen-server --no-rpm \
+            echo "rhn-ssl-tool --gen-server \
                 --dir="$SSL_BUILD_DIR" \
                 --set-country="$SSL_COUNTRY" \
                 --set-state="$SSL_STATE" \
@@ -377,7 +377,7 @@ function re-generate_server_ssl_certificate {
                 --set-email="$SSL_EMAIL" \
                 --set-hostname="${HOSTNAME}" \
             " >> $LOG
-            rhn-ssl-tool --gen-server --no-rpm \
+            rhn-ssl-tool --gen-server \
                 --dir="$SSL_BUILD_DIR" \
                 --set-country="$SSL_COUNTRY" \
                 --set-state="$SSL_STATE" \

--- a/utils/spacewalk-utils.changes.cbosdo.no-rpm
+++ b/utils/spacewalk-utils.changes.cbosdo.no-rpm
@@ -1,0 +1,2 @@
+- Remove rhn-ssl-tool --gen-server RPM feature and options
+  (bsc#1235696)


### PR DESCRIPTION
# What does this PR change?

Note that removing the options for --gen-ca is not yet possible since this RPM is used by the kiwi image building. bsc#1235696

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: code removal
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26194
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
