### PR TITLE
Fix openscap library on ubuntu-minion dockerfile

### DIFF
--- a/testsuite/dockerfiles/ubuntu-minion/Dockerfile
+++ b/testsuite/dockerfiles/ubuntu-minion/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 RUN echo "deb [trusted=yes] http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2404-Uyuni-Client-Tools/xUbuntu_24.04/ /" > /etc/apt/sources.list.d/uyuni-tools.list
 RUN apt-get update && \
   apt-get -y install ca-certificates && \
-  apt-get -y install venv-salt-minion openssh-server openssh-client hostname iproute2 libopenscap8 scap-security-guide-ubuntu udev dmidecode tar \
+  apt-get -y install venv-salt-minion openssh-server openssh-client hostname iproute2 openscap-utils openscap-scanner openscap-common ssg-debderived udev dmidecode tar \
     prometheus-node-exporter prometheus-apache-exporter prometheus-postgres-exporter prometheus-exporter-exporter prometheus-apache-exporter prometheus-node-exporter && \
   apt-get clean
 RUN echo "deb [trusted=yes] http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/ /" > /etc/apt/sources.list.d/test_repo_deb_pool.list


### PR DESCRIPTION
## What does this PR change?

Fix openscap library on ubuntu-minion dockerfile

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
