### PR TITLE
Supportdata salt module

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/supportdata.py
+++ b/susemanager-utils/susemanager-sls/src/modules/supportdata.py
@@ -1,0 +1,99 @@
+"""
+Module for Getting Supportdata
+"""
+
+from typing import Any, Dict
+import logging
+import os
+import shutil
+
+from datetime import datetime
+
+# Just for lint and static analysis, will be replaced by salt's loader
+__grains__ = {}
+__salt__ = {}
+
+__virtualname__ = "supportdata"
+
+# create a logger for the module
+log = logging.getLogger(__name__)
+
+
+def _get_supportdata_dir():
+    return "/var/log/supportdata-" + datetime.now().strftime("%Y%m%d%H%M%S")
+
+
+def get(cmd_args: str = "", **kwargs) -> Dict[str, Any]:
+    """
+    Collect supportdata like config and logfiles from the system
+    and upload them to the master's minion files cachedir
+    (defaults to ``/var/cache/salt/master/minions/minion-id/files``)
+
+    It needs ``file_recv`` set to ``True`` in the master configuration file.
+
+    cmd_args
+        extra commandline arguments for the executed tool
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*'  supportdata.get
+    """
+    supportconfig_path = "/sbin/supportconfig"
+    mgradm_path = "/usr/bin/mgradm"
+    mgrpxy_path = "/usr/bin/mgrpxy"
+    sosreport_path = "/usr/sbin/sosreport"
+    cmd = []
+
+    success = False
+    supportdata_dir = ""
+    error = None
+    returncode = None
+
+    del kwargs
+
+    output_dir = _get_supportdata_dir()
+    extra_args = cmd_args.split()
+
+    if "Suse" in __grains__["os_family"]:
+        if os.path.exists(mgradm_path):
+            cmd = [mgradm_path, "support", "config", "--output", output_dir]
+        elif os.path.exists(mgrpxy_path):
+            cmd = [mgrpxy_path, "support", "config", "--output", output_dir]
+        elif os.path.exists(supportconfig_path):
+            cmd = [supportconfig_path, "-R", output_dir]
+    elif "RedHat" in __grains__["os_family"]:
+        if os.path.exists(sosreport_path):
+            cmd = [sosreport_path, "--batch", "--tmp-dir", output_dir]
+    else:
+        error = "Getting supportdata not supported for " + __grains__["os"]
+        returncode = 1
+
+    if len(cmd) > 0:
+        os.makedirs(output_dir, exist_ok=True)
+        cmd.extend(extra_args)
+        log.debug("executing: %s", cmd)
+        ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+
+        log.debug("return: %s", ret)
+        returncode = ret["retcode"]
+        if returncode != 0:
+            error = f'Failed to run {cmd[0]}: {ret["stderr"]}'
+        else:
+            if __salt__["cp.push_dir"](output_dir):
+                # remove the output dir only when the upload was successful
+                # on salt-ssh it fail and we need to download it explict via scp
+                shutil.rmtree(output_dir, ignore_errors=True)
+            supportdata_dir = output_dir
+            success = True
+    elif returncode is None:
+        error = "Required tools to get support data are not installed"
+        returncode = 1
+
+    return dict(
+        success=success,
+        supportdata_dir=supportdata_dir,
+        error=error,
+        returncode=returncode,
+    )

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_supportdata.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_supportdata.py
@@ -1,0 +1,173 @@
+"""
+Author: mc@suse.com
+"""
+
+import pytest
+from ..modules import supportdata
+
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture(autouse=True)
+def patch_salt():
+    """Fixture that patches supportdata.__salt__"""
+    with patch.dict(
+        supportdata.__salt__,
+        {
+            "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": "sample"}),
+            "cp.push_dir": MagicMock(return_value=False),
+        },
+    ):
+        with patch(
+            "src.modules.supportdata._get_supportdata_dir",
+            MagicMock(return_value="/var/log/supportdata"),
+        ), patch("os.makedirs", MagicMock(return_value=True)):
+            yield
+
+
+def test_supportdata_suse():
+    """
+    Test getting supportdata on a standard SUSE system
+
+    :return:
+    """
+    supportdata.__grains__["os_family"] = "Suse"
+
+    with patch("os.path.exists", MagicMock(side_effect=[False, False, True])):
+        out = supportdata.get()
+        assert isinstance(out, dict)
+        assert "success" in out
+        assert out["success"] is True
+        assert out["supportdata_dir"] == "/var/log/supportdata"
+
+        supportdata.__salt__["cmd.run_all"].assert_called_once_with(
+            ["/sbin/supportconfig", "-R", "/var/log/supportdata"],
+            python_shell=False,
+        )
+
+
+def test_supportdata_suse_extra_args():
+    """
+    Test getting supportdata on a standard SUSE system
+
+    :return:
+    """
+    supportdata.__grains__["os_family"] = "Suse"
+
+    with patch("os.path.exists", MagicMock(side_effect=[False, False, True])):
+        out = supportdata.get("-o X,WEB -l 10000")
+        assert isinstance(out, dict)
+        assert "success" in out
+        assert out["success"] is True
+        assert out["supportdata_dir"] == "/var/log/supportdata"
+
+        supportdata.__salt__["cmd.run_all"].assert_called_once_with(
+            [
+                "/sbin/supportconfig",
+                "-R",
+                "/var/log/supportdata",
+                "-o",
+                "X,WEB",
+                "-l",
+                "10000",
+            ],
+            python_shell=False,
+        )
+
+
+def test_supportdata_mlm_proxy():
+    """
+    Test getting supportdata on a MLM Proxy
+
+    :return:
+    """
+    supportdata.__grains__["os_family"] = "Suse"
+
+    with patch("os.path.exists", MagicMock(side_effect=[False, True, True])):
+        out = supportdata.get()
+        assert isinstance(out, dict)
+        assert "success" in out
+        assert out["success"] is True
+        assert out["supportdata_dir"] == "/var/log/supportdata"
+
+        supportdata.__salt__["cmd.run_all"].assert_called_once_with(
+            [
+                "/usr/bin/mgrpxy",
+                "support",
+                "config",
+                "--output",
+                "/var/log/supportdata",
+            ],
+            python_shell=False,
+        )
+
+
+def test_supportdata_mlm_server():
+    """
+    Test getting supportdata on a MLM Server
+
+    :return:
+    """
+    supportdata.__grains__["os_family"] = "Suse"
+
+    with patch("os.path.exists", MagicMock(side_effect=[True, False, True])):
+        out = supportdata.get()
+        assert isinstance(out, dict)
+        assert "success" in out
+        assert out["success"] is True
+        assert out["supportdata_dir"] == "/var/log/supportdata"
+
+        supportdata.__salt__["cmd.run_all"].assert_called_once_with(
+            [
+                "/usr/bin/mgradm",
+                "support",
+                "config",
+                "--output",
+                "/var/log/supportdata",
+            ],
+            python_shell=False,
+        )
+
+
+def test_supportdata_redhat():
+    """
+    Test getting supportdata on a RedHat Server
+
+    :return:
+    """
+    supportdata.__grains__["os_family"] = "RedHat"
+
+    with patch("os.path.exists", MagicMock(side_effect=[True])):
+        out = supportdata.get()
+        assert isinstance(out, dict)
+        assert "success" in out
+        assert out["success"] is True
+        assert out["supportdata_dir"] == "/var/log/supportdata"
+
+        supportdata.__salt__["cmd.run_all"].assert_called_once_with(
+            [
+                "/usr/sbin/sosreport",
+                "--batch",
+                "--tmp-dir",
+                "/var/log/supportdata",
+            ],
+            python_shell=False,
+        )
+
+
+def test_supportdata_debian():
+    """
+    Test getting supportdata on a Debian Server
+
+    :return:
+    """
+    supportdata.__grains__["os_family"] = "Debian"
+    supportdata.__grains__["os"] = "Debian 12"
+
+    with patch("os.path.exists", MagicMock(side_effect=[True])):
+        out = supportdata.get()
+        assert isinstance(out, dict)
+        assert "success" in out
+        assert out["success"] is False
+        assert out["supportdata_dir"] == ""
+        assert out["error"] == "Getting supportdata not supported for Debian 12"

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.supportdata-salt-module
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.supportdata-salt-module
@@ -1,0 +1,1 @@
+- Add a salt execution module to get support data from clients


### PR DESCRIPTION
## What does this PR change?

Salt execution module to get support data

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- part of feature doc

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26616

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
