### PR TITLE
QE: Change the galaxy-noise email to be sent to localhost

### DIFF
--- a/testsuite/features/build_validation/core/srv_first_settings.feature
+++ b/testsuite/features/build_validation/core/srv_first_settings.feature
@@ -20,7 +20,7 @@ Feature: Very first settings
     And I select "Mr." from "prefix"
     And I enter "Admin" as "firstNames"
     And I enter "Admin" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Organization"
     Then I am logged in
 
@@ -36,9 +36,9 @@ Feature: Very first settings
     And I select "Mr." from "prefix"
     And I enter "Test" as "firstNames"
     And I enter "User" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Login"
-    Then I should see a "Account testing created, login information sent to galaxy-noise@suse.de" text
+    Then I should see a "Account testing created, login information sent to galaxy-noise@localhost" text
     And I should see a "testing" link
 
   Scenario: Grant testing user administrative priviledges

--- a/testsuite/features/core/srv_first_settings.feature
+++ b/testsuite/features/core/srv_first_settings.feature
@@ -33,7 +33,7 @@ Feature: Very first settings
     And I select "Mr." from "prefix"
     And I enter "Admin" as "firstNames"
     And I enter "Admin" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Organization"
     Then I am logged in
 
@@ -52,9 +52,9 @@ Feature: Very first settings
     And I select "Mr." from "prefix"
     And I enter "Test" as "firstNames"
     And I enter "User" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Login"
-    Then I should see a "Account testing created, login information sent to galaxy-noise@suse.de" text
+    Then I should see a "Account testing created, login information sent to galaxy-noise@localhost" text
     And I should see a "testing" link
 
   Scenario: Grant testing user administrative priviledges

--- a/testsuite/features/github_validation/core/first_settings.feature
+++ b/testsuite/features/github_validation/core/first_settings.feature
@@ -17,7 +17,7 @@ Feature: Very first settings
     And I select "Mr." from "prefix"
     And I enter "Admin" as "firstNames"
     And I enter "Admin" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Organization"
     Then I am logged in
 
@@ -33,9 +33,9 @@ Feature: Very first settings
     And I select "Mr." from "prefix"
     And I enter "Test" as "firstNames"
     And I enter "User" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Login"
-    Then I should see a "Account testing created, login information sent to galaxy-noise@suse.de" text
+    Then I should see a "Account testing created, login information sent to galaxy-noise@localhost" text
     And I should see a "testing" link
 
   Scenario: Grant testing user administrative priviledges
@@ -49,4 +49,3 @@ Feature: Very first settings
     And I click on "Update"
     Then I should see a "User information updated" text
     And I should see a "testing" text
-

--- a/testsuite/features/secondary/min_timezone.feature
+++ b/testsuite/features/secondary/min_timezone.feature
@@ -7,9 +7,9 @@
 @skip_if_github_validation
 @scope_visualization
 @sle_minion
-Feature: Correct timezone display 
+Feature: Correct timezone display
 #  1) create a user and assign him a timezone different than the server's timezone
-#  2) test that the popups in some scheduling actions appear in user's prefered timezone 
+#  2) test that the popups in some scheduling actions appear in user's prefered timezone
 #  3) some scheduler tests based on previous bugs are unavoidable
 
   Scenario: Log in as admin user
@@ -24,7 +24,7 @@ Feature: Correct timezone display
     And I select "Mr." from "prefix"
     And I enter "Test" as "firstNames"
     And I enter "User" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I select "(GMT+0800) Malaysia" from "timezone"
     And I click on "Create Login"
 
@@ -60,7 +60,7 @@ Feature: Correct timezone display
     Then I should see a "MYT" text
     # WORKAROUND for bsc #1195191, the below line is commented out but if the bug is fixed we should enable it.
     # And I should not see a "PM" text
-    
+
   Scenario: Login as the new Malaysian user if the previous scenario failed
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link
@@ -76,7 +76,7 @@ Feature: Correct timezone display
     And I enter "00:00" as "date_timepicker_widget_input"
     And I click on "Schedule"
     Then I should see a "00:00:00 MYT" text
-    
+
   Scenario: Login as the new Malaysian user if the previous scenario failed
     Given I am authorized as "MalaysianUser" with password "MalaysianUser"
     Then I should see a "MalaysianUser" link

--- a/testsuite/features/secondary/srv_users.feature
+++ b/testsuite/features/secondary/srv_users.feature
@@ -31,9 +31,9 @@ Feature: Manage users
     And I select "Mr." from "prefix"
     And I enter "Test" as "firstNames"
     And I enter "User" as "lastName"
-    And I enter "galaxy-noise@suse.de" as "email"
+    And I enter "galaxy-noise@localhost" as "email"
     And I click on "Create Login"
-    Then I should see a "Account user1 created, login information sent to galaxy-noise@suse.de" text
+    Then I should see a "Account user1 created, login information sent to galaxy-noise@localhost" text
     And I should see a "user1" link
     And I should see a "normal user" text
 
@@ -58,7 +58,7 @@ Feature: Manage users
     And option "Mr." is selected as "prefix"
     And I should see "Test" in field identified by "firstNames"
     And I should see "User" in field identified by "lastName"
-    And I should see a "galaxy-noise@suse.de" link
+    And I should see a "galaxy-noise@localhost" link
     And I should see a "Administrative Roles" text
     And I should see a "Roles:" text
     And I should see a "Created:" text

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -142,7 +142,7 @@ Given(/^I create a user with name "([^"]*)" and password "([^"]*)"/) do |user, p
   $current_password = password
   next if $api_test.user.list_users.to_s.include? user
 
-  $api_test.user.create(user, password, user, user, 'galaxy-noise@suse.de')
+  $api_test.user.create(user, password, user, user, 'galaxy-noise@localhost')
   roles = %w[org_admin channel_admin config_admin system_group_admin activation_key_admin image_admin]
   roles.each do |role|
     $api_test.user.add_role(user, role)


### PR DESCRIPTION
## What does this PR change?

We are generating too many emails, when we raise some issue in our tests.
This wasn't a big issue when we only had an admin user, but it becomes an issue now that we have a user per test suite.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/26419
- Manager-5.0 https://github.com/SUSE/spacewalk/pull/26418

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
