### PR TITLE
Fix how to process code coverage per feature

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -219,11 +219,17 @@ def process_code_coverage
   $code_coverage.push_feature_coverage(feature_filename)
 end
 
-# Dump feature code coverage into a Redis DB
-After do |scenario|
+# Dump feature code coverage into a Redis DB before we run next feature
+Before do |scenario|
   next unless $code_coverage_mode
-  next unless $feature_path != scenario.location.file
 
+  # Initialize $feature_path if that's the first feature
+  $feature_path ||= scenario.location.file
+
+  # Skip if still in the same feature file
+  next if $feature_path == scenario.location.file
+
+  # Runs only if a new feature file starts
   process_code_coverage
   $feature_path = scenario.location.file
 end


### PR DESCRIPTION
## What does this PR change?

Fix how to process code coverage per feature. We made a mistake and we were taking into account the first scenario of next feature, as it was before.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
