### PR TITLE
Select right patch to add to action chain

### DIFF
--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -1,10 +1,10 @@
-# Copyright (c) 2018-2023 SUSE LLC
+# Copyright (c) 2018-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Be able to list available products and enable them
+Feature: List available products and enable them
   In order to use software channels
   As root user
-  I want to be able to list available products and enable them
+  I want to list available products and enable them
 
 @susemanager
   Scenario: List available products

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -1,11 +1,11 @@
-# Copyright (c) 2015-2023 SUSE LLC
+# Copyright (c) 2015-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scc_credentials
-Feature: Be able to list available channels and enable them
+Feature: List available channels and enable them
   In order to use software channels
   As root user
-  I want to be able to list available channels and enable them
+  I want to list available channels and enable them
 
 @susemanager
   Scenario: List available channels

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 SUSE LLC
+# Copyright (c) 2018-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in the following features:
@@ -52,6 +52,8 @@ Feature: Action chains on Salt minions
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Patches" in the content area
+    And I enter "andromeda" as the filtered synopsis
+    And I click on the filter button
     And I check "andromeda-dummy-6789" in the list
     And I click on "Apply Patches"
     And I check radio button "schedule-by-action-chain"


### PR DESCRIPTION
## What does this PR change?

With many other patches, "andromeda-dummy" is not on first page anymore.

This PR does a pre-selection of the patch to add to the action chain.

Piggyback: A product feature is something that you do with the product, no need to state "Be able to".


## Links
Port(s):
 * 5.0:
 * 4.3:


## Changelogs

- [x] No changelog needed
