### PR TITLE
Fix: openscap audit is running immediately even when scheduled for next days (bsc#1239743)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
@@ -341,7 +341,7 @@ public class StrutsDelegate {
         //if it is not there, then that means we should always evaluate the
         //date picker.  Otherwise, we evaluate if it tells us to do so.
         if (!form.getMap().containsKey(DatePicker.SCHEDULE_TYPE) ||
-                form.get(DatePicker.SCHEDULE_TYPE) == null ||
+                StringUtils.isEmpty(String.valueOf(form.get(DatePicker.SCHEDULE_TYPE))) ||
                 form.get(DatePicker.SCHEDULE_TYPE).equals(DatePicker.ScheduleType.DATE.asString())) {
             DatePicker p = getDatePicker(name, yearDirection);
             p.readForm(form);

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-openscap-audit-date
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-openscap-audit-date
@@ -1,0 +1,2 @@
+- Fix: openscap audit is running immediately even when scheduled
+  for next days (bsc#1239743)


### PR DESCRIPTION
## What does this PR change?
The follwing bugged behaviour is fixed: when scheduling a new OpenScap XCCDF Scan, and the earliest date was set in the future, the scan use to start immediately.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested (UI)
- [x] **DONE**

## Links
Issue(s): 
Port(s): https://github.com/SUSE/spacewalk/pull/26747, https://github.com/SUSE/spacewalk/pull/26748
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

