### PR TITLE
Align test  POS images setup scripts with the released ones

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,19 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,19 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,19 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -22,7 +22,19 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,22 @@
 test -f /.kconfig && . /.kconfig
 test -f /.profile && . /.profile
 
-systemctl enable venv-salt-minion.service
+if [ -f /usr/bin/venv-salt-call ] ; then
+    systemctl enable venv-salt-minion.service
 
-# notify Uyuni about newly deployed image
-systemctl enable image-deployed.service
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed-bundle.service
+
+    systemctl enable migrate-to-bundle.service
+
+    # move the activation key injected by SUMA
+    mv /etc/salt/minion.d/kiwi_activation_key.conf /etc/venv-salt-minion/minion.d
+else
+    systemctl enable salt-minion.service
+
+    # notify SUSE Manager about newly deployed image
+    systemctl enable image-deployed.service
+fi
 
 # install bootloader and generate boot menu
 systemctl enable install-local-bootloader.service


### PR DESCRIPTION
## What does this PR change?

Aligns the setup scripts for the testing Kiwi POS images with the ones of the released build profiles at https://github.com/SUSE/manager-build-profiles/tree/master

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Resources used by Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26399
Port(s):  No

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
