### PR TITLE
Create a taskomatic job to refresh the trusted root CAs in ISSv3

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.taskomatic;
 
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -76,7 +77,7 @@ public class TaskomaticApi {
 
     private XmlRpcClient getClient() throws TaskomaticApiException {
         try {
-           return  new XmlRpcClient(
+            return new XmlRpcClient(
                     ConfigDefaults.get().getTaskoServerUrl(), false);
         }
         catch (MalformedURLException e) {
@@ -84,7 +85,7 @@ public class TaskomaticApi {
         }
     }
 
-    protected Object invoke(String name, Object...args) throws TaskomaticApiException {
+    protected Object invoke(String name, Object... args) throws TaskomaticApiException {
         try {
             return getClient().invoke(name, args);
         }
@@ -95,6 +96,7 @@ public class TaskomaticApi {
 
     /**
      * Returns whether taskomatic is running
+     *
      * @return True if taskomatic is running
      */
     public boolean isRunning() {
@@ -109,7 +111,8 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single ssh minion action.
-     * @param actionIn the action
+     *
+     * @param actionIn  the action
      * @param sshMinion the Salt ssh minion
      * @throws TaskomaticApiException if there was an error
      */
@@ -120,8 +123,9 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single ssh minion action.
-     * @param actionIn the action
-     * @param sshMinion the Salt ssh minion
+     *
+     * @param actionIn                the action
+     * @param sshMinion               the Salt ssh minion
      * @param forcePackageListRefresh force package list refresh when set to true
      * @throws TaskomaticApiException if there was an error
      */
@@ -142,12 +146,13 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single reposync
+     *
      * @param chan the channel
      * @param user the user
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleSingleRepoSync(Channel chan, User user)
-                                    throws TaskomaticApiException {
+            throws TaskomaticApiException {
         Map<String, Object> scheduleParams = new HashMap<>();
         scheduleParams.put("channel_id", chan.getId().toString());
         invoke("tasko.scheduleSingleBunchRun", user.getOrg().getId(),
@@ -158,6 +163,7 @@ public class TaskomaticApi {
      * Schedule a single reposync for a given list of channels. This is scheduled from
      * within another taskomatic job, so we don't have a user here. We pass in the
      * satellite org to create the job label internally.
+     *
      * @param channels list of channels
      * @throws TaskomaticApiException if there was an error
      */
@@ -175,13 +181,14 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single reposync
-     * @param chan the channel
-     * @param user the user
+     *
+     * @param chan   the channel
+     * @param user   the user
      * @param params parameters
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleSingleRepoSync(Channel chan, User user, Map<String, String> params)
-                                    throws TaskomaticApiException {
+            throws TaskomaticApiException {
 
         Map<String, String> scheduleParams = new HashMap<>();
         scheduleParams.put("channel_id", chan.getId().toString());
@@ -197,6 +204,7 @@ public class TaskomaticApi {
 
     /**
      * Schedule a recurring reposync
+     *
      * @param chan the channel
      * @param user the user
      * @param cron the cron format
@@ -204,7 +212,7 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleRepoSync(Channel chan, User user, String cron)
-                                        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         String jobLabel = createRepoSyncScheduleName(chan, user);
 
         Map<String, Object> task = findScheduleByBunchAndLabel("repo-sync-bunch", jobLabel, user);
@@ -219,15 +227,16 @@ public class TaskomaticApi {
 
     /**
      * Schedule a recurring reposync
-     * @param chan the channel
-     * @param user the user
-     * @param cron the cron format
+     *
+     * @param chan   the channel
+     * @param user   the user
+     * @param cron   the cron format
      * @param params parameters
      * @return the Date?
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleRepoSync(Channel chan, User user, String cron,
-            Map<String, String> params) throws TaskomaticApiException {
+                                 Map<String, String> params) throws TaskomaticApiException {
         String jobLabel = createRepoSyncScheduleName(chan, user);
 
         Map<String, Object> task = findScheduleByBunchAndLabel("repo-sync-bunch", jobLabel, user);
@@ -244,21 +253,23 @@ public class TaskomaticApi {
 
     /**
      * Creates a new single satellite schedule
-     * @param user shall be sat admin
+     *
+     * @param user      shall be sat admin
      * @param bunchName bunch name
-     * @param params parameters for the bunch
+     * @param params    parameters for the bunch
      * @return date of the first schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleSingleSatBunch(User user, String bunchName,
-            Map<String, String> params) throws TaskomaticApiException {
+                                       Map<String, String> params) throws TaskomaticApiException {
         ensureSatAdminRole(user);
         return (Date) invoke("tasko.scheduleSingleSatBunchRun", bunchName, params);
     }
 
-        /**
+    /**
      * Creates a new single gatherer schedule
-     * @param user shall be org admin
+     *
+     * @param user   shall be org admin
      * @param params parameters for the bunch
      * @return date of the first schedule
      * @throws TaskomaticApiException if there was an error
@@ -270,18 +281,20 @@ public class TaskomaticApi {
 
     /**
      * Validates user has sat admin role
+     *
      * @param user shall be sat admin
      * @throws PermissionException if there was an error
      */
     private void ensureSatAdminRole(User user) {
         if (!user.hasRole(RoleFactory.SAT_ADMIN)) {
             ValidatorException.raiseException("satadmin.jsp.error.notsatadmin",
-                                user.getLogin());
+                    user.getLogin());
         }
     }
 
     /**
      * Validates user has org admin role
+     *
      * @param user shall be org admin
      * @throws PermissionException if there was an error
      */
@@ -293,6 +306,7 @@ public class TaskomaticApi {
 
     /**
      * Validates user has channel admin role
+     *
      * @param user shall be channel admin
      * @throws PermissionException if there was an error
      */
@@ -304,15 +318,16 @@ public class TaskomaticApi {
 
     /**
      * Creates a new schedule, unschedules, if en existing is defined
-     * @param user shall be sat admin
-     * @param jobLabel name of the schedule
+     *
+     * @param user      shall be sat admin
+     * @param jobLabel  name of the schedule
      * @param bunchName bunch name
-     * @param cron cron expression
+     * @param cron      cron expression
      * @return date of the first schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Date scheduleSatBunch(User user, String jobLabel, String bunchName, String cron)
-    throws TaskomaticApiException {
+            throws TaskomaticApiException {
         ensureSatAdminRole(user);
         return doScheduleSatBunch(user, jobLabel, bunchName, cron);
     }
@@ -321,8 +336,8 @@ public class TaskomaticApi {
      * Schedule a recurring action
      *
      * @param action the {@link RecurringAction}
-     * @param user the scheduler user
-     * @throws PermissionException when given user does not have permissions for scheduling given action
+     * @param user   the scheduler user
+     * @throws PermissionException    when given user does not have permissions for scheduling given action
      * @throws TaskomaticApiException on Taskomatic error
      */
     public void scheduleRecurringAction(RecurringAction action, User user) throws TaskomaticApiException {
@@ -341,15 +356,15 @@ public class TaskomaticApi {
         if (task != null) {
             doUnscheduleSatTask(jobLabel);
         }
-        return (Date) invoke("tasko.scheduleSatBunch", bunchName, jobLabel , cron, new HashMap<>());
+        return (Date) invoke("tasko.scheduleSatBunch", bunchName, jobLabel, cron, new HashMap<>());
     }
 
     /**
      * Unschedule a recurring action
      *
      * @param action the {@link RecurringAction}
-     * @param user the unscheduler user
-     * @throws PermissionException when given user does not have permissions for unscheduling given action
+     * @param user   the unscheduler user
+     * @throws PermissionException    when given user does not have permissions for unscheduling given action
      * @throws TaskomaticApiException on Taskomatic error
      */
     public void unscheduleRecurringAction(RecurringAction action, User user) throws TaskomaticApiException {
@@ -375,6 +390,7 @@ public class TaskomaticApi {
 
     /**
      * Unchedule a reposync task
+     *
      * @param chan the channel
      * @param user the user
      * @throws TaskomaticApiException if there was an error
@@ -388,25 +404,27 @@ public class TaskomaticApi {
     }
 
     private void unscheduleRepoTask(String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         ensureChannelAdminRole(user);
         invoke("tasko.unscheduleBunch", user.getOrg().getId(), jobLabel);
     }
 
     /**
      * unschedule satellite task
+     *
      * @param jobLabel schedule name
-     * @param user shall be satellite admin
+     * @param user     shall be satellite admin
      * @throws TaskomaticApiException if there was an error
      */
     public void unscheduleSatTask(String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         ensureSatAdminRole(user);
         invoke("tasko.unscheduleSatBunches", singletonList(jobLabel));
     }
 
     /**
      * Return list of active schedules
+     *
      * @param user shall be sat admin
      * @return list of schedules
      * @throws TaskomaticApiException if there was an error
@@ -418,7 +436,8 @@ public class TaskomaticApi {
 
     /**
      * Return list of bunch runs
-     * @param user shall be sat admin
+     *
+     * @param user      shall be sat admin
      * @param bunchName name of the bunch
      * @return list of schedules
      * @throws TaskomaticApiException if there was an error
@@ -430,56 +449,58 @@ public class TaskomaticApi {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> findScheduleByBunchAndLabel(String bunchName, String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         List<Map<String, Object>> schedules = (List<Map<String, Object>>) invoke("tasko.listActiveSchedulesByBunch",
                 user.getOrg().getId(), bunchName);
         for (Map<String, Object> schedule : schedules) {
             if (schedule.get("job_label").equals(jobLabel)) {
                 return schedule;
             }
-         }
+        }
         return null;
     }
 
     private Map<String, Object> findSatScheduleByBunchAndLabel(String bunchName, String jobLabel,
-            User user) throws TaskomaticApiException {
+                                                               User user) throws TaskomaticApiException {
         List<Map<String, Object>> schedules = (List<Map<String, Object>>) invoke("tasko.listActiveSatSchedulesByBunch",
                 bunchName);
         for (Map<String, Object> schedule : schedules) {
             if (schedule.get("job_label").equals(jobLabel)) {
                 return schedule;
             }
-         }
+        }
         return null;
     }
 
     /**
      * Check whether there's an active schedule of given job label
+     *
      * @param jobLabel job label
-     * @param user the user
+     * @param user     the user
      * @return true, if schedule exists
      * @throws TaskomaticApiException if there was an error
      */
     public boolean satScheduleActive(String jobLabel, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         List<Map<String, Object>> schedules = (List<Map<String, Object>>) invoke("tasko.listActiveSatSchedules");
         for (Map<String, Object> schedule : schedules) {
             if (schedule.get("job_label").equals(jobLabel)) {
                 return Boolean.TRUE;
             }
-         }
+        }
         return Boolean.FALSE;
     }
 
     /**
      * Get the cron format for a single channel
+     *
      * @param chan the channel
      * @param user the user
      * @return the Cron format
      * @throws TaskomaticApiException if there was an error
      */
     public String getRepoSyncSchedule(Channel chan, User user)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         String jobLabel = createRepoSyncScheduleName(chan, user);
         Map<String, Object> task = findScheduleByBunchAndLabel("repo-sync-bunch", jobLabel, user);
         if (task == null) {
@@ -490,6 +511,7 @@ public class TaskomaticApi {
 
     /**
      * Return list of available bunches
+     *
      * @param user shall be sat admin
      * @return list of bunches
      * @throws TaskomaticApiException if there was an error
@@ -501,43 +523,47 @@ public class TaskomaticApi {
 
     /**
      * looks up schedule according to id
-     * @param user shall be sat admin
+     *
+     * @param user       shall be sat admin
      * @param scheduleId schedule id
      * @return schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Map<String, Object> lookupScheduleById(User user, Long scheduleId)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         return (Map<String, Object>) invoke("tasko.lookupScheduleById", scheduleId);
     }
 
     /**
      * looks up schedule according to label
-     * @param user shall be sat admin
-     * @param bunchName bunch name
+     *
+     * @param user          shall be sat admin
+     * @param bunchName     bunch name
      * @param scheduleLabel schedule label
      * @return schedule
      * @throws TaskomaticApiException if there was an error
      */
     public Map<String, Object> lookupScheduleByBunchAndLabel(User user, String bunchName,
-            String scheduleLabel) throws TaskomaticApiException {
+                                                             String scheduleLabel) throws TaskomaticApiException {
         return findSatScheduleByBunchAndLabel(bunchName, scheduleLabel, user);
     }
 
     /**
      * looks up bunch according to name
-     * @param user shall be sat admin
+     *
+     * @param user      shall be sat admin
      * @param bunchName bunch name
      * @return bunch
      * @throws TaskomaticApiException if there was an error
      */
     public Map<String, Object> lookupBunchByName(User user, String bunchName)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         return (Map<String, Object>) invoke("tasko.lookupBunchByName", bunchName);
     }
 
     /**
      * List all reposync schedules within an organization
+     *
      * @param org organization
      * @return list of schedules
      */
@@ -554,6 +580,7 @@ public class TaskomaticApi {
 
     /**
      * unschedule all outdated repo-sync schedules within an org
+     *
      * @param orgIn organization
      * @return number of removed schedules
      * @throws TaskomaticApiException if there was an error
@@ -578,9 +605,9 @@ public class TaskomaticApi {
     /**
      * Schedule an Action execution for Salt minions.
      *
-     * @param action the action to be executed
+     * @param action                  the action to be executed
      * @param forcePackageListRefresh is a package list is requested
-     * @param checkIfMinionInvolved check if action involves minions
+     * @param checkIfMinionInvolved   check if action involves minions
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleActionExecution(Action action, boolean forcePackageListRefresh, boolean checkIfMinionInvolved)
@@ -599,10 +626,11 @@ public class TaskomaticApi {
         }
         scheduleMinionActionExecutions(singletonList(action), forcePackageListRefresh);
     }
+
     /**
      * Schedule Actions execution for Salt minions.
      *
-     * @param actions the list of actions to be executed
+     * @param actions                 the list of actions to be executed
      * @param forcePackageListRefresh is a package list is requested
      * @throws TaskomaticApiException if there was an error
      */
@@ -610,7 +638,7 @@ public class TaskomaticApi {
             throws TaskomaticApiException {
         List<Map<String, String>> paramsList = new ArrayList<>();
         List<String> ids = new ArrayList<>();
-        for (Action action: actions) {
+        for (Action action : actions) {
             Map<String, String> params = new HashMap<>();
             String id = Long.toString(action.getId());
             params.put("action_id", id);
@@ -631,7 +659,7 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleActionChainExecution(ActionChain actionchain)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         if (!ActionChainFactory.isActionChainTargettingMinions(actionchain)) {
             return;
         }
@@ -649,13 +677,13 @@ public class TaskomaticApi {
     /**
      * Schedule a staging job for Salt minions.
      *
-     * @param actionId ID of the action to be executed
-     * @param minionId ID of the minion involved
+     * @param actionId        ID of the action to be executed
+     * @param minionId        ID of the minion involved
      * @param stagingDateTime scheduling time of staging
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleStagingJob(Long actionId, Long minionId, Date stagingDateTime)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         Map<String, String> params = new HashMap<>();
         params.put("action_id", Long.toString(actionId));
         params.put("staging_job", "true");
@@ -668,6 +696,7 @@ public class TaskomaticApi {
 
     /**
      * Schedule a staging job for Salt minions.
+     *
      * @param actionData Map containing mapping between action and minions data
      * @throws TaskomaticApiException if there was an error
      */
@@ -694,14 +723,14 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public void scheduleActionExecution(Action action)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
         scheduleActionExecution(action, false);
     }
 
     /**
      * Schedule an Action execution for Salt minions.
      *
-     * @param action the action to be executed
+     * @param action                  the action to be executed
      * @param forcePackageListRefresh is a package list is requested
      * @throws TaskomaticApiException if there was an error
      */
@@ -713,7 +742,7 @@ public class TaskomaticApi {
     /**
      * Schedule a channel subscription action.
      *
-     * @param user the user that schedules the action
+     * @param user   the user that schedules the action
      * @param action the action to schedule
      * @throws TaskomaticApiException if there was an error
      */
@@ -734,7 +763,7 @@ public class TaskomaticApi {
      * @throws TaskomaticApiException if there was an error
      */
     public void deleteScheduledActions(Map<Action, Set<Server>> actionMap)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
 
         List<Action> actionsToBeUnscheduled = actionMap.entrySet().stream()
                 // select Actions that have no minions besides those in the specified set
@@ -772,6 +801,7 @@ public class TaskomaticApi {
 
     /**
      * Schedule a single reposync
+     *
      * @param sshdata the payg ssh connection data
      * @throws TaskomaticApiException if there was an error
      */
@@ -784,10 +814,48 @@ public class TaskomaticApi {
 
     /**
      * Check if the Taskomatic java process has JMX enabled.
+     *
      * @return true is JMX enabled
      * @throws TaskomaticApiException if there was an error
      */
     public boolean isJmxEnabled() throws TaskomaticApiException {
-        return (Boolean)invoke("tasko.isJmxEnabled");
+        return (Boolean) invoke("tasko.isJmxEnabled");
+    }
+
+    /**
+     * Schedule one root ca certificate update
+     *
+     * @param fileName          filename of the ca certificate
+     * @param rootCaCertContent root ca certificate actual content
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSingleRootCaCertUpdate(String fileName, String rootCaCertContent)
+            throws TaskomaticApiException {
+        scheduleSingleRootCaCertUpdate(singletonMap(fileName, rootCaCertContent));
+    }
+
+    /**
+     * Schedule multiple root ca certificates update.
+     *
+     * @param filenameToRootCaCertMap maps filename to root ca certificate actual content
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSingleRootCaCertUpdate(Map<String, String> filenameToRootCaCertMap)
+            throws TaskomaticApiException {
+
+        if ((null == filenameToRootCaCertMap) || filenameToRootCaCertMap.isEmpty()) {
+            return; // nothing to do: avoid invoke call, to spare a potential exception
+        }
+
+        //sanitise map keys and values: XmlRpc actual call does not like null strings
+        //(exception: Cannot invoke "Object.toString()" because "key" is null)
+        Map<String, String> sanitisedFilenameToRootCaCertMap = filenameToRootCaCertMap.entrySet()
+                .stream()
+                .collect(Collectors.toMap(p -> Objects.toString(p.getKey(), ""),
+                        p -> Objects.toString(p.getValue(), "")));
+
+        Map<String, Object> paramList = new HashMap<>();
+        paramList.put("filename_to_root_ca_cert_map", sanitisedFilenameToRootCaCertMap);
+        invoke("tasko.scheduleSingleSatBunchRun", "root-ca-cert-update-bunch", paramList);
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RootCaCertUpdateTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RootCaCertUpdateTask.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.taskomatic.task;
+
+import com.suse.utils.CertificateUtils;
+
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Taskomatic task that checks if new certificates have been added or updated
+ * and saves them accordingly in the trusted certificate path.
+ * After saving the certificates, the system configuration is refreshed.
+ */
+public class RootCaCertUpdateTask extends RhnJavaJob {
+
+    private static final String MAP_KEY = "filename_to_root_ca_cert_map";
+
+    @Override
+    public String getConfigNamespace() {
+        return "root-ca-cert-update";
+    }
+
+    private Map<String, String> getFilenameToRootCaCertMap(final JobDataMap jobDataMap) {
+        Map<String, String> filenameToRootCaCertMap = new HashMap<>();
+
+        if (jobDataMap.containsKey(MAP_KEY)) {
+            try {
+                filenameToRootCaCertMap = (Map<String, String>) jobDataMap.get(MAP_KEY);
+            }
+            catch (ClassCastException e) {
+                //filenameToRootCaCertMap is already empty
+                log.debug("error while extracting filename to root certificate map");
+            }
+        }
+        return filenameToRootCaCertMap;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        final JobDataMap jobDataMap = context.getJobDetail().getJobDataMap();
+        Map<String, String> filenameToRootCaCertMap = getFilenameToRootCaCertMap(jobDataMap);
+
+        CertificateUtils.saveAndUpdateCertificates(filenameToRootCaCertMap);
+    }
+}

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -19,6 +19,8 @@ import com.redhat.rhn.domain.credentials.SCCCredentials;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssAccessToken;
@@ -53,11 +55,15 @@ public class HubManager {
 
     private final IssClientFactory clientFactory;
 
+    private TaskomaticApi taskomaticApi;
+
+    private static final String ROOT_CA_FILENAME_TEMPLATE = "%s_%s_root_ca.pem";
+
     /**
      * Default constructor
      */
     public HubManager() {
-        this(new HubFactory(), new IssClientFactory(), new MirrorCredentialsManager());
+        this(new HubFactory(), new IssClientFactory(), new MirrorCredentialsManager(), new TaskomaticApi());
     }
 
     /**
@@ -65,12 +71,14 @@ public class HubManager {
      * @param hubFactoryIn the hub factory
      * @param clientFactoryIn the ISS client factory
      * @param mirrorCredentialsManagerIn the mirror credentials manager
+     * @param taskomaticApiIn the TaskomaticApi object
      */
     public HubManager(HubFactory hubFactoryIn, IssClientFactory clientFactoryIn,
-                      MirrorCredentialsManager mirrorCredentialsManagerIn) {
+                      MirrorCredentialsManager mirrorCredentialsManagerIn, TaskomaticApi taskomaticApiIn) {
         this.hubFactory = hubFactoryIn;
         this.clientFactory = clientFactoryIn;
         this.mirrorCredentialsManager = mirrorCredentialsManagerIn;
+        this.taskomaticApi = taskomaticApiIn;
     }
 
     /**
@@ -135,7 +143,8 @@ public class HubManager {
      * @param rootCA the root certificate, if needed
      * @return the persisted remote server
      */
-    public IssServer saveNewServer(IssAccessToken accessToken, IssRole role, String rootCA) {
+    public IssServer saveNewServer(IssAccessToken accessToken, IssRole role, String rootCA)
+            throws TaskomaticApiException {
         ensureValidToken(accessToken);
 
         return createServer(role, accessToken.getServerFqdn(), rootCA);
@@ -157,7 +166,8 @@ public class HubManager {
      * @throws IOException when connecting to the server fails
      */
     public void register(User user, String remoteServer, IssRole role, String username, String password, String rootCA)
-        throws CertificateException, TokenBuildingException, IOException, TokenParsingException {
+        throws CertificateException, TokenBuildingException, IOException, TokenParsingException,
+            TaskomaticApiException {
         ensureSatAdmin(user);
 
         // Verify this server is not already registered as hub or peripheral
@@ -187,7 +197,8 @@ public class HubManager {
      * @throws IOException when connecting to the peripheral server fails
      */
     public void register(User user, String remoteServer, IssRole role, String remoteToken, String rootCA)
-        throws CertificateException, TokenBuildingException, IOException, TokenParsingException {
+        throws CertificateException, TokenBuildingException, IOException, TokenParsingException,
+            TaskomaticApiException {
         ensureSatAdmin(user);
 
         // Verify this server is not already registered as hub or peripheral
@@ -227,7 +238,8 @@ public class HubManager {
     }
 
     private void registerWithToken(String remoteServer, IssRole role, String rootCA, String remoteToken)
-        throws TokenParsingException, CertificateException, TokenBuildingException, IOException {
+        throws TokenParsingException, CertificateException, TokenBuildingException, IOException,
+            TaskomaticApiException {
         parseAndSaveToken(remoteServer, remoteToken);
 
         IssServer registeredServer = createServer(role, remoteServer, rootCA);
@@ -336,7 +348,12 @@ public class HubManager {
         hubFactory.saveToken(fqdn, token, TokenType.CONSUMED, parsedToken.getExpirationTime());
     }
 
-    private IssServer createServer(IssRole role, String serverFqdn, String rootCA) {
+    private static String computeRootCaFileName(IssRole role, String serverFqdn) {
+        return String.format(ROOT_CA_FILENAME_TEMPLATE, role.getLabel(), serverFqdn);
+    }
+
+    private IssServer createServer(IssRole role, String serverFqdn, String rootCA) throws TaskomaticApiException {
+        taskomaticApi.scheduleSingleRootCaCertUpdate(computeRootCaFileName(role, serverFqdn), rootCA);
         return switch (role) {
             case HUB -> {
                 IssHub hub = new IssHub(serverFqdn, rootCA);

--- a/java/code/src/com/suse/manager/hub/SyncController.java
+++ b/java/code/src/com/suse/manager/hub/SyncController.java
@@ -17,11 +17,13 @@ import static com.suse.manager.hub.IssSparkHelper.allowingOnlyUnregistered;
 import static com.suse.manager.hub.IssSparkHelper.usingTokenAuthentication;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.badRequest;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.internalServerError;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.message;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.success;
 import static spark.Spark.post;
 
 import com.redhat.rhn.domain.credentials.HubSCCCredentials;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.RegisterJson;
@@ -101,6 +103,10 @@ public class SyncController {
         catch (TokenParsingException ex) {
             LOGGER.error("Unable to parse the received token for server {}", token.getServerFqdn());
             return badRequest(response, "The specified token is not parseable");
+        }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Unable to schedule root CA certificate update {}", token.getServerFqdn());
+            return internalServerError(response, "Unable to schedule root CA certificate update");
         }
     }
 

--- a/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
@@ -30,6 +30,8 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.UserTestUtils;
 
@@ -67,6 +69,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -87,6 +90,57 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     private String originalServerSecret;
 
     private String originalFqdn;
+
+    static class MockTaskomaticApi extends TaskomaticApi {
+        private boolean invokeCalled;
+        private String invokeName;
+        private String invokeBunch;
+        private String invokeRootCaFilename;
+        private String invokeRootCaContent;
+
+        MockTaskomaticApi() {
+            resetTaskomaticCall();
+        }
+
+        public void resetTaskomaticCall() {
+            invokeCalled = false;
+            invokeName = "";
+            invokeBunch = "";
+            invokeRootCaFilename = null;
+            invokeRootCaContent = null;
+        }
+
+        public void verifyTaskoRootCaCertUpdateCall(String expectedRootCaFilename,
+                                                    String expectedRootCaContent) {
+            assertTrue(invokeCalled);
+            assertEquals("tasko.scheduleSingleSatBunchRun", invokeName);
+            assertEquals("root-ca-cert-update-bunch", invokeBunch);
+            assertEquals(expectedRootCaFilename, invokeRootCaFilename);
+            assertEquals(expectedRootCaContent, invokeRootCaContent);
+            resetTaskomaticCall();
+        }
+
+        @Override
+        protected Object invoke(String name, Object... args) throws TaskomaticApiException {
+            invokeCalled = true;
+            invokeName = name;
+            invokeBunch = (String) args[0];
+            Map<String, Object> paramList = (Map<String, Object>) args[1];
+            Map<String, String> fileToCaCertMap = (Map<String, String>) paramList.get("filename_to_root_ca_cert_map");
+            Optional<Map.Entry<String, String>> firstKeyVal = fileToCaCertMap.entrySet().stream().findFirst();
+            if (firstKeyVal.isPresent()) {
+                invokeRootCaFilename = firstKeyVal.get().getKey();
+                invokeRootCaContent = firstKeyVal.get().getValue();
+            }
+            else {
+                invokeRootCaFilename = null;
+                invokeRootCaContent = null;
+            }
+            return null;
+        }
+    }
+
+    private MockTaskomaticApi mockTaskomaticApi;
 
     @BeforeEach
     @Override
@@ -110,7 +164,8 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
         hubFactory = new HubFactory();
         clientFactoryMock = mock(IssClientFactory.class);
 
-        hubManager = new HubManager(hubFactory, clientFactoryMock, new MirrorCredentialsManager());
+        mockTaskomaticApi = new MockTaskomaticApi();
+        hubManager = new HubManager(hubFactory, clientFactoryMock, new MirrorCredentialsManager(), mockTaskomaticApi);
     }
 
     @AfterEach
@@ -315,7 +370,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
-    public void canSaveHubAndPeripheralServers() {
+    public void canSaveHubAndPeripheralServers() throws TaskomaticApiException {
         hubManager.saveNewServer(getValidToken("dummy.hub.fqdn"), IssRole.HUB, "dummy-certificate-data");
 
         Optional<IssHub> issHub = hubFactory.lookupIssHubByFqdn("dummy.hub.fqdn");
@@ -369,7 +424,39 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
-    public void canGenerateSCCCredentials() {
+    public void canSaveRootCa() throws TaskomaticApiException {
+        mockTaskomaticApi.resetTaskomaticCall();
+        hubManager.saveNewServer(getValidToken("dummy.hub.fqdn"), IssRole.HUB, "dummy-hub-certificate-data");
+        mockTaskomaticApi.verifyTaskoRootCaCertUpdateCall("hub_dummy.hub.fqdn_root_ca.pem",
+                "dummy-hub-certificate-data");
+
+        mockTaskomaticApi.resetTaskomaticCall();
+        hubManager.saveNewServer(getValidToken("dummy2.hub.fqdn"), IssRole.HUB, "");
+        mockTaskomaticApi.verifyTaskoRootCaCertUpdateCall("hub_dummy2.hub.fqdn_root_ca.pem", "");
+
+        mockTaskomaticApi.resetTaskomaticCall();
+        hubManager.saveNewServer(getValidToken("dummy3.hub.fqdn"), IssRole.HUB, null);
+        mockTaskomaticApi.verifyTaskoRootCaCertUpdateCall("hub_dummy3.hub.fqdn_root_ca.pem", "");
+
+        mockTaskomaticApi.resetTaskomaticCall();
+        hubManager.saveNewServer(getValidToken("dummy.periph.fqdn"), IssRole.PERIPHERAL,
+                "dummy-periph-certificate-data");
+        mockTaskomaticApi.verifyTaskoRootCaCertUpdateCall("peripheral_dummy.periph.fqdn_root_ca.pem",
+                "dummy-periph-certificate-data");
+
+        mockTaskomaticApi.resetTaskomaticCall();
+        hubManager.saveNewServer(getValidToken("dummy2.periph.fqdn"), IssRole.PERIPHERAL, "");
+        mockTaskomaticApi.verifyTaskoRootCaCertUpdateCall("peripheral_dummy2.periph.fqdn_root_ca.pem",
+                "");
+
+        mockTaskomaticApi.resetTaskomaticCall();
+        hubManager.saveNewServer(getValidToken("dummy3.periph.fqdn"), IssRole.PERIPHERAL, null);
+        mockTaskomaticApi.verifyTaskoRootCaCertUpdateCall("peripheral_dummy3.periph.fqdn_root_ca.pem",
+                "");
+    }
+
+    @Test
+    public void canGenerateSCCCredentials() throws TaskomaticApiException {
         String peripheralFqdn = "dummy.peripheral.fqdn";
 
         IssAccessToken peripheralToken = getValidToken(peripheralFqdn);
@@ -387,7 +474,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     }
 
     @Test
-    public void canStoreSCCCredentials() {
+    public void canStoreSCCCredentials() throws TaskomaticApiException {
         IssAccessToken hubToken = getValidToken("dummy.hub.fqdn");
         var hub = (IssHub) hubManager.saveNewServer(hubToken, IssRole.HUB, null);
 
@@ -404,7 +491,8 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void canRegisterPeripheralWithUserNameAndPassword()
-        throws TokenBuildingException, CertificateException, IOException, TokenParsingException {
+            throws TokenBuildingException, CertificateException, IOException, TokenParsingException,
+            TaskomaticApiException {
         IssExternalClient externalClient = mock(IssExternalClient.class);
         IssInternalClient internalClient = mock(IssInternalClient.class);
 
@@ -457,7 +545,8 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void canRegisterHubWithUserNameAndPassword()
-        throws TokenBuildingException, CertificateException, IOException, TokenParsingException {
+            throws TokenBuildingException, CertificateException, IOException, TokenParsingException,
+            TaskomaticApiException {
         IssExternalClient externalClient = mock(IssExternalClient.class);
         IssInternalClient internalClient = mock(IssInternalClient.class);
 

--- a/java/code/src/com/suse/manager/model/hub/IssRole.java
+++ b/java/code/src/com/suse/manager/model/hub/IssRole.java
@@ -11,7 +11,14 @@
 
 package com.suse.manager.model.hub;
 
-public enum IssRole {
+import com.redhat.rhn.domain.Labeled;
+
+public enum IssRole implements Labeled {
     HUB,
-    PERIPHERAL
+    PERIPHERAL;
+
+    @Override
+    public String getLabel() {
+        return name().toLowerCase();
+    }
 }

--- a/java/code/src/com/suse/manager/xmlrpc/iss/IssHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/IssHandler.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.frontend.xmlrpc.InvalidTokenException;
 import com.redhat.rhn.frontend.xmlrpc.TokenAlreadyExistsException;
 import com.redhat.rhn.frontend.xmlrpc.TokenCreationException;
 import com.redhat.rhn.frontend.xmlrpc.TokenExchangeFailedException;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.hub.HubManager;
 import com.suse.manager.model.hub.IssRole;
@@ -212,6 +213,10 @@ public class IssHandler extends BaseHandler {
             LOGGER.error("Unable to connect to remote server {}", fqdn, ex);
             throw new TokenExchangeFailedException(ex);
         }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Unable to schedule root CA certificate update {}", fqdn, ex);
+            throw new TokenExchangeFailedException(ex);
+        }
 
         return 1;
     }
@@ -286,6 +291,10 @@ public class IssHandler extends BaseHandler {
         }
         catch (IOException ex) {
             LOGGER.error("Unable to connect to remote server {}", fqdn, ex);
+            throw new TokenExchangeFailedException(ex);
+        }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Unable to schedule root CA certificate update {}", fqdn, ex);
             throw new TokenExchangeFailedException(ex);
         }
 

--- a/java/code/src/com/suse/utils/test/CertificateUtilsTest.java
+++ b/java/code/src/com/suse/utils/test/CertificateUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.utils.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import com.suse.utils.CertificateUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CertificateUtilsTest {
+
+    @Test
+    public void ensureSafePathRejectsNullEmptyFilenames() throws IllegalArgumentException {
+        String errorMessage = "File name cannot be null or empty";
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(null), errorMessage);
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(""), errorMessage);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"te$t1", "te%t2", ";test3", "te#t4", "te\\t5", "te\\u0003t6", "te\nt7",
+            "../test_1-8.txt", ".../test_1-9.txt", "..../test_1-10.txt", "test/../test_1-11.txt"})
+    public void ensureSafePathRejectsInvalidChars(String badFilename) throws IllegalArgumentException {
+        String errorMessage = "File name contains invalid characters";
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(badFilename), errorMessage);
+    }
+
+    @Test
+    public void ensureSafePathRejectsTraversalAttempt() throws IllegalArgumentException {
+        String errorMessage = "Attempted path traversal attack detected";
+        assertThrowsExactly(IllegalArgumentException.class,
+                () -> CertificateUtils.getCertificateSafePath(".."), errorMessage);
+    }
+
+    @Test
+    public void ensureSafePathAcceptsValidCases() throws IllegalArgumentException {
+        assertEquals("/etc/pki/trust/anchors/test_1-12.txt",
+                CertificateUtils.getCertificateSafePath("test_1-12.txt").toString());
+        assertEquals("/etc/pki/trust/anchors/test___1---13..txt",
+                CertificateUtils.getCertificateSafePath("test___1---13..txt").toString());
+        //ipv4
+        assertEquals("/etc/pki/trust/anchors/registration_server_10.1.2.245.pem",
+                CertificateUtils.getCertificateSafePath("registration_server_10.1.2.245.pem").toString());
+        //ipv6
+        assertEquals("/etc/pki/trust/anchors/registration_server_2001:db8:3333:4444:5555:6666:7777:8888.pem",
+                CertificateUtils.getCertificateSafePath(
+                        "registration_server_2001:db8:3333:4444:5555:6666:7777:8888.pem").toString());
+        assertEquals("/etc/pki/trust/anchors/registration_server_::.pem",
+                CertificateUtils.getCertificateSafePath("registration_server_::.pem").toString());
+        assertEquals("/etc/pki/trust/anchors/registration_server_2001:db8::.pem",
+                CertificateUtils.getCertificateSafePath("registration_server_2001:db8::.pem").toString());
+        assertEquals("/etc/pki/trust/anchors/registration_server_::1234:5678.pem",
+                CertificateUtils.getCertificateSafePath("registration_server_::1234:5678.pem").toString());
+    }
+}

--- a/java/spacewalk-java.changes.carlo.issv3-taskomatic-job
+++ b/java/spacewalk-java.changes.carlo.issv3-taskomatic-job
@@ -1,0 +1,2 @@
+- Create a task (root-ca-cert-update) in taskomatic to store
+  ca-certificates in the trusted certificate path

--- a/schema/spacewalk/common/data/rhnTaskoBunch.sql
+++ b/schema/spacewalk/common/data/rhnTaskoBunch.sql
@@ -141,4 +141,7 @@ VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'payg-dimension-computation-
 INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
 VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'oval-data-sync-bunch', 'Generate OVAL data required to increase the accuracy of CVE audit queries.', null);
 
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'root-ca-cert-update-bunch', 'Updates root ca certificates', null);
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -149,4 +149,7 @@ VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'payg-dimension-computation',
 INSERT INTO rhnTaskoTask (id, name, class)
 VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'oval-data-sync', 'com.redhat.rhn.taskomatic.task.OVALDataSync');
 
+INSERT INTO rhnTaskoTask (id, name, class)
+VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'root-ca-cert-update', 'com.redhat.rhn.taskomatic.task.RootCaCertUpdateTask');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -329,4 +329,11 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
                     0,
                     null);
 
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+             VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
+                    (SELECT id FROM rhnTaskoBunch WHERE name='root-ca-cert-update-bunch'),
+                    (SELECT id FROM rhnTaskoTask WHERE name='root-ca-cert-update'),
+                    0,
+                    null);
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes.carlo.issv3-taskomatic-job
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.issv3-taskomatic-job
@@ -1,0 +1,1 @@
+- Add SQL scripts to create root-ca-cert-update task in taskomatic

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.2-to-susemanager-schema-5.1.3/001-issv3-rootcacertificates-taskomatic.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.2-to-susemanager-schema-5.1.3/001-issv3-rootcacertificates-taskomatic.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+SELECT sequence_nextval('rhn_tasko_bunch_id_seq'), 'root-ca-cert-update-bunch', 'Updates root ca certificates', null FROM dual
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoBunch WHERE name = 'root-ca-cert-update-bunch');
+
+INSERT INTO rhnTaskoTask (id, name, class)
+SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'root-ca-cert-update', 'com.redhat.rhn.taskomatic.task.RootCaCertUpdateTask' FROM dual
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoTask WHERE name = 'root-ca-cert-update');
+
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+SELECT sequence_nextval('rhn_tasko_template_id_seq'),
+    (SELECT id FROM rhnTaskoBunch WHERE name='root-ca-cert-update-bunch'),
+    (SELECT id FROM rhnTaskoTask WHERE name='root-ca-cert-update'),
+    0,
+    null FROM dual
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoTemplate
+                                WHERE bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name='root-ca-cert-update-bunch')
+                                AND task_id = (SELECT id FROM rhnTaskoTask WHERE name='root-ca-cert-update'));


### PR DESCRIPTION
## What does this PR change?

When onboarding a peripheral or a hub, a root certificate might be needed if the two servers do not share a common one. The certificate is transferred during the registration process and stored in the database.

However, this does not alter the system trust configuration. This step cannot be implemented from the web UI/API backend, as Tomcat does not run with the required root privileges.

Therefore, we need to implement a Taskomatic job that checks if new certificates have been added or updated and stores them accordingly in the trusted certificate path

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/26180
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs
- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

