### PR TITLE
QE:  Removing deprecated versions of tools

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -37,7 +37,7 @@ Feature: List available channels and enable them
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 15 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.3 x86_64"
-    And I should get "  [ ] (R) SUSE Manager Client Tools for RHEL, Liberty and Clones 7 x86_64"
+    And I should get "  [ ] (R) SUSE Manager Client Tools for RHEL, Liberty and Clones 9 x86_64"
     And I should get "  [ ] (R) SUSE Manager Client Tools for SLE 15 x86_64"
 
   Scenario: List products with filter


### PR DESCRIPTION
## What does this PR change?

This PR removes the [ ] (R) SUSE Manager Client Tools for RHEL, Liberty and Clones 7 x86_64 because are eol and replacing them for [ ] (R) SUSE Manager Client Tools for RHEL, Liberty and Clones 9 x86_64

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): None
Port(s): 
- Manager 5.0: https://github.com/SUSE/spacewalk/pull/26640
- Manager 4.3: https://github.com/SUSE/spacewalk/pull/26641

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
