### PR TITLE
Change releasenotes URL for SUSE Multi-Linux Manager 5.1

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/UpdateAvailable.java
@@ -98,7 +98,7 @@ public class UpdateAvailable implements NotificationData, Serializable {
      */
     public String getReleaseNotesUrl() {
         return isUyuni ? "https://www.uyuni-project.org/pages/stable-version.html" :
-                "https://www.suse.com/releasenotes/x86_64/SUSE-MANAGER/" +
+                "https://www.suse.com/releasenotes/x86_64/multi-linux-manager/" +
                         version.getMajor() + "." + version.getMinor() +
                         "/index.html";
     }

--- a/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/types/test/UpdateAvailableTest.java
@@ -266,4 +266,20 @@ public class UpdateAvailableTest {
         );
     }
 
+    @Test
+    public void testReleaseNotesUrl() {
+        Config.get().setString(PRODUCT_NAME, UYUNI);
+        Config.get().setString(PRODUCT_VERSION_UYUNI, "2024.07");
+
+        UpdateAvailable updateAvailable = new UpdateAvailable();
+        assertEquals("https://www.uyuni-project.org/pages/stable-version.html",
+                updateAvailable.getReleaseNotesUrl());
+
+        Config.get().setString(PRODUCT_NAME, SUMA);
+        Config.get().setString(PRODUCT_VERSION_MGR, "5.1.1");
+
+        updateAvailable = new UpdateAvailable();
+        assertEquals("https://www.suse.com/releasenotes/x86_64/multi-linux-manager/5.1/index.html",
+                updateAvailable.getReleaseNotesUrl());
+    }
 }

--- a/java/spacewalk-java.changes.mcalmer.multi-linux-rebranding
+++ b/java/spacewalk-java.changes.mcalmer.multi-linux-rebranding
@@ -1,0 +1,1 @@
+- Change releasenotes URL for SUSE Multi-Linux Manager 5.1


### PR DESCRIPTION
## What does this PR change?

Change the URL for the release notes as our product get renamed to "SUSE Multi-Linux Manager".

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26459
Port(s): no port - 5.1 + only

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
