### PR TITLE
Distinguish between OS of real host and of container

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -274,7 +274,7 @@ end
 # @return [Boolean] Returns true if the system is a SLE/SL Micro one
 def slemicro_host?(name)
   node = get_target(name)
-  os_family = node.os_family
+  os_family = node.local_os_family
   (name.include? 'slemicro') || (name.include? 'micro') || os_family.include?('sle-micro') || os_family.include?('suse-microos')
 end
 
@@ -284,7 +284,7 @@ end
 # @return [Boolean] Returns true if the system is a openSUSE Leap Micro one.
 def leapmicro_host?(name)
   node = get_target(name)
-  os_family = node.os_family
+  os_family = node.local_os_family
   os_family.include?('opensuse-leap-micro')
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR makes the difference between OS family and version of real host and container.

In the case of non-containerized systems, both fields will be identical.


## Links

Port(s):
 * 5.0: https://github.com/SUSE/spacewalk/pull/26636
 * 4.3: non applicable


## Changelogs

- [x] No changelog needed
