### PR TITLE
find base channels for products which do not have child channels (bsc#1239747)

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -49,7 +49,8 @@ _sql_find_root_channel_label = """
 SELECT label
  FROM rhnChannel
 WHERE id IN (
-  SELECT DISTINCT c.parent_channel
+  SELECT DISTINCT
+         CASE WHEN c.parent_channel IS NOT NULL THEN c.parent_channel ELSE c.id END
     FROM rhnChannel c
     JOIN suseProductChannel pc ON pc.channel_id = c.id
     JOIN suseProducts p ON pc.product_id = p.id

--- a/susemanager/susemanager.changes.mcalmer.fix-bs-repo-basechannel-only
+++ b/susemanager/susemanager.changes.mcalmer.fix-bs-repo-basechannel-only
@@ -1,0 +1,2 @@
+- Fix creating bootstrap repositories for products which have
+  only a base channel (bsc#1239747)


### PR DESCRIPTION
## What does this PR change?

Create a bootstrap repo with --usecustomchannels was not possible when the root product had only
a base channel and no child channels. A query just looked for child channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **exception case QE only**

- [x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1239747
Port(s): https://github.com/SUSE/spacewalk/pull/26719

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
