### PR TITLE
Update copyright year to 2025

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -25094,7 +25094,7 @@ given channel.</source>
         <source>Credentials with this username already exist</source>
       </trans-unit>
       <trans-unit id="copyright.jsp.title" xml:space="preserve">
-        <source>Copyright (c) 2011 - 2024 SUSE LLC.</source>
+        <source>Copyright (c) 2011 - 2025 SUSE LLC.</source>
       </trans-unit>
       <trans-unit id="copyright.jsp.urlagreement" xml:space="preserve">
         <source>&lt;a href="/rhn/help/Eula.do"&gt;SUSE MANAGER LICENSE AGREEMENT&lt;/a&gt;</source>

--- a/testsuite/features/secondary/srv_mainpage.feature
+++ b/testsuite/features/secondary/srv_mainpage.feature
@@ -23,7 +23,7 @@ Feature: Main landing page options and preferences
     Given I am not authorized
     When I go to the home page
     And I follow "Copyright Notice"
-    Then I should see a "Copyright (c) 2011 - 2024 SUSE LLC." text
+    Then I should see a "Copyright (c) 2011 - 2025 SUSE LLC." text
 
 @susemanager
   Scenario: Access the EULA


### PR DESCRIPTION
## What does this PR change?

- Update copyright year from 2024 to 2025

## GUI diff

Before: `Copyright (c) 2011 - 2024 SUSE LLC.`

After: `Copyright (c) 2011 - 2025 SUSE LLC.`

Also the testsuite has been fixed

- [x] **DONE**

## Documentation
- No documentation needed: this doesn't require a documentation update

- [x] **DONE**

## Test coverage
- Updated tests: already covered, just updated the existing test

- [x] **DONE**

## Links

Issue(s): #
Port(s): # https://github.com/SUSE/spacewalk/pull/26260 and https://github.com/SUSE/spacewalk/pull/26259

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
