### PR TITLE
QE: Align `build_host` naming

### DIFF
--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -81,7 +81,7 @@ and then run the test suite.
 Inside of the test suite, the scenarios that are tagged with
 
 ```
-@buildhost
+@build_host
 ```
 
 are executed only if the Docker and Kiwi build host is available.

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -41,7 +41,7 @@ Feature: Sanity checks
     And "sle_minion" should communicate with the server using public interface
     And the clock from "sle_minion" should be exact
 
-@buildhost
+@build_host
   Scenario: The build host is healthy
     Then "build_host" should have a FQDN
     And reverse resolution should work for "build_host"

--- a/testsuite/features/github_validation/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/github_validation/init_clients/buildhost_bootstrap.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@buildhost
+@build_host
 Feature: Bootstrap a build host via the GUI
 
   Scenario: Log in as admin user
@@ -28,4 +28,3 @@ Feature: Bootstrap a build host via the GUI
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[Container Build Host]" text
     Then I should see a "[OS Image Build Host]" text
-

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2016-2023 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-@buildhost
+@build_host
 Feature: Bootstrap a build host via the GUI
 
   Scenario: Clean up sumaform leftovers on build host

--- a/testsuite/features/reposync/srv_create_dev_channels.feature
+++ b/testsuite/features/reposync/srv_create_dev_channels.feature
@@ -27,7 +27,7 @@ Feature: Create custom channels with development repositories
     When I prepare the development repositories of "sle_minion" as part of "dev-suse-channel" channel
 
 @uyuni
-@buildhost
+@build_host
   Scenario: Create a custom channel for Build Host
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
@@ -41,7 +41,7 @@ Feature: Create custom channels with development repositories
     Then I should see a "Channel Dev-Build-Host-Channel created." text
 
 @uyuni
-@buildhost
+@build_host
   Scenario: Create custom repositories inside the Build Host custom channel
     When I prepare the development repositories of "build_host" as part of "dev-build-host-channel" channel
 

--- a/testsuite/features/reposync/srv_sync_dev_channels.feature
+++ b/testsuite/features/reposync/srv_sync_dev_channels.feature
@@ -42,7 +42,7 @@ Feature: Synchronize development channels
     Then I should see a "Repository sync scheduled for Dev-RH-like-Channel." text
     And I wait until the channel "dev-rh-like-channel" has been synced
 
-@buildhost
+@build_host
 @uyuni
   Scenario: Synchronize Dev-Build-Host-Channel channel
     Given I am authorized for the "Admin" section

--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -4,7 +4,7 @@
 # This feature depends on:
 # - features/secondary/min_docker_api.feature
 
-@buildhost
+@build_host
 @scope_building_container_images
 @auth_registry
 Feature: Build image with authenticated registry
@@ -20,7 +20,7 @@ Feature: Build image with authenticated registry
     And I enter URI, username and password for registry
     And I click on "create-btn"
     Then I wait until I see "registry" text
-  
+
   @scc_credentials
   Scenario: Create a profile for the authenticated image store as Docker admin
     When I follow the left menu "Images > Profiles"
@@ -66,4 +66,3 @@ Feature: Build image with authenticated registry
 
   Scenario: Cleanup: delete registry image
     When I delete the image "auth_registry_profile" with version "latest" via API calls
-

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -14,7 +14,7 @@
 # - features/secondary/min_salt_install_with_staging.feature
 # Due to the images listed in the CVE Audit images
 
-@buildhost
+@build_host
 @scope_building_container_images
 @no_auth_registry
 @skip_if_github_validation
@@ -169,7 +169,7 @@ Feature: Build container images
     Given I am authorized as "admin" with password "admin"
     When I delete the image "suse_simple" with version "latest" via API calls
     And I delete the image "suse_simple" with version "Latest_simple" via API calls
-	
+
 @scc_credentials
   Scenario: Cleanup: delete all profiles with key
     When I follow the left menu "Images > Profiles"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -16,7 +16,7 @@
 # If the image is not created, the message shown is "There are no entries to show."
 
 @skip_if_cloud
-@buildhost
+@build_host
 @scope_retail
 @scope_building_container_images
 @scc_credentials

--- a/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
@@ -7,7 +7,7 @@
 @skip_if_github_validation
 @containerized_server
 @proxy
-@buildhost
+@build_host
 @private_net
 @pxeboot_minion
 @scope_cobbler

--- a/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
@@ -17,7 +17,7 @@
 
 @containerized_server
 @skip_if_github_validation
-@buildhost
+@build_host
 @proxy
 @private_net
 @pxeboot_minion

--- a/testsuite/features/secondary/proxy_traditional_retail_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_traditional_retail_pxeboot.feature
@@ -14,7 +14,7 @@
 
 @skip_if_containerized_server
 @skip_if_github_validation
-@buildhost
+@build_host
 @proxy
 @private_net
 @pxeboot_minion

--- a/testsuite/features/secondary/srv_rename_hostname.feature
+++ b/testsuite/features/secondary/srv_rename_hostname.feature
@@ -52,7 +52,7 @@ Feature: Reconfigure the server's hostname
   Scenario: Apply high state on the Debian-like Minion to populate new server CA
     When I apply highstate on "deblike_minion"
 
-@buildhost
+@build_host
   Scenario: Apply high state on the build host to populate new server CA
     When I apply highstate on "build_host"
 
@@ -109,7 +109,7 @@ Feature: Reconfigure the server's hostname
   Scenario: Apply high state on the Debian-like Minion to populate new server CA
     When I apply highstate on "deblike_minion"
 
-@buildhost
+@build_host
   Scenario: Apply high state on the build host to populate new server CA
     When I apply highstate on "build_host"
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -238,7 +238,7 @@ BASE_CHANNEL_BY_CLIENT = {
     'rhlike_minion' => 'RHEL8-Pool for x86_64',
     'deblike_minion' => 'ubuntu-2004-amd64-main for amd64',
     'pxeboot_minion' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
-    'buildhost' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
+    'build_host' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
     'sle12sp5_minion' => 'SLES12-SP5-Pool for x86_64',
     'sle12sp5_ssh_minion' => 'SLES12-SP5-Pool for x86_64',
     'sle12sp5_buildhost' => 'SLES12-SP5-Pool for x86_64',
@@ -313,7 +313,7 @@ BASE_CHANNEL_BY_CLIENT = {
     'rhlike_minion' => 'RHEL8-Pool for x86_64',
     'deblike_minion' => 'Ubuntu 20.04 LTS AMD64 Base for Uyuni',
     'pxeboot_minion' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
-    'buildhost' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
+    'build_host' => 'SLE-Product-SLES15-SP4-Pool for x86_64',
     'sle12sp5_minion' => 'SLES12-SP5-Pool for x86_64',
     'sle12sp5_ssh_minion' => 'SLES12-SP5-Pool for x86_64',
     'sle12sp5_buildhost' => 'SLES12-SP5-Pool for x86_64',
@@ -383,7 +383,7 @@ BASE_CHANNEL_BY_CLIENT = {
     'sle_minion' => 'Fake-Base-Channel-SUSE-like',
     'pxeboot_minion' => 'Fake-Base-Channel-SUSE-like',
     'proxy' => 'Fake-Base-Channel-SUSE-like',
-    'buildhost' => 'Fake-Base-Channel-SUSE-like'
+    'build_host' => 'Fake-Base-Channel-SUSE-like'
   }
 }.freeze
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -297,7 +297,7 @@ Before('@ssh_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['ssh_minion']
 end
 
-Before('@buildhost') do
+Before('@build_host') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['build_host']
 end
 


### PR DESCRIPTION
## What does this PR change?

Align `build_host` naming

![image](https://github.com/user-attachments/assets/37463346-9290-4c0d-b108-e08018fe9226)


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
