### PR TITLE
set a send date when preparing emails

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
@@ -142,6 +143,7 @@ public class SmtpMail implements Mail {
     public void send() {
 
         try {
+            message.setSentDate(new Date());
             Address[] addrs = message.getRecipients(RecipientType.TO);
             if (addrs == null || addrs.length == 0) {
                 log.warn("Aborting mail message {}: No recipients", message.getSubject());

--- a/java/spacewalk-java.changes.mcalmer.set-send-date-for-email
+++ b/java/spacewalk-java.changes.mcalmer.set-send-date-for-email
@@ -1,0 +1,1 @@
+- Set a send date when preparing emails


### PR DESCRIPTION
## What does this PR change?

Set a send date when we prepare emails.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26253 https://github.com/SUSE/spacewalk/pull/26254

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
