### PR TITLE
Fix unsafe unboxing of boxed Booleans.

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
@@ -50,7 +50,8 @@ public class ContentPropertiesValidator {
             result.addFieldError("label", "contentmanagement.label_required");
         }
 
-        if (!isLabelValid(label)) {
+        Boolean isValid = isLabelValid(label);
+        if (!Boolean.TRUE.equals(isValid)) {
             result.addFieldError("label", "contentmanagement.label_invalid");
         }
 
@@ -95,7 +96,8 @@ public class ContentPropertiesValidator {
             result.addFieldError("name", "contentmanagement.name_required");
         }
 
-        if (!isLabelValid(label)) {
+        Boolean isValid = isLabelValid(label);
+        if (!Boolean.TRUE.equals(isValid)) {
             result.addFieldError("label", "contentmanagement.label_invalid");
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfSearchAction.java
@@ -84,7 +84,8 @@ public class XccdfSearchAction extends BaseSearchAction {
     }
 
     private Date getPickerDate(HttpServletRequest request, String paramName) {
-        if (getOptionScanDateSearch(request)) {
+        Boolean shouldScan = getOptionScanDateSearch(request);
+        if (Boolean.TRUE.equals(shouldScan)) {
             DatePicker dPick = (DatePicker)request.getAttribute(paramName);
             if (dPick != null) {
                 return dPick.getDate();

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
@@ -111,7 +111,7 @@ public class ErrataSearchAction extends BaseSearchAction {
          * we'll never have been called with search being blank,
          * therefore normal setup of the form vars will not have happened.
          */
-        if (!StringUtils.isBlank(search) || dateSearch) {
+        if (!StringUtils.isBlank(search) || Boolean.TRUE.equals(dateSearch)) {
             // If doing a dateSearch use the DatePicker values from the
             // request params otherwise use the defaults.
             dates = picker.processDatePickers(dateSearch, true);
@@ -402,26 +402,20 @@ public class ErrataSearchAction extends BaseSearchAction {
             Boolean type = null;
             if (eo.isBugFix()) {
                 type = (Boolean)formIn.get(ERRATA_BUG);
-                if (type != null) {
-                    if (type) {
-                            filteredByType.add(eo);
-                    }
+                if (Boolean.TRUE.equals(type)) {
+                    filteredByType.add(eo);
                 }
             }
             if (eo.isSecurityAdvisory()) {
                 type = (Boolean)formIn.get(ERRATA_SEC);
-                if (type != null) {
-                    if (type) {
-                        filteredByType.add(eo);
-                    }
+                if (Boolean.TRUE.equals(type)) {
+                    filteredByType.add(eo);
                 }
             }
             if (eo.isProductEnhancement()) {
                 type = (Boolean)formIn.get(ERRATA_ENH);
-                if (type != null) {
-                    if (type) {
-                        filteredByType.add(eo);
-                    }
+                if (Boolean.TRUE.equals(type)) {
+                    filteredByType.add(eo);
                 }
             }
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartLocaleEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartLocaleEditAction.java
@@ -84,7 +84,7 @@ public class KickstartLocaleEditAction extends BaseKickstartEditAction {
         }
 
         if (localeCmd.getKickstartData().isUsingUtc() &&
-            !useUtc) {
+            Boolean.FALSE.equals(useUtc)) {
             localeCmd.doNotUseUtc();
         }
         else if (!localeCmd.getKickstartData().isUsingUtc() &&

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
@@ -101,7 +101,8 @@ public class OrgConfigAction extends RhnAction {
             if (StringUtils.isNotEmpty(request.getParameter(SCAP_RETENTION_PERIOD))) {
                 org.getOrgConfig().setScapRetentionPeriodDays(newScapRetentionPeriod);
             }
-            if (!getOptionScapRetentionPeriodSet(request)) {
+            Boolean isSet = getOptionScapRetentionPeriodSet(request);
+            if (!Boolean.TRUE.equals(isSet)) {
                 org.getOrgConfig().setScapRetentionPeriodDays(null);
             }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
@@ -177,7 +177,7 @@ public class SystemEntitlementsSubmitAction extends
             Long sid = element.getElement();
             Server server = ServerFactory.lookupByIdAndOrg(sid, user.getOrg());
             //We are adding the add on entitlement
-            if (add) {
+            if (Boolean.TRUE.equals(add)) {
                 //if the system already has the entitlement, do nothing
                 //  if so, neither success nor failure count will be updated.
                 if (!server.hasEntitlement(ent)) {

--- a/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
@@ -59,13 +59,13 @@ public abstract class UserEditActionHelper extends RhnAction {
 
         Boolean readOnly = (form.get("readonly") != null);
         if (!targetUser.isReadOnly()) {
-            if (readOnly && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
+            if (Boolean.TRUE.equals(readOnly) && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
                     targetUser.getOrg().numActiveOrgAdmins() < 2) {
                 errors.add(ActionMessages.GLOBAL_MESSAGE,
                         new ActionMessage("error.readonly_org_admin",
                                 targetUser.getOrg().getName()));
             }
-            if (readOnly && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
+            if (Boolean.TRUE.equals(readOnly) && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
                     SatManager.getActiveSatAdmins().size() < 2) {
                 errors.add(ActionMessages.GLOBAL_MESSAGE,
                         new ActionMessage("error.readonly_sat_admin",

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
@@ -460,8 +460,8 @@ public class ActivationKeyHandler extends BaseHandler {
 
         // Check if we need to override the usage_limit and set to unlimited:
         if (details.containsKey("unlimited_usage_limit")) {
-            Boolean unlimited = (Boolean)details.get("unlimited_usage_limit");
-            if (unlimited) {
+            Boolean unlimited = (Boolean) details.get("unlimited_usage_limit");
+            if (Boolean.TRUE.equals(unlimited)) {
                 aKey.setUsageLimit(null);
             }
         }
@@ -1078,13 +1078,13 @@ public class ActivationKeyHandler extends BaseHandler {
          List<ConfigChannel> channels = configHelper.
                               lookupGlobals(loggedInUser, configChannelLabels);
          ConfigChannelListProcessor proc = new ConfigChannelListProcessor();
-         if (addToTop) {
+         if (Boolean.TRUE.equals(addToTop)) {
              Collections.reverse(channels);
          }
 
          for (ActivationKey key : activationKeys) {
              for (ConfigChannel chan : channels) {
-                 if (addToTop) {
+                 if (Boolean.TRUE.equals(addToTop)) {
                      proc.add(key.getConfigChannelsFor(loggedInUser), chan, 0);
                  }
                  else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -550,7 +550,7 @@ public class ConfigChannelHandler extends BaseHandler {
         validKeys.add(ConfigRevisionSerializer.PERMISSIONS);
         validKeys.add(ConfigRevisionSerializer.REVISION);
         validKeys.add(ConfigRevisionSerializer.SELINUX_CTX);
-        if (!isDir) {
+        if (Boolean.FALSE.equals(isDir)) {
             validKeys.add(ConfigRevisionSerializer.CONTENTS);
             validKeys.add(ConfigRevisionSerializer.CONTENTS_ENC64);
             validKeys.add(ConfigRevisionSerializer.MACRO_START);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
@@ -685,7 +685,7 @@ public class ProfileHandler extends BaseHandler {
         script.setData(contents.getBytes());
         script.setInterpreter(interpreter.equals("") ? null : interpreter);
         script.setScriptType(type);
-        script.setChroot(chroot ? "Y" : "N");
+        script.setChroot(Boolean.TRUE.equals(chroot) ? "Y" : "N");
         script.setRaw(!template);
         script.setErrorOnFail(erroronfail);
         script.setKsdata(ksData);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandler.java
@@ -306,7 +306,7 @@ public class SystemDetailsHandler extends BaseHandler {
         }
 
         command.setTimezone(locale);
-        if (useUtc) {
+        if (Boolean.TRUE.equals(useUtc)) {
             command.useUtc();
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
@@ -175,7 +175,7 @@ public class OrgHandler extends BaseHandler {
         cmd.setPrefix(prefix);
 
         String pamAuthService = Config.get().getString(ConfigDefaults.WEB_PAM_AUTH_SERVICE);
-        if (usePamAuth) {
+        if (Boolean.TRUE.equals(usePamAuth)) {
             if (pamAuthService != null && !pamAuthService.trim().isEmpty()) {
                 cmd.setUsePam(usePamAuth);
             }
@@ -218,7 +218,7 @@ public class OrgHandler extends BaseHandler {
             throw new ValidationException(e.getMessage());
         }
 
-        if (!usePamAuth && StringUtils.isEmpty(password)) {
+        if (Boolean.FALSE.equals(usePamAuth) && StringUtils.isEmpty(password)) {
             throw new FaultException(-501, "passwordRequiredOrUsePam",
                     "Password is required if not using PAM authentication");
         }
@@ -657,7 +657,8 @@ public class OrgHandler extends BaseHandler {
         ensureUserRole(loggedInUser, RoleFactory.SAT_ADMIN);
         OrgConfig orgConfig = verifyOrgExists(orgId).getOrgConfig();
         if (newSettings.containsKey("enabled")) {
-            if ((Boolean) newSettings.get("enabled")) {
+            Boolean enabled = (Boolean) newSettings.get("enabled");
+            if (Boolean.TRUE.equals(enabled)) {
                 orgConfig.setScapRetentionPeriodDays(90L);
             }
             else {
@@ -826,7 +827,7 @@ public class OrgHandler extends BaseHandler {
                                      Boolean enable) {
         ensureUserRole(loggedInUser, RoleFactory.SAT_ADMIN);
         Org org = verifyOrgExists(orgId);
-        if (enable) {
+        if (Boolean.TRUE.equals(enable)) {
             org.getOrgConfig().setStagingContentEnabled(enable);
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ConfigRevisionSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ConfigRevisionSerializer.java
@@ -129,7 +129,8 @@ public class ConfigRevisionSerializer extends ApiResponseSerializer<ConfigRevisi
     protected void addFileContent(ConfigRevision rev, SerializationBuilder builder) {
         if (!rev.getConfigContent().isBinary()) {
             String content = rev.getConfigContent().getContentsString();
-            if (!StringUtil.containsInvalidXmlChars2(content)) {
+            Boolean valid = StringUtil.containsInvalidXmlChars2(content);
+            if (Boolean.FALSE.equals(valid)) {
                 builder.add(CONTENTS, content);
                 builder.add(CONTENTS_ENC64, Boolean.FALSE);
             }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ScriptResultSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ScriptResultSerializer.java
@@ -57,7 +57,8 @@ public class ScriptResultSerializer extends ApiResponseSerializer<ScriptResult> 
                 .add("returnCode", src.getReturnCode());
 
         String outputContents = src.getOutputContents();
-        if (StringUtil.containsInvalidXmlChars2(outputContents)) {
+        Boolean hasInvalidChars = StringUtil.containsInvalidXmlChars2(outputContents);
+        if (Boolean.TRUE.equals(hasInvalidChars)) {
             builder.add("output_enc64", Boolean.TRUE);
             builder.add("output", new String(Base64.encodeBase64(outputContents
                     .getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/sync/slave/SlaveHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/sync/slave/SlaveHandler.java
@@ -70,8 +70,8 @@ public class SlaveHandler extends BaseHandler {
 
         IssSlave slave = new IssSlave();
         slave.setSlave(slaveFqdn);
-        slave.setEnabled(isEnabled ? "Y" : "N");
-        slave.setAllowAllOrgs(allowAllOrgs ? "Y" : "N");
+        slave.setEnabled(Boolean.TRUE.equals(isEnabled) ? "Y" : "N");
+        slave.setAllowAllOrgs(Boolean.TRUE.equals(allowAllOrgs) ? "Y" : "N");
         IssFactory.save(slave);
         slave = HibernateFactory.reload(slave);
         return slave;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -887,7 +887,7 @@ public class SystemHandler extends BaseHandler {
         ret.put("id", channel.getId());
         ret.put("name", channel.getName());
         ret.put("label", channel.getLabel());
-        ret.put("current_base", currentBase ? Integer.valueOf(1) : Integer.valueOf(0));
+        ret.put("current_base", Boolean.TRUE.equals(currentBase) ? Integer.valueOf(1) : Integer.valueOf(0));
         return ret;
     }
 
@@ -1946,8 +1946,8 @@ public class SystemHandler extends BaseHandler {
             List<Server> servers = new ArrayList<>(1);
             servers.add(server);
 
-            if (member) {
-                //add to server group
+            if (Boolean.TRUE.equals(member)) {
+                // add to server group
                 serverGroupManager.addServers(group, servers, loggedInUser);
             }
             else {
@@ -3915,7 +3915,7 @@ public class SystemHandler extends BaseHandler {
             .map(Integer::longValue)
             .collect(toList());
 
-        if (!allowModules) {
+        if (Boolean.FALSE.equals(allowModules)) {
             for (Long sid : serverIds) {
                 Server server = SystemManager.lookupByIdAndUser(sid, loggedInUser);
                 for (Channel channel : server.getChannels()) {
@@ -4223,7 +4223,7 @@ public class SystemHandler extends BaseHandler {
 
         List<Long> actionIds = new ArrayList<>();
 
-        if (!allowModules) {
+        if (Boolean.FALSE.equals(allowModules)) {
             boolean hasModules = false;
             for (Integer sid : sids) {
                 Server server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);
@@ -5719,7 +5719,7 @@ public class SystemHandler extends BaseHandler {
         if (details.containsKey("auto_errata_update")) {
             Boolean autoUpdate = (Boolean)details.get("auto_errata_update");
 
-            if (autoUpdate) {
+            if (Boolean.TRUE.equals(autoUpdate)) {
                 server.setAutoUpdate("Y");
             }
             else {
@@ -5818,7 +5818,7 @@ public class SystemHandler extends BaseHandler {
                     server);
         }
         else {
-            if (lockStatus) {
+            if (Boolean.TRUE.equals(lockStatus)) {
                 // lock the server, if it isn't already locked.
                 if (server.getLock() == null) {
                     SystemManager.lockServer(loggedInUser, server,
@@ -7417,7 +7417,8 @@ public class SystemHandler extends BaseHandler {
             String interfaceName) {
         Server server = lookupServer(loggedInUser, sid);
 
-        if (!server.existsActiveInterfaceWithName(interfaceName)) {
+        Boolean hasInterface = server.existsActiveInterfaceWithName(interfaceName);
+        if (!Boolean.TRUE.equals(hasInterface)) {
             throw new NoSuchNetworkInterfaceException("No such network interface: " +
                     interfaceName);
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/XmlRpcSystemHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/XmlRpcSystemHelper.java
@@ -150,7 +150,7 @@ public class XmlRpcSystemHelper {
     public int bootstrap(User user, BootstrapParameters params, boolean saltSSH)
             throws BootstrapException {
         BootstrapResult result = Stream.of(saltSSH).map(ssh -> {
-            if (ssh) {
+            if (Boolean.TRUE.equals(ssh)) {
                 return sshMinionBootstrapper.bootstrap(params, user, ContactMethodUtil.getSSHMinionDefault());
             }
             else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
@@ -110,7 +110,7 @@ public class ServerConfigHandler extends BaseHandler {
             Integer sid, Boolean listLocal) {
         ConfigurationManager cm = ConfigurationManager.getInstance();
         Server server = xmlRpcSystemHelper.lookupServer(loggedInUser, sid);
-        if (listLocal) {
+        if (Boolean.TRUE.equals(listLocal)) {
             return cm.listFileNamesForSystemQuick(loggedInUser, server, null);
         }
         List<ConfigFileNameDto> files = new LinkedList<>();
@@ -197,7 +197,7 @@ public class ServerConfigHandler extends BaseHandler {
         validKeys.add(ConfigRevisionSerializer.PERMISSIONS);
         validKeys.add(ConfigRevisionSerializer.REVISION);
         validKeys.add(ConfigRevisionSerializer.SELINUX_CTX);
-        if (!isDir) {
+        if (Boolean.FALSE.equals(isDir)) {
             validKeys.add(ConfigRevisionSerializer.CONTENTS);
             validKeys.add(ConfigRevisionSerializer.CONTENTS_ENC64);
             validKeys.add(ConfigRevisionSerializer.MACRO_START);
@@ -209,7 +209,7 @@ public class ServerConfigHandler extends BaseHandler {
         Server server = xmlRpcSystemHelper.lookupServer(loggedInUser, sid);
         checkIfLocalPermissible(server);
         ConfigChannel channel;
-        if (commitToLocal) {
+        if (Boolean.TRUE.equals(commitToLocal)) {
             channel = server.getLocalOverride();
         }
         else {
@@ -217,7 +217,7 @@ public class ServerConfigHandler extends BaseHandler {
         }
         XmlRpcConfigChannelHelper configHelper = XmlRpcConfigChannelHelper.getInstance();
         return configHelper.createOrUpdatePath(loggedInUser, channel, path,
-                isDir ? ConfigFileType.dir() : ConfigFileType.file(), data);
+                Boolean.TRUE.equals(isDir) ? ConfigFileType.dir() : ConfigFileType.file(), data);
     }
 
 
@@ -273,7 +273,7 @@ public class ServerConfigHandler extends BaseHandler {
         Server server = xmlRpcSystemHelper.lookupServer(loggedInUser, sid);
         checkIfLocalPermissible(server);
         ConfigChannel channel;
-        if (commitToLocal) {
+        if (Boolean.TRUE.equals(commitToLocal)) {
             channel = server.getLocalOverride();
         }
         else {
@@ -321,7 +321,7 @@ public class ServerConfigHandler extends BaseHandler {
         List<ConfigRevision> revisions = new LinkedList<>();
         for (String path : paths) {
             ConfigFile cf;
-            if (searchLocal) {
+            if (Boolean.TRUE.equals(searchLocal)) {
                 cf = cm.lookupConfigFile(loggedInUser,
                         server.getLocalOverride().getId(), path);
 
@@ -375,7 +375,7 @@ public class ServerConfigHandler extends BaseHandler {
         List<ConfigFile> cfList = new ArrayList<>();
         for (String path : paths) {
             ConfigFile cf;
-            if (deleteFromLocal) {
+            if (Boolean.TRUE.equals(deleteFromLocal)) {
                 cf = cm.lookupConfigFile(loggedInUser,
                         server.getLocalOverride().getId(), path);
             }
@@ -513,7 +513,7 @@ public class ServerConfigHandler extends BaseHandler {
             if (channels.equals(server.getConfigChannelList())) {
                 continue;
             }
-            if (addToTop) {
+            if (Boolean.TRUE.equals(addToTop)) {
                 // Add the existing subscriptions to the end so they will be resubscribed
                 // and their ranks will be overridden
                 channelsToAdd = Stream

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -320,7 +320,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
             data.put(ConfigRevisionSerializer.SELINUX_CTX, selinuxCtx);
             String start = "#@";
             String end = "@#";
-            if (!isDir) {
+            if (Boolean.FALSE.equals(isDir)) {
                 data.put(ConfigRevisionSerializer.CONTENTS, contents);
                 data.put(ConfigRevisionSerializer.MACRO_START, start);
                 data.put(ConfigRevisionSerializer.MACRO_END, end);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
@@ -215,7 +215,7 @@ public class ServerGroupHandler extends BaseHandler {
 
         List servers = xmlRpcSystemHelper.lookupServers(loggedInUser, serverIds);
 
-        if (add) {
+        if (Boolean.TRUE.equals(add)) {
             serverGroupManager.addServers(group, servers, loggedInUser);
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
@@ -899,7 +899,7 @@ public class UserHandler extends BaseHandler {
             String login, List<String> sgNames, Boolean setDefault) {
         ensureUserRole(loggedInUser, RoleFactory.ORG_ADMIN);
 
-        if (setDefault) {
+        if (Boolean.TRUE.equals(setDefault)) {
             removeDefaultSystemGroups(loggedInUser, login, sgNames);
          }
 
@@ -1023,7 +1023,7 @@ public class UserHandler extends BaseHandler {
         UserManager.grantServerGroupPermission(targetUser.getId(), groupIds);
 
         // Follow up with a call to addDefaultSystemGroups if setDefault is true:
-        if (setDefault) {
+        if (Boolean.TRUE.equals(setDefault)) {
             addDefaultSystemGroups(loggedInUser, login, sgNames);
         }
 
@@ -1106,12 +1106,12 @@ public class UserHandler extends BaseHandler {
                 loggedInUser, login);
 
         if (!targetUser.isReadOnly()) {
-            if (readOnly && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
+            if (Boolean.TRUE.equals(readOnly) && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
                     targetUser.getOrg().numActiveOrgAdmins() < 2) {
                 throw new InvalidOperationException("error.readonly_org_admin",
                         targetUser.getOrg().getName());
             }
-            if (readOnly && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
+            if (Boolean.TRUE.equals(readOnly) && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
                     SatManager.getActiveSatAdmins().size() < 2) {
                 throw new InvalidOperationException("error.readonly_sat_admin");
             }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -364,7 +364,7 @@ public class ActionChainManager {
 
         Set<Long> sidSet = new HashSet<>(sids);
 
-        String summary = "Apply highstate" + (test.isPresent() && test.get() ? " in test-mode" : "");
+        String summary = "Apply highstate" + (test.isPresent() && Boolean.TRUE.equals(test.get()) ? " in test-mode" : "");
         Set<Action> result = createActions(user, ActionFactory.TYPE_APPLY_STATES, summary,
                 earliest, actionChain, null, sidSet);
         for (Action action : result) {

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelEditor.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelEditor.java
@@ -100,7 +100,7 @@ public class ChannelEditor {
         PackageManager.verifyPackagesChannelArchCompatAndOrgAccess(user,
                 channel, longPackageIds, add);
 
-        if (add) {
+        if (Boolean.TRUE.equals(add)) {
             ChannelManager.addPackages(channel, longPackageIds, user);
         }
         else {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -602,8 +602,9 @@ public class ContentManager {
 
         // if current Environment or the next 2 Environments in the chain are building -> FORBID promote
         // as it could affect the build in progress
+        Boolean next = nextEnv.getNextEnvironmentOpt();
         if (isEnvironmentBuilding(of(env)) || isEnvironmentBuilding(of(nextEnv)) ||
-                isEnvironmentBuilding(nextEnv.getNextEnvironmentOpt())) {
+                isEnvironmentBuilding(Boolean.TRUE.equals(next))) {
             throw new ContentManagementException("Build/Promote already in progress");
         }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
@@ -134,7 +134,7 @@ public class KickstartOptionsCommand  extends BaseKickstartCommand {
             v.setEnabled(mapIn.containsKey(name));
 
             String[] s = (String[]) mapIn.get(name + "_txt");
-            if ((s != null) && (v.getEnabled())) {
+            if (s != null && Boolean.TRUE.equals(v.getEnabled())) {
                 v.setArg(s[0]);
             }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/TreeDeleteOperation.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/TreeDeleteOperation.java
@@ -84,7 +84,7 @@ public class TreeDeleteOperation extends BaseTreeEditOperation {
 
         if (profiles != null && !profiles.isEmpty()) {
 
-            if (deleteProfiles) {
+            if (Boolean.TRUE.equals(deleteProfiles)) {
                 for (KickstartData profile : profiles) {
                     KickstartDeleteCommand cmd = new KickstartDeleteCommand(
                         profile.getId(), this.user);

--- a/java/code/src/com/redhat/rhn/manager/satellite/ConfigureSatelliteCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/ConfigureSatelliteCommand.java
@@ -201,7 +201,7 @@ public class ConfigureSatelliteCommand extends BaseConfigureCommand
             }
         }
         else {
-            if (Config.get().getBoolean(configKey) != newValue) {
+            if (Config.get().getBoolean(configKey) != Boolean.TRUE.equals(newValue)) {
                 Config.get().setBoolean(configKey, newValue.toString());
                 keysToBeUpdated.add(configKey);
             }

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3528,7 +3528,7 @@ public class SystemManager extends BaseManager {
             params = new HashMap<>();
             params.put("user_id", user.getId());
             params.put("pref", preference);
-            params.put("value", value ? 1 : 0);
+            params.put("value", Boolean.TRUE.equals(value) ? 1 : 0);
             mode.execute(params, new HashMap<>());
         }
     }
@@ -3556,7 +3556,7 @@ public class SystemManager extends BaseManager {
                 "set_auto_update_bulk");
         Map<String, Object> params = new HashMap<>();
         params.put("user_id", user.getId());
-        params.put("value", value ? "Y" : "N");
+        params.put("value", Boolean.TRUE.equals(value) ? "Y" : "N");
         mode.execute(params, new HashMap<>());
     }
 

--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -94,7 +94,7 @@ public class HttpApiRegistry {
             methodsByName.forEach((groupKey, methodList) -> {
                 String path = HTTP_API_ROOT + namespace.replace('.', '/') + '/' + groupKey.getLeft();
                 Route route = routeFactory.createRoute(methodList, handler);
-                if (groupKey.getRight()) {
+                if (Boolean.TRUE.equals(groupKey.getRight())) {
                     registrationHelper.addGetRoute(path, route);
                 }
                 else {
@@ -108,7 +108,7 @@ public class HttpApiRegistry {
                             groupKey.getLeft(),
                             methodList.size() > 1 ?
                                     MessageFormat.format(" ({0} overloads)", methodList.size()) : "",
-                            groupKey.getRight() ? " (Read-only)" : ""));
+                            Boolean.TRUE.equals(readOnly) ? " (Read-only)" : ""));
                 }
                 methodCount[0] += 1;
             });

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -996,7 +996,7 @@ public class SaltUtils {
                             Map<Boolean, String> moveRes = saltApi.storeMinionScapFiles(
                                     minion, openscapResult.getUploadDir(), action.getId());
                             moveRes.entrySet().stream().findFirst().ifPresent(moved -> {
-                                if (moved.getKey()) {
+                                if (Boolean.TRUE.equals(moved.getKey())) {
                                     Path resultsFile = Paths.get(moved.getValue(),
                                             "results.xml");
                                     try (InputStream resultsFileIn =

--- a/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
@@ -72,7 +72,7 @@ public class ChannelsApiController {
         return doWithoutAutoFlushing(() -> {
             Boolean filterClm = Boolean.parseBoolean(req.queryParams("filterClm"));
             Set<Long> filterOutIds = new HashSet<>();
-            if (filterClm) {
+            if (Boolean.TRUE.equals(filterClm)) {
                 // filtering Content Lifecycle Management target channels
                 filterOutIds.addAll(ContentProjectFactory.listSoftwareEnvironmentTarget().stream()
                         .map(tgt -> tgt.getChannel().getId())

--- a/java/code/src/com/suse/manager/webui/services/ConfigChannelSaltManager.java
+++ b/java/code/src/com/suse/manager/webui/services/ConfigChannelSaltManager.java
@@ -127,9 +127,10 @@ public class ConfigChannelSaltManager {
         finally {
             // channel has been renamed - trash the file structure associated with the old
             // label
-            if (Opt.fold(oldChannelLabel,
-                    () -> false,
-                    label -> !label.equals(channel.getLabel()))) {
+            Boolean shouldRemove = Opt.fold(oldChannelLabel, 
+                                                () -> false, 
+                                                label -> !label.equals(channel.getLabel()));
+            if (Boolean.TRUE.equals(shouldRemove)) {
                 removeConfigChannelFiles(channel.getOrgId(), oldChannelLabel.get());
             }
         }

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -224,7 +224,7 @@ public enum SaltStateGeneratorService {
                 bootImage.getKernel().getFilename());
 
         bootImagePillarSync.put("local_path", bootLocalPath);
-        if (isBundle) {
+        if (Boolean.TRUE.equals(isBundle)) {
             bootImagePillarSync.put("kernel_link", "../../" + systemLocalPath + '/' +
                     bootImage.getKernel().getFilename());
             bootImagePillarSync.put("initrd_link", "../../" + systemLocalPath + '/' +

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -84,9 +84,12 @@ public class SubscriptionMatchProcessor {
                     s.getProductIds(),
                     // see https://github.com/SUSE/spacewalk/wiki/
                     // Subscription-counting#definitions
-                    s.getPhysical() ?
-                        (s.getVirtualHost() ? "virtualHost" : "nonVirtual") :
-                        "virtualGuest",
+                    Boolean isPhysical = s.getPhysical();
+                    Boolean isVirtualHost = s.getVirtualHost();
+
+                    String type = Boolean.TRUE.equals(isPhysical)
+                        ? (Boolean.TRUE.equals(isVirtualHost) ? "virtualHost" : "nonVirtual")
+                        : "virtualGuest";
                     output.getMatches().stream()
                         .filter(m -> m.getSystemId().equals(s.getId()))
                         .map(MatchJson::getSubscriptionId)

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -136,7 +136,7 @@ public class LoginHelper {
                 RhnConfigurationFactory factory = RhnConfigurationFactory.getSingleton();
                 Boolean useOrgUnit =
                         factory.getBooleanConfiguration(RhnConfiguration.KEYS.EXTAUTH_USE_ORGUNIT).getValue();
-                if (useOrgUnit) {
+                if (Boolean.TRUE.equals(useOrgUnit)) {
                     String orgUnitString =
                             (String) request.getAttribute("REMOTE_USER_ORGUNIT");
                     newUserOrg = OrgFactory.lookupByName(orgUnitString);


### PR DESCRIPTION
## What does this PR change?

**add description**

This PR addresses the code reported by Sonar rule `java:S5411` by avoiding the direct use of boxed `Boolean` in conditional expressions.
Unboxing a `null` Boolean value can result in a `NullPointerException`. This change replaces instances like `if (b)` with safer alternatives such as `Boolean.TRUE.equals(b)` to improve code safety and maintainability.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
