### PR TITLE
Allow both GET and POST requests for /auth/logout API endpoint

### DIFF
--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -139,6 +139,7 @@ public class HttpApiRegistry {
      */
     private void registerAuthEndpoints() {
         registrationHelper.addPostRoute(HTTP_API_ROOT + "auth/login", LoginController::apiLogin);
+        registrationHelper.addPostRoute(HTTP_API_ROOT + "auth/logout", withUser(LoginController::logout));
         registrationHelper.addGetRoute(HTTP_API_ROOT + "auth/logout", withUser(LoginController::logout));
     }
 

--- a/java/code/src/com/suse/manager/api/test/HttpApiRegistryTest.java
+++ b/java/code/src/com/suse/manager/api/test/HttpApiRegistryTest.java
@@ -65,6 +65,7 @@ public class HttpApiRegistryTest extends RhnJmockBaseTestCase {
         context().checking(new Expectations() {{
             // Auth routes are added in all cases
             oneOf(helper).addPostRoute(with("/manager/api/auth/login"), with(any(Route.class)));
+            oneOf(helper).addPostRoute(with("/manager/api/auth/logout"), with(any(Route.class)));
             oneOf(helper).addGetRoute(with("/manager/api/auth/logout"), with(any(Route.class)));
 
             // Test routes

--- a/java/spacewalk-java.changes.cbbayburt.logout-api-get
+++ b/java/spacewalk-java.changes.cbbayburt.logout-api-get
@@ -1,0 +1,1 @@
+- Allow both GET and POST requests for /auth/logout API endpoint


### PR DESCRIPTION
## Documentation
- No documentation needed: Covered by API docs

## Test coverage
- No tests: routing not tested

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
