### PR TITLE
Revert "Use temporary image for pgsql unit tests"

### DIFF
--- a/susemanager-utils/testing/automation/VERSION.Uyuni
+++ b/susemanager-utils/testing/automation/VERSION.Uyuni
@@ -1,8 +1,7 @@
 REGISTRY=registry.opensuse.org
 VER=master
 BASE_CONTAINER=systemsmanagement/uyuni/master/docker/containers/uyuni-$VER-base
-# Temporary image to get tests run in the PR
-PGSQL_CONTAINER=home/cbosdonnat/branches/systemsmanagement/uyuni/master/docker/containers/uyuni-$VER-pgsql
+PGSQL_CONTAINER=systemsmanagement/uyuni/master/docker/containers/uyuni-$VER-pgsql
 NODEJS_CONTAINER=systemsmanagement/uyuni/master/docker/containers/uyuni-$VER-nodejs
 PUSH2OBS_CONTAINER=systemsmanagement/uyuni/master/docker/containers/uyuni-push-to-obs
 REPORTDB_DOC_CONTAINER=systemsmanagement/uyuni/master/docker/containers/uyuni-$VER-reportdb-docs


### PR DESCRIPTION
## What does this PR change?

I forgot to remove the temporary image used for the unit tests.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
