### PR TITLE
Adjust grafana to 5.0.3 BV

### DIFF
--- a/testsuite/features/build_validation/init_clients/monitoring_server.feature
+++ b/testsuite/features/build_validation/init_clients/monitoring_server.feature
@@ -89,7 +89,6 @@ Feature: Bootstrap the monitoring server
   Scenario: Test Grafana dashboards of monitoring server
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
-    And I check radio button "View as list", if not checked
     # These are the 4 dashboards created by default when enabling the Grafana formula
     Then I should see a "Apache2" text
     And I should see a "PostgreSQL database insights" text
@@ -100,7 +99,6 @@ Feature: Bootstrap the monitoring server
   Scenario: Test Grafana dashboards of monitoring server
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
-    And I check radio button "View as list", if not checked
     # These are the 4 dashboards created by default when enabling the Grafana formula
     Then I should see a "Apache2" text
     And I should see a "PostgreSQL database insights" text

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -236,8 +236,6 @@ Feature: Smoke tests for <client>
   Scenario: The data from <client> appear on Grafana dashboard
     When I visit the grafana dashboards of this "monitoring_server"
     And I wait until I do not see "Loading Grafana" text
-    And I wait until I see "General" text
-    And I check radio button "View as list", if not checked
     When I follow "Client Systems"
     Then I should see "<client>" hostname
     When I enter "<client>" hostname on grafana's host field


### PR DESCRIPTION
## What does this PR change?

Smoke tests on the minion are now passing:

```
suma-bv-50-controller:~/spacewalk/testsuite # cucumber features/build_validation/smoke_tests/debian11_minion_smoke_tests.feature:236
Minion IP address or domain name variable empty
Buildhost IP address or domain name variable empty
Red Hat-like minion IP address or domain name variable empty
Debian-like minion IP address or domain name variable empty
SSH minion IP address or domain name variable empty
PXE boot MAC address variable empty
KVM server minion IP address or domain name variable empty
Using Ruby version: 3.3.7
Capybara APP Host: https://suma-bv-50-server.mgr.suse.de:8888
Initializing a remote node for 'server'.
Node: suma-bv-50-server, OS Version: 15-SP6, Family: sles
Activating XML-RPC API
Using the default profile...
# Copyright (c) 2020-2024 SUSE LLC.
# Licensed under the terms of the MIT license.
@debian11_minion
Feature: Smoke tests for debian11_minion
  In order to manage debian11_minion
  As an authorized user
  I want to :
  - View the details of the system
  - Install a package via Web UI
  - Install a patch via Web UI
  - Remove a package via Web UI
  - Execute a remote command via Web UI
  - Apply a configuration file via Web UI
  - Schedule Software package refresh
  - Schedule Hardware refresh
  - Reboot the client via Web UI
  - Install spacecmd from client tools
  - Enable Prometheus and Prometheus Exporter

  # The client tools of SLE Micro and SL Micro (intentionally) do not contain spacecmd
  # Configure Prometheus exporter formula
  # workaround for SLE Micro minion issue bsc#1209374
  @skip_for_sle_micro_ssh_minion @monitoring_server
  Scenario: The data from debian11_minion appear on Grafana dashboard # features/build_validation/smoke_tests/debian11_minion_smoke_tests.feature:236
      This scenario ran at: 2025-02-06 10:26:36 +0100
Initializing a remote node for 'monitoring_server'.
Node: suma-bv-50-monitoring, OS Version: 15-SP4, Family: sles
    When I visit the grafana dashboards of this "monitoring_server"   # features/step_definitions/navigation_steps.rb:1262
    And I wait until I do not see "Loading Grafana" text              # features/step_definitions/navigation_steps.rb:43
    #And I wait until I see "General" text
    #And I check radio button "View as list", if not checked
    When I follow "Client Systems"                                    # features/step_definitions/navigation_steps.rb:299
Initializing a remote node for 'debian11_minion'.
Node: suma-bv-50-debian11-minion, OS Version: 11, Family: debian
    Then I should see "debian11_minion" hostname                      # features/step_definitions/navigation_steps.rb:627
    When I enter "debian11_minion" hostname on grafana's host field   # features/step_definitions/navigation_steps.rb:1215
    And I wait until I do not see "No data" text                      # features/step_definitions/navigation_steps.rb:43
      This scenario took: 10 seconds

1 scenario (1 passed)
6 steps (6 passed)
0m9.885s
```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26344
Port(s):
  * 5.0: https://github.com/SUSE/spacewalk/pull/26357
  * 4.3: https://github.com/SUSE/spacewalk/pull/26358

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
