### PR TITLE
Health Check: Reorganize and rename metrics to real parameters name

### DIFF
--- a/python/health-check/src/health_check/config/grafana/alerts.yaml
+++ b/python/health-check/src/health_check/config/grafana/alerts.yaml
@@ -571,7 +571,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: A
-                root_selector: config[name="java_salt_batch_size"].value
+                root_selector: java_config[name="java.salt_batch_size"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -722,7 +722,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: A
-                root_selector: config[name="server_limit"].value
+                root_selector: apache[name="server_limit"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -747,7 +747,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name="max_clients"].value
+                root_selector: apache[name="max_clients"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -815,7 +815,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: A
-                root_selector: config[name="max_threads"].value
+                root_selector: java_config[name="maxThreads"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -840,7 +840,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name="max_clients"].value
+                root_selector: apache[name="max_clients"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -963,7 +963,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: A
-                root_selector: config[name="queued_salt_events"].value
+                root_selector: misc[name="queued_salt_events"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1112,7 +1112,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name="taskomatic_channel_repodata_workers"].value
+                root_selector: java_config[name="java.taskomatic_channel_repodata_workers"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1207,7 +1207,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name="org_quartz_threadpool_threadcount"].value
+                root_selector: java_config[name="org.quartz.threadPool.threadCount"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1302,7 +1302,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name="org_quartz_scheduler_idlewaittime"].value
+                root_selector: java_config[name="org.quartz.scheduler.idleWaitTime"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1393,7 +1393,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name="taskomatic_minion_action_executor_parallel_threads"].value
+                root_selector: java_config[name="taskomatic.minion_action_executor.parallel_threads"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1460,7 +1460,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: A
-                root_selector: config[name="shared_buffers_to_mem_ratio"].value
+                root_selector: postgresql[name="shared_buffers_to_mem_ratio"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1531,7 +1531,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: A
-                root_selector: config[name = "java_message_queue_thread_pool_size"].value
+                root_selector: java_config[name = "java.message_queue_thread_pool_size"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1556,7 +1556,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name = "org_quartz_threadpool_threadcount"].value
+                root_selector: java_config[name = "org.quartz.threadPool.threadCount"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1581,7 +1581,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: C
-                root_selector: config[name = "salt_thread_pool"].value
+                root_selector: salt_configuration[name = "thread_pool"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json
@@ -1720,7 +1720,7 @@ groups:
                 maxDataPoints: 43200
                 parser: backend
                 refId: B
-                root_selector: config[name="salt_pub_hwm"].value
+                root_selector: salt_configuration[name="pub_hwm"].value
                 source: url
                 type: json
                 url: http://health_check_supportconfig_exporter:9000/metrics.json

--- a/python/health-check/src/health_check/config/templates/grafana_dashboard/supportconfig_with_logs.template.json
+++ b/python/health-check/src/health_check/config/templates/grafana_dashboard/supportconfig_with_logs.template.json
@@ -85,7 +85,7 @@
       },
       "id": 71,
       "panels": [],
-      "title": "Server configuration and Salt",
+      "title": "Server and Salt configuration",
       "type": "row"
     },
     {
@@ -170,7 +170,7 @@
           }
         }
       ],
-      "title": "Worker Threads",
+      "title": "worker_threads",
       "type": "gauge"
     },
     {
@@ -183,23 +183,26 @@
           "color": {
             "mode": "thresholds"
           },
+          "custom": {
+            "neutral": 0
+          },
           "mappings": [],
-          "max": 128,
-          "min": 0,
+          "max": 300,
+          "min": -1,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "yellow",
                 "value": null
               },
               {
                 "color": "green",
-                "value": 20
+                "value": 60
               },
               {
-                "color": "yellow",
-                "value": 40
+                "color": "#EAB839",
+                "value": 180
               }
             ]
           },
@@ -213,7 +216,7 @@
         "x": 3,
         "y": 7
       },
-      "id": 101,
+      "id": 113,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
@@ -242,7 +245,7 @@
           "global_query_id": "",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "salt_configuration[name=\"sock_pool_size\"]",
+          "root_selector": "salt_configuration[name=\"timeout\"]",
           "source": "url",
           "type": "json",
           "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
@@ -252,7 +255,89 @@
           }
         }
       ],
-      "title": "Socket Pool Size",
+      "title": "timeout",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100000,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1000
+              },
+              {
+                "color": "yellow",
+                "value": 10000
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 7
+      },
+      "id": 103,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^value$/",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "salt_configuration[name=\"pub_hwm\"]",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "pub_hwm",
       "type": "gauge"
     },
     {
@@ -309,8 +394,8 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 8,
-        "x": 6,
+        "w": 6,
+        "x": 9,
         "y": 7
       },
       "id": 112,
@@ -402,8 +487,8 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 10,
-        "x": 14,
+        "w": 9,
+        "x": 15,
         "y": 7
       },
       "id": 91,
@@ -483,6 +568,88 @@
           "color": {
             "mode": "thresholds"
           },
+          "mappings": [],
+          "max": 128,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 20
+              },
+              {
+                "color": "yellow",
+                "value": 40
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 12
+      },
+      "id": 101,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^value$/",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "salt_configuration[name=\"sock_pool_size\"]",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "sock_pool_size",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
           "custom": {
             "neutral": 0
           },
@@ -513,92 +680,10 @@
       "gridPos": {
         "h": 5,
         "w": 3,
-        "x": 0,
-        "y": 12
-      },
-      "id": 113,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^value$/",
-          "values": true
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "11.5.1",
-      "targets": [
-        {
-          "columns": [],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "infinity"
-          },
-          "filters": [],
-          "format": "table",
-          "global_query_id": "",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "salt_configuration[name=\"timeout\"]",
-          "source": "url",
-          "type": "json",
-          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "title": "Timeout",
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "infinity"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": 300,
-          "min": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "yellow",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 60
-              },
-              {
-                "color": "yellow",
-                "value": 180
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 3,
         "x": 3,
         "y": 12
       },
-      "id": 103,
+      "id": 128,
       "options": {
         "minVizHeight": 75,
         "minVizWidth": 75,
@@ -637,7 +722,93 @@
           }
         }
       ],
-      "title": "Gather Job Timeout",
+      "title": "gather_job_timeout",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1000,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 100
+              },
+              {
+                "color": "yellow",
+                "value": 150
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 6,
+        "y": 12
+      },
+      "id": 127,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^value$/",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "salt_configuration[name=\"thread_pool\"]",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "thread_pool",
       "type": "gauge"
     },
     {
@@ -670,8 +841,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 12,
+        "h": 8,
+        "w": 9,
         "x": 0,
         "y": 17
       },
@@ -697,7 +868,7 @@
           "global_query_id": "",
           "parser": "backend",
           "refId": "A",
-          "root_selector": "config",
+          "root_selector": "java_config",
           "source": "url",
           "type": "json",
           "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
@@ -709,6 +880,150 @@
       ],
       "title": "Java settings",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 9,
+        "y": 17
+      },
+      "id": 122,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "apache",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Apache settings",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 4998,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 17
+      },
+      "id": 120,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "misc[name = \"num_of_channels\"]",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Total Software Channels",
+      "type": "gauge"
     },
     {
       "datasource": {
@@ -734,10 +1049,234 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 4,
         "w": 4,
-        "x": 12,
+        "x": 20,
         "y": 17
+      },
+      "id": 124,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "vertical",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^value$/",
+          "values": true
+        },
+        "showPercentChange": false,
+        "text": {},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "computed_columns": [],
+          "filterExpression": "",
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "misc[name = \"major_version\"]",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Server major version",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [],
+            "fields": {}
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 9,
+        "y": 21
+      },
+      "id": 121,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": false
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "postgresql",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "PostgreSQL settings",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "mappings": [],
+          "max": 1000,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 21
+      },
+      "id": 125,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "columns": [],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "infinity"
+          },
+          "filters": [],
+          "format": "table",
+          "global_query_id": "",
+          "parser": "backend",
+          "refId": "A",
+          "root_selector": "misc[name = \"queued_salt_events\"]",
+          "source": "url",
+          "type": "json",
+          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
+          "url_options": {
+            "data": "",
+            "method": "GET"
+          }
+        }
+      ],
+      "title": "Java Salt Events Queue",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "uid": "infinity"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 21
       },
       "id": 119,
       "options": {
@@ -763,7 +1302,7 @@
         {
           "columns": [],
           "computed_columns": [],
-          "filterExpression": "name != \"num_of_channels\" && value == 1",
+          "filterExpression": "(name == \"master\" || name == \"proxy\" || name == \"client\") && value == 1",
           "filters": [],
           "format": "table",
           "global_query_id": "",
@@ -784,12 +1323,7 @@
         {
           "id": "convertFieldType",
           "options": {
-            "conversions": [
-              {
-                "destinationType": "boolean",
-                "targetField": "value"
-              }
-            ],
+            "conversions": [],
             "fields": {}
           }
         }
@@ -797,83 +1331,12 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "infinity"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 17
-      },
-      "id": 120,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "11.5.1",
-      "targets": [
-        {
-          "columns": [],
-          "datasource": {
-            "type": "yesoreyeram-infinity-datasource",
-            "uid": "infinity"
-          },
-          "filters": [],
-          "format": "table",
-          "global_query_id": "",
-          "parser": "backend",
-          "refId": "A",
-          "root_selector": "misc[\"num_of_channels\"]",
-          "source": "url",
-          "type": "json",
-          "url": "http://health_check_supportconfig_exporter:9000/metrics.json",
-          "url_options": {
-            "data": "",
-            "method": "GET"
-          }
-        }
-      ],
-      "title": "Total Software Channels",
-      "type": "gauge"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
       },
       "id": 109,
       "panels": [],
@@ -918,7 +1381,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 25
+        "y": 26
       },
       "id": 116,
       "options": {
@@ -1015,7 +1478,7 @@
         "h": 10,
         "w": 8,
         "x": 3,
-        "y": 25
+        "y": 26
       },
       "id": 110,
       "options": {
@@ -1127,7 +1590,7 @@
         "h": 10,
         "w": 13,
         "x": 11,
-        "y": 25
+        "y": 26
       },
       "id": 111,
       "options": {
@@ -1227,7 +1690,7 @@
         "h": 5,
         "w": 3,
         "x": 0,
-        "y": 30
+        "y": 31
       },
       "id": 118,
       "options": {
@@ -1278,7 +1741,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 36
       },
       "id": 63,
       "panels": [],
@@ -1349,7 +1812,7 @@
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 37
       },
       "id": 65,
       "options": {
@@ -1395,7 +1858,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 42
       },
       "id": 67,
       "options": {

--- a/python/health-check/src/health_check/exporters/static_metrics.py
+++ b/python/health-check/src/health_check/exporters/static_metrics.py
@@ -10,54 +10,65 @@ metrics_config = {
     "tomcat_xmx_size": {
         "filepath": "spacewalk-debug/conf/tomcat/tomcat/conf.d/tomcat_java_opts.conf",
         "pattern": r"-Xmx(\d)+([kKmMgG])",
+        "label": "java_config",
     },
-    "max_threads": {
+    "maxThreads": {
         "filepath": "spacewalk-debug/conf/tomcat/tomcat/server.xml",
         "pattern": r'<Connector[^>]*address="127\.0\.0\.1"[^>]*maxThreads="(\d+)"[^>]*\/>',
+        "label": "java_config",
     },
     "queued_salt_events": {
         "filepath": "plugin-susemanager.txt",
         "pattern": r"(?s)select count\(\*\) from susesaltevent.*?(\d+)",
+        "label": "misc",
     },
-    "java_salt_batch_size": {
+    "java.salt_batch_size": {
         "filepath": "spacewalk-debug/conf/rhn/rhn/rhn.conf",
         "pattern": r"^java.salt_batch_size\s*=\s*(\d+)\s*$",
         "default": 200,
+        "label": "java_config",
     },
-    "taskomatic_channel_repodata_workers": {
+    "java.taskomatic_channel_repodata_workers": {
         "filepath": "spacewalk-debug/conf/rhn/rhn/rhn.conf",
         "pattern": r"^java.taskomatic_channel_repodata_workers\s*=\s*(\d+)\s*$",
         "default": 2,
+        "label": "java_config",
     },
-    "org_quartz_threadpool_threadcount": {
+    "org.quartz.threadPool.threadCount": {
         "filepath": "spacewalk-debug/conf/rhn/rhn/rhn.conf",
         "pattern": r"^org.quartz.threadPool.threadCount\s*=\s*(\d+)\s*$",
         "default": 20,
+        "label": "java_config",
     },
-    "org_quartz_scheduler_idlewaittime": {
+    "org.quartz.scheduler.idleWaitTime": {
         "filepath": "spacewalk-debug/conf/rhn/rhn/rhn.conf",
         "pattern": r"^org.quartz.scheduler.idleWaitTime\s*=\s*(\d+)\s*$",
         "default": 5000,
+        "label": "java_config",
     },
-    "taskomatic_minion_action_executor_parallel_threads": {
+    "taskomatic.minion_action_executor.parallel_threads": {
         "filepath": "spacewalk-debug/conf/rhn/rhn/rhn.conf",
         "pattern": r"^taskomatic.minion_action_executor.parallel_threads\s*=\s*(\d+)\s*$",
         "default": 1,
+        "label": "java_config",
     },
-    "java_message_queue_thread_pool_size": {
+    "java.message_queue_thread_pool_size": {
         "filepath": "spacewalk-debug/conf/rhn/rhn/rhn.conf",
         "pattern": r"^java.message_queue_thread_pool_size\s*=\s*(\d+)\s*$",
         "default": 5,
+        "label": "java_config",
     },
-    "salt_thread_pool": {
+    "thread_pool": {
         "filepath": "plugin-saltconfiguration.txt",
         "pattern": r"^thread_pool\s*:\s*(\d+)\s*$",
         "default": 100,
+        "label": "salt_configuration",
     },
-    "salt_pub_hwm": {
+    "pub_hwm": {
         "filepath": "plugin-saltconfiguration.txt",
         "pattern": r"^pub_hwm\s*:\s*(\d+)\s*$",
         "default": 1000,
+        "label": "salt_configuration",
     },
     "cpu_count": {
         "filepath": "hardware.txt",
@@ -97,6 +108,7 @@ metrics_config = {
     "major_version": {
         "filepath": "basic-environment.txt",
         "pattern": r"^SUSE Manager release (\d)",
+        "label": "misc",
     },
 }
 

--- a/python/health-check/src/health_check/exporters/supportconfig_exporter.py
+++ b/python/health-check/src/health_check/exporters/supportconfig_exporter.py
@@ -481,7 +481,10 @@ class SupportConfigMetricsCollector:
 
     def merge_metrics(self):
         ret = {
+            "java_config": [],
             "config": [],
+            "apache": [],
+            "postgresql": [],
             "hw": [],
             "memory": [],
             "disk": self.disk_layout,
@@ -491,10 +494,10 @@ class SupportConfigMetricsCollector:
             "misc": self.roles,
         }
         self._append_static_properties(ret)
-        self._append_value_to_dict(ret, "config", "max_clients")
-        self._append_value_to_dict(ret, "config", "server_limit")
+        self._append_value_to_dict(ret, "apache", "max_clients")
+        self._append_value_to_dict(ret, "apache", "server_limit")
         self._append_value_to_dict(ret, "misc", "num_of_channels")
-        self._append_value_to_dict(ret, "config", "shared_buffers_to_mem_ratio")
+        self._append_value_to_dict(ret, "postgresql", "shared_buffers_to_mem_ratio")
         self._append_value_to_dict(ret, "memory", "fs_mount_insufficient")
         self._append_value_to_dict(ret, "memory", "fs_mount_out_of_space")
 


### PR DESCRIPTION
## What does this PR change?

This PR for `health-check-skeleton` branch is doing the following this:

- Rename some metrics to use same name as the real parameters.
- Add extra panels for some Salt configuration metrics.
- Split metrics across different panels for better understanding.

NOTE: Tested that "alerts" are not producing errors due these changes.

### Screenshot:

![image](https://github.com/user-attachments/assets/772ede06-c4e4-4fad-b726-cb2025689143)

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
