### PR TITLE
Fix sticky toolbar hiding notification messages on packages page (bsc#1239621)

### DIFF
--- a/web/html/javascript/spacewalk-essentials.js
+++ b/web/html/javascript/spacewalk-essentials.js
@@ -16,8 +16,6 @@ function onDocumentReadyGeneral(){
 
   // Show character length for textarea
   addTextareaLengthNotification();
-
-  scrollTopBehavior();
 }
 
 let isReady = false;
@@ -43,13 +41,6 @@ function listenForGlobalNotificationChanges() {
   observer.observe(globalNotificationsContainer, {subtree: true, childList: true});
 }
 
-// On section#spacewalk-content scroll
-function scrollTopBehavior() {
-  jQuery(scrollTarget).on("scroll", function () {
-    sstScrollBehavior();
-  });
-}
-
 // A container function for what should be fired
 // to set HTML tag dimensions
 function alignContentDimensions() {
@@ -57,33 +48,28 @@ function alignContentDimensions() {
     return;
   }
 
-  sstStyle();
   navbarToggleMobile();
-}
-
-// empty function by default hooked on window.scroll event
-var sstScrollBehavior = function() {
-  return;
 }
 
 var sstScrollBehaviorSetupIsDone = false; // flag to implement the function one time only
 function sstScrollBehaviorSetup(sst) {
-  sstScrollBehaviorSetupIsDone = true;
-  const adjustSpaceObject = jQuery('<div>').height(sst.outerHeight());
-  var fixedTop = sst.offset().top;
-
-  // override the empty function hooked on window.scroll event                                              │
-  sstScrollBehavior = function() {
-    var currentScroll = jQuery(scrollTarget).scrollTop();
-    if (currentScroll >= fixedTop) {
-      sst.after(adjustSpaceObject);
-      jQuery(sst).addClass('fixed');
-    } else {
-      jQuery(sst).removeClass('fixed');
-      adjustSpaceObject.remove();
-    }
-    sstStyle();
+  if (sstScrollBehaviorSetupIsDone) {
+    return;
   }
+  sstScrollBehaviorSetupIsDone = true;
+
+  const element = sst.get(0);
+  if (!element) {
+    return;
+  }
+
+  // See https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
+  const observer = new IntersectionObserver(
+    ([e]) => e.target.classList.toggle("is-sticky", e.intersectionRatio < 1),
+    { threshold: [1] }
+  );
+
+  observer.observe(element);
 }
 
 // when the page scrolls down and the toolbar is going up and hidden,
@@ -126,28 +112,7 @@ function handleSst() {
     });
   }
 
-  // setup the function only if there is the 'spacewalk-section-toolbar'
-  // and the function is not yet setup
-  if (!sstScrollBehaviorSetupIsDone && sst.length > 0) {
-    sstScrollBehaviorSetup(sst);
-  }
-}
-
-function sstStyle() {
-  var sst = jQuery('.spacewalk-section-toolbar').first();
-  if (sst.hasClass('fixed')) {
-    sst.css({
-      top: jQuery('header').outerHeight() - 1,
-      left: jQuery('section').offset().left,
-      'min-width': jQuery('section').outerWidth()
-    });
-  }
-  else {
-    sst.css({
-      'min-width': 0
-    });
-  }
-  sst.width(sst.parent().width() - sst.css('padding-left') - sst.css('padding-right'));
+  sstScrollBehaviorSetup(sst);
 }
 
 function navbarToggleMobile() {

--- a/web/html/src/branding/css/base/components/toolbar.scss
+++ b/web/html/src/branding/css/base/components/toolbar.scss
@@ -1,11 +1,15 @@
 .spacewalk-section-toolbar {
-  background: transparent;
+  position: sticky;
+  top: -1px;
+  background: $body-background;
   padding: 0;
   border: none;
+  z-index: 200;
+  padding: 0 $content-area-padding-side;
+  margin: 0 calc(-1 * $content-area-padding-side);
 
-  &.fixed {
-    background: $eos-bc-white;
-    border-bottom: 1px solid $eos-bc-gray-300;
+  &.is-sticky {
+    border-bottom: 1px solid $eos-bc-gray-100;
   }
 }
 

--- a/web/html/src/branding/css/base/theme.scss
+++ b/web/html/src/branding/css/base/theme.scss
@@ -148,7 +148,7 @@ section {
 
   /* fixing margins in the 1st and last columns */
   section {
-    padding: $content-area-padding;
+    padding: 0 $content-area-padding-side $content-area-padding-bottom;
     float: right;
   }
 }

--- a/web/html/src/branding/css/suse-light-variables.scss
+++ b/web/html/src/branding/css/suse-light-variables.scss
@@ -2,4 +2,5 @@ $body-color: $eos-bc-gray-1000;
 $body-font: $suse;
 $link-color: $eos-bc-blue-500;
 
-$content-area-padding: 0 4em 4em;
+$content-area-padding-side: 4em;
+$content-area-padding-bottom: 4em;

--- a/web/html/src/branding/css/uyuni-variables.scss
+++ b/web/html/src/branding/css/uyuni-variables.scss
@@ -5,7 +5,8 @@ $link-color: #337ab7;
 $header: $uyuni-blue-900;
 $header-text: $uyuni-gray-100;
 
-$content-area-padding: 0 2em 3em;
+$content-area-padding-side: 2em;
+$content-area-padding-bottom: 3em;
 
 $aside-background: $uyuni-blue-900;
 $aside-menu-text: $uyuni-gray-100;

--- a/web/spacewalk-web.changes.eth.bsc1239621
+++ b/web/spacewalk-web.changes.eth.bsc1239621
@@ -1,0 +1,2 @@
+- Fix sticky toolbar hiding notification messages on packages page 
+  (bsc#1239621)


### PR DESCRIPTION
## What does this PR change?

See https://bugzilla.suse.com/show_bug.cgi?id=1239621

Update the sticky toolbar used in Software → Packages → Lock/Unlock (and many other places) to use CSS sticky instead of Js sticky. We still use Js to apply styles after the fact, but this change ensures the bar always gets unstickied even when the layout shifts due to notifications or similar.

Gotta be honest, this is touching some very groovy old global scripts so I hope this didn't break some other magic behavior.

## GUI diff

The sticky bar unstickies as it should.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: UI bug

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1239621

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
