### PR TITLE
Remove refresh in testsuite CVE test

### DIFF
--- a/testsuite/features/secondary/min_cve_audit.feature
+++ b/testsuite/features/secondary/min_cve_audit.feature
@@ -91,7 +91,6 @@ Feature: CVE Audit on SLE Salt Minions
     And I follow "Patches" in the content area
     And I enter "milkyway" as the filtered synopsis
     And I click on the filter button
-    And I wait until I see "milkyway-dummy-2345" text, refreshing the page
     And I check "milkyway-dummy-2345" in the list
     And I click on "Apply Patches"
     And I click on "Confirm"


### PR DESCRIPTION
## What does this PR change?

Remove refresh in testsuite. The filtering fails because of the refresh on this feature. Tested on 5.0 testsuite directly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): no issue, directly from testsuite review
Port(s): 
5.0: https://github.com/SUSE/spacewalk/pull/26274
4.3: https://github.com/SUSE/spacewalk/pull/26275

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
