### PR TITLE
Fix delete button alignment in filter modal.

### DIFF
--- a/web/html/src/manager/content-management/list-filters/filter-edit.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.tsx
@@ -157,7 +157,7 @@ const FilterEdit = (props: FilterEditProps) => {
         onClosePopUp={() => setOpen(false)}
         buttons={
           <React.Fragment>
-            <div className="btn-group col-lg-6">
+            <div className="w-100">
               {props.editing && (
                 <Button
                   id={`${props.id}-modal-delete-button`}
@@ -177,8 +177,6 @@ const FilterEdit = (props: FilterEditProps) => {
                   }}
                 />
               )}
-            </div>
-            <div className="col-lg-6">
               <div className="pull-right btn-group">
                 <Button
                   id={`${props.id}-modal-cancel-button`}

--- a/web/spacewalk-web.changes.bisht-richa.filter-modal-buttons-alignment
+++ b/web/spacewalk-web.changes.bisht-richa.filter-modal-buttons-alignment
@@ -1,0 +1,1 @@
+- Fix button alignment in filter modal.


### PR DESCRIPTION
## What does this PR change?
- Fix the delete button alignment in the Filter Details modal.


## GUI diff

No difference.
Before:

<img width="1032" alt="Screenshot 2025-03-28 at 9 20 36" src="https://github.com/user-attachments/assets/a48e30f7-340d-4c68-8248-37e15d08cb42" />


After:

<img width="1213" alt="Screenshot 2025-03-28 at 9 17 44" src="https://github.com/user-attachments/assets/cac040a9-4795-4e2d-8b40-e8829dc8ea3c" />


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**


- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26817
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
