### PR TITLE
Change uptodate recurring action to use apt-get dist-upgrade bsc#1237060

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -42,6 +42,9 @@ mgr_keep_system_up2date_updatestack:
 mgr_keep_system_up2date_pkgs:
   pkg.uptodate:
     - refresh: True
+{%- if grains['os_family'] == 'Debian' %}
+    - dist_upgrade: True
+{%- endif %}
     - require:
       - sls: channels
       - mgr_keep_system_up2date_updatestack

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.mczernek_1237060
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.mczernek_1237060
@@ -1,0 +1,2 @@
+- Change uptodate recurring action to use dist-upgrade
+  instead of upgrade for Deb systems (bsc#1237060)


### PR DESCRIPTION
## What does this PR change?

The `uptodate` sls state currently uses `pkg.uptodate`, which uses `dist_upgrade: False` by default. This means that users using the `uptodate` recurring state on Ubuntu/Debian systems experience not fully patched systems.


## Documentation
- Issue created at https://github.com/uyuni-project/uyuni-docs/issues/3773

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24418
Port(s):

- 4.3: https://github.com/SUSE/spacewalk/pull/26649
- 5.0: https://github.com/SUSE/spacewalk/pull/26648

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
