### PR TITLE
make page number and page size selectable from the testsuite

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -243,6 +243,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "Setup Wizard" text
     And I wait until I do not see "Loading" text
     Then I should not see a "Operation not successful" text
+    And I select "250" from "pageSize"
     And I should only see success signs in the product list
 
 @scc_credentials

--- a/web/html/src/components/pagination.tsx
+++ b/web/html/src/components/pagination.tsx
@@ -68,6 +68,7 @@ type ItemsPerPageSelectorProps = {
 
 const ItemsPerPageSelector = (props: ItemsPerPageSelectorProps) => (
   <select
+    name="pageSize"
     className="display-number"
     defaultValue={props.currentValue}
     onChange={(e) => props.onChange(parseInt(e.target.value, 10))}
@@ -93,6 +94,7 @@ const PageSelector = (props: PageSelectorProps) => {
         {t("Page <dropdown></dropdown> of {total}", {
           dropdown: () => (
             <select
+              name="pageNumber"
               className="display-number small-select"
               value={props.currentValue}
               onChange={(e) => props.onChange(parseInt(e.target.value, 10))}


### PR DESCRIPTION
## What does this PR change?

To select the page size from the testsuite we need a name for the combox.

## Test coverage
- Cucumber tests were changes

- [x] **DONE**

## Links

Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
