### PR TITLE
QE: Fix typo build_host

### DIFF
--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -167,7 +167,7 @@ Feature: Update activation keys
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Build host Key x86_64" in the content area
     And I wait for child channels to appear
-    And I select the parent channel for the "buildhost" from "selectedBaseChannel"
+    And I select the parent channel for the "build_host" from "selectedBaseChannel"
     And I wait for child channels to appear
     And I include the recommended child channels
     And I wait until "SLE-Module-Basesystem15-SP4-Pool for x86_64" has been checked
@@ -191,7 +191,7 @@ Feature: Update activation keys
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Build host Key x86_64" in the content area
     And I wait for child channels to appear
-    And I select the parent channel for the "buildhost" from "selectedBaseChannel"
+    And I select the parent channel for the "build_host" from "selectedBaseChannel"
     And I wait for child channels to appear
     And I check "Uyuni Client Tools for SLES15 SP4 x86_64 (Development)"
     And I wait until "Uyuni Client Tools for SLES15 SP4 x86_64 (Development)" has been checked

--- a/testsuite/features/reposync/srv_create_dev_channels.feature
+++ b/testsuite/features/reposync/srv_create_dev_channels.feature
@@ -33,7 +33,7 @@ Feature: Create custom channels with development repositories
     And I follow "Create Channel"
     And I enter "Dev-Build-Host-Channel" as "Channel Name"
     And I enter "dev-build-host-channel" as "Channel Label"
-    And I select the parent channel for the "buildhost" from "Parent Channel"
+    And I select the parent channel for the "build_host" from "Parent Channel"
     And I select "x86_64" from "Architecture:"
     And I enter "Dev-Build-Host-Channel for development repositories" as "Channel Summary"
     And I enter "Channel containing development repositories" as "Channel Description"
@@ -43,7 +43,7 @@ Feature: Create custom channels with development repositories
 @uyuni
 @buildhost
   Scenario: Create custom repositories inside the Build Host custom channel
-    When I prepare the development repositories of "buildhost" as part of "dev-build-host-channel" channel
+    When I prepare the development repositories of "build_host" as part of "dev-build-host-channel" channel
 
 @deblike_minion
   Scenario: Create a custom channel for Debian-like minions


### PR DESCRIPTION
## What does this PR change?

Fix typo build_host

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/8c8abff1-0a75-42af-b000-5cee28a1ecca" />


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
