### PR TITLE
QE: Remove steps of not anymore sync channels on CI

### DIFF
--- a/testsuite/features/init_clients/proxy_traditional.feature
+++ b/testsuite/features/init_clients/proxy_traditional.feature
@@ -73,11 +73,6 @@ Feature: Setup Uyuni proxy
     And I wait until I do not see "Loading..." text
     And I check radio button "openSUSE Leap 15.5 (x86_64)"
     And I wait until I do not see "Loading..." text
-    And I check "openSUSE 15.5 non oss (x86_64)"
-    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.5 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -226,11 +226,6 @@ Feature: Channel subscription via SSM
     And I wait until I do not see "Loading..." text
     And I check radio button "openSUSE Leap 15.5 (x86_64)"
     And I wait until I do not see "Loading..." text
-    And I check "openSUSE 15.5 non oss (x86_64)"
-    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.5 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -44,7 +44,6 @@ Feature: Channel subscription with recommended or required dependencies
     And I wait for child channels to appear
     And I check radio button "openSUSE Leap 15.5 (x86_64)"
     Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" "unselected" and "disabled"
-    Then I should see the child channel "openSUSE 15.5 non oss (x86_64)" "selected"
     When I select the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)"
     Then I should see the child channel "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)" "selected"
 
@@ -82,8 +81,6 @@ Feature: Channel subscription with recommended or required dependencies
     When I select "No Change" from drop-down in table line with "openSUSE Leap 15.5 (x86_64)"
     And I click on "Next"
     Then I should see the toggler "disabled"
-    And I should see a "openSUSE 15.5 non oss (x86_64)" text
-    And I should see "No change" "selected" for the "openSUSE 15.5 non oss (x86_64)" channel
 
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
     When I click on the clear SSM button

--- a/testsuite/features/secondary/min_bootstrap_activation_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_activation_key.feature
@@ -71,11 +71,6 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I enter "20" as "usageLimit"
     And I select "openSUSE Leap 15.5 (x86_64)" from "selectedBaseChannel"
     And I wait for child channels to appear
-    And I check "openSUSE 15.5 non oss (x86_64)"
-    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.5 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Create Activation Key"

--- a/testsuite/features/secondary/min_bootstrap_api.feature
+++ b/testsuite/features/secondary/min_bootstrap_api.feature
@@ -72,11 +72,6 @@ Feature: Register a Salt minion via API
     And I wait until I do not see "Loading..." text
     And I check radio button "openSUSE Leap 15.5 (x86_64)"
     And I wait until I do not see "Loading..." text
-    And I check "openSUSE 15.5 non oss (x86_64)"
-    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.5 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -141,11 +141,6 @@ Feature: Assign child channel to a system
     Then radio button "openSUSE Leap 15.5 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
     And I wait until I see "openSUSE Leap 15.5 Updates (x86_64)" text
-    And I check "openSUSE 15.5 non oss (x86_64)"
-    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.5 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I uncheck "Uyuni Proxy Devel for openSUSE Leap 15.5 (x86_64) (Development)"

--- a/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
@@ -35,7 +35,6 @@ Feature: Repos file generation based on custom pillar data
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check radio button "openSUSE Leap 15.5 (x86_64)"
-    And I wait until I see "openSUSE 15.5 non oss (x86_64)" text
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
@@ -74,8 +73,6 @@ Feature: Repos file generation based on custom pillar data
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check radio button "openSUSE Leap 15.5 (x86_64)"
-    And I wait until I see "openSUSE 15.5 non oss (x86_64)" text
-    And I check "openSUSE 15.5 non oss (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
@@ -118,11 +115,6 @@ Feature: Repos file generation based on custom pillar data
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check radio button "openSUSE Leap 15.5 (x86_64)"
-    And I wait until I see "openSUSE 15.5 non oss (x86_64)" text
-    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.5 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"

--- a/testsuite/features/secondary/min_recurring_action.feature
+++ b/testsuite/features/secondary/min_recurring_action.feature
@@ -229,11 +229,6 @@ Feature: Recurring Actions
     And I wait until I do not see "Loading..." text
     And I check default base channel radio button of this "sle_minion"
     And I wait for child channels to appear
-    And I check "openSUSE 15.5 non oss (x86_64)"
-    And I check "openSUSE Leap 15.5 non oss Updates (x86_64)"
-    And I check "openSUSE Leap 15.5 Updates (x86_64)"
-    And I check "Update repository of openSUSE Leap 15.5 Backports (x86_64)"
-    And I check "Update repository with updates from SUSE Linux Enterprise 15 for openSUSE Leap 15.5 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"


### PR DESCRIPTION
## What does this PR change?

Following the PR https://github.com/uyuni-project/uyuni/pull/9670
This PR remove some steps in some scenarios that were wrong, because the channels are not anymore available.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were removed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
