### PR TITLE
Fix wrong feature name

### DIFF
--- a/testsuite/features/build_validation/finishing/srv_selinux.feature
+++ b/testsuite/features/build_validation/finishing/srv_selinux.feature
@@ -1,9 +1,0 @@
-# Copyright (c) 2025 SUSE LLC
-# Licensed under the terms of the MIT license.
-
-Feature: Sanity checks
-  In order for the server to behave correctly after a reboot
-  I want to be sure that there is no wrong SELinux label
-
-  Scenario: No previous operation has created wrong SELinux label
-    Then files on container volumes should all have the proper SELinux label

--- a/testsuite/features/finishing/srv_selinux.feature
+++ b/testsuite/features/finishing/srv_selinux.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Sanity checks
+Feature: SELinux debugging
   In order for the server to behave correctly after a reboot
   I want to be sure that there is no wrong SELinux label
 

--- a/testsuite/run_sets/build_validation/build_validation_finishing.yml
+++ b/testsuite/run_sets/build_validation/build_validation_finishing.yml
@@ -5,7 +5,6 @@
 # IMMUTABLE ORDER
 
 # these features are needed for gathering log/debug info
-- features/build_validation/finishing/srv_selinux.feature
 - features/build_validation/finishing/srv_debug.feature
 - features/build_validation/finishing/allcli_debug.feature
 


### PR DESCRIPTION
## What does this PR change?

* fix copy and paste error which lead to wrong feature name
* remove SELinux test from BV


## Links

Port(s):
 * 5.0: https://github.com/SUSE/spacewalk/pull/26589
 * 4.3: non applicable


## Changelogs

- [x] No changelog needed
