### PR TITLE
Switch to Python 3.11 Salt from SLE 15-SP7

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.deneb-alpha.saltVersion51susemanager-sls
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.deneb-alpha.saltVersion51susemanager-sls
@@ -1,0 +1,1 @@
+- Use Python3.11 Salt module version

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package susemanager-sls
 #
-# Copyright (c) 2024 SUSE LLC
+# Copyright (c) 2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,6 +15,15 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+## The productprettyname macros is controlled in the prjconf. If not defined, we fallback here
+%{!?productprettyname: %global productprettyname Uyuni}
+
+# Keep in sync with salt/salt.spec
+%if 0%{?suse_version} == 1500 && 0%{?sle_version} >= 150700
+%global use_python python311
+%else
+%global use_python python3
+%endif
 
 %if 0%{?suse_version} > 1320 || 0%{?rhel}
 # SLE15 builds on Python 3
@@ -32,7 +41,8 @@
 Name:           susemanager-sls
 Version:        5.1.5
 Release:        0
-Summary:        Static Salt state files for SUSE Manager
+Summary:        Static Salt state files for %{productprettyname}
+URL:            https://github.com/uyuni-project/uyuni
 License:        Apache-2.0 AND LGPL-2.1-only
 # FIXME: use correct group or remove it, see "https://en.opensuse.org/openSUSE:Package_group_guidelines"
 Group:          Applications/Internet
@@ -42,8 +52,8 @@ Requires(pre):  coreutils
 Requires(posttrans):spacewalk-admin
 Requires:       susemanager-build-keys-web >= 15.4.2
 %if 0%{?build_py3}
-BuildRequires:  python3-pytest
-BuildRequires:  python3-salt
+BuildRequires:  %{use_python}-pytest
+BuildRequires:  %{use_python}-salt
 BuildRequires:  python3-spacewalk-certs-tools
 # Different package names for SUSE and RHEL:
 Requires:       (python3-PyYAML >= 5.1 or python3-pyyaml >= 5.1)
@@ -56,17 +66,17 @@ Requires:       python-PyYAML >= 5.1
 BuildArch:      noarch
 
 %description
-Static Salt state files for SUSE Manager, where generic operations are
+Static Salt state files for %{productprettyname}, where generic operations are
 provided for the integration between infrastructure components.
 
 %package -n uyuni-config-modules
-Summary:        Salt modules to configure a Server
+Summary:        Salt modules to configure a %{productprettyname} Server
 # FIXME: use correct group or remove it, see "https://en.opensuse.org/openSUSE:Package_group_guidelines"
 Group:          Applications/Internet
 
 %description -n uyuni-config-modules
 This package contains Salt execution and state modules that can be used
-to configure a SUSE Manager or Uyuni Server.
+to configure %{productprettyname} Server.
 
 %prep
 %setup -q


### PR DESCRIPTION
## What does this PR change?

* Fix build unresolvable due to switch to `python311-salt` in SLE-15-SP7
* Add the missing URL tag in the specfile
* Make use of the `productprettyname` macro for not hardcoding  the product name

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Build tested on:
  - [IBS](https://build.suse.de/package/show/home:deneb_alpha:branches:SUSE:SLE-15-SP7:Update:Products:MultiLinuxManager51_fixpython/susemanager-sls)
  - [OBS](https://build.opensuse.org/package/show/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master_fixpython/susemanager-sls)

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26544

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
