### PR TITLE
QE: Handle 5.1 when resolving product_version

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -60,7 +60,7 @@ def product_version
   raise NotImplementedError, 'Could not determine product version'
 end
 
-# Retrieves the full product version using the 'salt-call' command.
+# Retrieves the full product version using the 'venv-salt-call' command.
 #
 # @return [String, nil] The full product version if the command execution was successful and
 #   the output is not empty, otherwise nil.
@@ -70,13 +70,15 @@ def product_version_full
   out.strip if code.zero? && !out.nil?
 end
 
+# TODO: All our current supported versions are using Salt Bundle, consider to remove this method
+#       Refactoring all the code call it.
 # Determines whether to use the Salt bundle based on the product and product version.
 #
 # @return [Boolean] true if the product is 'Uyuni' or the product version is 'head', '5.0', '4.3', or '4.2'
 # - false otherwise
 def use_salt_bundle
-  # Use venv-salt-minion in Uyuni, or SUMA Head, 5.0, 4.2 and 4.3
-  product == 'Uyuni' || %w[head 5.0 4.3 4.2].include?(product_version)
+  # Use venv-salt-minion in Uyuni, or SUMA Head, 5.1, 5.0, 4.2 and 4.3
+  product == 'Uyuni' || %w[develHead 5.1 5.0 4.3 4.2].include?(product_version)
 end
 
 # WARN: It's working for /24 mask, but couldn't not work properly with others


### PR DESCRIPTION
## What does this PR change?

This PR includes 5.1 as a valid product version to be included in the group of versions using salt bundle, instead of classic salt. Also fix the match for Head versions, so when Head will become the next 5.2 version, we don't really need to include 5.2, until it's released ;)


I added a TODO, as we ideally should refactor this code to only use Salt Bundle for now on, as all our current supported versions are using Salt Bundle.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
