### PR TITLE
Remove direct access to CFG when importing pkgs

### DIFF
--- a/python/spacewalk/satellite_tools/reposync.py
+++ b/python/spacewalk/satellite_tools/reposync.py
@@ -1749,6 +1749,7 @@ class RepoSync(object):
                 e = str(sys.exc_info()[1])
                 if e:
                     log2(0, 1, e, stream=sys.stderr)
+                log2(0, 1, traceback.format_exc(), stream=sys.stderr)
                 if self.fail:
                     raise
                 to_process[index] = (pack, False, False)

--- a/python/spacewalk/server/rhnPackage.py
+++ b/python/spacewalk/server/rhnPackage.py
@@ -21,7 +21,7 @@ from uyuni.common.usix import ListType
 
 from spacewalk.common import rhnFlags
 from spacewalk.common.rhnLog import log_debug, log_error
-from spacewalk.common.rhnConfig import CFG
+from spacewalk.common.rhnConfig import cfg_component
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnTranslate import _
 from spacewalk.server import rhnSQL
@@ -116,8 +116,8 @@ def check_package_file(rel_path, logpkg, raisepkg):
     if rel_path is None:
         log_error("Package path null for package id", logpkg)
         raise rhnFault(17, _("Invalid RPM package %s requested") % raisepkg)
-    # pylint: disable-next=consider-using-f-string
-    filePath = "%s/%s" % (CFG.MOUNT_POINT, rel_path)
+    with cfg_component("server.satellite") as CFG:
+        filePath = f"{CFG.MOUNT_POINT}/{rel_path}"
     if not os.access(filePath, os.R_OK):
         # Package not found on the filesystem
         log_error("Package not found", filePath)
@@ -133,7 +133,8 @@ def unlink_package_file(path):
         # pylint: disable-next=consider-using-f-string
         log_debug(1, "Error unlinking %s;" % path)
     dirname = os.path.dirname(path)
-    base_dirs = (CFG.MOUNT_POINT + "/" + CFG.PREPENDED_DIR, CFG.MOUNT_POINT)
+    with cfg_component("server.satellite") as CFG:
+        base_dirs = (CFG.MOUNT_POINT + "/" + CFG.PREPENDED_DIR, CFG.MOUNT_POINT)
     while dirname not in base_dirs:
         try:
             os.rmdir(dirname)

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.prepend-dir-fix
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.prepend-dir-fix
@@ -1,0 +1,2 @@
+- Fix PREPENDED_DIR error when importing
+  pkgs


### PR DESCRIPTION
## What does this PR change?

We get sporadic reports of the following error during reposync:

```
14:19:13     6758/6758 : wkhtmltopdf-opt-0.12.4-3.el8.remi.x86_64.rpm
14:19:14 Filtering packages that failed to download
14:19:14 
14:19:14   Importing packages to DB:
14:19:14 PREPENDED_DIR
14:19:14 PREPENDED_DIR
```

This seems not directly reproducible (we have not determined root cause), but we suspect that this is the result of direct access to `CFG`, where one component doesn't properly close the namespace while another component accesses it with unexpected/incorrect namespace.

In this PR, we use the `cfg_component` context manager to force proper initCFG.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9848
Port(s): 
- 5.0 - https://github.com/SUSE/spacewalk/pull/28175
- 5.1 - https://github.com/SUSE/spacewalk/pull/28176

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
