### PR TITLE
Issv3: Ensure sync hub APIs are responding correctly if a runtime exception occurs

### DIFF
--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -114,22 +114,12 @@ public class HubController {
             LOGGER.error("Invalid data provided: ", ex);
             return badRequest(response, "Invalid data");
         }
-        catch (Exception ex) {
-            LOGGER.error("Internal Server Error: ", ex);
-            return internalServerError(response, "Internal Server Error");
-        }
         return success(response);
     }
 
     private String deregister(Request request, Response response, IssAccessToken accessToken) {
         // request to delete the local access for the requesting server.
-        try {
-            hubManager.deleteIssServerLocal(accessToken, accessToken.getServerFqdn());
-        }
-        catch (Exception ex) {
-            LOGGER.error("Internal Server Error: ", ex);
-            return internalServerError(response, "Internal Server Error");
-        }
+        hubManager.deleteIssServerLocal(accessToken, accessToken.getServerFqdn());
         return success(response);
     }
 
@@ -151,7 +141,6 @@ public class HubController {
             LOGGER.error("Unable to build token");
             return badRequest(response, "The token could not be build");
         }
-
     }
 
     private String removeReportDbCredentials(Request request, Response response, IssAccessToken token) {

--- a/java/code/src/com/suse/manager/hub/HubSparkHelper.java
+++ b/java/code/src/com/suse/manager/hub/HubSparkHelper.java
@@ -11,6 +11,7 @@
 
 package com.suse.manager.hub;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.internalServerError;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 
 import com.redhat.rhn.frontend.security.AuthenticationServiceFactory;
@@ -96,6 +97,10 @@ public final class HubSparkHelper {
                 LOGGER.error("Invalid token provided - parsing error");
                 response.status(HttpServletResponse.SC_UNAUTHORIZED);
                 return json(response, ResultJson.error("Invalid token provided"), new TypeToken<>() { });
+            }
+            catch (Exception e) {
+                LOGGER.error("Internal Server Error", e);
+                return internalServerError(response, "Internal Server Error", e.getMessage());
             }
             finally {
                 var authenticationService = AuthenticationServiceFactory.getInstance().getAuthenticationService();


### PR DESCRIPTION
## What does this PR change?
On the APIs to synchronize on a peripheral server it has to be ensured that if anything goes wrong in the handling of the API endpoint request, for example an exception is thrown, a well-formed response is returned back anyway.
At the moment there are cases in which if a runtime exception happens in the code calling stack (routes referring to the HubController class), this exception is not caught, therefore letting the API server hang with no response.
These conditions should be tackled so that an "internal server error" with a meaningful error message could be issued instead.
Although these APIs are intended for inter server communication, this will eventually help with the debugging process.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26417
Port(s): 

- [x] **DONE**

## Changelogs
- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

