### PR TITLE
Fix: manage errors in user-defined pillars (bsc#1230403)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -76,6 +76,7 @@ import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.utils.Opt;
 
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -629,6 +630,14 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         catch (RegisterMinionException rme) {
             LOG.error("Error registering minion id: {}", minionId, rme);
             throw rme;
+        }
+        catch (JsonSyntaxException t) {
+            //log error without stack trace
+            LOG.error("Error registering minion id [{}]: {}", minionId, t.getMessage());
+            //convert into RegisterMinionException without stack trace
+            RegisterMinionException exception = new RegisterMinionException(minionId, org, t.getMessage());
+            exception.setStackTrace(new StackTraceElement[0]);
+            throw exception;
         }
         catch (Exception t) {
             LOG.error("Error registering minion id: {}", minionId, t);

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -87,6 +87,7 @@ import com.suse.utils.Json;
 import com.suse.utils.Opt;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.http.client.config.CookieSpecs;
@@ -1107,10 +1108,23 @@ public class SaltService implements SystemQuery, SaltApi {
      */
     @Override
     public Optional<SystemInfo> getSystemInfoFull(String minionId) {
-        return rawJsonCall(State.apply(Collections.singletonList(ApplyStatesEventMessage.SYSTEM_INFO_FULL),
-               Optional.empty()), minionId)
-               .flatMap(Result::result)
-               .map(result -> Json.GSON.fromJson(result, SystemInfo.class));
+        Optional<Result<JsonElement>> res = rawJsonCall(
+                State.apply(Collections.singletonList(ApplyStatesEventMessage.SYSTEM_INFO_FULL),
+                        Optional.empty()), minionId);
+        try {
+            return res.flatMap(Result::result).map(result -> Json.GSON.fromJson(result, SystemInfo.class));
+        }
+        catch (JsonSyntaxException ex) {
+            //catch errors when json element is an error message instead of a SystemInfo representation
+            String errorString = res.flatMap(Result::result)
+                    .filter(JsonElement::isJsonArray)
+                    .map(result ->
+                            String.join(" ", Json.GSON.fromJson(result.getAsJsonArray(), String[].class)))
+                    .orElse(ex.getMessage());
+            JsonSyntaxException newException = new JsonSyntaxException(errorString);
+            newException.setStackTrace(new StackTraceElement[0]);
+            throw newException;
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-user-pillar-errors
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-user-pillar-errors
@@ -1,0 +1,1 @@
+- Fix: manage errors in user-defined pillars (bsc#1230403)


### PR DESCRIPTION
## What does this PR change?
On a MLM server, let's assume a user creates an invalid top-level pillar file that for example references some non existing file 'bogus.sls':

e.g. uyuni-server:/ # cat /srv/pillar/top.sls 
base:
  '*':
    - 'bogus'

With this scenario, when onboarding a minion there are two problems:
1) the user gets an empty error message
![before_ui_error](https://github.com/user-attachments/assets/cfbe4aa9-1582-4419-8ad5-45f1cd681e3d)
2) the rhn_web_ui.log contains a backtrace
![before_log](https://github.com/user-attachments/assets/ed6685d0-932d-4110-a582-36401c478c67)

Both those two issues are undesirable. This PR fixes them both:

Here is the user error message:
![after_ui_error](https://github.com/user-attachments/assets/e5f9c777-628a-4da6-9c3a-eba0ba4b7766)
![after_ui_error_2](https://github.com/user-attachments/assets/31162b4e-89ee-4882-bcf2-f6830baea8ee)
 and here is the rhn_web_ui.log
![after_log](https://github.com/user-attachments/assets/4be901e5-89f1-4c00-a1fd-cf19570fa0bf)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26692, https://github.com/SUSE/spacewalk/pull/26698
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"  
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
