### PR TITLE
Fix Ansible add directory UI layout

### DIFF
--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -221,7 +221,8 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
                 <NewAnsiblePath
                   title={t("Add an Inventory file")}
                   pathType="inventory"
-                  newInventoryPath={this.state.newInventoryPath}
+                  // TODO: @parlt91: Is this bugfix correct?
+                  newPathValue={this.state.newInventoryPath}
                   placeholder={t("e.g., /etc/ansible/testing/hosts")}
                   newPath={(path: string) => this.newPath("inventory", path)}
                   savePath={() => this.savePath("inventory")}

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -221,7 +221,6 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
                 <NewAnsiblePath
                   title={t("Add an Inventory file")}
                   pathType="inventory"
-                  // TODO: @parlt91: Is this bugfix correct?
                   newPathValue={this.state.newInventoryPath}
                   placeholder={t("e.g., /etc/ansible/testing/hosts")}
                   newPath={(path: string) => this.newPath("inventory", path)}

--- a/web/html/src/manager/minion/ansible/new-ansible-path.tsx
+++ b/web/html/src/manager/minion/ansible/new-ansible-path.tsx
@@ -3,26 +3,39 @@ import * as React from "react";
 import { AsyncButton } from "components/buttons";
 import { TextField } from "components/fields";
 
-const NewAnsiblePath = (props) => {
+type Props = {
+  title: string;
+  pathType: string;
+  newPathValue: string;
+  newPath: (value: string) => any;
+  placeholder?: string;
+  savePath: (...args: any) => any;
+};
+
+const NewAnsiblePath = (props: Props) => {
   return (
     <>
       <h4>{props.title}</h4>
       <div className="form-group">
-        <TextField
-          id={"new_" + props.pathType + "_path_input"}
-          placeholder={props.placeholder}
-          value={props.newPathValue}
-          onChange={(e: any) => props.newPath(e.target.value.toString())}
-        />
+        <div>
+          <TextField
+            id={"new_" + props.pathType + "_path_input"}
+            placeholder={props.placeholder}
+            value={props.newPathValue}
+            onChange={(e: any) => props.newPath(e.target.value.toString())}
+          />
+        </div>
       </div>
-      <div className="pull-right btn-group">
-        <AsyncButton
-          id={"new_" + props.pathType + "_path_save"}
-          action={props.savePath}
-          defaultType="btn-primary"
-          text={t("Save")}
-          icon="fa-save"
-        />
+      <div className="d-flex justify-content-end">
+        <div className="btn-group">
+          <AsyncButton
+            id={"new_" + props.pathType + "_path_save"}
+            action={props.savePath}
+            defaultType="btn-primary"
+            text={t("Save")}
+            icon="fa-save"
+          />
+        </div>
       </div>
     </>
   );

--- a/web/spacewalk-web.changes.eth.ans
+++ b/web/spacewalk-web.changes.eth.ans
@@ -1,0 +1,1 @@
+- Fix layout issues on Ansible pages


### PR DESCRIPTION
## What does this PR change?

This is not the nicest fix, ideally we'd fix the global styles that affect this, but that would mean breaking many other things. For now, this fix applies only here and resolves the problem.

## GUI diff

After:

<img width="790" alt="Screenshot 2025-03-03 at 11 48 54" src="https://github.com/user-attachments/assets/0fcaee91-862f-43d5-b5e4-b06c1f7e8b48" />


- [x] **DONE**

## Documentation
- No documentation needed: layout bugfix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: layout bugfix

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/26555

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
