### PR TITLE
Fix: Filters of type Product Temporary Fix cannot be created (bsc#1238922)

### DIFF
--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -242,7 +242,7 @@ export const clmFilterOptions: ClmFilterOptionsEnumType = {
     ],
   },
   PTF_PACKAGE_NAME: {
-    key: "ptf_package_name",
+    key: "ptf_package",
     text: t("Fixes Package Name"),
     entityType: filterEntity.PTF,
     matchers: [filterMatchers.EQUALS, filterMatchers.MATCHES, filterMatchers.CONTAINS],

--- a/web/spacewalk-web.changes.carlo.uyuni-fix-filters
+++ b/web/spacewalk-web.changes.carlo.uyuni-fix-filters
@@ -1,0 +1,2 @@
+- Fix: Filters of type Product Temporary Fix cannot be created
+  (bsc#1238922)


### PR DESCRIPTION
## What does this PR change?
Fixes bug 1238922: Filters of type Product Temporary Fix (Fixes Package Name) can't be created 

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26671, https://github.com/SUSE/spacewalk/pull/26677
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
