### PR TITLE
Add possibility to change mgrctl exec option / Use -it option for mgr-create-bootstrap-repo

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1123,7 +1123,7 @@ When(/^I create the bootstrap repository for "([^"]*)" on the server((?: without
 
   log 'Creating the bootstrap repository on the server:'
   log "  #{cmd}"
-  get_target('server').run(cmd)
+  get_target('server').run(cmd, exec_option: '-it')
 end
 
 When(/^I create the bootstrap repositories including custom channels$/) do

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -102,8 +102,8 @@ class RemoteNode
   # @param buffer_size [Integer] The maximum buffer size in bytes.
   # @param verbose [Boolean] Whether to log the output of the command in case of success.
   # @return [Array<String, String, Integer>] The output, error, and exit code.
-  def run(cmd, runs_in_container: true, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, successcodes: [0], buffer_size: 65_536, verbose: false)
-    cmd_prefixed = @has_mgrctl && runs_in_container ? "mgrctl exec -i '#{cmd.gsub('\'', '\'"\'"\'')}'" : cmd
+  def run(cmd, runs_in_container: true, separated_results: false, check_errors: true, timeout: DEFAULT_TIMEOUT, successcodes: [0], buffer_size: 65_536, verbose: false, exec_option: '-i')
+    cmd_prefixed = @has_mgrctl && runs_in_container ? "mgrctl exec #{exec_option} '#{cmd.gsub('\'', '\'"\'"\'')}'" : cmd
     run_local(cmd_prefixed, separated_results: separated_results, check_errors: check_errors, timeout: timeout, successcodes: successcodes, buffer_size: buffer_size, verbose: verbose)
   end
 


### PR DESCRIPTION
## What does this PR change?
During mgr-create-bootstrap-repo, the output can be truncated and create issue.
After investigation by @Bischoff, we found out the error was cause by podman known issue. (https://github.com/SUSE/spacewalk/issues/25605).
A solution to this error is to use the option -it. Using this command all the time is creating other issue so it's better to only use it when needed (eg: create bootstrap repo).
To do so:
 - Add possibility to change mgrctl exec option
 - Use -it option for mgr-create-bootstrap-repo

<details>

## Example with option -i

```hcl
I create all bootstrap repos with --with-custom-channels option

  Scenario: Create the bootstrap repository for opensuse156arm_minion                                 # features/build_validation/create_bootstrap_repositories/opensuse156arm_minion_create_bootstrap_repository.feature:10
      This scenario ran at: 2025-03-19 01:17:24 +0100
    When I create the bootstrap repository for "opensuse156arm_minion" on the server without flushing # features/step_definitions/command_steps.rb:1064
      base_channel: openSUSE-Leap-15.6-Pool for aarch64
      channel: openSUSE-Leap-15.6-aarch64
      parent_channel: 
      Creating the bootstrap repository on the server:
        mgr-create-bootstrap-repo --create openSUSE-Leap-15.6-aarch64 --with-custom-channels
      FAIL: mgrctl exec -i  'mgr-create-bootstrap-repo --create openSUSE-Leap-15.6-aarch64 --with-custom-channels' returned status code = 1.
      Output:
      Directory walk started
      Directory walk done - 58 packages
      Temporary output repo path: /srv/www/htdocs/pub/repositories/opensuse/15/6/bootstrap.tmp/.repodata/
      Preparing sqlite DBs
      Pool started (with 5 workers)
      Pool finished
      
      Creating bootstrap repo for openSUSE-Leap-15.6-aarch64
      copy 'hostname-3.16-2.22.aarch64'
      copy 'iproute2-6.4-150600.7.3.1.aarch64'
      copy 'libmnl0-1.0.4-1.25.aarch64'
      copy 'libxtables12-1.8.7-1.1.aarch64'
      copy 'libpgm-5_2-0-5.2.122-150400.15.6.aarch64'
      copy 'libpython3_6m1_0-3.6.15-150300.10.81.1.aarch64'
      copy 'libsodium23-1.0.18-150000.4.8.1.aarch64'
      copy 'libzmq5-4.2.3-3.15.4.aarch64'
      copy 'logrotate-3.18.1-150400.3.10.1.aarch64'
      copy 'net-tools-2.0+git20170221.479bb4a-3.11.aarch64'
      copy 'openssl-3.1.4-150600.2.1.noarch'
      copy 'python3-3.6.15-150300.10.81.1.aarch64'
      copy 'python3-base-3.6.15-150300.10.81.1.aarch64'
      copy 'python3-appdirs-1.4.3-1.21.noarch'
      copy 'python3-asn1crypto-0.24.0-3.2.1.noarch'
      copy 'python3-Babel-2.8.0-3.3.1.noarch'
      copy 'python3-certifi-2018.1.18-150000.3.3.1.noarch'
      copy 'python3-cffi-1.13.2-3.2.5.aarch64'
      copy 'python3-chardet-3.0.4-150000.5.3.1.noarch'
      copy 'python3-cryptography-3.3.2-150400.23.1.aarch64'
      copy 'python3-distro-1.5.0-3.5.1.noarch'
      copy 'python3-idna-2.6-150000.3.3.1.noarch'
      copy 'python3-Jinja2-2.10.1-3.10.2.noarch'
      copy 'python3-MarkupSafe-1.0-1.29.aarch64'
      copy 'python3-M2Crypto-0.44.0-150600.19.3.1.aarch64'
      copy 'python3-msgpack-0.5.6-150100.3.3.1.aarch64'
      copy 'python3-ordered-set-4.0.2-150400.8.34.noarch'
      copy 'python3-packaging-21.3-150200.3.3.1.noarch'
      copy 'python3-psutil-5.9.1-150300.3.6.1.aarch64'
      copy 'python3-py-1.10.0-150100.5.12.1.noarch'
      copy 'python3-pyasn1-0.4.2-150000.3.5.1.noarch'
      copy 'python3-pycparser-2.17-3.2.1.noarch'
      copy 'python3-pyparsing-2.4.7-1.24.noarch'
      copy 'python3-pytz-2022.1-150300.3.6.1.noarch'
      copy 'python3-pyOpenSSL-21.0.0-150400.7.62.noarch'
      copy 'python3-PyYAML-5.4.1-1.1.aarch64'
      copy 'python3-pyzmq-17.1.2-150000.3.5.2.aarch64'
      copy 'python3-requests-2.25.1-150300.3.6.1.noarch'
      copy 'python3-rpm-4.14.3-150400.59.16.1.aarch64'
      copy 'python3-setuptools-44.1.1-150400.9.9.1.noarch'
      copy 'python3-simplejson-3.17.2-150300.3.4.1.aarch64'
      copy 'python3-six-1.14.0-12.1.noarch'
      copy 'python3-urllib3-1.25.10-150300.4.9.1.noarch'
      copy 'python3-immutables-0.11-150000.1.3.1.aarch64'
      copy 'python3-contextvars-2.4-150000.1.3.1.noarch'
      copy 'python3-zypp-plugin-0.6.5-150600.18.5.1.noarch'
      copy 'timezone-2025a-150600.91.3.1.aarch64'
      copy 'salt-3006.0-150500.4.47.1.aarch64'
      copy 'python3-salt-3006.0-150500.4.47.1.aarch64'
      copy 'salt-minion-3006.0-150500.4.47.1.aarch64'
      copy 'python3-apipkg-2.1.0-150500.1.1.noarch'
      copy 'python3-iniconfig-1.1.1-150000.1.11.1.noarch'
      copy 'python3-looseversion-1.0.2-150100.3.3.1.noarch'
      copy 'python3-jmespath-0.9.3-150000.3.5.1.noarch'
      copy 'python3-ply-3.10-150000.3.5.1.noarch'
      copy 'venv-salt-minion-3006.0-150000.3.72.1.aarch64'
      copy 'dmidecode-3.6-150400.16.11.2.aarch64'
      copy 'libunwind-1.5.0-4.5.1.aarch64'
       (ScriptError)
      ./features/support/remote_node.rb:123:in `run_local'
      ./features/support/remote_node.rb:107:in `run'
      ./features/step_definitions/command_steps.rb:1086:in `/^I create the bootstrap repository for "([^"]*)" on the server((?: without flushing)?)$/'
      features/build_validation/create_bootstrap_repositories/opensuse156arm_minion_create_bootstrap_repository.feature:11:in `I create the bootstrap repository for "opensuse156arm_minion" on the server without flushing'
```

## Example with option -it

```hcl
@opensuse156arm_minion
Feature: Create bootstrap repository for opensuse156arm_minion
In order to be able to enroll clients with MU repositories
As the system administrator
I create all bootstrap repos with --with-custom-channels option

  Scenario: Create the bootstrap repository for opensuse156arm_minion                                 # features/build_validation/create_bootstrap_repositories/opensuse156arm_minion_create_bootstrap_repository.feature:10
      This scenario ran at: 2025-03-19 01:16:22 +0100
    When I create the bootstrap repository for "opensuse156arm_minion" on the server without flushing # features/step_definitions/command_steps.rb:1064
      base_channel: openSUSE-Leap-15.6-Pool for aarch64
      channel: openSUSE-Leap-15.6-aarch64
      parent_channel: 
      Creating the bootstrap repository on the server:
        mgr-create-bootstrap-repo --create openSUSE-Leap-15.6-aarch64 --with-custom-channels
      FAIL: mgrctl exec -it  'mgr-create-bootstrap-repo --create openSUSE-Leap-15.6-aarch64 --with-custom-channels' returned status code = 1.
      Output:
      
      Creating bootstrap repo for openSUSE-Leap-15.6-aarch64
      copy 'hostname-3.16-2.22.aarch64'
      copy 'iproute2-6.4-150600.7.3.1.aarch64'
      copy 'libmnl0-1.0.4-1.25.aarch64'
      copy 'libxtables12-1.8.7-1.1.aarch64'
      copy 'libpgm-5_2-0-5.2.122-150400.15.6.aarch64'
      copy 'libpython3_6m1_0-3.6.15-150300.10.81.1.aarch64'
      copy 'libsodium23-1.0.18-150000.4.8.1.aarch64'
      copy 'libzmq5-4.2.3-3.15.4.aarch64'
      copy 'logrotate-3.18.1-150400.3.10.1.aarch64'
      copy 'net-tools-2.0+git20170221.479bb4a-3.11.aarch64'
      copy 'openssl-3.1.4-150600.2.1.noarch'
      copy 'python3-3.6.15-150300.10.81.1.aarch64'
      copy 'python3-base-3.6.15-150300.10.81.1.aarch64'
      copy 'python3-appdirs-1.4.3-1.21.noarch'
      copy 'python3-asn1crypto-0.24.0-3.2.1.noarch'
      copy 'python3-Babel-2.8.0-3.3.1.noarch'
      copy 'python3-certifi-2018.1.18-150000.3.3.1.noarch'
      copy 'python3-cffi-1.13.2-3.2.5.aarch64'
      copy 'python3-chardet-3.0.4-150000.5.3.1.noarch'
      copy 'python3-cryptography-3.3.2-150400.23.1.aarch64'
      copy 'python3-distro-1.5.0-3.5.1.noarch'
      copy 'python3-idna-2.6-150000.3.3.1.noarch'
      copy 'python3-Jinja2-2.10.1-3.10.2.noarch'
      copy 'python3-MarkupSafe-1.0-1.29.aarch64'
      copy 'python3-M2Crypto-0.44.0-150600.19.3.1.aarch64'
      copy 'python3-msgpack-0.5.6-150100.3.3.1.aarch64'
      copy 'python3-ordered-set-4.0.2-150400.8.34.noarch'
      copy 'python3-packaging-21.3-150200.3.3.1.noarch'
      copy 'python3-psutil-5.9.1-150300.3.6.1.aarch64'
      copy 'python3-py-1.10.0-150100.5.12.1.noarch'
      copy 'python3-pyasn1-0.4.2-150000.3.5.1.noarch'
      copy 'python3-pycparser-2.17-3.2.1.noarch'
      copy 'python3-pyparsing-2.4.7-1.24.noarch'
      copy 'python3-pytz-2022.1-150300.3.6.1.noarch'
      copy 'python3-pyOpenSSL-21.0.0-150400.7.62.noarch'
      copy 'python3-PyYAML-5.4.1-1.1.aarch64'
      copy 'python3-pyzmq-17.1.2-150000.3.5.2.aarch64'
      copy 'python3-requests-2.25.1-150300.3.6.1.noarch'
      copy 'python3-rpm-4.14.3-150400.59.16.1.aarch64'
      copy 'python3-setuptools-44.1.1-150400.9.9.1.noarch'
      copy 'python3-simplejson-3.17.2-150300.3.4.1.aarch64'
      copy 'python3-six-1.14.0-12.1.noarch'
      copy 'python3-urllib3-1.25.10-150300.4.9.1.noarch'
      copy 'python3-immutables-0.11-150000.1.3.1.aarch64'
      copy 'python3-contextvars-2.4-150000.1.3.1.noarch'
      copy 'python3-zypp-plugin-0.6.5-150600.18.5.1.noarch'
      copy 'timezone-2025a-150600.91.3.1.aarch64'
      copy 'salt-3006.0-150500.4.47.1.aarch64'
      copy 'python3-salt-3006.0-150500.4.47.1.aarch64'
      copy 'salt-minion-3006.0-150500.4.47.1.aarch64'
      copy 'python3-apipkg-2.1.0-150500.1.1.noarch'
      copy 'python3-iniconfig-1.1.1-150000.1.11.1.noarch'
      copy 'python3-looseversion-1.0.2-150100.3.3.1.noarch'
      copy 'python3-jmespath-0.9.3-150000.3.5.1.noarch'
      copy 'python3-ply-3.10-150000.3.5.1.noarch'
      copy 'venv-salt-minion-3006.0-150000.3.72.1.aarch64'
      copy 'dmidecode-3.6-150400.16.11.2.aarch64'
      copy 'libunwind-1.5.0-4.5.1.aarch64'
      Directory walk started
      Directory walk done - 58 packages
      Temporary output repo path: /srv/www/htdocs/pub/repositories/opensuse/15/6/bootstrap.tmp/.repodata/
      Preparing sqlite DBs
      Pool started (with 5 workers)
      Pool finished
      ERROR: package 'xz' not found
      
      Suggestions:
      mgr-create-bootstrap-repo uses the locally synchronized versions of files
      from the Tools repository, and uses the locally synchronized pool channel
      for dependency resolution.
      Both should be fully synced before running the mgr-create-bootstrap-repo script.
      
       (ScriptError)
      ./features/support/remote_node.rb:123:in `run_local'
      ./features/support/remote_node.rb:107:in `run'
      ./features/step_definitions/command_steps.rb:1086:in `/^I create the bootstrap repository for "([^"]*)" on the server((?: without flushing)?)$/'
      features/build_validation/create_bootstrap_repositories/opensuse156arm_minion_create_bootstrap_repository.feature:11:in `I create the bootstrap repository for "opensuse156arm_minion" on the server without flushing'

```

</details>

## GUI diff


No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered


- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26722

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
