### PR TITLE
fix subquery return more than one row error

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -539,7 +539,7 @@ ORDER BY UPPER(X.nvre)
 
 <mode name="system_installed_pkgs_non_suse_locking" class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
-    SELECT (SELECT p.id
+    SELECT (SELECT distinct p.id
               FROM rhnPackage p
               join rhnChannelPackage cp on p.id = cp.package_id
               join rhnServerChannel sc on sc.channel_id = cp.channel_id


### PR DESCRIPTION
## What does this PR change?

Fix
ERROR: more than one row returned by a subquery used as an expression

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26822

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
