### PR TITLE
fix config namespace to prevent duplicate entries

### DIFF
--- a/spacewalk/admin/uyuni-update-config
+++ b/spacewalk/admin/uyuni-update-config
@@ -99,7 +99,7 @@ def move_configuration(key, value, oldkey=None):
 
 def init_scc_login():
     # pylint: disable-next=invalid-name
-    with cfg_component("server") as CFG:
+    with cfg_component("server.susemanager") as CFG:
         try:
             if CFG.scc_backup_srv_usr:
                 # nothing to do


### PR DESCRIPTION
## What does this PR change?

Using the wrong namespace cause never finding the key when it already exists.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Additional fix for https://github.com/uyuni-project/uyuni/pull/9423

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
