### PR TITLE
Manager-5.1-Beta1: Prevent errors when generating proxy configuration (bsc#1240041)

### DIFF
--- a/spacewalk/certs-tools/mgr_ssl_cert_setup.py
+++ b/spacewalk/certs-tools/mgr_ssl_cert_setup.py
@@ -110,6 +110,7 @@ def processCommandline():
         "-k", "--server-key-file", help="Path to the Server Private Key"
     )
     parser.add_argument("--check-only", "-c", action="store_true")
+    parser.add_argument("--show-container-setup", action="store_true")
     parser.add_argument("--verbose", "-v", action="count", default=0)
     parser.add_argument("--skip-db", action="store_true")
 
@@ -683,6 +684,17 @@ def _main():
     """main routine"""
 
     options = processCommandline()
+
+    if options.show_container_setup:
+        container_setup = getContainersSetup(
+            options.root_ca_file,
+            options.intermediate_ca_file,
+            options.server_cert_file,
+            options.server_key_file,
+        )
+        sys.stdout.write(container_setup)
+        sys.exit(0)
+
     checkOptions(
         options.root_ca_file,
         options.server_cert_file,

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.meaksh.Manager-5.1-Beta1-bsc1240041
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.meaksh.Manager-5.1-Beta1-bsc1240041
@@ -1,0 +1,2 @@
+- Enhance mgr-ssl-cert-tool to allow generating container setup
+  from CLI (bsc#1240041)

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -197,16 +197,16 @@ def check_ssl_cert(root_ca, server_crt, server_key, intermediate_cas):
     try:
         mgr_ssl_cmd = [
             "mgr-ssl-cert-setup",
-            "-r",
+            "--root-ca-file",
             str(root_ca),
-            "-s",
+            "--server-cert-file",
             str(server_crt),
-            "-k",
+            "--server-key-file",
             str(server_key),
             "--show-container-setup",
         ]
         if intermediate_cas:
-            mgr_ssl_cmd.extend(["-i", str(intermediate_cas)])
+            mgr_ssl_cmd.extend(["--intermediate-ca-file", str(intermediate_cas)])
         result = subprocess.run(
             mgr_ssl_cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -9,10 +9,9 @@ import os
 import os.path
 import shutil
 import salt.utils
+import subprocess
 import tempfile
 from salt.utils.minions import CkMinions
-
-import certs.mgr_ssl_cert_setup
 
 
 log = logging.getLogger(__name__)
@@ -196,11 +195,23 @@ def check_ssl_cert(root_ca, server_crt, server_key, intermediate_cas):
     Check that the provided certificates are valid and return the certificate and key to deploy.
     """
     try:
-        cert = certs.mgr_ssl_cert_setup.getContainersSetup(
-            root_ca, intermediate_cas, server_crt, server_key
+        mgr_ssl_cmd = [
+            "mgr-ssl-cert-setup",
+            "-r",
+            str(root_ca),
+            "-s",
+            str(server_crt),
+            "-k",
+            str(server_key),
+            "--show-container-setup",
+        ]
+        if intermediate_cas:
+            mgr_ssl_cmd.extend(["-i", str(intermediate_cas)])
+        result = subprocess.run(
+            mgr_ssl_cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        return {"cert": cert}
-    except certs.mgr_ssl_cert_setup.CertCheckError as err:
+        return {"cert": result.stdout.decode()}
+    except subprocess.CalledProcessError as err:
         return {"error": str(err)}
 
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.Manager-5.1-Beta1-bsc1240041
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.Manager-5.1-Beta1-bsc1240041
@@ -1,0 +1,2 @@
+- mgrutil runner: use mgr-ssl-cert-tool CLI to generate container
+  configuration (bsc#1240041)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue seen in 5.1 Beta1, as the `spacewalk-certs-tools` are not yet migrated to Python 3.11, therefore our mgrutil runner (running in 3.11) is not able to import some helper function.

The way this PR solves the issue is by calling the `mgr-ssl-cert-setup` CLI instead of importing and using the particular helper function.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **tested manually**

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
