### PR TITLE
fix "Ambiguous match" as 4 products are found

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -170,7 +170,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Micro 6.1" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Linux Micro 6.1" as a product
+    And I select "SUSE Linux Micro 6.1 x86_64" as a product
     And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" as a product
     Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" selected
     When I click the Add Product button
@@ -205,7 +205,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Micro 6.1" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Linux Micro 6.1" as a product
+    And I select "SUSE Linux Micro 6.1 x86_64" as a product
     And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64 (BETA)" as a product
     Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64 (BETA)" selected
     When I click the Add Product button


### PR DESCRIPTION
## What does this PR change?

```shell
05:26:38  And I select "SUSE Linux Micro 6.1" as a product                         # features/step_definitions/setup_steps.rb:82
05:26:38        Ambiguous match, found 4 elements matching visible xpath "//span[contains(text(), 'SUSE Linux Micro 6.1')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/input[@type='checkbox']" (Capybara::Ambiguous)
05:26:38        ./features/step_definitions/setup_steps.rb:85:in `/^I (deselect|select) "([^"]*)" as a product$/'
05:26:38        features/reposync/srv_sync_products.feature:173:in `I select "SUSE Linux Micro 6.1" as a product'
```

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Ports: not needed

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
