### PR TITLE
Temporary workaround

### DIFF
--- a/testsuite/features/core/srv_first_settings.feature
+++ b/testsuite/features/core/srv_first_settings.feature
@@ -41,6 +41,10 @@ Feature: Very first settings
     Given I am authorized for the "Admin" section
 
   Scenario: Wait for refresh of list of products to finish
+    # WORKAROUND: remove when taskomatic has no more problem
+    #             sending the mgr-sync refresh via XML-RPC API
+    When I refresh SCC
+    # END OF WORKAROUND
     When I wait until mgr-sync refresh is finished
 
   Scenario: Create testing username


### PR DESCRIPTION
## What does this PR change?

Temporary workaround at test suite level
```
2025-01-27 07:17:49,745 [ajp-nio-0:0:0:0:0:0:0:1-8009-exec-3] ERROR com.redhat.rhn.manager.org.CreateOrgCommand - Problem when running Taskomatic mgr-sync-refresh job: redstone.xmlrpc.XmlRpcException: A network error occurred.
```
in case we don't manage to fix the product in time.

## Links

No ports, head only.


## Changelogs

- [x] No changelog needed
