### PR TITLE
Checkout the PR code on Tests Base workflow

### DIFF
--- a/.github/workflows/acceptance_tests_base.yml
+++ b/.github/workflows/acceptance_tests_base.yml
@@ -32,6 +32,9 @@ jobs:
       require_acceptance_tests: ${{ steps.filter.outputs.java == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.testsuite == 'true' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
         id: filter
         with:
@@ -69,6 +72,9 @@ jobs:
       - name: Checkout repository
         if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Cache jar files
         if: ${{ !inputs.skip_tests && needs.filter-paths.outputs.require_acceptance_tests == 'true' }}


### PR DESCRIPTION
## What does this PR change?

As we changed the workflow calling that one, to use `pull_request_target` now that code in use by default when we checkout, is the code from the base branch. Instead, we need to checkout the code from the PR.

## Links

No ports

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
