### PR TITLE
Field for uyuni-tools for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yaml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yaml
@@ -40,6 +40,12 @@ body:
     validations:
       required: false
   - type: textarea
+     attributes:
+       label: uyuni-tools version used to deploy/manage the server or proxy (if relevant)
+       placeholder: |
+         Paste output of `zypper info mgradm`, or `zypper info mgrpxy`, or `zypper info mgrctl`, depending on the context
+       render: bash
+  - type: textarea
     attributes:
       label: Useful logs
       description: Do you see anything in the logs under `/var/log/rhn/` that looks like it could be related?


### PR DESCRIPTION
## What does this PR change?

Since uyuni-tools is now used for deployment, updates, and part of the management, this PR is adding a field for it, for our GitHub issue template.

We are already noticed some bugs where the problem is that the user is using an old uyuni-tools version, and having this info would allow to provide better assistance.

It's not mandatory, as not all bugs require it. But I can change this is you think it will be useful to always have it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Issue template

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: Issue template

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
