### PR TITLE
Fix: remove SCAP file upload size limit setting (bsc#1240050)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/org/OrgConfig.java
+++ b/java/code/src/com/redhat/rhn/domain/org/OrgConfig.java
@@ -60,9 +60,6 @@ public class OrgConfig extends BaseDomainHelper {
     @Type(type = "yes_no")
     private boolean scapfileUploadEnabled;
 
-    @Column(name = "scap_file_sizelimit", nullable = false)
-    private Long scapFileSizelimit;
-
     @Column(name = "scap_retention_period_days")
     private Long scapRetentionPeriodDays;
 
@@ -146,22 +143,6 @@ public class OrgConfig extends BaseDomainHelper {
      */
     public void setScapfileUploadEnabled(boolean scapfileUploadEnabledIn) {
         scapfileUploadEnabled = scapfileUploadEnabledIn;
-    }
-
-    /**
-     * Get the org-wide SCAP file size limit.
-     * @return Returns the org-wide scap file size limit.
-     */
-    public Long getScapFileSizelimit() {
-        return scapFileSizelimit;
-    }
-
-    /**
-     * Set the org-wide SCAP file size limit.
-     * @param sizeLimitIn The org-wide SCAP file size limit to set.
-     */
-    public void setScapFileSizelimit(Long sizeLimitIn) {
-        scapFileSizelimit = sizeLimitIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
@@ -75,15 +75,12 @@ public class OrgConfigAction extends RhnAction {
             org.getOrgConfig().setScapfileUploadEnabled(request.
                     getParameter("scapfile_upload_enabled") != null);
 
-            Long newScapLimit = null;
             Long newScapRetentionPeriod = null;
             try {
-                newScapLimit = Long.parseLong(
-                           request.getParameter("scapfile_sizelimit"));
                 newScapRetentionPeriod = Long.parseLong(
                            request.getParameter(SCAP_RETENTION_PERIOD));
 
-                if (newScapLimit < 0 || newScapRetentionPeriod < 0) {
+                if (newScapRetentionPeriod < 0) {
                     throw new IllegalArgumentException();
                 }
             }
@@ -94,9 +91,6 @@ public class OrgConfigAction extends RhnAction {
 
                 return getStrutsDelegate().forwardParam(mapping.findForward("error"),
                            RequestContext.ORG_ID, org.getId().toString());
-            }
-            if (StringUtils.isNotEmpty(request.getParameter("scapfile_sizelimit"))) {
-                org.getOrgConfig().setScapFileSizelimit(newScapLimit);
             }
             if (StringUtils.isNotEmpty(request.getParameter(SCAP_RETENTION_PERIOD))) {
                 org.getOrgConfig().setScapRetentionPeriodDays(newScapRetentionPeriod);

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -3978,12 +3978,6 @@ button below, and &lt;b&gt;will be unable to log back in&lt;/b&gt;.</source>
           <context context-type="sourcefile">/rhn/admin/multiorg/OrgConfigDetails.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="org-config.scapfile-sizelimit.jsp" xml:space="preserve">
-        <source>SCAP File Upload Size Limit</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/multiorg/OrgConfigDetails.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="org-config.scap-retention" xml:space="preserve">
         <source>Allow Deletion of SCAP Results</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -520,4 +520,11 @@ public interface SaltApi extends Serializable {
      * @return list of matching minions
      */
      List<String> selectMinions(String target, String targetType);
+
+    /**
+     * Call 'salt-run config.get' to get info on the susemanager.conf configuration file
+     * @param key return key to retrieve from the configuration file
+     * @return retrieved value associated with the key, if any
+     */
+    Optional<String> configGet(String key);
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1557,4 +1557,11 @@ public class SaltService implements SystemQuery, SaltApi {
         RunnerCall<List<String>> call = MgrUtilRunner.selectMinions(target, targetType);
         return callSync(call).orElseThrow(() -> new IllegalStateException("Can't get minion list"));
     }
+
+    @Override
+    public Optional<String> configGet(String key) {
+        RunnerCall<String> runnerCall = new RunnerCall<>("config.get",
+                Optional.of(Map.of("key", key)), TypeToken.get(String.class));
+        return callSync(runnerCall);
+    }
 }

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -321,4 +321,8 @@ public class TestSaltApi implements SaltApi {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public Optional<String> configGet(String key) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/java/code/webapp/WEB-INF/pages/common/fragments/org-config.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/org-config.jspf
@@ -56,22 +56,6 @@
 </div>
 <div class="form-group">
     <label class="col-lg-3 control-label">
-        <bean:message key="org-config.scapfile-sizelimit.jsp"/>:
-    </label>
-    <div class="col-lg-2">
-        <input type="number"
-               class="form-control"
-               name="scapfile_sizelimit"
-               value="${org.orgConfig.scapFileSizelimit}"
-               id="scapfile_sizelimit"
-               <c:if test = "${edit_disabled}">
-                   disabled="disabled"
-               </c:if>
-        />
-    </div>
-</div>
-<div class="form-group">
-    <label class="col-lg-3 control-label">
         <bean:message key="org-config.scap-retention"/>
     </label>
     <div class="col-lg-6">

--- a/java/spacewalk-java.changes.carlo.uyuni-scap-upload-size-limit
+++ b/java/spacewalk-java.changes.carlo.uyuni-scap-upload-size-limit
@@ -1,0 +1,1 @@
+- Fix: remove SCAP file upload size limit setting (bsc#1240050)


### PR DESCRIPTION
## What does this PR change?
Removes all references in code and in UI about the org configuration parameter scap_file_sizelimit.
This setting is outdated and worked only when using the traditional stack which was removed in 5.0.
This parameter is now directly modified in salt master susemanager.conf file.

## GUI diff
Before:

The part in red has been **removed**

![ScapUploadFileSizeLimitWas](https://github.com/user-attachments/assets/676da60a-b04e-4fa3-9b98-058b29330a40)


After:
![ScapUploadFileSizeLimitIs](https://github.com/user-attachments/assets/1edcc97f-d5e6-4400-bc23-53733563a83f)


- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/issues/3845
- [x] **DONE**

## Test coverage
- No tests: manual tests
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26787
Port(s): **not backported to 4.3**  
- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
