### PR TITLE
Fix usage of Salt for Retail

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify SUSE Manager about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed-bundle.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=salt-minion.service
-After=salt-minion.service
+Requires=venv-salt-minion.service
+After=venv-salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+ExecStart=/usr/bin/venv-salt-call event.send suse/manager/image_deployed with_grains=True
 
 [Install]
 WantedBy=multi-user.target

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/root/etc/systemd/system/image-deployed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Notify Uyuni about newly deployed image
-Requires=venv-salt-minion.service
-After=venv-salt-minion.service
+Requires=salt-minion.service
+After=salt-minion.service
 
 # only if there are no susemanager channels configured
 ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo


### PR DESCRIPTION
## What does this PR change?

Fixup of commit 2d046a11e1ee5ecd579ecf8d7318e0712ed3502c

* in `image-deployed-bundle.service` we use `venv-salt-bundle` package and `venv-salt-call` utility
* in `image-deployed.service` we use regular `salt` package and `salt-call` utility


## GUI diff

No difference.

- [x] **DONE**


## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

- Cucumber tests were added

- [x] **DONE**


## Links

See https://github.com/SUSE/spacewalk/issues/26399

No ports, Uyuni only (the profiles are shared between all branches)

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
