### PR TITLE
CI: remove flaky tests in content lifecycle

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -158,6 +158,8 @@ Feature: Content lifecycle
     And I click on "Promote environment" in "Promote version 1 into prod_name" modal
     Then I wait at most 600 seconds until I see "Built" text in the environment "prod_name"
 
+# flaky test
+@skip_if_github_validation
   Scenario: Add new sources and promote again
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
@@ -708,6 +710,8 @@ Scenario: Create CLM filter of type Package (Build date) that allows packages wh
     And I list channels with spacewalk-remove-channel
     Then I shouldn't get "clp_label"
 
+# flaky test
+@skip_if_github_validation
 @uyuni
   Scenario: Cleanup: remove the created channels
     When I delete these channels with spacewalk-remove-channel:


### PR DESCRIPTION
## What does this PR change?

CI: remove flaky tests in content lifecycle

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [X] **DONE**

## Links
N/A

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
