### PR TITLE
Install "python311-pygit2" inside server-image as needed on SLE15SP7

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -61,6 +61,7 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         virtual-host-gatherer-VMware \
         vim \
         python3-pygit2 \
+        python311-pygit2 \
         ipmitool \
         sssd \
         sssd-dbus \

--- a/containers/server-image/server-image.changes.meaksh.master-fix-python-pygit2-on-sp7
+++ b/containers/server-image/server-image.changes.meaksh.master-fix-python-pygit2-on-sp7
@@ -1,0 +1,2 @@
+- Install python311-pygit2 inside server-image as needed on
+  SLE15SP7


### PR DESCRIPTION
## What does this PR change?

This PR ensures `python311-pygit2` is installed inside the server-image, as it can be used to configure gitfs integration for the Salt Master when building the image based on SLE15SP7.

Otherwise, gitfs integration won't be able to be configured for the Salt Master

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
