### PR TITLE
Fix content visibility issues on the Action Chains page

### DIFF
--- a/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
+++ b/java/code/webapp/WEB-INF/pages/schedule/actionchain.jsp
@@ -72,7 +72,7 @@
                                     <bean:message key="actionchain.jsp.systems"/>
                                 </span>
 
-                                <div class="system-list" id="system-list-${group.sortOrder}" hidden></div>
+                                <div class="system-list" id="system-list-${group.sortOrder}"></div>
                             </td>
                             <td>
                                 <a class="delete-group" href="#"><i class="fa fa-trash-o"></i>delete action</a>
@@ -82,7 +82,7 @@
                 </tbody>
             </table></div></div>
 
-            <div id="action-chain-save-input" class="form-group" hidden>
+            <div id="action-chain-save-input" class="form-group">
                 <div class="col-md-offset-3 offset-md-3 col-md-6">
                     <button class="btn btn-primary" id="save"><bean:message key="actionchain.jsp.save"/></button>
                     <button class="btn btn-default" id="cancel"><bean:message key="actionchain.jsp.cancel"/></button>

--- a/java/spacewalk-java.changes.welder.fix-action-chains
+++ b/java/spacewalk-java.changes.welder.fix-action-chains
@@ -1,0 +1,2 @@
+- Fix content visibility issues on the Action Chains page
+  (bsc#1239558, bsc#1239559)

--- a/web/html/javascript/actionchain.js
+++ b/web/html/javascript/actionchain.js
@@ -105,6 +105,12 @@ jQuery(function() {
     update: renumberGroups
   });
 
+  // hide change related buttons and systems lists when page loads
+  jQuery(document).ready(function () {
+    jQuery("#action-chain-save-input").hide();
+    jQuery("[id^='system-list-']").hide();
+  });
+
   // handle exit without save
   jQuery(window).on("beforeunload", function() {
     if (jQuery.unsaved == true) {

--- a/web/spacewalk-web.changes.welder.fix-action-chains
+++ b/web/spacewalk-web.changes.welder.fix-action-chains
@@ -1,0 +1,2 @@
+- Fix content visibility issues on the Action Chains page
+  (bsc#1239558, bsc#1239559)


### PR DESCRIPTION
## What does this PR change?

It updates the Action Chains page to use `jQuery.hide()` instead of the `hidden` property for managing content visibility. Previously, `jQuery.fadeIn()` had no effect because the Bootstrap `d-none` class, which we now use for hiding elements, takes precedence—likely due to an internal `!important` rule in Bootstrap's CSS. This change ensures that visibility toggling works as expected.

## GUI diff

No difference. Only bug fix.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: CSS related

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26682 https://github.com/SUSE/spacewalk/issues/26686

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
