### PR TITLE
QE: Improving systemgroups and ssm tests

### DIFF
--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -4,19 +4,19 @@
 @scope_ssm
 @sle_minion
 @scope_visualization
-Feature: Manage a group of systems
+Feature: Manage a group of systems and the Systems Set Manager
 
   Scenario: Log in as org admin user
     Given I am authorized for the "Admin" section
 
 @skip_if_github_validation
-  Scenario: Pre-requisite: enable dummy packages to fake an installation
+  Scenario: Pre-requisite: install dummy packages to allow patching
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
     And I install old package "andromeda-dummy-1.0" on this "sle_minion"
     And I install old package "virgo-dummy-1.0" on this "sle_minion"
 
-  Scenario: Pre-requisite: ensure that errata are computed
+  Scenario: Pre-requisite: ensure that fake patches are available
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
@@ -56,21 +56,21 @@ Feature: Manage a group of systems
     And I click on "Create Group"
     Then I should see a "System group new-systems-group created." text
 
-  Scenario: Add the SLE minion system to the group
+  Scenario: Add the SLE minion to the group and to SSM
     When I follow the left menu "Systems > System Groups"
     And I follow "new-systems-group"
     And I follow "Target Systems"
     And I check the "sle_minion" client
     And I click on "Add Systems"
     Then I should see a "1 systems were added to new-systems-group server group." text
-    And I click on "Add Selected to SSM"
+    When I click on "Add Selected to SSM"
 
   Scenario: The SLE minion is part of the new group
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Groups" in the content area
     Then I should see a "new-systems-group" text
 
-  Scenario: Apply a patch
+  Scenario: Apply a patch to systems in the system group
     When I follow the left menu "Systems > System Groups"
     And I follow "new-systems-group"
     And I follow first "Patches"
@@ -85,46 +85,47 @@ Feature: Manage a group of systems
     And I click on "Confirm"
     Then I should see a "Patch virgo-dummy-3456 has been scheduled for 1 system" text
 
-  Scenario: Apply a patch in the SSM
+  Scenario: Apply a patch to systems in the SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
     And I follow first "Patches"
-    When I enter "virgo-dummy" as the filtered synopsis
+    When I enter "andromeda-dummy" as the filtered synopsis
     And I click on the filter button
-    When I wait until I see "virgo-dummy-3456" text, refreshing the page
-    Then I should see a "virgo-dummy-3456" link
-    When I follow "virgo-dummy-3456"
+    When I wait until I see "andromeda-dummy-6789" text, refreshing the page
+    Then I should see a "andromeda-dummy-6789" link
+    When I follow "andromeda-dummy-6789"
     And I follow first "Affected Systems"
     And I check the "sle_minion" client
     And I click on "Apply Patches"
     And I click on "Confirm"
-    Then I should see a "Patch virgo-dummy-3456 has been scheduled for 1 system" text
+    Then I should see a "Patch andromeda-dummy-6789 has been scheduled for 1 system" text
 
 @skip_if_github_validation
-  Scenario: Install a package
+  Scenario: Delete a package from systems in the SSM
+    When I follow the left menu "Systems > System Set Manager > Overview"
+    And I follow "Packages"
+    And I follow "Remove"
+    And I wait until I see "andromeda-dummy-2.0-1.1" text, refreshing the page
+    And I enter "virgo-dummy" as the filtered package name
+    And I click on the filter button
+    And I check "virgo-dummy-2.0-1.1" in the list
+    And I click on "Remove Selected Packages"
+    And I click on "Confirm"
+    Then I should see a "Package removals are being scheduled, it may take several minutes for this to complete." text
+
+@skip_if_github_validation
+  Scenario: Install a package to systems in the SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
     And I follow "Packages"
     And I follow "Install"
     Then I should see a "Fake-RPM-SUSE-Channel" text
     When I follow "Fake-RPM-SUSE-Channel"
-    Then I should see a "andromeda-dummy-2.0-1.1" text
-    And I enter "andromeda-dummy" as the filtered package name
+    Then I should see a "virgo-dummy-2.0-1.1" text
+    And I enter "virgo-dummy" as the filtered package name
     And I click on the filter button
-    When I check "andromeda-dummy-2.0-1.1" in the list
+    When I check "virgo-dummy-2.0-1.1" in the list
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "Package installations are being scheduled, it may take several minutes for this to complete." text
-
-@skip_if_github_validation
-  Scenario: Delete a package
-    When I follow the left menu "Systems > System Set Manager > Overview"
-    And I follow "Packages"
-    And I follow "Remove"
-    And I enter "virgo-dummy" as the filtered package name
-    And I click on the filter button
-    And I check "virgo-dummy-1.0-1.2" in the list
-    And I click on "Remove Selected Packages"
-    And I click on "Confirm"
-    Then I should see a "Package removals are being scheduled, it may take several minutes for this to complete." text
 
 @rhlike_minion
   Scenario: Add the Red Hat-like minion to the group in a different way


### PR DESCRIPTION
## What does this PR change?

Doing the rrtg tasks we found that some of the system group and SSM tests are flaky. In this PR the tescases are improved.

Details:
 * the problem was that we were applying twice the same patch `virgo-dummy-3456`
 * so now we apply first `virgo-dummy-3456`, then `andromeda-dummy-6789`
 * but after that, `andromeda-dummy` is fully installed and patched to latest version, and installation fails
 * so we first uninstall  `andromeda-dummy`, and only then install it.




## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Port(s):
- Manager 5.0: https://github.com/SUSE/spacewalk/pull/26715

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
