### PR TITLE
fix accessibleUrl removing trailing / on urls (bsc#1236268)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -2547,22 +2547,18 @@ public class ContentSyncManager {
         try {
             URI uri = new URI(url);
 
-            // SMT doesn't do dir listings, so we try to get the metadata
-            Path testUrlPath = new File(StringUtils.defaultString(uri.getRawPath(), "/")).toPath();
-
             // Build full URL to test
             if (uri.getScheme().equals("file")) {
+                Path testUrlPath = new File(StringUtils.defaultString(uri.getRawPath(), "/")).toPath();
                 boolean res = Files.isReadable(testUrlPath);
                 LOG.debug("accessibleUrl:{} {}", testUrlPath, res);
                 return res;
             }
             else {
-                URI testUri = new URI(uri.getScheme(), null, uri.getHost(),
-                        uri.getPort(), testUrlPath.toString(), uri.getQuery(), null);
                 // Verify the mirrored repo by sending a HEAD request
-                int status = MgrSyncUtils.sendHeadRequest(testUri.toString(),
+                int status = MgrSyncUtils.sendHeadRequest(uri.toString(),
                         user, password).getStatusLine().getStatusCode();
-                LOG.debug("accessibleUrl: {} returned status {}", testUri, status);
+                LOG.debug("accessibleUrl: {} returned status {}", uri, status);
                 return (status == HttpURLConnection.HTTP_OK);
             }
         }

--- a/java/spacewalk-java.changes.kwalter.bsc1236268
+++ b/java/spacewalk-java.changes.kwalter.bsc1236268
@@ -1,0 +1,1 @@
+- Fix issue preventing OES products from showing up (bsc#1236268)


### PR DESCRIPTION
## What does this PR change?

This fixes an issue preventing OES from showing up in the products page. The problem was that the roundtrip from URI to Path and back removed the trailing / on the urls for OES which are required

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26285
Port(s): 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
