### PR TITLE
Fix datetime picker opening unexpectedly (bsc#1237710)

### DIFF
--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -1,6 +1,6 @@
 import "react-datepicker/dist/react-datepicker.css";
 
-import { forwardRef, useRef } from "react";
+import { forwardRef, useRef, useState } from "react";
 
 import ReactDatePicker from "react-datepicker";
 
@@ -44,6 +44,9 @@ export const DateTimePicker = (props: Props) => {
   const hideTimePicker = props.hideTimePicker ?? false;
   const timeZone = props.serverTimeZone ? localizedMoment.serverTimeZone : localizedMoment.userTimeZone;
 
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [showTimePicker, setShowTimePicker] = useState(false);
+
   // Legacy id offers compatibility with the DateTimePickerTag.java format
   const datePickerId = props.legacyId
     ? `${props.legacyId}_datepicker_widget_input`
@@ -57,14 +60,16 @@ export const DateTimePicker = (props: Props) => {
     : undefined;
 
   const openDatePicker = () => {
-    datePickerRef.current?.setOpen(true);
+    setShowDatePicker(true);
   };
 
   const openTimePicker = () => {
-    timePickerRef.current?.setOpen(true);
+    setShowTimePicker(true);
   };
 
   const onChange = (date: Date | null) => {
+    setShowDatePicker(false);
+    setShowTimePicker(false);
     // Currently we don't support propagating null values, we might want to do this in the future
     if (date === null) {
       return;
@@ -129,6 +134,7 @@ export const DateTimePicker = (props: Props) => {
             </span>
             <ReactDatePicker
               key="date-picker"
+              open={showDatePicker}
               /**
                * Here and below, since an element with this id doesn't exist it will be created for the portal in the document
                * body. Please don't remove this as it otherwise breaks z-index stacking.
@@ -137,6 +143,8 @@ export const DateTimePicker = (props: Props) => {
               ref={datePickerRef}
               selected={browserTimezoneValue.toDate()}
               onChange={onChange}
+              onClickOutside={() => setShowDatePicker(false)}
+              onInputClick={() => setShowDatePicker(true)}
               dateFormat={DATE_FORMAT}
               wrapperClassName="form-control date-time-picker-wrapper"
               popperModifiers={popperModifiers}
@@ -174,8 +182,10 @@ export const DateTimePicker = (props: Props) => {
               <i className="fa fa-clock-o"></i>
             </span>
             <ReactDatePicker
+              open={showTimePicker}
               key="time-picker"
               portalId="time-picker-portal"
+              onClickOutside={() => setShowTimePicker(false)}
               ref={timePickerRef}
               selected={browserTimezoneValue.toDate()}
               onChange={(date, event) => {
@@ -192,6 +202,7 @@ export const DateTimePicker = (props: Props) => {
                 mergedDate.setHours(date.getHours(), date.getMinutes());
                 onChange(mergedDate);
               }}
+              onInputClick={() => setShowTimePicker(true)}
               onChangeRaw={(event) => {
                 // In case the user pastes a value, clean it up and cut it to max length
                 const rawValue = event.target.value.replaceAll(/[^\d:]/g, "");

--- a/web/spacewalk-web.changes.welder.fix-datetime-picker
+++ b/web/spacewalk-web.changes.welder.fix-datetime-picker
@@ -1,0 +1,1 @@
+- Fix datetime picker opening unexpectedly (bsc#1237710)


### PR DESCRIPTION
## What does this PR change?

It updates the open/close control of the date/time picker to be managed using a React state instead of relying on a React ref. Previously, the component was opened using a ref without properly handling its closed state, which sometimes led to unexpected openings, as reported for some users.

## GUI diff

No difference. Bug fix.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26562

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
