### PR TITLE
Allow translation to wrap strings as weblate force it

### DIFF
--- a/client/rhel/spacewalk-client-tools/po/Makefile
+++ b/client/rhel/spacewalk-client-tools/po/Makefile
@@ -34,7 +34,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
+MSGMERGE = /usr/bin/msgmerge --previous
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.mcalmer.remove-no-wrap-for-translations
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.mcalmer.remove-no-wrap-for-translations
@@ -1,0 +1,1 @@
+- Allow translation to wrap strings as weblate force it

--- a/python/spacewalk/po/Makefile
+++ b/python/spacewalk/po/Makefile
@@ -35,7 +35,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
+MSGMERGE = /usr/bin/msgmerge --previous
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.remove-no-wrap-for-translations
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.remove-no-wrap-for-translations
@@ -1,0 +1,1 @@
+- Allow translation to wrap strings as weblate force it

--- a/spacecmd/po/Makefile
+++ b/spacecmd/po/Makefile
@@ -35,7 +35,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
+MSGMERGE = /usr/bin/msgmerge --previous
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 

--- a/spacecmd/spacecmd.changes.mcalmer.remove-no-wrap-for-translations
+++ b/spacecmd/spacecmd.changes.mcalmer.remove-no-wrap-for-translations
@@ -1,0 +1,1 @@
+- Allow translation to wrap strings as weblate force it

--- a/susemanager/po/Makefile
+++ b/susemanager/po/Makefile
@@ -35,7 +35,7 @@ INSTALL_DATA = ${INSTALL} -m 644
 
 GMSGFMT = /usr/bin/msgfmt
 MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/msgmerge --previous --no-wrap
+MSGMERGE = /usr/bin/msgmerge --previous
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 

--- a/susemanager/susemanager.changes.mcalmer.remove-no-wrap-for-translations
+++ b/susemanager/susemanager.changes.mcalmer.remove-no-wrap-for-translations
@@ -1,0 +1,1 @@
+- Allow translation to wrap strings as weblate force it

--- a/web/po/Makefile
+++ b/web/po/Makefile
@@ -43,7 +43,7 @@ endif
 
 GMSGFMT = ${BIN}/msgfmt
 MSGFMT = ${BIN}/msgfmt
-MSGMERGE = ${BIN}/msgmerge --previous --no-wrap
+MSGMERGE = ${BIN}/msgmerge --previous
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 

--- a/web/spacewalk-web.changes.mcalmer.remove-no-wrap-for-translations
+++ b/web/spacewalk-web.changes.mcalmer.remove-no-wrap-for-translations
@@ -1,0 +1,1 @@
+- Allow translation to wrap strings as weblate force it


### PR DESCRIPTION
## What does this PR change?

Weblate force string wrapping.
Using --no-wrap does not make sense

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
