### PR TITLE
Fix wrong timestamp when importing packages with rhnpush (bsc#1235970)

### DIFF
--- a/python/spacewalk/server/importlib/headerSource.py
+++ b/python/spacewalk/server/importlib/headerSource.py
@@ -17,7 +17,6 @@
 # Converts headers to the intermediate format
 #
 
-import time
 from .importLib import (
     File,
     Dependency,
@@ -94,7 +93,6 @@ class rpmPackage(IncompletePackage):
         self["org_id"] = org_id
         self["header_start"] = header_start
         self["header_end"] = header_end
-        self["last_modified"] = localtime(time.time())
         if "sigmd5" in self:
             if self["sigmd5"]:
                 self["sigchecksum_type"] = "md5"

--- a/python/spacewalk/spacewalk-backend.changes.parlt.fix-rhnpush-last-modified
+++ b/python/spacewalk/spacewalk-backend.changes.parlt.fix-rhnpush-last-modified
@@ -1,0 +1,2 @@
+- Fix wrong timestamp when importing packages
+  with rhnpush (bsc#1235970)


### PR DESCRIPTION
## What does this PR change?

When using `rhnpush` the `last_modified` column would get an incorrect timestamp when using timezones other than UTC on the server.

Remove calculation of the (wrong) timestamp from `headerSource.populate()` and rely on the trigger creating the timestamp when no value to last modified is provided.

[rhn_package_mod_trig_fun()](https://github.com/uyuni-project/uyuni/blob/master/schema/spacewalk/postgres/triggers/rhnPackage.sql)
```
if tg_op='UPDATE' then
  if new.last_modified = old.last_modified or
     new.last_modified is null then
       new.last_modified := current_timestamp;
  end if;
else
  if new.last_modified is null then
       new.last_modified := current_timestamp; <------
  end if;
end if;
new.modified := current_timestamp;
```

Tested ISSv1 not affected by this change (using different code to import packages).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **BUGFIX**

- [x] **DONE**

## Test coverage
- No tests: **BUGFIX**

- [x] **DONE**

## Links

Issue(s):  https://github.com/SUSE/spacewalk/issues/26231

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
