### PR TITLE
Vendor salt.utils.versions.Looseversion

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -24,7 +24,6 @@ import fnmatch
 import requests
 import logging
 from functools import cmp_to_key
-from salt.utils.versions import LooseVersion
 from uyuni.common import fileutils
 from spacewalk.common.suseLib import get_proxy
 from spacewalk.common.rhnConfig import cfg_component
@@ -33,6 +32,8 @@ from spacewalk.satellite_tools.repo_plugins import ContentPackage, CACHE_DIR
 from spacewalk.satellite_tools.syncLib import log2
 from spacewalk.server import rhnSQL
 from spacewalk.common import repo
+
+import looseversion
 
 try:
     #  python 2
@@ -477,9 +478,9 @@ class ContentSource:
                 # pylint: disable-next=consider-using-f-string
                 ident = "{}.{}".format(pkg.name, pkg.arch)
                 # pylint: disable-next=consider-iterating-dictionary
-                if ident not in latest_pkgs.keys() or LooseVersion(
+                if ident not in latest_pkgs.keys() or looseversion.LooseVersion(
                     pkg.evr()
-                ) > LooseVersion(latest_pkgs[ident].evr()):
+                ) > looseversion.LooseVersion(latest_pkgs[ident].evr()):
                     latest_pkgs[ident] = pkg
             pkglist = list(latest_pkgs.values())
         pkglist.sort(key=cmp_to_key(self._sort_packages))

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -51,6 +51,7 @@ import traceback
 # pylint: disable-next=unused-import
 import types
 import urlgrabber
+import looseversion
 import json
 
 try:
@@ -63,7 +64,6 @@ except:
 import xml.etree.ElementTree as etree
 
 from functools import cmp_to_key
-from salt.utils.versions import LooseVersion
 from shlex import quote as sh_quote
 from uyuni.common import checksum, fileutils
 from spacewalk.common import rhnLog
@@ -1500,9 +1500,9 @@ password={passwd}
                 # pylint: disable-next=consider-using-f-string
                 ident = "{}.{}".format(pkg.name, pkg.arch)
                 # pylint: disable-next=consider-iterating-dictionary
-                if ident not in latest_pkgs.keys() or LooseVersion(
+                if ident not in latest_pkgs.keys() or looseversion.LooseVersion(
                     str(pkg.evr)
-                ) > LooseVersion(str(latest_pkgs[ident].evr)):
+                ) > looseversion.LooseVersion(str(latest_pkgs[ident].evr)):
                     latest_pkgs[ident] = pkg
             pkglist = list(latest_pkgs.values())
 

--- a/python/spacewalk/spacewalk-backend.changes.agraul.vendor-looseversion
+++ b/python/spacewalk/spacewalk-backend.changes.agraul.vendor-looseversion
@@ -1,0 +1,2 @@
+- Remove import of Salt code that might be shipped for a different
+  Python version (bsc#1239859)

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-backend
 #
-# Copyright (c) 2024 SUSE LLC
+# Copyright (c) 2025 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -206,6 +206,7 @@ BuildRequires:  systemd-rpm-macros
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
 Requires:       python3-urlgrabber >= 4
+Requires:       python3-looseversion
 Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 Requires:       susemanager-tools

--- a/susemanager/susemanager.changes.agraul.use-correct-shebang-in-mgr-salt-ssh
+++ b/susemanager/susemanager.changes.agraul.use-correct-shebang-in-mgr-salt-ssh
@@ -1,0 +1,1 @@
+- Use correct shebang in mgr-salt-ssh (bsc#1239859)

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package susemanager
 #
-# Copyright (c) 2024 SUSE LLC
+# Copyright (c) 2025 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -21,6 +21,13 @@
 %global build_py3   1
 %endif
 %define pythonX %{?build_py3:python3}%{!?build_py3:python2}
+
+# Keep in sync with salt/salt.spec, used to set correct shebang in mgr-salt-ssh
+%if 0%{?suse_version} == 1500 && 0%{?sle_version} >= 150700
+%global use_python python311
+%else
+%global use_python python3
+%endif
 
 %if 0%{?rhel}
 %global apache_user root
@@ -177,10 +184,11 @@ Bash completion for SUSE Manager CLI tools
 
 # Fixing shebang for Python 3
 %if 0%{?build_py3}
-for i in `find . -type f`;
+for i in `find . -type f -not -name 'mgr-salt-ssh'`;
 do
     sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
 done
+sed -i '1s=^#!/usr/bin/python3=#!/usr/bin/%{use_python}=' src/mgr-salt-ssh
 %endif
 
 # Bash completion


### PR DESCRIPTION
## What does this PR change?

In preparation for running Salt Master with Python 3.11, we need to remove imports in the still Python 3.6 based spacewalk-backend as well as use the right shebang in `mgr-salt-ssh`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered, raised by QE

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26758
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
