### PR TITLE
Allow "reposync" to filter packages using the entire NEVRA (bsc#1234226)

### DIFF
--- a/python/spacewalk/rhn-conf/rhn_server_satellite.conf
+++ b/python/spacewalk/rhn-conf/rhn_server_satellite.conf
@@ -43,6 +43,7 @@ default_mail_from =
 reposync_download_threads = 5
 reposync_timeout = 300
 reposync_minrate = 1000
+reposync_nevra_filter = 0
 
 # URLGrabber log level. This parameter is used by spacewalk-repo-sync to provide
 # additional logs, overriding URLGRABBER_DEBUG. It takes the form "level,filename". 

--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -492,7 +492,9 @@ class ContentSource:
                 filters.append(("-", [p]))
 
         if filters:
-            pkglist = self._filter_packages(pkglist, filters, nevra_filter=self.nevra_filter)
+            pkglist = self._filter_packages(
+                pkglist, filters, nevra_filter=self.nevra_filter
+            )
             self.num_excluded = self.num_packages - len(pkglist)
 
         to_return = []

--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -68,6 +68,8 @@ class DebPackage:
         return setattr(self, key, value)
 
     def evr(self):
+        # The format is: [epoch:]upstream_version[-debian_revision].
+        # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
         evr = ""
         if self.epoch:
             # pylint: disable-next=consider-using-f-string
@@ -79,6 +81,9 @@ class DebPackage:
             # pylint: disable-next=consider-using-f-string
             evr = evr + "-{}".format(self.release)
         return evr
+
+    def nevra(self):
+        return f"{self.name}_{self.evr()}_{self.arch}"
 
     def is_populated(self):
         return all(
@@ -412,6 +417,14 @@ class ContentSource:
             except ValueError:
                 self.timeout = 300
 
+            try:
+                # extended reposync nevra filter enable
+                # this will filter packages based on full nevra
+                # instead of package name only.
+                self.nevra_filter = bool(CFG.REPOSYNC_NEVRA_FILTER)
+            except (AttributeError, ValueError):
+                self.nevra_filter = False
+
             # SUSE vendor repositories belongs to org = NULL
             # The repository cache root will be "/var/cache/rhn/reposync/REPOSITORY_LABEL/"
             root = os.path.join(CACHE_DIR, str(org or "NULL"), self.reponame)
@@ -479,7 +492,7 @@ class ContentSource:
                 filters.append(("-", [p]))
 
         if filters:
-            pkglist = self._filter_packages(pkglist, filters)
+            pkglist = self._filter_packages(pkglist, filters, nevra_filter=self.nevra_filter)
             self.num_excluded = self.num_packages - len(pkglist)
 
         to_return = []
@@ -510,7 +523,7 @@ class ContentSource:
             return -1
 
     @staticmethod
-    def _filter_packages(packages, filters):
+    def _filter_packages(packages, filters, nevra_filter=False):
         """implement include / exclude logic
         filters are: [ ('+', includelist1), ('-', excludelist1),
                        ('+', includelist2), ... ]
@@ -536,7 +549,11 @@ class ContentSource:
             if sense == "+":
                 # include
                 for excluded_pkg in excluded:
-                    if reobj.match(excluded_pkg["name"]):
+                    if nevra_filter:
+                        pkg_name = excluded_pkg.nevra()
+                    else:
+                        pkg_name = excluded_pkg["name"]
+                    if reobj.match(pkg_name):
                         allmatched_include.insert(0, excluded_pkg)
                         selected.insert(0, excluded_pkg)
                 for pkg in allmatched_include:
@@ -545,10 +562,13 @@ class ContentSource:
             elif sense == "-":
                 # exclude
                 for selected_pkg in selected:
-                    if reobj.match(selected_pkg["name"]):
+                    if nevra_filter:
+                        pkg_name = selected_pkg.nevra()
+                    else:
+                        pkg_name = selected_pkg["name"]
+                    if reobj.match(pkg_name):
                         allmatched_exclude.insert(0, selected_pkg)
                         excluded.insert(0, selected_pkg)
-
                 for pkg in allmatched_exclude:
                     if pkg in selected:
                         selected.remove(pkg)

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -1223,7 +1223,9 @@ password={passwd}
                 filters.append(("-", [p]))
 
         if filters:
-            pkglist = self._filter_packages(pkglist, filters, nevra_filter=self.nevra_filter)
+            pkglist = self._filter_packages(
+                pkglist, filters, nevra_filter=self.nevra_filter
+            )
             pkglist = self._get_solvable_dependencies(pkglist)
 
             # Do not pull in dependencies if there're explicitly excluded

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-extend-filters-on-reposync
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-extend-filters-on-reposync
@@ -1,0 +1,2 @@
+- Allow spacewalk-repo-sync filtering using NEVRA
+  instead of package name only (bsc#1234226)

--- a/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# pylint: disable=missing-module-docstring
+# pylint: disable=missing-module-docstring,missing-class-docstring
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2011 SUSE LLC
@@ -114,20 +114,21 @@ class YumSrcTest(unittest.TestCase):
     def test_list_packages_filters(self):
         cs = self._make_dummy_cs()
 
-        class ChecksumMock():
+        class ChecksumMock:
             def typestr(self):
                 pass
 
             def hex(self):
                 pass
 
-        class SolvableMock():
+        class SolvableMock:
             def __init__(self, name, evr, nevra, arch):
                 self.name = name
                 self.evr = evr
                 self.nevra = nevra
                 self.arch = arch
 
+            # pylint: disable-next=unused-argument
             def lookup_checksum(self, x):
                 return ChecksumMock()
 
@@ -140,31 +141,73 @@ class YumSrcTest(unittest.TestCase):
             def __str__(self):
                 return self.nevra
 
-        cs._get_solvable_packages = MagicMock(side_effect = lambda:
-            [
-                SolvableMock("pkg1", "1.2.3-xx.0.foobar", "pkg1-1.2.3-xx.0.foobar.x86_64", "x86_64"),
-                SolvableMock("pkg1", "1.2.4-xx.0.foobar", "pkg1-1.2.4-xx.0.foobar.x86_64", "x86_64"),
+        # pylint: disable-next=protected-access
+        cs._get_solvable_packages = MagicMock(
+            side_effect=lambda: [
+                SolvableMock(
+                    "pkg1",
+                    "1.2.3-xx.0.foobar",
+                    "pkg1-1.2.3-xx.0.foobar.x86_64",
+                    "x86_64",
+                ),
+                SolvableMock(
+                    "pkg1",
+                    "1.2.4-xx.0.foobar",
+                    "pkg1-1.2.4-xx.0.foobar.x86_64",
+                    "x86_64",
+                ),
                 SolvableMock("pkg2", "3.2.1-1", "pkg2-3.2.1-1.x86_64", "x86_64"),
                 SolvableMock("pkg2", "3.2.2-1", "pkg2-3.2.2-1.x86_64", "x86_64"),
             ]
         )
-        cs._get_solvable_dependencies = MagicMock(side_effect = lambda x: x)
+        # pylint: disable-next=protected-access
+        cs._get_solvable_dependencies = MagicMock(side_effect=lambda x: x)
 
         self.assertEqual(len(cs.list_packages(filters=None, latest=False)), 4)
 
         cs.nevra_filter = False
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg*"])], latest=False)), 4)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1*"])], latest=False)), 2)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2*"])], latest=False)), 0)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1"])], latest=False)), 2)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2.3-xx.0.foobar.x86_64"])], latest=False)), 0)
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg*"])], latest=False)), 4
+        )
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg1*"])], latest=False)), 2
+        )
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg1-1.2*"])], latest=False)), 0
+        )
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg1"])], latest=False)), 2
+        )
+        self.assertEqual(
+            len(
+                cs.list_packages(
+                    filters=[("+", ["pkg1-1.2.3-xx.0.foobar.x86_64"])], latest=False
+                )
+            ),
+            0,
+        )
 
         cs.nevra_filter = True
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg*"])], latest=False)), 4)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1*"])], latest=False)), 2)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2*"])], latest=False)), 2)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1"])], latest=False)), 0)
-        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2.3-xx.0.foobar.x86_64"])], latest=False)), 1)
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg*"])], latest=False)), 4
+        )
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg1*"])], latest=False)), 2
+        )
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg1-1.2*"])], latest=False)), 2
+        )
+        self.assertEqual(
+            len(cs.list_packages(filters=[("+", ["pkg1"])], latest=False)), 0
+        )
+        self.assertEqual(
+            len(
+                cs.list_packages(
+                    filters=[("+", ["pkg1-1.2.3-xx.0.foobar.x86_64"])], latest=False
+                )
+            ),
+            1,
+        )
 
     @unittest.skip
     def test_list_packages_with_pack(self):

--- a/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
@@ -111,8 +111,64 @@ class YumSrcTest(unittest.TestCase):
 
         self.assertEqual(cs.list_packages(filters=None, latest=False), [])
 
+    def test_list_packages_filters(self):
+        cs = self._make_dummy_cs()
+
+        class ChecksumMock():
+            def typestr(self):
+                pass
+
+            def hex(self):
+                pass
+
+        class SolvableMock():
+            def __init__(self, name, evr, nevra, arch):
+                self.name = name
+                self.evr = evr
+                self.nevra = nevra
+                self.arch = arch
+
+            def lookup_checksum(self, x):
+                return ChecksumMock()
+
+            def lookup_num(self, x):
+                pass
+
+            def lookup_location(self):
+                return ["foobar"]
+
+            def __str__(self):
+                return self.nevra
+
+        cs._get_solvable_packages = MagicMock(side_effect = lambda:
+            [
+                SolvableMock("pkg1", "1.2.3-xx.0.foobar", "pkg1-1.2.3-xx.0.foobar.x86_64", "x86_64"),
+                SolvableMock("pkg1", "1.2.4-xx.0.foobar", "pkg1-1.2.4-xx.0.foobar.x86_64", "x86_64"),
+                SolvableMock("pkg2", "3.2.1-1", "pkg2-3.2.1-1.x86_64", "x86_64"),
+                SolvableMock("pkg2", "3.2.2-1", "pkg2-3.2.2-1.x86_64", "x86_64"),
+            ]
+        )
+        cs._get_solvable_dependencies = MagicMock(side_effect = lambda x: x)
+
+        self.assertEqual(len(cs.list_packages(filters=None, latest=False)), 4)
+
+        cs.nevra_filter = False
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg*"])], latest=False)), 4)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1*"])], latest=False)), 2)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2*"])], latest=False)), 0)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1"])], latest=False)), 2)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2.3-xx.0.foobar.x86_64"])], latest=False)), 0)
+
+        cs.nevra_filter = True
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg*"])], latest=False)), 4)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1*"])], latest=False)), 2)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2*"])], latest=False)), 2)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1"])], latest=False)), 0)
+        self.assertEqual(len(cs.list_packages(filters=[("+", ["pkg1-1.2.3-xx.0.foobar.x86_64"])], latest=False)), 1)
+
     @unittest.skip
     def test_list_packages_with_pack(self):
+
         cs = self._make_dummy_cs()
 
         package_attrs = [

--- a/spacewalk/config/spacewalk-config.changes.meaksh.master-extend-filters-on-reposync
+++ b/spacewalk/config/spacewalk-config.changes.meaksh.master-extend-filters-on-reposync
@@ -1,0 +1,1 @@
+- Add new config: reposync_nevra_filter (bsc#1234226)

--- a/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
+++ b/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
@@ -80,3 +80,5 @@ pam_auth_service = susemanager
 # Maximum Java Heap Size (in MB)
 # taskomatic.java.maxmemory=4096
 
+# Extended reposync filters to use the entire NEVRA
+server.satellite.reposync_nevra_filter = 0


### PR DESCRIPTION
## What does this PR change?

This PR enables `spacewalk-repo-sync` to filter packages matching the entire "NEVRA" instead of the package name only.

This extended nevra filtering must be enabled in `rhn.conf` by setting:

```
server.satellite.reposync_nevra_filter = 1
```

This is particularly useful when dealing with big repositories, where package name filters are not enough and you want to use more fine-grained filters to synchronize only certain packages.

### Before this PR:
```console
# spacewalk-repo-sync -t deb -c testchannel-deb -u https://packages.gitlab.com/gitlab/gitlab-ee/ubuntu/dists/noble/main/binary-amd64/ -i gitlab-ee_17.1.0*
[...]
14:36:57 Repo URL: https://packages.gitlab.com/gitlab/gitlab-ee/ubuntu/dists/noble/main/binary-amd64/
14:36:57     Packages in repo:                45
14:36:57     Packages passed filter rules:     0
[...]
```

### After this PR (having `server.satellite.reposync_nevra_filter = 1`)
```console
# spacewalk-repo-sync -t deb -c testchannel-deb -u https://packages.gitlab.com/gitlab/gitlab-ee/ubuntu/dists/noble/main/binary-amd64/ -i gitlab-ee_17.1.0*
[...]
14:38:07 Repo URL: https://packages.gitlab.com/gitlab/gitlab-ee/ubuntu/dists/noble/main/binary-amd64/
14:38:07     Packages in repo:                45
14:38:07     Packages passed filter rules:     1
[...]
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/issues/3617

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25991
Port(s):
- https://github.com/SUSE/spacewalk/pull/26237
- https://github.com/SUSE/spacewalk/pull/26238

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
