### PR TITLE
Supportdata add Action Details and API

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionDetails;
 import com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionResult;
 import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptResult;
+import com.redhat.rhn.domain.action.supportdata.SupportDataActionDetails;
 import com.redhat.rhn.domain.audit.XccdfTestResult;
 import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.AppStream;
@@ -336,6 +337,7 @@ public class AnnotationRegistry {
             SslCryptoKey.class,
             StateChange.class,
             StateRevision.class,
+            SupportDataActionDetails.class,
             SUSEProduct.class,
             Task.class,
             TaskoBunch.class,

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -52,6 +52,7 @@ import com.redhat.rhn.domain.action.scap.ScapAction;
 import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.action.supportdata.SupportDataAction;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -370,7 +370,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             </set>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.SupportDataAction" lazy="true" discriminator-value="525" />
+        <subclass name="com.redhat.rhn.domain.action.supportdata.SupportDataAction"
+                  lazy="true" discriminator-value="525" >
+            <one-to-one name="details"
+                        class="com.redhat.rhn.domain.action.supportdata.SupportDataActionDetails"
+                        outer-join="false" cascade="all" property-ref="parentAction"/>
+        </subclass>
 
     </class>
     <query name="Action.findByIdandOrgId">

--- a/java/code/src/com/redhat/rhn/domain/action/supportdata/SupportDataAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/supportdata/SupportDataAction.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.domain.action.supportdata;
+
+import com.redhat.rhn.domain.action.Action;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+/**
+ * SupportDataAction - Class representing TYPE_SUPPORTDATA_GET
+ */
+public class SupportDataAction extends Action {
+
+    private SupportDataActionDetails details;
+
+    public SupportDataActionDetails getDetails() {
+        return details;
+    }
+
+    /**
+     * Sets the details for this SupportDataAction.
+     *
+     * @param detailsIn the Set of SupportDataActionDetails to be set
+     */
+    public void setDetails(SupportDataActionDetails detailsIn) {
+        details = detailsIn;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (this == oIn) {
+            return true;
+        }
+        if (!(oIn instanceof SupportDataAction that)) {
+            return false;
+        }
+        return new EqualsBuilder().appendSuper(super.equals(oIn)).append(details, that.details).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .appendSuper(super.hashCode())
+                .append(details)
+                .toHashCode();
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/action/supportdata/SupportDataActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/supportdata/SupportDataActionDetails.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.domain.action.supportdata;
+
+import com.redhat.rhn.domain.action.ActionChild;
+
+import org.hibernate.annotations.Type;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * SupportDataActionDetails
+ */
+@Entity
+@Table(name = "suseActionSupportDataDetails")
+public class SupportDataActionDetails extends ActionChild {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @Column(name = "case_number", nullable = false)
+    private String caseNumber;
+
+    @Column
+    private String parameter;
+
+    @Column(name = "upload_geo")
+    @Type(type = "com.redhat.rhn.domain.action.supportdata.UploadGeoEnumType")
+    private UploadGeoType geoType;
+
+    /**
+     * @return Returns the id.
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * @param i The id to set.
+     */
+    public void setId(Long i) {
+        this.id = i;
+    }
+
+    /**
+     * @return Returns the case number.
+     */
+    public String getCaseNumber() {
+        return caseNumber;
+    }
+
+    /**
+     * @param n The case number to set.
+     */
+    public void setCaseNumber(String n) {
+        caseNumber = n;
+    }
+
+    /**
+     * @return Returns the parameters.
+     */
+    public String getParameter() {
+        return parameter;
+    }
+
+    /**
+     * @param p The parameter to set.
+     */
+    public void setParameter(String p) {
+        parameter = p;
+    }
+
+    /**
+     * @return Returns the Upload Geo
+     */
+    public UploadGeoType getGeoType() {
+        return geoType;
+    }
+
+    /**
+     * Set the Upload Geo
+     * @param geoTypeIn the upload Geo
+     */
+    public void setGeoType(UploadGeoType geoTypeIn) {
+        geoType = geoTypeIn;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/action/supportdata/UploadGeoEnumType.java
+++ b/java/code/src/com/redhat/rhn/domain/action/supportdata/UploadGeoEnumType.java
@@ -8,12 +8,19 @@
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
  */
+package com.redhat.rhn.domain.action.supportdata;
 
-package com.redhat.rhn.domain.action;
+import com.redhat.rhn.domain.DatabaseEnumType;
 
 /**
- * SupportDataAction - Class representing TYPE_SUPPORTDATA_GET
+ * Maps the {@link UploadGeoType} enum to its label
  */
-public class SupportDataAction extends Action {
+public class UploadGeoEnumType extends DatabaseEnumType<UploadGeoType> {
 
+    /**
+     * Default Constructor
+     */
+    public UploadGeoEnumType() {
+        super(UploadGeoType.class);
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/supportdata/UploadGeoType.java
+++ b/java/code/src/com/redhat/rhn/domain/action/supportdata/UploadGeoType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.domain.action.supportdata;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.Labeled;
+
+public enum UploadGeoType implements Labeled {
+    EU,
+    US;
+
+    @Override
+    public String getLabel() {
+        return this.name().toLowerCase();
+    }
+
+    public String getDescription() {
+        return LocalizationService.getInstance().getMessage("supportdata.uploadGeoType." + this.name().toLowerCase());
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9169,6 +9169,12 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="hub.unable_to_deregister" xml:space="preserve">
         <source>Unable to deregister: an unexpected error is occurred while contacting the remote server. Please check the server logs.</source>
       </trans-unit>
+      <trans-unit id="supportdata.uploadGeoType.eu" xml:space="preserve">
+        <source>EU</source>
+      </trans-unit>
+      <trans-unit id="supportdata.uploadGeoType.us" xml:space="preserve">
+        <source>US</source>
+      </trans-unit>
       <trans-unit id="cveaudit.nav.title" xml:space="preserve">
         <source>CVE Audit</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -46,6 +46,8 @@ import com.redhat.rhn.domain.action.script.ScriptResult;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.server.test.ServerActionTest;
+import com.redhat.rhn.domain.action.supportdata.SupportDataAction;
+import com.redhat.rhn.domain.action.supportdata.SupportDataActionDetails;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFamily;
@@ -239,6 +241,24 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
+    }
+
+    @Test
+    public void testCreateSupportdataAction() throws Exception {
+        Server server = ServerFactoryTest.createTestServer(admin, true);
+
+        Integer aid = handler.scheduleSupportDataUpload(admin, server.getId().intValue(),
+                "012345", "-i LVM", "EU", getNow());
+        assertNotNull(aid);
+
+        Action action = ActionFactory.lookupById(Long.valueOf(aid));
+        assertEquals(ActionFactory.TYPE_SUPPORTDATA_GET, action.getActionType());
+        assertEquals("Get and Upload Support data", action.getName());
+        SupportDataActionDetails details = ((SupportDataAction) action).getDetails();
+        assertNotNull(details);
+        assertEquals("012345", details.getCaseNumber());
+        assertEquals("-i LVM", details.getParameter());
+        assertEquals("EU", details.getGeoType().name());
     }
 
     @Test

--- a/java/spacewalk-java.changes.mcalmer.supportdata-db-2
+++ b/java/spacewalk-java.changes.mcalmer.supportdata-db-2
@@ -1,0 +1,1 @@
+- Implement API to get and upload support data to SCC

--- a/schema/spacewalk/common/tables/suseActionSupportDataDetails.sql
+++ b/schema/spacewalk/common/tables/suseActionSupportDataDetails.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+CREATE TABLE suseActionSupportDataDetails (
+    id                  BIGINT CONSTRAINT suse_act_suppdata_id_pk PRIMARY KEY
+                        GENERATED ALWAYS AS IDENTITY,
+    action_id           NUMERIC NOT NULL
+                        CONSTRAINT suse_act_suppdata_act_fk
+                        REFERENCES rhnAction (id) ON DELETE CASCADE,
+    case_number         VARCHAR NOT NULL,
+    parameter           VARCHAR NULL,
+    upload_geo          upload_geo_t NOT NULL,
+    created             TIMESTAMPTZ
+                            DEFAULT (current_timestamp) NOT NULL,
+    modified            TIMESTAMPTZ
+                            DEFAULT (current_timestamp) NOT NULL
+);
+
+CREATE INDEX suse_act_suppdata_aid_idx ON suseActionSupportDataDetails (action_id);

--- a/schema/spacewalk/common/tables/tables.deps
+++ b/schema/spacewalk/common/tables/tables.deps
@@ -299,6 +299,7 @@ suseRecurringAction                :: web_customer web_contact rhnServerGroup su
 suseAnsiblePath                    :: rhnServer
 rhnActionPlaybook                  :: rhnAction
 susePaygDimensionResult            :: billing_dimension_t susePaygDimensionComputation
+suseActionSupportDataDetails       :: upload_geo_t rhnAction
 suseAppstream                      :: rhnChannel
 suseAppstreamPackage               :: suseAppstream rhnPackage
 suseAppstreamApi                   :: suseAppstream

--- a/schema/spacewalk/postgres/class/upload_geo_t.sql
+++ b/schema/spacewalk/postgres/class/upload_geo_t.sql
@@ -1,0 +1,15 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TYPE upload_geo_t AS ENUM (
+    'eu',
+    'us'
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.5-to-susemanager-schema-5.1.6/002-supportdata-action-details.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.5-to-susemanager-schema-5.1.6/002-supportdata-action-details.sql
@@ -1,0 +1,40 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'upload_geo_t') THEN
+        CREATE TYPE upload_geo_t AS ENUM (
+           'eu',
+           'us'
+        );
+    ELSE
+	RAISE NOTICE 'type "upload_geo_t" already exists, skipping';
+    END IF;
+END $$;
+
+
+CREATE TABLE IF NOT EXISTS suseActionSupportDataDetails (
+    id                  BIGINT CONSTRAINT suse_act_suppdata_id_pk PRIMARY KEY
+                        GENERATED ALWAYS AS IDENTITY,
+    action_id           NUMERIC NOT NULL
+                        CONSTRAINT suse_act_suppdata_act_fk
+                        REFERENCES rhnAction (id) ON DELETE CASCADE,
+    case_number         VARCHAR NOT NULL,
+    parameter           VARCHAR NULL,
+    upload_geo          upload_geo_t NOT NULL,
+    created             TIMESTAMPTZ
+                            DEFAULT (current_timestamp) NOT NULL,
+    modified            TIMESTAMPTZ
+                            DEFAULT (current_timestamp) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS suse_act_suppdata_aid_idx
+ON suseActionSupportDataDetails (action_id);


### PR DESCRIPTION
## What does this PR change?

We need additional parameter for the support data action. This PR add Action Details to store the case number and additional parameter which can be used at execution time.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Part of an extra issue

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26621

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
