### PR TITLE
Changelog validation: ensure changelog filename matches the package name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,9 +32,6 @@
 
 # Uyuni Code Owners
 
-# Workflows reviewers
-.github/workflows @uyuni-project/workflows-reviewers
-
 # Release Engineering
 rel-eng/ @uyuni-project/release-engineering
 tito.props @uyuni-project/release-engineering
@@ -47,6 +44,9 @@ java/conf/cobbler/snippets/ @uyuni-project/python
 *.py @uyuni-project/python
 # This file only holds data, no Python code
 mgr_bootstrap_data.py
+
+# Workflows reviewers
+.github/workflows @uyuni-project/workflows-reviewers
 
 # Frontend
 web/html/ @uyuni-project/frontend

--- a/.github/workflows/changelogs/changelogs.py
+++ b/.github/workflows/changelogs/changelogs.py
@@ -73,6 +73,7 @@ class IssueType:
     MISSING_CHLOG = "Changelog not added"
     WRONG_CHLOG = "Changelog added without changes"
     EMPTY_CHLOG = "No changelog entries found"
+    INVALID_CHLOG_FILENAME = "Changelog filename must be in format: '{}.changes.<author>.<feature>'"
     MISSING_NEWLINE = "Missing newline at the end"
     WRONG_CAP = "Wrong capitalization"
     WRONG_SPACING = "Wrong spacing"
@@ -265,7 +266,7 @@ class ChangelogValidator:
         for f in files:
             # Check if the file exists in a subdirectory of the base path of the package
             if f.startswith(pkg_path):
-                if os.path.basename(f).startswith(pkg_name + ".changes."):
+                if ".changes." in os.path.basename(f):
                     # Ignore if the change is a removal
                     if os.path.isfile(os.path.join(self.uyuni_root, f)):
                         pkg_chlogs.append(f)
@@ -629,6 +630,9 @@ class ChangelogValidator:
             if not files["changes"]:
                 # Files are modified but no changelog file added
                 issues.append(Issue(IssueType.MISSING_CHLOG, package=pkg))
+            for chlog_file in files["changes"]:
+                if not os.path.basename(chlog_file).startswith(f"{pkg}.changes."):
+                    issues.append(Issue(IssueType.INVALID_CHLOG_FILENAME.format(pkg), package=pkg))
 
             # Validate each changelog file and gather all the issues
             for file in files["changes"]:

--- a/.github/workflows/changelogs/test_changelogs.py
+++ b/.github/workflows/changelogs/test_changelogs.py
@@ -491,6 +491,14 @@ def test_validate_chlog_for_wrong_pkg(validator, chlog_file):
     )
 
 
+def test_validate_chlog_invalid_filename(validator, base_path):
+    chlog_file = base_path / "pkg/path/invalid.changes.my.feature"
+    chlog_file.write_text("- This is a changelog entry.\n")
+    issues = validator.validate(["pkg/path/invalid.changes.my.feature", "pkg/path/myfile.txt"])
+    assert len(issues) == 1, issues_to_str(issues, 1)
+    assert IssueType.INVALID_CHLOG_FILENAME.format("mypkg") in str(issues[0]) and "mypkg" in str(issues[0])
+
+
 def test_validate_change_in_subdir(validator, base_path):
     chlog_file = base_path / "pkg/other/otherpkg.changes.my.feature"
     chlog_file.write_text("- This is a changelog entry.\n")

--- a/.github/workflows/changelogs/test_changelogs.py
+++ b/.github/workflows/changelogs/test_changelogs.py
@@ -313,7 +313,7 @@ def test_validate_chlog_file_multiple_issues_and_entries(validator, chlog_file):
         ),
         (
             "- This entry has an  extra whitespace\n",
-            IssueType.MULTI_WHITESPACEi
+            IssueType.MULTI_WHITESPACE
         ),
         (
             " - This is an invalid changelog entry\n",


### PR DESCRIPTION
## GUI Diff

Before:
```
> changelogs.py java/spacewalk-NOT-JAVA.changes.cbbayburt.test ...

INFO: Changelog test passed
```

After:
```
> changelogs.py java/spacewalk-NOT-JAVA.changes.cbbayburt.test ...

INFO: Changelog test failed with 1 issue(s):
------------------------------------------------------------
ERROR: Changelog filename must be in format: 'spacewalk-java.changes.<author>.<feature>' for package spacewalk-java
```

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/9480

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
