### PR TITLE
Temporary workaround: do not check events on build host

### DIFF
--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -53,6 +53,10 @@ Feature: Bootstrap a build host via the GUI
     Then I should see a "[Container Build Host]" text
     Then I should see a "[OS Image Build Host]" text
 
+# WORKAROUND
+# Remove the skip tag when this PR is merged:
+#   https://github.com/uyuni-project/uyuni/pull/9707
+@skip
   Scenario: Check events history for failures on SLES build host
     Given I am on the Systems overview page of this "build_host"
     Then I check for failed events on history event page


### PR DESCRIPTION
## What does this PR change?

Workaround to reach secondary in head.

Remove as soon as SELinux fix is merged: https://github.com/uyuni-project/uyuni/pull/9707


## Links

Port(s): none, head only.


## Changelogs

- [x] No changelog needed
