### PR TITLE
Remove repeat command when getting the system id

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -403,15 +403,8 @@ end
 # @param [Node] node The node object representing the system.
 # @return [String] The system ID.
 def get_system_id(node)
-  # TODO: Remove this retrying code when this issue https://github.com/SUSE/spacewalk/issues/24084 is fixed:
-  result = []
-  repeat_until_timeout(message: "The API can't see the system id for '#{node.full_hostname}'", timeout: 10) do
-    result = $api_test.system.search_by_name(node.full_hostname)
-    break if result.any?
-
-    sleep 1
-  end
-  result.first['id']
+  result = $api_test.system.search_by_name(node.full_hostname)
+  result.any? ? result.first['id'] : nil
 end
 
 # Checks if a host has shut down within a specified timeout period.


### PR DESCRIPTION
## What does this PR change?

Remove retry method to get the system id. This retry method seems to bring some instability.

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port(s): 
 - 5.0: https://github.com/SUSE/spacewalk/pull/26412
 - 4.3: https://github.com/SUSE/spacewalk/pull/26411
 - uyuni: https://github.com/uyuni-project/uyuni/pull/9757

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
