### PR TITLE
Fix: severity levels are missing in API output of errata.getDetails (bsc#1240038)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -113,18 +113,19 @@ public class ErrataHandler extends BaseHandler {
      *          #prop("string", "issue_date")
      *          #prop("string", "update_date")
      *          #prop_desc("string", "last_modified_date", "last time the erratum was modified.")
-     *          #prop("string", "synopsis")
      *          #prop("int", "release")
      *          #prop("string", "advisory_status")
      *          #prop("string", "vendor_advisory")
-     *          #prop("string", "type")
      *          #prop("string", "product")
      *          #prop("string", "errataFrom")
-     *          #prop("string", "topic")
+     *          #prop("string", "solution")
      *          #prop("string", "description")
+     *          #prop("string", "synopsis")
+     *          #prop("string", "topic")
      *          #prop("string", "references")
      *          #prop("string", "notes")
-     *          #prop("string", "solution")
+     *          #prop("string", "type")
+     *          #prop("string", "severity")
      *          #prop_desc("boolean", "reboot_suggested", "A boolean flag signaling whether a system reboot is
      *          advisable following the application of the errata. Typical example is upon kernel update.")
      *          #prop_desc("boolean", "restart_suggested", "A boolean flag signaling a weather reboot of
@@ -142,26 +143,47 @@ public class ErrataHandler extends BaseHandler {
         if (errata.getIssueDate() != null) {
             errataMap.put("issue_date",
                     LocalizationService.getInstance()
-                    .formatShortDate(errata.getIssueDate()));
+                            .formatShortDate(errata.getIssueDate()));
         }
+        else {
+            errataMap.put("issue_date", "");
+        }
+
         if (errata.getUpdateDate() != null) {
             errataMap.put("update_date",
                     LocalizationService.getInstance()
-                    .formatShortDate(errata.getUpdateDate()));
+                            .formatShortDate(errata.getUpdateDate()));
         }
+        else {
+            errataMap.put("update_date", "");
+        }
+
         if (errata.getLastModified() != null) {
             errataMap.put("last_modified_date", errata.getLastModified().toString());
         }
+        else {
+            errataMap.put("last_modified_date", "");
+        }
+
         if (errata.getAdvisoryRel() != null) {
             errataMap.put("release", errata.getAdvisoryRel());
         }
+        else {
+            errataMap.put("release", "");
+        }
+
         if (errata.getAdvisoryStatus() != null) {
-            errataMap.put("advisory_status", errata.getAdvisoryStatus().getMetadataValue());
+            errataMap.put("advisory_status",
+                    StringUtils.defaultString(errata.getAdvisoryStatus().getMetadataValue()));
+        }
+        else {
+            errataMap.put("advisory_status", "");
         }
 
         try {
             final VendorSpecificErrataParser parser = ErrataParserFactory.getParser(errata);
-            errataMap.put("vendor_advisory", parser.getAdvisoryUri(errata).toString());
+            errataMap.put("vendor_advisory",
+                    StringUtils.defaultString(parser.getAdvisoryUri(errata).toString()));
         }
         catch (ErrataParsingException ex) {
             errataMap.put("vendor_advisory", "");
@@ -186,7 +208,10 @@ public class ErrataHandler extends BaseHandler {
         errataMap.put("type",
                 StringUtils.defaultString(errata.getAdvisoryType()));
         if (errata.getSeverity() != null) {
-            errataMap.put("severity", errata.getSeverity().getLocalizedLabel());
+            errataMap.put("severity", StringUtils.defaultString(errata.getSeverity().getLocalizedLabel()));
+        }
+        else {
+            errataMap.put("severity", "");
         }
 
         errataMap.put("reboot_suggested", errata.hasKeyword(Keyword.REBOOT_SUGGESTED));

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-errata-severity-levels
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-errata-severity-levels
@@ -1,0 +1,2 @@
+- Fix severity levels are missing in api output of
+  errata getDetails method (bsc#1240038)


### PR DESCRIPTION
## What does this PR change?
errata.getDetails API call does not show severity levels, if they are not present.
During the investigation of this bug, several points were found and fixed:
1) API documentation was misaligned with the code
2) several other items in the API return structure were missing the "null" case:
cases like the following
if (errata.getSomething() != null) {
            errataMap.put("something", StringUtils.defaultString(errata.getSomething().getLabel()));
 }
were not issuing an empty value in case the if clause was failing.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- API documentation corrected on the apidoc part of the method call
- [x] **DONE**

## Test coverage
- No tests: manually tested
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26781
Port(s): # **add upstream PR, if any**
- [ ] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
