### PR TITLE
Show Source String change for translations

### DIFF
--- a/client/rhel/spacewalk-client-tools/po/Makefile
+++ b/client/rhel/spacewalk-client-tools/po/Makefile
@@ -34,7 +34,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/intltool-update -x --gettext-package=$(PACKAGE) --dist
+MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 
@@ -158,7 +158,7 @@ update-po: Makefile POTFILES.in $(PACKAGE).pot
 	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
 	  echo "$$lang:"; \
 	  cp $$lang.po $$lang.old.po; \
-	  if $(MSGMERGE) $$lang; then \
+	  if $(MSGMERGE) -o $$lang.po $$lang.po $(PACKAGE).pot; then \
 	    rm -f $$lang.old.po ; \
 	  else \
 	    echo "msgmerge for $$cat failed!"; \

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.mcalmer.show-source-string-change
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.mcalmer.show-source-string-change
@@ -1,0 +1,1 @@
+- Show Source String change for translations

--- a/python/spacewalk/po/Makefile
+++ b/python/spacewalk/po/Makefile
@@ -35,7 +35,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/intltool-update -x --gettext-package=$(PACKAGE) --dist
+MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 
@@ -157,7 +157,7 @@ update-po: Makefile POTFILES.in $(PACKAGE).pot
 	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
 	  echo "$$lang:"; \
 	  cp $$lang.po $$lang.old.po; \
-	  if $(MSGMERGE) $$lang; then \
+	  if $(MSGMERGE) -o $$lang.po $$lang.po $(PACKAGE).pot; then \
 	    rm -f $$lang.old.po ; \
 	  else \
 	    echo "msgmerge for $$cat failed!"; \

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.show-source-string-change
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.show-source-string-change
@@ -1,0 +1,1 @@
+- Show Source String change for translations

--- a/spacecmd/po/Makefile
+++ b/spacecmd/po/Makefile
@@ -35,7 +35,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/intltool-update -x --gettext-package=$(PACKAGE) --dist
+MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 
@@ -157,7 +157,7 @@ update-po: Makefile POTFILES.in $(PACKAGE).pot
 	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
 	  echo "$$lang:"; \
 	  cp $$lang.po $$lang.old.po; \
-	  if $(MSGMERGE) $$lang; then \
+	  if $(MSGMERGE) -o $$lang.po $$lang.po $(PACKAGE).pot; then \
 	    rm -f $$lang.old.po ; \
 	  else \
 	    echo "msgmerge for $$cat failed!"; \

--- a/spacecmd/spacecmd.changes.mcalmer.show-source-string-change
+++ b/spacecmd/spacecmd.changes.mcalmer.show-source-string-change
@@ -1,0 +1,1 @@
+- Show Source String change for translations

--- a/susemanager/po/Makefile
+++ b/susemanager/po/Makefile
@@ -35,7 +35,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/intltool-update -x --gettext-package=$(PACKAGE) --dist
+MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 
@@ -157,7 +157,7 @@ update-po: Makefile POTFILES.in $(PACKAGE).pot
 	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
 	  echo "$$lang:"; \
 	  cp $$lang.po $$lang.old.po; \
-	  if $(MSGMERGE) $$lang; then \
+	  if $(MSGMERGE) -o $$lang.po $$lang.po $(PACKAGE).pot; then \
 	    rm -f $$lang.old.po ; \
 	  else \
 	    echo "msgmerge for $$cat failed!"; \

--- a/susemanager/susemanager.changes.mcalmer.show-source-string-change
+++ b/susemanager/susemanager.changes.mcalmer.show-source-string-change
@@ -1,0 +1,1 @@
+- Show Source String change for translations

--- a/web/po/Makefile
+++ b/web/po/Makefile
@@ -43,7 +43,7 @@ endif
 
 GMSGFMT = ${BIN}/msgfmt
 MSGFMT = ${BIN}/msgfmt
-MSGMERGE = ${BIN}/intltool-update -x --gettext-package=$(PACKAGE) --dist
+MSGMERGE = ${BIN}/msgmerge --previous --no-wrap
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 
@@ -166,7 +166,7 @@ update-po: Makefile POTFILES.in $(PACKAGE).pot
 	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
 	  echo "$$lang:"; \
 	  cp $$lang.po $$lang.old.po; \
-	  if $(MSGMERGE) $$lang; then \
+	  if $(MSGMERGE) -o $$lang.po $$lang.po $(PACKAGE).pot; then \
 	    rm -f $$lang.old.po ; \
 	  else \
 	    echo "msgmerge for $$cat failed!"; \

--- a/web/spacewalk-web.changes.mcalmer.show-source-string-change
+++ b/web/spacewalk-web.changes.mcalmer.show-source-string-change
@@ -1,0 +1,1 @@
+- Show Source String change for translations


### PR DESCRIPTION
## What does this PR change?

Change translation scripts to include previous changes of the source string for translators

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **translation tools**

- [x] **DONE**

## Links

Issue(s): None
Port(s): https://github.com/SUSE/spacewalk/pull/26201 https://github.com/SUSE/spacewalk/pull/26204

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
