### PR TITLE
Fix: Internal server error when accessing groups in activation keys (bsc#1237581) 

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/token/ActivationKeyDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/token/ActivationKeyDetailsAction.java
@@ -127,7 +127,12 @@ public class ActivationKeyDetailsAction extends RhnAction {
                         mapping.findForward("success"), params);
             }
             catch (ValidatorException ve) {
-                getStrutsDelegate().saveMessages(request, ve.getResult());
+                if (null == ve.getResult()) {
+                    getStrutsDelegate().saveMessage(ve.getMessage(), request);
+                }
+                else {
+                    getStrutsDelegate().saveMessages(request, ve.getResult());
+                }
                 return handleFailure(mapping, context);
             }
         }

--- a/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
@@ -237,7 +237,9 @@ public class StrutsDelegate {
      * @param result the validator result object..
      */
     public void saveMessages(HttpServletRequest request, ValidatorResult result) {
-        saveMessages(request, result.getErrors(), result.getWarnings());
+        if (null != result) {
+            saveMessages(request, result.getErrors(), result.getWarnings());
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/DataSetManipulator.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/DataSetManipulator.java
@@ -126,11 +126,11 @@ public class DataSetManipulator {
 
         String sortDir = getActiveSortDirection();
         try {
-            dataset.sort(new DynamicComparator<>(sortAttr, sortDir));
+            dataset = dataset.stream().sorted(new DynamicComparator<>(sortAttr, sortDir)).toList();
         }
         catch (IllegalArgumentException iae) {
             log.warn("Unable to sort dataset according to: {}", sortAttr);
-            dataset.sort(new DynamicComparator<>(defaultSortAttribute, sortDir));
+            dataset = dataset.stream().sorted(new DynamicComparator<>(defaultSortAttribute, sortDir)).toList();
         }
     }
 

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-sort-immutable
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-sort-immutable
@@ -1,0 +1,2 @@
+- Fix: Internal server error when accessing groups in
+  activation keys (bsc#1237581)


### PR DESCRIPTION
## What does this PR change?
Fixes bug 1237581 - L3: Internal server error when accessing groups in activation keys #26534 
Object `DataSetManipulator` gets and stores a `List dataset` member.
If this list is immutable, the instruction `dataset.sort()` throws an exception

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: tested manually
- [x] **DONE**

## Links

Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26660, https://github.com/SUSE/spacewalk/pull/26679
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
