### PR TITLE
Refactor to run the GH validation on the fork's runner

### DIFF
--- a/.github/workflows/acceptance_tests_coordinator.yml
+++ b/.github/workflows/acceptance_tests_coordinator.yml
@@ -41,7 +41,7 @@ jobs:
           REDIS_HOST: ${{ secrets.REDIS_HOST }}
           REDIS_PORT: ${{ secrets.REDIS_PORT }}
         run: |
-          recommended_tests=$(node .github/scripts/test_covering_pr.js ${{ steps.changed_files.outputs.added_modified }})
+          recommended_tests=$(node .github/scripts/test_covering_pr.js ${{ steps.changed_files.outputs.all }})
           echo "recommended_tests=$recommended_tests" >> $GITHUB_OUTPUT
           echo "Recommended Tests: $recommended_tests"
 

--- a/.github/workflows/acceptance_tests_coordinator.yml
+++ b/.github/workflows/acceptance_tests_coordinator.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  cancel-in-progress: true
 
 jobs:
   determine_tests:

--- a/.github/workflows/acceptance_tests_coordinator.yml
+++ b/.github/workflows/acceptance_tests_coordinator.yml
@@ -20,15 +20,19 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+
       - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
           node-version: 22
+
       - run: npm i ioredis
+
       - id: changed_files
         uses: Ana06/get-changed-files@v2.3.0
         with:
           filter: '*.java'
+
       - id: tests_covering_pr
         name: Tests covering the Pull Request
         env:
@@ -40,6 +44,7 @@ jobs:
           recommended_tests=$(node .github/scripts/test_covering_pr.js ${{ steps.changed_files.outputs.added_modified }})
           echo "recommended_tests=$recommended_tests" >> $GITHUB_OUTPUT
           echo "Recommended Tests: $recommended_tests"
+
       - name: Determine if we should run the full test suite
         id: determine_running_full_testsuite
         run: |
@@ -49,31 +54,59 @@ jobs:
           else
             echo "run_full_testsuite=false" >> $GITHUB_OUTPUT
           fi
+
     outputs:
       recommended_tests: ${{ steps.tests_covering_pr.outputs.recommended_tests }}
       run_full_testsuite: ${{ steps.determine_running_full_testsuite.outputs.run_full_testsuite }}
 
-  recommended:
+  trigger-recommended:
     name: Recommended Tests
     needs: determine_tests
-    uses: ./.github/workflows/acceptance_tests_recommended.yml
-    secrets: inherit
-    with:
-      skip_tests: ${{ needs.determine_tests.outputs.run_full_testsuite == 'true' }}
-      recommended_tests: ${{ needs.determine_tests.outputs.recommended_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: run-recommended-tests
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          client-payload: |
+            {
+              "ref": "${{ github.event.pull_request.head.ref }}",
+              "skip_tests": "${{ needs.determine_tests.outputs.run_full_testsuite == 'true' }}",
+              "recommended_tests": "${{ needs.determine_tests.outputs.recommended_tests }}"
+            }
 
-  acceptance:
+  trigger-acceptance:
     name: Acceptance Tests
     needs: determine_tests
-    uses: ./.github/workflows/acceptance_tests_sequential.yml
-    secrets: inherit
-    with:
-      skip_tests: ${{ needs.determine_tests.outputs.run_full_testsuite != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: run-acceptance-tests
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          client-payload: |
+            {
+              "ref": "${{ github.event.pull_request.head.ref }}",
+              "skip_tests": "${{ needs.determine_tests.outputs.run_full_testsuite != 'true' }}"
+            }
 
-  additional:
+  trigger-additional:
     name: Additional Tests
     needs: determine_tests
-    uses: ./.github/workflows/acceptance_tests_parallel.yml
-    secrets: inherit
-    with:
-      skip_tests: ${{ needs.determine_tests.outputs.run_full_testsuite != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: run-additional-tests
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          client-payload: |
+            {
+              "ref": "${{ github.event.pull_request.head.ref }}",
+              "skip_tests": "${{ needs.determine_tests.outputs.run_full_testsuite != 'true' }}"
+            }

--- a/.github/workflows/acceptance_tests_parallel.yml
+++ b/.github/workflows/acceptance_tests_parallel.yml
@@ -1,10 +1,5 @@
 name: Additional Tests
 on:
-  workflow_call:
-    inputs:
-      skip_tests:
-        required: true
-        type: boolean
   repository_dispatch:
     types: [run-additional-tests]
 
@@ -19,7 +14,7 @@ jobs:
     with:
       tests: "22_run_secondary_parallelizable_tests_subset.sh ${{ matrix.set }}"
       server_id: "additional_${{ matrix.set }}"
-      skip_tests: ${{ inputs.skip_tests == true }}
+      skip_tests: ${{ github.event.client_payload.skip_tests == 'true' }}
   scheduled-additional-tests:
     name: Scheduled ${{ matrix.set }}
     if: ${{ github.event_name == 'repository_dispatch' }}

--- a/.github/workflows/acceptance_tests_recommended.yml
+++ b/.github/workflows/acceptance_tests_recommended.yml
@@ -1,13 +1,5 @@
 name: Recommended Tests
 on:
-  workflow_call:
-    inputs:
-      skip_tests:
-        required: true
-        type: boolean
-      recommended_tests:
-        required: true
-        type: string
   repository_dispatch:
     types: [run-recommended-tests]
 
@@ -18,5 +10,5 @@ jobs:
     with:
       tests: "20_run_recommended_tests.sh"
       server_id: "recommended"
-      recommended_tests: ${{ inputs.recommended_tests }}
-      skip_tests: ${{ inputs.skip_tests == true }}
+      recommended_tests: ${{ github.event.client_payload.recommended_tests }}
+      skip_tests: ${{ github.event.client_payload.skip_tests == 'true' }}

--- a/.github/workflows/acceptance_tests_sequential.yml
+++ b/.github/workflows/acceptance_tests_sequential.yml
@@ -1,10 +1,5 @@
 name: Acceptance Tests
 on:
-  workflow_call:
-    inputs:
-      skip_tests:
-        required: true
-        type: boolean
   repository_dispatch:
     types: [run-acceptance-tests]
 
@@ -15,7 +10,7 @@ jobs:
     with:
       tests: "18_run_secondary_tests.sh"
       server_id: "acceptance"
-      skip_tests: ${{ inputs.skip_tests == true }}
+      skip_tests: ${{ github.event.client_payload.skip_tests == 'true' }}
   scheduled-acceptance-tests:
     name: Scheduled 0
     if: ${{ github.event_name == 'repository_dispatch' }}


### PR DESCRIPTION
## What does this PR change?

`acceptance_tests_coordinator.yml` still runs on `pull_request_target` (so it has access to secrets).
But instead of calling workflows directly via `workflow_call` (which would inherit pull_request_target), it triggers `repository_dispatch`.
`repository_dispatch` runs as an event on the forked repository (i.e., PR head branch), NOT the base repo.
Since the actual test workflows (`acceptance_tests_recommended.yml, acceptance_tests_sequential.yml, acceptance_tests_parallel.yml`) now run on `repository_dispatch`, the GitHub runner will execute on the fork, testing the PR code.

## Links

No ports

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed