### PR TITLE
susemanager-light.css does not exist anymore

### DIFF
--- a/testsuite/features/secondary/srv_security.feature
+++ b/testsuite/features/secondary/srv_security.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2022 SUSE LLC
+# Copyright (c) 2017-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_tomcat
@@ -11,7 +11,7 @@ Feature: Basic web security measures and recommendations
     When I clear browser cookies
 
   Scenario: Caching should be enabled for static content
-    Given I retrieve any static resource
+    When I retrieve a "css" static resource
     Then the response header "ETag" should not be present
     And the response header "Pragma" should not be present
     And the response header "Expires" should not be "0"
@@ -22,5 +22,5 @@ Feature: Basic web security measures and recommendations
     And the response header "X-Permitted-Cross-Domain-Policies" should be "master-only"
 
   Scenario: Obsolete and problematic headers for static content
-    Given I retrieve any static resource
+    Given I retrieve a "javascript" static resource
     Then the response header "X-WebKit-CSP" should not be present

--- a/testsuite/features/step_definitions/security_steps.rb
+++ b/testsuite/features/step_definitions/security_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2017-2023 SUSE LLC.
+# Copyright 2017-2025 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions of all steps concerning
@@ -8,28 +8,33 @@ require 'open-uri'
 require 'uri'
 require 'openssl'
 
-When(/^I retrieve any static resource$/) do
-  resource = %w[/img/action-add.gif /css/susemanager-light.css /fonts/DroidSans.ttf /javascript/actionchain.js].sample
-  @url = Capybara.app_host + resource
-  URI.open(@url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE) do |f|
-    @headers = f.meta
+When(/^I retrieve a "(.*)" static resource$/) do |resource_type|
+  static_resources = {
+    'img' => 'action-add.gif',
+    'css' => 'susemanager-sp-migration.css',
+    'fonts' => 'DroidSans.ttf',
+    'javascript' => 'actionchain.js'
+  }
+  @url = "#{Capybara.app_host}/#{resource_type}/#{static_resources[resource_type]}"
+  URI.open(@url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE) do |file|
+    @headers = file.meta
   end
 end
 
-Then(/^the response header "(.*?)" should be "(.*?)"$/) do |arg1, arg2|
-  assert_includes(@headers.keys, arg1.downcase, "Header '#{arg1}' not present in '#{@url}'")
-  assert_equal(arg2, @headers[arg1.downcase], "Header '#{arg1}' in '#{@url}' is not '#{arg2}'")
+Then(/^the response header "(.*?)" should be "(.*?)"$/) do |name, value|
+  assert_includes(@headers.keys, name.downcase, "Header '#{name}' not present in '#{@url}'")
+  assert_equal(value, @headers[name.downcase], "Header '#{name}' in '#{@url}' is not '#{value}'")
 end
 
-Then(/^the response header "(.*?)" should not be "(.*?)"$/) do |arg1, arg2|
-  refute_equal(arg2, @headers[arg1.downcase], "Header '#{arg1}' in '#{@url}' is '#{arg2}'")
+Then(/^the response header "(.*?)" should not be "(.*?)"$/) do |name, value|
+  refute_equal(value, @headers[name.downcase], "Header '#{name}' in '#{@url}' is '#{value}'")
 end
 
-Then(/^the response header "(.*?)" should contain "(.*?)"$/) do |arg1, arg2|
-  assert_includes(@headers.keys, arg1.downcase, "Header '#{arg1}' not present in '#{@url}'")
-  assert_includes(@headers[arg1.downcase], arg2, "Header '#{arg1}' in '#{@url}' does not contain '#{arg2}'")
+Then(/^the response header "(.*?)" should contain "(.*?)"$/) do |name, value|
+  assert_includes(@headers.keys, name.downcase, "Header '#{name}' not present in '#{@url}'")
+  assert_includes(@headers[name.downcase], value, "Header '#{name}' in '#{@url}' does not contain '#{value}'")
 end
 
-Then(/^the response header "(.*?)" should not be present$/) do |arg1|
-  refute_includes(@headers.keys, arg1.downcase, "Header '#{arg1}' present in '#{@url}'")
+Then(/^the response header "(.*?)" should not be present$/) do |name|
+  refute_includes(@headers.keys, name.downcase, "Header '#{name}' present in '#{@url}'")
 end


### PR DESCRIPTION
## What does this PR change?

* File `susemanager-light.css` does not exist anymore, replace it with `susemanager-sp-migration.css`.
* Do note use `sample`, or do not make tests random in any manner, we want predictable tests.
* Don't use `arg1` and `arg2`, prefer meaningful parameter names.


## Links

Port(s):
 * 5.0: https://github.com/SUSE/spacewalk/pull/26217
 * 4.3: https://github.com/SUSE/spacewalk/pull/26218


## Changelogs

- [x] No changelog needed

