### PR TITLE
Make the Python interpreter version configurable (bsc#1240645)

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -6,6 +6,10 @@ FROM $INIT_IMAGE
 
 ARG PRODUCT_PATTERN_PREFIX="patterns-uyuni"
 
+# Keep in sync with salt/salt.spec
+# For now Uyuni is still on python3-salt but the value can be overridden in the project config
+ARG USEPYTHON="python3"
+
 # Extra packages can be added via project configuration
 ARG EXTRAPACKAGES
 
@@ -58,7 +62,7 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         virtual-host-gatherer-Nutanix \
         virtual-host-gatherer-VMware \
         vim \
-        python3-pygit2 \
+        ${USEPYTHON}-pygit2 \
         ipmitool \
         sssd \
         sssd-dbus \

--- a/containers/server-image/server-image.changes.deneb-alpha.bsc1240645_fix_pygit2
+++ b/containers/server-image/server-image.changes.deneb-alpha.bsc1240645_fix_pygit2
@@ -1,0 +1,1 @@
+- Make the Python interpreter version configurable (bsc#1240645)


### PR DESCRIPTION
# IMPORTANT

**this is an alternative version of #10112 for not installing at the same time both python3 and python311 versions of the package, ~but in any case, python311-pygit2 is not available for Multi-Linux Manager and this PR or the alternative one that I did can NOT be merged.~**

python311-pygit2:
* Head:Other: https://build.suse.de/request/show/372959
* 5.1: https://build.suse.de/request/show/372960 

**See:  also https://bugzilla.suse.com/show_bug.cgi?id=1240645#c1**

## What does this PR change?

SUSE Linux Enterprise Server 15 SP7 uses Python3.11 Salt module version and there's now the need to configure which Python interpreter version we want to use for a given module. This PR introduces a new argument called USEPYTHON that can be controlled in the project config of the build service. The default value of this argument is python3 but, where needed, it can be changed, for example to python311.

After this PR, on the Prjconf of Multi-Linux Manager, we need to also specify the different value we want to pass.

`BuildFlags: dockerarg:USEPYTHON=python311`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Tested on both OBS and IBS:
  - OBS: https://build.opensuse.org/project/show/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master_bsc1240645_fix_pygit2
  - IBS: https://build.suse.de/project/show/home:deneb_alpha:branches:Devel:Galaxy:Manager:Head_bsc1240645_fix_pygit2

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26891 / https://bugzilla.suse.com/show_bug.cgi?id=1240645
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
