### PR TITLE
SonarCloud fix: java:S1874 Deprecated code should not be used (part 1)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -460,7 +460,7 @@ public abstract class HibernateFactory {
         try {
             session = HibernateFactory.getSession();
 
-            retval = session.get(clazz, id, LockMode.UPGRADE);
+            retval = session.get(clazz, id, LockMode.PESSIMISTIC_WRITE);
         }
         catch (MappingException me) {
             getLogger().error("Mapping not found for {}", clazz.getName(), me);

--- a/java/code/src/com/redhat/rhn/common/hibernate/ReportDbHibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/ReportDbHibernateFactory.java
@@ -449,7 +449,7 @@ public class ReportDbHibernateFactory {
         try {
             session = getSession();
 
-            retval = session.get(clazz, id, LockMode.UPGRADE);
+            retval = session.get(clazz, id, LockMode.PESSIMISTIC_WRITE);
         }
         catch (MappingException me) {
             getLogger().error("Mapping not found for " + clazz.getName(), me);

--- a/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletRequest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletRequest.java
@@ -123,7 +123,7 @@ public class RhnHttpServletRequest extends HttpServletRequestWrapper {
         if (isRequestedSessionIdFromCookie()) {
             retval.append("Requested Session Id came from Cookie\n");
         }
-        else if (isRequestedSessionIdFromUrl()) {
+        else if (isRequestedSessionIdFromURL()) {
             retval.append("Requested Session Id came from Url\n");
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletResponse.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletResponse.java
@@ -93,8 +93,7 @@ public class RhnHttpServletResponse extends HttpServletResponseWrapper {
      */
     @Override
     public String encodeRedirectUrl(String arg0) {
-        String rc = super.encodeRedirectUrl(arg0);
-        return rc;
+        return this.encodeRedirectURL(arg0);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
@@ -16,11 +16,10 @@ package com.redhat.rhn.taskomatic.core;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -94,7 +93,7 @@ public class TaskomaticDaemon {
         int retval = SUCCESS;
         CommandLineParser parser = null;
         try {
-            parser = new PosixParser();
+            parser = new DefaultParser();
             CommandLine cl = parser.parse(options, argv);
             retval = onStartup(cl);
         }
@@ -211,11 +210,12 @@ public class TaskomaticDaemon {
 
     private void createOption(Options accum, String longopt, boolean arg,
                               String argName, String description) {
-        OptionBuilder.withArgName(argName);
-        OptionBuilder.withLongOpt(longopt);
-        OptionBuilder.hasArg(arg);
-        OptionBuilder.withDescription(description);
-        Option option = OptionBuilder.create(longopt);
+        Option option = Option.builder(longopt)
+                .argName(argName)
+                .longOpt(longopt)
+                .hasArg(arg)
+                .desc(description)
+                .build();
         accum.addOption(option);
         this.masterOptionsMap.putIfAbsent(longopt, option);
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/core/test/TestDaemon.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/test/TestDaemon.java
@@ -17,6 +17,8 @@ package com.redhat.rhn.taskomatic.core.test;
 import com.redhat.rhn.taskomatic.core.TaskomaticDaemon;
 
 import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 
 public class TestDaemon extends TaskomaticDaemon {
 
@@ -34,6 +36,41 @@ public class TestDaemon extends TaskomaticDaemon {
     public static void main(String[] argv) {
         TestDaemon td = new TestDaemon();
         td.registerImplementation(argv);
+
+        optionListPseudoTest(td);
+    }
+
+    public static void optionListPseudoTest(TestDaemon td) {
+        Options options = td.buildOptionsList();
+        System.out.println(options.getOptions().size() == 9);
+        Option opt = options.getOption("debug");
+        System.out.println(opt.toString()
+                .equals("[ option: debug debug  :: turn on debug mode :: class java.lang.String ]"));
+        opt = options.getOption("daemon");
+        System.out.println(opt.toString()
+                .equals("[ option: daemon daemon  :: turn on daemon mode :: class java.lang.String ]"));
+        opt = options.getOption("single");
+        System.out.println(opt.toString()
+                .equals("[ option: single single  :: run a single task and exit :: class java.lang.String ]"));
+        opt = options.getOption("help");
+        System.out.println(opt.toString()
+                .equals("[ option: help help  :: prints out help screen :: class java.lang.String ]"));
+        opt = options.getOption("pidfile");
+        System.out.println(opt.toString()
+                .equals("[ option: pidfile pidfile  [ARG] :: use PID file <pidfile> :: class java.lang.String ]"));
+        opt = options.getOption("task");
+        System.out.println(opt.toString()
+                .equals("[ option: task task  [ARG] " +
+                        ":: run this task (may be specified multiple times) :: class java.lang.String ]"));
+        opt = options.getOption("dburl");
+        System.out.println(opt.toString()
+                .equals("[ option: dburl dburl  [ARG] :: jdbcurl :: class java.lang.String ]"));
+        opt = options.getOption("dbuser");
+        System.out.println(opt.toString()
+                .equals("[ option: dbuser dbuser  [ARG] :: database username :: class java.lang.String ]"));
+        opt = options.getOption("dbpassword");
+        System.out.println(opt.toString()
+                .equals("[ option: dbpassword dbpassword  [ARG] :: database password :: class java.lang.String ]"));
     }
 
     class DaemonLogic implements Runnable {

--- a/java/code/src/com/suse/manager/reactor/utils/ValueMap.java
+++ b/java/code/src/com/suse/manager/reactor/utils/ValueMap.java
@@ -14,7 +14,6 @@
  */
 package com.suse.manager.reactor.utils;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -23,6 +22,7 @@ import java.text.DecimalFormat;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -154,7 +154,7 @@ public class ValueMap {
         }
         else {
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Value '{}' could not be converted to string.", ObjectUtils.toString(value));
+                LOG.warn("Value '{}' could not be converted to string.", value);
             }
             return Optional.empty();
         }
@@ -187,7 +187,7 @@ public class ValueMap {
         }
         else {
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Value '{}' could not be converted to long.", ObjectUtils.toString(value));
+                LOG.warn("Value '{}' could not be converted to long.", Objects.toString(value, ""));
             }
             return Optional.empty();
         }
@@ -206,7 +206,7 @@ public class ValueMap {
         }
         else {
             if (LOG.isWarnEnabled()) {
-                LOG.warn("Value '{}' could not be converted to Boolean.", ObjectUtils.toString(value));
+                LOG.warn("Value '{}' could not be converted to Boolean.", Objects.toString(value, ""));
             }
             return Optional.empty();
         }

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.controllers;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.badRequest;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.result;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withOrgAdmin;
@@ -457,8 +458,8 @@ public class MinionsAPI {
             }
             else {
                 LOG.warn("Unable to schedule unknown action {}", scheduleRequest.getActionType());
-                return json(GSON, response, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error("Unable to schedule unknown action " + scheduleRequest.getActionType()));
+                return badRequest(response,
+                        "Unable to schedule unknown action " + scheduleRequest.getActionType());
             }
 
             result = chain != null ? chain.getId() : action.getId();

--- a/java/code/src/com/suse/manager/webui/controllers/PackageController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/PackageController.java
@@ -15,8 +15,9 @@
 package com.suse.manager.webui.controllers;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.forbidden;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.internalServerError;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
-import static com.suse.manager.webui.utils.SparkApplicationHelper.jsonError;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withDocsLocale;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
@@ -217,10 +218,10 @@ public class PackageController {
             PackageManager.deletePackages(ids, user);
         }
         catch (PermissionException e) {
-            return jsonError(response, HttpStatus.SC_FORBIDDEN, e.getLocalizedMessage());
+            return forbidden(response, e.getLocalizedMessage());
         }
         catch (RhnRuntimeException e) {
-            return jsonError(response, HttpStatus.SC_INTERNAL_SERVER_ERROR, e.getLocalizedMessage());
+            return internalServerError(response, e.getLocalizedMessage());
         }
 
         return json(response, "success");

--- a/java/code/src/com/suse/manager/webui/controllers/RecurringActionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/RecurringActionController.java
@@ -19,6 +19,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.notFound;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.result;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.success;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPreferences;
@@ -375,7 +376,7 @@ public class RecurringActionController {
             String errMsg = LocalizationService.getInstance().getMessage("recurring_action.not_in_maint_mode");
             Spark.halt(HttpStatus.SC_BAD_REQUEST, GSON.toJson(ResultJson.error(errMsg)));
         }
-        return json(response, ResultJson.success());
+        return success(response);
     }
 
     private static RecurringAction createOrGetAction(User user, RecurringActionScheduleJson json) {

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectActionsApiController.java
@@ -14,7 +14,7 @@
  */
 package com.suse.manager.webui.controllers.contentmanagement.handlers;
 
-import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.badRequest;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static spark.Spark.get;
 import static spark.Spark.post;
@@ -24,11 +24,6 @@ import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectBuildRequest;
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectPromoteRequest;
-import com.suse.manager.webui.utils.gson.ResultJson;
-
-import com.google.gson.Gson;
-
-import org.apache.http.HttpStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,7 +36,6 @@ import spark.Response;
  */
 public class ProjectActionsApiController {
 
-    private static final Gson GSON = ControllerApiUtils.GSON;
     private static final ContentManager CONTENT_MGR = ControllerApiUtils.CONTENT_MGR;
 
     private ProjectActionsApiController() {
@@ -80,7 +74,7 @@ public class ProjectActionsApiController {
         ProjectBuildRequest projectLabelRequest = ProjectActionsHandler.getProjectBuildRequest(req);
         List<String> requestErrors = ProjectActionsHandler.validateProjectBuildRequest(projectLabelRequest);
         if (!requestErrors.isEmpty()) {
-            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(requestErrors));
+            return badRequest(res, requestErrors.toArray(new String[0]));
         }
 
         String projectLabel = projectLabelRequest.getProjectLabel();
@@ -100,7 +94,7 @@ public class ProjectActionsApiController {
         ProjectPromoteRequest projectPromoteReq = ProjectActionsHandler.getProjectPromoteRequest(req);
         List<String> requestErrors = ProjectActionsHandler.validateProjectPromoteRequest(projectPromoteReq);
         if (!requestErrors.isEmpty()) {
-            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(requestErrors));
+            return badRequest(res, requestErrors.toArray(new String[0]));
         }
 
         String projectLabel = projectPromoteReq.getProjectLabel();

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.controllers.contentmanagement.handlers;
 
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.badRequest;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static spark.Spark.delete;
@@ -91,8 +92,7 @@ public class ProjectApiController {
             );
         }
         catch (EntityExistsException error) {
-            return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error(LOC.getMessage("contentmanagement.project_exists")));
+            return badRequest(res, LOC.getMessage("contentmanagement.project_exists"));
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
@@ -100,7 +100,7 @@ public class ProjectApiController {
                             ValidationUtils.convertFieldValidationErrors(e)));
         }
         catch (ContentManagementException error) {
-            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(error.getMessage()));
+            return badRequest(res, error.getMessage());
         }
 
         FlashScopeHelper.flash(
@@ -155,7 +155,7 @@ public class ProjectApiController {
             );
         }
         catch (ContentManagementException error) {
-            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(error.getMessage()));
+            return badRequest(res, error.getMessage());
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,


### PR DESCRIPTION
## What does this PR change?
Fixes the following SonarCloud issues **java:S1874 Deprecated code should not be used**
After review and approval, they will be squashed into one commit only

**1) deprecated call to Hibernate LockMode.UPGRADE**

> Deprecated. Instead use PESSIMISTIC_WRITE

[from: https://docs.jboss.org/hibernate/orm/3.5/javadocs/org/hibernate/LockMode.html#UPGRADE](https://docs.jboss.org/hibernate/orm/3.5/javadocs/org/hibernate/LockMode.html#UPGRADE)

**2) deprecated call to HttpServletRequest.isRequestedSessionIdFromUrl**

> Deprecated. As of Version 2.1 of the Java Servlet API, use isRequestedSessionIdFromURL() instead.

[from: https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#isRequestedSessionIdFromUrl()](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#isRequestedSessionIdFromUrl())


**3) deprecated call to HttpServletResponse.encodeRedirectUrl(String)**

> As of version 2.1, use encodeRedirectURL(String url) instead

[from: https://tomcat.apache.org/tomcat-5.5-doc/servletapi/javax/servlet/http/HttpServletResponse.html#encodeRedirectUrl(java.lang.String)
](https://tomcat.apache.org/tomcat-5.5-doc/servletapi/javax/servlet/http/HttpServletResponse.html#encodeRedirectUrl(java.lang.String)
)

**4) deprecated public class PosixParser**

> Deprecated. since 1.3, use the DefaultParser instead

[From: https://commons.apache.org/proper/commons-cli/apidocs/org/apache/commons/cli/PosixParser.html](https://commons.apache.org/proper/commons-cli/apidocs/org/apache/commons/cli/PosixParser.html)


**5) deprecated org.apache.commons.cli.OptionBuilder**

> Deprecated. since 1.3, use Option.builder(String) instead

[from: https://commons.apache.org/proper/commons-cli/javadocs/api-release/org/apache/commons/cli/OptionBuilder.html](https://commons.apache.org/proper/commons-cli/javadocs/api-release/org/apache/commons/cli/OptionBuilder.html)

**6) deprecated ObjectUtils.toString**

> Deprecated. To preserve behavior use java.util.Objects.toString(myObject, "")

[from https://commons.apache.org/proper/commons-lang/javadocs/api-3.3.1/org/apache/commons/lang3/ObjectUtils.html#toString(java.lang.Object)](https://commons.apache.org/proper/commons-lang/javadocs/api-3.3.1/org/apache/commons/lang3/ObjectUtils.html#toString(java.lang.Object))

**7) deprecated SparkApplicationHelper.json**

>  deprecated use methods that provide type token instead

[from the internal documentation]


## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

