### PR TITLE
Read the oscrc config from default and legacy locations

### DIFF
--- a/rel-eng/uyuni-check-version
+++ b/rel-eng/uyuni-check-version
@@ -109,7 +109,7 @@ def parse_arguments():
     args = parser.parse_args()
     if not args.user or not args.password:
         try:
-            creds_path = "%s/.oscrc" % expanduser('~')
+            creds_path = (expanduser('~/.config/osc/oscrc')) or (expanduser('~/.oscrc'))
             creds = ConfigParser()
             creds.read(creds_path)
             args.user = creds.get(args.apiurl, 'user')


### PR DESCRIPTION
## What does this PR change?

The default location of oscrc config file is `~/.config/osc/oscrc`. 
When running the `rel-eng/uyuni-check-version` validation script, search for a config at both `~/.config/osc/oscrc` and legacy path ``~/.oscrc``.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: internal script used only by relengs

- [x] **DONE**

## Links

Issue(s): #
Port(s): NONE required

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
