### PR TITLE
Use Tornado instead of CherryPy in Saline

### DIFF
--- a/containers/server-saline-image/Dockerfile
+++ b/containers/server-saline-image/Dockerfile
@@ -19,14 +19,12 @@ RUN find /var/cache/zypp/packages/ -type f -name '*.rpm'
 RUN rpm -ivh --nodeps $(find /var/cache/zypp/packages/ -type f \
     -name update-alternatives.rpm -o \
     -name python3-base.rpm -o -name 'libpython3*.rpm' -o -name 'libopenssl1*.rpm' -o -name libexpat1.rpm -o \
-    -name python3-CherryPy.rpm -o -name python3-zc.lockfile.rpm -o -name python3-cheroot.rpm -o -name python3-six.rpm -o \
-    -name python3-portend.rpm -o -name python3-tempora.rpm -o \
-    -name salt.rpm -o -name python3-salt.rpm -o \
+    -name salt.rpm -o -name python3-salt.rpm -o -name python3-tornado.rpm -o \
     -name python3-contextvars.rpm -o -name python3-immutables.rpm -o -name python3-looseversion.rpm -o \
     -name python3-packaging.rpm -o -name python3-distro.rpm -o \
     -name python3-PyYAML.rpm -o -name 'libyaml*.rpm' -o -name python3-Jinja2.rpm -o -name python3-MarkupSafe.rpm -o \
     -name python3-msgpack.rpm -o -name python3-more-itertools.rpm -o \
-    -name saline.rpm -o -name python3-saline.rpm -o -name python3-python-dateutil.rpm)
+    -name saline.rpm -o -name python3-saline.rpm -o -name python3-python-dateutil.rpm -o -name python3-six.rpm)
 RUN zypper clean --all
 
 RUN mkdir /etc/saline.defaults && cp -r /etc/salt/saline* /etc/saline.defaults/

--- a/containers/server-saline-image/server-saline-image.changes.vzhestkov.saline-switch-to-tornado
+++ b/containers/server-saline-image/server-saline-image.changes.vzhestkov.saline-switch-to-tornado
@@ -1,0 +1,1 @@
+- Use Tornado instead of CherryPy in Saline


### PR DESCRIPTION
## What does this PR change?

Use `Tornado` instead of `CherryPy` in `Saline` as it works better and more native with async manner of `Salt`.

Requires SR: https://build.opensuse.org/request/show/1245988

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: there is no any tests yet. TBD in future

## Links

SR: https://build.opensuse.org/request/show/1245988

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
