### PR TITLE
Kiwi images salt refactoring

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -85,7 +85,6 @@
         <package name="kernel-default"/>
         <package name="python-base"/>
         <package name="rsync"/>
-	    <package name="salt-minion"/>
         <package name="venv-salt-minion"/>
         <package name="suse-build-key"/>
         <package name="pkg-config"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -55,6 +55,7 @@
         <package name="btrfsmaintenance"/>
         <package name="cron"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="grub2-branding-SLE" bootinclude="true"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -85,7 +85,8 @@
         <package name="kernel-default"/>
         <package name="python-base"/>
         <package name="rsync"/>
-	<package name="salt-minion"/>
+	    <package name="salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="suse-build-key"/>
         <package name="pkg-config"/>
         <package name="sg3_utils"/>
@@ -94,7 +95,6 @@
         <package name="dialog"/>
         <package name="grub2-snapper-plugin"/>
         <package name="snapper-zypp-plugin"/>
-
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -95,7 +95,6 @@
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
         <package name="kernel-default"/>
-        <package name="salt-minion"/>
         <package name="venv-salt-minion"/>
         <package name="hostname"/>
 	    <package name="dracut-saltboot"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -98,7 +98,7 @@
         <package name="kernel-default"/>
         <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -68,6 +68,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -94,12 +94,11 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+        <package name="salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -65,6 +65,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -93,9 +93,9 @@
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
         <package name="kernel-default"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -91,12 +91,10 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -55,6 +55,7 @@
         <package name="btrfsmaintenance"/>
         <package name="cron"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="grub2-branding-SLE" bootinclude="true"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -85,7 +85,7 @@
         <package name="kernel-default"/>
         <package name="python-base"/>
         <package name="rsync"/>
-	<package name="salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="suse-build-key"/>
         <package name="pkg-config"/>
         <package name="sg3_utils"/>
@@ -94,7 +94,6 @@
         <package name="dialog"/>
         <package name="grub2-snapper-plugin"/>
         <package name="snapper-zypp-plugin"/>
-
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -94,12 +94,10 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -98,7 +98,7 @@
         <package name="kernel-default"/>
         <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -68,6 +68,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -65,6 +65,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -93,9 +93,9 @@
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
         <package name="kernel-default"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -91,12 +91,10 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -85,7 +85,7 @@
         <package name="kernel-default"/>
         <package name="python-base"/>
         <package name="rsync"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="suse-build-key"/>
         <package name="pkg-config"/>
         <package name="sg3_utils"/>
@@ -94,7 +94,6 @@
         <package name="dialog"/>
         <package name="grub2-snapper-plugin"/>
         <package name="snapper-zypp-plugin"/>
-
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -55,6 +55,7 @@
         <package name="btrfsmaintenance"/>
         <package name="cron"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="grub2-branding-SLE" bootinclude="true"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -85,7 +85,7 @@
         <package name="kernel-default"/>
         <package name="python-base"/>
         <package name="rsync"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="suse-build-key"/>
         <package name="pkg-config"/>
         <package name="sg3_utils"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -95,7 +95,7 @@
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
         <package name="kernel-default"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
 	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -94,12 +94,10 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -98,7 +98,7 @@
         <package name="kernel-default"/>
         <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -68,6 +68,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -65,6 +65,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -93,9 +93,9 @@
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
         <package name="kernel-default"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -91,12 +91,10 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -85,7 +85,7 @@
         <package name="kernel-default"/>
         <package name="python-base"/>
         <package name="rsync"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="suse-build-key"/>
         <package name="pkg-config"/>
         <package name="sg3_utils"/>
@@ -94,7 +94,6 @@
         <package name="dialog"/>
         <package name="grub2-snapper-plugin"/>
         <package name="snapper-zypp-plugin"/>
-
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -55,6 +55,7 @@
         <package name="btrfsmaintenance"/>
         <package name="cron"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="grub2-branding-SLE" bootinclude="true"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -85,7 +85,7 @@
         <package name="kernel-default"/>
         <package name="python-base"/>
         <package name="rsync"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="suse-build-key"/>
         <package name="pkg-config"/>
         <package name="sg3_utils"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -95,7 +95,7 @@
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
         <package name="kernel-default"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
 	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -94,12 +94,10 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -98,7 +98,7 @@
         <package name="kernel-default"/>
         <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -68,6 +68,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -65,6 +65,7 @@
         <package name="acl"/>
         <package name="chrony"/>
         <package name="curl"/>
+        <package name="procps"/>
         <package name="dracut"/>
         <package name="fipscheck"/>
         <package name="group(mail)"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -93,9 +93,9 @@
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
         <package name="kernel-default"/>
-	    <package name="venv-salt-minion"/>
+        <package name="venv-salt-minion"/>
         <package name="hostname"/>
-	    <package name="dracut-saltboot"/>
+        <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -91,12 +91,10 @@
         <package name="openssh"/>
         <package name="rsync"/>
         <package name="plymouth-plugin-label-ft"/>
-
         <package name="kernel-default"/>
-	<package name="salt-minion"/>
+	    <package name="venv-salt-minion"/>
         <package name="hostname"/>
-
-	<package name="dracut-saltboot"/>
+	    <package name="dracut-saltboot"/>
         <package name="mdadm"/>
         <package name="cryptsetup"/>
         <package name="kernel-firmware"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -22,7 +22,7 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable salt-minion.service
+systemctl enable venv-salt-minion.service
 
 # notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo


### PR DESCRIPTION
## What does this PR change?

After PXE booting and downloading the image, the terminal displays "Salt did not start", waits for 10 seconds, and reboots.
The terminal finds itself in an endless cycle of reboots on the https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature

Switching to salt bundle solves this problem and the image is getting downloaded:

![Screenshot from 2025-02-10 19-13-22](https://github.com/user-attachments/assets/543b3cc0-2aa4-4265-869e-a43cdea10dcb)

`procps` package is required due to:
```
dracut: dracut module 'network-legacy' will not be installed, because command 'pgrep' could not be found!
dracut: dracut module 'network' depends on 'network-legacy', which can't be installed
```

This PR also changed the indentation in config files to spaces everywhere.

## GUI diff

No difference from server POV.

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26392
Port(s): _This profiles are used across 5.0 and 4.3, no backports needed._

- [ ] **DONE**

## Changelogs

- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
