### PR TITLE
CI: add build test images to ghcr.io

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -314,3 +314,65 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-opensuse-test-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/opensuse/leap/15.4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./testsuite/dockerfiles/opensuse/leap/15.4
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-uyuni-master-testsuite-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/uyuni-master-testsuite
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./testsuite/dockerfiles/uyuni-master-testsuite
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -336,12 +336,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/opensuse/leap/15.4
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/opensuse/leap/15.5
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ./testsuite/dockerfiles/opensuse/leap/15.4
+          context: ./testsuite/dockerfiles/opensuse/leap/15.5
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/testsuite/dockerfiles/opensuse/leap/15.4/Dockerfile
+++ b/testsuite/dockerfiles/opensuse/leap/15.4/Dockerfile
@@ -1,2 +1,0 @@
-FROM opensuse/leap:15.4
-

--- a/testsuite/dockerfiles/opensuse/leap/15.4/Dockerfile
+++ b/testsuite/dockerfiles/opensuse/leap/15.4/Dockerfile
@@ -1,0 +1,2 @@
+FROM opensuse/leap:15.4
+

--- a/testsuite/dockerfiles/opensuse/leap/15.5/Dockerfile
+++ b/testsuite/dockerfiles/opensuse/leap/15.5/Dockerfile
@@ -1,0 +1,3 @@
+FROM opensuse/leap:15.4
+RUN zypper --non-interactive in avahi
+

--- a/testsuite/dockerfiles/opensuse/leap/15.5/Dockerfile
+++ b/testsuite/dockerfiles/opensuse/leap/15.5/Dockerfile
@@ -1,3 +1,3 @@
-FROM opensuse/leap:15.4
+FROM opensuse/leap:15.5
 RUN zypper --non-interactive in avahi
 

--- a/testsuite/dockerfiles/uyuni-master-testsuite/Dockerfile
+++ b/testsuite/dockerfiles/uyuni-master-testsuite/Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite

--- a/testsuite/dockerfiles/uyuni-master-testsuite/Dockerfile
+++ b/testsuite/dockerfiles/uyuni-master-testsuite/Dockerfile
@@ -1,1 +1,2 @@
 FROM registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
+RUN zypper --non-interactive in avahi


### PR DESCRIPTION
## What does this PR change?

This is the first step to fix https://github.com/SUSE/spacewalk/issues/25948

We need the test images in ghcr.io so we can later pull them and push them to the authenticated and non-authenticated registries that we use when running tests that build container images based on the content of the registries.

## GUI diff

No difference.



- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [ ] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/25948


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
