### PR TITLE
Catch when web session instance is nil

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -148,12 +148,19 @@ After do |scenario|
       print_server_logs
     end
   end
-  page.instance_variable_set(:@touched, false) if Capybara::Session.instance_created?
+  page.instance_variable_set(:@touched, false) if capybara_session_created?
 end
 
-# Test is web session is open
+# Test if capybara session instance was created
+def capybara_session_created?
+  return false if Capybara::Session.nil?
+
+  Capybara::Session.instance_created?
+end
+
+# Test if web session is open
 def web_session_is_active?
-  return false unless Capybara::Session.instance_created?
+  return false unless capybara_session_created?
 
   page.has_selector?('header') || page.has_selector?('#username-field')
 end
@@ -241,7 +248,7 @@ After('@scope_cobbler') do |scenario|
 end
 
 AfterStep do
-  next unless Capybara::Session.instance_created?
+  next unless capybara_session_created?
 
   log 'Timeout: Waiting AJAX transition' if has_css?('.senna-loading', wait: 0) && !has_no_css?('.senna-loading', wait: 30)
 end


### PR DESCRIPTION
## What does this PR change?

This PR manages the case where Capybara::Session is nil .

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Port(s):
 * 5.0: https://github.com/SUSE/spacewalk/pull/26764
 * 4.3: https://github.com/SUSE/spacewalk/pull/26765

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
