### PR TITLE
QE: refactor and reword action chain features

### DIFF
--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 SUSE LLC
+# Copyright (c) 2018-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # Skip if container because action chains fail on containers
@@ -52,9 +52,10 @@ Feature: Action chains on several systems at once
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-  Scenario: Pre-requisite: remove all action chains before testing on several systems
-    When I delete all action chains
-    And I cancel all scheduled actions
+  Scenario: Create a custom action chain for two systems
+    When I call actionchain.create_chain() with chain label "two_systems_action_chain"
+    And I follow the left menu "Schedule > Action Chains"
+    Then I should see a "two_systems_action_chain" text
 
   Scenario: Add an action chain using system set manager for SSH minion and SLE minion
     When I follow the left menu "Systems > System List > All"
@@ -86,13 +87,13 @@ Feature: Action chains on several systems at once
 
   Scenario: Verify action chain for two systems
     Given I am on the Systems overview page of this "sle_minion"
-    When I follow "Schedule"
+    And I follow "Schedule"
     And I follow "Action Chains"
-    And I follow "new action chain"
+    And I follow "two_systems_action_chain"
     And I should see a "1. Install or update andromeda-dummy on 2 systems" text
     And I should see a "2. Run a remote command on 2 systems" text
     And I click on "Save and Schedule"
-    Then I should see a "Action Chain new action chain has been scheduled for execution." text
+    Then I should see a "Action Chain two_systems_action_chain has been scheduled for execution." text
 
   Scenario: Verify that the action chain from the system set manager was executed successfully
     When I wait until file "/tmp/action_chain_done" exists on "ssh_minion"

--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -53,7 +53,7 @@ Feature: Action chains on several systems at once
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Create a custom action chain for two systems
-    When I call actionchain.create_chain() with chain label "two_systems_action_chain"
+    When I create an action chain with label "two_systems_action_chain" via API
     And I follow the left menu "Schedule > Action Chains"
     Then I should see a "two_systems_action_chain" text
 
@@ -87,7 +87,7 @@ Feature: Action chains on several systems at once
 
   Scenario: Verify action chain for two systems
     Given I am on the Systems overview page of this "sle_minion"
-    And I follow "Schedule"
+    When I follow "Schedule"
     And I follow "Action Chains"
     And I follow "two_systems_action_chain"
     And I should see a "1. Install or update andromeda-dummy on 2 systems" text

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -43,7 +43,7 @@ Feature: Action chains on Salt minions
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Create a custom action chain for the Salt minion
-    When I call actionchain.create_chain() with chain label "salt_minion_action_chain"
+    When I create an action chain with label "salt_minion_action_chain" via API 
     And I follow the left menu "Schedule > Action Chains"
     Then I should see a "salt_minion_action_chain" text
 
@@ -176,8 +176,8 @@ Feature: Action chains on Salt minions
 
   Scenario: Execute the action chain from the web UI on Salt minion
     Given I am authorized for the "Admin" section
-    And I am on the Systems overview page of this "sle_minion"
-    When I follow "Schedule"
+    When I am on the Systems overview page of this "sle_minion"
+    And I follow "Schedule"
     And I follow "Action Chains"
     And I follow "salt_minion_action_chain"
     And I click on "Save and Schedule"
@@ -187,7 +187,7 @@ Feature: Action chains on Salt minions
 
   # previous, completed, action chain will no longer be available
   Scenario: Create a custom action chain for the Salt minion
-    When I call actionchain.create_chain() with chain label "salt_minion_action_chain_to_delete"
+    When I create an action chain with label "salt_minion_action_chain_to_delete" via API
     And I follow the left menu "Schedule > Action Chains"
     Then I should see a "salt_minion_action_chain_to_delete" text
 
@@ -231,30 +231,30 @@ Feature: Action chains on Salt minions
 
   Scenario: Add operations to the action chain via API for Salt minions
     Given I want to operate on this "sle_minion"
-    When I call actionchain.create_chain() with chain label "salt_minion_api_chain"
-    And I call actionchain.add_package_install()
-    And I call actionchain.add_package_removal()
-    And I call actionchain.add_package_upgrade()
-    And I call actionchain.add_script_run() with the script "exit 1;"
-    And I call actionchain.add_system_reboot()
-    Then I should be able to see all these actions in the action chain
-    When I call actionchain.remove_action() on each action within the chain
+    When I create an action chain with label "salt_minion_api_chain" via API 
+    And I add a package install to the action chain via API
+    And I add a package removal to the action chain via API
+    And I add a package upgrade to the action chain via API
+    And I add the script "exit 1;" to the action chain via API
+    And I add a system reboot to the action chain via API
+    Then I should be able to see all these actions in the action chain via API
+    When I remove each action within the chain via API
     Then the current action chain should be empty
-    And I delete the action chain
+    And I delete the action chain via API
 
   Scenario: Run an action chain via API on Salt minion
     Given I want to operate on this "sle_minion"
-    When I call actionchain.create_chain() with chain label "salt_minion_multiple_scripts"
-    And I call actionchain.add_script_run() with the script "echo -n 1 >> /tmp/action_chain.log"
-    And I call actionchain.add_script_run() with the script "echo -n 2 >> /tmp/action_chain.log"
-    And I call actionchain.add_script_run() with the script "echo -n 3 >> /tmp/action_chain.log"
-    And I call actionchain.add_script_run() with the script "touch /tmp/action_chain_done"
-    Then I should be able to see all these actions in the action chain
-    When I schedule the action chain
-    And I wait until there are no more action chains
+    When I create an action chain with label "salt_minion_multiple_scripts" via API
+    And I add the script "echo -n 1 >> /tmp/action_chain.log" to the action chain via API
+    And I add the script "echo -n 2 >> /tmp/action_chain.log" to the action chain via API
+    And I add the script "echo -n 3 >> /tmp/action_chain.log" to the action chain via API
+    And I add the script "touch /tmp/action_chain_done" to the action chain via API
+    Then I should be able to see all these actions in the action chain via API
+    When I schedule the action chain via API
+    And I wait until there are no more action chains listed via API
     And I wait until file "/tmp/action_chain_done" exists on "sle_minion"
     Then file "/tmp/action_chain.log" should contain "123" on "sle_minion"
-    When I wait until there are no more scheduled actions
+    When I wait until there are no more scheduled actions listed via API
 
   Scenario: Cleanup: remove Salt minion from configuration channel
     When I follow the left menu "Configuration > Channels"

--- a/testsuite/features/secondary/min_timezone.feature
+++ b/testsuite/features/secondary/min_timezone.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # This is a known bug: https://bugzilla.suse.com/show_bug.cgi?id=1209231
@@ -83,7 +83,7 @@ Feature: Correct timezone display
 
   Scenario: Cleanup: Log in as admin user again and remove scheduled actions
     Given I am authorized for the "Admin" section
-    And I cancel all scheduled actions
+    And I cancel all scheduled actions via API
 
   Scenario: Cleanup: Remove role
     When I follow the left menu "Users > User List > Active"

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -44,9 +44,10 @@ Feature: Salt SSH action chain
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-  Scenario: Pre-requisite: remove all action chains before testing on SSH minion
-    When I delete all action chains
-    And I cancel all scheduled actions
+  Scenario: Create a custom action chain for the SSH minion
+    When I call actionchain.create_chain() with chain label "minssh_action_chain"
+    And I follow the left menu "Schedule > Action Chains"
+    Then I should see a "minssh_action_chain" text
 
   Scenario: Add a patch installation to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
@@ -150,7 +151,7 @@ Feature: Salt SSH action chain
 
   Scenario: Verify the action chain list on SSH minion
     When I follow the left menu "Schedule > Action Chains"
-    And I follow "new action chain"
+    And I follow "minssh_action_chain"
     Then I should see a "1. Apply patch(es) andromeda-dummy-6789 on 1 system" text
     And I should see a "2. Remove milkyway-dummy from 1 system" text
     And I should see a "3. Install or update virgo-dummy on 1 system" text
@@ -161,21 +162,27 @@ Feature: Salt SSH action chain
   Scenario: Check that a different user cannot see the action chain for SSH minion
     Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Schedule > Action Chains"
-    Then I should not see a "new action chain" link
+    Then I should not see a "minssh_action_chain" link
 
   Scenario: Execute the action chain from the web UI on SSH minion
     Given I am authorized for the "Admin" section
     When I follow the left menu "Schedule > Action Chains"
-    And I wait until I see "new action chain" text
-    And I follow "new action chain"
+    And I wait until I see "minssh_action_chain" text
+    And I follow "minssh_action_chain"
     Then I click on "Save and Schedule"
-    And I should see a "Action Chain new action chain has been scheduled for execution." text
+    And I should see a "Action Chain minssh_action_chain has been scheduled for execution." text
 
   Scenario: Verify that the action chain was executed successfully
     When I wait for "virgo-dummy" to be installed on "ssh_minion"
     And I wait at most 300 seconds until file "/tmp/action_chain_one_system_done" exists on "ssh_minion"
 
-  Scenario: Add a remote command to the new action chain on SSH minion
+  # previous, completed, action chain will no longer be available
+  Scenario: Create a custom action chain for the SSH minion
+    When I call actionchain.create_chain() with chain label "minssh_action_chain_to_delete"
+    And I follow the left menu "Schedule > Action Chains"
+    Then I should see a "minssh_action_chain_to_delete" text
+
+  Scenario: Add a remote command to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Remote Command"
     And I enter as remote command this script in
@@ -189,7 +196,7 @@ Feature: Salt SSH action chain
 
   Scenario: Delete the action chain for SSH minion
     When I follow the left menu "Schedule > Action Chains"
-    And I follow "new action chain"
+    And I follow "minssh_action_chain_to_delete"
     And I follow "delete action chain" in the content area
     Then I click on "Delete"
 
@@ -217,8 +224,8 @@ Feature: Salt SSH action chain
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Add operations to the action chain via API for SSH minions
-    And I want to operate on this "ssh_minion"
-    When I call actionchain.create_chain() with chain label "throwaway_chain"
+    Given I want to operate on this "ssh_minion"
+    When I call actionchain.create_chain() with chain label "minssh_api_chain"
     And I call actionchain.add_package_install()
     And I call actionchain.add_package_removal()
     And I call actionchain.add_package_upgrade()
@@ -226,11 +233,11 @@ Feature: Salt SSH action chain
     Then I should be able to see all these actions in the action chain
     When I call actionchain.remove_action() on each action within the chain
     Then the current action chain should be empty
-    When I delete the action chain
+    And I delete the action chain
 
   Scenario: Run an action chain via API on SSH minion
     And I want to operate on this "ssh_minion"
-    When I call actionchain.create_chain() with chain label "multiple_scripts"
+    When I call actionchain.create_chain() with chain label "minssh_multiple_scripts"
     And I call actionchain.add_script_run() with the script "echo -n 1 >> /tmp/action_chain.log"
     And I call actionchain.add_script_run() with the script "echo -n 2 >> /tmp/action_chain.log"
     And I call actionchain.add_script_run() with the script "echo -n 3 >> /tmp/action_chain.log"

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -45,7 +45,7 @@ Feature: Salt SSH action chain
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Create a custom action chain for the SSH minion
-    When I call actionchain.create_chain() with chain label "minssh_action_chain"
+    When I create an action chain with label "minssh_action_chain" via API  
     And I follow the left menu "Schedule > Action Chains"
     Then I should see a "minssh_action_chain" text
 
@@ -129,7 +129,6 @@ Feature: Salt SSH action chain
     And I check radio button "schedule-by-action-chain"
     And I click on "Apply Highstate"
 
-@skip_if_github_validation
   Scenario: Add a reboot action to the action chain on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow first "Schedule System Reboot"
@@ -157,7 +156,8 @@ Feature: Salt SSH action chain
     And I should see a "3. Install or update virgo-dummy on 1 system" text
     And I should see a text like "4. Deploy.*/etc/action-chain.cnf.*to 1 system"
     And I should see a "5. Apply Highstate" text
-    And I should see a "Run a remote command on 1 system" text
+    And I should see a "6. Reboot 1 system" text
+    And I should see a "7. Run a remote command on 1 system" text
 
   Scenario: Check that a different user cannot see the action chain for SSH minion
     Given I am authorized as "testing" with password "testing"
@@ -178,7 +178,7 @@ Feature: Salt SSH action chain
 
   # previous, completed, action chain will no longer be available
   Scenario: Create a custom action chain for the SSH minion
-    When I call actionchain.create_chain() with chain label "minssh_action_chain_to_delete"
+    When I create an action chain with label "minssh_action_chain_to_delete" via API 
     And I follow the left menu "Schedule > Action Chains"
     Then I should see a "minssh_action_chain_to_delete" text
 
@@ -225,29 +225,29 @@ Feature: Salt SSH action chain
 
   Scenario: Add operations to the action chain via API for SSH minions
     Given I want to operate on this "ssh_minion"
-    When I call actionchain.create_chain() with chain label "minssh_api_chain"
-    And I call actionchain.add_package_install()
-    And I call actionchain.add_package_removal()
-    And I call actionchain.add_package_upgrade()
-    And I call actionchain.add_script_run() with the script "exit 1;"
-    Then I should be able to see all these actions in the action chain
-    When I call actionchain.remove_action() on each action within the chain
+    When I create an action chain with label "minssh_api_chain" via API
+    And I add a package install to the action chain via API
+    And I add a package removal to the action chain via API
+    And I add a package upgrade to the action chain via API
+    And I add the script "exit 1;" to the action chain via API
+    Then I should be able to see all these actions in the action chain via API
+    When I remove each action within the chain via API
     Then the current action chain should be empty
-    And I delete the action chain
+    And I delete the action chain via API
 
   Scenario: Run an action chain via API on SSH minion
     And I want to operate on this "ssh_minion"
-    When I call actionchain.create_chain() with chain label "minssh_multiple_scripts"
-    And I call actionchain.add_script_run() with the script "echo -n 1 >> /tmp/action_chain.log"
-    And I call actionchain.add_script_run() with the script "echo -n 2 >> /tmp/action_chain.log"
-    And I call actionchain.add_script_run() with the script "echo -n 3 >> /tmp/action_chain.log"
-    And I call actionchain.add_script_run() with the script "touch /tmp/action_chain_done"
-    Then I should be able to see all these actions in the action chain
-    When I schedule the action chain
-    Then I wait until there are no more action chains
+    When I create an action chain with label "minssh_multiple_scripts" via API
+    And I add the script "echo -n 1 >> /tmp/action_chain.log" to the action chain via API
+    And I add the script "echo -n 2 >> /tmp/action_chain.log" to the action chain via API
+    And I add the script "echo -n 3 >> /tmp/action_chain.log" to the action chain via API
+    And I add the script "touch /tmp/action_chain_done" to the action chain via API
+    Then I should be able to see all these actions in the action chain via API
+    When I schedule the action chain via API
+    Then I wait until there are no more action chains listed via API
     When I wait until file "/tmp/action_chain_done" exists on "ssh_minion"
     Then file "/tmp/action_chain.log" should contain "123" on "ssh_minion"
-    When I wait until there are no more scheduled actions
+    When I wait until there are no more scheduled actions listed via API
 
   Scenario: Cleanup: remove SSH minion from configuration channel
     When I follow the left menu "Configuration > Channels"

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # skip if container because we do not have a domain name and the
@@ -124,7 +124,7 @@ Feature: Maintenance windows
     Then I should see a "Maintenance schedule has been cleared" text
 
   Scenario: Cleanup: cancel all scheduled actions
-    When I cancel all scheduled actions
+    When I cancel all scheduled actions via API
 
   Scenario: Delete maintenance schedules
     When I follow the left menu "Schedule > Maintenance Windows > Schedules"

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 SUSE LLC
+# Copyright (c) 2015-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning the API.
@@ -303,25 +303,25 @@ end
 
 # actionchain namespace
 
-When(/^I call actionchain\.create_chain\(\) with chain label "(.*?)"$/) do |label|
+When(/^I create an action chain with label "(.*?)" via API$/) do |label|
   action_id = $api_test.actionchain.create_chain(label)
   refute(action_id < 1)
   $chain_label = label
 end
 
-When(/^I call actionchain\.list_chains\(\) if label "(.*?)" is there$/) do |label|
+When(/^I see label "(.*?)" when I list action chains via API$/) do |label|
   assert_includes($api_test.actionchain.list_chains, label)
 end
 
-When(/^I delete the action chain$/) do
+When(/^I delete the action chain via API$/) do
   $api_test.actionchain.delete_chain($chain_label)
 end
 
-When(/^I delete an action chain, labeled "(.*?)"$/) do |label|
+When(/^I delete an action chain, labeled "(.*?)", via API$/) do |label|
   $api_test.actionchain.delete_chain(label)
 end
 
-When(/^I delete all action chains$/) do
+When(/^I delete all action chains via API$/) do
   $api_test.actionchain.list_chains.each do |label|
     log "Delete chain: #{label}"
     $api_test.actionchain.delete_chain(label)
@@ -329,28 +329,24 @@ When(/^I delete all action chains$/) do
 end
 
 # Renaming chain
-Then(/^I call actionchain\.rename_chain\(\) to rename it from "(.*?)" to "(.*?)"$/) do |old_label, new_label|
+Then(/^I rename the action chain with label "(.*?)" to "(.*?)" via API$/) do |old_label, new_label|
   $api_test.actionchain.rename_chain(old_label, new_label)
 end
 
-Then(/^there should be a new action chain with the label "(.*?)"$/) do |label|
+Then(/^there should be a new action chain with the label "(.*?)" listed via API$/) do |label|
   assert_includes($api_test.actionchain.list_chains, label)
 end
 
-Then(/^there should be no action chain with the label "(.*?)"$/) do |label|
-  refute_includes($api_test.actionchain.list_chains, label)
-end
-
-Then(/^no action chain with the label "(.*?)"$/) do |label|
+Then(/^there should be no action chain with the label "(.*?)" listed via API$/) do |label|
   refute_includes($api_test.actionchain.list_chains, label)
 end
 
 # Schedule scenario
-When(/^I call actionchain\.add_script_run\(\) with the script "(.*?)"$/) do |script|
+When(/^I add the script "(.*?)" to the action chain via API$/) do |script|
   refute($api_test.actionchain.add_script_run($client_id, $chain_label, 'root', 'root', 300, "#!/bin/bash\n#{script}") < 1)
 end
 
-Then(/^I should be able to see all these actions in the action chain$/) do
+Then(/^I should be able to see all these actions in the action chain via API$/) do
   actions = $api_test.actionchain.list_chain_actions($chain_label)
   refute_nil(actions)
   log 'Running actions:'
@@ -360,31 +356,31 @@ Then(/^I should be able to see all these actions in the action chain$/) do
 end
 
 # Reboot
-When(/^I call actionchain\.add_system_reboot\(\)$/) do
+When(/^I add a system reboot to the action chain via API$/) do
   refute($api_test.actionchain.add_system_reboot($client_id, $chain_label) < 1)
 end
 
 # Packages operations
-When(/^I call actionchain\.add_package_install\(\)$/) do
+When(/^I add a package install to the action chain via API$/) do
   pkgs = $api_test.system.list_all_installable_packages($client_id)
   refute_nil(pkgs)
   refute_empty(pkgs)
   refute($api_test.actionchain.add_package_install($client_id, [pkgs[0]['id']], $chain_label) < 1)
 end
 
-When(/^I call actionchain\.add_package_removal\(\)$/) do
+When(/^I add a package removal to the action chain via API$/) do
   pkgs = $api_test.system.list_all_installable_packages($client_id)
   refute($api_test.actionchain.add_package_removal($client_id, [pkgs[0]['id']], $chain_label) < 1)
 end
 
-When(/^I call actionchain\.add_package_upgrade\(\)$/) do
+When(/^I add a package upgrade to the action chain via API$/) do
   pkgs = $api_test.system.list_latest_upgradable_packages($client_id)
   refute_nil(pkgs)
   refute_empty(pkgs)
   refute($api_test.actionchain.add_package_upgrade($client_id, [pkgs[0]['to_package_id']], $chain_label) < 1)
 end
 
-When(/^I call actionchain\.add_package_verify\(\)$/) do
+When(/^I add a package verification to the action chain via API$/) do
   pkgs = $api_test.system.list_all_installable_packages($client_id)
   refute_nil(pkgs)
   refute_empty(pkgs)
@@ -392,7 +388,7 @@ When(/^I call actionchain\.add_package_verify\(\)$/) do
 end
 
 # Manage actions within the action chain
-When(/^I call actionchain\.remove_action\(\) on each action within the chain$/) do
+When(/^I remove each action within the chain via API$/) do
   actions = $api_test.actionchain.list_chain_actions($chain_label)
   refute_nil(actions)
   actions.each do |action|
@@ -406,11 +402,11 @@ Then(/^the current action chain should be empty$/) do
 end
 
 # Scheduling the action chain
-When(/^I schedule the action chain$/) do
+When(/^I schedule the action chain via API$/) do
   refute($api_test.actionchain.schedule_chain($chain_label, DateTime.now).negative?)
 end
 
-When(/^I wait until there are no more action chains$/) do
+When(/^I wait until there are no more action chains listed via API$/) do
   repeat_until_timeout(message: 'Action Chains still present') do
     break if $api_test.actionchain.list_chains.empty?
 
@@ -424,11 +420,11 @@ end
 
 # schedule API
 
-Then(/^I should see scheduled action, called "(.*?)"$/) do |label|
+Then(/^I should see scheduled action, called "(.*?)", listed via API$/) do |label|
   assert_includes($api_test.schedule.list_in_progress_actions.map { |a| a['name'] }, label)
 end
 
-Then(/^I cancel all scheduled actions$/) do
+Then(/^I cancel all scheduled actions via API$/) do
   actions =
     $api_test.schedule.list_in_progress_actions.reject do |action|
       action['prerequisite']
@@ -447,7 +443,7 @@ Then(/^I cancel all scheduled actions$/) do
   end
 end
 
-Then(/^I wait until there are no more scheduled actions$/) do
+Then(/^I wait until there are no more scheduled actions listed via API$/) do
   repeat_until_timeout(message: 'Scheduled actions still present') do
     break if $api_test.schedule.list_in_progress_actions.empty?
 


### PR DESCRIPTION
## What does this PR change?

Refactors the action chain related features in order to have each one of them use different names for different action chains.
Currently we reuse the same names over and over, both inside a single feature and between different features.
Switching to using different names allows to:

1) make the tests closer to what a customer will do
2) make debugging a little bit easier
3) possibly avoid testsuite failures due to sharing the same name for different chains - although that should be a non-issue, I have the impressions that if we schedule a bunch of commands, run and delete a chain, create another one with the same name, schedule more command (...) all in a short time span we might get into troubles as UI and internal serve state get out of sync.
Also, currently some failures leave behind a chain with the same name of the one that is supposed to be freshly created, messing things up even more.
4) possibly allow for parallelization if we can do without the step that cleanups previous actions/schedules (done in this PR) and drop the usage of a global variables to keep track  of which action chain we are working with (not done in this PR).

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): 

- https://github.com/SUSE/spacewalk/issues/21170
- https://github.com/SUSE/spacewalk/issues/21171
- https://github.com/SUSE/spacewalk/issues/21172

Port(s): 

- 4.3: https://github.com/SUSE/spacewalk/pull/26499
- 5.0: https://github.com/SUSE/spacewalk/pull/26584

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
