### PR TITLE
Fix unchecked types warning around PackageMetadata(Update ForceRecreationListType.java)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ForceRecreationListType.java
@@ -125,7 +125,7 @@ public class ForceRecreationListType implements UserCollectionType {
     public Object replaceElements(Object original, Object target,
             CollectionPersister persister, Object owner, Map copyCache,
             SharedSessionContractImplementor session) throws HibernateException {
-        List result = (List) target;
+        List<Object> result = (List) target;
         result.clear();
         result.addAll((Collection) original);
         return result;
@@ -177,7 +177,7 @@ public class ForceRecreationListType implements UserCollectionType {
          * @param session session implementation
          * @param list  list to persist
          */
-        ForceRecreationList(SharedSessionContractImplementor session, List list) {
+        ForceRecreationList(SharedSessionContractImplementor session, List<Object> list) {
             super(session, list);
         }
 


### PR DESCRIPTION
## What does this PR change?

This PR addresses and resolves unchecked types warnings related to the use of PackageMetadata in the ForceRecreationListType.java file.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #612 
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
