### PR TITLE
Enable packages metadata to be float when int is expected (gh#uyuni-project/uyuni#9613)

### DIFF
--- a/python/spacewalk/server/importlib/backend.py
+++ b/python/spacewalk/server/importlib/backend.py
@@ -3360,16 +3360,21 @@ def _buildDatabaseValue(row, fieldsHash):
 def _buildExternalValue(dict, entry, tableObj):
     # updates dict with values from entry
     # entry is a hash-like object (non-db)
-    for f, datatype in list(tableObj.getFields().items()):
-        if f in dict:
+    for field, datatype in list(tableObj.getFields().items()):
+        if field in dict:
             # initialized somewhere else
             continue
         # Get the attribute's name
-        attr = tableObj.getObjectAttribute(f)
+        attr = tableObj.getObjectAttribute(field)
         # Sanitize the value according to its datatype
         if attr not in entry:
             entry[attr] = None
-        dict[f] = sanitizeValue(entry[attr], datatype)
+        try:
+            dict[field] = sanitizeValue(entry[attr], datatype)
+        except ValueError as e:
+            raise ValueError(
+                f"Cannot sanitize value from {field}={entry[attr]} to {type(datatype)}"
+            ) from e
 
 
 # pylint: disable-next=invalid-name

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.round-int-values
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.round-int-values
@@ -1,0 +1,1 @@
+- Cast float pkg metadata to int (gh#uyuni-project/uyuni#9613)


### PR DESCRIPTION
## What does this PR change?

When we process package metadata, packages can mistakenly have float where we expect integer, for example `Installed Size`, `Size`, etc.

Though this is technically an invalid package, Uyuni can round such values to integer instead of throwing an exception.

In this PR, if a package contains a float value in metadata where we expect integer, we first round the value to the nearest integer.

In case where such value is neither float nor int, I improve the error that is displayed to the user.


## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9613
Port(s): TODO

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
