### PR TITLE
QE: remove workaround for building Kiwi images

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation
@@ -48,11 +48,6 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     And I enter the image filename for "sle12sp5_terminal" relative to profiles as "path"
     And I click on "create-btn"
     And I wait until no Salt job is running on "sle12sp5_buildhost"
-
-  # WORKAROUND
-  # Remove as soon as the issue is fixed
-  Scenario: Work around issue https://github.com/SUSE/spacewalk/issues/10360
-    When I let Kiwi build from external repositories
 
   Scenario: Build Kiwi image for SLES 12 SP5
     When I follow the left menu "Images > Build"

--- a/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @skip_if_github_validation
@@ -48,11 +48,6 @@ Feature: Prepare buildhost and build OS image for SLES 15 SP4
     And I enter the image filename for "sle15sp4_terminal" relative to profiles as "path"
     And I click on "create-btn"
     And I wait until no Salt job is running on "sle15sp4_buildhost"
-
-  # WORKAROUND
-  # Remove as soon as the issue is fixed
-  Scenario: Work around issue https://github.com/SUSE/spacewalk/issues/10360
-    When I let Kiwi build from external repositories
 
   Scenario: Build Kiwi image for SLES 15 SP4
     When I follow the left menu "Images > Build"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 SUSE LLC
+# Copyright (c) 2018-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature relies on having properly configured
@@ -35,11 +35,6 @@ Feature: Build OS images
     And I enter the image filename for "pxeboot_minion" relative to profiles as "path"
     And I click on "create-btn"
     And I wait until no Salt job is running on "build_host"
-
-  # WORKAROUND
-  # Remove as soon as the issue is fixed
-  Scenario: Work around issue https://github.com/SUSE/spacewalk/issues/10360
-    When I let Kiwi build from external repositories
 
   Scenario: Login as Kiwi image administrator and build an image
     Given I am authorized for the "Images" section

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1228,13 +1228,6 @@ When(/^I schedule apply configchannels for "([^"]*)"$/) do |host|
   get_target('server').run(command)
 end
 
-# WORKAROUND
-# Work around issue https://github.com/SUSE/spacewalk/issues/10360
-# Remove as soon as the issue is fixed
-When(/^I let Kiwi build from external repositories$/) do
-  get_target('server').run('sed -i \'s/--ignore-repos-used-for-build//\' /usr/share/susemanager/salt/images/kiwi-image-build.sls')
-end
-
 When(/^I refresh packages list via spacecmd on "([^"]*)"$/) do |client|
   node = get_system_name(client)
   get_target('server').run('spacecmd -u admin -p admin clear_caches')


### PR DESCRIPTION
## What does this PR change?

Removes and old workaround we had in place for https://github.com/SUSE/spacewalk/issues/10360

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/10360
Port(s): 

- 4.3 https://github.com/SUSE/spacewalk/pull/26511
- 5.0 https://github.com/SUSE/spacewalk/pull/26501

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
