### PR TITLE
Check SELinux labels on container volumes

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -25,6 +25,7 @@ Feature: Sanity checks
     And socket "tftp" is active on "server"
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
+    And files on container volumes should all have the proper SELinux label
 
 @proxy
   Scenario: The proxy is healthy

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Sanity checks
@@ -25,6 +25,7 @@ Feature: Sanity checks
     And socket "tftp" is active on "server"
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
+    And files on container volumes should all have the proper SELinux label
 
 @proxy
   Scenario: The proxy is healthy

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -762,6 +762,14 @@ Then(/^socket "([^"]*)" is active on "([^"]*)"$/) do |service, host|
   raise ScriptError, "Service #{service} not active" if output != 'active'
 end
 
+Then(/^files on container volumes should all have the proper SELinux label$/) do
+  node = get_target('server')
+  cmd = '[ "$(sestatus 2>/dev/null | head -n 1 | grep enabled)" != "" ] && ' \
+        '(find /var/lib/containers/storage/volumes/*/_data -exec ls -Zd {} \; | grep -v ":object_r:container_file_t:s0 ")'
+  output, _code = node.run_local(cmd, check_errors: false, verbose: true)
+  raise ScriptError, 'Wrong SELinux labels' if output != ''
+end
+
 When(/^I run "([^"]*)" on "([^"]*)"$/) do |cmd, host|
   node = get_target(host)
   node.run(cmd)


### PR DESCRIPTION
## What does this PR change?

This PR officializes Vladimir's test for SELinux problems.

Feel free to object this PR. It adds 5 minutes to the sanity checks!

Another option could be to run it at the end of the testsuite, at same time we check the logs. The idea to do it at the beginning is that we can spare ourselves a run if SELinux is going to block us.


## Links

Port(s):
 * 5.0:


## Changelogs

- [x] No changelog needed
