### PR TITLE
fix wrong type on list order query

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/scc/SCCCachingFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/scc/SCCCachingFactory.java
@@ -220,7 +220,7 @@ import javax.persistence.NoResultException;
                                     SELECT * from suseSCCOrderItem
                                     WHERE credentials_id = :credentials
                                     """, SCCOrderItem.class)
-                            .setParameter("credentials", credentials, StandardBasicTypes.LONG)
+                            .setParameter("credentials", credentials.getId(), StandardBasicTypes.LONG)
                             .getResultList())
                 .orElse(Collections.emptyList());
     }


### PR DESCRIPTION
## What does this PR change?

fixes an issue with the wrong parameter type being used for the query parameter

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
