### PR TITLE
Avoid SELinux + container volumes clashes

### DIFF
--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2022 SUSE LLC
+# Copyright (c) 2015-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_smdba
@@ -56,26 +56,26 @@ Feature: SMDBA database helper tool
 
   Scenario: Check SMDBA backup setup facility
     Given a postgresql database is running
-    And there is no such "/smdba-backup-test" directory
-    When I create backup directory "/smdba-backup-test" with UID "root" and GID "root"
-    And I take a backup with smdba in folder "/smdba-backup-test"
-    Then I should see error message that asks "/smdba-backup-test" belong to the same UID/GID as "/var/lib/pgsql/data" directory
-    And I remove backup directory "/smdba-backup-test"
-    When I create backup directory "/smdba-backup-test" with UID "postgres" and GID "postgres"
-    And I take a backup with smdba in folder "/smdba-backup-test"
-    Then I should see error message that asks "/smdba-backup-test" has same permissions as "/var/lib/pgsql/data" directory
-    And I remove backup directory "/smdba-backup-test"
+    And there is no such "/var/spacewalk/db-backup" directory
+    When I create backup directory "/var/spacewalk/db-backup" with UID "root" and GID "root"
+    And I take a backup with smdba in folder "/var/spacewalk/db-backup"
+    Then I should see error message that asks "/var/spacewalk/db-backup" belong to the same UID/GID as "/var/lib/pgsql/data" directory
+    And I remove backup directory "/var/spacewalk/db-backup"
+    When I create backup directory "/var/spacewalk/db-backup" with UID "postgres" and GID "postgres"
+    And I take a backup with smdba in folder "/var/spacewalk/db-backup"
+    Then I should see error message that asks "/var/spacewalk/db-backup" has same permissions as "/var/lib/pgsql/data" directory
+    And I remove backup directory "/var/spacewalk/db-backup"
 
   Scenario: Take backup with SMDBA
     Given a postgresql database is running
-    And there is no such "/smdba-backup-test" directory
-    When I create backup directory "/smdba-backup-test" with UID "postgres" and GID "postgres"
-    And I change Access Control List on "/smdba-backup-test" directory to "0700"
-    And I take a backup with smdba in folder "/smdba-backup-test"
+    And there is no such "/var/spacewalk/db-backup" directory
+    When I create backup directory "/var/spacewalk/db-backup" with UID "postgres" and GID "postgres"
+    And I change Access Control List on "/var/spacewalk/db-backup" directory to "0700"
+    And I take a backup with smdba in folder "/var/spacewalk/db-backup"
     Then base backup is taken
-    And in "/smdba-backup-test" directory there is "base.tar.gz" file and at least one backup checkpoint file
+    And in "/var/spacewalk/db-backup" directory there is "base.tar.gz" file and at least one backup checkpoint file
     And parameter "archive_command" in the configuration file "/var/lib/pgsql/data/postgresql.conf" is "/usr/bin/smdba-pgarchive"
-    And "/usr/bin/smdba-pgarchive" destination should be set to "/smdba-backup-test" in configuration file
+    And "/usr/bin/smdba-pgarchive" destination should be set to "/var/spacewalk/db-backup" in configuration file
 
   Scenario: Restore backup with SMDBA
     Given a postgresql database is running
@@ -93,8 +93,8 @@ Feature: SMDBA database helper tool
   Scenario: Cleanup: remove backup directory
     Given a postgresql database is running
     And database "susemanager" has no table "dummy"
-    When I disable backup in the directory "/smdba-backup-test"
-    And I remove backup directory "/smdba-backup-test"
+    When I disable backup in the directory "/var/spacewalk/db-backup"
+    And I remove backup directory "/var/spacewalk/db-backup"
 
   Scenario: Cleanup: start spacewalk services
     When I stop the database with the command "smdba db-stop"


### PR DESCRIPTION
## What does this PR change?

Avoid using `/smdba-backup-test` in the root filesystem, not in a container volume. SELinux does not like that.

Use instead `/var/spacewalk/db-backup`, like in our documentation.


## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1223142
Port(s):
 * 5.0: https://github.com/SUSE/spacewalk/pull/26329
 * 4.3: none, containerized server only


## Changelogs

- [x] No changelog needed
