### PR TITLE
Build a Redis docker container

### DIFF
--- a/.github/workflows/build_redis_container.yml
+++ b/.github/workflows/build_redis_container.yml
@@ -1,0 +1,47 @@
+name: Build Redis container
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  redis-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/redis
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 #v6.15.0
+        with:
+          context: ./testsuite/dockerfiles/redis/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            AWS_REDIS_USER=${{ secrets.REDIS_USER }}
+            AWS_REDIS_PASS=${{ secrets.REDIS_PASS }}
+            AWS_REDIS_HOST=${{ secrets.REDIS_HOST }}
+            AWS_REDIS_PORT=${{ secrets.REDIS_PORT }}

--- a/testsuite/dockerfiles/redis/Dockerfile
+++ b/testsuite/dockerfiles/redis/Dockerfile
@@ -1,0 +1,27 @@
+FROM redis:latest
+
+RUN apt-get update && apt-get install -y redis-tools
+
+# Define ARG values for build-time configuration
+ARG AWS_REDIS_USER
+ARG AWS_REDIS_PASS
+ARG AWS_REDIS_HOST
+ARG AWS_REDIS_PORT
+
+# Set the working directory for the backup
+WORKDIR /data
+
+# Define the backup file location
+ENV BACKUP_FILE /data/backup.rdb
+
+# Dump the remote Redis database from AWS into an RDB file using the correct redis-cli command
+RUN redis-cli -u "redis://${AWS_REDIS_USER}:${AWS_REDIS_PASS}@${AWS_REDIS_HOST}:${AWS_REDIS_PORT}" --rdb $BACKUP_FILE
+
+# Move the backup to the local Redis data directory (it will be mounted to Redis container by default)
+RUN mv $BACKUP_FILE /data/dump.rdb
+
+# Expose Redis default port
+EXPOSE 6379
+
+# Start Redis
+CMD redis-server

--- a/testsuite/dockerfiles/redis/README.md
+++ b/testsuite/dockerfiles/redis/README.md
@@ -1,0 +1,15 @@
+# Redis mirror
+
+This Docker container includes a **Redis** instance, which we will use to query information from the test **code coverage** map. This data is preloaded during the Docker **build** process by connecting to the Redis instance hosted on AWS.
+
+This approach allows us to avoid handling Redis **secrets** in the PR workflows, especially when running them with `workflow_run` in a **forked repository** using the fork's GitHub runner.
+
+### Build
+
+```
+docker build --build-arg AWS_REDIS_USER="your-user" \
+--build-arg AWS_REDIS_PASS="your-password" \
+--build-arg AWS_REDIS_HOST="your-aws-redis-host" \
+--build-arg AWS_REDIS_PORT="6379" \
+-t redis:latest .
+```

--- a/testsuite/podman_runner/run_redis.sh
+++ b/testsuite/podman_runner/run_redis.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -xe
+
+sudo -i podman run --privileged --rm -d --name redis -h redis -p 6379:6379 ghcr.io/$UYUNI_PROJECT/uyuni/redis:$UYUNI_VERSION


### PR DESCRIPTION
## What does this PR change?

Card: https://github.com/SUSE/spacewalk/issues/26907

This Docker container includes a **Redis** instance, which we will use to query information from the test **code coverage** map. This data is preloaded during the Docker **build** process by connecting to the Redis instance hosted on AWS.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- README was created

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
