### PR TITLE
Sonar Cloud miscellaneous fixes

### DIFF
--- a/java/code/src/com/redhat/rhn/common/messaging/MessageDispatcher.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageDispatcher.java
@@ -85,7 +85,7 @@ public class MessageDispatcher implements Runnable {
                 if (actionHandler == null) {
                     continue;
                 }
-                else if (actionHandler.canRunConcurrently()) {
+                if (actionHandler.canRunConcurrently()) {
                     log.info("Executing in thread pool: {}", actionHandler);
                     threadPool.execute(actionHandler);
                 }
@@ -95,7 +95,6 @@ public class MessageDispatcher implements Runnable {
             }
             catch (InterruptedException e) {
                 log.error("Error occurred in the MessageQueue", e);
-                return;
             }
             catch (Throwable t) {
                 // better log this puppy to let folks know we have a problem

--- a/java/code/src/com/redhat/rhn/common/validator/ValidatorService.java
+++ b/java/code/src/com/redhat/rhn/common/validator/ValidatorService.java
@@ -98,8 +98,7 @@ public class ValidatorService {
             List<String> constraintNames) {
 
         ValidatorResult result = new ValidatorResult();
-        for (Object oIn : validatorIn.getConstraints()) {
-            Constraint c = (Constraint) oIn;
+        for (Constraint c : validatorIn.getConstraints()) {
             if (constraintNames != null) {
                 if (!constraintNames.contains(c.getIdentifier())) {
                     continue;

--- a/java/code/src/com/redhat/rhn/domain/action/salt/StateResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/StateResult.java
@@ -182,16 +182,16 @@ public class StateResult {
     public String toString() {
         StringBuilder retval = new StringBuilder();
         Formatter form = new Formatter(retval);
-        form.format("----------\n");
-        form.format("%1$12s: %2$s\n", "ID", getId());
-        form.format("%1$12s: %2$s\n", "Function", getFunction());
-        form.format("%1$12s: %2$s\n", "Name", getName());
-        form.format("%1$12s: %2$s\n", "Result", isResult());
-        form.format("%1$12s: %2$s\n", "Comment", getComment());
-        form.format("%1$12s: %2$s\n", "Started", getStartTime());
-        form.format("%1$12s: %2$s\n", "Duration", getDuration());
-        form.format("%1$12s: %2$s\n", "SLS", getSls());
-        form.format("%1$12s: %2$s\n", "Changed", getChanges());
+        form.format("----------%n");
+        form.format("%1$12s: %2$s%n", "ID", getId());
+        form.format("%1$12s: %2$s%n", "Function", getFunction());
+        form.format("%1$12s: %2$s%n", "Name", getName());
+        form.format("%1$12s: %2$s%n", "Result", isResult());
+        form.format("%1$12s: %2$s%n", "Comment", getComment());
+        form.format("%1$12s: %2$s%n", "Started", getStartTime());
+        form.format("%1$12s: %2$s%n", "Duration", getDuration());
+        form.format("%1$12s: %2$s%n", "SLS", getSls());
+        form.format("%1$12s: %2$s%n", "Changed", getChanges());
         form.close();
         return retval.toString();
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -318,7 +318,7 @@ public class ContentProjectFactory extends HibernateFactory {
                 .orElse(false);
 
         if (hasDistributions) {
-            log.error("The target " + target + " is being used in an autoinstallation profile. Cannot remove.");
+            log.error("The target {} is being used in an autoinstallation profile. Cannot remove.", target);
             throw new ContentManagementException(LocalizationService.getInstance().getMessage(
                     "contentmanagement.used_in_autoinstallation_profile"
             ));

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/ssm/BaseSubscribeAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/ssm/BaseSubscribeAction.java
@@ -683,7 +683,7 @@ public class BaseSubscribeAction extends RhnLookupDispatchAction {
             if (srvrs.isEmpty()) {
                 continue;
             }
-            else if (toId != null && toId == -1L) {
+            if (toId != null && toId == -1L) {
                 am = new ActionMessage("basesub.jsp.success-default", srvrs.size());
                 msgs.add(ActionMessages.GLOBAL_MESSAGE, am);
             }
@@ -697,7 +697,7 @@ public class BaseSubscribeAction extends RhnLookupDispatchAction {
             if (srvrs.isEmpty()) {
                 continue;
             }
-            else if (toId != null && toId == -1L) {
+            if (toId != null && toId == -1L) {
                 am = new ActionMessage("basesub.jsp.skip-default", srvrs.size());
                 msgs.add(ActionMessages.GLOBAL_MESSAGE, am);
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/TrustAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/TrustAction.java
@@ -307,8 +307,8 @@ public class TrustAction extends FormDispatcher {
         Org usrOrg = OrgFactory.lookupById(userorg);
         String[] strings = request.getParameterValues("oid");
         Long[] oid = { Long.valueOf(strings[0]), Long.valueOf(strings[1]) };
-        Org orgA = OrgFactory.lookupById(Long.valueOf(oid[0]));
-        Org orgB = OrgFactory.lookupById(Long.valueOf(oid[1]));
+        Org orgA = OrgFactory.lookupById(oid[0]);
+        Org orgB = OrgFactory.lookupById(oid[1]);
         request.setAttribute("orgA", orgA);
         request.setAttribute("orgB", orgB);
         DataResult<Map<String, Object>> dr =

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/kickstart/SessionStatusAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/kickstart/SessionStatusAction.java
@@ -65,8 +65,7 @@ public class SessionStatusAction extends RhnAction {
         // Add the history items as "TRUE" values
         // to the request so the display can render or not
         // if this status has occurred.
-        for (Object oIn : kss.getHistory()) {
-            KickstartSessionHistory hist = (KickstartSessionHistory) oIn;
+        for (KickstartSessionHistory hist : kss.getHistory()) {
             request.setAttribute(hist.getState().getLabel(), Boolean.TRUE);
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/BaseDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/BaseDto.java
@@ -28,13 +28,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 public abstract class BaseDto extends SelectableAdapter implements Identifiable {
 
     /**
-     * Returns id to be stored in RhnSet.
-     * @return id to be stored in RhnSet.
-     */
-    @Override
-    public abstract Long getId();
-
-    /**
      * Adds the id of this object to a given set. For adding IdCombos to a set,
      * @see com.redhat.rhn.frontend.dto.IdComboDto
      * @param set The set to which we are adding an element.

--- a/java/code/src/com/redhat/rhn/frontend/dto/ChannelOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ChannelOverview.java
@@ -137,6 +137,7 @@ public class ChannelOverview extends BaseDto implements Comparable {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String toString() {
         return new ToStringBuilder(this).append("id", id).append("name", name)
                 .toString();

--- a/java/code/src/com/redhat/rhn/frontend/dto/ChannelTreeNode.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ChannelTreeNode.java
@@ -305,6 +305,7 @@ public class ChannelTreeNode extends BaseDto implements BaseListDto,
     /**
      * {@inheritDoc}
      */
+    @Override
     public String toString() {
         return new ToStringBuilder(this).
             append("id", id).append("name", name).toString();

--- a/java/code/src/com/redhat/rhn/frontend/dto/UpgradablePackageListItem.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/UpgradablePackageListItem.java
@@ -31,7 +31,7 @@ public class UpgradablePackageListItem extends PackageListItem {
     private List errataAdvisory = new ArrayList<>();
     private List errataAdvisoryType = new ArrayList<>();
     private Set installed;
-    private String installedPackage = new String();
+    private String installedPackage = "";
     private boolean packageReboot;
     private boolean errataReboot;
     private boolean errataRestart;

--- a/java/code/src/com/redhat/rhn/frontend/struts/SelectableAdapter.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/SelectableAdapter.java
@@ -21,11 +21,6 @@ package com.redhat.rhn.frontend.struts;
 public abstract class SelectableAdapter implements Selectable {
     private boolean selected;
     private boolean disabled = false;
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public abstract String getSelectionKey();
 
     /**
      * This says whether this object is selectable on a page with a set The

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -519,7 +519,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
             if (!validKeys.contains(key)) {
                 // user passed an invalid key...
                 if (errors == null) {
-                    errors = new String(key);
+                    errors = key;
                 }
                 else {
                     errors += ", " + key;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -2148,7 +2148,7 @@ public class SystemHandler extends BaseHandler {
                 returnMap.put(val.getKey().getLabel(), val.getValue());
             }
             else {
-                returnMap.put(val.getKey().getLabel(), new String(""));
+                returnMap.put(val.getKey().getLabel(), "");
             }
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
@@ -129,7 +129,7 @@ public class ServerGroupHandler extends BaseHandler {
             if ((user != null) && ((user.hasRole(RoleFactory.SAT_ADMIN) ||
                 (user.hasRole(RoleFactory.ORG_ADMIN))))) {
                 if (admins == null) {
-                    admins = new String(login);
+                    admins = login;
                 }
                 else {
                     admins += ", " + login;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
@@ -1005,8 +1005,7 @@ public class UserHandler extends BaseHandler {
         // prevent adding a bunch of valid groups and then throwing an exception
         // when coming across one that doesn't exist.
         List<ManagedServerGroup> groups = new LinkedList<>();
-        for (Object sgNameIn : sgNames) {
-            String serverGroupName = (String) sgNameIn;
+        for (String serverGroupName : sgNames) {
 
             // Make sure the server group exists:
             ManagedServerGroup group;

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1670,7 +1670,7 @@ public class ActionManager extends BaseManager {
         kad.setDiskGb(pcmd.getLocalStorageSize());
         kad.setMemMb(pcmd.getMemoryAllocation());
         kad.setDiskPath(pcmd.getFilePath());
-        kad.setVcpus(Long.valueOf(pcmd.getVirtualCpus()));
+        kad.setVcpus(pcmd.getVirtualCpus());
         kad.setGuestName(pcmd.getGuestName());
         kad.setMacAddress(pcmd.getMacAddress());
         kad.setKickstartSessionId(ksSessionId);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/IpAddress.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/IpAddress.java
@@ -154,10 +154,9 @@ public class IpAddress {
      */
     @Override
     public boolean equals(Object o) {
-        if (o == null || !(o instanceof IpAddress)) {
+        if (!(o instanceof IpAddress other)) {
             return false;
         }
-        IpAddress other = (IpAddress)o;
         return new EqualsBuilder().append(this.getOctets(), other.getOctets())
                                   .append(this.getNumber(), other.getNumber())
                                   .isEquals();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -495,7 +495,7 @@ public class DailySummary extends RhnJavaJob {
         args[6] = OrgFactory.EMAIL_ACCOUNT_INFO.getValue();
 
         if (cloudPaygManager.isPaygInstance() && !cloudPaygManager.isCompliant()) {
-            args[7] = String.format("%s\n", ls.getMessage("dailysummary.email.notpaygcompliant"));
+            args[7] = String.format("%s%n", ls.getMessage("dailysummary.email.notpaygcompliant"));
         }
         else {
             args[7] = "";

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/RpmRepositoryWriter.java
@@ -139,7 +139,7 @@ public class RpmRepositoryWriter extends RepositoryWriter {
                 FileUtils.copyFile(sourceFile, finalFile);
             }
             catch (IOException e) {
-                throw new RuntimeException(MessageFormat.format("Cannot copy '{0}' file, cancelling",
+                throw new RuntimeException(MessageFormat.format("Cannot copy {0} file, cancelling",
                         finalFilename), e);
             }
 

--- a/java/code/src/com/suse/manager/api/ApiResponseSerializer.java
+++ b/java/code/src/com/suse/manager/api/ApiResponseSerializer.java
@@ -95,7 +95,4 @@ public abstract class ApiResponseSerializer<T> implements XmlRpcCustomSerializer
 
         return json;
     }
-
-    @Override
-    public abstract Class<T> getSupportedClass();
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -1021,6 +1021,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         /**
          * @return return the message localized - if it was translated
          */
+        @Override
         public String getLocalizedMessage() {
             if (messageId.isEmpty()) {
                 return getMessage();

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
@@ -387,8 +387,7 @@ public class VirtualHostManagerController {
             try {
                 try (InputStream fi = new FileInputStream(kubeconfigPath)) {
                     Map<String, Object>  map = new Yaml().loadAs(fi, Map.class);
-                    if (map.get("contexts") != null &&
-                            map.get("contexts") instanceof List) {
+                    if (map.get("contexts") instanceof List) {
                         List<Map<String, Object>> contexts =
                                 (List<Map<String, Object>>)map.get("contexts");
                         contextNames = contexts.stream()


### PR DESCRIPTION
## What does this PR change?
Fixes the following SonarCloud issues, where the fixes are straightforward
After review and approval, they will be squashed into one commit only

SonarCloud fix: java:S3457 Format strings should be used correctly
SonarCloud fix: java:S4201 Remove unnecessary null checks: instanceof returns false for nulls
SonarCloud fix: java:S2153 Remove the boxing to Long: the argument is already of the same type
SonarCloud fix: java:S3626 Jump statements should not be redundant
SonarCloud fix: java:S4838 An iteration on a Collection should be performed on the type handled by the Collection
SonarCloud fix: java:S3038 Abstract methods  with the same signature as a method in an interface should not be redundant
SonarCloud fix: java:S1161 @Override should be used on overriding and implementing methods
SonarCloud fix: java:S2129 Constructors should not be used to instantiate String classes

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s):
Port(s): 
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

