### PR TITLE
do not show Vendor Advisory link for SL-Micro 6 products (bsc#1237770)

### DIFF
--- a/java/code/src/com/suse/manager/errata/SUSEErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/SUSEErrataParser.java
@@ -102,6 +102,12 @@ public class SUSEErrataParser implements VendorSpecificErrataParser {
     }
 
     private int extractId(String advisory) throws ErrataParsingException {
+        // SLE-Micro 6.0, 6.1 and 6.2 do not publish advisories yet
+        if (advisory.contains("SLE-Micro-6.2") || advisory.contains("SLE-Micro-6.1") ||
+                advisory.contains("SLE-Micro-6.0")) {
+            throw new ErrataParsingException("Product provide no Vendor Advisory");
+        }
+
         // The id is the last part of the advisoryId i.e. SUSE-15-SP3-2021-3411 or avahi-13947
         final int lastDash = advisory.lastIndexOf('-');
         if (lastDash == -1) {

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.0-no-advisory-link-for-slmirco
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.0-no-advisory-link-for-slmirco
@@ -1,0 +1,2 @@
+- Do not show Vendor Advisory link for SL-Micro 6.0 and 6.1
+  products. They are not published yet on the web (bsc#1237770)


### PR DESCRIPTION
## What does this PR change?

SUSE does not create Vendor Advisories for SL-Micro 6 products.
We should not generate the links in the patch UI which point only to not existing pages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26704

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
