### PR TITLE
QE: Refactor choose radio button

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -289,7 +289,7 @@ The radio button can be identified by name, id or label text.
 ```gherkin
   When I check "manageWithSSH"
   When I uncheck "role_org_admin"
-  When I check "Container Build Host" if not checked
+  When I check "Container Build Host"
 ```
 
 The check box can be identified by name, id or label text.

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -220,12 +220,12 @@ Then(/^the up2date logs on "([^"]*)" should contain no Traceback error$/) do |ho
 end
 
 # action chains
-When(/^I check radio button "(.*?)"$/) do |arg1|
-  raise ScriptError, "#{arg1} can't be checked" unless choose(arg1)
-end
-
-When(/^I check radio button "(.*?)", if not checked$/) do |arg1|
-  choose(arg1) unless has_checked_field?(arg1)
+When(/^I check radio button "(.*?)"$/) do |radio_button|
+  if has_checked_field?(radio_button)
+    log("Warning: Radio button '#{radio_button}' is already checked")
+  else
+    raise ScriptError, "#{radio_button} can't be checked" unless choose(radio_button)
+  end
 end
 
 When(/^I check default base channel radio button of this "([^"]*)"$/) do |host|


### PR DESCRIPTION
## What does this PR change?

Let's always check first if the button is present, for that, we will refactor the code and make use of another mechanism we had in a not used step definition, so aside of check if the button is present it also checks if the radio button is checked, in case it is, it will not try to check it again.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/26689
- Manager-5.0 https://github.com/SUSE/spacewalk/pull/26688

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
