### PR TITLE
Fix supportutils plugins to work with latest 3.2.9 version (bsc#1235145)

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes.meaksh.fix-requires
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.changes.meaksh.fix-requires
@@ -1,0 +1,2 @@
+- Adjust requires for plugin to allow compatibility with
+  supportutils 3.2.9 release (bsc#1235145)

--- a/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.spec
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/supportutils-plugin-susemanager-client.spec
@@ -26,8 +26,7 @@ Group:          Documentation/SuSE
 Source:         %{name}-%{version}.tar.gz
 URL:            https://github.com/uyuni-project/uyuni
 BuildRequires:  supportutils
-Requires:       supportconfig-plugin-resource
-Requires:       supportconfig-plugin-tag
+Requires:       supportutils
 Supplements:    packageand(salt-minion:supportutils)
 Supplements:    packageand(spacewalk-check:supportutils)
 BuildArch:      noarch

--- a/susemanager-utils/supportutils-plugin-susemanager-proxy/supportutils-plugin-susemanager-proxy.changes.meaksh.fix-requires
+++ b/susemanager-utils/supportutils-plugin-susemanager-proxy/supportutils-plugin-susemanager-proxy.changes.meaksh.fix-requires
@@ -1,0 +1,2 @@
+- Adjust requires for plugin to allow compatibility with
+  supportutils 3.2.9 release (bsc#1235145)

--- a/susemanager-utils/supportutils-plugin-susemanager-proxy/supportutils-plugin-susemanager-proxy.spec
+++ b/susemanager-utils/supportutils-plugin-susemanager-proxy/supportutils-plugin-susemanager-proxy.spec
@@ -26,8 +26,7 @@ Group:          Documentation/SuSE
 Source:         %{name}-%{version}.tar.gz
 URL:            https://github.com/uyuni-project/uyuni
 Requires:       spacewalk-proxy-common
-Requires:       supportconfig-plugin-resource
-Requires:       supportconfig-plugin-tag
+Requires:       supportutils
 Supplements:    packageand(spacewalk-proxy-installer:supportutils)
 BuildArch:      noarch
 

--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.meaksh.fix-requires
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes.meaksh.fix-requires
@@ -1,0 +1,2 @@
+- Adjust requires for plugin to allow compatibility with
+  supportutils 3.2.9 release (bsc#1235145)

--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.spec
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.spec
@@ -25,8 +25,7 @@ License:        GPL-2.0-only
 Group:          Documentation/SuSE
 Source:         %{name}-%{version}.tar.gz
 URL:            https://github.com/uyuni-project/uyuni
-Requires:       supportconfig-plugin-resource
-Requires:       supportconfig-plugin-tag
+Requires:       supportutils
 Requires:       susemanager
 Requires:       perl(XML::Simple)
 Supplements:    packageand(spacewalk-common:supportutils)


### PR DESCRIPTION
## What does this PR change?

This PR adjust the requires of the following packages to allow compatibility with latest 3.2.9 version of `supportutils` (as the used "provides" has been dropped):

- `supportutils-plugin-susemanager`
- `supportutils-plugin-susemanager-client`
- `supportutils-plugin-susemanager-proxy`

Since these plugins are running also with older versions of `supportutils`, like in SLE12 (version 3.0.12), we are not requiring provides anymore but the main `supportutils` package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26200

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
