### PR TITLE
ISSv3 - Use GET instead of POST for the logout

### DIFF
--- a/java/code/src/com/suse/manager/xmlrpc/iss/RestHubExternalClient.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/RestHubExternalClient.java
@@ -22,6 +22,7 @@ import com.google.gson.reflect.TypeToken;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.entity.ContentType;
@@ -127,7 +128,7 @@ public class RestHubExternalClient implements HubExternalClient {
             return;
         }
 
-        HttpPost request = createPostRequest("auth", "logout");
+        HttpGet request = createGetRequest("auth", "logout");
         HttpResponse response = httpClientAdapter.executeRequest(request);
         int statusCode = response.getStatusLine().getStatusCode();
         if (statusCode != HttpStatus.SC_OK) {
@@ -142,10 +143,6 @@ public class RestHubExternalClient implements HubExternalClient {
         logout();
     }
 
-    private HttpPost createPostRequest(String namespace, String method) {
-        return createPostRequest(namespace, method, Map.of());
-    }
-
     private HttpPost createPostRequest(String namespace, String method, Map<String, Object> paramtersMap) {
         String url = "https://%s/rhn/manager/api/%s/%s".formatted(remoteHost, namespace.replace(".", "/"), method);
         HttpPost request = new HttpPost(url);
@@ -156,5 +153,10 @@ public class RestHubExternalClient implements HubExternalClient {
         }
 
         return request;
+    }
+
+    private HttpGet createGetRequest(String namespace, String method) {
+        String url = "https://%s/rhn/manager/api/%s/%s".formatted(remoteHost, namespace.replace(".", "/"), method);
+        return new HttpGet(url);
     }
 }

--- a/java/spacewalk-java.changes.mackdk.fix-registration
+++ b/java/spacewalk-java.changes.mackdk.fix-registration
@@ -1,0 +1,1 @@
+- Update ISSv3 registration to the new logout scheme


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with ISSv3 registration using username/password. Due to [commit b023419](https://github.com/uyuni-project/uyuni/commit/b023419ebd4039e67164668088b95441d8da9292#diff-44d2ad9eae6435e6b813986a2988089cb3598816e3759a2dbacff2b1a4b9d153R142), the logout API has been changed from `POST` to `GET`. This breaks the peripheral registration, as 404 is received when trying to logout the user used for generating the token.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
