### PR TITLE
Use correct root ca when syncing a peripheral reporting database

### DIFF
--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -99,8 +99,6 @@ public class HubManager {
 
     private static final Logger LOG = LogManager.getLogger(HubManager.class);
 
-    private static final String ROOT_CA_FILENAME_TEMPLATE = "%s_%s_root_ca.pem";
-
     /**
      * A Hub deliver custom repositories via organization/repositories SCC endpoint.
      * We need a fake repo ID for it.
@@ -600,7 +598,8 @@ public class HubManager {
         });
 
         if (data.hasRootCA()) {
-            taskomaticApi.scheduleSingleRootCaCertUpdate(computeRootCaFileName(role, fqdn), data.getRootCA());
+            String filename = CertificateUtils.computeRootCaFileName(role.getLabel(), fqdn);
+            taskomaticApi.scheduleSingleRootCaCertUpdate(filename, data.getRootCA());
         }
     }
 
@@ -796,10 +795,6 @@ public class HubManager {
         hubFactory.saveToken(fqdn, token, TokenType.CONSUMED, parsedToken.getExpirationTime());
     }
 
-    private static String computeRootCaFileName(IssRole role, String serverFqdn) {
-        return String.format(ROOT_CA_FILENAME_TEMPLATE, role.getLabel(), serverFqdn);
-    }
-
     private IssServer lookupServerByFqdnAndRole(String serverFqdn, IssRole role) {
         return switch (role) {
             case HUB -> hubFactory.lookupIssHubByFqdn(serverFqdn).orElse(null);
@@ -816,7 +811,8 @@ public class HubManager {
 
     private IssServer createServer(IssRole role, String serverFqdn, String rootCA, String gpgKey, User user)
             throws TaskomaticApiException {
-        taskomaticApi.scheduleSingleRootCaCertUpdate(computeRootCaFileName(role, serverFqdn), rootCA);
+        String filename = CertificateUtils.computeRootCaFileName(role.getLabel(), serverFqdn);
+        taskomaticApi.scheduleSingleRootCaCertUpdate(filename, rootCA);
         return switch (role) {
             case HUB -> {
                 IssHub hub = new IssHub(serverFqdn, rootCA);

--- a/java/code/src/com/suse/utils/CertificateUtils.java
+++ b/java/code/src/com/suse/utils/CertificateUtils.java
@@ -49,10 +49,22 @@ public final class CertificateUtils {
 
     private static final Path CUSTOMER_GPG_RING = CUSTOMER_GPG_DIR.resolve("customer-build-keys.gpg");
 
+    private static final String ROOT_CA_FILENAME_TEMPLATE = "%s_%s_root_ca.pem";
+
     private static final Logger LOG = LogManager.getLogger(CertificateUtils.class);
 
     private CertificateUtils() {
         // Prevent instantiation
+    }
+
+    /**
+     * Compute a file name for a root certificate authority of the specified server
+     * @param prefix a prefix, defining the role of the server
+     * @param serverFqdn the server owning the root ca
+     * @return the full file path where the root ca can be store and retrieved
+     */
+    public static String computeRootCaFileName(String prefix, String serverFqdn) {
+        return ROOT_CA_FILENAME_TEMPLATE.formatted(prefix, serverFqdn);
     }
 
     /**

--- a/java/spacewalk-java.changes.mackdk.issv3-hub-reporting-different-rootca
+++ b/java/spacewalk-java.changes.mackdk.issv3-hub-reporting-different-rootca
@@ -1,0 +1,2 @@
+- Use correct root certificate authority, if available, for 
+  connecting to the remote reporting database


### PR DESCRIPTION
## What does this PR change?

This PR changes how the root ca is retrieved when syncing the hub reporting database and connecting to the peripheral. Currently, the logic assumed the root ca was the same among the hub and its peripheral. With the changes implemented for ISSv3 the hub is able to connect peripherals that have a different root ca and the certificate is stored in `/etc/pki/trust/anchors`.

This change ensure the correct certificate is picked up if available and used to establish a secure connection to the remote PostgreSQL database. This will allow the hub reporting feature to work when the peripheral has different root ca, if those machine are registered using the ISSv3 feature.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Addeded note to the documentation ticket:  https://github.com/SUSE/spacewalk/issues/25359

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
