### PR TITLE
SonarCloud fix: java:S3457 Format strings should be used correctly

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/StateResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/StateResult.java
@@ -182,16 +182,16 @@ public class StateResult {
     public String toString() {
         StringBuilder retval = new StringBuilder();
         Formatter form = new Formatter(retval);
-        form.format("----------\n");
-        form.format("%1$12s: %2$s\n", "ID", getId());
-        form.format("%1$12s: %2$s\n", "Function", getFunction());
-        form.format("%1$12s: %2$s\n", "Name", getName());
-        form.format("%1$12s: %2$s\n", "Result", isResult());
-        form.format("%1$12s: %2$s\n", "Comment", getComment());
-        form.format("%1$12s: %2$s\n", "Started", getStartTime());
-        form.format("%1$12s: %2$s\n", "Duration", getDuration());
-        form.format("%1$12s: %2$s\n", "SLS", getSls());
-        form.format("%1$12s: %2$s\n", "Changed", getChanges());
+        form.format("----------%n");
+        form.format("%1$12s: %2$s%n", "ID", getId());
+        form.format("%1$12s: %2$s%n", "Function", getFunction());
+        form.format("%1$12s: %2$s%n", "Name", getName());
+        form.format("%1$12s: %2$s%n", "Result", isResult());
+        form.format("%1$12s: %2$s%n", "Comment", getComment());
+        form.format("%1$12s: %2$s%n", "Started", getStartTime());
+        form.format("%1$12s: %2$s%n", "Duration", getDuration());
+        form.format("%1$12s: %2$s%n", "SLS", getSls());
+        form.format("%1$12s: %2$s%n", "Changed", getChanges());
         form.close();
         return retval.toString();
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -318,7 +318,7 @@ public class ContentProjectFactory extends HibernateFactory {
                 .orElse(false);
 
         if (hasDistributions) {
-            log.error("The target " + target + " is being used in an autoinstallation profile. Cannot remove.");
+            log.error("The target %s is being used in an autoinstallation profile. Cannot remove.", target);
             throw new ContentManagementException(LocalizationService.getInstance().getMessage(
                     "contentmanagement.used_in_autoinstallation_profile"
             ));

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -495,7 +495,7 @@ public class DailySummary extends RhnJavaJob {
         args[6] = OrgFactory.EMAIL_ACCOUNT_INFO.getValue();
 
         if (cloudPaygManager.isPaygInstance() && !cloudPaygManager.isCompliant()) {
-            args[7] = String.format("%s\n", ls.getMessage("dailysummary.email.notpaygcompliant"));
+            args[7] = String.format("%s%n", ls.getMessage("dailysummary.email.notpaygcompliant"));
         }
         else {
             args[7] = "";

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -139,7 +139,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
                 FileUtils.copyFile(sourceFile, finalFile);
             }
             catch (IOException e) {
-                throw new RuntimeException(MessageFormat.format("Cannot copy '{0}' file, cancelling",
+                throw new RuntimeException(MessageFormat.format("Cannot copy {0} file, cancelling",
                         finalFilename), e);
             }
 


### PR DESCRIPTION
## What does this PR change?
SonarCloud fix: java:S3457 Format strings should be used correctly
[https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS3457&rule_key=java%3AS3457](url)
## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): #
Port(s): 
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

