### PR TITLE
perform product refresh on peripheral after registration

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -119,6 +119,9 @@
         <!-- Compilation and testing -->
         <dependency org="suse" name="velocity-engine-core" rev="2.3"/>
         <dependency org="suse" name="jetty-util" rev="9.4.56" />
+        <dependency org="suse" name="jetty-server" rev="9.4.56" />
+        <dependency org="suse" name="jetty-http" rev="9.4.56" />
+        <dependency org="suse" name="jetty-io" rev="9.4.56" />
         <dependency org="checkstyle" name="checkstyle" rev="10.12.7" transitive="false">
           <artifact name="all" type="jar" url="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-10.12.7/checkstyle-10.12.7-all.jar"/>
         </dependency>

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -330,6 +330,12 @@ artifacts:
     repository: Uyuni_Other
   - artifact: jetty-util
     repository: Leap_sle
+  - artifact: jetty-server
+    repository: Leap_sle
+  - artifact: jetty-http
+    repository: Leap_sle
+  - artifact: jetty-io
+    repository: Leap_sle
   - artifact: glassfish-jaxb-api
     repository: Leap
   - artifact: jaxb-runtime

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -870,4 +870,15 @@ public class TaskomaticApi {
         }
         invoke("tasko.scheduleSingleSatBunchRun", "custom-gpg-key-import-bunch", Map.of("gpg-key", gpgKey));
     }
+
+    /**
+     * Schedule a product refresh via taskomatic
+     * @param earliest earliest execution
+     * @param withReposync perform also a repo-sync
+     * @throws TaskomaticApiException if there is an error
+     */
+    public void scheduleProductRefresh(Date earliest, boolean withReposync) throws TaskomaticApiException {
+        invoke("tasko.scheduleSingleSatBunchRun", "mgr-sync-refresh-bunch",
+                Map.of("noRepoSync", !withReposync), earliest);
+    }
 }

--- a/java/code/src/com/suse/manager/hub/DefaultHubInternalClient.java
+++ b/java/code/src/com/suse/manager/hub/DefaultHubInternalClient.java
@@ -93,6 +93,11 @@ public class DefaultHubInternalClient implements HubInternalClient {
     }
 
     @Override
+    public void scheduleProductRefresh() throws IOException {
+        invokePost("hub", "scheduleProductRefresh", Map.of());
+    }
+
+    @Override
     public void deregister() throws IOException {
         invokePost("hub/sync", "deregister", null);
     }

--- a/java/code/src/com/suse/manager/hub/HubInternalClient.java
+++ b/java/code/src/com/suse/manager/hub/HubInternalClient.java
@@ -67,4 +67,9 @@ public interface HubInternalClient {
      */
     String replaceTokens(String newHubToken) throws IOException;
 
+    /**
+     * Schedule a product refresh on the remote peripheral server
+     * @throws IOException when the communication fails
+     */
+    void scheduleProductRefresh() throws IOException;
 }

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -646,6 +646,7 @@ public class HubManager {
             if (changed) {
                 setReportDbUser(user, peripheralServer, false);
             }
+            internalApi.scheduleProductRefresh();
         }
         catch (Exception ex) {
             // cleanup the remote side

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler;
 import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.ErrataTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
@@ -45,6 +46,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.hub.HubController;
+import com.suse.manager.hub.HubManager;
 import com.suse.manager.model.hub.ChannelInfoJson;
 import com.suse.manager.model.hub.CustomChannelInfoJson;
 import com.suse.manager.model.hub.IssAccessToken;
@@ -59,6 +61,8 @@ import com.suse.utils.Json;
 
 import com.google.gson.JsonObject;
 
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -93,7 +97,13 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        HubController dummyHubController = new HubController();
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        context().checking(new Expectations() {{
+            allowing(taskomaticMock).scheduleProductRefresh(with(any(Date.class)), with(false));
+        }});
+
+        HubController dummyHubController = new HubController(new HubManager(), taskomaticMock);
         dummyHubController.initRoutes();
         //add dummy route that throws
         post("/hub/testThrowsRuntimeException", asJson(usingTokenAuthentication(this::testThrowsRuntimeException)));
@@ -110,6 +120,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
                 Arguments.of(HttpMethod.post, "/hub/sync/replaceTokens", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/sync/storeCredentials", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/sync/setHubDetails", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/scheduleProductRefresh", IssRole.HUB),
                 Arguments.of(HttpMethod.get, "/hub/managerinfo", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/storeReportDbCredentials", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/removeReportDbCredentials", IssRole.HUB),
@@ -327,6 +338,21 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         testUtils.cleanupReportDbUser(testReportDbUserName);
         assertFalse(testUtils.existsReportDbUser(testReportDbUserName),
                 "cleanup of user not working for user " + testReportDbUserName);
+    }
+
+    @Test
+    public void checkScheduleProductRefreshEndpoint() throws Exception {
+        String apiUnderTest = "/hub/scheduleProductRefresh";
+
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
+                .withApiEndpoint(apiUnderTest)
+                .withHttpMethod(HttpMethod.post)
+                .withRole(IssRole.HUB)
+                .withBearerTokenInHeaders()
+                .simulateControllerApiCall();
+        JsonObject jsonObj = Json.GSON.fromJson(answer, JsonObject.class);
+
+        assertTrue(jsonObj.get("success").getAsBoolean(), apiUnderTest + " API call is failing");
     }
 
     @Test

--- a/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
@@ -681,6 +681,8 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
             will(returnValue(mgrInfo));
 
             allowing(internalClient).storeReportDbCredentials(with(any(String.class)), with(any(String.class)));
+
+            allowing(internalClient).scheduleProductRefresh();
         }});
 
         // Register the remote server as PERIPHERAL for this local server

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -305,7 +305,7 @@ public class Router implements SparkApplication {
         HubManager hubManager = new HubManager();
 
         // ISS v3 Internal APIs
-        HubController hubController = new HubController(hubManager);
+        HubController hubController = new HubController(hubManager, new TaskomaticApi());
         hubController.initRoutes();
 
         // API for the web interface


### PR DESCRIPTION
## What does this PR change?

At the end of a registration, trigger a product refresh on the peripheral to have the product info from the Hub available.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25354

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
