### PR TITLE
HubController tests and new APIs to list organizations and channels on the peripheral server

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1220,6 +1220,15 @@ public class ChannelFactory extends HibernateFactory {
     }
 
     /**
+     * List all channels
+     *
+     * @return list of all channels
+     */
+    public static List<Channel> listAllChannels() {
+        return getSession().createQuery("FROM Channel c", Channel.class).getResultList();
+    }
+
+    /**
      * List all vendor channels (org is null)
      * @return list of vendor channels
      */

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -15,10 +15,13 @@ import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.credentials.HubSCCCredentials;
 import com.redhat.rhn.domain.credentials.ReportDBCredentials;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MgrServerInfo;
@@ -576,5 +579,27 @@ public class HubManager {
         // It will be called inside the method setBaseEntitlement. If we remove this line we need to manually call it
         systemEntitlementManagerIn.setBaseEntitlement(server, EntitlementManager.FOREIGN);
         return server;
+    }
+
+    /**
+     * Collect data about all organizations
+     *
+     * @param accessToken the accesstoken
+     * @return return list of {@link Org}
+     */
+    public List<Org> collectAllOrgs(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+        return OrgFactory.lookupAllOrgs();
+    }
+
+    /**
+     * Collect data about all channels
+     *
+     * @param accessToken the accesstoken
+     * @return return list of {@link Channel}
+     */
+    public List<Channel> collectAllChannels(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+        return ChannelFactory.listAllChannels();
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.hub.test;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.testing.RhnMockHttpServletResponse;
+import com.redhat.rhn.testing.SparkTestUtils;
+
+import com.suse.manager.model.hub.HubFactory;
+import com.suse.manager.model.hub.IssHub;
+import com.suse.manager.model.hub.IssPeripheral;
+import com.suse.manager.model.hub.IssRole;
+import com.suse.manager.model.hub.TokenType;
+import com.suse.manager.webui.utils.token.IssTokenBuilder;
+import com.suse.manager.webui.utils.token.Token;
+import com.suse.manager.webui.utils.token.TokenBuildingException;
+import com.suse.manager.webui.utils.token.TokenParsingException;
+import com.suse.utils.Json;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import spark.Request;
+import spark.RequestResponseFactory;
+import spark.Response;
+import spark.RouteImpl;
+import spark.route.HttpMethod;
+import spark.routematch.RouteMatch;
+
+public class ControllerTestUtils {
+
+    private String apiEndpoint;
+    private HttpMethod httpMethod;
+    private String serverFqdn;
+    private String authBearerToken;
+    private Instant authBearerTokenExpiration;
+    private IssRole role;
+    private boolean addBearerTokenToHeaders;
+    private Map<String, String> bodyMap;
+
+    public ControllerTestUtils() {
+        apiEndpoint = null;
+        httpMethod = null;
+        serverFqdn = null;
+        authBearerToken = null;
+        authBearerTokenExpiration = null;
+        role = null;
+        addBearerTokenToHeaders = false;
+        bodyMap = null;
+    }
+
+    public ControllerTestUtils withServerFqdn(String serverFqdnIn)
+            throws TokenBuildingException, TokenParsingException {
+        serverFqdn = serverFqdnIn;
+        Token dummyServerToken = new IssTokenBuilder(serverFqdn).usingServerSecret().build();
+        authBearerToken = dummyServerToken.getSerializedForm();
+        authBearerTokenExpiration = dummyServerToken.getExpirationTime();
+        return this;
+    }
+
+    public ControllerTestUtils withApiEndpoint(String apiEndpointIn) {
+        apiEndpoint = apiEndpointIn;
+        return this;
+    }
+
+    public ControllerTestUtils withHttpMethod(HttpMethod httpMethodIn) {
+        httpMethod = httpMethodIn;
+        return this;
+    }
+
+    public ControllerTestUtils withRole(IssRole roleIn) {
+        role = roleIn;
+        return this;
+    }
+
+    public ControllerTestUtils withBearerTokenInHeaders() {
+        addBearerTokenToHeaders = true;
+        return this;
+    }
+
+    public ControllerTestUtils withBody(Map<String, String> bodyMapIn) {
+        bodyMap = bodyMapIn;
+        return this;
+    }
+
+    public Object simulateControllerApiCall() throws Exception {
+        HubFactory hubFactory = new HubFactory();
+        hubFactory.saveToken(serverFqdn, authBearerToken, TokenType.ISSUED, authBearerTokenExpiration);
+        if (null != role) {
+            switch (role) {
+                case HUB:
+                    hubFactory.save(new IssHub(serverFqdn, ""));
+                    break;
+                case PERIPHERAL:
+                    hubFactory.save(new IssPeripheral(serverFqdn, ""));
+                    break;
+                default:
+                    throw new IllegalArgumentException("unsupported role " + role.getLabel());
+            }
+        }
+
+        String bodyString = (null == bodyMap) ? null : Json.GSON.toJson(bodyMap, Map.class);
+
+        return simulateApiEndpointCall(apiEndpoint, httpMethod,
+                addBearerTokenToHeaders ? authBearerToken : null, bodyString);
+    }
+
+    public static Object simulateApiEndpointCall(String apiEndpoint, HttpMethod httpMethod,
+                                                 String authBearerToken, String body)
+            throws Exception {
+        Optional<RouteMatch> routeMatch = spark.Spark.routes()
+                .stream()
+                .filter(e -> apiEndpoint.equals(e.getMatchUri()))
+                .filter(e -> httpMethod.equals(e.getHttpMethod()))
+                .findAny();
+
+        if (routeMatch.isEmpty()) {
+            throw new IllegalStateException("route not found for " + apiEndpoint);
+        }
+
+        RouteImpl routeImpl = (RouteImpl) routeMatch.get().getTarget();
+
+        Map<String, String> httpHeaders = (null == authBearerToken) ?
+                new HashMap<>() :
+                Map.of("Authorization", "Bearer " + authBearerToken);
+
+        Request dummyTestRequest = (null == body) ?
+                SparkTestUtils.createMockRequestWithParams(apiEndpoint, new HashMap<>(), httpHeaders) :
+                SparkTestUtils.createMockRequestWithBody(apiEndpoint, httpHeaders, body);
+
+        Response dummyTestResponse = RequestResponseFactory.create(new RhnMockHttpServletResponse());
+        Object returnObject = routeImpl.handle(dummyTestRequest, dummyTestResponse);
+        HibernateFactory.rollbackTransaction();
+        return returnObject;
+    }
+}

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.hub.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.ConnectionManager;
+import com.redhat.rhn.common.hibernate.ConnectionManagerFactory;
+import com.redhat.rhn.common.hibernate.ReportDbHibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.taskomatic.task.ReportDBHelper;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.hub.HubController;
+import com.suse.manager.model.hub.ChannelInfoJson;
+import com.suse.manager.model.hub.IssRole;
+import com.suse.manager.model.hub.ManagerInfoJson;
+import com.suse.manager.model.hub.OrgInfoJson;
+import com.suse.manager.webui.utils.gson.ResultJson;
+import com.suse.manager.webui.utils.token.IssTokenBuilder;
+import com.suse.manager.webui.utils.token.Token;
+import com.suse.utils.Json;
+
+import com.google.gson.JsonObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.servlet.http.HttpServletResponse;
+
+import spark.route.HttpMethod;
+
+public class HubControllerTest extends JMockBaseTestCaseWithUser {
+
+    private static final String DUMMY_SERVER_FQDN = "dummy-server.unit-test.local";
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        HubController dummyHubController = new HubController();
+        dummyHubController.initRoutes();
+    }
+
+    private String createTestUserName() {
+        return "testUser" + TestUtils.randomString();
+    }
+
+    private String createTestPassword() {
+        return "testPassword" + TestUtils.randomString();
+    }
+
+    private void createReportDbUser(String testReportDbUserName, String testReportDbPassword) {
+        String dbname = Config.get().getString(ConfigDefaults.REPORT_DB_NAME, "");
+        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+
+        dbHelper.createDBUser(localRh.getSession(), dbname, testReportDbUserName, testReportDbPassword);
+        localRcm.commitTransaction();
+    }
+
+    private boolean existsReportDbUser(String testReportDbUserName) {
+        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+
+        return dbHelper.hasDBUser(localRh.getSession(), testReportDbUserName);
+    }
+
+    private void cleanupReportDbUser(String testReportDbUserName) {
+        ConnectionManager localRcm = ConnectionManagerFactory.localReportingConnectionManager();
+        ReportDbHibernateFactory localRh = new ReportDbHibernateFactory(localRcm);
+        ReportDBHelper dbHelper = ReportDBHelper.INSTANCE;
+
+        dbHelper.dropDBUser(localRh.getSession(), testReportDbUserName);
+        localRcm.commitTransaction();
+    }
+
+    private static Stream<Arguments> allApiEndpoints() {
+        return Stream.of(Arguments.of(HttpMethod.post, "/hub/ping", null),
+                Arguments.of(HttpMethod.post, "/hub/sync/registerHub", null),
+                Arguments.of(HttpMethod.post, "/hub/sync/storeCredentials", IssRole.HUB),
+                Arguments.of(HttpMethod.get, "/hub/managerinfo", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/storeReportDbCredentials", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/removeReportDbCredentials", IssRole.HUB),
+                Arguments.of(HttpMethod.get, "/hub/listAllPeripheralOrgs", IssRole.PERIPHERAL),
+                Arguments.of(HttpMethod.get, "/hub/listAllPeripheralChannels", IssRole.PERIPHERAL)
+        );
+    }
+
+    private static Stream<Arguments> onlyGetApis() {
+        return allApiEndpoints().filter(e -> (HttpMethod.get == e.get()[0]));
+    }
+
+    private static Stream<Arguments> onlyPostApis() {
+        return allApiEndpoints().filter(e -> (HttpMethod.post == e.get()[0]));
+    }
+
+    private static Stream<Arguments> onlyHubApis() {
+        return allApiEndpoints().filter(e -> (IssRole.HUB == e.get()[2]));
+    }
+
+    private static Stream<Arguments> onlyPeripheralApis() {
+        return allApiEndpoints().filter(e -> (IssRole.PERIPHERAL == e.get()[2]));
+    }
+
+    @ParameterizedTest
+    @MethodSource("onlyGetApis")
+    public void ensureGetApisNotWorkingWithPost(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole) {
+        ControllerTestUtils utils = new ControllerTestUtils();
+
+        assertThrows(IllegalStateException.class, () ->
+                        utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                                .withApiEndpoint(apiEndpoint)
+                                .withHttpMethod(HttpMethod.post)
+                                .withRole(apiRole)
+                                .withBearerTokenInHeaders()
+                                .simulateControllerApiCall(),
+                apiEndpoint + " get API not failing when called with post method");
+    }
+
+    @ParameterizedTest
+    @MethodSource("onlyPostApis")
+    public void ensurePostApisNotWorkingWithGet(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole) {
+        ControllerTestUtils utils = new ControllerTestUtils();
+
+        assertThrows(IllegalStateException.class, () ->
+                        utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                                .withApiEndpoint(apiEndpoint)
+                                .withHttpMethod(HttpMethod.get)
+                                .withRole(apiRole)
+                                .withBearerTokenInHeaders()
+                                .simulateControllerApiCall(),
+                apiEndpoint + " post API not failing when called with get method");
+    }
+
+    @ParameterizedTest
+    @MethodSource("onlyHubApis")
+    public void ensureHubApisNotWorkingWithPeripheral(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole)
+            throws Exception {
+        ControllerTestUtils utils = new ControllerTestUtils();
+
+        String answerKO = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiEndpoint)
+                .withHttpMethod(apiMethod)
+                .withRole(IssRole.PERIPHERAL)
+                .withBearerTokenInHeaders()
+                .simulateControllerApiCall();
+
+        ResultJson<?> resultKO = Json.GSON.fromJson(answerKO, ResultJson.class);
+        assertFalse(resultKO.isSuccess(), apiEndpoint + " hub API not failing with peripheral server");
+        assertEquals("Token does not allow access to this resource", resultKO.getMessages().get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("onlyPeripheralApis")
+    public void ensurePeripheralApisNotWorkingWithHub(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole)
+            throws Exception {
+        ControllerTestUtils utils = new ControllerTestUtils();
+
+        String answerKO = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiEndpoint)
+                .withHttpMethod(apiMethod)
+                .withRole(IssRole.HUB)
+                .withBearerTokenInHeaders()
+                .simulateControllerApiCall();
+
+        ResultJson<?> resultKO = Json.GSON.fromJson(answerKO, ResultJson.class);
+        assertFalse(resultKO.isSuccess(), apiEndpoint + " peripheral API not failing with hub server");
+        assertEquals("Token does not allow access to this resource", resultKO.getMessages().get(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("allApiEndpoints")
+    public void ensureNotWorkingWithoutToken(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole)
+            throws Exception {
+        ControllerTestUtils utils = new ControllerTestUtils();
+
+        try {
+            utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                    .withApiEndpoint(apiEndpoint)
+                    .withHttpMethod(apiMethod)
+                    .withRole(apiRole)
+                    .simulateControllerApiCall();
+
+            Assertions.fail(apiEndpoint + " API call should have failed without token");
+        }
+        catch (spark.HaltException ex) {
+            assertEquals(HttpServletResponse.SC_BAD_REQUEST, ex.statusCode());
+        }
+    }
+
+    @Test
+    public void checkPingApiEndpoint() throws Exception {
+        String apiUnderTest = "/hub/ping";
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withBearerTokenInHeaders()
+                .simulateControllerApiCall();
+        JsonObject jsonObj = Json.GSON.fromJson(answer, JsonObject.class);
+
+        assertTrue(jsonObj.get("message").getAsString().startsWith("Pinged from"), "Unexpected ping message");
+    }
+
+    @Test
+    public void checkRegisterHubApiEndpoint() throws Exception {
+        String apiUnderTest = "/hub/sync/registerHub";
+
+        Token dummyToken = new IssTokenBuilder(ConfigDefaults.get().getHostname()).usingServerSecret().build();
+        Map<String, String> bodyMap = new HashMap<>();
+        bodyMap.put("rootCA", "----- BEGIN TEST ROOTCA ----");
+        bodyMap.put("token", dummyToken.getSerializedForm());
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(ConfigDefaults.get().getHostname())
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withBearerTokenInHeaders()
+                .withBody(bodyMap)
+                .simulateControllerApiCall();
+        JsonObject jsonObj = Json.GSON.fromJson(answer, JsonObject.class);
+
+        //taskomatic is not running!
+        assertFalse(jsonObj.get("success").getAsBoolean());
+        assertEquals("Unable to schedule root CA certificate update",
+                jsonObj.get("messages").getAsJsonArray().get(0).getAsString(), "Unexpected error message");
+    }
+
+    @Test
+    public void checkStoreCredentialsApiEndpoint() throws Exception {
+        String apiUnderTest = "/hub/sync/storeCredentials";
+
+        String testUserName = createTestUserName();
+        String testPassword = createTestPassword();
+        Map<String, String> bodyMap = new HashMap<>();
+        bodyMap.put("username", testUserName);
+        bodyMap.put("password", testPassword);
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(ConfigDefaults.get().getHostname())
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withRole(IssRole.HUB)
+                .withBearerTokenInHeaders()
+                .withBody(bodyMap)
+                .simulateControllerApiCall();
+        JsonObject jsonObj = Json.GSON.fromJson(answer, JsonObject.class);
+
+        assertTrue(jsonObj.get("success").getAsBoolean(), apiUnderTest + " API call is failing");
+    }
+
+    @Test
+    public void checkManagerinfoApiEndpoint() throws Exception {
+        String apiUnderTest = "/hub/managerinfo";
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.get)
+                .withRole(IssRole.HUB)
+                .withBearerTokenInHeaders()
+                .simulateControllerApiCall();
+        ManagerInfoJson mgrInfo = Json.GSON.fromJson(answer, ManagerInfoJson.class);
+
+        assertFalse(mgrInfo.getVersion().isBlank(), "ManagerInfo version is blank");
+        assertTrue(mgrInfo.hasReportDb(), "ManagerInfo has missing report db");
+        assertFalse(mgrInfo.getReportDbName().isBlank(), "ManagerInfo database name is blank");
+        assertFalse(mgrInfo.getReportDbHost().isBlank(), "ManagerInfo database host is blank");
+        assertEquals(5432, mgrInfo.getReportDbPort(), "ManagerInfo database port is not 5432");
+    }
+
+    @Test
+    public void checkStoreReportDbCredentialsApiEndpoint() throws Exception {
+        String apiUnderTest = "/hub/storeReportDbCredentials";
+
+        String testReportDbUserName = createTestUserName();
+        String testReportDbPassword = createTestPassword();
+        Map<String, String> bodyMap = new HashMap<>();
+        bodyMap.put("username", testReportDbUserName);
+        bodyMap.put("password", testReportDbPassword);
+
+        //check there is no user with that username
+        assertFalse(existsReportDbUser(testReportDbUserName));
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withRole(IssRole.HUB)
+                .withBearerTokenInHeaders()
+                .withBody(bodyMap)
+                .simulateControllerApiCall();
+        JsonObject jsonObj = Json.GSON.fromJson(answer, JsonObject.class);
+
+        assertTrue(jsonObj.get("success").getAsBoolean(), apiUnderTest + " API call is failing");
+
+        //check there is one user with that username
+        assertTrue(existsReportDbUser(testReportDbUserName),
+                apiUnderTest + " API reports no user " + testReportDbUserName);
+
+        //cleanup
+        cleanupReportDbUser(testReportDbUserName);
+        assertFalse(existsReportDbUser(testReportDbUserName),
+                "cleanup of user not working for user " + testReportDbUserName);
+    }
+
+    @Test
+    public void checkRemoveReportDbCredentialsApiEndpoint() throws Exception {
+        String apiUnderTest = "/hub/removeReportDbCredentials";
+
+        String testReportDbUserName = createTestUserName();
+        String testReportDbPassword = "testPassword" + TestUtils.randomString();
+        Map<String, String> bodyMap = new HashMap<>();
+        bodyMap.put("username", testReportDbUserName);
+
+        //create a user
+        createReportDbUser(testReportDbUserName, testReportDbPassword);
+        assertTrue(existsReportDbUser(testReportDbUserName),
+                "failed creation of user " + testReportDbUserName);
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withRole(IssRole.HUB)
+                .withBearerTokenInHeaders()
+                .withBody(bodyMap)
+                .simulateControllerApiCall();
+        JsonObject jsonObj = Json.GSON.fromJson(answer, JsonObject.class);
+
+        assertTrue(jsonObj.get("success").getAsBoolean(), apiUnderTest + " API call is failing");
+        //check the user is gone
+        assertFalse(existsReportDbUser(testReportDbUserName),
+                apiUnderTest + " API call fails to remove user " + testReportDbUserName);
+    }
+
+    @Test
+    public void checkApiListAllPeripheralOrgs() throws Exception {
+        String apiUnderTest = "/hub/listAllPeripheralOrgs";
+
+        Org org1 = UserTestUtils.findNewOrg("org1");
+        Org org2 = UserTestUtils.findNewOrg("org2");
+        Org org3 = UserTestUtils.findNewOrg("org3");
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.get)
+                .withRole(IssRole.PERIPHERAL)
+                .withBearerTokenInHeaders()
+                .simulateControllerApiCall();
+        List<OrgInfoJson> allOrgs = Arrays.asList(Json.GSON.fromJson(answer, OrgInfoJson[].class));
+
+        assertTrue(allOrgs.size() >= 3, "All 3 test test orgs are not listed");
+        assertTrue(allOrgs.stream()
+                        .anyMatch(e -> (e.getOrgId() == org1.getId()) && (e.getOrgName().startsWith("org1"))),
+                apiUnderTest + " API call not listing test organization [org1]");
+        assertTrue(allOrgs.stream()
+                        .anyMatch(e -> (e.getOrgId() == org2.getId()) && (e.getOrgName().startsWith("org2"))),
+                apiUnderTest + " API call not listing test organization [org2]");
+        assertTrue(allOrgs.stream()
+                        .anyMatch(e -> (e.getOrgId() == org3.getId()) && (e.getOrgName().startsWith("org3"))),
+                apiUnderTest + " API call not listing test organization [org3]");
+    }
+
+    @Test
+    public void checkApilistAllPeripheralChannels() throws Exception {
+        String apiUnderTest = "/hub/listAllPeripheralChannels";
+
+        user.addPermanentRole(RoleFactory.CHANNEL_ADMIN);
+        Channel testBaseChannel = ChannelTestUtils.createBaseChannel(user);
+        Channel testChildChannel = ChannelTestUtils.createChildChannel(user, testBaseChannel);
+
+        ControllerTestUtils utils = new ControllerTestUtils();
+        String answer = (String) utils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.get)
+                .withRole(IssRole.PERIPHERAL)
+                .withBearerTokenInHeaders()
+                .simulateControllerApiCall();
+        List<ChannelInfoJson> allChannels = Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
+
+        Optional<ChannelInfoJson> testBaseChannelInfo = allChannels.stream()
+                .filter(e -> e.getName().equals(testBaseChannel.getName()))
+                .findAny();
+        assertTrue(testBaseChannelInfo.isPresent(),
+                apiUnderTest + " API call not listing channel " + testBaseChannel);
+        assertEquals(testBaseChannel.getName(), testBaseChannelInfo.get().getName());
+        assertEquals(testBaseChannel.getLabel(), testBaseChannelInfo.get().getLabel());
+        assertEquals(user.getOrg().getId(), testBaseChannelInfo.get().getOrgId());
+        assertNull(testBaseChannelInfo.get().getParentChannelId());
+
+        Optional<ChannelInfoJson> testChildChannelInfo = allChannels.stream()
+                .filter(e -> e.getName().equals(testChildChannel.getName()))
+                .findAny();
+        assertTrue(testChildChannelInfo.isPresent(),
+                apiUnderTest + " API call not listing channel " + testChildChannel);
+        assertEquals(testChildChannel.getName(), testChildChannelInfo.get().getName());
+        assertEquals(testChildChannel.getLabel(), testChildChannelInfo.get().getLabel());
+        assertEquals(user.getOrg().getId(), testChildChannelInfo.get().getOrgId());
+        assertEquals(testBaseChannel.getId(), testChildChannelInfo.get().getParentChannelId());
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/ChannelInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/ChannelInfoJson.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub;
+
+public class ChannelInfoJson {
+
+    private final Long id;
+    private final String name;
+    private final String label;
+    private final String summary;
+    private final Long orgId;
+    private final Long parentChannelId;
+
+    /**
+     * Constructor
+     *
+     * @param idIn              the id of the channel, if present
+     * @param nameIn            the name of the channel
+     * @param labelIn           the label of the channel
+     * @param summaryIn         the summary of the channel
+     * @param orgIdIn           the organization id of the channel
+     * @param parentChannelIdIn the parent channel of the channel
+     */
+    public ChannelInfoJson(Long idIn, String nameIn, String labelIn, String summaryIn,
+                           Long orgIdIn, Long parentChannelIdIn) {
+        this.id = idIn;
+        this.name = nameIn;
+        this.label = labelIn;
+        this.summary = summaryIn;
+        this.orgId = orgIdIn;
+        this.parentChannelId = parentChannelIdIn;
+    }
+
+    /**
+     * @return the id of the channel
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @return the label of the channel
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * @return the name of the channel
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the summary of the channel
+     */
+    public String getSummary() {
+        return summary;
+    }
+
+    /**
+     * @return the organization id of the channel
+     */
+    public Long getOrgId() {
+        return orgId;
+    }
+
+    /**
+     * @return the parent channel of the channel
+     */
+    public Long getParentChannelId() {
+        return parentChannelId;
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/OrgInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/OrgInfoJson.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class OrgInfoJson {
+
+    private final Long orgId;
+
+    private final String orgName;
+
+    /**
+     * Constructor
+     *
+     * @param orgIdIn   the org id
+     * @param orgNameIn the org name
+     */
+    public OrgInfoJson(long orgIdIn, String orgNameIn) {
+        orgId = orgIdIn;
+        orgName = orgNameIn;
+    }
+
+    /**
+     * @return return the org id
+     */
+    public long getOrgId() {
+        return orgId;
+    }
+
+    /**
+     * @return return the org name
+     */
+    public String getOrgName() {
+        return orgName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof OrgInfoJson that)) {
+            return false;
+        }
+        return Objects.equals(orgId, that.orgId) &&
+                Objects.equals(orgName, that.orgName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(orgId, orgName);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", OrgInfoJson.class.getSimpleName() + "[", "]")
+                .add("orgId='" + getOrgId() + "'")
+                .add("orgName='" + getOrgName() + "'")
+                .toString();
+    }
+}


### PR DESCRIPTION
## What does this PR change?
The aim is to test a HubController API call without actually setting up a remote server and using tools like postman.
The idea is that unit tests can be done to test the behaviour and the returned values, while a single manual test can be done from the external (e.g. postman) to check that the API endpoint is really visible.

I tested all the old API endpoints with this testing method.

Also, I added two API endpoints to list all organizations and all the channels in the peripheral server.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/25353
Port(s): 
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

