### PR TITLE
Add org.apache.commons.text dependency to compilation

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -142,7 +142,7 @@
   <property name="common.jar.dependencies"
       value="bcel ${cglib-jar} commons-beanutils commons-cli commons-codec
              commons-collections commons-digester commons-discovery
-             commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate5deps}
+             commons-el commons-fileupload commons-io ${commons-lang} commons-text commons-logging ${commons-validator} ${hibernate5deps}
              ${commons-compress} ${javamail} smtp jdom ${jmock-jars}
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars} ${tomcat-jars}
              bcprov bcpg postgresql-jdbc ongres-scram/client ongres-scram/common
@@ -183,7 +183,7 @@
   <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpasyncclient simpleclient simpleclient_common simpleclient_hibernate simpleclient_servlet simpleclient_httpserver pgjdbc-ng/pgjdbc-ng pgjdbc-ng/spy netty/netty-common netty/netty-buffer netty/netty-resolver netty/netty-transport netty/netty-codec netty/netty-handler netty/netty-transport-native-unix-common java-saml java-saml-core joda-time woodstox-core-asl xmlsec stax2-api stax-api ${commons-jexl} ical4j ${product-common-jars} ${jaxb}" />
 
   <!-- SUSE extra dependencies: runtime only -->
-  <property name="suse-runtime-jars" value="${commons-lang} concurrentlinkedhashmap-lru
+  <property name="suse-runtime-jars" value="${commons-lang} commons-text concurrentlinkedhashmap-lru
     slf4j/api log4j/log4j-slf4j-impl ${product-runtime-jars} jctools/jctools-core" />
 
   <property name="install.build.jar.dependencies"
@@ -198,7 +198,7 @@
   <property name="install.common.jar.dependencies"
       value="bcel ${cglib-jar} commons-beanutils commons-cli commons-codec
              commons-collections commons-digester commons-discovery
-             commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate5deps}
+             commons-el commons-fileupload commons-io ${commons-lang} commons-text commons-logging ${commons-validator} ${hibernate5deps}
              ${commons-compress} ${tomcat-jars} ${javamail} jdom jsch
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars}
              postgresql-jdbc ongres-scram/client ongres-scram/common
@@ -210,7 +210,7 @@
       value="antlr objectweb-asm/asm bcel ${c3p0} ${cglib-jar}
              commons-collections commons-beanutils commons-cli commons-codec
              commons-digester commons-discovery commons-el commons-fileupload commons-io
-             ${commons-lang} commons-logging ${commons-compress}
+             ${commons-lang} commons-text commons-logging ${commons-compress}
              ${commons-validator} dom4j ${hibernate5deps} ${jta11-jars}
              ${jaf} ${jasper-jars} ${javamail} ${jaxb} jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -26,6 +26,7 @@
         <dependency org="suse" name="commons-io" rev="2.15.1" />
         <dependency org="suse" name="commons-jexl" rev="2.1.1" />
         <dependency org="suse" name="commons-lang3" rev="3.16.0" />
+        <dependency org="suse" name="commons-text" rev="1.10.0" />
         <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="commons-validator" rev="1.3.1" />
         <dependency org="suse" name="commons-compress" rev="1.26.0" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -73,6 +73,9 @@ artifacts:
   - artifact: commons-lang3
     package: apache-commons-lang3
     repository: Leap_sle
+  - artifact: commons-text
+    package: apache-commons-text
+    repository: Leap
   - artifact: commons-logging
     package: apache-commons-logging
     jar: apache-commons-logging\.jar

--- a/java/code/src/com/redhat/rhn/common/filediff/RhnHtmlDiffWriter.java
+++ b/java/code/src/com/redhat/rhn/common/filediff/RhnHtmlDiffWriter.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.common.filediff;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;

--- a/java/code/src/com/redhat/rhn/common/localization/LocalizationService.java
+++ b/java/code/src/com/redhat/rhn/common/localization/LocalizationService.java
@@ -22,7 +22,7 @@ import com.redhat.rhn.common.db.datasource.SelectMode;
 import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.frontend.context.Context;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/java/code/src/com/redhat/rhn/common/localization/XmlMessages.java
+++ b/java/code/src/com/redhat/rhn/common/localization/XmlMessages.java
@@ -16,7 +16,7 @@
 package com.redhat.rhn.common.localization;
 import com.redhat.rhn.common.conf.Config;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/java/code/src/com/redhat/rhn/common/util/StringUtil.java
+++ b/java/code/src/com/redhat/rhn/common/util/StringUtil.java
@@ -18,8 +18,8 @@ package com.redhat.rhn.common.util;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorException;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.xml.utils.XMLChar;

--- a/java/code/src/com/redhat/rhn/common/util/StringUtil.java
+++ b/java/code/src/com/redhat/rhn/common/util/StringUtil.java
@@ -18,7 +18,7 @@ package com.redhat.rhn.common.util;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorException;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -276,7 +276,7 @@ public class StringUtil {
      * href="http://foo.bar/example">http://foo.bar/example</a>
      * @param convertIn the String we want to convert
      * @return html version of the String
-     * @see org.apache.commons.lang3.StringEscapeUtils
+     * @see org.apache.commons.text.StringEscapeUtils
      */
     public static String htmlifyText(String convertIn) {
         if (convertIn == null) {

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFormatter.java
@@ -21,7 +21,7 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.yaml.snakeyaml.Yaml;

--- a/java/code/src/com/redhat/rhn/domain/action/PackageActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/PackageActionFormatter.java
@@ -18,7 +18,7 @@ import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.action.rhnpackage.PackageAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageActionDetails;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigActionFormatter.java
@@ -21,7 +21,7 @@ import com.redhat.rhn.domain.config.ConfigFile;
 import com.redhat.rhn.domain.config.ConfigFileName;
 import com.redhat.rhn.domain.config.ConfigRevision;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.HashSet;
 import java.util.Iterator;

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.config.ConfigFileName;
 import com.redhat.rhn.frontend.html.HtmlTag;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigActionFormatterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigActionFormatterTest.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ErrataActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ErrataActionFormatter.java
@@ -18,7 +18,7 @@ import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.action.ActionFormatter;
 import com.redhat.rhn.domain.errata.Errata;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/java/code/src/com/redhat/rhn/domain/action/errata/test/ErrataActionFormatterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/test/ErrataActionFormatterTest.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
@@ -22,7 +22,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 /**
  * ScapAction - Class representing TYPE_SCAP_*.
  */

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.manager.download.DownloadManager;
 
 import com.suse.manager.utils.SaltUtils;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 
 /**

--- a/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
@@ -21,7 +21,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.taglibs.list.ListTagHelper;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionErrors;

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/channel/ChannelOverviewTasks.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/channel/ChannelOverviewTasks.java
@@ -32,7 +32,7 @@ import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/CompareDeployedSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/CompareDeployedSubmitAction.java
@@ -30,7 +30,7 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/ManageRevisionSubmit.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/ManageRevisionSubmit.java
@@ -33,7 +33,7 @@ import com.redhat.rhn.manager.acl.AclManager;
 import com.redhat.rhn.manager.configuration.ConfigurationManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/DeleteGroupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/DeleteGroupAction.java
@@ -22,7 +22,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartFileDownloadAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartFileDownloadAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.manager.kickstart.KickstartFileDownloadCommand;
 import com.redhat.rhn.manager.kickstart.KickstartManager;
 import com.redhat.rhn.manager.kickstart.KickstartUrlHelper;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.DynaActionForm;
 
 import javax.servlet.http.HttpServletRequest;

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
@@ -23,8 +23,8 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgDeleteAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgDeleteAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.acl.AclManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgDetailsAction.java
@@ -26,7 +26,7 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.acl.AclManager;
 import com.redhat.rhn.manager.org.OrgManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageChangeLogAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageChangeLogAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageDependenciesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageDependenciesAction.java
@@ -25,7 +25,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageDetailsAction.java
@@ -30,7 +30,7 @@ import com.redhat.rhn.manager.EulaManager;
 import com.redhat.rhn.manager.download.DownloadManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/CatalinaAction.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
@@ -328,7 +328,7 @@ public class ProvisioningRemoteCommand extends RhnAction implements
 
         return MessageFormat.format(body,
                 scriptType, servers.size(), servers.size() > 1 ? plrl : sngl,
-                StringEscapeUtils.escapeXml(summary.toString()));
+                StringEscapeUtils.escapeXml10(summary.toString()));
     }
 
 

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
@@ -38,7 +38,7 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.system.SystemManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -36,7 +36,7 @@ import com.redhat.rhn.manager.user.UserManager;
 
 import com.suse.cloud.CloudPaygManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/tasko/BunchDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/tasko/BunchDetailAction.java
@@ -24,7 +24,7 @@ import com.redhat.rhn.frontend.taglibs.list.helper.Listable;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/user/AssignedGroupsSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/AssignedGroupsSetupAction.java
@@ -34,7 +34,7 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.user.UserManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
@@ -26,7 +26,7 @@ import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.manager.user.CreateUserCommand;
 import com.redhat.rhn.manager.user.UserManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;

--- a/java/code/src/com/redhat/rhn/frontend/action/user/DisableUserSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/DisableUserSetupAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.acl.AclManager;
 import com.redhat.rhn.manager.user.UserManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/action/user/EnableUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/EnableUserAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.manager.acl.AclManager;
 import com.redhat.rhn.manager.user.UserManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;

--- a/java/code/src/com/redhat/rhn/frontend/action/user/EnableUserSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/EnableUserSetupAction.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.acl.AclManager;
 import com.redhat.rhn.manager.user.UserManager;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigChannelTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigChannelTag.java
@@ -60,7 +60,7 @@ public class ConfigChannelTag extends TagSupport {
             result.append("<a href=\"" +
                         ConfigChannelTag.makeConfigChannelUrl(id) + "\">");
             result.append(writeIcon());
-            result.append(StringEscapeUtils.escapeXml(name) + "</a>");
+            result.append(StringEscapeUtils.escapeXml10(name) + "</a>");
         }
         JspWriter writer = pageContext.getOut();
         try {

--- a/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigChannelTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigChannelTag.java
@@ -16,7 +16,7 @@ package com.redhat.rhn.frontend.configuration.tags;
 
 import com.redhat.rhn.frontend.taglibs.IconTag;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 

--- a/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigFileTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigFileTag.java
@@ -16,7 +16,7 @@ package com.redhat.rhn.frontend.configuration.tags;
 
 import com.redhat.rhn.frontend.taglibs.IconTag;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 

--- a/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigFileTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/configuration/tags/ConfigFileTag.java
@@ -55,7 +55,7 @@ public class ConfigFileTag extends TagSupport {
          StringBuilder result = new StringBuilder();
          if (nolink  || id == null) {
              result.append(writeIcon());
-             result.append(StringEscapeUtils.escapeXml(path));
+             result.append(StringEscapeUtils.escapeXml10(path));
          }
          else {
              String url;
@@ -68,7 +68,7 @@ public class ConfigFileTag extends TagSupport {
 
              result.append("<a href=\"" + url + "\">");
              result.append(writeIcon());
-             result.append(StringEscapeUtils.escapeXml(path) + "</a>");
+             result.append(StringEscapeUtils.escapeXml10(path) + "</a>");
          }
          JspWriter writer = pageContext.getOut();
          try {

--- a/java/code/src/com/redhat/rhn/frontend/dto/MultiOrgAllUserOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/MultiOrgAllUserOverview.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.frontend.dto;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Simple DTO for transfering data from the DB to the UI through datasource.

--- a/java/code/src/com/redhat/rhn/frontend/dto/MultiOrgUserOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/MultiOrgUserOverview.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.frontend.dto;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Simple DTO for transfering data from the DB to the UI through datasource.

--- a/java/code/src/com/redhat/rhn/frontend/dto/UserOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/UserOverview.java
@@ -16,7 +16,7 @@ package com.redhat.rhn.frontend.dto;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Date;
 

--- a/java/code/src/com/redhat/rhn/frontend/nav/DialognavRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/DialognavRenderer.java
@@ -18,7 +18,7 @@ package com.redhat.rhn.frontend.nav;
 import com.redhat.rhn.frontend.html.HtmlTag;
 
 import org.apache.commons.text.StringEscapeUtils;
-import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.commons.text.StringSubstitutor;
 
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -119,7 +119,7 @@ public class DialognavRenderer extends Renderable {
         String href = node.getPrimaryURL();
         String hrefNew = href;
         if (parameters != null) {
-            StrSubstitutor substitutor = new StrSubstitutor(
+            StringSubstitutor substitutor = new StringSubstitutor(
                     ((Map<String, String[]>)parameters).entrySet().stream()
                         .filter(entry -> entry.getValue() != null && entry.getValue().length > 0)
                         .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue()[0])));

--- a/java/code/src/com/redhat/rhn/frontend/nav/DialognavRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/DialognavRenderer.java
@@ -17,7 +17,7 @@ package com.redhat.rhn.frontend.nav;
 
 import com.redhat.rhn.frontend.html.HtmlTag;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 
 import java.util.Map;

--- a/java/code/src/com/redhat/rhn/frontend/nav/NavNode.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/NavNode.java
@@ -17,9 +17,9 @@ package com.redhat.rhn.frontend.nav;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/java/code/src/com/redhat/rhn/frontend/nav/NavNode.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/NavNode.java
@@ -17,7 +17,7 @@ package com.redhat.rhn.frontend.nav;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/EnvironmentFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/EnvironmentFilter.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.StrutsDelegate;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionMessage;

--- a/java/code/src/com/redhat/rhn/frontend/struts/RhnAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RhnAction.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.MethodUtil;
 
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.Action;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionMessage;

--- a/java/code/src/com/redhat/rhn/frontend/struts/RhnListDispatchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RhnListDispatchAction.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.frontend.struts;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/IconTag.java
@@ -18,7 +18,7 @@ package com.redhat.rhn.frontend.taglibs;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTagBase.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTagBase.java
@@ -22,8 +22,8 @@ import com.redhat.rhn.common.util.ExportWriter;
 import com.redhat.rhn.frontend.html.HtmlTag;
 import com.redhat.rhn.frontend.struts.RequestContext;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTagBase.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTagBase.java
@@ -22,7 +22,7 @@ import com.redhat.rhn.common.util.ExportWriter;
 import com.redhat.rhn.frontend.html.HtmlTag;
 import com.redhat.rhn.frontend.struts.RequestContext;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/RhnHiddenTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/RhnHiddenTag.java
@@ -18,7 +18,7 @@ package com.redhat.rhn.frontend.taglibs;
 import com.redhat.rhn.frontend.html.HiddenInputTag;
 import com.redhat.rhn.frontend.html.HtmlTag;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.jsp.JspException;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/RhnHiddenTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/RhnHiddenTag.java
@@ -18,8 +18,8 @@ package com.redhat.rhn.frontend.taglibs;
 import com.redhat.rhn.frontend.html.HiddenInputTag;
 import com.redhat.rhn.frontend.html.HtmlTag;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/RhnTagFunctions.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/RhnTagFunctions.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.StringUtil;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.jsp.PageContext;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/RhnTagFunctions.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/RhnTagFunctions.java
@@ -20,8 +20,8 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.StringUtil;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.servlet.jsp.PageContext;
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTag.java
@@ -28,7 +28,7 @@ import com.redhat.rhn.frontend.taglibs.list.decorators.PageSizeDecorator;
 import com.redhat.rhn.frontend.taglibs.list.helper.ListHelper;
 import com.redhat.rhn.frontend.taglibs.list.row.RowRenderer;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.StringWriter;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTag.java
@@ -28,8 +28,8 @@ import com.redhat.rhn.frontend.taglibs.list.decorators.PageSizeDecorator;
 import com.redhat.rhn.frontend.taglibs.list.helper.ListHelper;
 import com.redhat.rhn.frontend.taglibs.list.row.RowRenderer;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.StringWriter;
 import java.util.ArrayList;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagHelper.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.frontend.struts.Selectable;
 import com.redhat.rhn.frontend.taglibs.list.decorators.PageSizeDecorator;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
@@ -21,7 +21,7 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.taglibs.list.decorators.ExtraButtonDecorator;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
@@ -21,8 +21,8 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.taglibs.list.decorators.ExtraButtonDecorator;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/decorators/PageSizeDecorator.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/decorators/PageSizeDecorator.java
@@ -19,8 +19,8 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.frontend.html.HtmlTag;
 import com.redhat.rhn.frontend.taglibs.list.ListTagUtil;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/decorators/PageSizeDecorator.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/decorators/PageSizeDecorator.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.frontend.html.HtmlTag;
 import com.redhat.rhn.frontend.taglibs.list.ListTagUtil;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/provider/PackagesProviderHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/provider/PackagesProviderHandler.java
@@ -27,7 +27,7 @@ import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 
 import com.suse.manager.api.ReadOnly;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.List;
 import java.util.Set;

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartUrlHelper.java
@@ -26,7 +26,7 @@ import com.redhat.rhn.domain.kickstart.RepoInfo;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cobbler.Profile;

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -149,8 +149,8 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -149,7 +149,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -76,7 +76,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.struts.action.ActionErrors;

--- a/java/code/src/com/suse/manager/webui/menu/MenuItem.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuItem.java
@@ -17,7 +17,7 @@ package com.suse.manager.webui.menu;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -89,6 +89,7 @@ BuildRequires:  apache-commons-el
 BuildRequires:  apache-commons-io >= 2.11.0
 BuildRequires:  apache-commons-jexl
 BuildRequires:  apache-commons-lang3 >= 3.4
+BuildRequires:  apache-commons-text
 BuildRequires:  apache-commons-logging
 BuildRequires:  bcel
 BuildRequires:  mvn(net.bytebuddy:byte-buddy) >= 1.14
@@ -174,6 +175,7 @@ Requires:       apache-commons-el
 Requires:       apache-commons-io
 Requires:       apache-commons-jexl
 Requires:       apache-commons-lang3
+Requires:       apache-commons-text
 Requires:       apache-commons-logging
 Requires:       bcel
 Requires:       mvn(net.bytebuddy:byte-buddy) >= 1.14
@@ -316,6 +318,7 @@ This package contains testing files of spacewalk-java.
 %{_datadir}/rhn/unit-tests/*
 %{_datadir}/rhn/unittest.xml
 %attr(644, tomcat, tomcat) %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-lang3.jar
+%attr(644, tomcat, tomcat) %{serverdir}/tomcat/webapps/rhn/WEB-INF/lib/commons-text.jar
 %endif
 
 %package apidoc-sources
@@ -352,6 +355,7 @@ Requires:       %{ehcache}
 Requires:       apache-commons-cli
 Requires:       apache-commons-codec
 Requires:       apache-commons-lang3
+Requires:       apache-commons-text
 Requires:       apache-commons-logging
 Requires:       bcel
 Requires:       mvn(net.bytebuddy:byte-buddy) >= 1.14


### PR DESCRIPTION
## What does this PR change?
There are about fifty SonarCloud issues (java:S1874 Deprecated code should not be used) that refer to deprecated methods of classes **StringEscapeUtils** and **StrSubstitutor**.
These methods have been moved from org.apache.commons.**lang3** to org.apache.commons.**text**.

This PR is about introducing _**org.apache.commons.text**_ into the compilation dependencies so that all deprecated code warnings could be solved simply importing _org.apache.commons.**text**.StringEscapeUtils_ instead of _org.apache.commons.**lang3**.StringEscapeUtils_

org.apache.commons.text library is already present with version 1.10.0 in:
https://build.suse.de/package/show/SUSE:SLE-15-SP2:Update/apache-commons-text.28294


### **SonarCloud fix: java:S1874 deprecated org.apache.commons.lang3.StringEscapeUtils into commons.text**
_org.apache.commons.lang3.StringEscapeUtils is deprecated. As of 3.6, use corg.apache.commons.text.StringEscapeUtils instead_

https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/StringEscapeUtils.html


### **SonarCloud fix: java:S1874 deprecated StringEscapeUtils.escapeXml into StringEscapeUtils.escapeXml10**

_use StringEscapeUtils.escapeXml10(java.lang.String) or StringEscapeUtils.escapeXml11(java.lang.String) instead._

https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringEscapeUtils.html#escapeXml(java.lang.String)


### **SonarCloud fix: java:S1874 deprecated org.apache.commons.lang3.text.StrSubstitutor into commons.text.StringSubstitutor**

_org.apache.commons.lang3.text.StrSubstitutor is deprecated. As of 3.6, use Apache Commons Text org.apache.commons.text.StringSubstitutor instead_

https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/text/StrSubstitutor.html



## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests needed (only compilation)
- [x] **DONE**

## Links
Issue(s): #
Port(s): NOT backported to 4.3 and 5.0
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [x] Re-run test "spacecmd_unittests"

