### PR TITLE
Adjust SLS files for 15SP7 and systems running higher Python version

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -10,13 +10,21 @@ mgr_install_docker:
     {%- if grains['osmajorrelease'] == 12 %}
       - python3-docker-py: '>=1.6.0'
     {%- else %}
+      {%- if grains['os_family'] == 'Suse' and grains['pythonversion'][1] > 6 %}
+      - python3{{ grains['pythonversion'][1] }}-docker: '>=1.6.0'
+      {%- else %}
       - python3-docker: '>=1.6.0'
+      {%- endif %}
     {%- endif %}
 {%- else %}
       - python-docker-py: '>=1.6.0'
 {%- endif %}
 {%- if grains['saltversioninfo'][0] >= 2018 %}
+      {%- if grains['os_family'] == 'Suse' and grains['pythonversion'][1] > 6 %}
+      - python3{{ grains['pythonversion'][1] }}-salt
+      {%- else %}
       - python3-salt
+      {%- endif %}
     {%- if grains['saltversioninfo'][0] < 3002 and salt['pkg.info_available']('python-Jinja2', 'python2-Jinja2') and salt['pkg.info_available']('python', 'python2') and salt['pkg.info_available']('python2-salt') %}
       - python2-salt
     {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/update-salt.sls
+++ b/susemanager-utils/susemanager-sls/salt/update-salt.sls
@@ -12,7 +12,11 @@ mgr_keep_salt_up2date:
       - salt-common
 {%- else %}
       - salt
+      {%- if grains['os_family'] == "Suse" and grains['osrelease'] == '15.7' %}
+      - python311-salt
+      {%- else %}
       - python3-salt
+      {%- endif %}
 {%- endif %}
 {%- endif %}
 {%- if salt['pkg.version']('venv-salt-minion') %}

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
@@ -79,7 +79,11 @@ mgr_purge_non_venv_salt_packages:
       - salt-common
       - salt-minion
       - python2-salt
+      {%- if grains['os_family'] == "Suse" and grains['osrelease'] == '15.7' %}
+      - python311-salt
+      {%- else %}
       - python3-salt
+      {%- endif %}
     - require:
       - service: mgr_disable_salt_minion
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-add-python311-cases-to--susemanager-sls
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.meaksh.master-add-python311-cases-to--susemanager-sls
@@ -1,0 +1,2 @@
+- Adjust SLS files for SLE15SP7 and other systems running higher
+  Python version


### PR DESCRIPTION
## What does this PR change?

In SLE15SP7 there is no more `python3-salt` package, in favor of new `python311-salt`.

 This PR adjusts the internal Uyuni SLS files that are explicitely mentioning `python3-salt` package to cover this 15SP7 case.

NOTE: in `update-salt.sls` and `mgr_switch_to_venv_minion.sls` we cannot use the `pythonversion[1]` trick to calculate the target package name, as those SLS bits run also for the Salt Bundle, so the target package calculation can be wrong.  

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26711
Port(s):
https://github.com/SUSE/spacewalk/pull/26824
https://github.com/SUSE/spacewalk/pull/26825

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
