### PR TITLE
Adds calling a highstate in the API for actionchain (bsc#1157520)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 SUSE LLC
+ * Copyright (c) 2014--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -42,9 +42,9 @@ import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.server.InstalledPackage;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
-import com.redhat.rhn.domain.session.InvalidSessionIdException;
 import com.redhat.rhn.frontend.dto.PackageListItem;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.InvalidPackageException;
@@ -92,10 +92,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
     private Errata errata;
     private Errata errata2;
     private ActionChain actionChain;
-    private static final String UNAUTHORIZED_EXCEPTION_EXPECTED =
-            "Expected an exception of type " +
-                      InvalidSessionIdException.class.getCanonicalName();
-
+    private static final String EXPECTED_EXCEPTION = "Expected exception: ";
     /**
      * {@inheritDoc}
      */
@@ -183,7 +180,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
     public void testAcCreateActionChainFailureOnEmptyName() {
         try {
             this.ach.createChain(this.admin, "");
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  InvalidParameterException.class.getCanonicalName());
         }
         catch (InvalidParameterException ex) {
@@ -267,7 +264,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                                        this.server.getId().intValue(),
                                        packages,
                                        CHAIN_LABEL);
-            fail("Expected exception: " + InvalidPackageException.class.getCanonicalName());
+            fail(EXPECTED_EXCEPTION + InvalidPackageException.class.getCanonicalName());
         }
         catch (InvalidPackageException ex) {
             assertTrue(actionChain.getEntries().isEmpty());
@@ -300,7 +297,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
             assertTrue(this.ach.addPackageRemoval(
                     this.admin, this.server.getId().intValue(),
                     new ArrayList<>(), CHAIN_LABEL) > 0);
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  InvalidParameterException.class.getCanonicalName());
         }
         catch (InvalidParameterException ex) {
@@ -321,7 +318,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                     this.server.getId().intValue(),
                     packagesToRemove,
                     CHAIN_LABEL) > 0);
-            fail("Expected exception: " + InvalidPackageException.class.getCanonicalName());
+            fail(EXPECTED_EXCEPTION + InvalidPackageException.class.getCanonicalName());
         }
         catch (InvalidPackageException ex) {
             assertEquals(0, actionChain.getEntries().size());
@@ -393,7 +390,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         int previousChainCount = this.ach.listChains(this.admin).size();
         try {
             this.ach.deleteChain(this.admin, "");
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  NoSuchActionChainException.class.getCanonicalName());
         }
         catch (NoSuchActionChainException ex) {
@@ -409,7 +406,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         int previousChainCount = this.ach.listChains(this.admin).size();
         try {
             this.ach.deleteChain(this.admin, TestUtils.randomString());
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  NoSuchActionChainException.class.getCanonicalName());
         }
         catch (NoSuchActionChainException ex) {
@@ -429,27 +426,9 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                 this.admin, CHAIN_LABEL).isEmpty());
         assertTrue(this.ach.removeAction(
                 this.admin, CHAIN_LABEL,
-                ((Long) ((Map) this.ach.listChainActions(this.admin, CHAIN_LABEL).get(0))
+                ((Long) (this.ach.listChainActions(this.admin, CHAIN_LABEL).get(0))
                         .get("id")).intValue()) > 0);
         assertTrue(this.ach.listChainActions(this.admin, CHAIN_LABEL).isEmpty());
-    }
-
-    /**
-     * Test empty list does not remove any actions, schedule does not happening.
-     */
-    @Test
-    public void testAcRemoveActionsEmpty() {
-        assertTrue(this.ach.addSystemReboot(this.admin,
-                this.server.getId().intValue(),
-                CHAIN_LABEL) > 0);
-        try {
-            this.ach.removeAction(this.admin, CHAIN_LABEL, 0);
-            fail("Expected exception: " +
-                 NoSuchActionException.class.getCanonicalName());
-        }
-        catch (NoSuchActionException ex) {
-            assertFalse(this.ach.listChainActions(this.admin, CHAIN_LABEL).isEmpty());
-        }
     }
 
     /**
@@ -462,7 +441,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                 CHAIN_LABEL) > 0);
         try {
             this.ach.removeAction(this.admin, "", 0);
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  NoSuchActionChainException.class.getCanonicalName());
         }
         catch (NoSuchActionChainException ex) {
@@ -482,7 +461,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                 CHAIN_LABEL) > 0);
         try {
             this.ach.removeAction(this.admin, CHAIN_LABEL, 0);
-            fail("Expected exception: " + NoSuchActionException.class.getCanonicalName());
+            fail(EXPECTED_EXCEPTION + NoSuchActionException.class.getCanonicalName());
         }
         catch (NoSuchActionException ex) {
             assertFalse(this.ach.listChainActions(
@@ -526,7 +505,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                                        this.server.getId().intValue(),
                                        upgradePackages,
                                        CHAIN_LABEL);
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  InvalidParameterException.class.getCanonicalName());
         }
         catch (InvalidParameterException ex) {
@@ -546,7 +525,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                                        this.server.getId().intValue(),
                                        upgradePackages,
                                        CHAIN_LABEL);
-            fail("Expected exception: " + InvalidPackageException.class.getCanonicalName());
+            fail(EXPECTED_EXCEPTION + InvalidPackageException.class.getCanonicalName());
         }
         catch (InvalidPackageException ex) {
             assertTrue(actionChain.getEntries().isEmpty());
@@ -584,7 +563,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                                       this.server.getId().intValue(),
                     new ArrayList<>(),
                                       CHAIN_LABEL);
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  InvalidParameterException.class.getCanonicalName());
         }
         catch (InvalidParameterException ex) {
@@ -604,7 +583,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                                       this.server.getId().intValue(),
                                       packages,
                                       CHAIN_LABEL);
-            fail("Expected exception: " + InvalidPackageException.class.getCanonicalName());
+            fail(EXPECTED_EXCEPTION + InvalidPackageException.class.getCanonicalName());
         }
         catch (InvalidPackageException ex) {
             assertEquals(0, actionChain.getEntries().size());
@@ -677,7 +656,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
     public void testAcScheduleOnTimeFailureNoChain() {
         try {
             this.ach.scheduleChain(this.admin, "", new Date());
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  NoSuchActionChainException.class.getCanonicalName());
         }
         catch (NoSuchActionChainException ex) {
@@ -730,7 +709,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                                                 this.server.getId().intValue(),
                                                 Collections.singletonList(revisionSpecifier)
             );
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  NoSuchActionChainException.class.getCanonicalName());
         }
         catch (NoSuchActionChainException ex) {
@@ -759,7 +738,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         try {
             assertEquals(Integer.valueOf(1),
                          this.ach.renameChain(this.admin, CHAIN_LABEL, CHAIN_LABEL));
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  InvalidParameterException.class.getCanonicalName());
         }
         catch (InvalidParameterException ex) {
@@ -776,7 +755,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         try {
             assertEquals(Integer.valueOf(1),
                          this.ach.renameChain(this.admin, "", CHAIN_LABEL));
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  InvalidParameterException.class.getCanonicalName());
         }
         catch (InvalidParameterException ex) {
@@ -793,11 +772,27 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
         try {
             assertEquals(Integer.valueOf(1),
                          this.ach.renameChain(this.admin, CHAIN_LABEL, ""));
-            fail("Expected exception: " +
+            fail(EXPECTED_EXCEPTION +
                  InvalidParameterException.class.getCanonicalName());
         }
         catch (InvalidParameterException ex) {
             assertTrue(actionChain.getLabel().equals(CHAIN_LABEL));
         }
+    }
+
+    /**
+     * Test add apply highstate.
+     */
+    @Test
+    public void testAcAddApplyHighstate() {
+        Server minionServer = ServerFactoryTest.createTestServer(this.admin, true,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled(), ServerFactoryTest.TYPE_SERVER_MINION);
+
+        assertTrue(this.ach.addApplyHighstate(this.admin,
+                minionServer.getId().intValue(),
+                CHAIN_LABEL) > 0);
+        assertEquals(1, actionChain.getEntries().size());
+        Action action = actionChain.getEntries().iterator().next().getAction();
+        assertEquals(ActionFactory.TYPE_APPLY_STATES, action.getActionType());
     }
 }

--- a/java/spacewalk-java.changes.carlo.uyuni-api-add-highstate
+++ b/java/spacewalk-java.changes.carlo.uyuni-api-add-highstate
@@ -1,0 +1,2 @@
+- Adds calling a highstate in the API for actionchain
+  (bsc#1157520)


### PR DESCRIPTION
## What does this PR change?
It seems that in the API for action chain the scheduling of the highstate is forgotten. 
This PR adds an API `addApplyHighstate` to add an highstate application at an action chain

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- API documentation added (apidoc)
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/26098
Port(s): https://github.com/SUSE/spacewalk/pull/26725, https://github.com/SUSE/spacewalk/pull/26729
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
