### PR TITLE
ISSv3 - schedule a root CA refresh after the field is updated

### DIFF
--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -48,6 +48,7 @@ import com.suse.manager.webui.utils.token.TokenParsingException;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -143,7 +144,7 @@ public class HubController {
     }
 
     private String setHubDetails(Request request, Response response, IssAccessToken accessToken) {
-        Map<String, String> data = GSON.fromJson(request.body(), Map.class);
+        Map<String, String> data = GSON.fromJson(request.body(), new TypeToken<Map<String, String>>() { }.getType());
 
         try {
             hubManager.updateServerData(accessToken, accessToken.getServerFqdn(), IssRole.HUB, data);
@@ -151,6 +152,10 @@ public class HubController {
         catch (IllegalArgumentException ex) {
             LOGGER.error("Invalid data provided: ", ex);
             return badRequest(response, "Invalid data");
+        }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Unable to schedule Taskomatic execution to refresh the root ca: ", ex);
+            return internalServerError(response, "Unable to schedule refresh of the root CA certificate");
         }
         return success(response);
     }

--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -42,6 +42,7 @@ import com.suse.manager.model.hub.ModifyCustomChannelInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
 import com.suse.manager.model.hub.RegisterJson;
 import com.suse.manager.model.hub.SCCCredentialsJson;
+import com.suse.manager.model.hub.UpdatableServerData;
 import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
 import com.suse.manager.webui.utils.token.TokenBuildingException;
 import com.suse.manager.webui.utils.token.TokenParsingException;
@@ -54,6 +55,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -144,7 +146,8 @@ public class HubController {
     }
 
     private String setHubDetails(Request request, Response response, IssAccessToken accessToken) {
-        Map<String, String> data = GSON.fromJson(request.body(), new TypeToken<Map<String, String>>() { }.getType());
+        Type mapType = new TypeToken<Map<String, String>>() { }.getType();
+        UpdatableServerData data = new UpdatableServerData(GSON.fromJson(request.body(), mapType));
 
         try {
             hubManager.updateServerData(accessToken, accessToken.getServerFqdn(), IssRole.HUB, data);

--- a/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
@@ -58,6 +58,7 @@ import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.IssServer;
 import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.TokenType;
+import com.suse.manager.model.hub.UpdatableServerData;
 import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.test.TestSaltApi;
@@ -830,8 +831,11 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals("---- BEGIN ROOT CA ----", hub.getRootCa());
         assertEquals("---- BEGIN GPG PUB KEY -----", hub.getGpgKey());
 
-        Map<String, String> data = Map.of("gpg_key", "---- BEGIN NEW GPG PUB KEY -----",
-                "root_ca", "---- BEGIN NEW ROOT CA ----");
+        UpdatableServerData data = new UpdatableServerData(Map.of(
+            "gpg_key", "---- BEGIN NEW GPG PUB KEY -----",
+            "root_ca", "---- BEGIN NEW ROOT CA ----")
+        );
+
         hubManager.updateServerData(satAdmin, "hub.domain.com", IssRole.valueOf("HUB"), data);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();

--- a/java/code/src/com/suse/manager/model/hub/HubFactory.java
+++ b/java/code/src/com/suse/manager/model/hub/HubFactory.java
@@ -36,19 +36,12 @@ public class HubFactory extends HibernateFactory {
 
     /**
      * Save a {@link IssHub} object
-     * @param issHubIn object to save
+     * @param issServer object to save
      */
-    public void save(IssHub issHubIn) {
-        saveObject(issHubIn);
+    public void save(IssServer issServer) {
+        saveObject(issServer);
     }
 
-    /**
-     * Save a {@link IssPeripheral} object
-     * @param issPeripheralIn object to save
-     */
-    public void save(IssPeripheral issPeripheralIn) {
-        saveObject(issPeripheralIn);
-    }
 
     /**
      * Save a {@link IssPeripheralChannels} object

--- a/java/code/src/com/suse/manager/model/hub/UpdatableServerData.java
+++ b/java/code/src/com/suse/manager/model/hub/UpdatableServerData.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub;
+
+import java.util.Map;
+
+public class UpdatableServerData {
+    private final boolean rootCADefined;
+
+    private final String rootCA;
+
+    private final boolean gpgKeyDefined;
+
+    private final String gpgKey;
+
+    /**
+     * Builds an instance from the given map
+     * @param dataMap the map containing the new values. null as value is supported.
+     */
+    public UpdatableServerData(Map<String, String> dataMap) {
+        this.rootCADefined = dataMap.containsKey("root_ca");
+        this.rootCA = dataMap.get("root_ca");
+        this.gpgKeyDefined = dataMap.containsKey("gpg_key");
+        this.gpgKey = dataMap.get("gpg_key");
+    }
+
+    /**
+     * Check if the root CA is defined
+     * @return true if the root ca is part of this object
+     */
+    public boolean hasRootCA() {
+        return rootCADefined;
+    }
+
+    /**
+     * Retrieves the value of the root CA, possibly null.
+     * @return the value of the root CA.
+     * @throws IllegalStateException if the field is not defined in this object.
+     * Use {@link #hasRootCA()} to check beforehand.
+     */
+    public String getRootCA() {
+        if (!rootCADefined) {
+            throw new IllegalStateException("rootCA is not defined");
+        }
+
+        return rootCA;
+    }
+
+    /**
+     * Check if the GPG key is defined
+     * @return true if the GPG key is part of this object
+     */
+    public boolean hasGpgKey() {
+        return gpgKeyDefined;
+    }
+
+    /**
+     * Returns the value of the GPG key, possibly null.
+     * @return the value of the GPG key
+     * @throws IllegalStateException if the field is not defined in this object
+     * Use {@link #hasGpgKey()} to check beforehand.
+     */
+    public String getGpgKey() {
+        if (!gpgKeyDefined) {
+            throw new IllegalStateException("gpgKey is not defined");
+        }
+
+        return gpgKey;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
@@ -34,6 +34,7 @@ import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.IssServer;
 import com.suse.manager.model.hub.TokenType;
+import com.suse.manager.model.hub.UpdatableServerData;
 import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
 import com.suse.manager.webui.controllers.admin.beans.CreateTokenRequest;
 import com.suse.manager.webui.controllers.admin.beans.HubRegisterRequest;
@@ -63,7 +64,6 @@ import java.security.cert.CertificateException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import javax.net.ssl.SSLException;
 
@@ -333,8 +333,8 @@ public class HubApiController {
 
         try {
             // Collections.singletonMap() is used in place of Map.of() because it allows null as value
-            Map<String, String> dataMap = Collections.singletonMap("root_ca", rootCA);
-            hubManager.updateServerData(user, server.getFqdn(), role, dataMap);
+            UpdatableServerData data = new UpdatableServerData(Collections.singletonMap("root_ca", rootCA));
+            hubManager.updateServerData(user, server.getFqdn(), role, data);
         }
         catch (TaskomaticApiException e) {
             return internalServerError(response, LOC.getMessage("hub.cannot_refresh_certificate"));

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
@@ -331,9 +331,14 @@ public class HubApiController {
             return badRequest(response, LOC.getMessage("hub.cannot_find_server"));
         }
 
-        // Collections.singletonMap() is used in place of Map.of() because it allows null as value
-        Map<String, String> dataMap = Collections.singletonMap("root_ca", rootCA);
-        hubManager.updateServerData(user, server.getFqdn(), role, dataMap);
+        try {
+            // Collections.singletonMap() is used in place of Map.of() because it allows null as value
+            Map<String, String> dataMap = Collections.singletonMap("root_ca", rootCA);
+            hubManager.updateServerData(user, server.getFqdn(), role, dataMap);
+        }
+        catch (TaskomaticApiException e) {
+            return internalServerError(response, LOC.getMessage("hub.cannot_refresh_certificate"));
+        }
 
         return success(response);
     }

--- a/java/code/src/com/suse/manager/xmlrpc/iss/HubHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/HubHandler.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.hub.HubManager;
 import com.suse.manager.model.hub.IssRole;
+import com.suse.manager.model.hub.UpdatableServerData;
 import com.suse.manager.webui.utils.token.TokenBuildingException;
 import com.suse.manager.webui.utils.token.TokenException;
 import com.suse.manager.webui.utils.token.TokenParsingException;
@@ -397,7 +398,7 @@ public class HubHandler extends BaseHandler {
     public int setDetails(User loggedInUser, String fqdn, String role, Map<String, String> data) {
         ensureSatAdmin(loggedInUser);
         try {
-            hubManager.updateServerData(loggedInUser, fqdn, IssRole.valueOf(role), data);
+            hubManager.updateServerData(loggedInUser, fqdn, IssRole.valueOf(role), new UpdatableServerData(data));
         }
         catch (TaskomaticApiException e) {
             throw new com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException("Unable to refresh root CA certificate");

--- a/java/code/src/com/suse/manager/xmlrpc/iss/HubHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/HubHandler.java
@@ -317,7 +317,7 @@ public class HubHandler extends BaseHandler {
         }
         catch (TaskomaticApiException ex) {
             LOGGER.error("Unable to schedule root CA certificate update {}", fqdn, ex);
-            throw new TokenExchangeFailedException(ex);
+            throw new com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException("Unable to refresh root CA certificate");
         }
 
         return 1;
@@ -396,7 +396,12 @@ public class HubHandler extends BaseHandler {
      */
     public int setDetails(User loggedInUser, String fqdn, String role, Map<String, String> data) {
         ensureSatAdmin(loggedInUser);
-        hubManager.updateServerData(loggedInUser, fqdn, IssRole.valueOf(role), data);
+        try {
+            hubManager.updateServerData(loggedInUser, fqdn, IssRole.valueOf(role), data);
+        }
+        catch (TaskomaticApiException e) {
+            throw new com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException("Unable to refresh root CA certificate");
+        }
         return 1;
     }
 }


### PR DESCRIPTION
## What does this PR change?

This PR ensure the root CA is refreshed by calling the Taskomatic job if the field is updated through the API or the UI. It also uses a POJO instead of map to improve type safety.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
-  Documentation WIP TBD

- [ ] **DONE**

## Test coverage
- Unit tests were updated

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
