### PR TITLE
Fix bug found after merging uyuni-fix-openscap-audit-date

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
@@ -341,7 +341,8 @@ public class StrutsDelegate {
         //if it is not there, then that means we should always evaluate the
         //date picker.  Otherwise, we evaluate if it tells us to do so.
         if (!form.getMap().containsKey(DatePicker.SCHEDULE_TYPE) ||
-                StringUtils.isEmpty(String.valueOf(form.get(DatePicker.SCHEDULE_TYPE))) ||
+                form.get(DatePicker.SCHEDULE_TYPE) == null ||
+                String.valueOf(form.get(DatePicker.SCHEDULE_TYPE)).isEmpty() ||
                 form.get(DatePicker.SCHEDULE_TYPE).equals(DatePicker.ScheduleType.DATE.asString())) {
             DatePicker p = getDatePicker(name, yearDirection);
             p.readForm(form);


### PR DESCRIPTION
## What does this PR change?
Patch to a bug found after closing [https://github.com/uyuni-project/uyuni/pull/10015](url) 

The datePicker is chosen when:
the form does not specify a SCHEDULE_TYPE
or the SCHEDULE_TYPE key is null or empty
or the SCHEDULE_TYPE key is equal to the datetime schedule type

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manual tests
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26717
Port(s): # **add downstream PR(s), if any**
- [ ] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
