### PR TITLE
ISSv3: API to perform a product refresh on the peripheral from the hub

### DIFF
--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -18,6 +18,7 @@ import static com.suse.manager.hub.HubSparkHelper.usingTokenAuthentication;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.badRequest;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.internalServerError;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.message;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.success;
 import static spark.Spark.get;
@@ -110,6 +111,14 @@ public class HubController {
                 asJson(usingTokenAuthentication(onlyFromHub(this::addCustomChannels))));
         post("/hub/modifyCustomChannels",
                 asJson(usingTokenAuthentication(onlyFromHub(this::modifyCustomChannels))));
+        post("/hub/sync/channelfamilies",
+                asJson(usingTokenAuthentication(onlyFromHub(this::synchronizeChannelFamilies))));
+        post("/hub/sync/products",
+                asJson(usingTokenAuthentication(onlyFromHub(this::synchronizeProducts))));
+        post("/hub/sync/repositories",
+                asJson(usingTokenAuthentication(onlyFromHub(this::synchronizeRepositories))));
+        post("/hub/sync/subscriptions",
+                asJson(usingTokenAuthentication(onlyFromHub(this::synchronizeSubscriptions))));
     }
 
     private String setHubDetails(Request request, Response response, IssAccessToken accessToken) {
@@ -346,5 +355,21 @@ public class HubController {
                                 (null == ch.getParentChannel()) ? null : ch.getParentChannel().getId()))
                         .toList();
         return success(response, modifiedCustomChannelsInfoList);
+    }
+
+    private String synchronizeChannelFamilies(Request request, Response response, IssAccessToken token) {
+        return json(response, hubManager.synchronizeChannelFamilies(token));
+    }
+
+    private String synchronizeProducts(Request request, Response response, IssAccessToken token) {
+        return json(response, hubManager.synchronizeProducts(token));
+    }
+
+    private String synchronizeRepositories(Request request, Response response, IssAccessToken token) {
+        return json(response, hubManager.synchronizeRepositories(token));
+    }
+
+    private String synchronizeSubscriptions(Request request, Response response, IssAccessToken token) {
+        return json(response, hubManager.synchronizeSubscriptions(token));
     }
 }

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -55,6 +55,7 @@ import com.suse.manager.model.hub.IssServer;
 import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
 import com.suse.manager.model.hub.TokenType;
+import com.suse.manager.webui.controllers.ProductsController;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
 import com.suse.manager.webui.utils.token.Token;
 import com.suse.manager.webui.utils.token.TokenBuildingException;
@@ -998,5 +999,49 @@ public class HubManager {
                 .stream()
                 .filter(e -> modifiedChannelsLabelList.contains(e.getLabel()))
                 .toList();
+    }
+
+    /**
+     * Trigger a synchronization of Channel Families on the peripheral
+     *
+     * @param accessToken the access token
+     * @return a boolean flag of the success/failed result
+     */
+    public boolean synchronizeChannelFamilies(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+        return ProductsController.doSynchronizeChannelFamilies();
+    }
+
+    /**
+     * Trigger a synchronization of Products on the peripheral
+     *
+     * @param accessToken the access token
+     * @return a boolean flag of the success/failed result
+     */
+    public boolean synchronizeProducts(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+        return ProductsController.doSynchronizeProducts();
+    }
+
+    /**
+     * Trigger a synchronization of Repositories on the peripheral
+     *
+     * @param accessToken the access token
+     * @return a boolean flag of the success/failed result
+     */
+    public boolean synchronizeRepositories(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+        return ProductsController.doSynchronizeRepositories();
+    }
+
+    /**
+     * Trigger a synchronization of Subscriptions on the peripheral
+     *
+     * @param accessToken the access token
+     * @return a boolean flag of the success/failed result
+     */
+    public boolean synchronizeSubscriptions(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+        return ProductsController.doSynchronizeSubscriptions();
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -117,7 +117,11 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
                 Arguments.of(HttpMethod.get, "/hub/listAllPeripheralChannels", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/addVendorChannels", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/addCustomChannels", IssRole.HUB),
-                Arguments.of(HttpMethod.post, "/hub/modifyCustomChannels", IssRole.HUB)
+                Arguments.of(HttpMethod.post, "/hub/modifyCustomChannels", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/sync/channelfamilies", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/sync/products", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/sync/repositories", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/sync/subscriptions", IssRole.HUB)
         );
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -154,21 +154,30 @@ public class ProductsController {
     /**
      * Trigger a synchronization of Products
      *
-     * @param request the request
+     * @param request  the request
      * @param response the response
-     * @param user the user
+     * @param user     the user
      * @return a JSON flag of the success/failed result
      */
     public static String synchronizeProducts(Request request, Response response, User user) {
+        return json(response, doSynchronizeProducts());
+    }
+
+    /**
+     * Trigger a synchronization of Products
+     *
+     * @return a boolean flag of the success/failed result
+     */
+    public static boolean doSynchronizeProducts() {
         return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
             try {
                 ContentSyncManager csm = new ContentSyncManager();
                 csm.updateSUSEProducts(csm.getProducts());
-                return json(response, true);
+                return true;
             }
             catch (Exception e) {
                 log.fatal(e.getMessage(), e);
-                return json(response, false);
+                return false;
             }
         });
     }
@@ -182,15 +191,24 @@ public class ProductsController {
      * @return a JSON flag of the success/failed result
      */
     public static String synchronizeChannelFamilies(Request request, Response response, User user) {
+        return json(response, doSynchronizeChannelFamilies());
+    }
+
+    /**
+     * Trigger a synchronization of Channel Families
+     *
+     * @return a boolean flag of the success/failed result
+     */
+    public static boolean doSynchronizeChannelFamilies() {
         return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
             try {
                 ContentSyncManager csm = new ContentSyncManager();
                 csm.updateChannelFamilies(csm.readChannelFamilies());
-                return json(response, true);
+                return true;
             }
             catch (Exception e) {
                 log.fatal(e.getMessage(), e);
-                return json(response, false);
+                return false;
             }
         });
     }
@@ -198,21 +216,30 @@ public class ProductsController {
     /**
      * Trigger a synchronization of Repositories
      *
-     * @param request the request
+     * @param request  the request
      * @param response the response
-     * @param user the user
+     * @param user     the user
      * @return a JSON flag of the success/failed result
      */
     public static String synchronizeRepositories(Request request, Response response, User user) {
+        return json(response, doSynchronizeRepositories());
+    }
+
+    /**
+     * Trigger a synchronization of Repositories
+     *
+     * @return a boolean flag of the success/failed result
+     */
+    public static boolean doSynchronizeRepositories() {
         return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
             try {
                 ContentSyncManager csm = new ContentSyncManager();
                 csm.updateRepositories(null);
-                return json(response, true);
+                return true;
             }
             catch (Exception e) {
                 log.fatal(e.getMessage(), e);
-                return json(response, false);
+                return false;
             }
         });
     }
@@ -220,21 +247,30 @@ public class ProductsController {
     /**
      * Trigger a synchronization of Subscriptions
      *
-     * @param request the request
+     * @param request  the request
      * @param response the response
-     * @param user the user
+     * @param user     the user
      * @return a JSON flag of the success/failed result
      */
     public static String synchronizeSubscriptions(Request request, Response response, User user) {
+        return json(response, doSynchronizeSubscriptions());
+    }
+
+    /**
+     * Trigger a synchronization of Subscriptions
+     *
+     * @return a boolean flag of the success/failed result
+     */
+    public static boolean doSynchronizeSubscriptions() {
         return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
             try {
                 ContentSyncManager csm = new ContentSyncManager();
                 csm.updateSubscriptions();
-                return json(response, true);
+                return true;
             }
             catch (Exception e) {
                 log.fatal(e.getMessage(), e);
-                return json(response, false);
+                return false;
             }
         });
     }


### PR DESCRIPTION
## What does this PR change?

After registration of a new peripheral, we need to sync the products from the Hub or we cannot add channels.
Currently this needs to be performed on the Peripheral using mgr-sync refresh.

This PR adds the APIs for it using with the new Token API and provide this feature from the Hub side similar to
the Refresh on the Product Page.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: it has to be tested manually
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/26496
Port(s): 
- [x] **DONE**

## Changelogs
- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

