### PR TITLE
Fix: Applying the highstate to Salt SSH minions causes HHH000179 warning at rhn_taskomatic_daemon.log (bsc#1216936)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionResult.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -70,6 +71,20 @@ public class ImageInspectActionResult implements Serializable {
          */
         public void setServerId(Long serverIdIn) {
             serverId = serverIdIn;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof ImageInspectActionResultId that)) {
+                return false;
+            }
+            return Objects.equals(getServerId(), that.getServerId()) &&
+                    Objects.equals(getActionImageInspectId(), that.getActionImageInspectId());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getServerId(), getActionImageInspectId());
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -3,7 +3,7 @@
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
-    <class name="com.redhat.rhn.domain.server.Server" table="rhnServer">
+    <class name="com.redhat.rhn.domain.server.Server" table="rhnServer" lazy="false">
         <id name="id" type="long" column="id">
             <meta attribute="scope-set">protected</meta>
             <generator class="org.hibernate.id.enhanced.SequenceStyleGenerator">
@@ -198,7 +198,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             <one-to-many class="com.redhat.rhn.domain.server.ServerAppStream"/>
         </set>
 
-        <joined-subclass name="com.redhat.rhn.domain.server.MinionServer"
+        <joined-subclass name="com.redhat.rhn.domain.server.MinionServer" lazy="false"
                          table="suseMinionInfo">
             <key column="server_id"/>
             <property name="minionId" column="minion_id" />

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -534,6 +534,8 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
+        testMinionServer = TestUtils.saveAndReload(testMinionServer);
+
         Channel pool = ChannelFactory.lookupByLabel("sles12-pool-x86_64");
         Channel update = ChannelFactory.lookupByLabel("sles12-updates-x86_64");
         Channel legacy = ChannelFactory.lookupByLabel("sle-module-legacy12-pool-x86_64");

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-taskomatic-warning
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-taskomatic-warning
@@ -1,0 +1,2 @@
+- Fix: applying the highstate to Salt SSH minions
+  causes HHH000179 warning at taskomatic (bsc#1216936)


### PR DESCRIPTION
## What does this PR change?
Taskomatic log file shows a warning like:

`     WARN  org.hibernate.engine.internal.StatefulPersistenceContext - HHH000179: Narrowing proxy to class com.redhat.rhn.domain.server.MinionServer - this operation breaks ==`

This fix solves this problem. The problem seems related to the Hibernate lazy initialization of class MinionServer, which is a child class from Server: as you may see from the following two queries, there seems to be an issue of what type to infer when doing lazy initialization
```
    <query name="Server.findByIds">
        <![CDATA[from com.redhat.rhn.domain.server.Server as s where s.id in (:serverIds)]]>
    </query>

    <query name="Server.findMinionsByServerIds">
        <![CDATA[from com.redhat.rhn.domain.server.MinionServer as s where s.id in (:serverIds)]]>
    </query>
```

While I was checking the taskomatic logs, I noticed that there was another recurring warning when restarting taskomatic    

```
WARN  org.hibernate.mapping.RootClass - HHH000038: Composite-id class does not override equals(): 
com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionResult$ImageInspectActionResultId
WARN  org.hibernate.mapping.RootClass - HHH000039: Composite-id class does not override hashCode(): 
com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionResult$ImageInspectActionResultId
```

So I decided to fix it as well (boy-scout rule). I won't squash this second commit.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/22968
Port(s): # **add downstream PR(s), if any**
- [ ] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

