### PR TITLE
fix billing-data-service configuration after upgrade (bsc#1236118)

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes.mcalmer.Manager-5.0-fix-bds-migration
+++ b/spacewalk/admin/spacewalk-admin.changes.mcalmer.Manager-5.0-fix-bds-migration
@@ -1,0 +1,2 @@
+- Fix billing-data-service configuration after upgrade from 4.3
+  (bsc#1236118)

--- a/spacewalk/admin/uyuni-update-config
+++ b/spacewalk/admin/uyuni-update-config
@@ -164,12 +164,35 @@ def copy_ca():
     sys.stdout.flush()
 
 
+def change_billing_data_service():
+    sysconf = "/etc/sysconfig/billing-data-service"
+    content = []
+    changed = False
+    if os.path.exists(sysconf):
+        with open(sysconf, "r", encoding="utf8") as f:
+            for line in f:
+                line = line.strip()
+                if line == 'LISTEN="127.0.0.1"':
+                    line = 'LISTEN="0.0.0.0"'
+                    changed = True
+                content.append(line)
+
+        if not changed:
+            sys.stdout.write("billing-data-service sysconfig file unchanged\n")
+            return
+        with open(sysconf, "w", encoding="utf8") as r:
+            for line in content:
+                r.write(f"{line}\n")
+        sys.stdout.write("billing-data-service sysconfig: changed LISTEN address\n")
+
+
 def main():
     run_uyuni_configfiles_sync()
     init_scc_login()
     import_suma_gpg_keyring()
     copy_ca()
     move_config_to_db()
+    change_billing_data_service()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR change?

When migrating from 4.3 PAYG to 5.0 the config for billing-data-service is migrated.
But in 4.3 the listen address was 127.0.0.1 while in 5.0 running inside of the container it must be 0.0.0.0 to be accessible from the outside.
This PR check in uyuni-update-config if the listen address is 127.0.0.1 and change it to 0.0.0.0.
Anything other value found stay untouched to keep customer configuration changes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual tested**

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26708

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
