### PR TITLE
Add ltss product for sles12sp5

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -15,6 +15,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Linux Enterprise Server 12 SP5" as the filtered product description
     And I select "SUSE Linux Enterprise Server 12 SP5 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP5 x86_64" selected
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP5 x86_64"
+    And I select "SUSE Linux Enterprise Server LTSS 12 SP5 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server LTSS 12 SP5 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
     And I wait until all synchronized channels for "sles12-sp5" have finished

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -766,6 +766,7 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         managertools-sle12-pool-x86_64-sp5
         managertools-sle12-updates-x86_64-sp5
         sles12-sp5-installer-updates-x86_64
+        sles12-sp5-ltss-updates-x86_64
       ],
     'sles15-sp3' => # CHECKED
       %w[
@@ -1103,6 +1104,7 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sles12-sp5-installer-updates-x86_64
         sles12-sp5-pool-x86_64
         sles12-sp5-updates-x86_64
+        sles12-sp5-ltss-updates-x86_64
         sles12-sp5-uyuni-client-devel-x86_64
       ],
     'sles15-sp3' => # CHECKED
@@ -1562,6 +1564,7 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-server-applications15-sp6-updates-x86_64' => 60,
   'sle-module-server-applications15-sp7-pool-x86_64' => 60,
   'sle-module-server-applications15-sp7-updates-x86_64' => 60,
+  'sles12-sp5-ltss-updates-x86_64' => 1620,
   'sle-product-sles15-sp3-ltss-updates-x86_64' => 960,
   'sle-product-sles15-sp3-pool-x86_64' => 60,
   'sle-product-sles15-sp3-updates-x86_64' => 60,


### PR DESCRIPTION
## What does this PR change?

Sles12sp is now LTSS.
Add the product for BV testing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
