### PR TITLE
Fix: avoids taskomatic log warning HHH000038: Composite-id class does not override equals/hashCode

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectActionResult.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -70,6 +71,20 @@ public class ImageInspectActionResult implements Serializable {
          */
         public void setServerId(Long serverIdIn) {
             serverId = serverIdIn;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof ImageInspectActionResultId that)) {
+                return false;
+            }
+            return Objects.equals(getServerId(), that.getServerId()) &&
+                    Objects.equals(getActionImageInspectId(), that.getActionImageInspectId());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getServerId(), getActionImageInspectId());
         }
     }
 


### PR DESCRIPTION
## What does this PR change?
Fixes issue https://github.com/SUSE/spacewalk/issues/26741 (Applying the highstate to Salt SSH minions causes a warning HHH000038 at rhn_taskomatic_daemon.log)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/26741
Port(s): no backports
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

