### PR TITLE
Fix package locking for packages not available anymore (bsc#1236877)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -12,7 +12,8 @@
     -->
   <query params="sid">
 SELECT * FROM
-(SELECT distinct pn.name AS NAME,
+(SELECT distinct avl.package_id AS package_id,
+        pn.name AS NAME,
         pn.name || '-' || evr_t_as_vre_simple(avl.evr) AS NVRE,
         pn.name || '-' || evr_t_as_vre_simple(avl.evr) || '.' || avl.arch_label AS NVREA,
         pn.id || '|' || lookup_evr((avl.evr).epoch, (avl.evr).version, (avl.evr).release, (avl.evr).type) || '|' || avl.arch_id AS ID_COMBO,
@@ -22,7 +23,8 @@ SELECT * FROM
              ELSE NULL
         END AS locked
   FROM  (
-         SELECT  p.name_id name_id, max(pe.evr) evr, pe.id evr_id,
+         SELECT  p.id package_id,
+                 p.name_id name_id, max(pe.evr) evr, pe.id evr_id,
                  pa.label as arch_label, pa.id as arch_id
            FROM  rhnPackageEVR PE, rhnPackage P,
                  suseChannelPackageRetractedStatusView CP, rhnServerChannel SC,
@@ -34,7 +36,7 @@ SELECT * FROM
             AND  p.package_arch_id = pa.id
             AND  NOT CP.is_retracted
             AND  NOT EXISTS (SELECT 1 FROM suseServerAppStreamHiddenPackagesView WHERE sid = :sid AND pid = p.id)
-       GROUP BY  p.name_id, pa.label, pa.id, pe.id
+       GROUP BY  p.id, p.name_id, pa.label, pa.id, pe.id
 ) avl
        left join rhnpackagename pn on pn.id = avl.name_id
        left join rhnpackage pkg on pkg.name_id = avl.name_id and pkg.evr_id = avl.evr_id and pkg.package_arch_id = avl.arch_id
@@ -537,24 +539,33 @@ ORDER BY UPPER(X.nvre)
 
 <mode name="system_installed_pkgs_non_suse_locking" class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
-SELECT PN.name as NAME,
-       PN.name || '-' || evr_t_as_vre_simple(SPE.evr) AS NVRE,
-       PN.name || '-' || evr_t_as_vre_simple(SPE.evr) || '.' || PA.label AS NVREA,
-       PN.id || '|' || lookup_evr((SPE.evr).epoch, (SPE.evr).version, (SPE.evr).release, (SPE.evr).type) || '|' || PA.id AS ID_COMBO,
-       PA.label AS ARCH,
-       lck.pending,
-       CASE WHEN lck.server_id IS NOT NULL THEN 'Y' ELSE NULL END AS locked
-  FROM rhnServerPackage SP
-  JOIN rhnPackageName PN ON SP.name_id = PN.id
-  JOIN rhnPackageEVR SPE ON SP.evr_id = SPE.id
-  LEFT JOIN rhnPackageArch PA ON SP.package_arch_id = PA.id
-  LEFT JOIN rhnArchType AT ON AT.id = PA.arch_type_id
-  LEFT JOIN rhnlockedpackages lck ON lck.name_id = SP.name_id
-                                 AND lck.evr_id = SP.evr_id
-                                 AND lck.arch_id = SP.package_arch_id
-                                 AND lck.server_id = SP.server_id
- WHERE SP.server_id = :sid
- ORDER BY locked ASC NULLS LAST, NAME
+    SELECT (SELECT p.id
+              FROM rhnPackage p
+              join rhnChannelPackage cp on p.id = cp.package_id
+              join rhnServerChannel sc on sc.channel_id = cp.channel_id
+             where sc.server_id = SP.server_id
+               AND p.name_id = SP.name_id
+               AND p.evr_id = SP.evr_id
+               AND p.package_arch_id = SP.package_arch_id
+    ) AS package_id,
+    PN.name as NAME,
+    PN.name || '-' || evr_t_as_vre_simple(SPE.evr) AS NVRE,
+    PN.name || '-' || evr_t_as_vre_simple(SPE.evr) || '.' || PA.label AS NVREA,
+    PN.id || '|' || lookup_evr((SPE.evr).epoch, (SPE.evr).version, (SPE.evr).release, (SPE.evr).type) || '|' || PA.id AS ID_COMBO,
+    PA.label AS ARCH,
+    lck.pending,
+    CASE WHEN lck.server_id IS NOT NULL THEN 'Y' ELSE NULL END AS locked
+    FROM rhnServerPackage SP
+    JOIN rhnPackageName PN ON SP.name_id = PN.id
+    JOIN rhnPackageEVR SPE ON SP.evr_id = SPE.id
+    LEFT JOIN rhnPackageArch PA ON SP.package_arch_id = PA.id
+    LEFT JOIN rhnArchType AT ON AT.id = PA.arch_type_id
+    LEFT JOIN rhnlockedpackages lck ON (lck.name_id = SP.name_id
+                                    AND lck.evr_id = SP.evr_id
+                                    AND lck.arch_id = SP.package_arch_id
+                                    AND lck.server_id = SP.server_id)
+    WHERE SP.server_id = :sid
+    ORDER BY locked ASC NULLS LAST, NAME
   </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -18,6 +18,7 @@ package com.redhat.rhn.frontend.action.rhnpackage;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.util.DatePicker;
 import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.Server;
@@ -228,8 +229,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
      * (typically: Taskomatic is down)
      */
     private void lockSelectedPackages(Set<Package> pkgsAlreadyLocked, Date scheduleDate,
-            Server server, HttpServletRequest request)
-        throws TaskomaticApiException {
+            Server server, HttpServletRequest request) throws TaskomaticApiException {
         RequestContext context = new RequestContext(request);
         Long sid = context.getRequiredParam("sid");
         User user = context.getCurrentUser();
@@ -273,10 +273,8 @@ public class LockPackageAction extends BaseSystemPackagesAction {
      */
     private Package findPackage(Long sid, String combo, User user) {
         PackageListItem pkgInfo = PackageListItem.parse(combo.split("\\~\\*\\~")[0]);
-        Package pkg = PackageManager.guestimatePackageBySystem(sid, pkgInfo.getIdOne(),
-                        pkgInfo.getIdTwo(),
-                        pkgInfo.getIdThree() != null ? pkgInfo.getIdThree() : 0,
-                        user.getOrg());
+        Package pkg = PackageFactory.lookupByNevraIds(user.getOrg(), pkgInfo.getIdOne(),
+                pkgInfo.getIdTwo(), pkgInfo.getIdThree()).get(0);
         if (pkg != null) {
             pkg.setLockPending(Boolean.TRUE);
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -198,14 +198,13 @@ public class LockPackageAction extends BaseSystemPackagesAction {
             Server server, HttpServletRequest request)
         throws TaskomaticApiException {
         RequestContext context = new RequestContext(request);
-        Long sid = context.getRequiredParam("sid");
         User user = context.getCurrentUser();
         Set<Package> pkgsToUnlock = new HashSet<>();
         String[] selectedPkgs = ListTagHelper.getSelected(LIST_NAME, request);
 
         if (selectedPkgs != null) {
             for (String label : selectedPkgs) {
-                Package pkg = this.findPackage(sid, label, user);
+                Package pkg = this.findPackage(label, user);
                 if (pkg != null) {
                     pkgsToUnlock.add(pkg);
                 }
@@ -239,7 +238,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
         // Lock all selected packages, if they are not already in the list
         if (selectedPkgs != null) {
             for (String label : selectedPkgs) {
-                Package pkg = this.findPackage(sid, label, user);
+                Package pkg = this.findPackage(label, user);
 
                 if (pkg == null || pkgsAlreadyLocked.contains(pkg)) {
                     continue;
@@ -266,12 +265,11 @@ public class LockPackageAction extends BaseSystemPackagesAction {
     /**
      * Find the package.
      *
-     * @param sid System ID
      * @param combo Package combo (Separated by "|" name ID, evr ID and arch ID).
      * @param user User.
      * @return Returns Package or null.
      */
-    private Package findPackage(Long sid, String combo, User user) {
+    private Package findPackage(String combo, User user) {
         PackageListItem pkgInfo = PackageListItem.parse(combo.split("\\~\\*\\~")[0]);
         Package pkg = PackageFactory.lookupByNevraIds(user.getOrg(), pkgInfo.getIdOne(),
                 pkgInfo.getIdTwo(), pkgInfo.getIdThree()).get(0);

--- a/java/code/webapp/WEB-INF/pages/systems/details/packages/lockpkgs.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/details/packages/lockpkgs.jsp
@@ -34,7 +34,7 @@
                     <i class="fa fa-clock-o"></i>&nbsp;
                     </c:if>
                 <c:choose>
-                    <c:when test="${not checkPackageId or not empty current.packageId}">
+                    <c:when test="${not empty current.packageId}">
                         <a href="/rhn/software/packages/Details.do?sid=${param.sid}&amp;id_combo=${current.idCombo}">${current.nvre}</a>
                     </c:when>
                     <c:otherwise>

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-pkglock-ui
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-pkglock-ui
@@ -1,0 +1,2 @@
+- Fix package locking for packages not available anymore
+  in the assigned repositories (bsc#1236877)


### PR DESCRIPTION
## What does this PR change?

When a package installed on a system is not available anymore in the repository it could not be send for locking anymore.
This happens with 5.0 now more often with 3rd party OSes as we now remove packages from our repos when they are removed from the upstream repository.

Additionally these packages are not links anymore in the list as the link result anyway in a "not found" or "permission error"

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26685

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
