### PR TITLE
Fix issue 9947, use isEmpty() for checking emptiness

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListConfirmSubmitAction.java
@@ -102,7 +102,7 @@ public class FileListConfirmSubmitAction extends RhnListDispatchAction {
         RhnSet set = RhnSetDecl.CONFIG_IMPORT_FILE_NAMES.get(user);
         Set cfnids = getCfnids(set);
         //if they don't have a set, don't do anything.
-        if (cfnids.size() < 1) {
+        if (cfnids.isEmpty()) {
             return createErrorMessage(request, mapping, formIn, server.getId(),
                     "sdcfilelist.jsp.noSelected");
         }
@@ -173,7 +173,7 @@ public class FileListConfirmSubmitAction extends RhnListDispatchAction {
         RhnSet set = RhnSetDecl.CONFIG_FILE_NAMES.get(user);
         Set revisions = getCrids(set, sid);
         //if they don't have a set, don't do anything.
-        if (revisions.size() < 1) {
+        if (revisions.isEmpty()) {
             return createErrorMessage(request, mapping, form, sid,
                     "sdcfilelist.jsp.noSelected");
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/FileListSubmitAction.java
@@ -93,7 +93,7 @@ public class FileListSubmitAction extends RhnSetAction {
                                      HttpServletRequest request,
                                      HttpServletResponse response) {
         //They didn't select anything. Tell them to select something.
-        if (updateSet(request).size() < 1) {
+        if (updateSet(request).isEmpty()) {
             ActionErrors errors = new ActionErrors();
             errors.add(ActionMessages.GLOBAL_MESSAGE,
                     new ActionMessage("sdcfilelist.jsp.noSelected"));

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -282,7 +282,7 @@ public class SPMigrationAction extends RhnAction {
                 request.setAttribute(LATEST_SP, true);
                 return forward;
             }
-            else if (migrationTargets.size() >= 1) {
+            else if (!migrationTargets.isEmpty()) {
                 // At least one target available
                 logger.debug("Found at least one migration target");
                 request.setAttribute(TARGET_PRODUCTS, migrationTargets);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
@@ -996,7 +996,7 @@ public class UserHandler extends BaseHandler {
         User targetUser = XmlRpcUserHelper.getInstance().lookupTargetUser(
                 loggedInUser, login);
 
-        if (sgNames == null || sgNames.size() < 1) {
+        if (sgNames == null || sgNames.isEmpty()) {
             throw new IllegalArgumentException("no servergroup names supplied");
         }
 

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -233,7 +233,7 @@ public class ActionManager extends BaseManager {
         params.put("org_id", user.getOrg().getId());
         params.put("aid", aid);
         params.put("include_orphans", user.hasRole(RoleFactory.ORG_ADMIN) ? "Y" : "N");
-        if (m.execute(params).size() < 1) {
+        if (m.execute(params).isEmpty()) {
             returnedAction = null;
         }
 
@@ -577,7 +577,7 @@ public class ActionManager extends BaseManager {
         }
 
         //if this is a pointless action, don't do it.
-        if (a.getConfigFileNameAssociations().size() < 1) {
+        if (a.getConfigFileNameAssociations().isEmpty()) {
             return null;
         }
 

--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -519,7 +519,7 @@ public class CVEAuditManager {
 
                     // ...if it has a target with that base product...
                     List<SUSEProductDto> targets = findAllTargetProducts(suseProductID);
-                    if (log.isDebugEnabled() && targets.size() <= 0) {
+                    if (log.isDebugEnabled() && targets.isEmpty()) {
                         log.debug("No target products found for {}", suseProductID);
                     }
                     for (SUSEProductDto target : targets) {
@@ -552,7 +552,7 @@ public class CVEAuditManager {
 
                     // ...if it has a source with that base product...
                     List<SUSEProductDto> sources = findAllSourceProducts(suseProductID);
-                    if (log.isDebugEnabled() && sources.size() <= 0) {
+                    if (log.isDebugEnabled() && sources.isEmpty()) {
                         log.debug("No source products found for {}", suseProductID);
                     }
                     for (SUSEProductDto source : sources) {

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2327,7 +2327,7 @@ public class SystemManager extends BaseManager {
         Map<String, Object> params = new HashMap<>();
         params.put("uid", user.getId());
         params.put("sid", sid);
-        return m.execute(params).size() >= 1;
+        return !m.execute(params).isEmpty();
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/SSOController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SSOController.java
@@ -109,7 +109,7 @@ public final class SSOController {
 
                     final Collection<String> keys = attributes.keySet();
 
-                    if (keys.contains((String) "uid") && attributes.get("uid").size() >= 1) {
+                    if (keys.contains((String) "uid") && !attributes.get("uid").isEmpty()) {
                         final Optional uidOpt = Optional.ofNullable(attributes.get("uid").get(0));
                         if (uidOpt.isPresent()) {
                             final User user = UserFactory.lookupByLogin(String.valueOf(uidOpt.get()));

--- a/java/code/src/com/suse/utils/Lists.java
+++ b/java/code/src/com/suse/utils/Lists.java
@@ -50,7 +50,7 @@ public class Lists {
      * @return cartesian product of the input
      */
     public static <T> List<List<T>>  combinations(List<List<T>> lists) {
-        if (lists.size() < 1) {
+        if (lists.isEmpty()) {
             return new ArrayList<>();
         }
         else {


### PR DESCRIPTION
## What does this PR change?

Refactored Java code to comply with SonarCloud rule **S1155**:  
Replaced instances of `collection.size() < 1` with `collection.isEmpty()`, and `collection.size() >= 1` with `!collection.isEmpty()`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user-invisible changes

- [x] **DONE**

## Test coverage
- No tests done: just fixing sonar cloud issues

- [x] **DONE**

## Links

Issue(s): #9947  

- [x] **DONE**

## Changelogs

- [x] No changelog needed *(If maintainers agree that this change is minor and does not require a changelog entry)*

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
