### PR TITLE
Feature: Assign child channel to a system | Scenario: Cleanup: subscribe the system back to previous channels

### DIFF
--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -142,9 +142,9 @@ Feature: Assign child channel to a system
     Then radio button "openSUSE Leap 15.6 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
     And I wait until I see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" text
+    And I uncheck "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)"
     And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
-    And I uncheck "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"


### PR DESCRIPTION
## What does this PR change?

Box checking and unchecking matching the `Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)*` regex is problematic (as it was with *BETA). In this scenario we have both `Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)` and `Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)`.

Changing the sequence to `Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)` be served first makes the scenario passing:

```
uyuni-ci-master-podman-controller:~/spacewalk/testsuite # cucumber features/secondary/min_change_software_channel.feature:140
Using Ruby version: 3.3.7
QUALITY INTELLIGENCE MODE ENABLED.
Capybara APP Host: https://uyuni-ci-master-podman-server.mgr.suse.de:8888
Initializing a remote node for 'server'.
Host 'server' is alive with determined hostname uyuni-ci-master-podman-server and FQDN uyuni-ci-master-podman-server.mgr.suse.de
Node: uyuni-ci-master-podman-server, OS Version: 15-SP6, Family: sles
Activating HTTP API
Using the default profile...
# Copyright (c) 2021-2024 SUSE LLC
# Licensed under the terms of the MIT license.
#
# This feature can cause failures in the following features:
# - features/secondary/allcli_software_channels.feature
# If "SLE15-SP4-Installer-Updates for x86_64" fails to be unchecked
# This test fails on github validation
@skip_if_github_validation @scc_credentials @scope_changing_software_channels @sle_minion @under_debugging
Feature: Assign child channel to a system

  @uyuni
  Scenario: Cleanup: subscribe the system back to previous channels                                      # features/secondary/min_change_software_channel.feature:140
      This scenario ran at: 2025-03-06 16:52:17 +0100
    Given I am authorized                                                                                # features/step_definitions/navigation_steps.rb:570
Initializing a remote node for 'sle_minion'.
Host 'sle_minion' is alive with determined hostname uyuni-ci-master-podman-suse-minion and FQDN uyuni-ci-master-podman-suse-minion.mgr.suse.de
Node: uyuni-ci-master-podman-suse-minion, OS Version: 15.5, Family: opensuse-leap
    Given I am on the Systems overview page of this "sle_minion"                                         # features/step_definitions/navigation_steps.rb:431
    When I follow "Software" in the content area                                                         # features/step_definitions/navigation_steps.rb:313
    And I follow "Software Channels" in the content area                                                 # features/step_definitions/navigation_steps.rb:313
    And I wait until I do not see "Loading..." text                                                      # features/step_definitions/navigation_steps.rb:43
    Then radio button "openSUSE Leap 15.5 (x86_64)" should be checked                                    # features/step_definitions/navigation_steps.rb:1011
    And I wait until I do not see "Loading..." text                                                      # features/step_definitions/navigation_steps.rb:43
    And I wait until I see "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)" text                     # features/step_definitions/navigation_steps.rb:39
    And I uncheck "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"                                   # features/step_definitions/navigation_steps.rb:159
    And I check "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64) (Development)"                       # features/step_definitions/navigation_steps.rb:154
    And I check "Fake-RPM-SUSE-Channel"                                                                  # features/step_definitions/navigation_steps.rb:154
    #    And I uncheck "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)"
    And I click on "Next"                                                                                # features/step_definitions/navigation_steps.rb:259
    Then I should see a "Confirm Software Channel Change" text                                           # features/step_definitions/navigation_steps.rb:620
    When I click on "Confirm"                                                                            # features/step_definitions/navigation_steps.rb:259
    Then I should see a "Changing the channels has been scheduled." text                                 # features/step_definitions/navigation_steps.rb:620
    When I follow "scheduled" in the content area                                                        # features/step_definitions/navigation_steps.rb:313
    And I wait until I see "1 system successfully completed this action." text, refreshing the page      # features/step_definitions/navigation_steps.rb:55
    Then channel "Uyuni Client Tools for openSUSE Leap 15.5 (x86_64)" should be disabled on "sle_minion" # features/step_definitions/api_common.rb:209
      This scenario took: 44 seconds

1 scenario (1 passed)
18 steps (18 passed)
0m43.875s
```

## GUI diff

Changes on the SLE minion of uyuni (Software > Software Channels):

Before:

![Screenshot from 2025-03-06 16-27-37](https://github.com/user-attachments/assets/f47c738a-5d2a-4605-a0ab-f758ec58ad17)


After:

![Screenshot from 2025-03-06 16-53-16](https://github.com/user-attachments/assets/14a5fd8b-2e5e-4392-a420-9600bfb43607)


- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26624
Port(s): only for Uyuni

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
