### PR TITLE
Fix GH workflows filter paths

### DIFF
--- a/.github/workflows/acceptance_tests_base.yml
+++ b/.github/workflows/acceptance_tests_base.yml
@@ -47,7 +47,6 @@ jobs:
     name: Run
     runs-on: ubuntu-22.04
     needs: filter-paths
-    if: ${{ needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
     steps:
       - name: Skipping tests
         if: ${{ inputs.skip_tests }}
@@ -56,23 +55,23 @@ jobs:
           echo "This is a workaround to avoid running the tests, but still have a passing status check."
           echo "The job will be marked as success, but the steps will be skipped."
       - name: Install Podman
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: sudo apt install podman=3.4.4+ds1-1ubuntu1 --allow-downgrades
 
       - name: Install Python dependencies
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: pip install pyyaml
 
       - name: Welcome message
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: echo "Running acceptance tests. More info at https://github.com/uyuni-project/uyuni/wiki/Running-Acceptance-Tests-at-PR"
 
       - name: Checkout repository
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Cache jar files
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: java/buildconf/ivy/repository/
@@ -81,7 +80,7 @@ jobs:
             ${{ runner.os }}-build-cache-uyuni-jars-
 
       - name: Cache obs-to-maven files
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: java/.obs-to-maven-cache
@@ -90,7 +89,7 @@ jobs:
             ${{ runner.os }}-build-cache-uyuni-obs-to-maven-
 
       - name: Cache NodeJS modules
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: web/html/src/node_modules
@@ -99,50 +98,50 @@ jobs:
             ${{ runner.os }}-build-cache-uyuni-nodejs-
 
       - name: Create temporary directories
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/01_setup_tmp_dirs.sh
 
       - name: Create Podman network
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/02_setup_network.sh
 
       - name: Start controller, registry and build host
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh
 
       - name: Create SSH configuration in controller
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/04_setup_ssh_controller.sh
 
       - name: Parse recommended tests coming from the input as XML
-        if: ${{ !inputs.skip_tests && inputs.recommended_tests != '' }}
+        if: ${{ !inputs.skip_tests && inputs.recommended_tests != '' && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: python .github/scripts/get_tests.py '${{ inputs.recommended_tests }}' > testsuite/run_sets/filter.yml
 
       - name: Generate recommended tests as YAML
-        if: ${{ !inputs.skip_tests && inputs.recommended_tests != '' }}
+        if: ${{ !inputs.skip_tests && inputs.recommended_tests != '' && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/19_generate_recommended_tests_yml.sh
 
       - name: Install gems in controller
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/05_install_gems_in_controller.sh
 
       - name: Collect and tag flaky tests in controller
         # Until we refactor the usage of the secret, it only runs on uyuni-project/uyuni repository branches
-        if: ${{ !inputs.skip_tests && github.repository == 'uyuni-project/uyuni' }}
+        if: ${{ !inputs.skip_tests && github.repository == 'uyuni-project/uyuni'  && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/06_collect_and_tag_flaky_tests_in_controller.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_GALAXY_CI }}
 
       - name: Setup server container
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/07_server_setup.sh
 
       - name: Start server container
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/08_start_server.sh
 
       - name: Build server code
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/09_build_server_code.sh
       #     - name: copy_ca
       #     run: podman exec server bash -c "cp /etc/pki/tls/certs/spacewalk.crt /tmp"
@@ -150,70 +149,70 @@ jobs:
       #       run: podman exec controller bash -c "cat /tmp/spacewalk.crt >> /etc/ssl/ca-bundle.pem"
 
       - name: Run SSH minion container
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/10_run_sshminion.sh
 
       - name: Test access to server from controller
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: curl --insecure https://localhost:8443/rhn/help/Copyright.do
 
       - name: Test access to server from SSH minion
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: sudo -i podman exec opensusessh curl --insecure https://server:443/rhn/help/Copyright.do
 
       - name: Configure SSHD in controller, server, build host and SSH minion
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/11_setup_sshd.sh
 
       - name: Run and configure Salt Minion container
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/12_run_salt_sle_minion.sh
 
       - name: Run and configure RH-Like Minion container
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/13_run_salt_rhlike_minion.sh
 
       - name: Run and configure Deb-Like Minion container
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/14_run_salt_deblike_minion.sh
 
       - name: Run Core tests
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/15_run_core_tests.sh
 
       - name: Accept all keys
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/16_accept_all_keys.sh
 
       - name: Run init clients
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/17_run_init_clients_tests.sh
 
       - name: Split tests into multiple YAML files
-        if: ${{ !inputs.skip_tests && contains(inputs.server_id, 'additional') }}
+        if: ${{ !inputs.skip_tests && contains(inputs.server_id, 'additional') && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/23_split_secondary_p_tests.sh
 
       - name: Run acceptance tests
-        if: ${{ !inputs.skip_tests }}
+        if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/${{ inputs.tests }}
 
       - name: Get server logs
-        if: ${{ failure() && !inputs.skip_tests }}
+        if: ${{ failure() && !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true'}}
         run: ./testsuite/podman_runner/24_get_server_logs.sh ${{ inputs.server_id }}
 
       - name: Get client logs
-        if: ${{ failure() && !inputs.skip_tests }}
+        if: ${{ failure() && !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/25_get_client_logs.sh ${{ inputs.server_id }}
 
       - name: Upload server log artifacts
-        if: ${{ failure() && !inputs.skip_tests }}
+        if: ${{ failure() && !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 #v4.6.1
         with:
           name: server_rhn_logs_${{ inputs.server_id }}
           path: /tmp/testing/server-logs/${{ inputs.server_id }}
 
       - name: Upload client log artifacts
-        if: ${{ failure() && !inputs.skip_tests }}
+        if: ${{ failure() && !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 #v4.6.1
         with:
           name: client_logs_${{ inputs.server_id }}

--- a/.github/workflows/acceptance_tests_coordinator.yml
+++ b/.github/workflows/acceptance_tests_coordinator.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - reopened
       - synchronize
-    paths:
-      - '**.java'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## What does this PR change?

Fix GH workflows filter paths.
We moved an `if`, so we run it at step level, instead of job level, in order to generate at least `Skipping tests` step, to allow having correct status checks.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
