### PR TITLE
Copy generated CA rpms instead of moving them

### DIFF
--- a/spacewalk/certs-tools/gen-rpm.sh
+++ b/spacewalk/certs-tools/gen-rpm.sh
@@ -348,6 +348,6 @@ RPMOPTS="--define \"_topdir $RPM_BUILD_DIR\"\
 
 eval "rpmbuild -ta $RPMOPTS --clean $RPM_BUILD_DIR/$TARBALL" || exit 1
 
-mv $RPM_BUILD_DIR/$ARCH/$NAME-$VERSION-$RELEASE.$ARCH.rpm .
-mv $RPM_BUILD_DIR/$NAME-$VERSION-$RELEASE.src.rpm .
+cp $RPM_BUILD_DIR/$ARCH/$NAME-$VERSION-$RELEASE.$ARCH.rpm .
+cp $RPM_BUILD_DIR/$NAME-$VERSION-$RELEASE.src.rpm .
 rm -rf $RPM_BUILD_DIR

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.oholecek.copy-generated-rpm
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.oholecek.copy-generated-rpm
@@ -1,0 +1,2 @@
+- Copy generated CA rpms instead of moving them to prevent
+  SELinux context category issues


### PR DESCRIPTION
## What does this PR change?

moving the file from container space to volume preserve SELinux context category (MCS) which them prevents access to them after container restart. Copying it stores the file with correct context.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered, problem found by testsuite

- [X] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
