### PR TITLE
Fix the date picker in CLM filter creation

### DIFF
--- a/web/html/src/branding/css/base/components/date-time-picker.scss
+++ b/web/html/src/branding/css/base/components/date-time-picker.scss
@@ -1,6 +1,6 @@
 /* This element already has `position: absolute` */
 .react-datepicker-popper {
-  z-index: 1050 !important;
+  z-index: 1060 !important;
 }
 
 .react-datepicker,

--- a/web/spacewalk-web.changes.welder.bsc1237710
+++ b/web/spacewalk-web.changes.welder.bsc1237710
@@ -1,0 +1,1 @@
+- Fix the date picker in CLM filter creation (bsc#1237710)


### PR DESCRIPTION
## What does this PR change?

It fixes the date picker visibility issue in CLM filter creation by increasing the z-index.

## GUI diff

Before:
![image](https://github.com/user-attachments/assets/387bb25a-bc2d-4ec1-ab21-a77d7f981a3e)


After:
![image](https://github.com/user-attachments/assets/ae462edc-900a-4d4f-a767-eede2cef426e)


- [x] **DONE**

## Documentation
- No documentation needed: bug fix.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: CSS

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26562

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
