### PR TITLE
Add fakeipmi container for test purpose

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -252,3 +252,34 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-fakeipmi-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/ci-fakeipmi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./testsuite/dockerfiles/fakeipmi/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/testsuite/dockerfiles/fakeipmi/Dockerfile
+++ b/testsuite/dockerfiles/fakeipmi/Dockerfile
@@ -1,0 +1,8 @@
+FROM opensuse/leap:15.6
+
+RUN zypper -n in OpenIPMI && \
+    mkdir -p /etc/ipmi
+
+COPY ipmisim1.emu lan.conf fake_ipmi_host.sh /etc/ipmi
+
+CMD ["ipmi_sim", "-n"]

--- a/testsuite/dockerfiles/fakeipmi/fake_ipmi_host.sh
+++ b/testsuite/dockerfiles/fakeipmi/fake_ipmi_host.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+echo
+echo "#### Fake IPM host started ####"
+echo
+
+while true; do
+  sleep 5
+done

--- a/testsuite/dockerfiles/fakeipmi/ipmisim1.emu
+++ b/testsuite/dockerfiles/fakeipmi/ipmisim1.emu
@@ -1,0 +1,17 @@
+# Minimalistic simulation setup for ipmi_sim.
+
+# The BMC is the MC at address 20
+mc_setbmc 0x20
+
+# Now add the BMC
+mc_add 0x20 0 no-device-sdrs 0x23 9 8 0x9f 0x1291 0xf02 persist_sdr
+sel_enable 0x20 1000 0x0a
+
+# Watchdog sensor.  This must be sensor zero.
+sensor_add 0x20 0 0 35 0x6f event-only
+sensor_set_event_support 0x20 0 0 enable scanning per-state \
+	000000000001111 000000000000000 \
+	000000000001111 000000000000000
+
+# Turn on the BMC
+mc_enable 0x20

--- a/testsuite/dockerfiles/fakeipmi/lan.conf
+++ b/testsuite/dockerfiles/fakeipmi/lan.conf
@@ -1,0 +1,25 @@
+name "ipmisim1"
+
+set_working_mc 0x20
+
+  # Define a LAN channel on channel 1
+  startlan 1
+    addr :: 623
+    priv_limit admin
+
+    allowed_auths_callback none md2 md5 straight
+    allowed_auths_user none md2 md5 straight
+    allowed_auths_operator none md2 md5 straight
+    allowed_auths_admin none md2 md5 straight
+
+    guid a123456789abcdefa123456789abcdef
+  endlan
+
+  serial 15 :: 9002 codec VM
+
+  startcmd "/etc/ipmi/fake_ipmi_host.sh"
+  startnow false
+
+  user 1 true  "admin"   "admin" user     10       none md2 md5 straight
+  user 2 true  "ipmiusr" "test"  admin    10       none md2 md5 straight
+


### PR DESCRIPTION
## What does this PR change?

Use a fake IPMI server container instead of relying on this feature to be in the container during the tests.

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: preparing test refactoring

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
