### PR TITLE
Switch to Ubuntu 24.04 in CI/refenv 5.0/head/uyuni

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -145,7 +145,7 @@ If you want a Debian-like minion, make this variable point to the machine
 that will be the Debian-like minion:
 
 ```bash
-export DEBLIKE_MINION=ubuntu2204.example.com
+export DEBLIKE_MINION=ubuntu2404.example.com
 ```
 
 and then run the test suite.

--- a/testsuite/documentation/static-run.md
+++ b/testsuite/documentation/static-run.md
@@ -31,7 +31,7 @@ export MINION="${PREFIX}min-sles15.tf.local"
 export BUILD_HOST="${PREFIX}min-build.tf.local"
 export SSH_MINION="${PREFIX}minssh-sles15.tf.local"
 export RHLIKE_MINION="${PREFIX}min-rocky8.tf.local"
-export DEBLIKE_MINION="${PREFIX}min-ubuntu2204.tf.local"
+export DEBLIKE_MINION="${PREFIX}min-ubuntu2404.tf.local"
 run-testsuite
 ```
 

--- a/testsuite/features/reposync/reference_srv_check_reposync.feature
+++ b/testsuite/features/reposync/reference_srv_check_reposync.feature
@@ -1,45 +1,45 @@
-# Copyright (c) 2020-2023 SUSE LLC
+# Copyright (c) 2020-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Reposync works as expected
+Feature: Synchronize product channels
 
 @scc_credentials
 @susemanager
-  Scenario: Check reposync of Rocky Linux 8 channels being finished
-    Then I wait until the channel "rockylinux8-x86_64" has been synced
+  Scenario: Reposync of Rocky Linux 8 channels has finished
+    When I wait until the channel "rockylinux8-x86_64" has been synced
     And I wait until the channel "rockylinux8-appstream-x86_64" has been synced
 
 @uyuni
-  Scenario: Check reposync of Rocky Linux 8 channels being finished
-    Then I wait until the channel "rockylinux8-x86_64" has been synced
+  Scenario: Reposync of Rocky Linux 8 channels has finished
+    When I wait until the channel "rockylinux8-x86_64" has been synced
     And I wait until the channel "rockylinux8-x86_64-appstream" has been synced
 
 @scc_credentials
 @susemanager
-  Scenario: Check reposync of Ubuntu 22.04 channels being finished
-    Then I wait until the channel "ubuntu-2204-amd64-main-amd64" has been synced
-    And I wait until the channel "ubuntu-2204-amd64-main-updates-amd64" has been synced
-    And I wait until the channel "ubuntu-2204-amd64-main-security-amd64" has been synced
+  Scenario: Reposync of Ubuntu 24.04 channels has finished
+    When I wait until the channel "ubuntu-2404-amd64-main-amd64" has been synced
+    And I wait until the channel "ubuntu-2404-amd64-main-updates-amd64" has been synced
+    And I wait until the channel "ubuntu-2404-amd64-main-security-amd64" has been synced
 
 @uyuni
-  Scenario: Check reposync of Ubuntu 22.04 channels being finished
-    Then I wait until the channel "ubuntu-2204-pool-amd64-uyuni" has been synced
-    And I wait until the channel "ubuntu-2204-amd64-main-uyuni" has been synced
-    And I wait until the channel "ubuntu-2204-amd64-main-updates-uyuni" has been synced
-    And I wait until the channel "ubuntu-2204-amd64-main-security-uyuni" has been synced
+  Scenario: Reposync of Ubuntu 24.04 channels has finished
+    When I wait until the channel "ubuntu-2404-pool-amd64-uyuni" has been synced
+    And I wait until the channel "ubuntu-2404-amd64-main-uyuni" has been synced
+    And I wait until the channel "ubuntu-2404-amd64-main-updates-uyuni" has been synced
+    And I wait until the channel "ubuntu-2404-amd64-main-security-uyuni" has been synced
 
 @scc_credentials
 @susemanager
-  Scenario: Check reposync of SLES 15 SP4 channels being finished
-    Then I wait until the channel "sle-module-basesystem15-sp4-updates-x86_64" has been synced
+  Scenario: Reposync of SLES 15 SP4 channels has finished
+    When I wait until the channel "sle-module-basesystem15-sp4-updates-x86_64" has been synced
     And I wait until the channel "sle-module-server-applications15-sp4-updates-x86_64" has been synced
     And I wait until the channel "sle-module-desktop-applications15-sp4-updates-x86_64" has been synced
     And I wait until the channel "sle-module-devtools15-sp4-updates-x86_64" has been synced
     And I wait until the channel "sle-module-containers15-sp4-pool-x86_64" has been synced
 
 @uyuni
-  Scenario: Check reposync of openSUSE Leap 15.5 channels being finished
-    Then I wait until the channel "opensuse_leap15_5-x86_64" has been synced
+  Scenario: Reposync of openSUSE Leap 15.5 channels has finished
+    When I wait until the channel "opensuse_leap15_5-x86_64" has been synced
     And I wait until the channel "opensuse_leap15_5-non-oss-x86_64" has been synced
     And I wait until the channel "opensuse_leap15_5-non-oss-updates-x86_64" has been synced
     And I wait until the channel "opensuse_leap15_5-updates-x86_64" has been synced
@@ -50,22 +50,22 @@ Feature: Reposync works as expected
 
 @scc_credentials
 @susemanager
-  Scenario: Check reposync of Client Tools being finished
+  Scenario: Reposync of client tools has finished
     When I wait until the channel "sle-manager-tools15-pool-x86_64-sp4" has been synced
     And I wait until the channel "sle-manager-tools15-updates-x86_64-sp4" has been synced
     And I wait until the channel "res8-manager-tools-updates-x86_64-rocky" has been synced
     And I wait until the channel "res8-manager-tools-pool-x86_64-rocky" has been synced
-    And I wait until the channel "ubuntu-2204-suse-manager-tools-amd64" has been synced
+    And I wait until the channel "ubuntu-2404-suse-manager-tools-amd64" has been synced
 
 @beta
 @scc_credentials
 @susemanager
-  Scenario: Check reposync of Client Tools being finished
+  Scenario: Reposync of beta client tools has finished
     When I wait until the channel "sle-manager-tools15-beta-pool-x86_64-sp4" has been synced
     And I wait until the channel "sle-manager-tools15-beta-updates-x86_64-sp4" has been synced
 
 @uyuni
-  Scenario: Check reposync of Client Tools being finished
-    And I wait until the channel "opensuse_leap15_5-uyuni-client-x86_64" has been synced
+  Scenario: Reposync of Uyuni client tools has finished
+    When I wait until the channel "opensuse_leap15_5-uyuni-client-x86_64" has been synced
     And I wait until the channel "rockylinux8-uyuni-client-x86_64" has been synced
-    And I wait until the channel "ubuntu-2204-amd64-uyuni-client" has been synced
+    And I wait until the channel "ubuntu-2404-amd64-uyuni-client" has been synced

--- a/testsuite/features/reposync/reference_srv_sync_products_extra.feature
+++ b/testsuite/features/reposync/reference_srv_sync_products_extra.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 SUSE LLC
+# Copyright (c) 2023-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Synchronize extra products in the products page of the Setup Wizard
@@ -34,18 +34,18 @@ Feature: Synchronize extra products in the products page of the Setup Wizard
 
 @scc_credentials
 @susemanager
-  Scenario: Add Ubuntu 22.04 product with recommended sub-products
+  Scenario: Add Ubuntu 24.04 product with recommended sub-products
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "Ubuntu" as the filtered product description
     And I select "amd64-deb" from "product-arch-filter"
-    And I wait until I see "Ubuntu 22.04" text
-    And I select "Ubuntu 22.04" as a product
-    Then I should see the "Ubuntu 22.04" selected
+    And I wait until I see "Ubuntu 24.04" text
+    And I select "Ubuntu 24.04" as a product
+    Then I should see the "Ubuntu 24.04" selected
     When I click the Add Product button
-    And I wait until I see "Ubuntu 22.04" product has been added
+    And I wait until I see "Ubuntu 24.04" product has been added
 
 @uyuni
-  Scenario: Enable Ubuntu 22.04 Uyuni client tools for creating bootstrap repositories
-    When I use spacewalk-common-channel to add channel "ubuntu-2204-pool-amd64-uyuni ubuntu-2204-amd64-main-uyuni ubuntu-2204-amd64-main-updates-uyuni ubuntu-2204-amd64-main-security-uyuni ubuntu-2204-amd64-uyuni-client" with arch "amd64-deb"
+  Scenario: Enable Ubuntu 24.04 Uyuni client tools for creating bootstrap repositories
+    When I use spacewalk-common-channel to add channel "ubuntu-2404-pool-amd64-uyuni ubuntu-2404-amd64-main-uyuni ubuntu-2404-amd64-main-updates-uyuni ubuntu-2404-amd64-main-security-uyuni ubuntu-2404-amd64-uyuni-client" with arch "amd64-deb"

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2024 SUSE LLC
+# Copyright (c) 2017-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization
@@ -89,13 +89,6 @@ Feature: Manage a group of systems
     And I should see a "Action Details" text
     And I wait until I see "2 systems successfully completed this action." text, refreshing the page
 
-  Scenario: Remove SLE client from new group
-    Given I am on the Systems overview page of this "rhlike_minion"
-    When I follow "Groups"
-    And I check "new-systems-group" in the list
-    And I click on "Leave Selected Groups"
-    Then I should see a "1 system groups removed." text
-
   Scenario: Remove SLE minion from new group
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Groups"
@@ -105,7 +98,7 @@ Feature: Manage a group of systems
 
   # Red Hat-like minion is intentionally not removed from group
 
-  @skip_if_containerized_server
+@skip_if_containerized_server
   Scenario: Cleanup: uninstall formula from the server
     When I manually uninstall the "locale" formula from the server
 

--- a/testsuite/features/secondary/min_deblike_openscap_audit.feature
+++ b/testsuite/features/secondary/min_deblike_openscap_audit.feature
@@ -33,6 +33,8 @@ Feature: OpenSCAP audit of Debian-like Salt minion
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
+    # WORKAROUND: the security guide for 24.04 does not exist yet
+    #             for now we still use the security guide for 22.04
     And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu2204-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text

--- a/testsuite/features/secondary/srv_dist_channel_mapping.feature
+++ b/testsuite/features/secondary/srv_dist_channel_mapping.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 SUSE LLC
+# Copyright (c) 2022-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Distribution Channel Mapping
@@ -43,16 +43,16 @@ Feature: Distribution Channel Mapping
     Then I should see a "openSUSE Leap 15.5" link in the content area
 
 @deblike_minion
-  Scenario: Create new map for x86_64 Ubuntu clients with test base channel
+  Scenario: Create new map for amd64 Ubuntu clients with test base channel
     When I follow the left menu "Software > Distribution Channel Mapping"
     And I follow "Create Distribution Channel Mapping"
     Then I should see a "Create Distribution Channel Map" text
-    When I enter "Ubuntu 22.04.01 LTS" as "os"
-    And I enter "22.04" as "release"
-    And I select "x86_64" from "architecture"
+    When I enter "Ubuntu 24.04" as "os"
+    And I enter "24.04" as "release"
+    And I select "AMD64 Debian" from "architecture"
     And I select "Fake-Base-Channel-Debian-like" from "channel_label"
     And I click on "Create Mapping"
-    Then I should see a "Ubuntu 22.04.01 LTS" link in the content area
+    Then I should see a "Ubuntu 24.04" link in the content area
 
 @scc_credentials
   Scenario: Create new map for iSeries SUSE clients using test channel
@@ -97,17 +97,15 @@ Feature: Distribution Channel Mapping
     And I should see the text "opensuse_leap15_5-x86_64" in the Channel Label field
 
 @deblike_minion
-  Scenario: Update map for x86_64 Ubuntu clients using test base channel
+  Scenario: Update map for amd64 Ubuntu clients using test base channel
     When I follow the left menu "Software > Distribution Channel Mapping"
-    Then I should see the text "Ubuntu 22.04.01 LTS" in the Operating System field
-    And I should see the text "x86_64" in the Architecture field
-    And I should see the text "sle-product-sles15-sp4-pool-x86_64" in the Channel Label field
-    When I follow "Ubuntu 22.04.01 LTS"
-    And I enter "Ubuntu 22.04.01 LTS modified" as "os"
-    And I select "Fake-Base-Channel-Debian-like" from "channel_label"
+    Then I should see the text "Ubuntu 24.04" in the Operating System field
+    And I should see the text "AMD64 Debian" in the Architecture field
+    And I should see the text "fake-base-channel-debian-like" in the Channel Label field
+    When I follow "Ubuntu 24.04"
+    And I enter "Ubuntu 24.04 modified" as "os"
     And I click on "Update Mapping"
-    Then I should see the text "Ubuntu 22.04.01 LTS modified" in the Operating System field
-    And I should see the text "fake-base-channel-suse-like" in the Channel Label field
+    Then I should see the text "Ubuntu 24.04 modified" in the Operating System field
 
 @scc_credentials
   Scenario: Update map for IA-32 SUSE clients using amd deb test channel
@@ -151,17 +149,17 @@ Feature: Distribution Channel Mapping
     Then I should not see a "openSUSE Leap 15.5 modified" link
 
 @deblike_minion
-  Scenario: Cleanup: delete the map created for x68_64 Ubuntu clients
+  Scenario: Cleanup: delete the map created for amd64 Ubuntu clients
     When I follow the left menu "Software > Distribution Channel Mapping"
-    Then I should see the text "Ubuntu 22.04.01 LTS modified" in the Operating System field
-    And I should see the text "x86_64" in the Architecture field
-    When I follow "Ubuntu 22.04.01 LTS modified"
+    Then I should see the text "Ubuntu 24.04 modified" in the Operating System field
+    And I should see the text "AMD64 Debian" in the Architecture field
+    When I follow "Ubuntu 24.04 modified"
     Then I should see a "Update Distribution Channel Map" text
     And I should see a "Delete Distribution Channel" link
     When I follow "Delete Distribution Channel Mapping"
     Then I should see a "Delete Distribution Channel Map" text
     When I click on "Delete Mapping"
-    Then I should not see a "Ubuntu 22.04.01 LTS modified" link
+    Then I should not see a "Ubuntu 24.04 modified" link
 
 @scc_credentials
   Scenario: Cleanup: delete the map created for i586 clients

--- a/testsuite/features/secondary/srv_mgr_sync_list_products.feature
+++ b/testsuite/features/secondary/srv_mgr_sync_list_products.feature
@@ -1,10 +1,10 @@
 # Copyright (c) 2018-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: List available products and enable them
+Feature: List available products
   In order to use software channels
   As root user
-  I want to list available products and enable them
+  I want to list available products from command line
 
 @susemanager
   Scenario: List available products

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -932,7 +932,7 @@ When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |actio
   when /^centos/, /^rocky/
     pkgs = 'openscap-utils scap-security-guide-redhat'
   when /^ubuntu/
-    pkgs = 'libopenscap8 scap-security-guide-ubuntu'
+    pkgs = 'openscap-utils openscap-scanner openscap-common ssg-debderived'
   else
     raise ScriptError, "The node #{node.hostname} has not a supported OS Family (#{os_family})"
   end

--- a/testsuite/run_sets/github_validation/github_validation_core.yml
+++ b/testsuite/run_sets/github_validation/github_validation_core.yml
@@ -9,7 +9,6 @@
 - features/reposync/srv_disable_scheduled_reposync.feature
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
-- features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_create_fake_channels.feature
 - features/reposync/srv_create_fake_repositories.feature
 - features/reposync/srv_create_dev_channels.feature

--- a/testsuite/run_sets/reference_reposync.yml
+++ b/testsuite/run_sets/reference_reposync.yml
@@ -12,7 +12,6 @@
 #- features/reposync/srv_disable_scheduled_reposync.feature
 #- features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
-#- features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_create_fake_channels.feature
 - features/reposync/srv_create_fake_repositories.feature
 - features/reposync/srv_sync_fake_channels.feature

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -23,7 +23,6 @@
 # these features sync real channels (last core features)
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
-- features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_create_fake_channels.feature
 - features/reposync/srv_create_fake_repositories.feature
 - features/reposync/srv_sync_fake_channels.feature

--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -12,7 +12,6 @@
 - features/reposync/srv_disable_scheduled_reposync.feature
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
-- features/reposync/srv_enable_sync_products.feature
 - features/reposync/srv_create_fake_channels.feature
 - features/reposync/srv_create_fake_repositories.feature
 - features/reposync/srv_create_dev_channels.feature

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -10,6 +10,7 @@
 
 - features/secondary/srv_users.feature
 - features/secondary/srv_menu.feature
+- features/secondary/srv_mgr_sync_list_products.feature
 - features/secondary/srv_monitoring.feature
 - features/secondary/srv_virtual_host_manager.feature
 - features/secondary/srv_power_management.feature


### PR DESCRIPTION
## What does this PR change?

This PR bumps to Ubuntu 24.04 in feature files.

Tested on 5.0 branch with:
  * sanity checks
  * core features
  * reposync features
  * proxy features
  * init client features
  * some secondary features:
      - allcli_config_channel.feature
      - allcli_overview_systems_details.feature
      - allcli_reboot.feature
      - allcli_software_channels.feature
      - allcli_software_channels_dependencies.feature
      - allcli_system_group.feature
      - min_deblike_monitoring.feature
      - min_deblike_openscap_audit.feature
      - min_deblike_remote_command.feature
      - min_deblike_salt_install_package.feature
      - min_deblike_salt_install_with_staging.feature
      - min_deblike_ssh.feature

Piggybacks:
 * rename a file which purpose has changed over time
 * remove a scenario that we explicitely say we don't do a few lines later


## Links

Port(s):
* 5.0: https://github.com/SUSE/spacewalk/pull/26447
* no 4.3


## Changelogs

- [x] No changelog needed
