### PR TITLE
QE: Manually generate the bootstrap repo for Uyuni Build Host

### DIFF
--- a/testsuite/features/reposync/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/reposync/srv_create_bootstrap_repositories.feature
@@ -8,3 +8,8 @@ Feature: Create bootstrap repositories
 
   Scenario: Create the bootstrap repositories including custom channels
     When I create the bootstrap repositories including custom channels
+
+@uyuni
+@build_host
+  Scenario: Create the bootstrap repository for Uyuni Build Host
+    When I create the bootstrap repository for "build_host" on the server


### PR DESCRIPTION
## What does this PR change?

Manually generate the bootstrap repo for Uyuni Build Host, because it will NOT be triggered automatically using `mgr-create-bootstrap-repo --auto --force --with-custom-channels`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
