### PR TITLE
Remove product synchronization duplication

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -347,24 +347,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I use spacewalk-common-channel to add channel "sle-micro-5.4-devel-uyuni-client" with arch "x86_64"
     And I wait until the channel "sle-micro-5.4-devel-uyuni-client-x86_64" has been synced
 
-@susemanager
-@slemicro55_minion
-  Scenario: Add SUSE Linux Enterprise Micro 5.5
-    Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > Products"
-    And I wait until I do not see "currently running" text
-    And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Enterprise Micro 5.5" as the filtered product description
-    And I select "SUSE Linux Enterprise Micro 5.5 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Micro 5.5 x86_64" selected
-    When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.5 x86_64"
-    And I select "SUSE Manager Client Tools for SLE Micro 5 x86_64" as a product
-    Then I should see the "SUSE Manager Client Tools for SLE Micro 5 x86_64" selected
-    When I click the Add Product button
-    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Linux Enterprise Micro 5.5 x86_64" product has been added
-    And I wait until all synchronized channels for "sle-micro-5.5" have finished
-
 @uyuni
 @slemicro55_minion
   Scenario: Add SUSE Linux Enterprise Micro 5.5


### PR DESCRIPTION
## What does this PR change?

In BV, we are currently synchronizing twice slemicro 5.5 causing issue. 
Remove the 5.5 synchronization to only get the product during proxy tag.
I choose to keep proxy because I think there is an issue for MU pipeline and we will always have proxy for the deployment but not necessary slemiro5.5 client.
The client will be cover by proxy

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
