### PR TITLE
Fix: Using reboot_suggested or restart_suggested by API always responds false (bsc#1236910)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -178,6 +178,7 @@ ORDER BY E.update_date DESC, E.id
   </query>
   <elaborator name="relevant_elab" />
   <elaborator name="errata_overview" />
+  <elaborator name="errata_flags" />
 </mode>
 
 <mode name="relevant_to_system_by_types" class="com.redhat.rhn.frontend.dto.ErrataOverview">

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -1411,7 +1411,10 @@ public class SystemManager extends BaseManager {
         elabParams.put("sid", sid);
         elabParams.put("user_id", user.getId());
 
-        return makeDataResultNoPagination(params, elabParams, m);
+        DataResult<ErrataOverview> dr = makeDataResultNoPagination(params, elabParams, m);
+        //elaborate the data result to get the detailed information.
+        dr.elaborate(elabParams);
+        return dr;
     }
 
     /**

--- a/java/spacewalk-java.changes.carlo.uyuni-errata-overview
+++ b/java/spacewalk-java.changes.carlo.uyuni-errata-overview
@@ -1,0 +1,2 @@
+- Fix: Using reboot_suggested or restart_suggested by API
+  always responds false (bsc#1236910)


### PR DESCRIPTION
## What does this PR change?
Fixes bug bsc#1236910: Using "reboot_suggested" or "restart_suggested" by API always responds "False"

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: API tested manually
- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26657, https://github.com/SUSE/spacewalk/pull/26676
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
