### PR TITLE
QE: Reinforce and warn the check of a channel synchronization.

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -601,14 +601,16 @@ def channel_sync_completed?(channel_name)
     elsif line.include?('Channel: ') && !line.include?(channel_name)
       channel_found = false
     elsif line.include?('Sync of channel completed.') && channel_found
-      return true
+      return true if channel_is_synced?(channel_name)
+
+      log "WARN: Repository metadata for #{channel_name} seems not synchronized. Even if the reposync log says it is."
+      return false
     end
   end
 
   false
 end
 
-# TODO: This method is not used anywhere, consider removing it
 # Determines whether a channel is synchronized on the server.
 #
 # @param channel [String] The name of the channel to check.


### PR DESCRIPTION
## What does this PR change?

This PR reinforce how we check if a channel is fully synchronized.
In theory, if the reposync log file prints that a channel is synchronized and prints the total time, we can guess the channel is synchronized, but in practice that can be wrong.

With this reinforcement, we are not only checking the log file, but also assuring that the solv files are completed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
