### PR TITLE
fix config channels not following priority in highstate (bsc#1237694)

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/SaltConfigChannelState.java
+++ b/java/code/src/com/suse/manager/webui/utils/SaltConfigChannelState.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.utils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ public class SaltConfigChannelState implements SaltState {
     private List<String> includedStates = new ArrayList<>();
 
     /**
-     * @param includedStatesIn the states to be included
+     * @param includedStatesIn the states to be included in order of priority (high to low)
      */
     public SaltConfigChannelState(List<String> includedStatesIn) {
         this.includedStates = includedStatesIn;
@@ -41,7 +42,12 @@ public class SaltConfigChannelState implements SaltState {
     @Override
     public Map<String, Object> getData() {
         Map<String, Object> state = new LinkedHashMap<>();
-        state.put("include", new ArrayList<>(includedStates));
+        List<String> include = new ArrayList<>(includedStates);
+        // since states are ordered highest to lowest priority and salt will execute them in the order of the list,
+        // we need to reverse the list so the highest priority state will run last. This way higher priority states can
+        // override the effects of lower priority states i.e deploying to the same file path
+        Collections.reverse(include);
+        state.put("include", include);
         return state;
     }
 

--- a/java/spacewalk-java.changes.kwalter.bsc1237694
+++ b/java/spacewalk-java.changes.kwalter.bsc1237694
@@ -1,0 +1,2 @@
+- Fix config channels not following priority in highstate
+  (bsc#1237694)


### PR DESCRIPTION
## What does this PR change?

Writes out the config channel states in reverse priority order so that higher priority goes last and can override the effects of lower priority states.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26547


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
