### PR TITLE
Refactor RemoteNode to encapsulate host and container as System objects.

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -265,8 +265,7 @@ end
 # @return [Boolean] Returns true if the host is a SUSE host, false otherwise.
 def suse_host?(name, runs_in_container: true)
   node = get_target(name)
-  os_family = runs_in_container ? node.os_family : node.local_os_family
-  %w[sles opensuse opensuse-leap sle-micro suse-microos opensuse-leap-micro].include? os_family
+  (runs_in_container ? node.container : node.host).is_suse?
 end
 
 # Determines if the given host name is a SLE/SL Micro host.
@@ -275,8 +274,7 @@ end
 # @return [Boolean] Returns true if the system is a SLE/SL Micro one
 def slemicro_host?(name, runs_in_container: true)
   node = get_target(name)
-  os_family = runs_in_container ? node.os_family : node.local_os_family
-  (name.include? 'slemicro') || (name.include? 'micro') || os_family.include?('sle-micro') || os_family.include?('suse-microos') || os_family.include?('sl-micro')
+  (runs_in_container ? node.container : node.host).is_slemicro?
 end
 
 # Determines if the given host name is a openSUSE Leap Micro host.
@@ -285,8 +283,7 @@ end
 # @return [Boolean] Returns true if the system is a openSUSE Leap Micro one.
 def leapmicro_host?(name, runs_in_container: true)
   node = get_target(name)
-  os_family = runs_in_container ? node.os_family : node.local_os_family
-  os_family.include?('opensuse-leap-micro')
+  (runs_in_container ? node.container : node.host).is_leapmicro?
 end
 
 # Determines if the given host name is a transactional system
@@ -295,7 +292,8 @@ end
 # @param name [String] The host name to check.
 # @return [Boolean] Returns true if the system is a transactional system
 def transactional_system?(name, runs_in_container: true)
-  slemicro_host?(name, runs_in_container: runs_in_container) || leapmicro_host?(name, runs_in_container: runs_in_container)
+  node = get_target(name)
+  (runs_in_container ? node.container : node.host).is_transactional?
 end
 
 # Determines if a given host name belongs to a Red Hat-like distribution.

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -3,6 +3,7 @@
 
 require 'timeout'
 require_relative 'network_utils'
+require_relative 'system'
 
 # The RemoteNode class represents a remote node.
 # It is used to interact with the remote node through SSH.
@@ -360,5 +361,13 @@ class RemoteNode
     os_version.gsub!('.', '-SP') if os_family.match(/^sles/)
     $stdout.puts "Node: #{@hostname}, OS Version: #{os_version}, Family: #{os_family}"
     [os_version, os_family]
+  end
+
+  def host
+    @host_system ||= System.new(local_os_family)
+  end
+
+  def container
+    @container_system ||= System.new(os_family)
   end
 end

--- a/testsuite/features/support/system.rb
+++ b/testsuite/features/support/system.rb
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+# Represents a system OS identity (host or container) and offers helper predicates.
+class System
+    def initialize(os_family)
+      @os_family = os_family
+    end
+  
+    def is_suse?
+      %w[sles opensuse opensuse-leap sle-micro suse-microos opensuse-leap-micro].include?(@os_family)
+    end
+  
+    def is_slemicro?
+      @os_family.include?('sle-micro') || @os_family.include?('suse-microos') || @os_family.include?('sl-micro')
+    end
+  
+    def is_leapmicro?
+      @os_family.include?('opensuse-leap-micro')
+    end
+  
+    def is_transactional?
+      is_slemicro? || is_leapmicro?
+    end
+  
+    def to_s
+      "System<#{@os_family}>"
+    end
+  end


### PR DESCRIPTION
## What does this PR change?

**add description**

This PR refactors the `RemoteNote` class to improve encapsulation and clarity by introducing a new `System` class.  
Instead of spreading platform-specific logic (e.g., `is_suse?`, `is_rhel?`, etc.) across `host` and `container`, this logic is now encapsulated in the new `System` class.  

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
