### PR TITLE
Measured rocky 8 reposync timings

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -710,10 +710,12 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         managertools-el9-pool-x86_64-rocky
         managertools-el9-updates-x86_64-rocky
       ],
-    'rockylinux8' =>
+    'rockylinux8' => # CHECKED
       %w[
         rockylinux-8-x86_64
         rockylinux-8-appstream-x86_64
+        res8-manager-tools-pool-x86_64-rocky
+        res8-manager-tools-updates-x86_64-rocky
       ],
     'rockylinux9' => # CHECKED
       %w[
@@ -1409,11 +1411,13 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'oraclelinux9-x86_64' => 840,
   'res-7-ltss-updates-x86_64' => 960,
   'res7-x86_64' => 21_000,
+  'res8-manager-tools-pool-x86_64-rocky' => 60,
+  'res8-manager-tools-updates-x86_64-rocky' => 60,
   'rhel-x86_64-server-7' => 60,
   'rocky-8-iso' => 600,
   'rockylinux8-uyuni-client-devel-x86_64' => 120,
-  'rockylinux8-x86_64' => 600,
-  'rockylinux8-x86_64-appstream' => 1260,
+  'rockylinux8-x86_64' => 660,
+  'rockylinux8-x86_64-appstream' => 1560,
   'rockylinux8-x86_64-extras' => 420,
   'rockylinux9-appstream-x86_64' => 480,
   'rockylinux9-uyuni-client-devel-x86_64' => 120,


### PR DESCRIPTION
## What does this PR change?

Add rocky 8 reposync timings to the constants.

Measured on 5.0.4 BV.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

- Cucumber tests were added

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/26796
 * 5.0: https://github.com/SUSE/spacewalk/pull/26795

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
