### PR TITLE
Duplicate - To be deleted -Create a taskomatic job to refresh the trusted root CAs in ISSv3

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -790,4 +790,17 @@ public class TaskomaticApi {
     public boolean isJmxEnabled() throws TaskomaticApiException {
         return (Boolean)invoke("tasko.isJmxEnabled");
     }
+
+    /**
+     * Schedule a single root ca certificate update
+     *
+     * @param rootCa the root ca certificate content
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSingleRootCaCertUpdate(String rootCa)
+            throws TaskomaticApiException {
+        Map<String, Object> paramList = new HashMap<>();
+        paramList.put("root_ca", rootCa);
+        invoke("tasko.scheduleSingleSatBunchRun", "root-ca-cert-update-bunch", paramList);
+    }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -835,15 +835,25 @@ public class TaskomaticApi {
     }
 
     /**
-     * Schedule multiple root ca certificates update
+     * Schedule multiple root ca certificates update.
+     * Filters out null certificates or the ones that have no content
      *
      * @param filenameToRootCaCertMap maps filename to root ca certificate actual content
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleSingleRootCaCertUpdate(Map<String, String> filenameToRootCaCertMap)
             throws TaskomaticApiException {
-        Map<String, Object> paramList = new HashMap<>();
-        paramList.put("filename_to_root_ca_cert_map", filenameToRootCaCertMap);
-        invoke("tasko.scheduleSingleSatBunchRun", "root-ca-cert-update-bunch", paramList);
+
+        //filters out meaningless certificates
+        Map<String, String> realFilenameToRootCaCertMap = filenameToRootCaCertMap.entrySet()
+                .stream()
+                .filter(e -> StringUtils.isNotEmpty(e.getValue()))
+                .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()));
+
+        if (!realFilenameToRootCaCertMap.isEmpty()) {
+            Map<String, Object> paramList = new HashMap<>();
+            paramList.put("filename_to_root_ca_cert_map", realFilenameToRootCaCertMap);
+            invoke("tasko.scheduleSingleSatBunchRun", "root-ca-cert-update-bunch", paramList);
+        }
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.taskomatic;
 
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -76,7 +77,7 @@ public class TaskomaticApi {
 
     private XmlRpcClient getClient() throws TaskomaticApiException {
         try {
-           return  new XmlRpcClient(
+            return new XmlRpcClient(
                     ConfigDefaults.get().getTaskoServerUrl(), false);
         }
         catch (MalformedURLException e) {
@@ -84,7 +85,7 @@ public class TaskomaticApi {
         }
     }
 
-    protected Object invoke(String name, Object...args) throws TaskomaticApiException {
+    protected Object invoke(String name, Object... args) throws TaskomaticApiException {
         try {
             return getClient().invoke(name, args);
         }
@@ -95,6 +96,7 @@ public class TaskomaticApi {
 
     /**
      * Returns whether taskomatic is running
+     *
      * @return True if taskomatic is running
      */
     public boolean isRunning() {
@@ -109,7 +111,8 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single ssh minion action.
-     * @param actionIn the action
+     *
+     * @param actionIn  the action
      * @param sshMinion the Salt ssh minion
      * @throws TaskomaticApiException if there was an error
      */
@@ -120,8 +123,9 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single ssh minion action.
-     * @param actionIn the action
-     * @param sshMinion the Salt ssh minion
+     *
+     * @param actionIn                the action
+     * @param sshMinion               the Salt ssh minion
      * @param forcePackageListRefresh force package list refresh when set to true
      * @throws TaskomaticApiException if there was an error
      */
@@ -142,12 +146,13 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single reposync
+     *
      * @param chan the channel
      * @param user the user
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleSingleRepoSync(Channel chan, User user)
-                                    throws TaskomaticApiException {
+            throws TaskomaticApiException {
         Map<String, Object> scheduleParams = new HashMap<>();
         scheduleParams.put("channel_id", chan.getId().toString());
         invoke("tasko.scheduleSingleBunchRun", user.getOrg().getId(),
@@ -158,6 +163,7 @@ public class TaskomaticApi {
      * Schedule a single reposync for a given list of channels. This is scheduled from
      * within another taskomatic job, so we don't have a user here. We pass in the
      * satellite org to create the job label internally.
+     *
      * @param channels list of channels
      * @throws TaskomaticApiException if there was an error
      */
@@ -175,13 +181,14 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single reposync
-     * @param chan the channel
-     * @param user the user
+     *
+     * @param chan   the channel
+     * @param user   the user
      * @param params parameters
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleSingleRepoSync(Channel chan, User user, Map<String, String> params)
-                                    throws TaskomaticApiException {
+            throws TaskomaticApiException {
 
         Map<String, String> scheduleParams = new HashMap<>();
         scheduleParams.put("channel_id", chan.getId().toString());
@@ -197,6 +204,7 @@ public class TaskomaticApi {
 
     /**
      * Schedule a recurring reposync
+     *
      * @param chan the channel
      * @param user the user
      * @param cron the cron format
@@ -204,7 +212,7 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleRepoSync(Channel chan, User user, String cron)
-                                        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         String jobLabel = createRepoSyncScheduleName(chan, user);
 
         Map<String, Object> task = findScheduleByBunchAndLabel("repo-sync-bunch", jobLabel, user);
@@ -219,15 +227,16 @@ public class TaskomaticApi {
 
     /**
      * Schedule a recurring reposync
-     * @param chan the channel
-     * @param user the user
-     * @param cron the cron format
+     *
+     * @param chan   the channel
+     * @param user   the user
+     * @param cron   the cron format
      * @param params parameters
      * @return the Date?
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleRepoSync(Channel chan, User user, String cron,
-            Map<String, String> params) throws TaskomaticApiException {
+                                 Map<String, String> params) throws TaskomaticApiException {
         String jobLabel = createRepoSyncScheduleName(chan, user);
 
         Map<String, Object> task = findScheduleByBunchAndLabel("repo-sync-bunch", jobLabel, user);
@@ -244,21 +253,23 @@ public class TaskomaticApi {
 
     /**
      * Creates a new single satellite schedule
-     * @param user shall be sat admin
+     *
+     * @param user      shall be sat admin
      * @param bunchName bunch name
-     * @param params parameters for the bunch
+     * @param params    parameters for the bunch
      * @return date of the first schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleSingleSatBunch(User user, String bunchName,
-            Map<String, String> params) throws TaskomaticApiException {
+                                       Map<String, String> params) throws TaskomaticApiException {
         ensureSatAdminRole(user);
         return (Date) invoke("tasko.scheduleSingleSatBunchRun", bunchName, params);
     }
 
-        /**
+    /**
      * Creates a new single gatherer schedule
-     * @param user shall be org admin
+     *
+     * @param user   shall be org admin
      * @param params parameters for the bunch
      * @return date of the first schedule
      * @throws TaskomaticApiException if there was an error
@@ -270,18 +281,20 @@ public class TaskomaticApi {
 
     /**
      * Validates user has sat admin role
+     *
      * @param user shall be sat admin
      * @throws PermissionException if there was an error
      */
     private void ensureSatAdminRole(User user) {
         if (!user.hasRole(RoleFactory.SAT_ADMIN)) {
             ValidatorException.raiseException("satadmin.jsp.error.notsatadmin",
-                                user.getLogin());
+                    user.getLogin());
         }
     }
 
     /**
      * Validates user has org admin role
+     *
      * @param user shall be org admin
      * @throws PermissionException if there was an error
      */
@@ -293,6 +306,7 @@ public class TaskomaticApi {
 
     /**
      * Validates user has channel admin role
+     *
      * @param user shall be channel admin
      * @throws PermissionException if there was an error
      */
@@ -304,15 +318,16 @@ public class TaskomaticApi {
 
     /**
      * Creates a new schedule, unschedules, if en existing is defined
-     * @param user shall be sat admin
-     * @param jobLabel name of the schedule
+     *
+     * @param user      shall be sat admin
+     * @param jobLabel  name of the schedule
      * @param bunchName bunch name
-     * @param cron cron expression
+     * @param cron      cron expression
      * @return date of the first schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleSatBunch(User user, String jobLabel, String bunchName, String cron)
-    throws TaskomaticApiException {
+            throws TaskomaticApiException {
         ensureSatAdminRole(user);
         return doScheduleSatBunch(user, jobLabel, bunchName, cron);
     }
@@ -321,8 +336,8 @@ public class TaskomaticApi {
      * Schedule a recurring action
      *
      * @param action the {@link RecurringAction}
-     * @param user the scheduler user
-     * @throws PermissionException when given user does not have permissions for scheduling given action
+     * @param user   the scheduler user
+     * @throws PermissionException    when given user does not have permissions for scheduling given action
      * @throws TaskomaticApiException on Taskomatic error
      */
     public void scheduleRecurringAction(RecurringAction action, User user) throws TaskomaticApiException {
@@ -341,15 +356,15 @@ public class TaskomaticApi {
         if (task != null) {
             doUnscheduleSatTask(jobLabel);
         }
-        return (Date) invoke("tasko.scheduleSatBunch", bunchName, jobLabel , cron, new HashMap<>());
+        return (Date) invoke("tasko.scheduleSatBunch", bunchName, jobLabel, cron, new HashMap<>());
     }
 
     /**
      * Unschedule a recurring action
      *
      * @param action the {@link RecurringAction}
-     * @param user the unscheduler user
-     * @throws PermissionException when given user does not have permissions for unscheduling given action
+     * @param user   the unscheduler user
+     * @throws PermissionException    when given user does not have permissions for unscheduling given action
      * @throws TaskomaticApiException on Taskomatic error
      */
     public void unscheduleRecurringAction(RecurringAction action, User user) throws TaskomaticApiException {
@@ -375,6 +390,7 @@ public class TaskomaticApi {
 
     /**
      * Unchedule a reposync task
+     *
      * @param chan the channel
      * @param user the user
      * @throws TaskomaticApiException if there was an error
@@ -388,25 +404,27 @@ public class TaskomaticApi {
     }
 
     private void unscheduleRepoTask(String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         ensureChannelAdminRole(user);
         invoke("tasko.unscheduleBunch", user.getOrg().getId(), jobLabel);
     }
 
     /**
      * unschedule satellite task
+     *
      * @param jobLabel schedule name
-     * @param user shall be satellite admin
+     * @param user     shall be satellite admin
      * @throws TaskomaticApiException if there was an error
      */
     public void unscheduleSatTask(String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         ensureSatAdminRole(user);
         invoke("tasko.unscheduleSatBunches", singletonList(jobLabel));
     }
 
     /**
      * Return list of active schedules
+     *
      * @param user shall be sat admin
      * @return list of schedules
      * @throws TaskomaticApiException if there was an error
@@ -418,7 +436,8 @@ public class TaskomaticApi {
 
     /**
      * Return list of bunch runs
-     * @param user shall be sat admin
+     *
+     * @param user      shall be sat admin
      * @param bunchName name of the bunch
      * @return list of schedules
      * @throws TaskomaticApiException if there was an error
@@ -430,56 +449,58 @@ public class TaskomaticApi {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> findScheduleByBunchAndLabel(String bunchName, String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         List<Map<String, Object>> schedules = (List<Map<String, Object>>) invoke("tasko.listActiveSchedulesByBunch",
                 user.getOrg().getId(), bunchName);
         for (Map<String, Object> schedule : schedules) {
             if (schedule.get("job_label").equals(jobLabel)) {
                 return schedule;
             }
-         }
+        }
         return null;
     }
 
     private Map<String, Object> findSatScheduleByBunchAndLabel(String bunchName, String jobLabel,
-            User user) throws TaskomaticApiException {
+                                                               User user) throws TaskomaticApiException {
         List<Map<String, Object>> schedules = (List<Map<String, Object>>) invoke("tasko.listActiveSatSchedulesByBunch",
                 bunchName);
         for (Map<String, Object> schedule : schedules) {
             if (schedule.get("job_label").equals(jobLabel)) {
                 return schedule;
             }
-         }
+        }
         return null;
     }
 
     /**
      * Check whether there's an active schedule of given job label
+     *
      * @param jobLabel job label
-     * @param user the user
+     * @param user     the user
      * @return true, if schedule exists
      * @throws TaskomaticApiException if there was an error
      */
     public boolean satScheduleActive(String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         List<Map<String, Object>> schedules = (List<Map<String, Object>>) invoke("tasko.listActiveSatSchedules");
         for (Map<String, Object> schedule : schedules) {
             if (schedule.get("job_label").equals(jobLabel)) {
                 return Boolean.TRUE;
             }
-         }
+        }
         return Boolean.FALSE;
     }
 
     /**
      * Get the cron format for a single channel
+     *
      * @param chan the channel
      * @param user the user
      * @return the Cron format
      * @throws TaskomaticApiException if there was an error
      */
     public String getRepoSyncSchedule(Channel chan, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         String jobLabel = createRepoSyncScheduleName(chan, user);
         Map<String, Object> task = findScheduleByBunchAndLabel("repo-sync-bunch", jobLabel, user);
         if (task == null) {
@@ -490,6 +511,7 @@ public class TaskomaticApi {
 
     /**
      * Return list of available bunches
+     *
      * @param user shall be sat admin
      * @return list of bunches
      * @throws TaskomaticApiException if there was an error
@@ -501,43 +523,47 @@ public class TaskomaticApi {
 
     /**
      * looks up schedule according to id
-     * @param user shall be sat admin
+     *
+     * @param user       shall be sat admin
      * @param scheduleId schedule id
      * @return schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Map<String, Object> lookupScheduleById(User user, Long scheduleId)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         return (Map<String, Object>) invoke("tasko.lookupScheduleById", scheduleId);
     }
 
     /**
      * looks up schedule according to label
-     * @param user shall be sat admin
-     * @param bunchName bunch name
+     *
+     * @param user          shall be sat admin
+     * @param bunchName     bunch name
      * @param scheduleLabel schedule label
      * @return schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Map<String, Object> lookupScheduleByBunchAndLabel(User user, String bunchName,
-            String scheduleLabel) throws TaskomaticApiException {
+                                                             String scheduleLabel) throws TaskomaticApiException {
         return findSatScheduleByBunchAndLabel(bunchName, scheduleLabel, user);
     }
 
     /**
      * looks up bunch according to name
-     * @param user shall be sat admin
+     *
+     * @param user      shall be sat admin
      * @param bunchName bunch name
      * @return bunch
      * @throws TaskomaticApiException if there was an error
      */
     public Map<String, Object> lookupBunchByName(User user, String bunchName)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         return (Map<String, Object>) invoke("tasko.lookupBunchByName", bunchName);
     }
 
     /**
      * List all reposync schedules within an organization
+     *
      * @param org organization
      * @return list of schedules
      */
@@ -554,6 +580,7 @@ public class TaskomaticApi {
 
     /**
      * unschedule all outdated repo-sync schedules within an org
+     *
      * @param orgIn organization
      * @return number of removed schedules
      * @throws TaskomaticApiException if there was an error
@@ -578,9 +605,9 @@ public class TaskomaticApi {
     /**
      * Schedule an Action execution for Salt minions.
      *
-     * @param action the action to be executed
+     * @param action                  the action to be executed
      * @param forcePackageListRefresh is a package list is requested
-     * @param checkIfMinionInvolved check if action involves minions
+     * @param checkIfMinionInvolved   check if action involves minions
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleActionExecution(Action action, boolean forcePackageListRefresh, boolean checkIfMinionInvolved)
@@ -599,10 +626,11 @@ public class TaskomaticApi {
         }
         scheduleMinionActionExecutions(singletonList(action), forcePackageListRefresh);
     }
+
     /**
      * Schedule Actions execution for Salt minions.
      *
-     * @param actions the list of actions to be executed
+     * @param actions                 the list of actions to be executed
      * @param forcePackageListRefresh is a package list is requested
      * @throws TaskomaticApiException if there was an error
      */
@@ -610,7 +638,7 @@ public class TaskomaticApi {
             throws TaskomaticApiException {
         List<Map<String, String>> paramsList = new ArrayList<>();
         List<String> ids = new ArrayList<>();
-        for (Action action: actions) {
+        for (Action action : actions) {
             Map<String, String> params = new HashMap<>();
             String id = Long.toString(action.getId());
             params.put("action_id", id);
@@ -631,7 +659,7 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleActionChainExecution(ActionChain actionchain)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         if (!ActionChainFactory.isActionChainTargettingMinions(actionchain)) {
             return;
         }
@@ -649,13 +677,13 @@ public class TaskomaticApi {
     /**
      * Schedule a staging job for Salt minions.
      *
-     * @param actionId ID of the action to be executed
-     * @param minionId ID of the minion involved
+     * @param actionId        ID of the action to be executed
+     * @param minionId        ID of the minion involved
      * @param stagingDateTime scheduling time of staging
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleStagingJob(Long actionId, Long minionId, Date stagingDateTime)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         Map<String, String> params = new HashMap<>();
         params.put("action_id", Long.toString(actionId));
         params.put("staging_job", "true");
@@ -668,6 +696,7 @@ public class TaskomaticApi {
 
     /**
      * Schedule a staging job for Salt minions.
+     *
      * @param actionData Map containing mapping between action and minions data
      * @throws TaskomaticApiException if there was an error
      */
@@ -694,14 +723,14 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleActionExecution(Action action)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         scheduleActionExecution(action, false);
     }
 
     /**
      * Schedule an Action execution for Salt minions.
      *
-     * @param action the action to be executed
+     * @param action                  the action to be executed
      * @param forcePackageListRefresh is a package list is requested
      * @throws TaskomaticApiException if there was an error
      */
@@ -713,7 +742,7 @@ public class TaskomaticApi {
     /**
      * Schedule a channel subscription action.
      *
-     * @param user the user that schedules the action
+     * @param user   the user that schedules the action
      * @param action the action to schedule
      * @throws TaskomaticApiException if there was an error
      */
@@ -734,7 +763,7 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public void deleteScheduledActions(Map<Action, Set<Server>> actionMap)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
 
         List<Action> actionsToBeUnscheduled = actionMap.entrySet().stream()
                 // select Actions that have no minions besides those in the specified set
@@ -772,6 +801,7 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single reposync
+     *
      * @param sshdata the payg ssh connection data
      * @throws TaskomaticApiException if there was an error
      */
@@ -784,23 +814,36 @@ public class TaskomaticApi {
 
     /**
      * Check if the Taskomatic java process has JMX enabled.
+     *
      * @return true is JMX enabled
      * @throws TaskomaticApiException if there was an error
      */
     public boolean isJmxEnabled() throws TaskomaticApiException {
-        return (Boolean)invoke("tasko.isJmxEnabled");
+        return (Boolean) invoke("tasko.isJmxEnabled");
     }
 
     /**
-     * Schedule a single root ca certificate update
+     * Schedule one root ca certificate update
      *
-     * @param rootCa the root ca certificate content
+     * @param fileName          filename of the ca certificate
+     * @param rootCaCertContent root ca certificate actual content
      * @throws TaskomaticApiException if there was an error
      */
-    public void scheduleSingleRootCaCertUpdate(String rootCa)
+    public void scheduleSingleRootCaCertUpdate(String fileName, String rootCaCertContent)
+            throws TaskomaticApiException {
+        scheduleSingleRootCaCertUpdate(singletonMap(fileName, rootCaCertContent));
+    }
+
+    /**
+     * Schedule multiple root ca certificates update
+     *
+     * @param filenameToRootCaCertMap maps filename to root ca certificate actual content
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSingleRootCaCertUpdate(Map<String, String> filenameToRootCaCertMap)
             throws TaskomaticApiException {
         Map<String, Object> paramList = new HashMap<>();
-        paramList.put("root_ca", rootCa);
+        paramList.put("filename_to_root_ca_cert_map", filenameToRootCaCertMap);
         invoke("tasko.scheduleSingleSatBunchRun", "root-ca-cert-update-bunch", paramList);
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RootCaCertUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RootCaCertUpdateTask.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.taskomatic.task;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+/**
+ * Taskomatic task that checks if new certificates have been added or updated
+ * * and stores them accordingly in the trusted certificate path
+ */
+public class RootCaCertUpdateTask extends RhnJavaJob {
+
+    private static final String ROOT_CA_KEY = "root_ca";
+
+    @Override
+    public String getConfigNamespace() {
+        return "root-ca-cert-update";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        final JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
+        final String rootCa = getRootCa(jobDataMap);
+
+        //TODO: do something
+        log.info("Root Ca is: {}", rootCa);
+
+    }
+
+    private String getRootCa(final JobDataMap jobDataMap) {
+        String rootCa = "";
+        if (jobDataMap.containsKey(ROOT_CA_KEY)) {
+            try {
+                rootCa = jobDataMap.getString(ROOT_CA_KEY);
+            }
+            catch (ClassCastException e) {
+                rootCa = "";
+            }
+        }
+        return rootCa;
+    }
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
@@ -17,9 +17,8 @@ package com.redhat.rhn.taskomatic.task.payg;
 
 import com.redhat.rhn.domain.cloudpayg.CloudRmtHost;
 import com.redhat.rhn.domain.cloudpayg.CloudRmtHostFactory;
-import com.redhat.rhn.taskomatic.TaskomaticApi;
-import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.taskomatic.task.RhnJavaJob;
+import com.redhat.rhn.taskomatic.task.RootCaCertUpdateTask;
 
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -64,14 +63,8 @@ public class PaygUpdateHostsTask extends RhnJavaJob {
             filenameToRootCaCertMap.put(caFileName, host.getSslCert());
         }
 
-        TaskomaticApi taskomaticApi = new TaskomaticApi();
-        try {
-            taskomaticApi.scheduleSingleRootCaCertUpdate(filenameToRootCaCertMap);
-        }
-        catch (TaskomaticApiException e) {
-            log.error(e.getMessage(), e);
-            throw new JobExecutionException(e);
-        }
+        RootCaCertUpdateTask a = new RootCaCertUpdateTask();
+        a.saveAndUpdateCaCertificates(filenameToRootCaCertMap);
     }
 
     private void updateHost(List<CloudRmtHost> hostToUpdate) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
@@ -17,6 +17,8 @@ package com.redhat.rhn.taskomatic.task.payg;
 
 import com.redhat.rhn.domain.cloudpayg.CloudRmtHost;
 import com.redhat.rhn.domain.cloudpayg.CloudRmtHostFactory;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.taskomatic.task.RhnJavaJob;
 
 import org.quartz.JobExecutionContext;
@@ -28,7 +30,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class PaygUpdateHostsTask extends RhnJavaJob {
     private static final String HOSTS = "/etc/hosts";
@@ -36,7 +40,7 @@ public class PaygUpdateHostsTask extends RhnJavaJob {
     private static final String HOST_COMMENT_START = "# Added by Suma - Start";
     private static final String HOST_COMMENT_END = "# Added by Suma - End";
 
-    private static final String CA_LOCATION_TEMPLATE = "/etc/pki/trust/anchors/registration_server_%s.pem";
+    private static final String CA_FILENAME_TEMPLATE_WITH_IP = "registration_server_%s.pem";
 
     @Override
     public String getConfigNamespace() {
@@ -54,29 +58,19 @@ public class PaygUpdateHostsTask extends RhnJavaJob {
     }
 
     private void loadHttpsCertificates(List<CloudRmtHost> hostToUpdate) throws JobExecutionException {
+        Map<String, String> filenameToRootCaCertMap = new HashMap<>();
+        for (CloudRmtHost host : hostToUpdate) {
+            String caFileName = String.format(CA_FILENAME_TEMPLATE_WITH_IP, host.getIp());
+            filenameToRootCaCertMap.put(caFileName, host.getSslCert());
+        }
+
+        TaskomaticApi taskomaticApi = new TaskomaticApi();
         try {
-            for (CloudRmtHost host : hostToUpdate) {
-                String caFileName = String.format(CA_LOCATION_TEMPLATE, host.getIp());
-                try (FileWriter fw = new FileWriter(caFileName, false)) {
-                    fw.write(host.getSslCert());
-                }
-            }
+            taskomaticApi.scheduleSingleRootCaCertUpdate(filenameToRootCaCertMap);
         }
-        catch (IOException e) {
-            log.error("error when writing the hosts file", e);
-        }
-        finally {
-            if (!hostToUpdate.isEmpty()) {
-                try {
-                    String[] cmd = {"systemctl", "is-active", "--quiet", "ca-certificates.path"};
-                    executeExtCmd(cmd);
-                }
-                catch (Exception e) {
-                    log.debug("ca-certificates.path service is not active, we will call 'update-ca-certificates' tool");
-                    String[] cmd = {"/usr/share/rhn/certs/update-ca-cert-trust.sh"};
-                    executeExtCmd(cmd);
-                }
-            }
+        catch (TaskomaticApiException e) {
+            log.error(e.getMessage(), e);
+            throw new JobExecutionException(e);
         }
     }
 

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -19,6 +19,8 @@ import com.redhat.rhn.domain.credentials.SCCCredentials;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssAccessToken;
@@ -53,6 +55,10 @@ public class HubManager {
 
     private final IssClientFactory clientFactory;
 
+    private TaskomaticApi taskomaticApi = new TaskomaticApi();
+
+    private static final String ROOT_CA_FILENAME_TEMPLATE = "%s_%s_root_ca.pem";
+
     /**
      * Default constructor
      */
@@ -71,6 +77,21 @@ public class HubManager {
         this.hubFactory = hubFactoryIn;
         this.clientFactory = clientFactoryIn;
         this.mirrorCredentialsManager = mirrorCredentialsManagerIn;
+    }
+
+    /**
+     * Builds an instance with the given dependencies
+     * used to inject TaskomaticApi object for testing purposes
+     *
+     * @param hubFactoryIn               the hub factory
+     * @param clientFactoryIn            the ISS client factory
+     * @param mirrorCredentialsManagerIn the mirror credentials manager
+     * @param taskomaticApiIn            the TaskomaticApi object
+     */
+    public HubManager(HubFactory hubFactoryIn, IssClientFactory clientFactoryIn,
+                      MirrorCredentialsManager mirrorCredentialsManagerIn, TaskomaticApi taskomaticApiIn) {
+        this(hubFactoryIn, clientFactoryIn, mirrorCredentialsManagerIn);
+        this.taskomaticApi = taskomaticApiIn;
     }
 
     /**
@@ -135,7 +156,8 @@ public class HubManager {
      * @param rootCA the root certificate, if needed
      * @return the persisted remote server
      */
-    public IssServer saveNewServer(IssAccessToken accessToken, IssRole role, String rootCA) {
+    public IssServer saveNewServer(IssAccessToken accessToken, IssRole role, String rootCA)
+            throws TaskomaticApiException {
         ensureValidToken(accessToken);
 
         return createServer(role, accessToken.getServerFqdn(), rootCA);
@@ -157,7 +179,8 @@ public class HubManager {
      * @throws IOException when connecting to the server fails
      */
     public void register(User user, String remoteServer, IssRole role, String username, String password, String rootCA)
-        throws CertificateException, TokenBuildingException, IOException, TokenParsingException {
+        throws CertificateException, TokenBuildingException, IOException, TokenParsingException,
+            TaskomaticApiException {
         ensureSatAdmin(user);
 
         // Verify this server is not already registered as hub or peripheral
@@ -187,7 +210,8 @@ public class HubManager {
      * @throws IOException when connecting to the peripheral server fails
      */
     public void register(User user, String remoteServer, IssRole role, String remoteToken, String rootCA)
-        throws CertificateException, TokenBuildingException, IOException, TokenParsingException {
+        throws CertificateException, TokenBuildingException, IOException, TokenParsingException,
+            TaskomaticApiException {
         ensureSatAdmin(user);
 
         // Verify this server is not already registered as hub or peripheral
@@ -227,7 +251,8 @@ public class HubManager {
     }
 
     private void registerWithToken(String remoteServer, IssRole role, String rootCA, String remoteToken)
-        throws TokenParsingException, CertificateException, TokenBuildingException, IOException {
+        throws TokenParsingException, CertificateException, TokenBuildingException, IOException,
+            TaskomaticApiException {
         parseAndSaveToken(remoteServer, remoteToken);
 
         IssServer registeredServer = createServer(role, remoteServer, rootCA);
@@ -336,16 +361,25 @@ public class HubManager {
         hubFactory.saveToken(fqdn, token, TokenType.CONSUMED, parsedToken.getExpirationTime());
     }
 
-    private IssServer createServer(IssRole role, String serverFqdn, String rootCA) {
+    private String computeRootCaFileName(IssRole role, String serverFqdn) {
+        return switch (role) {
+            case HUB -> String.format(ROOT_CA_FILENAME_TEMPLATE, "hub", serverFqdn);
+            case PERIPHERAL -> String.format(ROOT_CA_FILENAME_TEMPLATE, "peripheral", serverFqdn);
+        };
+    }
+
+    private IssServer createServer(IssRole role, String serverFqdn, String rootCA) throws TaskomaticApiException {
         return switch (role) {
             case HUB -> {
                 IssHub hub = new IssHub(serverFqdn, rootCA);
                 hubFactory.save(hub);
+                taskomaticApi.scheduleSingleRootCaCertUpdate(computeRootCaFileName(role, serverFqdn), rootCA);
                 yield hub;
             }
             case PERIPHERAL -> {
                 IssPeripheral peripheral = new IssPeripheral(serverFqdn, rootCA);
                 hubFactory.save(peripheral);
+                taskomaticApi.scheduleSingleRootCaCertUpdate(computeRootCaFileName(role, serverFqdn), rootCA);
                 yield peripheral;
             }
         };

--- a/java/code/src/com/suse/manager/hub/SyncController.java
+++ b/java/code/src/com/suse/manager/hub/SyncController.java
@@ -22,6 +22,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.success;
 import static spark.Spark.post;
 
 import com.redhat.rhn.domain.credentials.HubSCCCredentials;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.RegisterJson;
@@ -101,6 +102,10 @@ public class SyncController {
         catch (TokenParsingException ex) {
             LOGGER.error("Unable to parse the received token for server {}", token.getServerFqdn());
             return badRequest(response, "The specified token is not parseable");
+        }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Unable to schedule root CA certificate update {}", token.getServerFqdn());
+            return badRequest(response, "Unable to schedule root CA certificate update");
         }
     }
 

--- a/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
@@ -106,8 +106,8 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
             invokeCalled = false;
             invokeName = "";
             invokeBunch = "";
-            invokeRootCaFilename = "";
-            invokeRootCaContent = "";
+            invokeRootCaFilename = null;
+            invokeRootCaContent = null;
         }
 
         public void testTaskoRootCaCertUpdateCall(String expectedRootCaFilename,
@@ -142,8 +142,8 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
                 invokeRootCaContent = firstKeyVal.get().getValue();
             }
             else {
-                invokeRootCaFilename = "";
-                invokeRootCaContent = "";
+                invokeRootCaFilename = null;
+                invokeRootCaContent = null;
             }
             return null;
         }
@@ -441,11 +441,11 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
 
         mockTaskomaticApi.resetTaskomaticCall();
         hubManager.saveNewServer(getValidToken("dummy2.hub.fqdn"), IssRole.HUB, "");
-        mockTaskomaticApi.testTaskoNoRootCaCertUpdateCall();
+        mockTaskomaticApi.testTaskoRootCaCertUpdateCall("hub_dummy2.hub.fqdn_root_ca.pem", "");
 
         mockTaskomaticApi.resetTaskomaticCall();
         hubManager.saveNewServer(getValidToken("dummy3.hub.fqdn"), IssRole.HUB, null);
-        mockTaskomaticApi.testTaskoNoRootCaCertUpdateCall();
+        mockTaskomaticApi.testTaskoRootCaCertUpdateCall("hub_dummy3.hub.fqdn_root_ca.pem", "");
 
         mockTaskomaticApi.resetTaskomaticCall();
         hubManager.saveNewServer(getValidToken("dummy.periph.fqdn"), IssRole.PERIPHERAL,
@@ -455,11 +455,13 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
 
         mockTaskomaticApi.resetTaskomaticCall();
         hubManager.saveNewServer(getValidToken("dummy2.periph.fqdn"), IssRole.PERIPHERAL, "");
-        mockTaskomaticApi.testTaskoNoRootCaCertUpdateCall();
+        mockTaskomaticApi.testTaskoRootCaCertUpdateCall("peripheral_dummy2.periph.fqdn_root_ca.pem",
+                "");
 
         mockTaskomaticApi.resetTaskomaticCall();
         hubManager.saveNewServer(getValidToken("dummy3.periph.fqdn"), IssRole.PERIPHERAL, null);
-        mockTaskomaticApi.testTaskoNoRootCaCertUpdateCall();
+        mockTaskomaticApi.testTaskoRootCaCertUpdateCall("peripheral_dummy3.periph.fqdn_root_ca.pem",
+                "");
     }
 
     @Test

--- a/java/code/src/com/suse/manager/xmlrpc/iss/IssHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/IssHandler.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.frontend.xmlrpc.InvalidTokenException;
 import com.redhat.rhn.frontend.xmlrpc.TokenAlreadyExistsException;
 import com.redhat.rhn.frontend.xmlrpc.TokenCreationException;
 import com.redhat.rhn.frontend.xmlrpc.TokenExchangeFailedException;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.hub.HubManager;
 import com.suse.manager.model.hub.IssRole;
@@ -212,6 +213,10 @@ public class IssHandler extends BaseHandler {
             LOGGER.error("Unable to connect to remote server {}", fqdn, ex);
             throw new TokenExchangeFailedException(ex);
         }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Unable to schedule root CA certificate update {}", fqdn, ex);
+            throw new TokenExchangeFailedException(ex);
+        }
 
         return 1;
     }
@@ -286,6 +291,10 @@ public class IssHandler extends BaseHandler {
         }
         catch (IOException ex) {
             LOGGER.error("Unable to connect to remote server {}", fqdn, ex);
+            throw new TokenExchangeFailedException(ex);
+        }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Unable to schedule root CA certificate update {}", fqdn, ex);
             throw new TokenExchangeFailedException(ex);
         }
 

--- a/java/code/src/com/suse/utils/CertificateUtils.java
+++ b/java/code/src/com/suse/utils/CertificateUtils.java
@@ -12,8 +12,11 @@
 package com.suse.utils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -23,6 +26,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateParsingException;
+import java.util.Map;
 import java.util.Optional;
 
 public final class CertificateUtils {
@@ -30,6 +34,8 @@ public final class CertificateUtils {
     public static final Path CERTS_PATH = Path.of("/etc/pki/trust/anchors/");
 
     private static final Path LOCAL_TRUSTED_ROOT = CERTS_PATH.resolve("LOCAL-RHN-ORG-TRUSTED-SSL-CERT");
+
+    private static final Logger LOG = LogManager.getLogger(CertificateUtils.class);
 
     private CertificateUtils() {
         // Prevent instantiation
@@ -89,5 +95,118 @@ public final class CertificateUtils {
 
         CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
         return Optional.of(certificateFactory.generateCertificate(inputStream));
+    }
+
+    /**
+     * Saves multiple root ca certificates in the local filesystem
+     *
+     * @param filenameToRootCaCertMap maps filename to root ca certificate actual content
+     */
+    public static void saveCertificates(Map<String, String> filenameToRootCaCertMap) {
+        if ((null == filenameToRootCaCertMap) || filenameToRootCaCertMap.isEmpty()) {
+            return; // nothing to do
+        }
+
+        for (Map.Entry<String, String> pair : filenameToRootCaCertMap.entrySet()) {
+            String fileName = pair.getKey();
+            String rootCaCertContent = pair.getValue();
+
+            if (fileName.isEmpty()) {
+                LOG.error("Illegal empty certificate file name");
+                continue;
+            }
+
+            try {
+                if (rootCaCertContent.isEmpty()) {
+                    CertificateUtils.safeDeleteCertificate(fileName);
+                    LOG.warn("CA certificate file: {} successfully removed", fileName);
+                }
+                else {
+                    CertificateUtils.safeSaveCertificate(fileName, rootCaCertContent);
+                    LOG.warn("CA certificate file: {} successfully written", fileName);
+                }
+            }
+            catch (IOException e) {
+                LOG.error("Error when {} CA certificate file [{}] {}",
+                        rootCaCertContent.isEmpty() ? "removing" : "writing", fileName, e);
+            }
+            catch (IllegalArgumentException e) {
+                LOG.error("Illegal certificate file name [{}] {}", fileName, e);
+            }
+        }
+    }
+
+    /**
+     * gets a safe path to a certificate, given its filename
+     *
+     * @param fileName the certificate filename
+     * @return the path in which the certificate should reside
+     * @throws IllegalArgumentException when the certificate filename is not valid or there is an attack attempt
+     */
+    public static Path getCertificateSafePath(String fileName) throws IllegalArgumentException {
+        if (null == fileName || fileName.isEmpty()) {
+            throw new IllegalArgumentException("File name cannot be null or empty");
+        }
+
+        if (!fileName.matches("[a-zA-Z0-9._-]+")) {
+            throw new IllegalArgumentException("File name contains invalid characters");
+        }
+
+        Path filePath = CERTS_PATH.resolve(fileName).normalize();
+        if (!filePath.startsWith(CERTS_PATH)) {
+            //Prevent unauthorized access through path traversal (CWE-22)
+            throw new IllegalArgumentException("Attempted path traversal attack detected");
+        }
+        if (Files.isSymbolicLink(filePath)) {
+            throw new IllegalArgumentException("Refusing to delete/create symbolic link: " + filePath);
+        }
+
+        return filePath;
+    }
+
+    /**
+     * safely saves a certificate file, given its filename
+     *
+     * @param fileName      the certificate filename
+     * @param caCertContent the certificate content
+     * @throws IOException              when an error occurs while saving the certificate file
+     * @throws IllegalArgumentException when the certificate filename is not valid or there is an attack attempt
+     */
+    public static void safeSaveCertificate(String fileName, String caCertContent)
+            throws IOException, IllegalArgumentException {
+        try (FileWriter fw = new FileWriter(getCertificateSafePath(fileName).toFile(), false)) {
+            fw.write(caCertContent);
+        }
+    }
+
+    /**
+     * safely deletes a certificate file, given its filename
+     *
+     * @param fileName the certificate filename
+     * @throws IOException              when an error occurs while deleting the certificate file
+     * @throws IllegalArgumentException when the certificate filename is not valid or there is an attack attempt
+     */
+    public static void safeDeleteCertificate(String fileName)
+            throws IOException, IllegalArgumentException {
+        Files.delete(getCertificateSafePath(fileName));
+    }
+
+    /**
+     * gets a system command to check if a service to update the ca certificates is present
+     *
+     * @return system command
+     */
+    public static String[] getCertificatesUpdateServiceCmd() {
+        return new String[]{"systemctl", "is-active", "--quiet", "ca-certificates.path"};
+    }
+
+    /**
+     * gets a system command to update the ca certificates
+     * a tool to be run as a "backup" if an update service is not present
+     *
+     * @return system command
+     */
+    public static String[] getCertificatesUpdateShellCmd() {
+        return new String[]{"/usr/share/rhn/certs/update-ca-cert-trust.sh"};
     }
 }

--- a/java/code/src/com/suse/utils/test/CertificateUtilsTest.java
+++ b/java/code/src/com/suse/utils/test/CertificateUtilsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.utils.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import com.suse.utils.CertificateUtils;
+
+import org.junit.jupiter.api.Test;
+
+public class CertificateUtilsTest {
+
+    @Test
+    public void testGetGertificateSafePathNullEmpty() throws IllegalArgumentException {
+        String errorMessage = "File name cannot be null or empty";
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(null), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(""), errorMessage);
+    }
+
+    @Test
+    public void testGetGertificateSafePathInvalidChars() throws IllegalArgumentException {
+
+        String errorMessage = "File name contains invalid characters";
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("te$t1"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("te%t2"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(":test3"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("te#t4"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("te\\t5"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("te\\u0003t6"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("te\nt7"), errorMessage);
+    }
+
+    @Test
+    public void testGetGertificateSafePathTraversalAttempt() throws IllegalArgumentException {
+        String errorMessage = "Attempted path traversal attack detected";
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(".."), errorMessage);
+
+        errorMessage = "File name contains invalid characters";
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("../test_1-8.txt"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(".../test_1-9.txt"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("..../test_1-10.txt"), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath("test/../test_1-11.txt"), errorMessage);
+    }
+
+    @Test
+    public void testGetGertificateSafePathValidCases() throws IllegalArgumentException {
+        assertEquals("/etc/pki/trust/anchors/test_1-12.txt",
+                CertificateUtils.getCertificateSafePath("test_1-12.txt").toString());
+        assertEquals("/etc/pki/trust/anchors/test___1---13..txt",
+                CertificateUtils.getCertificateSafePath("test___1---13..txt").toString());
+        assertEquals("/etc/pki/trust/anchors/registration_server_10.1.2.245.pem",
+                CertificateUtils.getCertificateSafePath("registration_server_10.1.2.245.pem").toString());
+    }
+}

--- a/java/spacewalk-java.changes.carlo.issv3-taskomatic-job
+++ b/java/spacewalk-java.changes.carlo.issv3-taskomatic-job
@@ -1,0 +1,2 @@
+- Create a task (root-ca-cert-update) in taskomatic to store
+  ca-certificates in the trusted certificate path

--- a/schema/spacewalk/common/data/rhnTaskoBunch.sql
+++ b/schema/spacewalk/common/data/rhnTaskoBunch.sql
@@ -141,4 +141,7 @@ VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'payg-dimension-computation-
 INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
 VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'oval-data-sync-bunch', 'Generate OVAL data required to increase the accuracy of CVE audit queries.', null);
 
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'root-ca-cert-update-bunch', 'Updates root ca certificates', null);
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -149,4 +149,7 @@ VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'payg-dimension-computation',
 INSERT INTO rhnTaskoTask (id, name, class)
 VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'oval-data-sync', 'com.redhat.rhn.taskomatic.task.OVALDataSync');
 
+INSERT INTO rhnTaskoTask (id, name, class)
+VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'root-ca-cert-update', 'com.redhat.rhn.taskomatic.task.RootCaCertUpdateTask');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -329,4 +329,11 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
                     0,
                     null);
 
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+             VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
+                    (SELECT id FROM rhnTaskoBunch WHERE name='root-ca-cert-update-bunch'),
+                    (SELECT id FROM rhnTaskoTask WHERE name='root-ca-cert-update'),
+                    0,
+                    null);
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes.carlo.issv3-taskomatic-job
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.issv3-taskomatic-job
@@ -1,0 +1,1 @@
+- Add SQL scripts to create root-ca-cert-update task in taskomatic

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.2-to-susemanager-schema-5.1.3/001-issv3-rootcacertificates-taskomatic.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.2-to-susemanager-schema-5.1.3/001-issv3-rootcacertificates-taskomatic.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+SELECT sequence_nextval('rhn_tasko_bunch_id_seq'), 'root-ca-cert-update-bunch', 'Updates root ca certificates', null FROM dual
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoBunch WHERE name = 'root-ca-cert-update-bunch');
+
+INSERT INTO rhnTaskoTask (id, name, class)
+SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'root-ca-cert-update', 'com.redhat.rhn.taskomatic.task.RootCaCertUpdateTask' FROM dual
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoTask WHERE name = 'root-ca-cert-update');
+
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+SELECT sequence_nextval('rhn_tasko_template_id_seq'),
+    (SELECT id FROM rhnTaskoBunch WHERE name='root-ca-cert-update-bunch'),
+    (SELECT id FROM rhnTaskoTask WHERE name='root-ca-cert-update'),
+    0,
+    null FROM dual
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoTemplate
+                                WHERE bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name='root-ca-cert-update-bunch')
+                                AND task_id = (SELECT id FROM rhnTaskoTask WHERE name='root-ca-cert-update'));


### PR DESCRIPTION
## What does this PR change?

When onboarding a peripheral or a hub, a root certificate might be needed if the two servers do not share a common one. The certificate is transferred during the registration process and stored in the database.

However, this does not alter the system trust configuration. This step cannot be implemented from the web UI/API backend, as Tomcat does not run with the required root privileges.

Therefore, we need to implement a Taskomatic job that checks if new certificates have been added or updated and stores them accordingly in the trusted certificate path

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26180
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

