### PR TITLE
Fix immutability issue in audit.listSystemsByPatchStatus (bsc#1235908)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/channel/ssm/BaseSubscribeAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/ssm/BaseSubscribeAction.java
@@ -55,7 +55,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -464,7 +463,7 @@ public class BaseSubscribeAction extends RhnLookupDispatchAction {
             //  change the systems base channel
             Channel c = ChannelFactory.lookupById(spc.getId());
 
-            Set<EssentialChannelDto> compatibles = ChannelManager.listCompatibleBaseChannelsForChannel(user, c);
+            List<EssentialChannelDto> compatibles = ChannelManager.listCompatibleBaseChannelsForChannel(user, c);
             log.debug("Sorting channels: {}", compatibles.size());
             List<EssentialChannelDto> rhn = new ArrayList<>();
             List<EssentialChannelDto> custom = new ArrayList<>();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsAction.java
@@ -46,7 +46,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -121,7 +120,7 @@ public class SystemChannelsAction extends RhnLookupDispatchAction {
         }
 
 
-        Set<EssentialChannelDto> orgChannels = ChannelManager.listBaseChannelsForSystem(user, s);
+        List<EssentialChannelDto> orgChannels = ChannelManager.listBaseChannelsForSystem(user, s);
 
         List<EssentialChannelDto> rhnChannels = new LinkedList<>();
         List<EssentialChannelDto> customChannels = new LinkedList<>();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -693,7 +693,7 @@ public class SystemHandler extends BaseHandler {
         Channel baseChannel = server.getBaseChannel();
         List<Map<String, Object>> returnList = new ArrayList<>();
 
-        Set<EssentialChannelDto> list = ChannelManager.listBaseChannelsForSystem(loggedInUser, server);
+        List<EssentialChannelDto> list = ChannelManager.listBaseChannelsForSystem(loggedInUser, server);
         for (EssentialChannelDto ch : list) {
             Boolean currentBase = (baseChannel != null) &&
                     baseChannel.getId().equals(ch.getId());

--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -867,8 +867,7 @@ public class CVEAuditManager {
             throw new UnknownCVEIdentifierException();
         }
 
-        List<CVEPatchStatus> results = listSystemsByPatchStatus(user, cveIdentifier)
-                .toList();
+        Stream<CVEPatchStatus> results = listSystemsByPatchStatus(user, cveIdentifier);
 
         return listSystemsByPatchStatus(results, patchStatuses)
                 .stream()
@@ -898,8 +897,7 @@ public class CVEAuditManager {
             throw new UnknownCVEIdentifierException();
         }
 
-        List<CVEPatchStatus> results = listImagesByPatchStatus(user, cveIdentifier)
-                .toList();
+        Stream<CVEPatchStatus> results = listImagesByPatchStatus(user, cveIdentifier);
 
         return listSystemsByPatchStatus(results, patchStatuses)
                 .stream()
@@ -933,14 +931,14 @@ public class CVEAuditManager {
      * @param patchStatuses the patch statuses
      * @return list of system records with patch status
      */
-    private static List<CVEAuditSystemBuilder> listSystemsByPatchStatus(List<CVEPatchStatus> results,
+    private static List<CVEAuditSystemBuilder> listSystemsByPatchStatus(Stream<CVEPatchStatus> results,
             EnumSet<PatchStatus> patchStatuses) {
 
         List<CVEAuditSystemBuilder> ret = new LinkedList<>();
 
         // Group the results by system
         Map<Long, List<CVEPatchStatus>> resultsBySystem =
-                results.stream().collect(Collectors.groupingBy(CVEPatchStatus::getSystemId));
+                results.collect(Collectors.groupingBy(CVEPatchStatus::getSystemId));
 
         // Loop for each system, calculating the patch status individually
         for (Map.Entry<Long, List<CVEPatchStatus>> systemResultMap : resultsBySystem.entrySet()) {

--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -878,7 +878,7 @@ public class CVEAuditManager {
                         system.getChannels(),
                         system.getErratas(),
                         Set.of(ScanDataSource.CHANNELS)
-                )).toList();
+                )).collect(Collectors.toList());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.channel;
 
+import static java.util.Comparator.comparing;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
@@ -1687,9 +1688,9 @@ public class ChannelManager extends BaseManager {
      *
      * @param usr requesting list
      * @param s Server to check against
-     * @return Set of Channel objects that match
+     * @return List of Channel objects that match
      */
-    public static Set<EssentialChannelDto> listBaseChannelsForSystem(User usr, Server s) {
+    public static List<EssentialChannelDto> listBaseChannelsForSystem(User usr, Server s) {
 
         Set<EssentialChannelDto> channelDtos = new HashSet<>();
         PackageEvr releaseEvr = PackageManager.lookupReleasePackageEvrFor(s);
@@ -1726,7 +1727,7 @@ public class ChannelManager extends BaseManager {
             channelDtos.add(new EssentialChannelDto(dcm.getChannel()));
         }
 
-        return channelDtos;
+        return channelDtos.stream().sorted(comparing(EssentialChannelDto::getName)).toList();
     }
 
     /**
@@ -1800,9 +1801,10 @@ public class ChannelManager extends BaseManager {
      *
      * @param u      User of interest
      * @param inChan Base-channel of interest
-     * @return Set of channels that a system subscribed to "c" could be re-subscribed to
+     * @return List of channels that a system subscribed to "c" could be re-subscribed to
      */
-    public static Set<EssentialChannelDto> listCompatibleBaseChannelsForChannel(User u, Channel inChan) {
+    public static List<EssentialChannelDto> listCompatibleBaseChannelsForChannel(User u, Channel inChan) {
+
         // Get all the custom-channels owned by this org and add them
         Set<EssentialChannelDto> retval = ChannelFactory.listCustomBaseChannelsForSSM(u, inChan)
                 .stream()
@@ -1843,7 +1845,7 @@ public class ChannelManager extends BaseManager {
             }
         }
 
-       return retval;
+       return retval.stream().sorted(comparing(EssentialChannelDto::getName)).toList();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -436,11 +436,31 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
 
         ChannelTestUtils.createTestChannel(user);
         ChannelTestUtils.createTestChannel(user);
-        Set<EssentialChannelDto> channels = ChannelManager.listBaseChannelsForSystem(user, s);
+        List<EssentialChannelDto> channels = ChannelManager.listBaseChannelsForSystem(user, s);
 
         assertTrue(channels.size() >= 2);
     }
 
+    @Test
+    public void testBaseChannelsForSystemSorted() throws Exception {
+        Server s = ServerTestUtils.createTestSystem(user);
+
+        Channel c = ChannelTestUtils.createTestChannel(user);
+        c.setName("A Channel");
+        TestUtils.saveAndReload(c);
+        c = ChannelTestUtils.createTestChannel(user);
+        c.setName("C Channel");
+        TestUtils.saveAndReload(c);
+        c = ChannelTestUtils.createTestChannel(user);
+        c.setName("B Channel");
+        TestUtils.saveAndReload(c);
+
+        List<String> channelNames = ChannelManager.listBaseChannelsForSystem(user, s).stream()
+                .map(EssentialChannelDto::getName).toList();
+
+        assertTrue(channelNames.indexOf("A Channel") < channelNames.indexOf("B Channel"));
+        assertTrue(channelNames.indexOf("B Channel") < channelNames.indexOf("C Channel"));
+    }
 
     @Test
     public void testBaseChannelsForLiberty() throws Exception {
@@ -464,7 +484,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
         // Test: list base channels for Liberty 7
         SUSEProductTestUtils.installSUSEProductOnServer(resProduct, s);
 
-        Set<EssentialChannelDto> channels = ChannelManager.listBaseChannelsForSystem(user, s);
+        List<EssentialChannelDto> channels = ChannelManager.listBaseChannelsForSystem(user, s);
 
         assertEquals(2, channels.size());
         List<String> expectedNames = new ArrayList<>(List.of(
@@ -525,7 +545,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
                 ChannelManager.RHEL_PRODUCT_NAME, version, release3);
         HibernateFactory.getSession().flush();
 
-        Set<EssentialChannelDto> channels = ChannelManager.listBaseChannelsForSystem(user, s);
+        List<EssentialChannelDto> channels = ChannelManager.listBaseChannelsForSystem(user, s);
         assertTrue(channels.size() >= 2);
     }
 
@@ -813,7 +833,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
         commitHappened();
 
         // Ask for channels compatible with the new server's base
-        Set<EssentialChannelDto> compatibles = ChannelManager.listCompatibleBaseChannelsForChannel(user, c);
+        List<EssentialChannelDto> compatibles = ChannelManager.listCompatibleBaseChannelsForChannel(user, c);
 
         // There should be two - we now list ALL custom-channelsl
         assertNotNull(compatibles);

--- a/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
@@ -295,7 +295,7 @@ public class SsmManager {
         boolean newBaseIsCompatible = true;
         if (baseChange) {
             if (currentBase.isPresent()) {
-                Set<EssentialChannelDto> compatibleBaseChannels = ChannelManager
+                List<EssentialChannelDto> compatibleBaseChannels = ChannelManager
                         .listCompatibleBaseChannelsForChannel(user, currentBase.get());
                 newBaseIsCompatible =
                         // new base is in the compatible channels list
@@ -305,7 +305,7 @@ public class SsmManager {
             }
             else {
                 // system doesn't have a base
-                Set<EssentialChannelDto> availableBaseChannels = ChannelManager.listBaseChannelsForSystem(user, srv);
+                List<EssentialChannelDto> availableBaseChannels = ChannelManager.listBaseChannelsForSystem(user, srv);
                 newBaseIsCompatible = availableBaseChannels.stream()
                         .anyMatch(abc -> abc.getId().equals(srvChange.getNewBaseId().orElse(null)));
             }
@@ -496,7 +496,7 @@ public class SsmManager {
                 }
                 else if (change.getNewBaseId() > 0) {
                     // explicit base channel change
-                    Set<EssentialChannelDto> compatibleBases = ChannelManager
+                    List<EssentialChannelDto> compatibleBases = ChannelManager
                             .listCompatibleBaseChannelsForChannel(user, currentBase);
                     Channel newBase = compatibleBases.stream()
                             .filter(cb -> cb.getId() == change.getNewBaseId())

--- a/java/code/src/com/suse/manager/webui/controllers/SsmController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SsmController.java
@@ -57,7 +57,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import spark.Request;
@@ -107,7 +106,7 @@ public class SsmController {
             SsmAllowedBaseChannelsJson allowedBaseJson = new SsmAllowedBaseChannelsJson();
             allowedBaseJson.setBase(new SsmChannelDto(c.getId(), c.getName(), c.isCustom()));
 
-            Set<EssentialChannelDto> compatibles = ChannelManager.listCompatibleBaseChannelsForChannel(user, c);
+            List<EssentialChannelDto> compatibles = ChannelManager.listCompatibleBaseChannelsForChannel(user, c);
 
             allowedBaseJson.setAllowedBaseChannels(
                 compatibles.stream().map(cc ->

--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -499,7 +499,7 @@ public class SystemsController {
      */
     public String getAvailableBaseChannels(Request request, Response response, User user) {
         return withServer(request, response, user, server -> {
-            Set<EssentialChannelDto> orgChannels = ChannelManager.listBaseChannelsForSystem(user, server);
+            List<EssentialChannelDto> orgChannels = ChannelManager.listBaseChannelsForSystem(user, server);
             List<ChannelsJson.ChannelJson> baseChannels =
                     orgChannels.stream().map(c -> new ChannelsJson.ChannelJson(c.getId(),
                             c.getLabel(),

--- a/java/spacewalk-java.changes.cbbayburt.bsc1233724
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1233724
@@ -1,0 +1,1 @@
+- Ensure channel lists are reliably sorted by name (bsc#1233724)

--- a/java/spacewalk-java.changes.cbbayburt.bsc1235908
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1235908
@@ -1,0 +1,2 @@
+- Fix internal server error in 'listSystemsByPatchStatus' API
+  endpoint (bsc#1235908)


### PR DESCRIPTION
The recent refactoring from `Stream.collect(Collectors.toList())` to `Stream.toList()` makes all the lists immutable. This causes an exception when the API handler method tries to sort the list down the line. This PR reverts the refactoring for this instance.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: handler not tested

## Links

Fixes https://github.com/SUSE/spacewalk/issues/26222

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
