### PR TITLE
Add an autoinstallation snippet generating repositories for Autoyast

### DIFF
--- a/java/conf/cobbler/snippets/autoyast_channels
+++ b/java/conf/cobbler/snippets/autoyast_channels
@@ -1,0 +1,9 @@
+#import uyuni_cobbler_helper
+#for $label, $channel in $uyuni_cobbler_helper.channels($distrotree).items()
+      <listentry>
+        <ask_on_error config:type="boolean">true</ask_on_error>
+        <media_url>https://$redhat_management_server/ks/dist/child/$label/$distrotree</media_url>
+        <name>$channel["name"]</name>
+        <product>$channel["product"]</product>
+     </listentry>
+#end for

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -245,6 +245,7 @@ Requires:       tomcat-native
 Requires(pre):  salt
 Requires(pre):  tomcat >= 7
 Requires(pre):  uyuni-base-server
+Requires:       uyuni-cobbler-helper
 
 %if 0%{?rhel}
 Recommends:     rng-tools
@@ -581,6 +582,7 @@ install -m 644 conf/cobbler/snippets/redhat_register_using_salt    %{buildroot}%
 install -m 644 conf/cobbler/snippets/minion_script    %{buildroot}%{spacewalksnippetsdir}/minion_script
 install -m 644 conf/cobbler/snippets/sles_no_signature_checks %{buildroot}%{spacewalksnippetsdir}/sles_no_signature_checks
 install -m 644 conf/cobbler/snippets/wait_for_networkmanager_script %{buildroot}%{spacewalksnippetsdir}/wait_for_networkmanager_script
+install -m 644 conf/cobbler/snippets/autoyast_channels %{buildroot}%{spacewalksnippetsdir}/autoyast_channels
 
 # special links for rhn-search
 RHN_SEARCH_BUILD_DIR=%{_datadir}/rhn/search/lib

--- a/python/uyuni-cobbler-helper/cobbler_helper.spec
+++ b/python/uyuni-cobbler-helper/cobbler_helper.spec
@@ -1,0 +1,51 @@
+#
+# spec file for package uyuni-cobbler-helper
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+%{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+
+
+Name:           uyuni-cobbler-helper
+Version:        0.1.0
+Release:        0
+Summary:        Python helper functions for Uyuni cobbler snippets
+License:        Apache-2.0
+Group:          System/Management
+URL:            https://github.com/uyuni-project/uyuni
+Source0:        %{name}-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%if !0%{?suse_version} || 0%{?suse_version} >= 1120
+BuildArch:      noarch
+%endif
+
+Requires:       python3
+Requires:       python3-psycopg2 >= 2.8.4
+BuildRequires:  python3-rpm
+BuildRequires:  python3-rpm-macros
+
+%description
+This package provides utility functions to expose Uyuni data to cobbler snippets.
+
+%prep
+%autosetup
+
+%install
+install -m 644 uyuni_cobbler_helper.py %{python3_sitelib}/uyuni_cobbler_helper.py
+
+%files
+%{python3_sitelib}/uyuni_cobbler_helper.py
+
+%changelog

--- a/python/uyuni-cobbler-helper/uyuni-cobbler-helper.changes.cbosdo.profile-dl
+++ b/python/uyuni-cobbler-helper/uyuni-cobbler-helper.changes.cbosdo.profile-dl
@@ -1,0 +1,1 @@
+- Add helper function getting channels from a distribution tree

--- a/python/uyuni-cobbler-helper/uyuni_cobbler_helper.py
+++ b/python/uyuni-cobbler-helper/uyuni_cobbler_helper.py
@@ -1,0 +1,41 @@
+import psycopg2
+import configparser
+
+
+def channels(distrotree):
+    cnx = _connect_db()
+    cursor = cnx.cursor()
+
+    query = """SELECT CT.name, CT.label, CP.product
+FROM rhnkickstartabletree T,
+     rhnchanneltreeview CT,
+     rhnchannel C,
+     rhnchannelproduct CP
+WHERE T.channel_id = CT.parent_or_self_id
+  AND CT.id = C.id
+  AND C.channel_product_id = CP.id
+  AND T.label = %s;"""
+
+    cursor.execute(query, (distrotree,))
+    channels = {}
+    for row in cursor.fetchall():
+        channels[row[1]] = {"name": row[0], "product": row[2]}
+
+    cnx.close()
+    return channels
+
+
+def _connect_db():
+    config = configparser.ConfigParser()
+    with open("/etc/rhn/rhn.conf", "r") as fd:
+        content = "[default]\n" + fd.read()
+        config.read_string(content)
+
+    # pylint: disable-next=undefined-variable
+    return psycopg2.connect(
+        host=config.get("default", "db_host"),
+        user=config.get("default", "db_user"),
+        password=config.get("default", "db_password"),
+        dbname=config.get("default", "db_name"),
+        port=int(config.get("default", "db_port")),
+    )

--- a/rel-eng/packages/uyuni-cobbler-helper
+++ b/rel-eng/packages/uyuni-cobbler-helper
@@ -1,0 +1,1 @@
+0.1.0-0 python/uyuni-cobbler-helper/

--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -77,6 +77,7 @@ def manipulate_cobbler_settings(config_dir: str, settings_yaml: str, fqdn: str):
     filecontent["redhat_management_server"] = fqdn or socket.getfqdn()
     filecontent["client_use_localhost"] = True
     filecontent["uyuni_authentication_endpoint"] = "http://localhost"
+    filecontent["cheetah_import_whitelist"].append("uyuni_cobbler_helper")
     yaml_dump = yaml.safe_dump(filecontent)
     with open(full_path, "w") as settings_file:
         settings_file.write(yaml_dump)

--- a/spacewalk/setup/spacewalk-setup.changes.cbosdo.profile-dl
+++ b/spacewalk/setup/spacewalk-setup.changes.cbosdo.profile-dl
@@ -1,0 +1,1 @@
+- Add uyuni-cobbler-helper to cobbler's python module whitelist


### PR DESCRIPTION
## What does this PR change?

Creating the list of repositories for an autoinstallation profile is painful and error prone. Since we know which repositories are associated with the profile's distro tree, generate them using the DB data.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: do we want to add cobbler snippets tests?

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
