### PR TITLE
Improve read timeout failing

### DIFF
--- a/testsuite/features/secondary/srv_change_task_schedule.feature
+++ b/testsuite/features/secondary/srv_change_task_schedule.feature
@@ -5,7 +5,7 @@
 Feature: Change the schedule of a task
 
   Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+    Given I am authorized
 
   Scenario: Change the schedule of task sandbox-cleanup-default to weekly
     When I follow the left menu "Admin > Task Schedules"

--- a/testsuite/features/secondary/srv_payg_ssh_connection.feature
+++ b/testsuite/features/secondary/srv_payg_ssh_connection.feature
@@ -7,7 +7,7 @@ Feature: Pay as you go
   I want to list available ssh connections and add or remove them
 
   Scenario: Log in as admin user
-    Given I am authorized for the "Admin" section
+    Given I am authorized
 
   Scenario: Enter minimal information for payg ssh connection data
     When I follow the left menu "Admin > Setup Wizard > PAYG Connections"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -57,6 +57,8 @@ $current_user = 'admin'
 $current_password = 'admin'
 $chromium_dev_tools = ENV.fetch('REMOTE_DEBUG', false)
 $chromium_dev_port = 9222 + ENV['TEST_ENV_NUMBER'].to_i
+$timeout_failure_counter = 0
+$timeout_threshold = 10  # Set the threshold for stopping the suite
 
 # maximal wait before giving up
 # the tests return much before that delay in case of success
@@ -131,21 +133,31 @@ $quality_intelligence = QualityIntelligence.new if $quality_intelligence_mode
 # Define the current feature scope
 Before do |scenario|
   $feature_scope = scenario.location.file.split(%r{(\.feature|/)})[-2]
+  check_read_timeout_threshold
 end
 
-# Embed a screenshot after each failed scenario
+# After hook to handle scenario failures and dump feature code coverage into Redis DB
 After do |scenario|
+  check_read_timeout_threshold
+
   current_epoch = Time.new.to_i
   log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
+
+  # Check if the scenario failed due to a Net::ReadTimeout
   if scenario.failed?
-    begin
-      if web_session_is_active?
-        handle_screenshot_and_relog(scenario, current_epoch)
-      else
-        warn 'There is no active web session; unable to take a screenshot or relog.'
+    if scenario.exception.is_a?(Net::ReadTimeout)
+      increase_read_timeout_count
+      log_server_response_time
+    else
+      begin
+        if web_session_is_active?
+          handle_screenshot_and_relog(scenario, current_epoch)
+        else
+          warn 'There is no active web session; unable to take a screenshot or relog.'
+        end
+      ensure
+        print_server_logs
       end
-    ensure
-      print_server_logs
     end
   end
   page.instance_variable_set(:@touched, false) if capybara_session_created?
@@ -158,11 +170,25 @@ def capybara_session_created?
   Capybara::Session.instance_created?
 end
 
-# Test if web session is open
+# Test is web session is open
 def web_session_is_active?
   return false unless capybara_session_created?
 
   page.has_selector?('header') || page.has_selector?('#username-field')
+end
+
+def check_read_timeout_threshold
+  # Check if the consecutive timeout threshold is reached
+  if $timeout_failure_counter >= $timeout_threshold
+    warn "Timeout failure threshold reached, stopping test suite."
+    exit(1)
+  end
+end
+
+def increase_read_timeout_count
+  $timeout_failure_counter += 1
+
+  warn "Net::ReadTimeout detected! Consecutive ReadTimeouts: #{$timeout_failure_counter}"
 end
 
 # Take a screenshot and try to log back at suse manager server
@@ -205,6 +231,7 @@ def relog_and_visit_previous_url
     end
   rescue Timeout::Error
     warn "Timed out while attempting to relog and visit the previous URL: #{current_url}"
+    increase_read_timeout_count
   rescue StandardError => e
     warn "An error occurred while relogging and visiting the previous URL: #{e.message}"
   end
@@ -275,6 +302,7 @@ end
 
 # Create a user for each feature
 Before do |scenario|
+  check_read_timeout_threshold
   feature_path = scenario.location.file
   $feature_filename = feature_path.split(%r{(\.feature|/)})[-2]
   next if get_context('user_created') == true

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -58,8 +58,7 @@ $current_password = 'admin'
 $chromium_dev_tools = ENV.fetch('REMOTE_DEBUG', false)
 $chromium_dev_port = 9222 + ENV['TEST_ENV_NUMBER'].to_i
 $timeout_failure_counter = 0
-$timeout_threshold = 10  # Set the threshold for stopping the suite
-
+$timeout_threshold = 10 # Set the threshold for stopping the suite
 # maximal wait before giving up
 # the tests return much before that delay in case of success
 $stdout.sync = true
@@ -177,14 +176,15 @@ def web_session_is_active?
   page.has_selector?('header') || page.has_selector?('#username-field')
 end
 
+# Check if the consecutive timeout threshold is reached
 def check_read_timeout_threshold
-  # Check if the consecutive timeout threshold is reached
-  if $timeout_failure_counter >= $timeout_threshold
-    warn "Timeout failure threshold reached, stopping test suite."
-    exit(1)
-  end
+  return unless $timeout_failure_counter >= $timeout_threshold
+
+  warn 'Timeout failure threshold reached, stopping test suite.'
+  exit(1)
 end
 
+# Increase read timeout count
 def increase_read_timeout_count
   $timeout_failure_counter += 1
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -248,6 +248,7 @@ end
 
 # Dump feature code coverage into a Redis DB before we run next feature
 Before do |scenario|
+  check_read_timeout_threshold
   next unless $code_coverage_mode
 
   # Initialize $feature_path if that's the first feature

--- a/testsuite/features/support/system_monitoring.rb
+++ b/testsuite/features/support/system_monitoring.rb
@@ -113,3 +113,16 @@ def channel_synchronization_duration(channel)
 
   duration
 end
+
+# Method to check server response time (could be using an HTTP request or ping)
+def log_server_response_time
+  begin
+    start_time = Time.now
+    uri = URI.parse("https://#{ENV.fetch('SERVER', nil)}")
+    Net::HTTP.get_response(uri)
+    response_time = Time.now - start_time
+    log "Server response time: #{response_time} seconds"
+  rescue => e
+    warn "Error checking server response time: #{e.message}"
+  end
+end

--- a/testsuite/features/support/system_monitoring.rb
+++ b/testsuite/features/support/system_monitoring.rb
@@ -122,7 +122,7 @@ def log_server_response_time
     Net::HTTP.get_response(uri)
     response_time = Time.now - start_time
     log "Server response time: #{response_time} seconds"
-  rescue => e
+  rescue StandardError => e
     warn "Error checking server response time: #{e.message}"
   end
 end


### PR DESCRIPTION
## What does this PR change?

Improve the failing the time when we have read:timeout for more than 10 times.
Currently, in the testsuite, when we have the read:timeout, the failing time is taking more than 18 hours.
This error is probably related to the server or network behind slow to response. See: https://github.com/SUSE/spacewalk/issues/26585

This change will show use the current time response of the server and fail fast the features.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
