### PR TITLE
Implement module to get configuration values from the database

### DIFF
--- a/python/spacewalk/satellite_tools/accounts/satpasswd
+++ b/python/spacewalk/satellite_tools/accounts/satpasswd
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 #
 # Copyright (c) 2014--2015 Red Hat, Inc.
+# Copyright (c) 2025 SUSE LLC
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -16,7 +17,7 @@
 import getpass
 import sys
 
-from spacewalk.common.rhnConfig import initCFG, CFG
+from spacewalk.server import db_config
 from spacewalk.server import rhnSQL, rhnUser
 
 
@@ -30,18 +31,19 @@ def print_help():
 def read_passwd(stdin, msg):
     passwordIn = None
     if stdin:
-        passwordIn = sys.stdin.readline().rstrip('\n')
+        passwordIn = sys.stdin.readline().rstrip("\n")
     else:
         passwordIn = getpass.getpass(msg)
     return passwordIn
 
-if __name__ == '__main__':
-    if '-h' in sys.argv or '--help' in sys.argv:
+
+if __name__ == "__main__":
+    if "-h" in sys.argv or "--help" in sys.argv:
         print_help()
         sys.exit(0)
 
     stdin = False
-    for a in ('-s', '--stdin'):
+    for a in ("-s", "--stdin"):
         if a in sys.argv:
             stdin = True
             sys.argv.remove(a)
@@ -52,7 +54,6 @@ if __name__ == '__main__':
 
     userIn = sys.argv.pop()
 
-    initCFG('server.satellite')
     rhnSQL.initDB()
 
     user = rhnUser.search(userIn)
@@ -71,10 +72,11 @@ if __name__ == '__main__':
         print("Empty password is not permitted.")
         sys.exit(1)
 
-    if len(passwordIn) < CFG.MIN_PASSWD_LEN:
-        print(("User password should be at least %d characters long.") % CFG.MIN_PASSWD_LEN)
+    MIN_PASSWD_LEN = db_config.value("PSW_CHECK_LENGTH_MIN")
+    if len(passwordIn) < MIN_PASSWD_LEN:
+        print(("User password should be at least %d characters long.") % MIN_PASSWD_LEN)
         sys.exit(1)
 
-    user.contact['password'] = rhnUser.encrypt_password(passwordIn)
+    user.contact["password"] = rhnUser.encrypt_password(passwordIn)
     user.contact.save()
     rhnSQL.commit()

--- a/python/spacewalk/server/Makefile
+++ b/python/spacewalk/server/Makefile
@@ -17,7 +17,7 @@ SPACEWALK_FILES		= __init__ \
                   rhnHandler rhnImport rhnMapping rhnLib rhnPackage \
                   rhnPackageUpload basePackageUpload rhnRepository \
                   rhnSession rhnUser taskomatic \
-                  suseEula
+                  suseEula db_config
 SUBDIRS		= rhnSQL rhnServer handlers importlib repomd
 
 include $(TOP)/Makefile.defs

--- a/python/spacewalk/server/db_config.py
+++ b/python/spacewalk/server/db_config.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2025 SUSE LLC
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+
+"""A module that reads values from the database"""
+
+
+from typing import Optional, Union
+from spacewalk.server import rhnSQL
+
+
+def sanitize_value(key: str, val: str) -> Optional[Union[str, float, int]]:
+    """
+    attempt to convert a string value to the proper type
+    """
+    convert_table = {
+        "PSW_CHECK_SPECIAL_CHARACTERS": str,
+    }
+    val = val.strip()
+
+    if key in convert_table:
+        try:
+            val = convert_table[key](val)
+        except ValueError:
+            pass
+    else:
+        try:
+            val = int(val)  # make int if can.
+        except ValueError:
+            try:
+                val = float(val)  # make float if can.
+            except ValueError:
+                pass
+    if val == "":  # Empty strings treated as None
+        val = None
+    return val
+
+
+def value(key: str) -> Optional[Union[str, float, int]]:
+    """
+    Return the value of the given key. If the value is not defined, return the default value
+    When the key is not found, an AttributeError is raised
+    """
+    rhnSQL.initDB()
+
+    h = rhnSQL.prepare(
+        """
+            SELECT value, default_value
+            FROM rhnConfiguration
+            WHERE key = :key
+            """
+    )
+    h.execute(key=key)
+    data = h.fetchone_dict()
+    if not data:
+        raise AttributeError(key)
+
+    result = data["value"] if data["value"] else data["default_value"]
+    return sanitize_value(key, result)

--- a/python/spacewalk/server/rhnUser.py
+++ b/python/spacewalk/server/rhnUser.py
@@ -1,6 +1,7 @@
 #  pylint: disable=missing-module-docstring,invalid-name
 #
 # Copyright (c) 2008--2017 Red Hat, Inc.
+# Copyright (c) 2025 SUSE LLC
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -29,12 +30,12 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common.rhnTranslate import _
 
-from . import rhnSQL
-from . import rhnSession
+from spacewalk.server import db_config
+from spacewalk.server import rhnSQL
+from spacewalk.server import rhnSession
 
 
 class User:
-
     """Main User class"""
 
     def __init__(self, username, password):
@@ -696,16 +697,18 @@ def validate_new_password(password):
     # regular expression
     if not password:
         raise rhnFault(12)
-    if len(password) < CFG.MIN_PASSWD_LEN:
+    MIN_PASSWD_LEN = db_config.value("PSW_CHECK_LENGTH_MIN")
+    MAX_PASSWD_LEN = db_config.value("PSW_CHECK_LENGTH_MAX")
+    if len(password) < MIN_PASSWD_LEN:
         raise rhnFault(
-            14, _("password must be at least %d characters") % CFG.MIN_PASSWD_LEN
+            14, _("password must be at least %d characters") % MIN_PASSWD_LEN
         )
-    if len(password) > CFG.MAX_PASSWD_LEN:
+    if len(password) > MAX_PASSWD_LEN:
         raise rhnFault(
-            701, _("Password must be shorter than %d characters") % CFG.MAX_PASSWD_LEN
+            701, _("Password must be shorter than %d characters") % MAX_PASSWD_LEN
         )
 
-    password = password[: CFG.MAX_PASSWD_LEN]
+    password = password[:MAX_PASSWD_LEN]
     invalid_re = re.compile(r"[^ A-Za-z0-9`!@#$%^&*()-_=+[{\]}\\|;:'\",<.>/?~]")
     asterisks_re = re.compile(r"^\**$")
 

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.fix-min_passwd_len-config
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.fix-min_passwd_len-config
@@ -1,0 +1,1 @@
+- Implement module to get configuration values from the database

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -419,6 +419,7 @@ fi
 %{python3rhnroot}/server/apacheRequest.py*
 %{python3rhnroot}/server/apacheServer.py*
 %{python3rhnroot}/server/apacheUploadServer.py*
+%{python3rhnroot}/server/db_config.py*
 %{python3rhnroot}/server/rhnAction.py*
 %{python3rhnroot}/server/rhnAuthPAM.py*
 %{python3rhnroot}/server/rhnCapability.py*


### PR DESCRIPTION
## What does this PR change?

We started to move configuration values from rhn.conf into the database rhnConfiguration table.
As we need now some of the moved values in python code, we need a function which get us these
from the DB.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

Addition to: https://github.com/uyuni-project/uyuni/pull/9423

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
