### PR TITLE
QE: Leap 15.5 is no longer supported. Switch to 15.6

### DIFF
--- a/testsuite/features/secondary/srv_manage_channels_page.feature
+++ b/testsuite/features/secondary/srv_manage_channels_page.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2024 SUSE LLC
+# Copyright (c) 2021-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization
@@ -44,7 +44,7 @@ Feature: Managing channels
   Scenario: Fail when trying to use reserved names for channels
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    And I enter "openSUSE-Leap-15.5-Pool for x86_64" as "Channel Name"
+    And I enter "openSUSE-Leap-15.6-Pool for x86_64" as "Channel Name"
     And I enter "test123" as "Channel Label"
     And I enter "test123" as "Channel Summary"
     And I click on "Create Channel"
@@ -55,7 +55,7 @@ Feature: Managing channels
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "test123" as "Channel Name"
-    And I enter "opensuse-leap-15.5-pool-x86_64" as "Channel Label"
+    And I enter "opensuse-leap-15.6-pool-x86_64" as "Channel Label"
     And I enter "test123" as "Channel Summary"
     And I click on "Create Channel"
     Then I should see a "The channel label 'opensuse-leap-15.5-pool-x86_64' is reserved, please enter a different name" text
@@ -73,7 +73,7 @@ Feature: Managing channels
   Scenario: Fail when trying to change the channel name to a reserved name
     When I follow the left menu "Software > Manage > Channels"
     And I follow "aaaSLE-12-Cloud-Compute5-Pool for x86_64"
-    And I enter "openSUSE-Leap-15.5-Pool for x86_64" as "Channel Name"
+    And I enter "openSUSE-Leap-15.6-Pool for x86_64" as "Channel Name"
     And I click on "Update Channel"
     Then I should see a "The channel name 'openSUSE-Leap-15.5-Pool for x86_64' is reserved, please enter a different name" text
 

--- a/testsuite/features/secondary/srv_mgr_sync_list_products.feature
+++ b/testsuite/features/secondary/srv_mgr_sync_list_products.feature
@@ -14,7 +14,7 @@ Feature: List available products
 @uyuni
   Scenario: List available products
     When I execute mgr-sync "list products" with user "admin" and password "admin"
-    Then I should get "[ ] openSUSE Leap 15.5 x86_64"
+    Then I should get "[ ] openSUSE Leap 15.6 x86_64"
 
 @susemanager
   Scenario: List all available products


### PR DESCRIPTION
## What does this PR change?

The following products are now unsupported:

- Debian < 12
- Ubuntu < 20.04
- openSUSE Leap < 15.6
- SUMA < 4.2

Some CI tests are failing because they still check for Leap 15.5 channels. Let's switch to 15.6

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test Coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s):  https://github.com/SUSE/spacewalk/issues/26493
Port(s):  No port needed - change needed only for Uyuni/Head

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
