### PR TITLE
Fix tooltip text for icons in the patches list

### DIFF
--- a/java/code/webapp/WEB-INF/pages/systems/errata.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/errata.jsp
@@ -102,10 +102,12 @@
                           </c:choose>
             </c:if>
             <c:if test="${current.bugFix}">
-                <rhn:icon type="errata-bugfix" />
+                <rhn:icon type="errata-bugfix"
+                title="erratalist.jsp.bugadvisory" />
             </c:if>
             <c:if test="${current.productEnhancement}">
-                <rhn:icon type="errata-enhance" />
+                <rhn:icon type="errata-enhance"
+                title="erratalist.jsp.productenhancementadvisory" />
             </c:if>
             <c:if test="${current.rebootSuggested}">
                 <rhn:icon type="errata-reboot" title="errata-legend.jsp.reboot" />

--- a/java/spacewalk-java.changes.bisht-richa.patch-icon-hover-text
+++ b/java/spacewalk-java.changes.bisht-richa.patch-icon-hover-text
@@ -1,0 +1,1 @@
+- Fix the tooltip text for specific icons in the patches list


### PR DESCRIPTION
## What does this PR change?

**add description**

Fix tooltip text for icons in the patches list
## GUI diff

No difference.

Before:

After:
<img width="1319" alt="Screenshot 2025-02-14 at 15 12 02" src="https://github.com/user-attachments/assets/33260877-41cb-4ac8-9956-c1b7f973e009" />

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**


- [x] **DONE**

## Links

Fixes: [#26076](https://github.com/SUSE/spacewalk/issues/26076)
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
