### PR TITLE
Adjust max squid cache time also for tftp metadata

### DIFF
--- a/containers/proxy-squid-image/squid.conf
+++ b/containers/proxy-squid-image/squid.conf
@@ -41,7 +41,7 @@ refresh_pattern /saltboot/.*$ 10080 100% 525600 ignore-no-store ignore-reload ig
 # kernel and initrd are tied to images, will never change as well
 refresh_pattern /tftp/images/.*$ 10080 100% 525600 ignore-no-store ignore-reload ignore-private
 # rest of tftp are config files prone to change frequently
-refresh_pattern /tftp/.*$ 0 1% 1440 reload-into-ims refresh-ims
+refresh_pattern /tftp/.*$ 0 1% 5 reload-into-ims refresh-ims
 refresh_pattern 	.		0	100%	525600
 
 # secure squid


### PR DESCRIPTION
## What does this PR change?

https://github.com/uyuni-project/uyuni/pull/9602 modified maximum squid cache time to proper 5 minutes, but did not modify tftp metadata timeout. This PR adjust that to 5 minutes as well.

I chose not to write new changelog entry as this can be covered by changelog provided by @mcalmer in mentioned PR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
