### PR TITLE
ISSv3 - Migration from ISS v1

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/iss/IssSlave.java
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssSlave.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 SUSE LLC
  * Copyright (c) 2013 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -19,6 +20,7 @@ import com.redhat.rhn.frontend.dto.BaseDto;
 
 import java.util.Date;
 import java.util.Set;
+import java.util.StringJoiner;
 
 /**
  * IssSlave - Class representation of the table rhnissslave.
@@ -221,4 +223,13 @@ public class IssSlave extends BaseDto {
         return true;
     }
 
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", IssSlave.class.getSimpleName() + "[", "]")
+            .add("id=" + id)
+            .add("slave='" + slave + "'")
+            .add("enabled='" + enabled + "'")
+            .add("allowAllOrgs='" + allowAllOrgs + "'")
+            .toString();
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 SUSE LLC
  * Copyright (c) 2009--2016 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -1595,7 +1596,9 @@ public class ServerFactory extends HibernateFactory {
             return;
         }
         ReportDBCredentials credentials = serverInfo.getReportDbCredentials();
-        CredentialsFactory.removeCredentials(credentials);
+        if (credentials != null) {
+            CredentialsFactory.removeCredentials(credentials);
+        }
         SINGLETON.removeObject(serverInfo);
         server.setMgrServerInfo(null);
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2020--2025 SUSE LLC
  * Copyright (c) 2009--2017 Red Hat, Inc.
- * Copyright (c) 2020--2021 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -19,6 +19,7 @@ import com.suse.manager.api.ApiResponseSerializer;
 import com.suse.manager.xmlrpc.serializer.CoCoAttestationResultSerializer;
 import com.suse.manager.xmlrpc.serializer.MaintenanceCalendarSerializer;
 import com.suse.manager.xmlrpc.serializer.MaintenanceScheduleSerializer;
+import com.suse.manager.xmlrpc.serializer.MigrationResultSerializer;
 import com.suse.manager.xmlrpc.serializer.RescheduleResultSerializer;
 import com.suse.manager.xmlrpc.serializer.ServerCoCoAttestationReportSerializer;
 import com.suse.manager.xmlrpc.serializer.SystemEventDetailsDtoSerializer;
@@ -172,6 +173,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(ManagerInfoJsonSerializer.class);
         SERIALIZER_CLASSES.add(ChannelInfoJsonSerializer.class);
         SERIALIZER_CLASSES.add(OrgInfoJsonSerializer.class);
+        SERIALIZER_CLASSES.add(MigrationResultSerializer.class);
     }
 
     /**

--- a/java/code/src/com/suse/manager/hub/DefaultHubInternalClient.java
+++ b/java/code/src/com/suse/manager/hub/DefaultHubInternalClient.java
@@ -126,6 +126,11 @@ public class DefaultHubInternalClient implements HubInternalClient {
         invokePost("hub", "syncChannels", channelInfo);
     }
 
+    @Override
+    public void deleteIssV1Master() throws IOException {
+        invokePost("hub/sync/migrate/v1", "deleteMaster", null);
+    }
+
     private <R> R invokeGet(String namespace, String apiMethod, Type responseType)
             throws IOException {
         return invoke(HttpGet.METHOD_NAME, namespace, apiMethod, null, responseType);

--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -282,11 +282,11 @@ public class HubController {
             return success(response);
         }
         catch (TokenParsingException ex) {
-            LOGGER.error("Unable to parse the received token for server {}", token.getServerFqdn());
+            LOGGER.error("Unable to parse the received token for server {}", token.getServerFqdn(), ex);
             return badRequest(response, "The specified token is not parseable");
         }
         catch (TaskomaticApiException ex) {
-            LOGGER.error("Unable to schedule root CA certificate update {}", token.getServerFqdn());
+            LOGGER.error("Unable to schedule root CA certificate update {}", token.getServerFqdn(), ex);
             return internalServerError(response, "Unable to schedule root CA certificate update");
         }
     }

--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -129,6 +129,8 @@ public class HubController {
                 asJson(usingTokenAuthentication(onlyFromHub(this::synchronizeRepositories))));
         post("/hub/sync/subscriptions",
                 asJson(usingTokenAuthentication(onlyFromHub(this::synchronizeSubscriptions))));
+        post("/hub/sync/migrate/v1/deleteMaster",
+                asJson(usingTokenAuthentication(onlyFromHub(this::deleteV1Master))));
     }
 
     private String scheduleProductRefresh(Request request, Response response, IssAccessToken issAccessToken) {
@@ -359,5 +361,17 @@ public class HubController {
 
     private String synchronizeSubscriptions(Request request, Response response, IssAccessToken token) {
         return json(response, hubManager.synchronizeSubscriptions(token));
+    }
+
+    private String deleteV1Master(Request request, Response response, IssAccessToken token) {
+
+        try {
+            hubManager.deleteIssV1Master(token);
+            return success(response);
+        }
+        catch (IllegalStateException ex) {
+            LOGGER.error("Invalid fqdn {}", token.getServerFqdn(), ex);
+            return badRequest(response, ex.getMessage());
+        }
     }
 }

--- a/java/code/src/com/suse/manager/hub/HubInternalClient.java
+++ b/java/code/src/com/suse/manager/hub/HubInternalClient.java
@@ -98,4 +98,9 @@ public interface HubInternalClient {
      * @throws IOException when the communication fails
      */
     void syncChannels(List<ChannelInfoDetailsJson> channelInfo) throws IOException;
+
+    /**
+     * Deletes the ISSv1 Master
+     */
+    void deleteIssV1Master() throws IOException;
 }

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -22,6 +22,9 @@ import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.credentials.HubSCCCredentials;
 import com.redhat.rhn.domain.credentials.ReportDBCredentials;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.domain.iss.IssFactory;
+import com.redhat.rhn.domain.iss.IssMaster;
+import com.redhat.rhn.domain.iss.IssSlave;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
@@ -386,12 +389,13 @@ public class HubManager {
      * @param password the password of the specified user
      * @param rootCA the optional root CA of the remote server. can be null
      *
+     * @return the registered peripheral
      * @throws CertificateException if the specified certificate is not parseable
      * @throws TokenParsingException if the specified token is not parseable
      * @throws TokenBuildingException if an error occurs while generating the token for the server
      * @throws IOException when connecting to the server fails
      */
-    public void register(User user, String remoteServer, String username, String password, String rootCA)
+    public IssPeripheral register(User user, String remoteServer, String username, String password, String rootCA)
         throws CertificateException, TokenBuildingException, IOException, TokenParsingException,
             TaskomaticApiException {
         ensureSatAdmin(user);
@@ -405,7 +409,7 @@ public class HubManager {
             remoteToken = externalClient.generateAccessToken(ConfigDefaults.get().getHostname());
         }
 
-        registerWithToken(user, remoteServer, rootCA, remoteToken);
+        return registerWithToken(user, remoteServer, rootCA, remoteToken);
     }
 
     /**
@@ -416,12 +420,13 @@ public class HubManager {
      * @param remoteToken the token used to connect to the peripheral server
      * @param rootCA the optional root CA of the peripheral server
      *
+     * @return the registered peripheral
      * @throws CertificateException if the specified certificate is not parseable
      * @throws TokenParsingException if the specified token is not parseable
      * @throws TokenBuildingException if an error occurs while generating the token for the peripheral server
      * @throws IOException when connecting to the peripheral server fails
      */
-    public void register(User user, String remoteServer, String remoteToken, String rootCA)
+    public IssPeripheral register(User user, String remoteServer, String remoteToken, String rootCA)
         throws CertificateException, TokenBuildingException, IOException, TokenParsingException,
             TaskomaticApiException {
         ensureSatAdmin(user);
@@ -429,7 +434,7 @@ public class HubManager {
         // Verify this server is not already registered as hub or peripheral
         ensureServerNotRegistered(remoteServer);
 
-        registerWithToken(user, remoteServer, rootCA, remoteToken);
+        return registerWithToken(user, remoteServer, rootCA, remoteToken);
     }
 
     /**
@@ -662,28 +667,31 @@ public class HubManager {
                 reportDbName, reportDbHost, reportDbPort);
     }
 
-    private void registerWithToken(User user, String remoteServer, String rootCA, String remoteToken)
+    private IssPeripheral registerWithToken(User user, String remoteServer, String rootCA, String remoteToken)
         throws TokenParsingException, CertificateException, TokenBuildingException, IOException,
             TaskomaticApiException {
         parseAndSaveToken(remoteServer, remoteToken);
 
         IssServer registeredServer = createServer(IssRole.PERIPHERAL, remoteServer, rootCA, null, user);
-        registerToRemote(user, registeredServer, remoteToken, rootCA);
-    }
-
-    private void registerToRemote(User user, IssServer remoteServer, String remoteToken, String rootCA)
-            throws CertificateException, TokenParsingException, TokenBuildingException, IOException {
 
         // Ensure the remote server is a peripheral
-        if (!(remoteServer instanceof IssPeripheral peripheral)) {
+        if (!(registeredServer instanceof IssPeripheral peripheral)) {
             throw new IllegalStateException(remoteServer + "is not a peripheral server");
         }
 
+        registerToRemote(user, peripheral, remoteToken, rootCA);
+
+        return peripheral;
+    }
+
+    private void registerToRemote(User user, IssPeripheral peripheral, String remoteToken, String rootCA)
+            throws CertificateException, TokenParsingException, TokenBuildingException, IOException {
+
         // Create a client to connect to the internal API of the remote server
-        var internalApi = clientFactory.newInternalClient(remoteServer.getFqdn(), remoteToken, rootCA);
+        var internalApi = clientFactory.newInternalClient(peripheral.getFqdn(), remoteToken, rootCA);
         try {
             // Issue a token for granting access to the remote server
-            Token localAccessToken = createAndSaveToken(remoteServer.getFqdn());
+            Token localAccessToken = createAndSaveToken(peripheral.getFqdn());
             // Send the local trusted root, if we needed a different certificate to connect
             String localRootCA = rootCA != null ? CertificateUtils.loadLocalTrustedRoot() : null;
             // Send the local GPG key used to sign metadata, if configured.
@@ -701,7 +709,7 @@ public class HubManager {
             // Query Report DB connection values and set create a User
             ManagerInfoJson managerInfo = internalApi.getManagerInfo();
             Server peripheralServer = getOrCreateManagerSystem(systemEntitlementManager, user,
-                    remoteServer.getFqdn(), Set.of(remoteServer.getFqdn()));
+                    peripheral.getFqdn(), Set.of(peripheral.getFqdn()));
             boolean changed = SystemManager.updateMgrServerInfo(peripheralServer, managerInfo);
             if (changed) {
                 setReportDbUser(user, peripheralServer, false);
@@ -716,7 +724,7 @@ public class HubManager {
 
     private void cleanup(HubInternalClient internalApi) {
         try {
-            // try to cleanup the remote side
+            // try to clean up the remote side
             internalApi.deregister();
         }
         catch (Exception ex) {
@@ -1249,5 +1257,55 @@ public class HubManager {
                 accessToken.getToken(),
                 issPeripheral.getRootCa());
         internalClient.syncChannels(channelInfo);
+    }
+
+    /**
+     * Delete an ISS v1 slave if it's also registered as a ISS v3 peripheral
+     * @param user the user performing the operation
+     * @param fqdn the fully qualified domain name of the slave and corresponding peripheral
+     * @param onlyLocal true to perform the removal only on the local server, false to also delete the master on the
+     * remote slave
+     * @throws CertificateException when it's not possible to use remote server certificate
+     * @throws IOException when the connection with the remote server fails
+     */
+    public void deleteIssV1Slave(User user, String fqdn, boolean onlyLocal) throws CertificateException, IOException {
+        ensureSatAdmin(user);
+
+        IssSlave slave = Optional.ofNullable(IssFactory.lookupSlaveByName(fqdn)).orElseThrow(() ->
+            new IllegalStateException(fqdn + " is not registered as an ISS v1 slave"));
+        IssPeripheral peripheral = hubFactory.lookupIssPeripheralByFqdn(fqdn).orElseThrow(() ->
+            new IllegalStateException(fqdn + " is not registered as an ISS v3 peripheral"));
+
+        if (!onlyLocal) {
+            // Delete the master remotely
+            IssAccessToken accessToken = hubFactory.lookupAccessTokenFor(fqdn);
+            var internalClient = clientFactory.newInternalClient(fqdn, accessToken.getToken(), peripheral.getRootCa());
+            internalClient.deleteIssV1Master();
+        }
+
+        // Delete the slave locally
+        IssFactory.delete(slave);
+    }
+
+    /**
+     * Delete an ISS v1 master if it's also registered as an ISS v3 hub
+     * @param accessToken the access token granting access and identifying the caller
+     * remote slave
+     * @throws IllegalStateException if a master or a hub does not exist with the fqdn identified by the token
+     */
+    public void deleteIssV1Master(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+
+        String fqdn = accessToken.getServerFqdn();
+
+        IssMaster master = Optional.ofNullable(IssFactory.lookupMasterByLabel(fqdn)).orElseThrow(() ->
+            new IllegalStateException(fqdn + " is not registered as an ISS v1 master"));
+
+        // Ensure that the server is registered as hub
+        hubFactory.lookupIssHubByFqdn(fqdn).orElseThrow(() ->
+            new IllegalStateException(fqdn + " is not registered as an ISS v3 hub"));
+
+        // Remove the master
+        IssFactory.delete(master);
     }
 }

--- a/java/code/src/com/suse/manager/hub/migration/IssMigrator.java
+++ b/java/code/src/com/suse/manager/hub/migration/IssMigrator.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.hub.migration;
+
+import com.redhat.rhn.common.security.PermissionException;
+import com.redhat.rhn.domain.iss.IssFactory;
+import com.redhat.rhn.domain.iss.IssSlave;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.user.User;
+
+import com.suse.manager.hub.HubManager;
+import com.suse.manager.model.hub.migration.MigrationItem;
+import com.suse.manager.model.hub.migration.MigrationMessageLevel;
+import com.suse.manager.model.hub.migration.MigrationResult;
+import com.suse.manager.model.hub.migration.MigrationResultCode;
+import com.suse.manager.model.hub.migration.SlaveMigrationData;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class IssMigrator {
+
+    private static final Logger LOGGER = LogManager.getLogger(IssMigrator.class);
+
+    private final HubManager hubManager;
+
+    private final User user;
+
+    private MigrationResult result;
+
+    /**
+     * Default constructor
+     * @param userIn the user performing the migration
+     */
+    public IssMigrator(User userIn) {
+        this(new HubManager(), userIn);
+    }
+
+    /**
+     * Constractor with explicit dependencies for testing
+     * @param hubManagerIn the hub manager to perform the operations
+     * @param userIn the user performing the migration
+     * @throws PermissionException if the user is not a {@link RoleFactory#SAT_ADMIN}.
+     */
+    public IssMigrator(HubManager hubManagerIn, User userIn) {
+        this.hubManager = hubManagerIn;
+        this.user = userIn;
+
+        this.result = null;
+
+        // ensure the user has the correct role
+        if (!user.hasRole(RoleFactory.SAT_ADMIN)) {
+            throw new PermissionException(RoleFactory.SAT_ADMIN);
+        }
+    }
+
+    /**
+     * Migrate ISSv1 slaves and configure them as peripheral servers
+     * @param migrationDataMap a map containing the mandatory information for migrating an existing slave
+     * @return the migration result
+     */
+    public MigrationResult migrateFromV1(Map<String, SlaveMigrationData> migrationDataMap) {
+        // Initialize the result
+        result = new MigrationResult();
+
+        // Load and cache all the ISS Slaves currently configured
+        Map<String, IssSlave> slavesMap = IssFactory.listAllIssSlaves().stream()
+            .collect(Collectors.toMap(IssSlave::getSlave, Function.identity()));
+
+        if (slavesMap.isEmpty()) {
+            LOGGER.warn("This server does not have any register slaves, nothing to migrate");
+
+            result.setResultCode(MigrationResultCode.FAILURE);
+            result.addMessage(MigrationMessageLevel.ERROR, "This server does not have any ISSv1 slave");
+
+            return result;
+        }
+
+        // Check if some of the specified migration data does not match with the existing slaves
+        migrationDataMap.keySet().stream()
+            .filter(fqdn -> !slavesMap.containsKey(fqdn))
+            .forEach(fqdn -> {
+                LOGGER.warn("Migration data for {} is invalid, such slave does not exist", fqdn);
+                result.addMessage(MigrationMessageLevel.WARN, "Slave %s does not exist".formatted(fqdn));
+            });
+
+
+        // Process all the extracted slaves in parallel.
+        // The migration item is immutable so each step returns the updated version
+        List<MigrationItem> migratedItems = slavesMap.values().stream()
+            // Step 1 - Create a migration item from the slave
+            .map(slave -> createMigrationItem(migrationDataMap, slave))
+            // Step 2 - Exclude the items that are not part of the migration data
+            .filter(item -> migrationDataAvailable(item))
+            // Step 3 - Register the slave as peripheral
+            .map(item -> registerSlaveAsPeripheral(item))
+            // Last step - Cleanup the data that is no longer needed
+            .map(item -> cleanupDanglingData(item))
+            // Collect all the migrated items for determining the final result
+            .toList();
+
+        // Adjust the result code
+        result.setResultCode(computeResultCode(migratedItems));
+
+        return result;
+    }
+
+    private static MigrationItem createMigrationItem(Map<String, SlaveMigrationData> migrationDataMap, IssSlave slave) {
+        LOGGER.debug(
+            "Creating item for slave {} (migration data available: {})",
+            () -> slave, () -> migrationDataMap.containsKey(slave.getSlave())
+        );
+
+        return new MigrationItem(slave, migrationDataMap.get(slave.getSlave()));
+    }
+
+    private boolean migrationDataAvailable(MigrationItem item) {
+        if (item.migrationData() == null) {
+            LOGGER.info("Migration data is missing for slave {}. It will be skipped.", item.slave());
+
+            String message = "Slave %s has no migration data and will not be migrated";
+            result.addMessage(MigrationMessageLevel.INFO, message.formatted(item.slave().getSlave()));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private MigrationItem registerSlaveAsPeripheral(MigrationItem item) {
+        // Do not migrate the slave if it is disabled
+        if (!"Y".equals(item.slave().getEnabled())) {
+            LOGGER.info("Slave {} is disabled. It will be skipped.", item.slave());
+
+            String message = "Slave %s is currently disabled and will not be migrated";
+            result.addMessage(MigrationMessageLevel.WARN, message.formatted(item.slave().getSlave()));
+
+            return item.fail();
+        }
+
+        try {
+            LOGGER.debug("Registering slave {} as peripheral", item.slave());
+            var peripheral = hubManager.register(user, item.fqdn(), item.token(), item.rootCA());
+            return item.withPeripheral(peripheral);
+        }
+        catch (Exception ex) {
+            LOGGER.error("Unable to migrate slave {}", item.slave(), ex);
+
+            String message = "Unable to migrate %s: %s";
+            result.addMessage(MigrationMessageLevel.ERROR, message.formatted(item.fqdn(), ex.getMessage()));
+
+            return item.fail();
+        }
+    }
+
+    private MigrationItem cleanupDanglingData(MigrationItem item) {
+        // Remove the ISSv1 data if the item was successfully migrated
+        if (item.success()) {
+            return removeIssConfiguration(item);
+        }
+
+        // The item was not migrated, rollback what was created during the process
+        return rollbackPeripheral(item);
+    }
+
+    private static MigrationResultCode computeResultCode(List<MigrationItem> migratedItems) {
+        long successCount = migratedItems.stream().filter(MigrationItem::success).count();
+        if (successCount == migratedItems.size()) {
+            return MigrationResultCode.SUCCESS;
+        }
+
+        if (successCount == 0) {
+            return MigrationResultCode.FAILURE;
+        }
+
+        return MigrationResultCode.PARTIAL;
+    }
+
+    private MigrationItem removeIssConfiguration(MigrationItem item) {
+        try {
+            LOGGER.debug("Slave {} was migrated to a peripheral. Removing ISSv1 configuration", item.slave());
+            hubManager.deleteIssV1Slave(user, item.fqdn(), false);
+        }
+        catch (Exception ex) {
+            LOGGER.error("Unable to remove ISSv1 data for {}", item.slave(), ex);
+
+            String message = "Unable remove ISSv1 data for slave %s";
+            result.addMessage(MigrationMessageLevel.ERROR, message.formatted(item.fqdn()));
+        }
+
+        return item;
+    }
+
+    private MigrationItem rollbackPeripheral(MigrationItem item) {
+        if (item.peripheral() == null) {
+            // The peripheral was not created, nothing to rollback
+            return item;
+        }
+
+        try {
+            LOGGER.debug("Peripheral {} was not correctly migrated. Deregistering.", item.peripheral());
+            hubManager.deregister(user, item.fqdn(), false);
+        }
+        catch (Exception ex) {
+            LOGGER.error("Unable to deregister peripheral {}", item.peripheral(), ex);
+
+            String message = "Unable to remove partially migrated peripheral %s: %s";
+            result.addMessage(MigrationMessageLevel.ERROR, message.formatted(item.fqdn(), ex.getMessage()));
+        }
+
+        return item;
+    }
+}

--- a/java/code/src/com/suse/manager/hub/migration/IssMigratorFactory.java
+++ b/java/code/src/com/suse/manager/hub/migration/IssMigratorFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.hub.migration;
+
+import com.redhat.rhn.domain.user.User;
+
+public class IssMigratorFactory {
+
+    /**
+     * Creates a new migrator instance.
+     * @param user the user performing the migration.
+     * @return a new {@link IssMigrator} instance.
+     */
+    public IssMigrator createFor(User user) {
+        return new IssMigrator(user);
+    }
+}

--- a/java/code/src/com/suse/manager/hub/migration/test/IssMigratorTest.java
+++ b/java/code/src/com/suse/manager/hub/migration/test/IssMigratorTest.java
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.hub.migration.test;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.iss.IssFactory;
+import com.redhat.rhn.domain.iss.IssSlave;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.setup.MirrorCredentialsManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.hub.HubClientFactory;
+import com.suse.manager.hub.HubInternalClient;
+import com.suse.manager.hub.HubManager;
+import com.suse.manager.hub.migration.IssMigrator;
+import com.suse.manager.model.hub.HubFactory;
+import com.suse.manager.model.hub.IssAccessToken;
+import com.suse.manager.model.hub.IssPeripheral;
+import com.suse.manager.model.hub.migration.MigrationMessage;
+import com.suse.manager.model.hub.migration.MigrationResult;
+import com.suse.manager.model.hub.migration.MigrationResultCode;
+import com.suse.manager.model.hub.migration.SlaveMigrationData;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.utils.token.IssTokenBuilder;
+import com.suse.manager.webui.utils.token.Token;
+import com.suse.utils.Exceptions;
+
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class IssMigratorTest extends JMockBaseTestCaseWithUser {
+
+    private static final String LOCAL_SERVER_FQDN = "local-server.unit-test.local";
+
+    public static final String ALPHA = "alpha.unit-test.local";
+    public static final String BETA = "beta.unit-test.local";
+    public static final String GAMMA = "gamma.unit-test.local";
+
+    private final String originalFqdn;
+
+    private HubFactory hubFactory;
+
+    private HubClientFactory hubClientFactory;
+
+    private TaskomaticApi taskomaticApi;
+
+    private IssMigrator migrator;
+
+    public IssMigratorTest() {
+        originalFqdn = ConfigDefaults.get().getHostname();
+    }
+
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Config.get().setString(ConfigDefaults.SERVER_HOSTNAME, LOCAL_SERVER_FQDN);
+
+        User satAdmin = UserTestUtils.createUser("satUser", user.getOrg().getId());
+        satAdmin.addPermanentRole(RoleFactory.SAT_ADMIN);
+        UserFactory.save(satAdmin);
+
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+
+        hubFactory = new HubFactory();
+
+        hubClientFactory = mock(HubClientFactory.class);
+        taskomaticApi = mock(TaskomaticApi.class);
+
+        var credentialsManager = mock(MirrorCredentialsManager.class);
+        var saltApi = new TestSaltApi();
+        var monitoringManager = new FormulaMonitoringManager(saltApi);
+        var serverGroupManager = new ServerGroupManager(saltApi);
+        var sysEntMgr = new SystemEntitlementManager(
+            new SystemUnentitler(monitoringManager, serverGroupManager),
+            new SystemEntitler(saltApi, monitoringManager, serverGroupManager)
+        );
+
+        var hubManager = new HubManager(hubFactory, hubClientFactory, credentialsManager, taskomaticApi, sysEntMgr);
+
+        migrator = new IssMigrator(hubManager, satAdmin);
+    }
+
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        Config.get().setString(ConfigDefaults.SERVER_HOSTNAME, originalFqdn);
+    }
+
+    @Test
+    @DisplayName("Migrate successfully existing slaves with correct data")
+    public void migrateSuccessfullyExistingSlaves() throws Exception {
+        // Setup some slaves and create the migration data
+        Map<String, SlaveMigrationData> migrationData = Stream.of(
+                createSlave(ALPHA),
+                createSlave(BETA),
+                createSlave(GAMMA)
+            ).collect(Collectors.toMap(IssSlave::getSlave, slave -> createMigrationData(slave.getSlave())));
+
+        // Expect a successful migration for all the slaves and set up the mock accordingly
+        checking(new MigrationExpectations() {{
+            expectMigrated(migrationData.get(ALPHA));
+            expectMigrated(migrationData.get(BETA));
+            expectMigrated(migrationData.get(GAMMA));
+        }});
+
+        MigrationResult migrationResult = migrator.migrateFromV1(migrationData);
+
+        // Verify everything succeeded
+        assertEquals(MigrationResultCode.SUCCESS, migrationResult.getResultCode());
+        assertEquals(Set.of(), migrationResult.getMessages());
+
+        // Ensure the slaves has been removed
+        List<IssSlave> issSlaves = IssFactory.listAllIssSlaves();
+        assertTrue(issSlaves.isEmpty());
+
+        // Ensure the peripheral have been created
+        List<IssPeripheral> peripherals = hubFactory.listPeripherals();
+        assertEquals(3, peripherals.size());
+
+        // Verify if everything was configured successfully
+        for (var data : migrationData.values()) {
+            IssPeripheral issPeripheral = hubFactory.lookupIssPeripheralByFqdn(data.fqdn())
+                .orElseThrow(() -> new AssertionFailedError("Cannot find ISS Peripheral with fqdn " + data.fqdn()));
+            assertEquals(data.rootCA(), issPeripheral.getRootCa());
+
+            IssAccessToken issAccessToken = hubFactory.lookupAccessTokenFor(data.fqdn());
+            assertNotNull(issAccessToken);
+            assertEquals(data.token(), issAccessToken.getToken());
+
+            Server server = ServerFactory.findByFqdn(data.fqdn())
+                .orElseThrow(() -> new AssertionFailedError("Cannot find server with fqdn " + data.fqdn()));
+
+            assertEquals(Set.of(EntitlementManager.FOREIGN), server.getEntitlements());
+        }
+    }
+
+    @Test
+    @DisplayName("Skip slaves if they are disabled or missing migration data")
+    public void skipSlavesWhenDisabledOrMissingMigrationData() throws Exception {
+        // Setup some slaves and create the migration data
+        createSlave(ALPHA);
+        createSlave(BETA);
+        createSlave(GAMMA, false); // Disabled
+
+        // Omit the data for alpha
+        Map<String, SlaveMigrationData> migrationData = Stream.of(
+                createMigrationData(BETA),
+                createMigrationData(GAMMA)
+            )
+            .collect(Collectors.toMap(SlaveMigrationData::fqdn, Function.identity()));
+
+        // Expect a successful migration for all the slaves and set up the mock accordingly
+        context().checking(new MigrationExpectations() {{
+            expectSkipped(migrationData.get(ALPHA));
+            expectMigrated(migrationData.get(BETA));
+            expectSkipped(migrationData.get(GAMMA));
+        }});
+
+        MigrationResult migrationResult = migrator.migrateFromV1(migrationData);
+
+        // Verify everything succeeded
+        assertEquals(MigrationResultCode.PARTIAL, migrationResult.getResultCode());
+        assertEquals(Set.of(
+            MigrationMessage.info("Slave alpha.unit-test.local has no migration data and will not be migrated"),
+            MigrationMessage.warn("Slave gamma.unit-test.local is currently disabled and will not be migrated")
+        ), migrationResult.getMessages());
+
+        // Ensure only one slave has been removed
+        List<IssSlave> issSlaves = IssFactory.listAllIssSlaves();
+        assertEquals(2, issSlaves.size());
+
+        // Ensure the peripheral have been created
+        List<IssPeripheral> peripherals = hubFactory.listPeripherals();
+        assertEquals(1, peripherals.size());
+
+        // Verify if everything was configured successfully for beta.unit-test.local
+        SlaveMigrationData data = migrationData.get(BETA);
+
+        IssPeripheral issPeripheral = hubFactory.lookupIssPeripheralByFqdn(data.fqdn())
+            .orElseThrow(() -> new AssertionFailedError("Cannot find ISS Peripheral with fqdn " + data.fqdn()));
+        assertEquals(data.rootCA(), issPeripheral.getRootCa());
+
+        IssAccessToken issAccessToken = hubFactory.lookupAccessTokenFor(data.fqdn());
+        assertNotNull(issAccessToken);
+        assertEquals(data.token(), issAccessToken.getToken());
+
+        Server server = ServerFactory.findByFqdn(data.fqdn())
+            .orElseThrow(() -> new AssertionFailedError("Cannot find server with fqdn " + data.fqdn()));
+
+        assertEquals(Set.of(EntitlementManager.FOREIGN), server.getEntitlements());
+        assertNull(IssFactory.lookupSlaveByName(data.fqdn()));
+    }
+
+    @Test
+    @DisplayName("Warn when invalid data is present in migration data")
+    public void warnsAboutInvalidDataInTheMigrationData() throws Exception {
+        // Setup some slaves and create the migration data
+        createSlave(ALPHA);
+
+        // Omit the data for alpha
+        Map<String, SlaveMigrationData> migrationData = Stream.of(
+                createMigrationData(ALPHA),
+                createMigrationData(BETA)
+            )
+            .collect(Collectors.toMap(SlaveMigrationData::fqdn, Function.identity()));
+
+        // Expect a successful migration for all the slaves and set up the mock accordingly
+        context().checking(new MigrationExpectations() {{
+            expectMigrated(migrationData.get(ALPHA));
+        }});
+
+        MigrationResult migrationResult = migrator.migrateFromV1(migrationData);
+
+        // Verify everything succeeded
+        assertEquals(MigrationResultCode.SUCCESS, migrationResult.getResultCode());
+        assertEquals(Set.of(
+            MigrationMessage.warn("Slave beta.unit-test.local does not exist")
+        ), migrationResult.getMessages());
+
+        // Ensure only one slave has been removed
+        List<IssSlave> issSlaves = IssFactory.listAllIssSlaves();
+        assertEquals(0, issSlaves.size());
+
+        // Ensure the peripheral have been created
+        List<IssPeripheral> peripherals = hubFactory.listPeripherals();
+        assertEquals(1, peripherals.size());
+
+        // Verify if everything was configured successfully for beta.unit-test.local
+        SlaveMigrationData data = migrationData.get(ALPHA);
+
+        IssPeripheral issPeripheral = hubFactory.lookupIssPeripheralByFqdn(data.fqdn())
+            .orElseThrow(() -> new AssertionFailedError("Cannot find ISS Peripheral with fqdn " + data.fqdn()));
+        assertEquals(data.rootCA(), issPeripheral.getRootCa());
+
+        IssAccessToken issAccessToken = hubFactory.lookupAccessTokenFor(data.fqdn());
+        assertNotNull(issAccessToken);
+        assertEquals(data.token(), issAccessToken.getToken());
+
+        Server server = ServerFactory.findByFqdn(data.fqdn())
+            .orElseThrow(() -> new AssertionFailedError("Cannot find server with fqdn " + data.fqdn()));
+
+        assertEquals(Set.of(EntitlementManager.FOREIGN), server.getEntitlements());
+        assertNull(IssFactory.lookupSlaveByName(data.fqdn()));
+    }
+
+    @Test
+    @DisplayName("Fails when there are no slaves to migrate")
+    public void failsWhenThereAreNoSlavesToMigrate() {
+        MigrationResult migrationResult = migrator.migrateFromV1(Map.of());
+        assertEquals(MigrationResultCode.FAILURE, migrationResult.getResultCode());
+        assertNotNull(migrationResult.getMessages());
+        assertEquals(Set.of(
+            MigrationMessage.error("This server does not have any ISSv1 slave")
+        ), migrationResult.getMessages());
+    }
+
+
+    @Test
+    @DisplayName("Fails when all slave fail to migrate")
+    public void failsWhenAllSlavesFailToMigrate() throws Exception {
+        // Setup some slaves and create the migration data
+        createSlave(ALPHA);
+        createSlave(BETA);
+
+        Map<String, SlaveMigrationData> migrationData = Stream.of(
+                createMigrationData(ALPHA),
+                createMigrationData(BETA)
+            )
+            .collect(Collectors.toMap(SlaveMigrationData::fqdn, Function.identity()));
+
+        // Expect a successful migration for all the slaves and set up the mock accordingly
+        context().checking(new MigrationExpectations() {{
+            expectFailureAtRegistration(migrationData.get(ALPHA));
+            expectFailureAtRegistration(migrationData.get(BETA));
+        }});
+
+        MigrationResult migrationResult = migrator.migrateFromV1(migrationData);
+        assertEquals(MigrationResultCode.FAILURE, migrationResult.getResultCode());
+        assertNotNull(migrationResult.getMessages());
+        assertEquals(Set.of(
+            MigrationMessage.error("Unable to migrate alpha.unit-test.local: Remote failure"),
+            MigrationMessage.error("Unable to migrate beta.unit-test.local: Remote failure")
+        ), migrationResult.getMessages());
+    }
+
+    private static IssSlave createSlave(String slaveName) {
+        return createSlave(slaveName, true);
+    }
+
+    private static IssSlave createSlave(String slaveName, boolean enabled) {
+        IssSlave slave = new IssSlave();
+        slave.setSlave(slaveName);
+        slave.setEnabled(enabled ? "Y" : "N");
+        // Migration does not take into account organizations
+        slave.setAllowAllOrgs("Y");
+
+        IssFactory.save(slave);
+        return slave;
+    }
+
+    private static SlaveMigrationData createMigrationData(String slaveFqdn) {
+        Token accessToken = Exceptions.handleByWrapping(
+            () -> new IssTokenBuilder(LOCAL_SERVER_FQDN).usingServerSecret().build(),
+            ex -> new IllegalStateException("Unable to create a fake token issued by " + slaveFqdn, ex)
+        );
+
+        return new SlaveMigrationData(slaveFqdn, accessToken.getSerializedForm(), TestUtils.randomString(16));
+    }
+
+    private class MigrationExpectations extends Expectations {
+
+        protected void expectMigrated(SlaveMigrationData data)
+            throws TaskomaticApiException, CertificateException, IOException {
+
+            HubInternalClient internalClientMock = mock(HubInternalClient.class, "internalClient_" + data.fqdn());
+
+            allowRegistration(data, internalClientMock);
+            allowIssV1Removal(internalClientMock);
+        }
+
+        protected void expectSkipped(SlaveMigrationData data) {
+            // Nothing to do
+        }
+
+        protected void expectFailureAtRegistration(SlaveMigrationData data)
+            throws TaskomaticApiException, CertificateException, IOException {
+
+            HubInternalClient internalClientMock = mock(HubInternalClient.class, "internalClient_" + data.fqdn());
+
+            failingRegistration(data, internalClientMock);
+
+            allowingRollback(internalClientMock);
+        }
+
+        private void allowRegistration(SlaveMigrationData data, HubInternalClient internalClientMock)
+            throws TaskomaticApiException, CertificateException, IOException {
+            allowing(taskomaticApi)
+                .scheduleSingleRootCaCertUpdate("peripheral_" + data.fqdn() + "_root_ca.pem", data.rootCA());
+
+            allowing(hubClientFactory).newInternalClient(data.fqdn(), data.token(), data.rootCA());
+            will(returnValue(internalClientMock));
+
+            allowing(internalClientMock).registerHub(
+                with(any(String.class)),
+                with(anyOf(nullValue(String.class), any(String.class))),
+                with(anyOf(nullValue(String.class), any(String.class)))
+            );
+
+            allowing(internalClientMock)
+                .storeCredentials(with(any(String.class)), with(any(String.class)));
+
+            allowing(internalClientMock).getManagerInfo();
+            will(returnValue(null));
+
+            allowing(internalClientMock).scheduleProductRefresh();
+        }
+
+        private void failingRegistration(SlaveMigrationData data, HubInternalClient internalClientMock)
+            throws TaskomaticApiException, CertificateException, IOException {
+            allowing(taskomaticApi)
+                .scheduleSingleRootCaCertUpdate("peripheral_" + data.fqdn() + "_root_ca.pem", data.rootCA());
+
+            allowing(hubClientFactory).newInternalClient(data.fqdn(), data.token(), data.rootCA());
+            will(returnValue(internalClientMock));
+
+            allowing(internalClientMock).registerHub(
+                with(any(String.class)),
+                with(anyOf(nullValue(String.class), any(String.class))),
+                with(anyOf(nullValue(String.class), any(String.class)))
+            );
+            will(throwException(new IOException("Remote failure")));
+        }
+
+        private void allowIssV1Removal(HubInternalClient internalClientMock) throws IOException {
+            allowing(internalClientMock).deleteIssV1Master();
+        }
+
+        private void allowingRollback(HubInternalClient internalClientMock) throws IOException {
+            allowing(internalClientMock).deregister();
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -60,6 +60,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 import spark.Request;
 import spark.RequestResponseFactory;
@@ -397,11 +398,6 @@ public class ControllerTestUtils {
         }
     }
 
-    @FunctionalInterface
-    private interface CheckMethod {
-        void checkCompatible(Object modified, Object pristine);
-    }
-
     public void checkEqualModifications(ChannelInfoDetailsJson modifyInfo, Channel ch) {
         checkModifications(modifyInfo, ch, ControllerTestUtils::checkEqualIfModified);
     }
@@ -410,35 +406,36 @@ public class ControllerTestUtils {
         checkModifications(modifyInfo, ch, ControllerTestUtils::checkDifferentIfModified);
     }
 
-    private void checkModifications(ChannelInfoDetailsJson modifyInfo, Channel ch, CheckMethod checkMethod) {
+    private void checkModifications(ChannelInfoDetailsJson modifyInfo, Channel ch,
+                                    BiConsumer<Object, Object> checkMethod) {
         assertEquals(modifyInfo.getLabel(), ch.getLabel());
 
         if (null != modifyInfo.getPeripheralOrgId()) {
-            checkMethod.checkCompatible(modifyInfo.getPeripheralOrgId(), ch.getOrg().getId());
+            checkMethod.accept(modifyInfo.getPeripheralOrgId(), ch.getOrg().getId());
         }
 
-        checkMethod.checkCompatible(modifyInfo.getOriginalChannelLabel(), ch.getOriginal().getLabel());
+        checkMethod.accept(modifyInfo.getOriginalChannelLabel(), ch.getOriginal().getLabel());
 
-        checkMethod.checkCompatible(modifyInfo.getBaseDir(), ch.getBaseDir());
-        checkMethod.checkCompatible(modifyInfo.getName(), ch.getName());
-        checkMethod.checkCompatible(modifyInfo.getSummary(), ch.getSummary());
-        checkMethod.checkCompatible(modifyInfo.getDescription(), ch.getDescription());
-        checkMethod.checkCompatible(modifyInfo.getProductNameLabel(), ch.getProductName().getLabel());
-        checkMethod.checkCompatible(modifyInfo.isGpgCheck(), ch.isGPGCheck());
-        checkMethod.checkCompatible(modifyInfo.getGpgKeyUrl(), ch.getGPGKeyUrl());
-        checkMethod.checkCompatible(modifyInfo.getGpgKeyId(), ch.getGPGKeyId());
-        checkMethod.checkCompatible(modifyInfo.getGpgKeyFp(), ch.getGPGKeyFp());
-        checkMethod.checkCompatible(modifyInfo.getEndOfLifeDate().toString(), ch.getEndOfLife().toString());
+        checkMethod.accept(modifyInfo.getBaseDir(), ch.getBaseDir());
+        checkMethod.accept(modifyInfo.getName(), ch.getName());
+        checkMethod.accept(modifyInfo.getSummary(), ch.getSummary());
+        checkMethod.accept(modifyInfo.getDescription(), ch.getDescription());
+        checkMethod.accept(modifyInfo.getProductNameLabel(), ch.getProductName().getLabel());
+        checkMethod.accept(modifyInfo.isGpgCheck(), ch.isGPGCheck());
+        checkMethod.accept(modifyInfo.getGpgKeyUrl(), ch.getGPGKeyUrl());
+        checkMethod.accept(modifyInfo.getGpgKeyId(), ch.getGPGKeyId());
+        checkMethod.accept(modifyInfo.getGpgKeyFp(), ch.getGPGKeyFp());
+        checkMethod.accept(modifyInfo.getEndOfLifeDate().toString(), ch.getEndOfLife().toString());
 
-        checkMethod.checkCompatible(modifyInfo.getChannelProductProduct(), ch.getProduct().getProduct());
-        checkMethod.checkCompatible(modifyInfo.getChannelProductVersion(), ch.getProduct().getVersion());
-        checkMethod.checkCompatible(modifyInfo.getChannelAccess(), ch.getAccess());
-        checkMethod.checkCompatible(modifyInfo.getMaintainerName(), ch.getMaintainerName());
-        checkMethod.checkCompatible(modifyInfo.getMaintainerEmail(), ch.getMaintainerEmail());
-        checkMethod.checkCompatible(modifyInfo.getMaintainerPhone(), ch.getMaintainerPhone());
-        checkMethod.checkCompatible(modifyInfo.getSupportPolicy(), ch.getSupportPolicy());
-        checkMethod.checkCompatible(modifyInfo.getUpdateTag(), ch.getUpdateTag());
-        checkMethod.checkCompatible(modifyInfo.isInstallerUpdates(), ch.isInstallerUpdates());
+        checkMethod.accept(modifyInfo.getChannelProductProduct(), ch.getProduct().getProduct());
+        checkMethod.accept(modifyInfo.getChannelProductVersion(), ch.getProduct().getVersion());
+        checkMethod.accept(modifyInfo.getChannelAccess(), ch.getAccess());
+        checkMethod.accept(modifyInfo.getMaintainerName(), ch.getMaintainerName());
+        checkMethod.accept(modifyInfo.getMaintainerEmail(), ch.getMaintainerEmail());
+        checkMethod.accept(modifyInfo.getMaintainerPhone(), ch.getMaintainerPhone());
+        checkMethod.accept(modifyInfo.getSupportPolicy(), ch.getSupportPolicy());
+        checkMethod.accept(modifyInfo.getUpdateTag(), ch.getUpdateTag());
+        checkMethod.accept(modifyInfo.isInstallerUpdates(), ch.isInstallerUpdates());
     }
 
     public void createTestChannel(ChannelInfoDetailsJson modifyInfo, User userIn) throws Exception {

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -30,6 +30,8 @@ import com.redhat.rhn.domain.channel.ChannelProduct;
 import com.redhat.rhn.domain.channel.ClonedChannel;
 import com.redhat.rhn.domain.channel.ProductName;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.iss.IssFactory;
+import com.redhat.rhn.domain.iss.IssMaster;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.user.User;
@@ -48,6 +50,7 @@ import com.suse.manager.model.hub.ChannelInfoDetailsJson;
 import com.suse.manager.model.hub.ChannelInfoJson;
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssAccessToken;
+import com.suse.manager.model.hub.IssHub;
 import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssPeripheralChannels;
 import com.suse.manager.model.hub.IssRole;
@@ -130,7 +133,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
                 Arguments.of(HttpMethod.post, "/hub/sync/channelfamilies", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/sync/products", IssRole.HUB),
                 Arguments.of(HttpMethod.post, "/hub/sync/repositories", IssRole.HUB),
-                Arguments.of(HttpMethod.post, "/hub/sync/subscriptions", IssRole.HUB)
+                Arguments.of(HttpMethod.post, "/hub/sync/subscriptions", IssRole.HUB),
+                Arguments.of(HttpMethod.post, "/hub/sync/migrate/v1/deleteMaster", IssRole.HUB)
         );
     }
 
@@ -944,5 +948,71 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
         testUtils.checkSyncChannelsApiThrows(DUMMY_SERVER_FQDN, List.of(modifyInfo),
                 "Information about the original channel");
+    }
+
+    @Test
+    public void checkDeleteMaster() throws Exception {
+        String apiUnderTest = "/hub/sync/migrate/v1/deleteMaster";
+
+        IssMaster master = new IssMaster();
+        master.setLabel(DUMMY_SERVER_FQDN);
+        master.makeDefaultMaster();
+        master.setCaCert("/etc/pki/trust/anchors/master.pem");
+
+        IssFactory.save(master);
+        TestUtils.flushAndEvict(master);
+
+        HubFactory hubFactory = new HubFactory();
+        IssHub hub = new IssHub(DUMMY_SERVER_FQDN, "");
+        hubFactory.save(hub);
+
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
+            .withApiEndpoint(apiUnderTest)
+            .withHttpMethod(HttpMethod.post)
+            .withRole(IssRole.HUB)
+            .withBearerTokenInHeaders()
+            .simulateControllerApiCall();
+
+        ResultJson<?> result = Json.GSON.fromJson(answer, ResultJson.class);
+        assertTrue(result.isSuccess(), "Failed: " + answer);
+
+        assertNull(IssFactory.lookupMasterByLabel(DUMMY_SERVER_FQDN));
+        assertNull(IssFactory.getCurrentMaster());
+    }
+
+    @Test
+    public void ensureThrowsWhenMasterIsNotFound() throws Exception {
+        String apiUnderTest = "/hub/sync/migrate/v1/deleteMaster";
+
+        IssMaster master = new IssMaster();
+        // label not matching the hub fqdn
+        master.setLabel("iss-master.unit-test.local");
+        master.makeDefaultMaster();
+        master.setCaCert("/etc/pki/trust/anchors/master.pem");
+
+        IssFactory.save(master);
+        TestUtils.flushAndEvict(master);
+
+        String answer = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
+            .withApiEndpoint(apiUnderTest)
+            .withHttpMethod(HttpMethod.post)
+            .withRole(IssRole.HUB)
+            .withBearerTokenInHeaders()
+            .simulateControllerApiCall();
+
+        ResultJson<?> result = Json.GSON.fromJson(answer, ResultJson.class);
+        assertFalse(result.isSuccess(), "Failed: " + answer);
+        assertNotNull(result.getMessages());
+        assertEquals(1, result.getMessages().size());
+        assertEquals(
+            "dummy-server.unit-test.local is not registered as an ISS v1 master",
+            result.getMessages().get(0)
+        );
+
+        IssMaster reloaded = IssFactory.getCurrentMaster();
+        assertNotNull(reloaded);
+        assertEquals("iss-master.unit-test.local", reloaded.getLabel());
+        assertTrue(reloaded.isDefaultMaster());
+        assertEquals("/etc/pki/trust/anchors/master.pem", reloaded.getCaCert());
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -64,6 +64,7 @@ import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -145,8 +146,16 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         return allApiEndpoints().filter(e -> (IssRole.HUB == e.get()[2]));
     }
 
+    private static boolean noHubApis() {
+        return onlyHubApis().findAny().isEmpty();
+    }
+
     private static Stream<Arguments> onlyPeripheralApis() {
         return allApiEndpoints().filter(e -> (IssRole.PERIPHERAL == e.get()[2]));
+    }
+
+    private static boolean noPeripheralApis() {
+        return onlyPeripheralApis().findAny().isEmpty();
     }
 
     @ParameterizedTest
@@ -177,6 +186,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
     @ParameterizedTest
     @MethodSource("onlyHubApis")
+    @DisabledIf(value = "noHubApis", disabledReason = "No API can be called only from a Hub")
     public void ensureHubApisNotWorkingWithPeripheral(HttpMethod apiMethod, String apiEndpoint, IssRole apiRole)
             throws Exception {
         String answerKO = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
@@ -191,8 +201,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
         assertEquals("Token does not allow access to this resource", resultKO.getMessages().get(0));
     }
 
-    //@ParameterizedTest
-    //@MethodSource("onlyPeripheralApis")
+    @ParameterizedTest
+    @MethodSource("onlyPeripheralApis")
+    @DisabledIf(value = "noPeripheralApis", disabledReason = "No API can be called only from a Peripheral")
     public void ensurePeripheralApisNotWorkingWithHub(HttpMethod apiMethod, String apiEndpoint/*, IssRole apiRole*/)
             throws Exception {
         String answerKO = (String) testUtils.withServerFqdn(DUMMY_SERVER_FQDN)
@@ -483,8 +494,6 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @MethodSource("allBaseAndVendorChannelAlreadyPresentCombinations")
     public void checkApiSyncChannel(boolean baseChannelAlreadyPresentInPeripheral,
                                     boolean channelAlreadyPresentInPeripheral) throws Exception {
-        String apiUnderTest = "/hub/syncChannels";
-
         //SUSE Linux Enterprise Server 15 SP7 x86_64
         String vendorBaseChannelTemplateName = "SLES15-SP7-Pool for x86_64";
         String vendorBaseChannelTemplateLabel = "sles15-sp7-pool-x86_64";

--- a/java/code/src/com/suse/manager/model/hub/migration/MigrationItem.java
+++ b/java/code/src/com/suse/manager/model/hub/migration/MigrationItem.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub.migration;
+
+import com.redhat.rhn.domain.iss.IssSlave;
+
+import com.suse.manager.model.hub.IssPeripheral;
+
+/**
+ * Immutable class to represent an item to be processed by the migration process from ISSv1 to ISSv3.
+ * @param slave the ISSv1 slave
+ * @param migrationData the data needed for the migration
+ * @param peripheral the ISSv3 peripheral, if correctly created
+ * @param success true if the process is successful
+ */
+public record MigrationItem(
+    IssSlave slave,
+    SlaveMigrationData migrationData,
+    IssPeripheral peripheral,
+    boolean success
+) {
+
+    /**
+     * Create an item for the migration process.
+     * @param slaveIn the ISSv1 slave
+     * @param migrationDataIn the data needed for the migration
+     */
+    public MigrationItem(IssSlave slaveIn, SlaveMigrationData migrationDataIn) {
+        this(slaveIn, migrationDataIn, null, true);
+    }
+
+    /**
+     * Gets the fully qualified domain of this server. See {@link SlaveMigrationData#fqdn()}.
+     * @return the FQDN of this server
+     */
+    public String fqdn() {
+        return migrationData.fqdn();
+    }
+
+    /**
+     * Gets the token needed for accessing ISSv3 API. See {@link SlaveMigrationData#token()}.
+     * @return the access token
+     */
+    public String token() {
+        return migrationData.token();
+    }
+
+    /**
+     * Gets the root certificate authority, needed to establish a secure connection.
+     * See {@link SlaveMigrationData#rootCA()}.
+     * @return the root certificate authority
+     */
+    public String rootCA() {
+        return migrationData.rootCA();
+    }
+
+    /**
+     * Creates a new migration item with the current data and the specified peripheral.
+     * @param peripheralIn the migrated ISSv3 peripheral server
+     * @return a new migration item.
+     */
+    public MigrationItem withPeripheral(IssPeripheral peripheralIn) {
+        return new MigrationItem(slave, migrationData, peripheralIn, true);
+    }
+
+    /**
+     * Creates a new migration item with the same data, but marked as failed in the migration process.
+     * @return a new failed migration item.
+     */
+    public MigrationItem fail() {
+        return new MigrationItem(slave, migrationData, peripheral, false);
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/migration/MigrationItem.java
+++ b/java/code/src/com/suse/manager/model/hub/migration/MigrationItem.java
@@ -15,6 +15,8 @@ import com.redhat.rhn.domain.iss.IssSlave;
 
 import com.suse.manager.model.hub.IssPeripheral;
 
+import java.util.function.UnaryOperator;
+
 /**
  * Immutable class to represent an item to be processed by the migration process from ISSv1 to ISSv3.
  * @param slave the ISSv1 slave
@@ -36,6 +38,14 @@ public record MigrationItem(
      */
     public MigrationItem(IssSlave slaveIn, SlaveMigrationData migrationDataIn) {
         this(slaveIn, migrationDataIn, null, true);
+    }
+
+    /**
+     * Create an item for the migration process.
+     * @param migrationDataIn the data needed for the migration
+     */
+    public MigrationItem(SlaveMigrationData migrationDataIn) {
+        this(null, migrationDataIn, null, true);
     }
 
     /**
@@ -78,5 +88,18 @@ public record MigrationItem(
      */
     public MigrationItem fail() {
         return new MigrationItem(slave, migrationData, peripheral, false);
+    }
+
+    /**
+     * Execute the specified action if this item is failed
+     * @param action a unary operation that receives this item, perform the needed operations in case of failure and
+     * returns a possibly updated version of this item.
+     */
+    public MigrationItem ifFailed(UnaryOperator<MigrationItem> action) {
+        if (success) {
+            return this;
+        }
+
+        return action.apply(this);
     }
 }

--- a/java/code/src/com/suse/manager/model/hub/migration/MigrationMessage.java
+++ b/java/code/src/com/suse/manager/model/hub/migration/MigrationMessage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub.migration;
+
+public record MigrationMessage(MigrationMessageLevel severity, String message) {
+
+    /**
+     * Creates an info message
+     * @param message the message
+     * @return a {@link MigrationMessage} instance
+     */
+    public static MigrationMessage info(String message) {
+        return new MigrationMessage(MigrationMessageLevel.INFO, message);
+    }
+
+    /**
+     * Creates an info message
+     * @param message the message
+     * @return a {@link MigrationMessage} instance
+     */
+    public static MigrationMessage warn(String message) {
+        return new MigrationMessage(MigrationMessageLevel.WARN, message);
+    }
+
+    /**
+     * Creates an info message
+     * @param message the message
+     * @return a {@link MigrationMessage} instance
+     */
+    public static MigrationMessage error(String message) {
+        return new MigrationMessage(MigrationMessageLevel.ERROR, message);
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/migration/MigrationMessageLevel.java
+++ b/java/code/src/com/suse/manager/model/hub/migration/MigrationMessageLevel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub.migration;
+
+import com.redhat.rhn.domain.Labeled;
+
+public enum MigrationMessageLevel implements Labeled {
+    INFO,
+    WARN,
+    ERROR;
+
+    @Override
+    public String getLabel() {
+        return name().toLowerCase();
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/migration/MigrationResult.java
+++ b/java/code/src/com/suse/manager/model/hub/migration/MigrationResult.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub.migration;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class MigrationResult {
+
+    private MigrationResultCode resultCode;
+
+    private final Set<MigrationMessage> messageSet;
+
+    /**
+     * Default constructor
+     */
+    public MigrationResult() {
+        this.resultCode = MigrationResultCode.SUCCESS;
+        this.messageSet = new HashSet<>();
+    }
+
+    public synchronized MigrationResultCode getResultCode() {
+        return resultCode;
+    }
+
+    public synchronized void setResultCode(MigrationResultCode resultCodeIn) {
+        this.resultCode = resultCodeIn;
+    }
+
+    public Set<MigrationMessage> getMessages() {
+        return Collections.unmodifiableSet(messageSet);
+    }
+
+    /**
+     * Add a message to the result messages
+     * @param severity the severity level
+     * @param message the message
+     */
+    public synchronized void addMessage(MigrationMessageLevel severity, String message) {
+        messageSet.add(new MigrationMessage(severity, message));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (!(o instanceof MigrationResult that)) {
+            return false;
+        }
+
+        return new EqualsBuilder()
+            .append(resultCode, that.resultCode)
+            .append(messageSet, that.messageSet)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(resultCode)
+            .append(messageSet)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("MigrationResult{");
+        sb.append("success=").append(resultCode);
+        sb.append(", messageList=").append(messageSet);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/migration/MigrationResultCode.java
+++ b/java/code/src/com/suse/manager/model/hub/migration/MigrationResultCode.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub.migration;
+
+import com.redhat.rhn.domain.Labeled;
+
+public enum MigrationResultCode implements Labeled {
+    SUCCESS,
+    PARTIAL,
+    FAILURE;
+
+    @Override
+    public String getLabel() {
+        return name().toLowerCase();
+    }
+}

--- a/java/code/src/com/suse/manager/model/hub/migration/SlaveMigrationData.java
+++ b/java/code/src/com/suse/manager/model/hub/migration/SlaveMigrationData.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub.migration;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record SlaveMigrationData(String fqdn, String token, String rootCA) {
+
+    /**
+     * Builds an instance from the request data
+     * @param dataMap the data as received from the request
+     */
+    public SlaveMigrationData(Map<String, String> dataMap) {
+        this (
+            Objects.requireNonNull(dataMap.get("fqdn"), "Missing slave fully qualified domain name"),
+            Objects.requireNonNull(dataMap.get("token"), () -> "Missing access token for " + dataMap.get("fqdn")),
+            dataMap.get("root_ca")
+        );
+    }
+
+}

--- a/java/code/src/com/suse/manager/xmlrpc/iss/HubHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/HubHandler.java
@@ -695,7 +695,7 @@ public class HubHandler extends BaseHandler {
      * Migrate the existing ISSv1 slaves to Hub Online Synchronization peripherals.
      *
      * @param loggedInUser The current user
-     * @param migrationData         A list of peripheral migration data
+     * @param migrationData A list of peripheral migration data
      * @return the migration result
      *
      * @apidoc.doc Migrate the existing ISSv1 slaves to Hub Online Synchronization peripherals.
@@ -705,12 +705,13 @@ public class HubHandler extends BaseHandler {
      *     #struct_begin("slave_migration_data")
      *       #prop_desc("string", "fqdn", "The fully qualified domain name of the remote slave server.")
      *       #prop_desc("string", "token", "The token used to authenticate on the remote server.")
-     *       #prop_desc("string", "root_ca", "The root ca neeed to establish a secure connection to the remote server.")
+     *       #prop_desc("string", "root_ca", "The root ca needed to establish a secure connection to the
+     *       remote server.")
      *     #struct_end()
      *   #array_end()
      * @apidoc.returntype $MigrationResultSerializer
      */
-    public MigrationResult migrateIssSlaves(User loggedInUser, List<Map<String, String>> migrationData) {
+    public MigrationResult migrateFromISSv1(User loggedInUser, List<Map<String, String>> migrationData) {
         ensureSatAdmin(loggedInUser);
 
         if (CollectionUtils.isEmpty(migrationData)) {
@@ -730,5 +731,47 @@ public class HubHandler extends BaseHandler {
 
         return migratorFactory.createFor(loggedInUser)
             .migrateFromV1(migrationDataMap);
+    }
+
+    /**
+     * Migrate the existing ISSv2 peripherals to Hub Online Synchronization peripherals.
+     *
+     * @param loggedInUser The current user
+     * @param migrationData A list of peripheral migration data
+     * @return the migration result
+     *
+     * @apidoc.doc Migrate the existing ISSv2 peripherals to Hub Online Synchronization peripherals.
+     * @apidoc.param #session_key()
+     * @apidoc.param
+     *   #array_begin("migration_data")
+     *     #struct_begin("peripheral_migration_data")
+     *       #prop_desc("string", "fqdn", "The fully qualified domain name of the remote peripheral server.")
+     *       #prop_desc("string", "token", "The token used to authenticate on the remote server.")
+     *       #prop_desc("string", "root_ca", "The root ca needed to establish a secure connection to the
+     *       remote server.")
+     *     #struct_end()
+     *   #array_end()
+     * @apidoc.returntype $MigrationResultSerializer
+     */
+    public MigrationResult migrateFromISSv2(User loggedInUser, List<Map<String, String>> migrationData) {
+        ensureSatAdmin(loggedInUser);
+
+        if (CollectionUtils.isEmpty(migrationData)) {
+            throw new InvalidParameterException("migration data must not be empty");
+        }
+
+        List<SlaveMigrationData> migrationDataList;
+
+        try {
+            migrationDataList = migrationData.stream()
+                .map(SlaveMigrationData::new)
+                .toList();
+        }
+        catch (NullPointerException ex) {
+            throw new InvalidParameterException("Migration data is not valid: %s".formatted(ex.getMessage()));
+        }
+
+        return migratorFactory.createFor(loggedInUser)
+            .migrateFromV2(migrationDataList);
     }
 }

--- a/java/code/src/com/suse/manager/xmlrpc/serializer/MigrationResultSerializer.java
+++ b/java/code/src/com/suse/manager/xmlrpc/serializer/MigrationResultSerializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.xmlrpc.serializer;
+
+import com.suse.manager.api.ApiResponseSerializer;
+import com.suse.manager.api.SerializationBuilder;
+import com.suse.manager.api.SerializedApiResponse;
+import com.suse.manager.model.hub.migration.MigrationResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Convert a migration result into a XMLRPC &lt;struct&gt;.
+ *
+ * @apidoc.doc
+ *   #struct_begin("result")
+ *     #prop_array_begin("messages")
+ *       #struct_begin("message")
+ *         #prop_desc("string", "severity", "the severity of the message")
+ *         #prop_desc("string", "message", "the message")
+ *       #struct_end()
+ *     #prop_array_end()
+ *     #prop("result_code", "success")
+ *   #struct_end()
+ */
+public class MigrationResultSerializer extends ApiResponseSerializer<MigrationResult> {
+    @Override
+    public Class<MigrationResult> getSupportedClass() {
+        return MigrationResult.class;
+    }
+
+    @Override
+    public SerializedApiResponse serialize(MigrationResult src) {
+        List<Map<String, String>> messagesList = src.getMessages()
+            .stream()
+            .map(m -> Map.of("severity", m.severity().getLabel(), "message", m.message()))
+            .toList();
+
+        SerializationBuilder builder = new SerializationBuilder()
+            .add("result_code", src.getResultCode())
+            .add("messages", messagesList);
+
+        return builder.build();
+    }
+}

--- a/java/code/src/com/suse/utils/CustomCollectors.java
+++ b/java/code/src/com/suse/utils/CustomCollectors.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.utils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public final class CustomCollectors {
+
+    private CustomCollectors() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Returns a Collector implementing a "group by" operation on input elements of type T, grouping elements according
+     * to a classification function, and returning the results in a Map.
+     *
+     * <p>The classification function maps elements to some key type K. The collector produces a
+     * Map&lt;K, List&lt;V&gt;&gt; whose keys are the values resulting from applying the classification function to
+     * the input elements, and whose corresponding values are Lists containing the input elements which map to the
+     * associated key under the classification function.
+     *
+     * <p>In contrast with the default {@link Collectors#groupingBy(Function)}, this implementation is designed to
+     * handle null as key values.
+     *
+     * @param <T>         The type of input elements.
+     * @param <K>         The type of the keys in the resulting map.
+     * @param classifier  The classifier function mapping input elements to keys.
+     * @return A {@link Collector} that groups elements into a {@link Map}.
+     */
+    public static <T, K> Collector<T, ?, Map<K, List<T>>> nullSafeGroupingBy(
+        Function<? super T, ? extends K> classifier) {
+        return nullSafeGroupingBy(classifier, Function.identity());
+    }
+
+
+    /**
+     * Returns a Collector implementing a "group by" operation on input elements of type T, grouping elements according
+     * to a classification function, and returning the results in a Map.
+     *
+     * <p>The classification function maps elements to some key type K. The collector produces a
+     * Map&lt;K, List&lt;V&gt;&gt; whose keys are the values resulting from applying the classification function to
+     * the input elements, and whose corresponding values are Lists containing the result of the application of the
+     * value mapping function.
+     *
+     * <p>In contrast with the default {@link Collectors#groupingBy(Function)}, this implementation is designed to
+     * handle null as key values.
+     *
+     * @param <T>         The type of input elements.
+     * @param <K>         The type of the keys in the resulting map.
+     * @param <V>         The type of the values in the resulting lists.
+     * @param classifier  The classifier function mapping input elements to keys.
+     * @param mapper      The mapper function, mapping input elements to the result list values
+     * @return A {@link Collector} that groups elements into a {@link Map}.
+     */
+    public static <T, K, V> Collector<T, ?, Map<K, List<V>>> nullSafeGroupingBy(
+        Function<? super T, ? extends K> classifier, Function<T, V> mapper) {
+        return Collectors.toMap(
+            classifier,
+            item -> List.of(mapper.apply(item)),
+            (list1, list2) -> Lists.union(list1, list2),
+            () -> new HashMap<>()
+        );
+    }
+}

--- a/java/code/src/com/suse/utils/Lists.java
+++ b/java/code/src/com/suse/utils/Lists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) 2016--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.utils;
 
@@ -19,6 +15,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 
 /**
@@ -28,6 +25,7 @@ public class Lists {
 
     private Lists() {
     }
+
 
     private static <T> List<List<T>>  combinations(List<List<T>> acc, List<T> list) {
         List<List<T>> result = new LinkedList<>();
@@ -50,20 +48,19 @@ public class Lists {
      * @return cartesian product of the input
      */
     public static <T> List<List<T>>  combinations(List<List<T>> lists) {
-        if (lists.size() < 1) {
+        if (lists.isEmpty()) {
             return new ArrayList<>();
         }
-        else {
-            List<List<T>> result = new ArrayList<>(lists.get(0).size());
-            for (T t : lists.get(0)) {
-                result.add(Collections.singletonList(t));
-            }
-            List<List<T>> rest = lists.subList(1, lists.size());
-            for (List<T> list : rest) {
-                result = combinations(result, list);
-            }
-            return result;
+
+        List<List<T>> result = new ArrayList<>(lists.get(0).size());
+        for (T t : lists.get(0)) {
+            result.add(Collections.singletonList(t));
         }
+        List<List<T>> rest = lists.subList(1, lists.size());
+        for (List<T> list : rest) {
+            result = combinations(result, list);
+        }
+        return result;
     }
 
     /**
@@ -73,31 +70,46 @@ public class Lists {
      * @param <T> list element type
      * @return a comparator for lists of T
      */
-    public static <T> Comparator<List<T>> listOfListComparator(
-            Comparator<T> elementComparator) {
+    public static <T> Comparator<List<T>> listOfListComparator(Comparator<T> elementComparator) {
         return (o1, o2) -> {
             if (o1 == o2) {
                 return 0;
             }
-            else {
-                for (int i = 0; i < o1.size(); i++) {
-                    T t1 = o1.get(i);
-                    T t2 = o2.get(i);
-                    if (t1 == null && t2 != null) {
-                        return 1;
-                    }
-                    else if (t2 == null && t1 != null) {
-                        return -1;
-                    }
-                    else {
-                        int compare = elementComparator.compare(t1, t2);
-                        if (compare != 0) {
-                            return compare;
-                        }
-                    }
+
+            for (int i = 0; i < o1.size(); i++) {
+                T t1 = o1.get(i);
+                T t2 = o2.get(i);
+
+                if (t1 == null && t2 != null) {
+                    return 1;
                 }
-                return 0;
+
+                if (t2 == null && t1 != null) {
+                    return -1;
+                }
+
+                int compare = elementComparator.compare(t1, t2);
+                if (compare != 0) {
+                    return compare;
+                }
             }
+
+            return 0;
         };
+    }
+
+    /**
+     * Returns a new list containing all elements from the given lists, with duplicates preserved.
+     * If either list is null, it is treated as an empty list.
+     *
+     * @param <T>   The type of elements in the lists.
+     * @param list1 The first list. May be null.
+     * @param list2 The second list. May be null.
+     * @return      A new list containing all elements from both input lists.
+     */
+    public static <T> List<T> union(List<T> list1, List<T> list2) {
+        ArrayList<T> result = new ArrayList<>(Objects.requireNonNullElseGet(list1, () -> List.of()));
+        result.addAll(Objects.requireNonNullElseGet(list2, () -> List.of()));
+        return result;
     }
 }

--- a/java/code/src/com/suse/utils/test/CustomCollectorsTest.java
+++ b/java/code/src/com/suse/utils/test/CustomCollectorsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.utils.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.suse.utils.CustomCollectors;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class CustomCollectorsTest {
+
+    @Test
+    public void testNullSafeGroupingBy() {
+        Map<Long, List<String>> collectorResult = Stream.of(
+            new Data(1L, "test-1"),
+            new Data(1L, "test-2"),
+            new Data(1L, "test-3"),
+            new Data(5L, "test-4"),
+            new Data(null, "test-5"),
+            new Data(null, "test-6")
+        ).collect(CustomCollectors.nullSafeGroupingBy(Data::orgId, Data::label));
+
+        // Can't use Map.of(), it doesn't allow null
+        Map<Long, List<String>> expectedMap = new HashMap<>();
+        expectedMap.put(1L, List.of("test-1", "test-2", "test-3"));
+        expectedMap.put(5L, List.of("test-4"));
+        expectedMap.put(null, List.of("test-5", "test-6"));
+
+        assertEquals(expectedMap, collectorResult);
+    }
+
+    @Test
+    public void testNullSafeGroupingBySingleParameter() {
+        Map<Character, List<String>> collectorResult = Stream.of(
+            "Bright",
+            "snakes",
+            "slid",
+            "silly",
+            "birds",
+            "flew",
+            "high",
+            "fast"
+        ).collect(CustomCollectors.nullSafeGroupingBy(word -> Character.toLowerCase(word.charAt(0))));
+
+        assertEquals(Map.of(
+            's', List.of("snakes", "slid", "silly"),
+            'b', List.of("Bright", "birds"),
+            'f', List.of("flew", "fast"),
+            'h', List.of("high")
+        ), collectorResult);
+    }
+
+    private record Data(Long orgId, String label) { }
+}

--- a/java/code/src/com/suse/utils/test/ListsTest.java
+++ b/java/code/src/com/suse/utils/test/ListsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) 2016--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.utils.test;
 
@@ -21,60 +17,73 @@ import com.suse.utils.Lists;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class ListsTest  {
 
     @Test
    public void testEmpty() {
-       assertTrue(Lists.combinations(Collections.emptyList()).isEmpty());
+       assertTrue(Lists.combinations(List.of()).isEmpty());
    }
 
     @Test
    public void testCombinations() {
       assertTrue(
-          Lists.combinations(Arrays.asList(
-                  Arrays.asList(1, 2),
-                  Collections.emptyList(),
-                  Arrays.asList(5, 6)
+          Lists.combinations(List.of(
+                  List.of(1, 2),
+                  List.of(),
+                  List.of(5, 6)
           )).isEmpty()
       );
       assertTrue(
-          Lists.combinations(Arrays.asList(
-                  Collections.emptyList(),
-                  Arrays.asList(1, 2),
-                  Arrays.asList(5, 6)
+          Lists.combinations(List.of(
+                  List.of(),
+                  List.of(1, 2),
+                  List.of(5, 6)
           )).isEmpty()
       );
       assertTrue(
-          Lists.combinations(Arrays.asList(
-                  Arrays.asList(1, 2),
-                  Arrays.asList(5, 6),
-                  Collections.emptyList()
+          Lists.combinations(List.of(
+                  List.of(1, 2),
+                  List.of(5, 6),
+                  List.of()
           )).isEmpty()
       );
    }
 
     @Test
    public void testCombination() {
-       List<List<Integer>> combinations = Lists.combinations(Arrays.asList(
-               Arrays.asList(1, 2),
-               Arrays.asList(3, 4),
-               Arrays.asList(5, 6)
+       List<List<Integer>> combinations = Lists.combinations(List.of(
+               List.of(1, 2),
+               List.of(3, 4),
+               List.of(5, 6)
        ));
 
-       List<List<Integer>> lists = Arrays.asList(
-               Arrays.asList(1, 3, 5),
-               Arrays.asList(1, 3, 6),
-               Arrays.asList(1, 4, 5),
-               Arrays.asList(1, 4, 6),
-               Arrays.asList(2, 3, 5),
-               Arrays.asList(2, 3, 6),
-               Arrays.asList(2, 4, 5),
-               Arrays.asList(2, 4, 6)
+       List<List<Integer>> lists = List.of(
+               List.of(1, 3, 5),
+               List.of(1, 3, 6),
+               List.of(1, 4, 5),
+               List.of(1, 4, 6),
+               List.of(2, 3, 5),
+               List.of(2, 3, 6),
+               List.of(2, 4, 5),
+               List.of(2, 4, 6)
        );
        assertEquals(lists, combinations);
    }
+
+    @Test
+    public void testUnion() {
+        List<Integer> result = Lists.union(List.of(1, 2, 3), List.of(3, 4, 5));
+        assertEquals(List.of(1, 2, 3, 3, 4, 5), result);
+    }
+
+    @Test
+    public void testNullSafetyUnion() {
+        List<Integer> result = Lists.union(null, List.of(3, 4, 5));
+        assertEquals(List.of(3, 4, 5), result);
+
+        result = Lists.union(List.of(1, 2, 3), null);
+        assertEquals(List.of(1, 2, 3), result);
+    }
 }


### PR DESCRIPTION
## What does this PR change?

This PR introduces an API to migrate ISS v1 slaves, turning them into ISS v3 peripherals

## GUI diff

UI work-in-progess

- [ ] **DONE**

## Documentation
- API documentation added

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25357

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
