### PR TITLE
QE: Adding testcases that test the content lifecycle filters

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -20,19 +20,6 @@ Feature: Content lifecycle
     And I click on "Save" in "Create a new filter" modal
     Then I should see a "remove fonts packages" text
 
-  Scenario: Create CLM filter to enable Ruby 2.7 module
-    When I follow the left menu "Content Lifecycle > Filters"
-    And I click on "Create Filter"
-    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
-    Then I should see a "Create a new filter" text
-    And I enter "ruby 2.7 module" as "filter_name"
-    And I select "Module (Stream)" from "type"
-    And I select "equals" from "matcher"
-    And I enter "ruby" as "moduleName"
-    And I enter "2.7" as "moduleStream"
-    And I click on "Save" in "Create a new filter" modal
-    Then I should see a "ruby 2.7 module" text
-
   Scenario: Create a content lifecycle project
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "Create Project"
@@ -200,6 +187,439 @@ Feature: Content lifecycle
     And I wait for "1" second
     Then I wait at most 600 seconds until I see "Built" text in the environment "prod_name"
 
+
+  Scenario: Create a CLM filter of type Package(NEVRA) that allows packages whose version and release number are lower to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "mercury" as "filter_name"
+    And I select "Package (NEVRA)" from "type"
+    And I select "lower" from "matcher"
+    And I enter "mercury" as "Package Name"
+    And I enter "mercury" as "Epoch"
+    And I enter "0.0.0" as "version"
+    And I enter "0.0.0" as "Release"
+    And I enter "x86_64" as "Architecture"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+   Scenario: Create a CLM filter of type Package(NEVRA) that denys packages whose version and release number are lower to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "venus" as "filter_name"
+    And I select "Package (NEVRA)" from "type"
+    And I select "lower" from "matcher"
+    And I enter "venus" as "Package Name"
+    And I enter "venus" as "Epoch"
+    And I enter "0.0.0" as "version"
+    And I enter "0.0.0" as "Release"
+    And I enter "x86_64" as "Architecture"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+Scenario: Create CLM filter that allows packages of type Package (Provides Name)
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "cereal" as "filter_name"
+    And I select "Package (Provides Name)" from "type"
+    And I select "provides name" from "matcher"
+    And I enter "cereal" as "Provides Name"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+  
+  Scenario: Create CLM filter that denys packages of type Package (Provides Name)
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "potato" as "filter_name"
+    And I select "Package (Provides Name)" from "type"
+    And I select "provides name" from "matcher"
+    And I enter "potato" as "Provides Name"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+Scenario: Create CLM filter of type Package (Build date) that allows packages whose date is lower than a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "cherry" as "filter_name"
+    And I select "Package (Build date)" from "type"
+    And I select "lower" from "matcher"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+  
+  Scenario: Create CLM filter of type Package (Build date) that denys packages whose date is lower than a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "drummer" as "filter_name"
+    And I select "Package (Build date)" from "type"
+    And I select "lower" from "matcher"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Advisory Name) that allows patches that are equal to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "africa-patch" as "filter_name"
+    And I select "Patch (Advisory Name)" from "type"
+    And I select "equals" from "matcher"
+    And I enter "africa" as "Advisory name"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Advisory Name) that denys patches that are equal to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "asia-patch" as "filter_name"
+    And I select "Patch (Advisory Name)" from "type"
+    And I select "equals" from "matcher"
+    And I enter "asia" as "Advisory name"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Advisory Type) that allows Security Advisory patches that are equal to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "virgo-patch" as "filter_name"
+    And I select "Patch (Advisory Type)" from "type"
+    And I select "equals" from "matcher"
+    And I check radio button "Security Advisory"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Advisory Type) that denys Security Advisory patches that are equal to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "geminis-patch" as "filter_name"
+    And I select "Patch (Advisory Type)" from "type"
+    And I select "equals" from "matcher"
+    And I check radio button "Security Advisory"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Synopsis) that allows patches that that are equal to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "aries-patch" as "filter_name"
+    And I select "Patch (Synopsis)" from "type"
+    And I select "equals" from "matcher"
+    And I enter "aries" as "Synopsis"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Synopsis) that denys patches that are equal to a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "andromeda-patch" as "filter_name"
+    And I select "Patch (Synopsis)" from "type"
+    And I select "equals" from "matcher"
+    And I enter "andromeda" as "Synopsis"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Keyword) that allows patches that contains Package Manager Restart Required keyword in its name
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "mars-patch" as "filter_name"
+    And I select "Patch (Keyword)" from "type"
+    And I select "contains" from "matcher"
+    And I check radio button "Package Manager Restart Required"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Keyword) that denys patches that contains Package Manager Restart Required Keyword in its name
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "eurasia-patch" as "filter_name"
+    And I select "Patch (Keyword)" from "type"
+    And I select "contains" from "matcher"
+    And I check radio button "Package Manager Restart Required"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Issue date) that allows patches whose date is greater or equal than a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "milkyway-patch" as "filter_name"
+    And I select "Patch (Issue date)" from "type"
+    And I select "greater or equal" from "matcher"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+  
+  Scenario: Create CLM filter of type Patch(Issue date) that denys patches whose date is greater or equal than a defined one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "venus-patch" as "filter_name"
+    And I select "Patch (Issue date)" from "type"
+    And I select "greater or equal" from "matcher"
+    When I enter "solar" as "filter_name"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package Name) that allows patches that are equal to a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "Triangulum-patch" as "filter_name"
+    And I select "Patch (Contains Package Name)" from "type"
+    And I select "equals" from "matcher"
+    When I enter "Triangulum-patch" as "Package Name"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package Name) that denys patches that are equal to a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "Pinwheel-patch" as "filter_name"
+    And I select "Patch (Contains Package Name)" from "type"
+    And I select "equals" from "matcher"
+    When I enter "Pinwheel-patch" as "Package Name"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter that allows patches of type Patch(Contains Package Name) that matches to a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "Sunflower-patch" as "filter_name"
+    And I select "Patch (Contains Package Name)" from "type"
+    And I select "matches" from "matcher"
+    When I enter "Sunflower-patch" as "Package Name"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package Name) that denys patches that matches to a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "Whirlpool-patch" as "filter_name"
+    And I select "Patch (Contains Package Name)" from "type"
+    And I select "matches" from "matcher"
+    When I enter "Whirlpool-patch" as "Package Name"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package Provides Name) that allows patches with a specific name
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "Antennae-patch" as "filter_name"
+    And I select "Patch (Contains Package Provides Name)" from "type"
+    And I select "provides name" from "matcher"
+    When I enter "Antennae-patch" as "Package Provides Name"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package Provides Name) that denys patches with a specific name
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "hat-patch" as "filter_name"
+    And I select "Patch (Contains Package Provides Name)" from "type"
+    And I select "provides name" from "matcher"
+    When I enter "hat-patch" as "Package Provides Name"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package) that allows patches whose version is lower than a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "Hubble-patch" as "filter_name"
+    And I select "Patch (Contains Package)" from "type"
+    And I select "version lower than" from "matcher"
+    When I enter "Hubble-patch" as "Package Name"
+    And I enter "Hubble-patch" as "Epoch"
+    And I enter "0.0.0" as "Version"
+    And I enter "0.0.0" as "Release"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package) that denys patches whose version is lower than a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "galaxy-patch" as "filter_name"
+    And I select "Patch (Contains Package)" from "type"
+    And I select "version lower than" from "matcher"
+    When I enter "galaxy-patch" as "Package Name"
+    And I enter "galaxy-patch" as "Epoch"
+    And I enter "0.0.0" as "Version"
+    And I enter "0.0.0" as "Release"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package) that allows patches whose version is lower or equal than a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "earth-patch" as "filter_name"
+    And I select "Patch (Contains Package)" from "type"
+    And I select "version lower or equal" from "matcher"
+    When I enter "earth-patch" as "Package Name"
+    And I enter "earth-patch" as "Epoch"
+    And I enter "0.0.0" as "Version"
+    And I enter "0.0.0" as "Release"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Patch(Contains Package) that denys patches whose version is lower or equal than a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "moon-patch" as "filter_name"
+    And I select "Patch (Contains Package)" from "type"
+    And I select "version lower or equal" from "matcher"
+    When I enter "moon-patch" as "Package Name"
+    And I enter "moon-patch" as "Epoch"
+    And I enter "0.0.0" as "Version"
+    And I enter "0.0.0" as "Release"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter to enable Ruby 2.7 module
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    And I enter "ruby 2.7 module" as "filter_name"
+    And I select "Module (Stream)" from "type"
+    And I select "equals" from "matcher"
+    And I enter "ruby" as "moduleName"
+    And I enter "2.7" as "moduleStream"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "ruby 2.7 module" text
+
+  Scenario: Create CLM filter that allows Product Temporary Fix (All)
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "mars" as "filter_name"
+    And I select "Product Temporary Fix (All)" from "type"
+    And I select "all" from "matcher"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter that denys Product Temporary Fix (All)
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "mercury-patch" as "filter_name"
+    And I select "Product Temporary Fix (All)" from "type"
+    And I select "all" from "matcher"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+    Scenario: Create CLM filter of type Product Temporary Fix (Number) that allows packages of a version lower than a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "jupiter-patch" as "filter_name"
+    And I select "Product Temporary Fix (Number)" from "type"
+    And I select "lower" from "matcher"
+    And I enter "1" as "Number"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+  Scenario: Create CLM filter of type Product Temporary Fix (Number) that denys packages of a version lower than a specific one
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "pluto-patch" as "filter_name"
+    And I select "Product Temporary Fix (Number)" from "type"
+    And I select "lower" from "matcher"
+    And I enter "2" as "Number"
+    And I check radio button "Deny"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
+# This test fails, but this error is tracked in the bug 1238922
+@skip_if_github_validation
+  Scenario: Create CLM filter that allows packages versions that are equal to a specific Product Temporary Fix (Fixes Package Name)
+    When I follow the left menu "Content Lifecycle > Filters"
+    And I click on "Create Filter"
+    And I wait at most 10 seconds until I see modal containing "Create a new filter" text
+    Then I should see a "Create a new filter" text
+    When I enter "comet-patch" as "filter_name"
+    And I select "Product Temporary Fix (Fixes Package Name)" from "type"
+    And I select "equals" from "matcher"
+    And I enter "comet-patch" as "Package Name"
+    And I check radio button "Allow"
+    And I click on "Save" in "Create a new filter" modal
+    Then I should see a "Filter created successfully" text
+
   Scenario: Cleanup: remove the Content Lifecycle Management project
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
@@ -211,8 +631,66 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Filters"
     And I click the "remove fonts packages" item delete button
     And I click the "ruby 2.7 module" item delete button
+    And I click the "virgo-patch" item delete button
+    And I click the "africa-patch" item delete button
+    And I click the "andromeda-patch" item delete button
+    And I click the "Antennae-patch" item delete button
+    And I click the "aries-patch" item delete button
+    And I click the "eurasia-patch" item delete button
+    And I click the "asia-patch" item delete button
+    And I click the "cereal" item delete button
+    And I click the "cherry" item delete button
+    And I click the "drummer" item delete button
+    And I click the "earth-patch" item delete button
+    And I click the "galaxy-patch" item delete button
+    And I click the "hat-patch" item delete button
+    And I click the "Hubble-patch" item delete button
+    And I click the "mars-patch" item delete button
+    And I click the "mars" item delete button
+    And I click the "mercury-patch" item delete button
+    And I click the "mercury" item delete button
+    And I click the "milkyway-patch" item delete button
+    And I click the "moon-patch" item delete button
+    And I click the "Pinwheel-patch" item delete button
+    And I click the "pluto-patch" item delete button
+    And I click the "solar" item delete button
+    And I click the "Sunflower-patch" item delete button
+    And I click the "Triangulum-patch" item delete button
+    And I click the "venus" item delete button
+    And I click the "Whirlpool-patch" item delete button
+    And I click the "geminis-patch" item delete button
+    And I click the "jupiter-patch" item delete button
+    And I click the "potato" item delete button
     Then I should not see a "remove fonts packages" text
     And I should not see a "ruby 2.7 module" text
+    And I should not see a "africa-patch" text
+    And I should not see a "andromeda-patch" text
+    And I should not see a "Antennae-patch" text
+    And I should not see a "aries-patch" text
+    And I should not see a "asia-patch" text
+    And I should not see a "cereal" text
+    And I should not see a "cherry" text
+    And I should not see a "drummer" text
+    And I should not see a "earth-patch" text
+    And I should not see a "galaxy-patch" text
+    And I should not see a "hat-patch" text
+    And I should not see a "Hubble-patch" text
+    And I should not see a "mars" text
+    And I should not see a "mars-patch" text
+    And I should not see a "mercury" text
+    And I should not see a "milkyway-patch" text
+    And I should not see a "moon-patch" text
+    And I should not see a "Pinwheel-patch" text
+    And I should not see a "pluto-patch" text
+    And I should not see a "ruby 2.7 module" text
+    And I should not see a "solar" text
+    And I should not see a "Sunflower-patch" text
+    And I should not see a "Triangulum-patch" text
+    And I should not see a "venus" text
+    And I should not see a "Whirlpool-patch" text
+    And I should not see a "remove fonts packages" text
+    And I should not see a "ruby 2.7 module" text
+    And I should not see a "virgo-patch" text
 
 @susemanager
   Scenario: Cleanup: remove the created channels

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scc_credentials
@@ -302,7 +302,7 @@ Scenario: Create CLM filter of type Package (Build date) that allows packages wh
     And I click on "Create Filter"
     And I wait at most 10 seconds until I see modal containing "Create a new filter" text
     Then I should see a "Create a new filter" text
-    When I enter "virgo-patch" as "filter_name"
+    When I enter "key" as "filter_name"
     And I select "Patch (Advisory Type)" from "type"
     And I select "equals" from "matcher"
     And I check radio button "Security Advisory"
@@ -553,7 +553,7 @@ Scenario: Create CLM filter of type Package (Build date) that allows packages wh
     And I enter "ruby" as "moduleName"
     And I enter "2.7" as "moduleStream"
     And I click on "Save" in "Create a new filter" modal
-    Then I should see a "ruby 2.7 module" text
+    Then I should see a "Filter created successfully" text
 
   Scenario: Create CLM filter that allows Product Temporary Fix (All)
     When I follow the left menu "Content Lifecycle > Filters"
@@ -579,7 +579,7 @@ Scenario: Create CLM filter of type Package (Build date) that allows packages wh
     And I click on "Save" in "Create a new filter" modal
     Then I should see a "Filter created successfully" text
 
-    Scenario: Create CLM filter of type Product Temporary Fix (Number) that allows packages of a version lower than a specific one
+  Scenario: Create CLM filter of type Product Temporary Fix (Number) that allows packages of a version lower than a specific one
     When I follow the left menu "Content Lifecycle > Filters"
     And I click on "Create Filter"
     And I wait at most 10 seconds until I see modal containing "Create a new filter" text
@@ -629,46 +629,47 @@ Scenario: Create CLM filter of type Package (Build date) that allows packages wh
 
   Scenario: Cleanup: remove the CLM filters
     When I follow the left menu "Content Lifecycle > Filters"
-    And I click the "remove fonts packages" item delete button
-    And I click the "ruby 2.7 module" item delete button
-    And I click the "virgo-patch" item delete button
-    And I click the "africa-patch" item delete button
-    And I click the "andromeda-patch" item delete button
-    And I click the "Antennae-patch" item delete button
-    And I click the "aries-patch" item delete button
-    And I click the "eurasia-patch" item delete button
-    And I click the "asia-patch" item delete button
-    And I click the "cereal" item delete button
-    And I click the "cherry" item delete button
-    And I click the "drummer" item delete button
-    And I click the "earth-patch" item delete button
-    And I click the "galaxy-patch" item delete button
-    And I click the "hat-patch" item delete button
-    And I click the "Hubble-patch" item delete button
-    And I click the "mars-patch" item delete button
-    And I click the "mars" item delete button
-    And I click the "mercury-patch" item delete button
-    And I click the "mercury" item delete button
-    And I click the "milkyway-patch" item delete button
-    And I click the "moon-patch" item delete button
-    And I click the "Pinwheel-patch" item delete button
-    And I click the "pluto-patch" item delete button
-    And I click the "solar" item delete button
-    And I click the "Sunflower-patch" item delete button
-    And I click the "Triangulum-patch" item delete button
-    And I click the "venus" item delete button
-    And I click the "Whirlpool-patch" item delete button
-    And I click the "geminis-patch" item delete button
-    And I click the "jupiter-patch" item delete button
-    And I click the "potato" item delete button
+    And I click the "africa-patch" item delete button if exists
+    And I click the "andromeda-patch" item delete button if exists
+    And I click the "Antennae-patch" item delete button if exists
+    And I click the "aries-patch" item delete button if exists
+    And I click the "eurasia-patch" item delete button if exists
+    And I click the "asia-patch" item delete button if exists
+    And I click the "cereal" item delete button if exists
+    And I click the "comet-patch" item delete button if exists
+    And I click the "cherry" item delete button if exists
+    And I click the "drummer" item delete button if exists
+    And I click the "earth-patch" item delete button if exists
+    And I click the "galaxy-patch" item delete button if exists
+    And I click the "geminis-patch" item delete button if exists
+    And I click the "hat-patch" item delete button if exists
+    And I click the "Hubble-patch" item delete button if exists
+    And I click the "jupiter-patch" item delete button if exists
+    And I click the "key" item delete button if exists
+    And I click the "mars-patch" item delete button if exists
+    And I click the "mars" item delete button if exists
+    And I click the "mercury-patch" item delete button if exists
+    And I click the "mercury" item delete button if exists
+    And I click the "milkyway-patch" item delete button if exists
+    And I click the "moon-patch" item delete button if exists
+    And I click the "Pinwheel-patch" item delete button if exists
+    And I click the "pluto-patch" item delete button if exists
+    And I click the "potato" item delete button if exists
+    And I click the "ruby 2.7 module" item delete button if exists
+    And I click the "solar" item delete button if exists
+    And I click the "remove fonts packages" item delete button if exists
+    And I click the "Sunflower-patch" item delete button if exists
+    And I click the "Triangulum-patch" item delete button if exists
+    And I click the "venus" item delete button if exists
+    And I click the "Whirlpool-patch" item delete button if exists
     Then I should not see a "remove fonts packages" text
-    And I should not see a "ruby 2.7 module" text
     And I should not see a "africa-patch" text
     And I should not see a "andromeda-patch" text
     And I should not see a "Antennae-patch" text
     And I should not see a "aries-patch" text
     And I should not see a "asia-patch" text
     And I should not see a "cereal" text
+    And I should not see a "comet-patch" text
     And I should not see a "cherry" text
     And I should not see a "drummer" text
     And I should not see a "earth-patch" text
@@ -682,7 +683,6 @@ Scenario: Create CLM filter of type Package (Build date) that allows packages wh
     And I should not see a "moon-patch" text
     And I should not see a "Pinwheel-patch" text
     And I should not see a "pluto-patch" text
-    And I should not see a "ruby 2.7 module" text
     And I should not see a "solar" text
     And I should not see a "Sunflower-patch" text
     And I should not see a "Triangulum-patch" text
@@ -690,7 +690,7 @@ Scenario: Create CLM filter of type Package (Build date) that allows packages wh
     And I should not see a "Whirlpool-patch" text
     And I should not see a "remove fonts packages" text
     And I should not see a "ruby 2.7 module" text
-    And I should not see a "virgo-patch" text
+    And I should not see a "key" text
 
 @susemanager
   Scenario: Cleanup: remove the created channels

--- a/testsuite/features/step_definitions/content_lifecycle_steps.rb
+++ b/testsuite/features/step_definitions/content_lifecycle_steps.rb
@@ -66,6 +66,26 @@ When(/^I click the "([^"]*)" item (.*?) button$/) do |name, action|
   raise ScriptError, "xpath: #{action} button not found" unless button_element.click
 end
 
+When(/^I click the "([^"]*)" item (.*?) button if exists$/) do |name, action|
+  button =
+    case action
+    when /details/ then 'i[contains(@class, \'fa-list\')]'
+    when /edit/ then 'i[contains(@class, \'fa-edit\')]'
+    when /delete/ then 'i[contains(@class, \'fa-trash\')]'
+    else raise ScriptError, "Unknown element with description '#{action}'"
+    end
+
+  begin
+    td_element = find(:xpath, "//td[contains(text(), '#{name}')]")
+    raise ScriptError, "xpath: #{name} item not found" unless td_element
+
+    button_element = td_element.find(:xpath, "./ancestor::tr/td/button/#{button} | ./ancestor::tr/td/div/button/#{button}")
+    raise ScriptError, "xpath: #{action} button not found" unless button_element.click
+  rescue Capybara::ElementNotFound
+    # ignored - pending actions cannot be found
+  end
+end
+
 When(/^I backup the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
   auth_keys_path = '/root/.ssh/authorized_keys'


### PR DESCRIPTION
## What does this PR change?

This PR add testcases that test the content lifecycle filters.
Fixes: https://github.com/uyuni-project/uyuni/issues/7967

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/7967
Port(s): 
- Manager 5.0

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
