### PR TITLE
Sonar Cloud miscellaneous fixes 2

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/sso/SSOConfig.java
+++ b/java/code/src/com/redhat/rhn/common/conf/sso/SSOConfig.java
@@ -41,11 +41,11 @@ public final class SSOConfig {
     private SSOConfig() {
 
         final Map<String, Object> samlData = new HashMap<>();
-        Config.get().getNamespaceProperties(ConfigDefaults.get().SINGLE_SIGN_ON_ENABLED).forEach((k, v) -> {
-            if (k.toString().startsWith(ConfigDefaults.get().SINGLE_SIGN_ON_ENABLED + ".")) {
+        Config.get().getNamespaceProperties(ConfigDefaults.SINGLE_SIGN_ON_ENABLED).forEach((k, v) -> {
+            if (k.toString().startsWith(ConfigDefaults.SINGLE_SIGN_ON_ENABLED + ".")) {
                 LOG.info("putting {} into SAML configuration", k);
                 samlData.put(k.toString().replace(
-                        ConfigDefaults.get().SINGLE_SIGN_ON_ENABLED + ".", ""),
+                                ConfigDefaults.SINGLE_SIGN_ON_ENABLED + ".", ""),
                         Config.get().getString((String) k));
             }
             final SettingsBuilder builder = new SettingsBuilder();

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
@@ -203,17 +203,6 @@ public class ServerAction extends ActionChild implements Serializable {
     }
 
     /**
-    *
-    * Sets the parent Action associated with this ServerAction record.
-    *
-    * @param parentActionIn The parentAction to set.
-    */
-    @Override
-    public void setParentAction(Action parentActionIn) {
-        super.setParentAction(parentActionIn);
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFamilyFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFamilyFactoryTest.java
@@ -56,7 +56,7 @@ public class ChannelFamilyFactoryTest extends RhnBaseTestCase {
     }
 
     @Test
-    public void testLookupByLabel() throws Exception {
+    public void testLookupByLabel() {
         ChannelFamily cfam = createTestChannelFamily();
         ChannelFamily cfam2 = ChannelFamilyFactory.lookupByLabel(cfam.getLabel(),
                                                                  cfam.getOrg());
@@ -65,7 +65,7 @@ public class ChannelFamilyFactoryTest extends RhnBaseTestCase {
     }
 
     @Test
-    public void testLookupByLabelLike() throws Exception {
+    public void testLookupByLabelLike() {
         ChannelFamily cfam = createTestChannelFamily();
         List cfams = ChannelFamilyFactory.lookupByLabelLike(cfam.getLabel(),
                 cfam.getOrg());
@@ -99,22 +99,21 @@ public class ChannelFamilyFactoryTest extends RhnBaseTestCase {
         assertEquals(orgfam.getName(), orgfam2.getName());
     }
 
-    public static ChannelFamily createNullOrgTestChannelFamily() throws Exception {
+    public static ChannelFamily createNullOrgTestChannelFamily() {
         User user = UserTestUtils.findNewUser("testUser", "testOrgCreateTestChannelFamily");
         return createTestChannelFamily(user, true);
     }
 
-    public static ChannelFamily createTestChannelFamily() throws Exception {
+    public static ChannelFamily createTestChannelFamily() {
         User user = UserTestUtils.findNewUser("testUser", "testOrgCreateTestChannelFamily");
         return createTestChannelFamily(user);
     }
 
-    public static ChannelFamily createTestChannelFamily(User user) throws Exception {
+    public static ChannelFamily createTestChannelFamily(User user) {
         return createTestChannelFamily(user, false);
     }
 
-    public static ChannelFamily createTestChannelFamily(User user, boolean nullOrg)
-        throws Exception {
+    public static ChannelFamily createTestChannelFamily(User user, boolean nullOrg) {
         return createTestChannelFamily(user, nullOrg, "ChannelFamily");
     }
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartScript.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartScript.java
@@ -133,7 +133,7 @@ public class KickstartScript extends BaseDto implements Comparable<KickstartScri
      * @return true if the script is run in a chrooted environment
      */
     public boolean thisScriptIsChroot() {
-        return !this.chroot.toLowerCase().equals("n");
+        return !this.chroot.equalsIgnoreCase("n");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -92,7 +92,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
      * @param family the channel family
      * @return the newly created SUSE product
      */
-    public static SUSEProduct createTestSUSEProduct(ChannelFamily family) throws Exception {
+    public static SUSEProduct createTestSUSEProduct(ChannelFamily family) {
         return createTestSUSEProduct(family, TestUtils.randomString().toLowerCase());
     }
 
@@ -101,9 +101,8 @@ public class SUSEProductTestUtils extends HibernateFactory {
      * @param family the channel family
      * @param name the product name
      * @return the newly created SUSE product
-     * @throws Exception if anything goes wrong
      */
-    public static SUSEProduct createTestSUSEProduct(ChannelFamily family, String name) throws Exception {
+    public static SUSEProduct createTestSUSEProduct(ChannelFamily family, String name) {
         SUSEProduct product = new SUSEProduct();
         product.setName(name);
         product.setVersion("1");
@@ -511,10 +510,8 @@ public class SUSEProductTestUtils extends HibernateFactory {
      * @param admin the user
      * @param testDataPath the path to test data
      * @param withRepos set true if repos should be added
-     * @throws Exception
      */
-    public static void createVendorSUSEProductEnvironment(User admin, String testDataPath, boolean withRepos)
-            throws Exception {
+    public static void createVendorSUSEProductEnvironment(User admin, String testDataPath, boolean withRepos) {
         createVendorSUSEProductEnvironment(admin, testDataPath, withRepos, false);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.java
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.java
@@ -70,7 +70,7 @@ public class SaltEvent {
      * @param minionIdIn the new id
      */
     public void setMinionId(String minionIdIn) {
-        this.minionId = minionId;
+        this.minionId = minionIdIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerHistoryEvent.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerHistoryEvent.java
@@ -152,7 +152,9 @@ public class ServerHistoryEvent extends BaseDomainHelper {
      */
     @Override
     public boolean equals(Object obj) {
-        ServerHistoryEvent that = (ServerHistoryEvent) obj;
+        if (!(obj instanceof ServerHistoryEvent that)) {
+            return false;
+        }
         return new EqualsBuilder().
                 append(this.getId(), that.getId()).
                 append(this.getServer(), that.getServer()).

--- a/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.java
@@ -264,7 +264,9 @@ public class ServerSnapshot extends BaseDomainHelper {
      */
     @Override
     public boolean equals(Object obj) {
-        ServerSnapshot other = (ServerSnapshot) obj;
+        if (!(obj instanceof ServerSnapshot other)) {
+            return false;
+        }
         return new EqualsBuilder().append(reason.hashCode(), other.reason.hashCode())
                                   .append(channels.hashCode(), other.channels.hashCode())
                                   .append(configChannels.hashCode(),

--- a/java/code/src/com/redhat/rhn/domain/server/ServerSnapshotTagLink.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerSnapshotTagLink.java
@@ -90,7 +90,9 @@ public class ServerSnapshotTagLink extends BaseDomainHelper implements Serializa
      */
     @Override
     public boolean equals(Object obj) {
-        ServerSnapshotTagLink link = (ServerSnapshotTagLink) obj;
+        if (!(obj instanceof ServerSnapshotTagLink link)) {
+            return false;
+        }
         EqualsBuilder build = new EqualsBuilder();
 
         return build.append(this.getServer(), link.getServer()).

--- a/java/code/src/com/redhat/rhn/domain/server/SnapshotTag.java
+++ b/java/code/src/com/redhat/rhn/domain/server/SnapshotTag.java
@@ -113,7 +113,9 @@ public class SnapshotTag extends BaseDomainHelper {
      */
     @Override
     public boolean equals(Object obj) {
-        SnapshotTag other = (SnapshotTag) obj;
+        if (!(obj instanceof SnapshotTag other)) {
+            return false;
+        }
         return new EqualsBuilder().append(name.hashCode(), other.name.hashCode())
                                   .append(org.hashCode(), other.org.hashCode())
                                   .isEquals();

--- a/java/code/src/com/redhat/rhn/domain/server/SnapshotTagName.java
+++ b/java/code/src/com/redhat/rhn/domain/server/SnapshotTagName.java
@@ -71,7 +71,9 @@ public class SnapshotTagName extends BaseDomainHelper {
      */
     @Override
     public boolean equals(Object obj) {
-        SnapshotTagName other = (SnapshotTagName) obj;
+        if (!(obj instanceof SnapshotTagName other)) {
+            return false;
+        }
         return new EqualsBuilder().append(name, other.name)
                                   .isEquals();
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/common/BaseSetOperateOnDiffAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/BaseSetOperateOnDiffAction.java
@@ -150,7 +150,7 @@ public abstract class BaseSetOperateOnDiffAction extends RhnSetAction {
             String msgKey = getSetDecl().getLabel() + ".removed";
 
             Object[] args = new Object[1];
-            args[0] = Integer.valueOf(removed.size()).toString();
+            args[0] = Integer.toString(removed.size());
             msg.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(msgKey, args));
         }
 
@@ -158,7 +158,7 @@ public abstract class BaseSetOperateOnDiffAction extends RhnSetAction {
             String msgKey = getSetDecl().getLabel() + ".added";
 
             Object[] args = new Object[1];
-            args[0] = Integer.valueOf(added.size()).toString();
+            args[0] = Integer.toString(added.size());
             msg.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(msgKey, args));
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/SubscribeConfirm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ssm/SubscribeConfirm.java
@@ -159,7 +159,7 @@ public class SubscribeConfirm extends RhnAction {
                     request);
         }
         else {
-            String[] params = {Integer.valueOf(successes).toString()};
+            String[] params = {Integer.toString(successes)};
             getStrutsDelegate().saveMessage("ssm.config.subscribeconfirm.jsp.success",
                     params, request);
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ChannelAction.java
@@ -268,7 +268,7 @@ public class ChannelAction extends RhnSetAction {
     private ActionMessages getMessages(Errata errata) {
         ActionMessages msgs = new ActionMessages();
         //get the size of the channels set into a string
-        String size = Long.valueOf(errata.getChannels().size()).toString();
+        String size = Long.toString(errata.getChannels().size());
         if (errata.getChannels().size() == 1) { //singular version '1 channel'
             msgs.add(ActionMessages.GLOBAL_MESSAGE,
                      new ActionMessage("errata.channels.updated.singular",

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/NotifySetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/NotifySetupAction.java
@@ -14,26 +14,9 @@
  */
 package com.redhat.rhn.frontend.action.errata;
 
-import org.apache.struts.action.ActionForm;
-import org.apache.struts.action.ActionForward;
-import org.apache.struts.action.ActionMapping;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 /**
  * NotifySetupAction
  */
 public class NotifySetupAction extends BaseErrataSetupAction {
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ActionForward execute(ActionMapping mapping,
-                                 ActionForm formIn,
-                                 HttpServletRequest request,
-                                 HttpServletResponse response) {
-        return super.execute(mapping, formIn, request, response);
-    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
@@ -118,8 +118,7 @@ public class ForgotCredentialsAction extends RhnAction {
         try {
             User foundUser = UserFactory.lookupByLogin(login);
             // Check if email and login agrees
-            if (foundUser.getEmail().toUpperCase().equals(
-                    email.toUpperCase())) {
+            if (foundUser.getEmail().equalsIgnoreCase(email)) {
                 ResetPassword rp = ResetPasswordFactory.createNewEntryFor(foundUser);
                 String link = ResetPasswordFactory.generateLink(rp);
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/ErrataCacheDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ErrataCacheDto.java
@@ -82,7 +82,9 @@ public class ErrataCacheDto {
      */
     @Override
     public boolean equals(Object obj) {
-        ErrataCacheDto ecd = (ErrataCacheDto) obj;
+        if (!(obj instanceof ErrataCacheDto ecd)) {
+            return false;
+        }
 
         return new EqualsBuilder().append(getErrataId(), ecd.getErrataId())
                                   .append(getPackageId(), ecd.getPackageId())

--- a/java/code/src/com/redhat/rhn/frontend/listview/AlphaBar.java
+++ b/java/code/src/com/redhat/rhn/frontend/listview/AlphaBar.java
@@ -90,12 +90,12 @@ public class AlphaBar {
             if (charsEnabled.containsKey(ch.charAt(0))) {
                 Object[] charArg = {ch, charsEnabled.get(ch.charAt(0)).toString()};
                 form = new MessageFormat(charEnabled);
-                target.append(form.format(charArg).toString());
+                target.append(form.format(charArg));
             }
             else {
                 Object[] charArg = {ch};
                 form = new MessageFormat(charDisabled);
-                target.append(form.format(charArg).toString());
+                target.append(form.format(charArg));
             }
 
         }

--- a/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletRequest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletRequest.java
@@ -24,7 +24,6 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Vector;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
@@ -83,14 +82,6 @@ public class RhnHttpServletRequest extends HttpServletRequestWrapper {
         }
 
         return "http";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isSecure() {
-        return super.isSecure();
     }
 
     /**
@@ -193,15 +184,6 @@ public class RhnHttpServletRequest extends HttpServletRequestWrapper {
     @Override
     public Enumeration<Locale> getLocales() {
         return this.locales.elements();
-    }
-
-    /**
-     *
-     * {@inheritDoc}
-     */
-    @Override
-    public Cookie[] getCookies() {
-        return super.getCookies();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
@@ -85,14 +85,6 @@ public class DateTimePickerTag extends TagSupport {
        return super.doEndTag();
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int doStartTag() throws JspException {
-        return super.doStartTag();
-    }
-
     private HtmlTag createInputAddonTag(String type, String icon) {
         HtmlTag dateAddon = new HtmlTag("span");
         dateAddon.setAttribute("class", "input-group-addon input-group-text text");

--- a/java/code/src/com/redhat/rhn/manager/configuration/ConfigChannelCreationHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/ConfigChannelCreationHelper.java
@@ -195,9 +195,8 @@ public class ConfigChannelCreationHelper {
      */
     public void update(ConfigChannel cc, String name,
                             String label, String description) {
-        ConfigurationManager cm = ConfigurationManager.getInstance();
         if (!label.equals(cc.getLabel()) &&
-                cm.conflictingChannelExists(label, cc.getConfigChannelType(), cc.getOrg())) {
+                ConfigurationManager.conflictingChannelExists(label, cc.getConfigChannelType(), cc.getOrg())) {
             ValidatorException.raiseException("channelOverview.error.labelexists",
                     label);
         }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -300,7 +300,7 @@ public class KickstartUrlHelper {
         // /ks/dist/session/
         // 94xe86321bae3cb74551d995e5eafa065c0/ks-rhel-i386-as-4-u2
         String file = getLongMediaPath(session);
-        TinyUrl turl = CommonFactory.createTinyUrl(file.toString(),
+        TinyUrl turl = CommonFactory.createTinyUrl(file,
                 date);
         CommonFactory.saveTinyUrl(turl);
         if (log.isDebugEnabled()) {
@@ -329,7 +329,7 @@ public class KickstartUrlHelper {
         // /ks/dist/session/
         // 94xe86321bae3cb74551d995e5eafa065c0/ks-rhel-i386-as-4-u2
         String file = getLongMediaPath(session);
-        TinyUrl turl = CommonFactory.createTinyUrl(file.toString(),
+        TinyUrl turl = CommonFactory.createTinyUrl(file,
                 new Date());
         CommonFactory.saveTinyUrl(turl);
         if (log.isDebugEnabled()) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
@@ -200,7 +200,7 @@ public abstract class CobblerCommand {
      */
     protected SystemRecord lookupExisting(Server server) {
         if (server.getCobblerId() != null) {
-            SystemRecord rec = SystemRecord.lookupById(this.getCobblerConnection(user), server.getCobblerId());
+            SystemRecord rec = SystemRecord.lookupById(getCobblerConnection(user), server.getCobblerId());
             if (rec != null) {
                 return rec;
             }
@@ -211,7 +211,7 @@ public abstract class CobblerCommand {
         if (sysmap != null) {
             log.debug("getSystemHandleByMAC.found match.");
             String uid = (String) sysmap.get("uid");
-            SystemRecord rec = SystemRecord.lookupById(this.getCobblerConnection(user), uid);
+            SystemRecord rec = SystemRecord.lookupById(getCobblerConnection(user), uid);
             if (rec != null) {
                 return rec;
             }

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
@@ -296,11 +296,10 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
      * @param packageName the name of the package to add
      * @param s the system to associate with the package
      * @param c The channel to which to add the package
-     * @throws Exception something bad happened
      * @return the new package
      */
     public static Package addPackageToSystemAndChannel(String packageName,
-            Server s, Channel c) throws Exception {
+            Server s, Channel c) {
         Package retval = addPackageToChannel(packageName, c);
         PackageManagerTest.associateSystemToPackage(s, retval);
         return retval;
@@ -433,10 +432,8 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
      * Add a kickstart package with the given name to the given channel.
      * @param packageName the name of the package to add
      * @param channel the channel to add the package to
-     * @throws Exception something bad happened
      */
-    public static void addKickstartPackageToChannel(String packageName, Channel channel)
-    throws Exception {
+    public static void addKickstartPackageToChannel(String packageName, Channel channel) {
         PackageCapability kickstartCapability =  findOrCreateKickstartCapability();
         Package kickstartPkg =
             PackageManagerTest.addPackageToChannel(packageName, channel);
@@ -457,9 +454,8 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
     /**
      * Find the kickstart package capability if it exists, create it otherwise.
      * @return The kickstart package capability.
-     * @throws Exception
      */
-    private static PackageCapability findOrCreateKickstartCapability() throws Exception {
+    private static PackageCapability findOrCreateKickstartCapability() {
         Session session = HibernateFactory.getSession();
         Query query = session.createQuery(
                 "from PackageCapability where name = :capability");

--- a/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
@@ -318,10 +318,9 @@ public class ErrataTestUtils {
      * @param channel the channel in which the new package is to be published
      * @param arch the package architecture label
      * @return the newly created patch
-     * @throws Exception if anything goes wrong
      */
     public static Package createTestPackage(User user, Channel channel,
-            String arch) throws Exception {
+            String arch) {
         return createTestPackage(user, null, channel, arch);
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
@@ -188,7 +188,7 @@ public class VirtualHostManagerController {
         String module = request.params("name");
         Optional<GathererModule> gathererModule = getGathererModules()
                 .entrySet().stream()
-                .filter(e -> module.toLowerCase().equals(e.getKey().toLowerCase()))
+                .filter(e -> module.equalsIgnoreCase(e.getKey()))
                 .map(Map.Entry::getValue)
                 .findFirst();
         return result(response,

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -735,7 +735,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     private ServerAction createChildServerAction(Action action, ActionStatus status,
-                                                 long remainingTries) throws Exception {
+                                                 long remainingTries) {
         return createChildServerAction(action, status, minion, remainingTries);
     }
 

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -348,7 +348,7 @@ public class LoginHelper {
         String osrelease = FileUtils.readStringFromFile("/etc/os-release");
         for (String line : osrelease.split("\\r?\\n")) {
             String[] resultKV = line.split("=", 2);
-            if (resultKV[0].toUpperCase().equals("VERSION_ID")) {
+            if (resultKV[0].equalsIgnoreCase("VERSION_ID")) {
                 try {
                     osVersion = Double.valueOf(resultKV[1].replaceAll("\"", ""));
                 }
@@ -356,7 +356,7 @@ public class LoginHelper {
                     log.error("Unable to parse OS versionnumber {}", resultKV[1]);
                 }
             }
-            else if (resultKV[0].toUpperCase().equals("PRETTY_NAME")) {
+            else if (resultKV[0].equalsIgnoreCase("PRETTY_NAME")) {
                 osName = resultKV[1].replaceAll("\"", "'");
             }
         }

--- a/java/code/src/com/suse/scc/model/SCCMinProductJson.java
+++ b/java/code/src/com/suse/scc/model/SCCMinProductJson.java
@@ -37,11 +37,11 @@ public class SCCMinProductJson {
      */
     public SCCMinProductJson(long idIn, String identifierIn, String versionIn,
             String releaseTypeIn, String archIn) {
-        this.id = id;
-        this.identifier = identifier;
-        this.version = version;
-        this.releaseType = releaseType;
-        this.arch = arch;
+        this.id = idIn;
+        this.identifier = identifierIn;
+        this.version = versionIn;
+        this.releaseType = releaseTypeIn;
+        this.arch = archIn;
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?
Fixes the following SonarCloud issues, where the fixes are straightforward
After review and approval, they will be squashed into one commit only

SonarCloud fix: java:S1858 toString() should never be called on a String object
SonarCloud fix: java:S1158 Use static primitive wrapper class toString() method
SonarCloud fix: java:S1185 Overriding methods should do more than simply call the same method in the super class
SonarCloud fix: java:S1656 Remove or correct useless self-assignment
SonarCloud fix: java:S1157 Replace toUpperCase()/toLowerCase() and equals() calls with a single equalsIgnoreCase() call
SonarCloud fix: java:S1130 Remove the declaration of thrown exception as it cannot be thrown from method body
SonarCloud fix: java:S2209 Static members should be accessed statically
SonarCloud fix: java:S2097 equals(Object obj) should test the argument type

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): 
Port(s): 
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
