### PR TITLE
Remove unnecessary salt upgrade cleanup from highstate

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -24,13 +24,6 @@ mgr_salt_minion_inst:
     - require:
       - pkg: mgr_salt_minion_inst
 
-{%- if salt_minion_name == 'venv-salt-minion' %}
-rm_old_venv_python_env:
-  cmd.run:
-    - name: /usr/lib/venv-salt-minion/bin/post_start_cleanup.sh
-    - onlyif: test -f /usr/lib/venv-salt-minion/bin/post_start_cleanup.sh
-{%- endif %}
-
 mgr_salt_minion_run:
   service.running:
     - name: {{ salt_minion_name }}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.remove-unnecessary-state
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.remove-unnecessary-state
@@ -1,0 +1,1 @@
+- Remove unnecessary salt minion upgrade cleanup from highstate


### PR DESCRIPTION
## What does this PR change?

This PR removes the call to `post_start_cleanup.sh` in highstate. We now have a systemd timer mechanism that calls the script, so we don't have to rely on the script being executed from highstate.

## Links

Port(s): TODO

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
