### PR TITLE
Fix permissions of files contained in root.tar.gz

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -9,6 +9,8 @@ ARG PRODUCT_PATTERN_PREFIX="patterns-uyuni"
 # Extra packages can be added via project configuration
 ARG EXTRAPACKAGES
 
+ADD --chown=root:root root.tar.gz /
+
 # Main packages
 RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
     zypper ref && zypper --non-interactive up && \
@@ -69,8 +71,6 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         sssd-tools && \
     systemctl enable prometheus-node_exporter && \
     systemctl enable sssd
-
-ADD root.tar.gz /
 
 # Initialize environments to sync configuration and package files to persistent volumes
 RUN systemctl enable timezone_alignment && \

--- a/rel-eng/custom/custom.py
+++ b/rel-eng/custom/custom.py
@@ -12,6 +12,7 @@ Code for building packages in SUSE that need generated code not tracked in git.
 import os
 import shutil
 import tarfile
+import subprocess
 
 from tito.builder import Builder
 from tito.common import  run_command, debug, info_out
@@ -141,11 +142,7 @@ def tar(src, dest):
     Create a dest tar.gz file from the files in the src folder.
     '''
     debug(f"Compressing {src} into {dest}")
-    with tarfile.open(dest, "w:gz") as tarball:
-        for name in os.listdir(src):
-            tarball.add(os.path.join(src, name), name)
-
-
+    subprocess.run(["tar", "cf", dest, "--gzip", "--owner", "root", "--group", "root", "--directory", src, "."], check=True)
 
 
 class ChartBuilder(ContainerBuilder):


### PR DESCRIPTION
## What does this PR change?

This is done in two steps:

  1. Unpack the tarball before installing the packages. This allows permissions defined the packages to take precedence.

  2. Change the push code to set all root.tar.gz archive as owned by root user and group. If any change is needed it can be done in the Dockerfile.

set all files in container's root.tar.gz as root

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
