### PR TITLE
Click refresh when minion is down

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -180,7 +180,7 @@ When(/^I wait (\d+) seconds until the event is picked up and (\d+) seconds until
     And I follow first "#{event}"
     And I wait until I see "This action will be executed after" text
     And I wait until I see "#{event}" text
-    And I wait at most #{complete_timeout} seconds until the event is completed, refreshing the page
+    And I wait at most #{complete_timeout} seconds until the "#{event}" is completed, refreshing the page
   )
 end
 

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -81,12 +81,17 @@ When(/^I wait at most "([^"]*)" seconds until I do not see "([^"]*)" text$/) do 
   end
 end
 
-When(/^I wait at most (\d+) seconds until the event is completed, refreshing the page$/) do |timeout|
+When(/^I wait at most (\d+) seconds until the "([^"]*)" is completed, refreshing the page$/) do |timeout, event|
   last = Time.now
   next if has_content?('This action\'s status is: Completed.', wait: 3)
 
   repeat_until_timeout(timeout: timeout.to_i, message: 'Event not yet completed') do
     break if has_content?('This action\'s status is: Completed.', wait: 3)
+
+    if has_content?('Minion is down or could not be contacted.', wait: 3)
+      find(:xpath, "//input[@value='Reschedule']").click
+      step %(I wait 30 seconds until the event is picked up and #{timeout} seconds until the event "#{event}" is completed)
+    end
     raise SystemCallError, 'Event failed' if has_content?('This action\'s status is: Failed.', wait: 3)
 
     current = Time.now


### PR DESCRIPTION
## What does this PR change?
Fixes an issue where the Salt service is sometimes down on the minion, causing failures when checking the event. In most cases, refreshing the event resolves the problem.

This PR introduces a default behavior to prevent flaky tests. If the "Minion down" message appears during the event check, the process will automatically click the refresh button and restart the event check. Since these actions are performed within repeat_until_timeout, there is no risk of an infinite loop (verified through testing).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
