### PR TITLE
bring back the virtpoller beacon

### DIFF
--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -83,7 +83,7 @@ public class GlobalInstanceHolder {
             new SSHMinionBootstrapper(SYSTEM_QUERY, SALT_API, PAYG_MANAGER, ATTESTATION_MANAGER);
     public static final MonitoringManager MONITORING_MANAGER = new FormulaMonitoringManager(SALT_API);
     public static final SystemEntitlementManager SYSTEM_ENTITLEMENT_MANAGER = new SystemEntitlementManager(
-            new SystemUnentitler(MONITORING_MANAGER, SERVER_GROUP_MANAGER),
+            new SystemUnentitler(SALT_API, MONITORING_MANAGER, SERVER_GROUP_MANAGER),
             new SystemEntitler(SALT_API, MONITORING_MANAGER,
                     SERVER_GROUP_MANAGER)
     );

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -237,6 +237,10 @@ public class ConfigDefaults {
 
     public static final String CVE_AUDIT_ENABLE_OVAL_METADATA = "java.cve_audit.enable_oval_metadata";
 
+    public static final String VIRTPOLLER_CACHE_EXPIRATION = "server.susemanager.virtpoller.expire_time";
+    public static final String VIRTPOLLER_CACHE_FILE = "server.susemanager.virtpoller.cache_file";
+    public static final String VIRTPOLLER_INTERVAL = "server.susemanager.virtpoller.interval";
+
     /**
      * Token lifetime in seconds
      */

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -69,7 +69,7 @@ public class AccessTest extends BaseTestCaseWithUser {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -50,7 +50,7 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -45,7 +45,7 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -46,7 +46,7 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/PeripheralServerEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/PeripheralServerEntitlementTest.java
@@ -48,7 +48,7 @@ public class PeripheralServerEntitlementTest extends BaseEntitlementTestCase {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -48,7 +48,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -108,7 +108,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -155,7 +155,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     );
     private static final MonitoringManager MONITORING_MANAGER = new FormulaMonitoringManager(SALT_API);
     private static final SystemEntitlementManager SYSTEM_ENTITLEMENT_MANAGER = new SystemEntitlementManager(
-            new SystemUnentitler(MONITORING_MANAGER, SERVER_GROUP_MANAGER),
+            new SystemUnentitler(SALT_API, MONITORING_MANAGER, SERVER_GROUP_MANAGER),
             new SystemEntitler(SALT_API, MONITORING_MANAGER, SERVER_GROUP_MANAGER)
     );
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -70,7 +70,7 @@ public class ServerTest extends BaseTestCaseWithUser {
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
-    private final SystemUnentitler systemUnentitler = new SystemUnentitler(
+    private final SystemUnentitler systemUnentitler = new SystemUnentitler(saltApi,
             monitoringManager, serverGroupManager);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             systemUnentitler, new SystemEntitler(saltApi, monitoringManager, serverGroupManager)

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -72,7 +72,7 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
@@ -81,7 +81,7 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltServiceMock);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltServiceMock, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltServiceMock, monitoringManager, serverGroupManager)
         );
         context.checking(new Expectations() {{

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -64,7 +64,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -65,7 +65,7 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -62,7 +62,7 @@ public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/AdminConfigurationHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/configuration/test/AdminConfigurationHandlerTest.java
@@ -108,7 +108,7 @@ public class AdminConfigurationHandlerTest extends BaseHandlerTestCase {
     );
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
     private SystemManager systemManager =

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
@@ -325,7 +325,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager groupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager entitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, groupManager),
+                new SystemUnentitler(saltApi, monitoringManager, groupManager),
                 new SystemEntitler(saltApi, monitoringManager, groupManager)
         );
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -123,7 +123,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     );
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
     private SystemManager systemManager =

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -114,7 +114,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltServiceMock);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltServiceMock, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltServiceMock, monitoringManager, serverGroupManager)
         );
         handler = new ImageInfoHandler(saltServiceMock);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerProvisioningTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerProvisioningTest.java
@@ -96,7 +96,7 @@ public class SystemHandlerProvisioningTest extends BaseHandlerTestCase {
         private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
         private final SystemManager systemManager =

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerPtfTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerPtfTest.java
@@ -116,7 +116,7 @@ public class SystemHandlerPtfTest extends BaseHandlerTestCase {
         ServerGroupManager groupManager = new ServerGroupManager(saltApi);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
 
-        SystemUnentitler unentitler = new SystemUnentitler(monitoringManager, groupManager);
+        SystemUnentitler unentitler = new SystemUnentitler(saltApi, monitoringManager, groupManager);
         SystemEntitler entitler = new SystemEntitler(saltApi, monitoringManager, groupManager);
 
         SystemEntitlementManager entitlementManager = new SystemEntitlementManager(unentitler, entitler);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -220,7 +220,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
     private SystemManager systemManager =

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -152,7 +152,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
     private final SystemManager systemManager =

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -100,7 +100,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
     private final CloudPaygManager paygManager = new TestCloudPaygManagerBuilder().build();

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -75,7 +75,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
     );
     private final MigrationManager migrationManager = new MigrationManager(serverGroupManager);

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -207,7 +207,7 @@ public class SystemManager extends BaseManager {
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApiIn);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApiIn, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApiIn, monitoringManager, serverGroupManager)
         );
     }

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
@@ -38,9 +38,9 @@ import java.util.stream.Collectors;
  */
 public class VirtualInstanceManager extends BaseManager {
 
-    public static final String EVENT_TYPE_FULLREPORT = "fullreport";
-    public static final String EVENT_TYPE_EXISTS = "exists";
-    public static final String EVENT_TYPE_REMOVED = "removed";
+    private static final String EVENT_TYPE_FULLREPORT = "fullreport";
+    private static final String EVENT_TYPE_EXISTS = "exists";
+    private static final String EVENT_TYPE_REMOVED = "removed";
 
     /**
      * Logger for this class

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -62,7 +62,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltServiceMock);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltServiceMock, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltServiceMock, monitoringManager, serverGroupManager)
         );
         context().checking(new Expectations() {{

--- a/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
@@ -465,7 +465,7 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager groupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager entitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, groupManager),
+                new SystemUnentitler(saltApi, monitoringManager, groupManager),
                 new SystemEntitler(saltApi, monitoringManager, groupManager)
         );
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -222,7 +222,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
         this.systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltServiceMock);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/test/PaygComputeDimensionsTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/test/PaygComputeDimensionsTaskTest.java
@@ -75,7 +75,7 @@ public class PaygComputeDimensionsTaskTest extends JMockBaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
 
         systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
             new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
     }

--- a/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
@@ -231,7 +231,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager sysEntMgr = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -111,7 +111,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -45,6 +45,8 @@ import com.suse.manager.reactor.messaging.RunnableEventMessage;
 import com.suse.manager.reactor.messaging.RunnableEventMessageAction;
 import com.suse.manager.reactor.messaging.SystemIdGenerateEventMessage;
 import com.suse.manager.reactor.messaging.SystemIdGenerateEventMessageAction;
+import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessage;
+import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessageAction;
 import com.suse.manager.saltboot.PXEEvent;
 import com.suse.manager.saltboot.PXEEventMessage;
 import com.suse.manager.saltboot.PXEEventMessageAction;
@@ -56,6 +58,7 @@ import com.suse.manager.webui.utils.salt.custom.ImageDeployedEvent;
 import com.suse.manager.webui.utils.salt.custom.ImageSyncedEvent;
 import com.suse.manager.webui.utils.salt.custom.MinionStartupGrains;
 import com.suse.manager.webui.utils.salt.custom.SystemIdGenerateEvent;
+import com.suse.manager.webui.utils.salt.custom.VirtpollerData;
 import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.event.BatchStartedEvent;
 import com.suse.salt.netapi.event.BeaconEvent;
@@ -128,6 +131,8 @@ public class SaltReactor {
                 RefreshGeneratedSaltFilesEventMessage.class);
         MessageQueue.registerAction(new RunnableEventMessageAction(),
                 RunnableEventMessage.class);
+        MessageQueue.registerAction(new VirtpollerBeaconEventMessageAction(),
+                VirtpollerBeaconEventMessage.class);
         MessageQueue.registerAction(new SystemIdGenerateEventMessageAction(systemQuery),
                 SystemIdGenerateEventMessage.class);
         MessageQueue.registerAction(new ImageDeployedEventMessageAction(systemQuery),
@@ -293,6 +298,12 @@ public class SaltReactor {
                     SystemManager.updateSystemOverview(m);
                 }
             );
+        }
+        else if (beaconEvent.getBeacon().equals("virtpoller")) {
+            return of(new VirtpollerBeaconEventMessage(
+                beaconEvent.getMinionId(),
+                beaconEvent.getData(VirtpollerData.class)
+            ));
         }
         return empty();
     }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -135,7 +135,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager groupManager = new ServerGroupManager(saltApi);
         entitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, groupManager),
+                new SystemUnentitler(saltApi, monitoringManager, groupManager),
                 new SystemEntitler(saltApi, monitoringManager, groupManager)
         );
     }

--- a/java/code/src/com/suse/manager/reactor/messaging/VirtpollerBeaconEventMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/VirtpollerBeaconEventMessage.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.reactor.messaging;
+
+import com.redhat.rhn.common.messaging.EventMessage;
+
+import com.suse.manager.webui.utils.salt.custom.VirtpollerData;
+
+/**
+ * Virtpoller Beacon Event message to handle
+ */
+public class VirtpollerBeaconEventMessage implements EventMessage {
+
+    private final VirtpollerData data;
+
+    private final String minionId;
+
+    /**
+     * Constructor
+     *
+     * @param minionIdIn the minionId
+     * @param dataIn the virtpoller data from salt
+     */
+    public VirtpollerBeaconEventMessage(String minionIdIn, VirtpollerData dataIn) {
+        minionId = minionIdIn;
+        data = dataIn;
+    }
+
+    /**
+     * @return the minionId
+     */
+    public String getMinionId() {
+        return minionId;
+    }
+
+    /**
+     * @return the virtpoller data from salt
+     */
+    public VirtpollerData getVirtpollerData() {
+        return data;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toText() {
+        return toString();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Long getUserId() {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "VirtpollerBeaconEventMessage[minionId: " + minionId + "]";
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/VirtpollerBeaconEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/VirtpollerBeaconEventMessageAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.reactor.messaging;
+
+import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
+import com.redhat.rhn.domain.server.MinionServerFactory;
+import com.redhat.rhn.domain.server.VirtualInstanceFactory;
+import com.redhat.rhn.manager.system.VirtualInstanceManager;
+
+/**
+ * Virtpoller Beacon Event Action Handler
+ */
+public class VirtpollerBeaconEventMessageAction implements MessageAction {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(EventMessage msg) {
+        VirtpollerBeaconEventMessage vMsg = (VirtpollerBeaconEventMessage) msg;
+
+        MinionServerFactory.findByMinionId(vMsg.getMinionId()).ifPresent(minion -> {
+            VirtualInstanceManager.updateHostVirtualInstance(minion,
+                    VirtualInstanceFactory.getInstance().getFullyVirtType());
+            VirtualInstanceManager.updateGuestsVirtualInstances(minion,
+                    vMsg.getVirtpollerData().getPlan());
+        });
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -160,7 +160,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltServiceMock);
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltServiceMock);
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltServiceMock, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltServiceMock, monitoringManager, serverGroupManager)
         );
         saltUtils = new SaltUtils(saltServiceMock, saltServiceMock);

--- a/java/code/src/com/suse/manager/webui/controllers/test/SystemsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/SystemsControllerTest.java
@@ -84,7 +84,7 @@ public class SystemsControllerTest extends BaseControllerTestCase {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(new TestSaltApi(), monitoringManager, serverGroupManager),
                 new SystemEntitler(new TestSaltApi(), monitoringManager, serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionVirtualizationPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionVirtualizationPillarGenerator.java
@@ -14,9 +14,16 @@
  */
 package com.suse.manager.webui.services.pillar;
 
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Pillar;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -24,8 +31,16 @@ import java.util.Optional;
  */
 public class MinionVirtualizationPillarGenerator extends MinionPillarGeneratorBase {
 
+    private static final Logger LOG = LogManager.getLogger(MinionVirtualizationPillarGenerator.class);
     public static final MinionVirtualizationPillarGenerator INSTANCE = new MinionVirtualizationPillarGenerator();
+    private static final Map<String, Object> VIRTPOLLER_BEACON_PROPS = new HashMap<>();
+    public static final String CATEGORY = "virtualization";
 
+    static {
+        VIRTPOLLER_BEACON_PROPS.put("cache_file", Config.get().getString(ConfigDefaults.VIRTPOLLER_CACHE_FILE));
+        VIRTPOLLER_BEACON_PROPS.put("expire_time", Config.get().getInt(ConfigDefaults.VIRTPOLLER_CACHE_EXPIRATION));
+        VIRTPOLLER_BEACON_PROPS.put("interval", Config.get().getInt(ConfigDefaults.VIRTPOLLER_INTERVAL));
+    }
 
     /**
      * Generates pillar activating the virtpoller on a virtualization host
@@ -34,14 +49,32 @@ public class MinionVirtualizationPillarGenerator extends MinionPillarGeneratorBa
      */
     @Override
     public Optional<Pillar> generatePillarData(MinionServer minion) {
-        // The virtpoller pillar data used to be created on minions in the past.
-        // We want to ensure those are not lingering around.
-        removePillar(minion);
-        return Optional.empty();
+        LOG.debug("Generating virtualization pillar file for minion: {}", minion.getMinionId());
+
+        Pillar pillar = null;
+        if (minion.hasVirtualizationEntitlement()) {
+
+            pillar = minion.getPillarByCategory(CATEGORY).orElseGet(() -> {
+                Pillar newPillar = new Pillar(CATEGORY, new HashMap<>(), minion);
+                minion.getPillars().add(newPillar);
+                return newPillar;
+            });
+            pillar.getPillar().clear();
+
+            // this add the configuration for the beacon that tell us about
+            // virtual guests running on that minion
+            // The virtpoller is still usefull with the libvirt events: it will help
+            // synchronizing the DB with the actual guest lists in case we had a temporary shutdown.
+            Map<String, Object> beaconConfig = new HashMap<>();
+            beaconConfig.put("virtpoller", VIRTPOLLER_BEACON_PROPS);
+            pillar.add("beacons", beaconConfig);
+        }
+
+        return Optional.ofNullable(pillar);
     }
 
     @Override
     public String getCategory() {
-        return "virtualization";
+        return CATEGORY;
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -243,7 +243,7 @@ public class TestSaltApi implements SaltApi {
 
     @Override
     public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
-        throw new UnsupportedOperationException();
+        return Optional.empty();
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/VirtpollerData.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/VirtpollerData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.salt.custom;
+
+import java.util.List;
+
+/**
+ * Data object for virtpoller
+ */
+public class VirtpollerData {
+
+    private final List<VmInfo> plan;
+
+    /**
+     * Constructor
+     *
+     * @param planIn the plan
+     */
+    public VirtpollerData(List<VmInfo> planIn) {
+        this.plan = planIn;
+    }
+
+    /**
+     * @return the plan
+     */
+    public List<VmInfo> getPlan() {
+        return plan;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/VmInfo.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/VmInfo.java
@@ -17,7 +17,7 @@ package com.suse.manager.webui.utils.salt.custom;
 import com.google.gson.annotations.SerializedName;
 
 /**
- * Represent VM info needed to update the database
+ * Represent VM info returned from the virtpoller beacon
  */
 public class VmInfo {
 

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
@@ -340,7 +340,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager sysEntMgr = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
 
@@ -429,7 +429,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager sysEntMgr = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
 
@@ -527,7 +527,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         MonitoringManager monitoringManager = new FormulaMonitoringManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
         SystemEntitlementManager sysEntMgr = new SystemEntitlementManager(
-                new SystemUnentitler(monitoringManager, serverGroupManager),
+                new SystemUnentitler(saltApi, monitoringManager, serverGroupManager),
                 new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
         );
 

--- a/java/spacewalk-java.changes.mcalmer.bring-back-virtpoller-beacon
+++ b/java/spacewalk-java.changes.mcalmer.bring-back-virtpoller-beacon
@@ -1,0 +1,2 @@
+- Add virtpoller beacon again to provide information about
+  Virtual host to guest relation

--- a/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/engine-events.sls
@@ -1,0 +1,22 @@
+{% if pillar['virt_entitled'] %}
+{% set minion_config_dir = salt["config.get"]("config_dir") %}
+{{ minion_config_dir }}/minion.d/libvirt-events.conf:
+  file.managed:
+    - contents: |
+        engines:
+          - libvirt_events:
+              filters:
+                - domain/lifecycle
+                - pool/lifecycle
+                - pool/refresh
+                - network/lifecycle
+
+/var/cache/virt_state.cache:
+  file.absent
+
+{% else %}
+
+{{ minion_config_dir }}/minion.d/libvirt-events.conf:
+  file.absent
+
+{% endif %}

--- a/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/virtpoller.py
@@ -1,0 +1,398 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2008--2014 Red Hat, Inc.
+# Copyright (c) 2016 SUSE LLC
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+#
+# Red Hat trademarks are not licensed under GPLv2. No permission is
+# granted to use or replicate Red Hat trademarks that are incorporated
+# in this software or its documentation.
+#
+'''
+Watch libvirt and fire events with changes to virtual machines
+
+Author: Michael Calmer <mc@suse.com>
+'''
+
+from __future__ import absolute_import
+import sys
+import os
+import logging
+log = logging.getLogger(__name__)
+
+try:
+    import libvirt  # pylint: disable=import-error
+    from libvirt import libvirtError
+    HAS_LIBVIRT = True
+except ImportError:
+    HAS_LIBVIRT = False
+    libvirt = None
+
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+import time
+import traceback
+import binascii
+
+CACHE_DATA_PATH = '/var/cache/virt_state.cache'
+CACHE_EXPIRE_SECS = 60 * 60 * 6   # 6 hours, in seconds
+
+##
+# This structure maps the libvirt state enumeration to labels that
+# SUSE Manager understands.
+# Reasons we don't care about differences between NOSTATE, RUNNING and BLOCKED:
+# 1. technically, the domain is still "running"
+# 2. RHN Classic / Red Hat Satellite / Spacewalk are not able to
+# display 'blocked' & 'nostate'
+#    as valid states
+# 3. to avoid 'Abuse of Service' messages: bugs #230106 and #546676
+
+VIRT_STATE_NAME_MAP = ( 'running',  # VIR_DOMAIN_NOSTATE
+                        'running',  # VIR_DOMAIN_RUNNING
+                        'running',  # VIR_DOMAIN_BLOCKED
+                        'paused',   # VIR_DOMAIN_PAUSED
+                        'stopped',  # VIR_DOMAIN_SHUTDOWN
+                        'stopped',  # VIR_DOMAIN_SHUTOFF
+                        'crashed')  # VIR_DOMAIN_CRASHED
+
+class EventType:
+    EXISTS      = 'exists'
+    REMOVED     = 'removed'
+    FULLREPORT  = 'fullreport'
+
+class TargetType:
+    SYSTEM      = 'system'
+    DOMAIN      = 'domain'
+
+class VirtualizationType:
+    PARA  = 'para_virtualized'
+    FULLY = 'fully_virtualized'
+
+class PropertyType:
+    NAME        = 'name'
+    UUID        = 'uuid'
+    TYPE        = 'virt_type'
+    MEMORY      = 'memory_size'
+    VCPUS       = 'vcpus'
+    STATE       = 'state'
+    IDENTITY    = 'identity'
+    ID          = 'id'
+    MESSAGE     = 'message'
+
+__virtualname__ = 'virtpoller'
+
+
+###############################################################################
+# PollerStateCache Class
+###############################################################################
+
+class PollerStateCache:
+
+    ###########################################################################
+    # Public Interface
+    ###########################################################################
+
+    def __init__(self, domain_data, cache_file = CACHE_DATA_PATH,
+            expire_time = CACHE_EXPIRE_SECS):
+        """
+        This method creates a new poller state based on the provided domain
+        list.  The domain_data list should be in the form returned from
+        poller.poll_hypervisor.  That is,
+
+             { uuid : { 'name'        : '...',
+                        'uuid'        : '...',
+                        'virt_type'   : '...',
+                        'memory_size' : '...',
+                        'vcpus'       : '...',
+                        'state'       : '...' }, ... }
+        """
+        self.__expire_time = expire_time
+        self.__cache_file = cache_file
+
+        # Start by loading the old state, if necessary.
+        self._load_state()
+        self.__new_domain_data = domain_data
+
+        # Now compare the given domain_data against the one loaded in the old
+        # state.
+        self._compare_domain_data()
+
+        log.debug("Added: %s"    % repr(self.__added))
+        log.debug("Removed: %s"  % repr(self.__removed))
+        log.debug("Modified: %s" % repr(self.__modified))
+
+    def save(self):
+        """
+        Updates the cache on disk with the latest domain data.
+        """
+        self._save_state()
+
+    def is_expired(self):
+        """
+        Returns true if this cache is expired.
+        """
+        if self.__expire_time is None:
+            return False
+        else:
+            return int(time.time()) >= self.__expire_time
+
+    def is_changed(self):
+        return self.__added or self.__removed or self.__modified
+
+    def get_added(self):
+        """
+        Returns a list of uuids for each domain that has been added since the
+        last state poll.
+        """
+        return self.__added
+
+    def get_modified(self):
+        """
+        Returns a list of uuids for each domain that has been modified since
+        the last state poll.
+        """
+        return self.__modified
+
+    def get_removed(self):
+        """
+        Returns a list of uuids for each domain that has been removed since
+        the last state poll.
+        """
+        return self.__removed
+
+    ###########################################################################
+    # Helper Methods
+    ###########################################################################
+
+    def _load_state(self):
+        """
+        Loads the last hypervisor state from disk.
+        """
+        # Attempt to open up the cache file.
+        cache_file = None
+        try:
+            cache_file = open(self.__cache_file, 'rb')
+        except IOError as ioe:
+            # Couldn't open the cache file.  That's ok, there might not be one.
+            # We'll only complain if debugging is enabled.
+            log.debug("Could not open cache file '{0}': {1}".format(
+                self.__cache_file, str(ioe)))
+
+        # Now, if a previous state was cached, load it.
+        state = {}
+        if cache_file:
+            try:
+                state = pickle.load(cache_file)
+            except pickle.PickleError as pe:
+                # Strange.  Possibly, the file is corrupt.  We'll load an empty
+                # state instead.
+                log.debug("Error occurred while loading state: {0}".format(str(pe)))
+            except EOFError:
+                log.debug("Unexpected EOF. Probably an empty file.")
+                cache_file.close()
+
+            cache_file.close()
+
+        if state:
+            log.debug("Loaded state: {0}".format(repr(state)))
+
+            self.__expire_time = int(state['expire_time'])
+
+            # If the cache is expired, set the old data to None so we force
+            # a refresh.
+            if self.is_expired():
+                self.__old_domain_data = None
+                os.unlink(self.__cache_file)
+            else:
+                self.__old_domain_data = state['domain_data']
+
+        else:
+            self.__old_domain_data = None
+            self.__expire_time     = None
+
+    def _save_state(self):
+        """
+        Saves the given polling state to disk.
+        """
+        # First, ensure that the proper parent directory is created.
+        cache_dir_path = os.path.dirname(self.__cache_file)
+        if not os.path.exists(cache_dir_path):
+            os.makedirs(cache_dir_path, 0o700)
+
+        state = {}
+        state['domain_data'] = self.__new_domain_data
+        if self.__expire_time is None or self.is_expired():
+            state['expire_time'] = int(time.time()) + CACHE_EXPIRE_SECS
+        else:
+            state['expire_time'] = self.__expire_time
+
+        # Now attempt to open the file for writing.  We'll just overwrite
+        # whatever's already there.  Also, let any exceptions bounce out.
+        cache_file = open(self.__cache_file, "wb")
+        pickle.dump(state, cache_file)
+        cache_file.close()
+
+    def _compare_domain_data(self):
+        """
+        Compares the old domain_data to the new domain_data.  Returns a tuple
+        of lists, relative to the new domain_data:
+
+            (added, removed, modified)
+        """
+        self.__added    = {}
+        self.__removed  = {}
+        self.__modified = {}
+
+        # First, figure out the modified and added uuids.
+        if self.__new_domain_data:
+            for (uuid, new_properties) in list(self.__new_domain_data.items()):
+                if not self.__old_domain_data or \
+                    uuid not in self.__old_domain_data:
+
+                    self.__added[uuid] = self.__new_domain_data[uuid]
+                else:
+                    old_properties = self.__old_domain_data[uuid]
+                    if old_properties != new_properties:
+                        self.__modified[uuid] = self.__new_domain_data[uuid]
+
+        # Now, figure out the removed uuids.
+        if self.__old_domain_data:
+            for uuid in list(self.__old_domain_data.keys()):
+                if not self.__new_domain_data or \
+                    uuid not in self.__new_domain_data:
+
+                    self.__removed[uuid] = self.__old_domain_data[uuid]
+
+
+###############################################################################
+### beacon                                                                  ###
+###############################################################################
+
+def __virtual__():
+    return HAS_LIBVIRT and __virtualname__ or False
+
+
+def validate(config):
+    '''
+    Validate the beacon configuration.
+    '''
+    if not isinstance(config, dict):
+        return False, ('Configuration for virtpoller '
+                       'beacon must be a dictionary.')
+    else:
+        return True, 'Configuration validated'
+
+
+def beacon(config):
+    '''
+    polls the hypervisor for information about the currently
+    running set of domains.
+
+    Example Config
+
+    .. code-block:: yaml
+
+        beacons:
+          virtpoller:
+            expire_time: 21600
+            cache_file: '/var/cache/virt_state.cache'
+            interval: 320
+    '''
+
+    ret = []
+
+    if not libvirt:
+        log.trace("no libvirt")
+        return ret
+
+    try:
+        conn = libvirt.openReadOnly(None)
+    except libvirt.libvirtError as lve:
+        log.error("Warning: Could not retrieve virtualization information! libvirtd service needs to be running.")
+        conn = None
+
+    if not conn:
+        # No connection to hypervisor made
+        return ret
+
+    domains = conn.listAllDomains(0)
+
+    state = {}
+    for domain in domains:
+        uuid = binascii.hexlify(domain.UUID())
+        # SEE: http://libvirt.org/html/libvirt-libvirt.html#virDomainInfo
+        # for more info.
+        domain_info = domain.info()
+
+        # Set the virtualization type.  We can tell if the domain is fully virt
+        # by checking the domain's OSType() attribute.
+        virt_type = VirtualizationType.PARA
+        if domain.OSType().lower() == 'hvm':
+            virt_type = VirtualizationType.FULLY
+
+        # we need to filter out the small per/minute KB changes
+        # that occur inside a vm.  To do this we divide by 1024 to
+        # drop our precision down to megabytes with an int then
+        # back up to KB
+        memory = int(domain_info[2] / 1024);
+        memory = memory * 1024;
+        properties = {
+            PropertyType.NAME   : domain.name(),
+            PropertyType.UUID   : uuid,
+            PropertyType.TYPE   : virt_type,
+            PropertyType.MEMORY : str(memory), # current memory
+            PropertyType.VCPUS  : domain_info[3],
+            PropertyType.STATE  : VIRT_STATE_NAME_MAP[domain_info[0]] }
+
+        state[uuid] = properties
+
+    poller_state = PollerStateCache(state,
+                                    cache_file = config.get('cache_file', CACHE_DATA_PATH),
+                                    expire_time = config.get('expire_time', CACHE_EXPIRE_SECS))
+
+    plan = []
+    if poller_state.is_changed():
+        added    = poller_state.get_added()
+        removed  = poller_state.get_removed()
+        modified = poller_state.get_modified()
+
+        if poller_state.is_expired():
+            item = {'time': int(time.time()),
+                    'event_type': EventType.FULLREPORT,
+                    'target_type': TargetType.DOMAIN }
+            plan.append(item)
+
+        for (uuid, data) in list(added.items()):
+            item = {'time': int(time.time()),
+                    'event_type': EventType.EXISTS,
+                    'target_type': TargetType.DOMAIN,
+                    'guest_properties': data}
+            plan.append(item)
+
+        for (uuid, data) in list(modified.items()):
+            item = {'time': int(time.time()),
+                    'event_type': EventType.EXISTS,
+                    'target_type': TargetType.DOMAIN,
+                    'guest_properties': data}
+            plan.append(item)
+
+        for (uuid, data) in list(removed.items()):
+            item = {'time': int(time.time()),
+                    'event_type': EventType.REMOVED,
+                    'target_type': TargetType.DOMAIN,
+                    'guest_properties': data}
+            plan.append(item)
+
+    poller_state.save()
+    if len(plan) > 0:
+        ret.append({'plan': plan})
+    return ret

--- a/susemanager-utils/susemanager-sls/src/tests/test_beacon_virtpoller.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_beacon_virtpoller.py
@@ -1,0 +1,167 @@
+'''
+Author: Michael Calmer <mc@suse.com>
+'''
+import sys
+import os
+import shutil
+from mock import MagicMock, patch
+sys.modules['libvirt'] = MagicMock()
+from ..beacons import virtpoller
+
+virtpoller.__context__ = dict()
+
+CACHE_FILE = '/tmp/virt_state-test.cache'
+
+def test_virtual():
+    '''
+    Test virtual function.
+    '''
+    #with patch(virtpoller.HAS_LIBVIRT, True):
+    assert virtpoller.__virtual__() == virtpoller.__virtualname__
+
+
+def test_validate():
+    '''
+    Test validate() function
+    '''
+    res, msg = virtpoller.validate({'cache_file': '/bogus/path',
+                                    'expire_time': 2})
+    assert res is True
+    assert msg == 'Configuration validated'
+
+
+def test_beacon():
+    '''
+    Test beacon functionality.
+    First run without cache file. All systems are "new" and should be reported.
+    '''
+    domain = MagicMock()
+    domain.info = MagicMock(name='info')
+    domain.info.return_value = [0, 1024, 1024, 2, 30]
+    domain.name = MagicMock(name='name')
+    domain.name.return_value = 'testvm'
+
+    conn = MagicMock()
+    conn.listAllDomains = MagicMock(name='listAllDomains')
+    conn.listAllDomains.return_value = [domain]
+
+    if os.path.exists(CACHE_FILE):
+        os.unlink(CACHE_FILE)
+
+    with patch.object(virtpoller, 'libvirt', MagicMock(return_value=True)):
+        with patch.object(virtpoller.libvirt, 'openReadOnly', MagicMock(return_value=conn)):
+            with patch.object(virtpoller.binascii, 'hexlify', MagicMock(return_value=5)):
+                ret = virtpoller.beacon({'cache_file': CACHE_FILE,
+                                         'expire_time': 2})
+    assert isinstance(ret, list)
+    assert isinstance(ret[0], dict)
+    assert sorted(ret[0].keys()) == ['plan']
+    assert ret[0]['plan'][0]['event_type'] == 'exists'
+    assert 'guest_properties' in ret[0]['plan'][0]
+    data = ret[0]['plan'][0]['guest_properties']
+    assert data['name'] == 'testvm'
+    assert data['virt_type'] == 'para_virtualized'
+    assert data['state'] == 'running'
+    assert data['vcpus'] == 2
+    assert data['memory_size'] == '1024'
+    assert data['uuid'] == 5
+
+def test_beacon_update():
+    '''
+    Test beacon functionality. Second run with cache file.
+    Nothing has changed so the return value of the function
+    Should be an empty list
+    '''
+    domain = MagicMock()
+    domain.info = MagicMock(name='info')
+    domain.info.return_value = [0, 1024, 1024, 2, 30]
+    domain.name = MagicMock(name='name')
+    domain.name.return_value = 'testvm'
+
+    conn = MagicMock()
+    conn.listAllDomains = MagicMock(name='listAllDomains')
+    conn.listAllDomains.return_value = [domain]
+
+    if os.path.exists(CACHE_FILE):
+        os.unlink(CACHE_FILE)
+    shutil.copyfile(os.path.sep.join([os.path.abspath(''), 'data', 'virt_state-test.initcache']), CACHE_FILE)
+
+    with patch.object(virtpoller, 'libvirt', MagicMock(return_value=True)):
+        with patch.object(virtpoller.libvirt, 'openReadOnly', MagicMock(return_value=conn)):
+            with patch.object(virtpoller.binascii, 'hexlify', MagicMock(return_value=5)):
+                ret = virtpoller.beacon({'cache_file': CACHE_FILE,
+                                         'expire_time': 2})
+    assert isinstance(ret, list)
+    print("%s" % ret)
+    assert len(ret) == 0
+
+def test_beacon_change():
+    '''
+    Test beacon functionality. Another run with cache file.
+    There are changes so it should report the new values.
+    '''
+    domain = MagicMock()
+    domain.info = MagicMock(name='info')
+    domain.info.return_value = [4, 1024, 2048, 2, 30]
+    domain.name = MagicMock(name='name')
+    domain.name.return_value = 'testvm'
+
+    conn = MagicMock()
+    conn.listAllDomains = MagicMock(name='listAllDomains')
+    conn.listAllDomains.return_value = [domain]
+
+    if os.path.exists(CACHE_FILE):
+        os.unlink(CACHE_FILE)
+    shutil.copyfile(os.path.sep.join([os.path.abspath(''), 'data', 'virt_state-test.initcache']), CACHE_FILE)
+
+    with patch.object(virtpoller, 'libvirt', MagicMock(return_value=True)):
+        with patch.object(virtpoller.libvirt, 'openReadOnly', MagicMock(return_value=conn)):
+            with patch.object(virtpoller.binascii, 'hexlify', MagicMock(return_value=5)):
+                ret = virtpoller.beacon({'cache_file': CACHE_FILE,
+                                         'expire_time': 2})
+    assert isinstance(ret, list)
+    assert isinstance(ret[0], dict)
+    assert sorted(ret[0].keys()) == ['plan']
+    assert ret[0]['plan'][0]['event_type'] == 'exists'
+    assert 'guest_properties' in ret[0]['plan'][0]
+    data = ret[0]['plan'][0]['guest_properties']
+    assert data['name'] == 'testvm'
+    assert data['virt_type'] == 'para_virtualized'
+    assert data['state'] == 'stopped'
+    assert data['vcpus'] == 2
+    assert data['memory_size'] == '2048'
+    assert data['uuid'] == 5
+
+def test_beacon_remove():
+    '''
+    Test beacon functionality. Another run with cache file.
+    The former host is not available anymore. Report should
+    say "removed"
+    '''
+
+    conn = MagicMock()
+    conn.listAllDomains = MagicMock(name='listAllDomains')
+    conn.listAllDomains.return_value = []
+
+    if os.path.exists(CACHE_FILE):
+        os.unlink(CACHE_FILE)
+    shutil.copyfile(os.path.sep.join([os.path.abspath(''), 'data', 'virt_state-test.initcache']), CACHE_FILE)
+
+    with patch.object(virtpoller, 'libvirt', MagicMock(return_value=True)):
+        with patch.object(virtpoller.libvirt, 'openReadOnly', MagicMock(return_value=conn)):
+            with patch.object(virtpoller.binascii, 'hexlify', MagicMock(return_value=5)):
+                ret = virtpoller.beacon({'cache_file': CACHE_FILE,
+                                         'expire_time': 2})
+    assert isinstance(ret, list)
+    assert isinstance(ret[0], dict)
+    assert sorted(ret[0].keys()) == ['plan']
+    assert ret[0]['plan'][0]['event_type'] == 'removed'
+    assert 'guest_properties' in ret[0]['plan'][0]
+    data = ret[0]['plan'][0]['guest_properties']
+    assert data['name'] == 'testvm'
+    assert data['virt_type'] == 'para_virtualized'
+    assert data['state'] == 'running'
+    assert data['vcpus'] == 2
+    assert data['memory_size'] == '1024'
+    assert data['uuid'] == 5
+

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.bring-back-virtpoller-beacon
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.bring-back-virtpoller-beacon
@@ -1,0 +1,2 @@
+- Add virtpoller beacon again to provide information about
+  Virtual host to guest relation

--- a/susemanager/rhn-conf/rhn_server_susemanager.conf
+++ b/susemanager/rhn-conf/rhn_server_susemanager.conf
@@ -18,6 +18,16 @@ fromdir =
 # if the repo is available. Otherwise fallback to SCC.
 mirror =
 
+#
+# configure virtpoller beacon
+#
+# cache file
+virtpoller.cache_file = /var/cache/virt_state.cache
+# cache expire time (6 hours)
+virtpoller.expire_time = 21600
+# beacon call interval (5 minutes)
+virtpoller.interval = 300
+
 # 1 hour
 temp_token_lifetime = 60
 # ~ 1 year

--- a/susemanager/susemanager.changes.mcalmer.bring-back-virtpoller-beacon
+++ b/susemanager/susemanager.changes.mcalmer.bring-back-virtpoller-beacon
@@ -1,0 +1,1 @@
+- Add back virtpoller beacon configuration


### PR DESCRIPTION
## What does this PR change?

After removing the virtualization feature we need to take care to still get the virtual host <=> guest relation for 
SCC reporting.
To achieve this we bring back the virtpoller based on beacon data.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- ???

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25437

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
