### PR TITLE
do not log debug messages as error (bsc#1240124)

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -775,7 +775,7 @@ class ContentSource:
                 log(0, msg)
             if rhnLog.LOG and rhnLog.LOG.level >= 1:
                 # pylint: disable-next=consider-using-f-string
-                msg = "ERROR[%s/%s]: Mirror list download failed: %s - %s%s" % (
+                msg = "DEBUG[%s/%s]: Mirror list download failed: %s - %s%s" % (
                     exc.errno,
                     exc.code if hasattr(exc, "code") else "-",
                     url,
@@ -1454,15 +1454,15 @@ password={passwd}
                 )
                 msg = msg.replace(url, repl_url)
                 log(0, msg)
-            if rhnLog.LOG and rhnLog.LOG.level >= 1:
+            if rhnLog.LOG and rhnLog.LOG.level >= 2:
                 # pylint: disable-next=consider-using-f-string
-                msg = "ERROR[%s/%s]: Media product file download failed: %s - %s%s" % (
+                msg = "DEBUG[%s/%s]: Media product file download failed: %s - %s%s" % (
                     exc.errno,
                     exc.code if hasattr(exc, "code") else "-",
                     url,
                     exc.strerror,
                     # pylint: disable-next=consider-using-f-string
-                    ": %s" % (traceback.format_exc()) if rhnLog.LOG.level >= 2 else "",
+                    ": %s" % (traceback.format_exc()) if rhnLog.LOG.level >= 3 else "",
                 )
                 msg = msg.replace(url, repl_url)
                 log(0, msg)

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.fix-reposync-logging
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.fix-reposync-logging
@@ -1,0 +1,1 @@
+- Do not log debug messages as errors (bsc#1240124)


### PR DESCRIPTION
## What does this PR change?

Do not log messages meant for debugging with a tag named "ERROR".
This is missleading and may result in useless bug reports

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1240124
Port(s): https://github.com/SUSE/spacewalk/pull/26810

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
