### PR TITLE
QE: Fix reference reposync file

### DIFF
--- a/testsuite/run_sets/reference_reposync.yml
+++ b/testsuite/run_sets/reference_reposync.yml
@@ -15,6 +15,7 @@
 - features/reposync/srv_create_fake_channels.feature
 - features/reposync/srv_create_fake_repositories.feature
 - features/reposync/srv_sync_fake_channels.feature
+- features/reposync/srv_create_devel_channels.feature
 
 # Activation keys can only be created after products and channels are synced
 - features/reposync/srv_create_activationkey.feature


### PR DESCRIPTION
## What does this PR change?

The devel channels were missing in the `run_sets` files for the reference environments. This is an issue for all our reference envs.
![image](https://github.com/user-attachments/assets/7cf2d28f-bc97-4e9c-9f9c-78eb6c32b5a2)
![image](https://github.com/user-attachments/assets/e8a3f7be-6b01-4319-934c-259cdd70a11f)
![image](https://github.com/user-attachments/assets/ff63eaf8-c6eb-4afa-933c-30825c40fc37)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added/edited

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
