### PR TITLE
unify addCustomChannel and addVendorChannel into one addChannel function

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -26,21 +26,18 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.common.ChecksumType;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
-import com.redhat.rhn.domain.product.ChannelTemplate;
-import com.redhat.rhn.domain.product.SUSEProductFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.scc.SCCRepository;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
 import com.redhat.rhn.manager.appstreams.AppStreamsManager;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.content.MgrSyncUtils;
 import com.redhat.rhn.manager.ssm.SsmChannelDto;
 
-import com.suse.manager.model.hub.CustomChannelInfoJson;
+import com.suse.manager.model.hub.CreateChannelInfoJson;
 import com.suse.manager.model.hub.HubFactory;
-import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
+import com.suse.manager.model.hub.ModifyChannelInfoJson;
 import com.suse.scc.SCCEndpoints;
 import com.suse.scc.model.SCCRepositoryJson;
 
@@ -1550,16 +1547,16 @@ public class ChannelFactory extends HibernateFactory {
      * @param peripheralOrgId            the peripheral org id this channel will be assigned to in the peripheral
      * @param forcedOriginalChannelLabel an optional string setting the original of a cloned channel,
      *                                   instead of the pristine one
-     * @return CustomChannelInfoJson the converted info of the custom channel
+     * @return CreateChannelInfoJson the converted info of the custom channel
      */
-    public static CustomChannelInfoJson toCustomChannelInfo(Channel customChannel, long peripheralOrgId,
+    public static CreateChannelInfoJson toCustomChannelInfo(Channel customChannel, long peripheralOrgId,
                                                             Optional<String> forcedOriginalChannelLabel) {
 
         if (!customChannel.isCustom()) {
             throw new IllegalArgumentException("Channel [" + customChannel.getLabel() + "] is not custom");
         }
 
-        CustomChannelInfoJson customChannelInfo = new CustomChannelInfoJson(customChannel.getLabel());
+        CreateChannelInfoJson customChannelInfo = new CreateChannelInfoJson(customChannel.getLabel());
 
         customChannelInfo.setPeripheralOrgId(peripheralOrgId);
 
@@ -1626,115 +1623,99 @@ public class ChannelFactory extends HibernateFactory {
     /**
      * Converts a custom channel info structure to a custom channel
      *
-     * @param customChannelInfo the custom channel info to be converted
+     * @param channelInfo the custom channel info to be converted
      * @return customChannel the converted custom channel
      */
-    public static Channel toCustomChannel(CustomChannelInfoJson customChannelInfo) {
-        Org org = OrgFactory.lookupById(customChannelInfo.getPeripheralOrgId());
-        Channel parentChannel = ChannelFactory.lookupByLabel(customChannelInfo.getParentChannelLabel());
-        ChannelArch channelArch = ChannelFactory.findArchByLabel(customChannelInfo.getChannelArchLabel());
-        ChecksumType checksumType = ChannelFactory.findChecksumTypeByLabel(customChannelInfo.getChecksumTypeLabel());
+    public static Channel toChannel(CreateChannelInfoJson channelInfo) {
+        Org org = Optional.ofNullable(channelInfo.getPeripheralOrgId())
+                .map(OrgFactory::lookupById)
+                .orElse(null);
+        Channel parentChannel = ChannelFactory.lookupByLabel(channelInfo.getParentChannelLabel());
+        ChannelArch channelArch = ChannelFactory.findArchByLabel(channelInfo.getChannelArchLabel());
+        ChecksumType checksumType = ChannelFactory.findChecksumTypeByLabel(channelInfo.getChecksumTypeLabel());
 
-        Channel customChannel = new Channel();
-        if (StringUtils.isNotEmpty(customChannelInfo.getOriginalChannelLabel())) {
-            Channel originalChannel = ChannelFactory.lookupByLabel(customChannelInfo.getOriginalChannelLabel());
+        Channel channel = new Channel();
+        if (StringUtils.isNotEmpty(channelInfo.getOriginalChannelLabel())) {
+            Channel originalChannel = ChannelFactory.lookupByLabel(channelInfo.getOriginalChannelLabel());
 
             ClonedChannel temp = new ClonedChannel();
             temp.setOriginal(originalChannel);
-            customChannel = temp;
+            channel = temp;
         }
 
-        customChannel.setOrg(org);
-        customChannel.setParentChannel(parentChannel);
-        customChannel.setChannelArch(channelArch);
+        channel.setOrg(org);
+        channel.setParentChannel(parentChannel);
+        channel.setChannelArch(channelArch);
 
-        customChannel.setLabel(customChannelInfo.getLabel());
-        customChannel.setBaseDir(customChannelInfo.getBaseDir());
-        customChannel.setName(customChannelInfo.getName());
-        customChannel.setSummary(customChannelInfo.getSummary());
-        customChannel.setDescription(customChannelInfo.getDescription());
+        channel.setLabel(channelInfo.getLabel());
+        channel.setBaseDir(channelInfo.getBaseDir());
+        channel.setName(channelInfo.getName());
+        channel.setSummary(channelInfo.getSummary());
+        channel.setDescription(channelInfo.getDescription());
 
-        customChannel.setProductName(MgrSyncUtils.findOrCreateProductName(customChannelInfo.getProductNameLabel()));
+        channel.setProductName(MgrSyncUtils.findOrCreateProductName(channelInfo.getProductNameLabel()));
 
-        customChannel.setGPGCheck(customChannelInfo.isGpgCheck());
-        customChannel.setGPGKeyUrl(customChannelInfo.getGpgKeyUrl());
-        customChannel.setGPGKeyId(customChannelInfo.getGpgKeyId());
-        customChannel.setGPGKeyFp(customChannelInfo.getGpgKeyFp());
+        channel.setGPGCheck(channelInfo.isGpgCheck());
+        channel.setGPGKeyUrl(channelInfo.getGpgKeyUrl());
+        channel.setGPGKeyId(channelInfo.getGpgKeyId());
+        channel.setGPGKeyFp(channelInfo.getGpgKeyFp());
 
-        customChannel.setEndOfLife(customChannelInfo.getEndOfLifeDate());
-        customChannel.setChecksumType(checksumType);
+        channel.setEndOfLife(channelInfo.getEndOfLifeDate());
+        channel.setChecksumType(checksumType);
 
-        customChannel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(
-                customChannelInfo.getChannelProductProduct(), customChannelInfo.getChannelProductVersion()));
+        channel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(
+                channelInfo.getChannelProductProduct(), channelInfo.getChannelProductVersion()));
 
-        customChannel.setAccess(customChannelInfo.getChannelAccess());
-        customChannel.setMaintainerName(customChannelInfo.getMaintainerName());
-        customChannel.setMaintainerEmail(customChannelInfo.getMaintainerEmail());
-        customChannel.setMaintainerPhone(customChannelInfo.getMaintainerPhone());
-        customChannel.setSupportPolicy(customChannelInfo.getSupportPolicy());
-        customChannel.setUpdateTag(customChannelInfo.getUpdateTag());
-        customChannel.setInstallerUpdates(customChannelInfo.isInstallerUpdates());
+        channel.setAccess(channelInfo.getChannelAccess());
+        channel.setMaintainerName(channelInfo.getMaintainerName());
+        channel.setMaintainerEmail(channelInfo.getMaintainerEmail());
+        channel.setMaintainerPhone(channelInfo.getMaintainerPhone());
+        channel.setSupportPolicy(channelInfo.getSupportPolicy());
+        channel.setUpdateTag(channelInfo.getUpdateTag());
+        channel.setInstallerUpdates(channelInfo.isInstallerUpdates());
 
         // rebuild repository
         ContentSyncManager csm = new ContentSyncManager();
         HubFactory hubFactory = new HubFactory();
-        csm.refreshCustomRepo(List.of(customChannelInfo.getRepositoryInfo()), hubFactory.lookupIssHub().orElse(null));
+        csm.refreshOrCreateRepository(channelInfo.getRepositoryInfo(), channel,
+                hubFactory.lookupIssHub().orElse(null));
 
-        return customChannel;
-    }
-
-    /**
-     * Ensures that the vendor channels json info structure is valid, as well as all consequent data
-     *
-     * @param vendorChannelLabelList list of vendor channel labels to be checked
-     * @throws IllegalArgumentException if something is wrong
-     */
-    public static void ensureValidVendorChannels(List<String> vendorChannelLabelList) {
-        for (String vendorChannelLabel : vendorChannelLabelList) {
-            Optional<ChannelTemplate> vendorChannelTemplate = SUSEProductFactory
-                    .lookupByChannelLabelFirst(vendorChannelLabel);
-
-            if (vendorChannelTemplate.isEmpty()) {
-                throw new InvalidChannelLabelException(vendorChannelLabel,
-                        InvalidChannelLabelException.Reason.IS_MISSING,
-                        "Invalid data: vendor channel label not found", vendorChannelLabel);
-            }
-        }
+        return channel;
     }
 
     /**
      * Ensures that the custom channels json info structure is valid, as well as all consequent data
      *
-     * @param customChannelInfoJsonList list of custom channel info structures to be checked
+     * @param createChannelInfoJsonListIn list of custom channel info structures to be checked
      * @throws IllegalArgumentException if something is wrong
      */
-    public static void ensureValidCustomChannels(List<CustomChannelInfoJson> customChannelInfoJsonList) {
-        for (CustomChannelInfoJson customChannelInfo : customChannelInfoJsonList) {
+    public static void ensureValidChannelInfo(List<CreateChannelInfoJson> createChannelInfoJsonListIn) {
+        for (CreateChannelInfoJson channelInfo : createChannelInfoJsonListIn) {
 
-            if (ChannelFactory.doesChannelLabelExist(customChannelInfo.getLabel())) {
+            if (ChannelFactory.doesChannelLabelExist(channelInfo.getLabel())) {
                 throw new IllegalArgumentException("Channel already found with the same label " +
-                        "for custom channel [" + customChannelInfo.getLabel() + "]");
+                        "for channel [" + channelInfo.getLabel() + "]");
             }
-
-            ensureValidOrgIds(customChannelInfoJsonList);
-
-            ensureExistingOrAboutToCreate(customChannelInfoJsonList, false, "channel arch",
-                    CustomChannelInfoJson::getChannelArchLabel, ChannelFactory::findArchByLabel, null);
-
-            ensureExistingOrAboutToCreate(customChannelInfoJsonList, false, "checksum type",
-                    CustomChannelInfoJson::getChecksumTypeLabel, ChannelFactory::findChecksumTypeByLabel, null);
-
-            ensureExistingOrAboutToCreate(customChannelInfoJsonList, true, "parent channel",
-                    CustomChannelInfoJson::getParentChannelLabel, ChannelFactory::lookupByLabel,
-                    CustomChannelInfoJson::getLabel);
-
-            ensureExistingOrAboutToCreate(customChannelInfoJsonList, true, "original channel",
-                    CustomChannelInfoJson::getOriginalChannelLabel, ChannelFactory::lookupByLabel,
-                    CustomChannelInfoJson::getLabel);
         }
+        ensureValidOrgIds(createChannelInfoJsonListIn);
+
+        ensureExistingOrAboutToCreate(createChannelInfoJsonListIn, false, "channel arch",
+                CreateChannelInfoJson::getChannelArchLabel, ChannelFactory::findArchByLabel, null);
+
+        ensureExistingOrAboutToCreate(createChannelInfoJsonListIn, false, "checksum type",
+                CreateChannelInfoJson::getChecksumTypeLabel, ChannelFactory::findChecksumTypeByLabel, null);
+
+        ensureExistingOrAboutToCreate(createChannelInfoJsonListIn, true, "parent channel",
+                CreateChannelInfoJson::getParentChannelLabel, ChannelFactory::lookupByLabel,
+                CreateChannelInfoJson::getLabel);
+
+        ensureExistingOrAboutToCreate(createChannelInfoJsonListIn, true, "original channel",
+                CreateChannelInfoJson::getOriginalChannelLabel, ChannelFactory::lookupByLabel,
+                CreateChannelInfoJson::getLabel);
+
     }
 
-    private static <T extends ModifyCustomChannelInfoJson>
+    private static <T extends ModifyChannelInfoJson>
     void ensureExistingOrAboutToCreate(List<T> customChannelInfoJsonList,
                                        boolean emptyIsAllowed, String informationTypeString,
                                        Function<T, String> searchLabelMethod,
@@ -1766,15 +1747,15 @@ public class ChannelFactory extends HibernateFactory {
         }
     }
 
-    private static <T extends ModifyCustomChannelInfoJson> void ensureValidOrgIds(List<T> customChannelInfoJsonList) {
+    private static <T extends ModifyChannelInfoJson> void ensureValidOrgIds(List<T> customChannelInfoJsonList) {
         Set<Long> orgSet = new HashSet<>();
 
         for (T customChannelInfo : customChannelInfoJsonList) {
             Long orgId = customChannelInfo.getPeripheralOrgId();
 
             if (null == orgId) {
-                throw new IllegalArgumentException("Custom channel info [" +
-                        customChannelInfo.getLabel() + "] must have a defined OrgId");
+                // orgId NULL is a vendor channel
+                continue;
             }
 
             if (!orgSet.contains(orgId)) {
@@ -1794,20 +1775,19 @@ public class ChannelFactory extends HibernateFactory {
      * @param modifyCustomChannelList list of custom channel info structures to be checked
      * @throws IllegalArgumentException if something is wrong
      */
-    public static void ensureValidModifyCustomChannels(List<ModifyCustomChannelInfoJson> modifyCustomChannelList) {
-        for (ModifyCustomChannelInfoJson modifyCustomChannelInfo : modifyCustomChannelList) {
+    public static void ensureValidModifyCustomChannels(List<ModifyChannelInfoJson> modifyCustomChannelList) {
+        for (ModifyChannelInfoJson modifyCustomChannelInfo : modifyCustomChannelList) {
 
             if (!ChannelFactory.doesChannelLabelExist(modifyCustomChannelInfo.getLabel())) {
                 throw new IllegalArgumentException("Channel to modify not found for custom channel [" +
                         modifyCustomChannelInfo.getLabel() + "]");
             }
-
-            ensureValidOrgIds(modifyCustomChannelList);
-
-            ensureExistingOrAboutToCreate(modifyCustomChannelList, true, "original channel",
-                    ModifyCustomChannelInfoJson::getOriginalChannelLabel, ChannelFactory::lookupByLabel,
-                    ModifyCustomChannelInfoJson::getLabel);
         }
+        ensureValidOrgIds(modifyCustomChannelList);
+
+        ensureExistingOrAboutToCreate(modifyCustomChannelList, true, "original channel",
+                ModifyChannelInfoJson::getOriginalChannelLabel, ChannelFactory::lookupByLabel,
+                ModifyChannelInfoJson::getLabel);
     }
 
     private static <T> void setValueIfNotNull(Channel channelIn, T valueIn,
@@ -1823,7 +1803,7 @@ public class ChannelFactory extends HibernateFactory {
      * @param modifyCustomChannelInfo the custom channel info with the info on how to modify the custom channel
      * @return customChannel the modified custom channel
      */
-    public static Channel modifyCustomChannel(ModifyCustomChannelInfoJson modifyCustomChannelInfo) {
+    public static Channel modifyCustomChannel(ModifyChannelInfoJson modifyCustomChannelInfo) {
 
         Channel customChannel = ChannelFactory.lookupByLabel(modifyCustomChannelInfo.getLabel());
         if (null == customChannel) {

--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -34,11 +34,11 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.taskomatic.task.ReportDBHelper;
 
 import com.suse.manager.model.hub.ChannelInfoJson;
-import com.suse.manager.model.hub.CustomChannelInfoJson;
+import com.suse.manager.model.hub.CreateChannelInfoJson;
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.ManagerInfoJson;
-import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
+import com.suse.manager.model.hub.ModifyChannelInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
 import com.suse.manager.model.hub.RegisterJson;
 import com.suse.manager.model.hub.SCCCredentialsJson;
@@ -114,10 +114,8 @@ public class HubController {
                 asJson(usingTokenAuthentication(onlyFromHub(this::listAllPeripheralOrgs))));
         get("/hub/listAllPeripheralChannels",
                 asJson(usingTokenAuthentication(onlyFromHub(this::listAllPeripheralChannels))));
-        post("/hub/addVendorChannels",
-                asJson(usingTokenAuthentication(onlyFromHub(this::addVendorChannels))));
-        post("/hub/addCustomChannels",
-                asJson(usingTokenAuthentication(onlyFromHub(this::addCustomChannels))));
+        post("/hub/addChannels",
+                asJson(usingTokenAuthentication(onlyFromHub(this::addChannels))));
         post("/hub/modifyCustomChannels",
                 asJson(usingTokenAuthentication(onlyFromHub(this::modifyCustomChannels))));
         post("/hub/sync/channelfamilies",
@@ -305,52 +303,29 @@ public class HubController {
         return success(response, allChannelsInfo);
     }
 
-    private String addVendorChannels(Request request, Response response, IssAccessToken token) {
+    private String addChannels(Request request, Response response, IssAccessToken token) {
         Map<String, String> requestList = GSON.fromJson(request.body(), Map.class);
 
-        if ((null == requestList) || (!requestList.containsKey("vendorchannellabellist"))) {
-            return badRequest(response, "Invalid data: missing vendorchannellabellist entry");
+        if ((null == requestList) || (!requestList.containsKey("channellist"))) {
+            return badRequest(response, "Invalid data: missing channellist entry");
         }
 
-        List<String> vendorChannelLabelList = GSON.fromJson(requestList.get("vendorchannellabellist"), List.class);
-        if (vendorChannelLabelList == null || vendorChannelLabelList.isEmpty()) {
-            LOGGER.error("Bad Request: invalid invalid vendor channel label list");
-            return badRequest(response, "Invalid data: invalid vendor channel label list");
+        List<CreateChannelInfoJson> channelInfoList = Arrays.asList(
+                GSON.fromJson(requestList.get("channellist"), CreateChannelInfoJson[].class));
+
+        if (channelInfoList.isEmpty()) {
+            LOGGER.error("Bad Request: invalid channels list");
+            return badRequest(response, "Invalid data: invalid channels list");
         }
 
-        List<ChannelInfoJson> createdVendorChannelInfoList =
-                hubManager.addVendorChannels(token, vendorChannelLabelList)
+        List<ChannelInfoJson> createdChannelsInfoList =
+                hubManager.addChannels(token, channelInfoList)
                         .stream()
                         .map(ch -> new ChannelInfoJson(ch.getId(), ch.getName(), ch.getLabel(), ch.getSummary(),
                                 ((null == ch.getOrg()) ? null : ch.getOrg().getId()),
                                 (null == ch.getParentChannel()) ? null : ch.getParentChannel().getId()))
                         .toList();
-        return success(response, createdVendorChannelInfoList);
-    }
-
-    private String addCustomChannels(Request request, Response response, IssAccessToken token) {
-        Map<String, String> requestList = GSON.fromJson(request.body(), Map.class);
-
-        if ((null == requestList) || (!requestList.containsKey("customchannellist"))) {
-            return badRequest(response, "Invalid data: missing customchannellist entry");
-        }
-
-        List<CustomChannelInfoJson> customChannelInfoList = Arrays.asList(
-                GSON.fromJson(requestList.get("customchannellist"), CustomChannelInfoJson[].class));
-
-        if (customChannelInfoList.isEmpty()) {
-            LOGGER.error("Bad Request: invalid custom channels list");
-            return badRequest(response, "Invalid data: invalid custom channels list");
-        }
-
-        List<ChannelInfoJson> createdCustomChannelsInfoList =
-                hubManager.addCustomChannels(token, customChannelInfoList)
-                        .stream()
-                        .map(ch -> new ChannelInfoJson(ch.getId(), ch.getName(), ch.getLabel(), ch.getSummary(),
-                                ((null == ch.getOrg()) ? null : ch.getOrg().getId()),
-                                (null == ch.getParentChannel()) ? null : ch.getParentChannel().getId()))
-                        .toList();
-        return success(response, createdCustomChannelsInfoList);
+        return success(response, createdChannelsInfoList);
     }
 
     private String modifyCustomChannels(Request request, Response response, IssAccessToken token) {
@@ -360,8 +335,8 @@ public class HubController {
             return badRequest(response, "Invalid data: missing modifycustomchannellist entry");
         }
 
-        List<ModifyCustomChannelInfoJson> modifyCustomChannelInfoList = Arrays.asList(
-                GSON.fromJson(requestList.get("modifycustomchannellist"), ModifyCustomChannelInfoJson[].class));
+        List<ModifyChannelInfoJson> modifyCustomChannelInfoList = Arrays.asList(
+                GSON.fromJson(requestList.get("modifycustomchannellist"), ModifyChannelInfoJson[].class));
 
         if (modifyCustomChannelInfoList.isEmpty()) {
             LOGGER.error("Bad Request: invalid modify custom channels list");

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -23,8 +23,6 @@ import com.redhat.rhn.domain.credentials.ReportDBCredentials;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
-import com.redhat.rhn.domain.product.ChannelTemplate;
-import com.redhat.rhn.domain.product.SUSEProductFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MgrServerInfo;
 import com.redhat.rhn.domain.server.Server;
@@ -32,7 +30,6 @@ import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.listview.PageControl;
-import com.redhat.rhn.frontend.xmlrpc.InvalidChannelLabelException;
 import com.redhat.rhn.manager.content.ContentSyncException;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
@@ -45,7 +42,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.model.hub.AccessTokenDTO;
-import com.suse.manager.model.hub.CustomChannelInfoJson;
+import com.suse.manager.model.hub.CreateChannelInfoJson;
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssHub;
@@ -53,7 +50,7 @@ import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.IssServer;
 import com.suse.manager.model.hub.ManagerInfoJson;
-import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
+import com.suse.manager.model.hub.ModifyChannelInfoJson;
 import com.suse.manager.model.hub.TokenType;
 import com.suse.manager.webui.controllers.ProductsController;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
@@ -936,77 +933,16 @@ public class HubManager {
     }
 
     /**
-     * add vendor channel to peripheral
-     *
-     * @param accessToken            the access token
-     * @param vendorChannelLabelList the vendor channel label list
-     * @return returns a list of the vendor channel that have been added {@link Channel}
-     * the possible return cases are:
-     * 1) empty list: the vendor channel and its base channel were already present in the peripheral (nothing created)
-     * 2) one-channel list: if only the vendor channel was created while the base channel was already present
-     * 3) two-channel list: if both the vendor and the base channel were added to the peripheral
-     */
-    public List<Channel> addVendorChannels(IssAccessToken accessToken, List<String> vendorChannelLabelList) {
-        ensureValidToken(accessToken);
-        ChannelFactory.ensureValidVendorChannels(vendorChannelLabelList);
-
-        String mirrorUrl = null;
-
-        ContentSyncManager csm = new ContentSyncManager();
-        if (csm.isRefreshNeeded(mirrorUrl)) {
-            throw new ContentSyncException("Product Data refresh needed. Please call mgr-sync refresh.");
-        }
-
-        List<String> addedVendorChannelLabels = new ArrayList<>();
-        for (String vendorChannelLabel : vendorChannelLabelList) {
-            //retrieve vendor channel template
-            Optional<ChannelTemplate> vendorChannelTemplate = SUSEProductFactory
-                    .lookupByChannelLabelFirst(vendorChannelLabel);
-
-            if (vendorChannelTemplate.isEmpty()) {
-                throw new InvalidChannelLabelException(vendorChannelLabel,
-                        InvalidChannelLabelException.Reason.IS_MISSING,
-                        "Invalid data: vendor channel label not found", vendorChannelLabel);
-            }
-
-            // get base channel of target channel
-            if (!vendorChannelTemplate.get().isRoot()) {
-                String vendorBaseChannelLabel = vendorChannelTemplate.get().getParentChannelLabel();
-
-                // check if base channel is already added
-                if (!ChannelFactory.doesChannelLabelExist(vendorBaseChannelLabel)) {
-                    // if not, add base channel
-                    addedVendorChannelLabels.add(vendorBaseChannelLabel);
-                }
-            }
-
-            // check if channel is already added
-            if (!ChannelFactory.doesChannelLabelExist(vendorChannelLabel)) {
-                //add target channel
-                addedVendorChannelLabels.add(vendorChannelLabel);
-            }
-        }
-
-        //add target channels
-        addedVendorChannelLabels.forEach(l -> csm.addChannel(l, mirrorUrl));
-
-        return ChannelFactory.listAllChannels()
-                .stream()
-                .filter(e -> addedVendorChannelLabels.contains(e.getLabel()))
-                .toList();
-    }
-
-    /**
-     * add custom channels to peripheral
+     * add channels to peripheral
      *
      * @param accessToken               the access token
-     * @param customChannelInfoJsonList the list of custom channel info to add
-     * @return returns a list of the custom channels {@link Channel} that have been added
+     * @param createChannelInfoJsonListIn the list of channel info to add
+     * @return returns a list of the channels {@link Channel} that have been added
      */
-    public List<Channel> addCustomChannels(IssAccessToken accessToken,
-                                           List<CustomChannelInfoJson> customChannelInfoJsonList) {
+    public List<Channel> addChannels(IssAccessToken accessToken,
+                                     List<CreateChannelInfoJson> createChannelInfoJsonListIn) {
         ensureValidToken(accessToken);
-        ChannelFactory.ensureValidCustomChannels(customChannelInfoJsonList);
+        ChannelFactory.ensureValidChannelInfo(createChannelInfoJsonListIn);
 
         String mirrorUrl = null;
 
@@ -1016,9 +952,9 @@ public class HubManager {
         }
 
         List<String> addedChannelsLabelList = new ArrayList<>();
-        for (CustomChannelInfoJson customChannelInfo : customChannelInfoJsonList) {
+        for (CreateChannelInfoJson channelInfo : createChannelInfoJsonListIn) {
             // Create the channel
-            Channel customChannel = ChannelFactory.toCustomChannel(customChannelInfo);
+            Channel customChannel = ChannelFactory.toChannel(channelInfo);
             ChannelFactory.save(customChannel);
 
             addedChannelsLabelList.add(customChannel.getLabel());
@@ -1038,7 +974,7 @@ public class HubManager {
      * @return returns a list of the custom channel that have been added {@link Channel}
      */
     public List<Channel> modifyCustomChannels(IssAccessToken accessToken,
-                                              List<ModifyCustomChannelInfoJson> modifyCustomChannelList) {
+                                              List<ModifyChannelInfoJson> modifyCustomChannelList) {
         ensureValidToken(accessToken);
         ChannelFactory.ensureValidModifyCustomChannels(modifyCustomChannelList);
 
@@ -1050,7 +986,7 @@ public class HubManager {
         }
 
         List<String> modifiedChannelsLabelList = new ArrayList<>();
-        for (ModifyCustomChannelInfoJson modifyCustomChannelInfo : modifyCustomChannelList) {
+        for (ModifyChannelInfoJson modifyCustomChannelInfo : modifyCustomChannelList) {
             // modify the channel
             Channel customChannel = ChannelFactory.modifyCustomChannel(modifyCustomChannelInfo);
             ChannelFactory.save(customChannel);

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -31,7 +31,6 @@ import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
 import com.redhat.rhn.domain.org.Org;
-import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.taskomatic.task.ReportDBHelper;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
@@ -40,18 +39,19 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.model.hub.ChannelInfoJson;
-import com.suse.manager.model.hub.CustomChannelInfoJson;
+import com.suse.manager.model.hub.CreateChannelInfoJson;
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssHub;
 import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssRole;
-import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
+import com.suse.manager.model.hub.ModifyChannelInfoJson;
 import com.suse.manager.model.hub.TokenType;
 import com.suse.manager.webui.utils.gson.ResultJson;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
 import com.suse.manager.webui.utils.token.Token;
 import com.suse.manager.webui.utils.token.TokenBuildingException;
 import com.suse.manager.webui.utils.token.TokenParsingException;
+import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.utils.Json;
 
 import java.time.Instant;
@@ -245,16 +245,16 @@ public class ControllerTestUtils {
         return (dateIn.getTime() - nowDate.getTime() < 24L * 60L * 60L * 1000L);
     }
 
-    public CustomChannelInfoJson createCustomChannelInfoJson(Long orgId,
-                                                             String channelLabel,
-                                                             String parentChannelLabel,
-                                                             String originalChannelLabel,
-                                                             boolean isGpgCheck,
-                                                             boolean isInstallerUpdates,
-                                                             String archLabel,
-                                                             String checksumLabel,
-                                                             Date endOfLifeDate) {
-        CustomChannelInfoJson info = new CustomChannelInfoJson(channelLabel);
+    public CreateChannelInfoJson createChannelInfoJson(Long orgId,
+                                                       String channelLabel,
+                                                       String parentChannelLabel,
+                                                       String originalChannelLabel,
+                                                       boolean isGpgCheck,
+                                                       boolean isInstallerUpdates,
+                                                       String archLabel,
+                                                       String checksumLabel,
+                                                       Date endOfLifeDate) {
+        CreateChannelInfoJson info = new CreateChannelInfoJson(channelLabel);
 
         info.setPeripheralOrgId(orgId);
         info.setParentChannelLabel(parentChannelLabel);
@@ -281,6 +281,11 @@ public class ControllerTestUtils {
         info.setInstallerUpdates(isInstallerUpdates);
 
         info.setOriginalChannelLabel(originalChannelLabel);
+
+        SCCRepositoryJson repo = new SCCRepositoryJson();
+        repo.setUrl("https://hub.domain.top/rhn/manager/download/channel_" + channelLabel);
+        repo.setName(channelLabel);
+        info.setRepositoryInfo(repo);
 
         return info;
     }
@@ -330,64 +335,24 @@ public class ControllerTestUtils {
         assertEquals("channelProductVersion", ch.getProduct().getVersion());
     }
 
-    public String createTestVendorChannels(User userIn, String serverFqdnIn) throws Exception {
-
-        //SUSE Linux Enterprise Server 11 SP3 x86_64
-        return createTestVendorChannels(userIn, serverFqdnIn,
-                "SLES11-SP3-Pool for x86_64", "sles11-sp3-pool-x86_64", true,
-                "SLES11-SP3-Updates for x86_64", "sles11-sp3-updates-x86_64", true);
-
-    }
-
-    public String createTestVendorChannels(User userIn, String serverFqdnIn,
-                                           String vendorBaseChannelTemplateNameIn,
-                                           String vendorBaseChannelTemplateLabelIn,
-                                           boolean createBaseChannelIn,
-                                           String vendorChannelTemplateNameIn,
-                                           String vendorChannelTemplateLabelIn,
-                                           boolean createChildChannelIn) throws Exception {
-
-        SUSEProductTestUtils.createVendorSUSEProductEnvironment(userIn, null, true);
-
-        Channel vendorBaseChannel = null;
-        if (createBaseChannelIn) {
-            vendorBaseChannel = createVendorBaseChannel(vendorBaseChannelTemplateNameIn,
-                    vendorBaseChannelTemplateLabelIn);
-        }
-        if (createChildChannelIn) {
-            createVendorChannel(vendorChannelTemplateNameIn, vendorChannelTemplateLabelIn, vendorBaseChannel);
-        }
-
-        Map<String, String> bodyMapIn = new HashMap<>();
-        bodyMapIn.put("vendorchannellabellist", Json.GSON.toJson(List.of(vendorChannelTemplateLabelIn)));
-
-        return (String) withServerFqdn(serverFqdnIn)
-                .withApiEndpoint("/hub/addVendorChannels")
-                .withHttpMethod(HttpMethod.post)
-                .withRole(IssRole.HUB)
-                .withBearerTokenInHeaders()
-                .withBody(bodyMapIn)
-                .simulateControllerApiCall();
-    }
-
-    public CustomChannelInfoJson createValidCustomChInfo() {
+    public CreateChannelInfoJson createValidCustomChInfo() {
         return createValidCustomChInfo("customCh");
     }
 
-    public CustomChannelInfoJson createValidCustomChInfo(String channelLabel) {
+    public CreateChannelInfoJson createValidCustomChInfo(String channelLabel) {
         User testPeripheralUser = UserTestUtils.findNewUser("peripheral_user_", "peripheral_org_", true);
-        return createCustomChannelInfoJson(testPeripheralUser.getOrg().getId(),
+        return createChannelInfoJson(testPeripheralUser.getOrg().getId(),
                 channelLabel, "", "",
                 true, true, "channel-s390", "sha256",
                 createDateUtil(2096, 10, 22));
     }
 
-    public Object testAddCustomChannelsApiCall(String serverFqdnIn,
-                                               List<CustomChannelInfoJson> customChannelInfoListIn) throws Exception {
-        String apiUnderTest = "/hub/addCustomChannels";
+    public Object testAddChannelsApiCall(String serverFqdnIn,
+                                         List<CreateChannelInfoJson> channelInfoListIn) throws Exception {
+        String apiUnderTest = "/hub/addChannels";
 
         Map<String, String> bodyMapIn = new HashMap<>();
-        bodyMapIn.put("customchannellist", Json.GSON.toJson(customChannelInfoListIn));
+        bodyMapIn.put("channellist", Json.GSON.toJson(channelInfoListIn));
 
         return withServerFqdn(serverFqdnIn)
                 .withApiEndpoint(apiUnderTest)
@@ -399,50 +364,50 @@ public class ControllerTestUtils {
     }
 
     public void checkAddCustomChannelsApiNotThrowing(String serverFqdnIn,
-                                                     List<CustomChannelInfoJson> customChannelInfoListIn)
+                                                     List<CreateChannelInfoJson> customChannelInfoListIn)
             throws Exception {
         try {
-            String answer = (String) testAddCustomChannelsApiCall(serverFqdnIn, customChannelInfoListIn);
+            String answer = (String) testAddChannelsApiCall(serverFqdnIn, customChannelInfoListIn);
 
             List<ChannelInfoJson> peripheralCreatedCustomChInfo =
                     Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
 
             assertNotNull(peripheralCreatedCustomChInfo,
-                    "addCustomChannels API failing when creating peripheral channel");
+                    "addChannels API failing when creating peripheral channel");
         }
         catch (IllegalArgumentException e) {
-            fail("addCustomChannels API should not throw");
+            fail("addChannels API should not throw");
         }
     }
 
     public void checkAddCustomChannelsApiThrows(String serverFqdnIn,
-                                                List<CustomChannelInfoJson> customChannelInfoListIn,
+                                                List<CreateChannelInfoJson> customChannelInfoListIn,
                                                 String errorStartsWith) throws Exception {
         try {
-            String answer = (String) testAddCustomChannelsApiCall(serverFqdnIn, customChannelInfoListIn);
+            String answer = (String) testAddChannelsApiCall(serverFqdnIn, customChannelInfoListIn);
 
             ResultJson<?> result = Json.GSON.fromJson(answer, ResultJson.class);
             assertFalse(result.isSuccess(),
-                    "addCustomChannels API not failing when creating peripheral channel with " +
+                    "addChannels API not failing when creating peripheral channel with " +
                             errorStartsWith);
             assertEquals("Internal Server Error", result.getMessages().get(0));
             assertTrue(result.getMessages().get(1).startsWith(errorStartsWith),
                     "Wrong expected start of error message: [" + result.getMessages().get(1) + "]");
         }
         catch (IllegalArgumentException e) {
-            fail("addCustomChannels API should not throw");
+            fail("addChannels API should not throw");
         }
     }
 
-    public ModifyCustomChannelInfoJson createValidModifyCustomChInfo() {
+    public ModifyChannelInfoJson createValidModifyCustomChInfo() {
         return createValidModifyCustomChInfo("customCh");
     }
 
-    public ModifyCustomChannelInfoJson createValidModifyCustomChInfo(String channelLabel) {
+    public ModifyChannelInfoJson createValidModifyCustomChInfo(String channelLabel) {
         User testPeripheralUser = UserTestUtils.findNewUser("peripheral_user_", "peripheral_org_", true);
         boolean isGpgCheck = true;
         boolean isInstallerUpdates = true;
-        ModifyCustomChannelInfoJson info = new ModifyCustomChannelInfoJson(channelLabel);
+        ModifyChannelInfoJson info = new ModifyChannelInfoJson(channelLabel);
 
         info.setPeripheralOrgId(testPeripheralUser.getOrg().getId());
         info.setOriginalChannelLabel("");
@@ -471,7 +436,7 @@ public class ControllerTestUtils {
     }
 
     public Object testModifyCustomChannelsApiCall(String serverFqdnIn,
-                                                  List<ModifyCustomChannelInfoJson> modifyCustomChannelInfoListIn)
+                                                  List<ModifyChannelInfoJson> modifyCustomChannelInfoListIn)
             throws Exception {
         String apiUnderTest = "/hub/modifyCustomChannels";
 
@@ -488,7 +453,7 @@ public class ControllerTestUtils {
     }
 
     public void checkModifyCustomChannelsApiNotThrowing(String serverFqdnIn,
-                                                        List<ModifyCustomChannelInfoJson> modifyCustomChannelInfoListIn)
+                                                        List<ModifyChannelInfoJson> modifyCustomChannelInfoListIn)
             throws Exception {
 
         try {
@@ -498,7 +463,7 @@ public class ControllerTestUtils {
                     Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
 
             assertNotNull(peripheralCreatedCustomChInfo,
-                    "addCustomChannels API failing when creating peripheral channel");
+                    "addChannels API failing when creating peripheral channel");
 
         }
         catch (IllegalArgumentException e) {
@@ -507,7 +472,7 @@ public class ControllerTestUtils {
     }
 
     public void checkModifyCustomChannelsApiThrows(String serverFqdnIn,
-                                                   List<ModifyCustomChannelInfoJson> modifyCustomChannelInfoListIn,
+                                                   List<ModifyChannelInfoJson> modifyCustomChannelInfoListIn,
                                                    String errorStartsWith) throws Exception {
         try {
             String answer = (String) testModifyCustomChannelsApiCall(serverFqdnIn, modifyCustomChannelInfoListIn);
@@ -542,15 +507,15 @@ public class ControllerTestUtils {
         void checkCompatible(Object modified, Object pristine);
     }
 
-    public void checkEqualModifications(ModifyCustomChannelInfoJson modifyInfo, Channel ch) {
+    public void checkEqualModifications(ModifyChannelInfoJson modifyInfo, Channel ch) {
         checkModifications(modifyInfo, ch, ControllerTestUtils::checkEqualIfModified);
     }
 
-    public void checkDifferentModifications(ModifyCustomChannelInfoJson modifyInfo, Channel ch) {
+    public void checkDifferentModifications(ModifyChannelInfoJson modifyInfo, Channel ch) {
         checkModifications(modifyInfo, ch, ControllerTestUtils::checkDifferentIfModified);
     }
 
-    private void checkModifications(ModifyCustomChannelInfoJson modifyInfo, Channel ch, CheckMethod checkMethod) {
+    private void checkModifications(ModifyChannelInfoJson modifyInfo, Channel ch, CheckMethod checkMethod) {
         assertEquals(modifyInfo.getLabel(), ch.getLabel());
 
         if (null != modifyInfo.getPeripheralOrgId()) {
@@ -581,7 +546,7 @@ public class ControllerTestUtils {
         checkMethod.checkCompatible(modifyInfo.isInstallerUpdates(), ch.isInstallerUpdates());
     }
 
-    public void createTestChannel(ModifyCustomChannelInfoJson modifyInfo, User userIn) throws Exception {
+    public void createTestChannel(ModifyChannelInfoJson modifyInfo, User userIn) throws Exception {
         ChannelFamily cfam = ChannelFamilyFactoryTest.createTestChannelFamily();
         String query = "ChannelArch.findById";
         ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheById(500L, query);

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -25,14 +25,11 @@ import static spark.Spark.post;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.channel.ChannelArch;
 import com.redhat.rhn.domain.channel.ChannelFactory;
-import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelProduct;
 import com.redhat.rhn.domain.channel.ClonedChannel;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
-import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.user.User;
@@ -48,11 +45,11 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.hub.HubController;
 import com.suse.manager.hub.HubManager;
 import com.suse.manager.model.hub.ChannelInfoJson;
-import com.suse.manager.model.hub.CustomChannelInfoJson;
+import com.suse.manager.model.hub.CreateChannelInfoJson;
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.ManagerInfoJson;
-import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
+import com.suse.manager.model.hub.ModifyChannelInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
 import com.suse.manager.webui.utils.gson.ResultJson;
 import com.suse.manager.webui.utils.token.IssTokenBuilder;
@@ -126,8 +123,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
                 Arguments.of(HttpMethod.post, "/hub/removeReportDbCredentials", IssRole.HUB),
                 Arguments.of(HttpMethod.get, "/hub/listAllPeripheralOrgs", IssRole.HUB),
                 Arguments.of(HttpMethod.get, "/hub/listAllPeripheralChannels", IssRole.HUB),
-                Arguments.of(HttpMethod.post, "/hub/addVendorChannels", IssRole.HUB),
-                Arguments.of(HttpMethod.post, "/hub/addCustomChannels", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/addChannels", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/modifyCustomChannels", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/sync/channelfamilies", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/sync/products", IssRole.HUB),
@@ -475,26 +471,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         assertEquals(TEST_ERROR_MESSAGE, jsonObj.get("messages").getAsJsonArray().get(1).getAsString());
     }
 
-    private Channel utilityCreateVendorBaseChannel(String name, String label) throws Exception {
-        Org nullOrg = null;
-        ChannelFamily cfam = ChannelFamilyFactoryTest.createNullOrgTestChannelFamily();
-        String query = "ChannelArch.findById";
-        ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheById(500L, query);
-        return ChannelFactoryTest.createTestChannel(name, label, nullOrg, arch, cfam);
-    }
-
-    private Channel utilityCreateVendorChannel(String name, String label, Channel vendorBaseChannel) throws Exception {
-        Channel vendorChannel = utilityCreateVendorBaseChannel(name, label);
-        vendorChannel.setParentChannel(vendorBaseChannel);
-        vendorChannel.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha512"));
-        ChannelFactory.save(vendorChannel);
-        return vendorChannel;
-    }
-
     private static Stream<Arguments> allBaseAndVendorChannelAlreadyPresentCombinations() {
         return Stream.of(Arguments.of(false, false),
-                Arguments.of(true, false),
-                Arguments.of(true, true)
+                Arguments.of(true, false)
         );
     }
 
@@ -502,19 +481,49 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @MethodSource("allBaseAndVendorChannelAlreadyPresentCombinations")
     public void checkApiAddVendorChannel(boolean baseChannelAlreadyPresentInPeripheral,
                                          boolean channelAlreadyPresentInPeripheral) throws Exception {
-        String apiUnderTest = "/hub/addVendorChannels";
+        String apiUnderTest = "/hub/addChannels";
 
         //SUSE Linux Enterprise Server 11 SP3 x86_64
         String vendorBaseChannelTemplateName = "SLES11-SP3-Pool for x86_64";
         String vendorBaseChannelTemplateLabel = "sles11-sp3-pool-x86_64";
         String vendorChannelTemplateName = "SLES11-SP3-Updates for x86_64";
         String vendorChannelTemplateLabel = "sles11-sp3-updates-x86_64";
+        boolean testIsGpgCheck = true;
+        boolean testIssInstallerUpdates = false;
+        String testArchLabel = "channel-x86_64";
+        String testChecksumLabel = "sha256";
 
-        String answer = testUtils.createTestVendorChannels(user, DUMMY_SERVER_FQDN,
-                vendorBaseChannelTemplateName, vendorBaseChannelTemplateLabel,
-                baseChannelAlreadyPresentInPeripheral,
-                vendorChannelTemplateName, vendorChannelTemplateLabel,
-                channelAlreadyPresentInPeripheral);
+        Date endOfLifeDate = testUtils.createDateUtil(2096, 10, 22);
+
+        //create peripheral vendor Channels
+        List<CreateChannelInfoJson> vendorChannelInfoListIn = new ArrayList<>();
+        Channel vendorCh = null;
+        if (baseChannelAlreadyPresentInPeripheral) {
+            vendorCh = testUtils.createVendorBaseChannel(vendorBaseChannelTemplateName, vendorBaseChannelTemplateLabel);
+        }
+        else {
+            CreateChannelInfoJson vendorBaseChInfo = testUtils.createChannelInfoJson(null,
+                    vendorBaseChannelTemplateLabel, "", "",
+                    testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+            vendorBaseChInfo.setName(vendorBaseChannelTemplateName);
+            vendorChannelInfoListIn.add(vendorBaseChInfo);
+        }
+
+        if (channelAlreadyPresentInPeripheral) {
+            testUtils.createVendorChannel(vendorChannelTemplateName, vendorChannelTemplateLabel, vendorCh);
+        }
+        else {
+            CreateChannelInfoJson vendorChInfo = testUtils.createChannelInfoJson(null,
+                    vendorChannelTemplateLabel, vendorBaseChannelTemplateLabel, "",
+                    testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+            vendorChInfo.setName(vendorChannelTemplateName);
+            vendorChannelInfoListIn.add(vendorChInfo);
+        }
+
+
+        String answer = (String) testUtils.testAddChannelsApiCall(DUMMY_SERVER_FQDN, vendorChannelInfoListIn);
+        List<ChannelInfoJson> peripheralCreatedVendorChInfo =
+                Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
 
         int expectedNumOfPeripheralCreatedChannels = 2;
         if (baseChannelAlreadyPresentInPeripheral) {
@@ -583,8 +592,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     public void checkApiAddCustomChannel(boolean testIncludeTestChannelInChain) throws Exception {
         boolean testIsGpgCheck = true;
         boolean testIssInstallerUpdates = true;
-        String testArchLabel = "channel-s390";
-        String testChecksumLabel = "sha256";
+        String testArchLabel = "channel-x86_64";
+        String testChecksumLabel = "sha512";
 
         Date endOfLifeDate = testUtils.createDateUtil(2096, 10, 22);
 
@@ -600,36 +609,56 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         String vendorBaseChannelTemplateLabel = "sles11-sp3-pool-x86_64"; //SUSE Linux Enterprise Server 11 SP3 x86_64
         String vendorChannelTemplateLabel = "sles11-sp3-updates-x86_64";
 
-        CustomChannelInfoJson cloneBaseChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
-                "cloneBaseCh", "", vendorBaseChannelTemplateLabel,
+        CreateChannelInfoJson vendorBaseChInfo = testUtils.createChannelInfoJson(null,
+                vendorBaseChannelTemplateLabel, "", "",
                 testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
 
-        CustomChannelInfoJson cloneDevelChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
-                "cloneDevelCh", "cloneBaseCh", vendorChannelTemplateLabel,
+        CreateChannelInfoJson vendorChInfo = testUtils.createChannelInfoJson(null,
+                vendorChannelTemplateLabel, vendorBaseChannelTemplateLabel, "",
                 testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
 
-        CustomChannelInfoJson cloneTestChInfo = null;
-        String originalOfProdCh = "cloneDevelCh";
-        if (testIncludeTestChannelInChain) {
-            cloneTestChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
-                    "cloneTestCh", "", "cloneDevelCh",
-                    testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
-            originalOfProdCh = "cloneTestCh";
-        }
 
-        CustomChannelInfoJson cloneProdChInfo = testUtils.createCustomChannelInfoJson(testPeripheralOrgId,
-                "cloneProdCh", "", originalOfProdCh,
-                testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+        //create peripheral vendor Channels
+        List<CreateChannelInfoJson> vendorChannelInfoListIn = new ArrayList<>();
+        vendorChannelInfoListIn.add(vendorBaseChInfo);
+        vendorChannelInfoListIn.add(vendorChInfo);
 
-        testUtils.createTestVendorChannels(user, DUMMY_SERVER_FQDN);
+        String answer = (String) testUtils.testAddChannelsApiCall(DUMMY_SERVER_FQDN, vendorChannelInfoListIn);
+        List<ChannelInfoJson> peripheralCreatedVendorChInfo =
+                Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
+        assertEquals(2, peripheralCreatedVendorChInfo.size());
 
         Channel vendorBaseCh = ChannelFactory.lookupByLabel(vendorBaseChannelTemplateLabel);
         assertNotNull(vendorBaseCh);
         Channel vendorCh = ChannelFactory.lookupByLabel(vendorChannelTemplateLabel);
         assertNotNull(vendorCh);
 
+
+        CreateChannelInfoJson cloneBaseChInfo = testUtils.createChannelInfoJson(testPeripheralOrgId,
+                "cloneBaseCh", "", vendorBaseChannelTemplateLabel,
+                testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+
+        CreateChannelInfoJson cloneDevelChInfo = testUtils.createChannelInfoJson(testPeripheralOrgId,
+                "cloneDevelCh", "cloneBaseCh", vendorChannelTemplateLabel,
+                testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+
+        CreateChannelInfoJson cloneTestChInfo = null;
+        String originalOfProdCh = "cloneDevelCh";
+        if (testIncludeTestChannelInChain) {
+            cloneTestChInfo = testUtils.createChannelInfoJson(testPeripheralOrgId,
+                    "cloneTestCh", "", "cloneDevelCh",
+                    testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+            originalOfProdCh = "cloneTestCh";
+        }
+
+        CreateChannelInfoJson cloneProdChInfo = testUtils.createChannelInfoJson(testPeripheralOrgId,
+                "cloneProdCh", "", originalOfProdCh,
+                testIsGpgCheck, testIssInstallerUpdates, testArchLabel, testChecksumLabel, endOfLifeDate);
+
+
+
         //create peripheral vendorCh custom cloned channels
-        List<CustomChannelInfoJson> customChannelInfoListIn = new ArrayList<>();
+        List<CreateChannelInfoJson> customChannelInfoListIn = new ArrayList<>();
         customChannelInfoListIn.add(cloneBaseChInfo);
         customChannelInfoListIn.add(cloneDevelChInfo);
         if (testIncludeTestChannelInChain) {
@@ -637,7 +666,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         }
         customChannelInfoListIn.add(cloneProdChInfo);
 
-        String answer = (String) testUtils.testAddCustomChannelsApiCall(DUMMY_SERVER_FQDN, customChannelInfoListIn);
+        answer = (String) testUtils.testAddChannelsApiCall(DUMMY_SERVER_FQDN, customChannelInfoListIn);
         List<ChannelInfoJson> peripheralCreatedCustomChInfo =
                 Arrays.asList(Json.GSON.fromJson(answer, ChannelInfoJson[].class));
 
@@ -721,14 +750,14 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureNotThrowingWhenDataIsValid() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
 
         testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN, List.of(customChInfo));
     }
 
     @Test
     public void ensureThrowsWhenMissingPeriperhalOrg() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
         customChInfo.setPeripheralOrgId(75842L);
 
         testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No org id");
@@ -736,7 +765,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenMissingChannelArch() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
         customChInfo.setChannelArchLabel("channel-dummy-arch");
 
         testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No channel arch");
@@ -744,7 +773,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenMissingChecksumType() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
         customChInfo.setChecksumTypeLabel("sha123456");
 
         testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No checksum type");
@@ -752,7 +781,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenMissingParentChannel() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
         customChInfo.setParentChannelLabel("missingParentChannelLabel");
 
         testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(customChInfo), "No parent channel");
@@ -760,9 +789,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureNotThrowingWhenParentChannelIsCreatedBefore() throws Exception {
-        CustomChannelInfoJson customParentChInfo = testUtils.createValidCustomChInfo("parentChannel");
+        CreateChannelInfoJson customParentChInfo = testUtils.createValidCustomChInfo("parentChannel");
 
-        CustomChannelInfoJson customChildChInfo = testUtils.createValidCustomChInfo("childChannel");
+        CreateChannelInfoJson customChildChInfo = testUtils.createValidCustomChInfo("childChannel");
         customChildChInfo.setParentChannelLabel("parentChannel");
 
         testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN,
@@ -771,9 +800,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenParentChannelIsCreatedAfter() throws Exception {
-        CustomChannelInfoJson customParentChInfo = testUtils.createValidCustomChInfo("parentChannel");
+        CreateChannelInfoJson customParentChInfo = testUtils.createValidCustomChInfo("parentChannel");
 
-        CustomChannelInfoJson customChildChInfo = testUtils.createValidCustomChInfo("childChannel");
+        CreateChannelInfoJson customChildChInfo = testUtils.createValidCustomChInfo("childChannel");
         customChildChInfo.setParentChannelLabel("parentChannel");
 
         testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN,
@@ -782,9 +811,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenMissingOriginalChannelInClonedChannels() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo();
 
-        CustomChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
+        CreateChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
         clonedCustomChInfo.setOriginalChannelLabel(customChInfo.getLabel() + "MISSING");
 
         testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN,
@@ -793,9 +822,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureNotThrowingWhenOriginalChannelIsCreatedBefore() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo("originalCustomCh");
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo("originalCustomCh");
 
-        CustomChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
+        CreateChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
         clonedCustomChInfo.setOriginalChannelLabel("originalCustomCh");
 
         testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN,
@@ -804,9 +833,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenOriginalChannelIsCreatedAfter() throws Exception {
-        CustomChannelInfoJson customChInfo = testUtils.createValidCustomChInfo("originalCustomCh");
+        CreateChannelInfoJson customChInfo = testUtils.createValidCustomChInfo("originalCustomCh");
 
-        CustomChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
+        CreateChannelInfoJson clonedCustomChInfo = testUtils.createValidCustomChInfo("clonedCustomCh");
         clonedCustomChInfo.setOriginalChannelLabel("originalCustomCh");
 
         testUtils.checkAddCustomChannelsApiThrows(DUMMY_SERVER_FQDN,
@@ -845,7 +874,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         Channel productionCh = ChannelFactory.lookupById((long) productionChId);
         productionCh.setProduct(testCh.getProduct());
 
-        CustomChannelInfoJson testChInfo = ChannelFactory.toCustomChannelInfo(testCh,
+        CreateChannelInfoJson testChInfo = ChannelFactory.toCustomChannelInfo(testCh,
                 peripheralUser.getOrg().getId(), Optional.empty());
 
         assertEquals(localUser.getOrg().getId(), testCh.getOrg().getId());
@@ -858,7 +887,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         assertEquals("sha512", testChInfo.getChecksumTypeLabel());
         assertEquals("sles11-sp3-updates-x86_64", testChInfo.getOriginalChannelLabel());
 
-        CustomChannelInfoJson productionChInfo = ChannelFactory.toCustomChannelInfo(productionCh,
+        CreateChannelInfoJson productionChInfo = ChannelFactory.toCustomChannelInfo(productionCh,
                 peripheralUser.getOrg().getId(), Optional.empty());
 
         assertEquals(localUser.getOrg().getId(), productionCh.getOrg().getId());
@@ -875,12 +904,12 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @Test
     public void checkModifyCustomChannels() throws Exception {
         // cloneDevelCh -> cloneTestCh -> cloneProdCh
-        CustomChannelInfoJson cloneDevelChInfo = testUtils.createValidCustomChInfo("cloneDevelCh");
+        CreateChannelInfoJson cloneDevelChInfo = testUtils.createValidCustomChInfo("cloneDevelCh");
 
-        CustomChannelInfoJson cloneTestChInfo = testUtils.createValidCustomChInfo("cloneTestCh");
+        CreateChannelInfoJson cloneTestChInfo = testUtils.createValidCustomChInfo("cloneTestCh");
         cloneTestChInfo.setOriginalChannelLabel("cloneDevelCh");
 
-        CustomChannelInfoJson cloneProdChInfo = testUtils.createValidCustomChInfo("cloneProdCh");
+        CreateChannelInfoJson cloneProdChInfo = testUtils.createValidCustomChInfo("cloneProdCh");
         cloneProdChInfo.setOriginalChannelLabel("cloneTestCh");
 
         testUtils.checkAddCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN,
@@ -898,7 +927,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         User anotherPeripheralUser = UserTestUtils.findNewUser(
                 "another_peripheral_user_", "another_peripheral_org_", true);
 
-        ModifyCustomChannelInfoJson modifyInfo = new ModifyCustomChannelInfoJson("cloneProdCh");
+        ModifyChannelInfoJson modifyInfo = new ModifyChannelInfoJson("cloneProdCh");
         modifyInfo.setPeripheralOrgId(anotherPeripheralUser.getOrg().getId());
         modifyInfo.setOriginalChannelLabel("cloneDevelCh");
 
@@ -935,7 +964,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureNotThrowingWhenModifyingDataIsValid() throws Exception {
-        ModifyCustomChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
+        ModifyChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
         testUtils.createTestChannel(modifyInfo, user);
 
         testUtils.checkModifyCustomChannelsApiNotThrowing(DUMMY_SERVER_FQDN, List.of(modifyInfo));
@@ -943,7 +972,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenModifyingMissingPeriperhalOrg() throws Exception {
-        ModifyCustomChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
+        ModifyChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
         testUtils.createTestChannel(modifyInfo, user);
 
         modifyInfo.setPeripheralOrgId(75842L);
@@ -953,7 +982,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void ensureThrowsWhenModifyingMissingOriginalChannelInClonedChannels() throws Exception {
-        ModifyCustomChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
+        ModifyChannelInfoJson modifyInfo = testUtils.createValidModifyCustomChInfo("customCh");
         testUtils.createTestChannel(modifyInfo, user);
 
         modifyInfo.setOriginalChannelLabel(modifyInfo.getLabel() + "MISSING");

--- a/java/code/src/com/suse/manager/model/hub/CreateChannelInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/CreateChannelInfoJson.java
@@ -15,7 +15,7 @@ import com.suse.scc.model.SCCRepositoryJson;
 
 import java.util.Objects;
 
-public class CustomChannelInfoJson extends ModifyCustomChannelInfoJson {
+public class CreateChannelInfoJson extends ModifyChannelInfoJson {
 
     private String parentChannelLabel;
     private String channelArchLabel;
@@ -27,7 +27,7 @@ public class CustomChannelInfoJson extends ModifyCustomChannelInfoJson {
      *
      * @param labelIn The channel label
      */
-    public CustomChannelInfoJson(String labelIn) {
+    public CreateChannelInfoJson(String labelIn) {
         super(labelIn);
         repositoryInfo = new SCCRepositoryJson();
     }
@@ -96,7 +96,7 @@ public class CustomChannelInfoJson extends ModifyCustomChannelInfoJson {
         if (!super.equals(oIn)) {
             return false;
         }
-        CustomChannelInfoJson that = (CustomChannelInfoJson) oIn;
+        CreateChannelInfoJson that = (CreateChannelInfoJson) oIn;
         return Objects.equals(getParentChannelLabel(), that.getParentChannelLabel()) &&
                 Objects.equals(getChannelArchLabel(), that.getChannelArchLabel()) &&
                 Objects.equals(getChecksumTypeLabel(), that.getChecksumTypeLabel()) &&
@@ -111,7 +111,7 @@ public class CustomChannelInfoJson extends ModifyCustomChannelInfoJson {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("CustomChannelInfoJson{");
+        final StringBuilder sb = new StringBuilder("CreateChannelInfoJson{");
         sb.append(toStringCore());
         sb.append("parentChannelLabel='").append(parentChannelLabel).append('\'');
         sb.append(", channelArchLabel='").append(channelArchLabel).append('\'');

--- a/java/code/src/com/suse/manager/model/hub/ModifyChannelInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/ModifyChannelInfoJson.java
@@ -16,7 +16,7 @@ import com.redhat.rhn.domain.channel.Channel;
 import java.util.Date;
 import java.util.Objects;
 
-public class ModifyCustomChannelInfoJson {
+public class ModifyChannelInfoJson {
 
     private final String label;
 
@@ -49,7 +49,7 @@ public class ModifyCustomChannelInfoJson {
      *
      * @param labelIn The channel label
      */
-    public ModifyCustomChannelInfoJson(String labelIn) {
+    public ModifyChannelInfoJson(String labelIn) {
         label = labelIn;
 
         gpgCheck = true;
@@ -382,7 +382,7 @@ public class ModifyCustomChannelInfoJson {
         if (oIn == null || getClass() != oIn.getClass()) {
             return false;
         }
-        ModifyCustomChannelInfoJson that = (ModifyCustomChannelInfoJson) oIn;
+        ModifyChannelInfoJson that = (ModifyChannelInfoJson) oIn;
         return Objects.equals(getLabel(), that.getLabel()) &&
                 Objects.equals(getPeripheralOrgId(), that.getPeripheralOrgId()) &&
                 Objects.equals(getOriginalChannelLabel(), that.getOriginalChannelLabel()) &&
@@ -421,8 +421,8 @@ public class ModifyCustomChannelInfoJson {
         sb.append("label='").append(label).append('\'');
         sb.append(", peripheralOrgId=").append(peripheralOrgId);
         sb.append(", originalChannelLabel='").append(originalChannelLabel).append('\'');
-        sb.append(", baseDir='").append(baseDir).append('\'');
         sb.append(", name='").append(name).append('\'');
+        sb.append(", baseDir='").append(baseDir).append('\'');
         sb.append(", summary='").append(summary).append('\'');
         sb.append(", description='").append(description).append('\'');
         sb.append(", productNameLabel='").append(productNameLabel).append('\'');
@@ -445,7 +445,7 @@ public class ModifyCustomChannelInfoJson {
 
     @Override
     public String toString() {
-        final StringBuilder sb = new StringBuilder("ModifyCustomChannelInfoJson{");
+        final StringBuilder sb = new StringBuilder("ModifyChannelInfoJson{");
         sb.append(toStringCore());
         sb.append('}');
         return sb.toString();


### PR DESCRIPTION
## What does this PR change?

Unify `addVendorChannels()` and `addCustomChannels()` into one `addChannels()` function in the HubController API

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
