### PR TITLE
QE: Disable some features until the volumes permission issue is fixed on GH validation

### DIFF
--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -4,6 +4,7 @@
 @scope_openscap
 @scope_deblike
 @deblike_minion
+@skip_if_github_validation
 Feature: OpenSCAP audit of Debian-like Salt minion
   In order to audit a Debian-like Salt minion
   As an authorized user

--- a/testsuite/features/secondary/min_rhlike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_rhlike_openscap_audit.feature
@@ -4,6 +4,7 @@
 @scope_openscap
 @scope_res
 @rhlike_minion
+@skip_if_github_validation
 Feature: OpenSCAP audit of Red Hat-like Salt minion
   In order to audit a Red Hat-like Salt minion
   As an authorized user

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -7,6 +7,7 @@
 
 @sle_minion
 @scope_salt
+@skip_if_github_validation
 Feature: Lock packages on SLES salt minion
 
   Scenario: Log in as org admin user


### PR DESCRIPTION
## What does this PR change?

Since the last changes introduced in our GH validation setup, we are using now shared volumes that seems to have permission issues on the server.

This cause issues in some tests during the GH validation, and this prevents to merge unrelated PRs. For that reason, I would like to skip these issues until the issue with the volumes is fixed, unblocked the rest of PRs.

Issue:
![image](https://github.com/user-attachments/assets/4166f5ce-ea93-446e-b17e-649d2b338b0b)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were skipped

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
