### PR TITLE
multiple server.susemanager.scc_backup_srv_usr inside rhn.conf fix

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.serpico.password-policy-hotfix
+++ b/schema/spacewalk/susemanager-schema.changes.serpico.password-policy-hotfix
@@ -1,0 +1,1 @@
+- Fix for bad schema migration

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.3-to-susemanager-schema-5.1.4/101-default-settings-updates.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.3-to-susemanager-schema-5.1.4/101-default-settings-updates.sql
@@ -3,28 +3,40 @@ alter table rhnConfiguration disable trigger rhn_conf_mod_trig;
 INSERT INTO rhnConfiguration (key, description, value, default_value)
     SELECT 'EXTAUTH_DEFAULT_ORGID', description, value, null
     FROM rhnConfiguration
-    WHERE key = 'extauth_default_orgid';
+    WHERE key = 'extauth_default_orgid'
+ON CONFLICT (key) DO UPDATE
+  SET default_value = EXCLUDED.default_value;
+
 DELETE FROM rhnConfiguration
     WHERE key = 'extauth_default_orgid';
 
 INSERT INTO rhnConfiguration (key, description, default_value, value)
     SELECT 'EXTAUTH_USE_ORGUNIT', description, 'false', COALESCE(value, 'false')
     FROM rhnConfiguration
-    WHERE key = 'extauth_use_orgunit';
+    WHERE key = 'extauth_use_orgunit'
+ON CONFLICT (key) DO UPDATE
+  SET default_value = EXCLUDED.default_value;
+
 DELETE FROM rhnConfiguration
     WHERE key = 'extauth_use_orgunit';
 
 INSERT INTO rhnConfiguration (key, description, default_value, value)
     SELECT 'SYSTEM_CHECKIN_THRESHOLD', description, '1', COALESCE(value, '1')
     FROM rhnConfiguration
-    WHERE key = 'system_checkin_threshold';
+    WHERE key = 'system_checkin_threshold'
+ON CONFLICT (key) DO UPDATE
+  SET default_value = EXCLUDED.default_value;
+
 DELETE FROM rhnConfiguration
     WHERE key = 'system_checkin_threshold';
 
 INSERT INTO rhnConfiguration (key, description, default_value, value)
     SELECT 'EXTAUTH_KEEP_TEMPROLES', description, 'false', COALESCE(value, 'false')
     FROM rhnConfiguration
-    WHERE key = 'extauth_keep_temproles';
+    WHERE key = 'extauth_keep_temproles'
+ON CONFLICT (key) DO UPDATE
+  SET default_value = rhnConfiguration.default_value;
+
 DELETE FROM rhnConfiguration
     WHERE key = 'extauth_keep_temproles';
 

--- a/spacewalk/admin/spacewalk-admin.changes.serpico.password-policy-hotfix
+++ b/spacewalk/admin/spacewalk-admin.changes.serpico.password-policy-hotfix
@@ -1,0 +1,1 @@
+- Fix for multiple entries of scc_backup_srv_usr

--- a/spacewalk/admin/uyuni-update-config
+++ b/spacewalk/admin/uyuni-update-config
@@ -122,9 +122,33 @@ def init_scc_login():
         # scc expects either a SCC machine login (must exists in SCC)
         # or a UUID4 following rfc4122 to identify a anonyme proxy
         uuid_num = str(uuid.uuid4())
-    with open("/etc/rhn/rhn.conf", "a", encoding="utf8") as r:
-        r.write("\n")
-        r.write(f"server.susemanager.scc_backup_srv_usr = {uuid_num}\n")
+    write_scc_config(uuid_num)
+
+# ugly way to ensure server.susemanager.scc_backup_srv_usr stays unique
+def write_scc_config(uuid_num):
+    conf_file = "/etc/rhn/rhn.conf"
+    key = "server.susemanager.scc_backup_srv_usr"
+    new_line = f"{key} = {uuid_num}\n"
+    if os.path.exists(conf_file):
+        with open(conf_file, "r", encoding="utf8") as file:
+            lines = file.readlines()
+    else:
+        lines = []
+    updated = False
+    for i, line in enumerate(lines):
+        if key in line:
+            lines[i] = new_line
+            updated = True
+            break  # if there's only one occurrence, you can exit the loop
+    # If the key wasn't found, append the new line at the end
+    if not updated:
+        # Ensure the file ends with a newline
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(new_line)
+    # Write the updated contents back to the file
+    with open(conf_file, "w", encoding="utf8") as file:
+        file.writelines(lines)
 
 
 def import_suma_gpg_keyring():


### PR DESCRIPTION
## What does this PR change?

fix for multiple configuration keys for server.susemanager.scc_backup_srv_usr introduced with https://github.com/uyuni-project/uyuni/pull/9423

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
