### PR TITLE
QE: Development custom channel for a Uyuni Build Host

### DIFF
--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -187,7 +187,7 @@ Feature: Update activation keys
 
 @scc_credentials
 @uyuni
-  Scenario: Update build host key with Uyuni client tools
+  Scenario: Update build host key with Uyuni client tools and dev child channel
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Build host Key x86_64" in the content area
     And I wait for child channels to appear
@@ -195,6 +195,8 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I check "Uyuni Client Tools for SLES15 SP4 x86_64 (Development)"
     And I wait until "Uyuni Client Tools for SLES15 SP4 x86_64 (Development)" has been checked
+    And I check "Dev-Build-Host-Channel"
+    And I wait until "Dev-Build-Host-Channel" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key Build host Key x86_64 has been modified" text
 

--- a/testsuite/features/reposync/srv_create_dev_channels.feature
+++ b/testsuite/features/reposync/srv_create_dev_channels.feature
@@ -26,6 +26,25 @@ Feature: Create custom channels with development repositories
   Scenario: Create custom repositories inside the SUSE custom channel
     When I prepare the development repositories of "sle_minion" as part of "dev-suse-channel" channel
 
+@uyuni
+@buildhost
+  Scenario: Create a custom channel for Build Host
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    And I enter "Dev-Build-Host-Channel" as "Channel Name"
+    And I enter "dev-build-host-channel" as "Channel Label"
+    And I select the parent channel for the "buildhost" from "Parent Channel"
+    And I select "x86_64" from "Architecture:"
+    And I enter "Dev-Build-Host-Channel for development repositories" as "Channel Summary"
+    And I enter "Channel containing development repositories" as "Channel Description"
+    And I click on "Create Channel"
+    Then I should see a "Channel Dev-Build-Host-Channel created." text
+
+@uyuni
+@buildhost
+  Scenario: Create custom repositories inside the Build Host custom channel
+    When I prepare the development repositories of "buildhost" as part of "dev-build-host-channel" channel
+
 @deblike_minion
   Scenario: Create a custom channel for Debian-like minions
     When I follow the left menu "Software > Manage > Channels"

--- a/testsuite/features/reposync/srv_sync_dev_channels.feature
+++ b/testsuite/features/reposync/srv_sync_dev_channels.feature
@@ -41,3 +41,16 @@ Feature: Synchronize development channels
     And I click on "Sync Now"
     Then I should see a "Repository sync scheduled for Dev-RH-like-Channel." text
     And I wait until the channel "dev-rh-like-channel" has been synced
+
+@buildhost
+@uyuni
+  Scenario: Synchronize Dev-Build-Host-Channel channel
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Dev-Build-Host-Channel"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I wait at most 60 seconds until I do not see "Repository sync is running." text, refreshing the page
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled for Dev-Build-Host-Channel." text
+    And I wait until the channel "dev-build-host-channel" has been synced


### PR DESCRIPTION
## What does this PR change?

On Uyuni, we must deploy a Build Host using SLES 15 SP4 as of today.
This diverge from MLM because on MLM we have the Minion and the Build Host using the same base channel, while on Uyuni we have a Leap Minion. Therefore, we need this extra custom channel on Uyuni.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
