### PR TITLE
Use direct package install temporarily instead of using spacecmd command

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -41,12 +41,12 @@ Feature: Setup containerized proxy
 
    # WORKAROUND: Disable until https://bugzilla.suse.com/show_bug.cgi?id=1235692 is fixed
 #  Scenario: Upgrade mgrpxy tool
-#    Then I upgrade "proxy" with the last "mgrpxy" version
+#    Then I upgrade "proxy" with the last "mgrpxy" version using spacecmd
 #    And I reboot the "proxy" minion through the web UI
 
   # WORKAROUND: Remove once https://bugzilla.suse.com/show_bug.cgi?id=1235692 is fixed
   Scenario: Upgrade mgrpxy tool
-    Then I install packages "mgrpxy" on this "proxy"
+    When I install packages "mgrpxy" on this "proxy"
     And I reboot the "proxy" minion through the web UI
 
   Scenario: Generate containerized proxy configuration

--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -46,7 +46,7 @@ Feature: Setup containerized proxy
 
   # WORKAROUND: Remove once https://bugzilla.suse.com/show_bug.cgi?id=1235692 is fixed
   Scenario: Upgrade mgrpxy tool
-    When I install packages "mgrpxy" on this "proxy"
+    When I install package "mgrpxy" on this "proxy"
     And I reboot the "proxy" minion through the web UI
 
   Scenario: Generate containerized proxy configuration

--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -39,8 +39,14 @@ Feature: Setup containerized proxy
   Scenario: Wait until the proxy host appears
     When I wait until onboarding is completed for "proxy"
 
+   # WORKAROUND: Disable until https://bugzilla.suse.com/show_bug.cgi?id=1235692 is fixed
+#  Scenario: Upgrade mgrpxy tool
+#    Then I upgrade "proxy" with the last "mgrpxy" version
+#    And I reboot the "proxy" minion through the web UI
+
+  # WORKAROUND: Remove once https://bugzilla.suse.com/show_bug.cgi?id=1235692 is fixed
   Scenario: Upgrade mgrpxy tool
-    Then I upgrade "proxy" with the last "mgrpxy" version
+    Then I install packages "mgrpxy" on this "proxy"
     And I reboot the "proxy" minion through the web UI
 
   Scenario: Generate containerized proxy configuration

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1775,7 +1775,7 @@ Then(/^the word "([^']*)" does not occur more than (\d+) times in "(.*)" on "([^
   raise "The word #{word} occured #{occurences} times, which is more more than #{threshold} times in file #{path}" if occurences > threshold
 end
 
-Then(/^I upgrade "([^"]*)" with the last "([^"]*)" version$/) do |host, package|
+Then(/^I upgrade "([^"]*)" with the last "([^"]*)" version using spacecmd$/) do |host, package|
   system_name = get_system_name(host)
   last_event_before_upgrade = get_last_event(host)
   last_event = last_event_before_upgrade


### PR DESCRIPTION
## What does this PR change?

To follow the documentation and fix the 5.0 proxy setup, we need to install/update mgrpxy package.
At first we were using spacewalk to update this package but because of this bug https://bugzilla.suse.com/show_bug.cgi?id=1235692, this command is not usable.

This change is temporary and use direct installation instead of using SUMA to install/update mgrpxy package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links
Port(s):  https://github.com/SUSE/spacewalk/pull/26207

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
