### PR TITLE
Use new leap 15 build profiles

### DIFF
--- a/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh
+++ b/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh
@@ -16,9 +16,9 @@ sudo -i podman exec buildhost bash -c "sed -e 's/http:\/\/download.opensuse.org/
 sudo -i podman exec buildhost bash -c "sed -e 's/https:\/\/download.opensuse.org/file:\/\/\/mirror\/download.opensuse.org/g' -i /etc/zypp/repos.d/*"
 sudo podman ps
 
-sudo docker pull ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.5:master
-sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.5:master localhost:5002/opensuse/leap:15.5
-sudo docker push localhost:5002/opensuse/leap:15.5
+sudo docker pull ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.6:master
+sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.6:master localhost:5002/opensuse/leap:15.6
+sudo docker push localhost:5002/opensuse/leap:15.6
 
 sudo docker pull ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:master
 sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:master localhost:5002/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite


### PR DESCRIPTION
## What does this PR change?

Use new leap 15 build profiles. This goes after https://github.com/uyuni-project/uyuni/pull/10115

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [ ] **DONE**

## Links

Partial fix for https://github.com/SUSE/spacewalk/issues/26493

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
