### PR TITLE
fix state apply result formatting

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/StateResult.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/StateResult.java
@@ -40,7 +40,7 @@ public class StateResult {
      * @param e map
      */
     public StateResult(Map.Entry<String, Map<String, Object>> e) {
-        String[] arr = e.getKey().split("_|-");
+        String[] arr = e.getKey().split("_\\|-");
         function = arr[0] + "." + arr[arr.length - 1];
 
         e.getValue().forEach((key, val) -> {

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-state-apply-result-formatting
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-state-apply-result-formatting
@@ -1,0 +1,2 @@
+- Fix state apply result formatting by splitting one the correct
+  string token


### PR DESCRIPTION
## What does this PR change?

Split takes a regex and the | is a regex symbol or "or". We were splitting at _ or - and not at the places where _|- appear

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26908

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
