### PR TITLE
ISSv3 - Use criteria query instead of concatenating strings

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/listview/PageControl.java
+++ b/java/code/src/com/redhat/rhn/frontend/listview/PageControl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 SUSE LLC
  * Copyright (c) 2009--2010 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -38,6 +39,47 @@ public class PageControl extends ListControl {
      */
     public PageControl() {
         this(1);
+    }
+
+    /**
+     * Initialize an object with the specified controls
+     * @param startIn the first result
+     * @param pageSizeIn the page size
+     * @param sortColumnIn the column used to sort in ascending order
+     */
+    public PageControl(int startIn, int pageSizeIn, String sortColumnIn) {
+        this(startIn, pageSizeIn, sortColumnIn, false, null, null);
+    }
+
+    /**
+     * Initialize an object with the specified controls
+     * @param startIn the first result
+     * @param pageSizeIn the page size
+     * @param sortColumnIn the column used to sort
+     * @param sortDescendingIn true for descending order
+     */
+    public PageControl(int startIn, int pageSizeIn, String sortColumnIn, boolean sortDescendingIn) {
+        this(startIn, pageSizeIn, sortColumnIn, sortDescendingIn, null, null);
+    }
+
+        /**
+         * Initialize an object with the specified controls
+         * @param startIn the first result
+         * @param pageSizeIn the page size
+         * @param sortColumnIn the column used to sort
+         * @param sortDescendingIn true for descending order
+         * @param filterColumnIn the filter column
+         * @param filterDataIn the filter data
+         */
+    public PageControl(int startIn, int pageSizeIn, String sortColumnIn, boolean sortDescendingIn,
+                       String filterColumnIn, String filterDataIn) {
+        this.start = startIn;
+        this.pageSize = pageSizeIn;
+        this.sortColumn = sortColumnIn;
+        this.sortDescending = sortDescendingIn;
+        this.setFilter(filterColumnIn != null);
+        this.setFilterColumn(filterColumnIn);
+        this.setFilterData(filterDataIn);
     }
 
     /**

--- a/java/code/src/com/suse/manager/model/hub/HubFactory.java
+++ b/java/code/src/com/suse/manager/model/hub/HubFactory.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.frontend.listview.PageControl;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.hibernate.type.StandardBasicTypes;
 
@@ -30,6 +31,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.persistence.Tuple;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Root;
 
 public class HubFactory extends HibernateFactory {
 
@@ -158,7 +163,11 @@ public class HubFactory extends HibernateFactory {
      * @return the number of peripherals
      */
     public long countPeripherals(PageControl pc) {
-        return buildQueryFromPageControl("IssPeripheral", Long.class, pc).uniqueResult();
+        if (pc == null) {
+            return countPeripherals();
+        }
+
+        return buildCountQueryFromPageControl(IssPeripheral.class, pc).uniqueResult();
     }
 
     /**
@@ -167,7 +176,11 @@ public class HubFactory extends HibernateFactory {
      * @return a list of paginated peripherals
      */
     public List<IssPeripheral> listPaginatedPeripherals(PageControl pc) {
-        return buildQueryFromPageControl("IssPeripheral", IssPeripheral.class, pc).list();
+        if (pc == null) {
+            return listPeripherals();
+        }
+
+        return buildListQueryFromPageControl(IssPeripheral.class, pc).list();
     }
 
     /**
@@ -438,30 +451,42 @@ public class HubFactory extends HibernateFactory {
         return Optional.empty();
     }
 
-    private static <T> Query<T> buildQueryFromPageControl(String entityName, Class<T> resultClass, PageControl pc) {
-        boolean countQuery = Long.class.equals(resultClass);
-        String hql = "FROM %s e".formatted(entityName);
+    private static <E> Query<Long> buildCountQueryFromPageControl(Class<E> entityClass, PageControl pc) {
+        Session session = getSession();
+
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaQuery<Long> criteria = builder.createQuery(Long.class);
+
+        Root<E> root = criteria.from(entityClass);
+
+        criteria.select(builder.count(root));
+
         if (pc.hasFilter()) {
-            hql += " WHERE e.%s LIKE :filter".formatted(pc.getFilterColumn());
+            criteria.where(builder.like(root.get(pc.getFilterColumn()), "%" + pc.getFilterData() + "%"));
         }
 
-        if (countQuery) {
-            hql = "SELECT COUNT(*) " + hql;
-        }
-        else {
-            hql += " ORDER BY e.%s %s".formatted(pc.getSortColumn(), pc.isSortDescending() ? "DESC" : "ASC");
-        }
+        return session.createQuery(criteria);
+    }
 
-        Query<T> query = getSession().createQuery(hql, resultClass);
+    private static <E> Query<E> buildListQueryFromPageControl(Class<E> entityClass, PageControl pc) {
+        Session session = getSession();
+
+        CriteriaBuilder builder = session.getCriteriaBuilder();
+        CriteriaQuery<E> criteria = builder.createQuery(entityClass);
+
+        Root<E> root = criteria.from(entityClass);
+
+        criteria.select(root);
+
         if (pc.hasFilter()) {
-            query.setParameter("filter", "%" + pc.getFilterData() + "%");
+            criteria.where(builder.like(root.get(pc.getFilterColumn()), "%" + pc.getFilterData() + "%"));
         }
 
-        if (!countQuery) {
-            query.setFirstResult(pc.getStart() - 1);
-            query.setMaxResults(pc.getPageSize());
-        }
+        Path<Object> sortColumn = root.get(pc.getSortColumn());
+        criteria.orderBy(pc.isSortDescending() ? builder.desc(sortColumn) : builder.asc(sortColumn));
 
-        return query;
+        return session.createQuery(criteria)
+            .setFirstResult(pc.getStart() - 1)
+            .setMaxResults(pc.getPageSize());
     }
 }

--- a/java/code/src/com/suse/manager/model/hub/test/HubFactoryTest.java
+++ b/java/code/src/com/suse/manager/model/hub/test/HubFactoryTest.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.credentials.HubSCCCredentials;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
@@ -467,6 +468,90 @@ public class HubFactoryTest extends BaseTestCaseWithUser {
                 fail("Unexpected channel");
             }
         }
+    }
+
+    @Test
+    public void canCountPeripheralWithPaginationControl() {
+        // Create a bunch of peripherals
+        createPeripherals();
+
+        PageControl pc = new PageControl();
+        pc.setFilter(true);
+        pc.setFilterColumn("fqdn");
+
+        assertEquals(5, hubFactory.countPeripherals(null));
+
+        pc.setFilterData("local");
+        assertEquals(3, hubFactory.countPeripherals(pc));
+
+        pc.setFilterData("dev");
+        assertEquals(2, hubFactory.countPeripherals(pc));
+
+        pc.setFilterData("aws");
+        assertEquals(2, hubFactory.countPeripherals(pc));
+
+        pc.setFilterData("test.local");
+        assertEquals(1, hubFactory.countPeripherals(pc));
+
+        pc.setFilterData("gamma");
+        assertEquals(1, hubFactory.countPeripherals(pc));
+
+        pc.setFilterData("03");
+        assertEquals(3, hubFactory.countPeripherals(pc));
+
+        pc.setFilterData("omega");
+        assertEquals(0, hubFactory.countPeripherals(pc));
+    }
+
+    @Test
+    public void canListPeripheralWithPaginationControl() {
+        // Create a bunch of peripherals
+        createPeripherals();
+
+        // Ensure sorting is correct
+        List<IssPeripheral> resultList;
+
+        // First just sort all the items in ascending order
+        resultList = hubFactory.listPaginatedPeripherals(new PageControl(1, 10, "fqdn"));
+        assertNotEmpty(resultList);
+        assertEquals(
+            List.of("alpha", "beta", "delta", "epsilon", "gamma"),
+            resultList.stream().map(ph -> ph.getFqdn().split("-")[0]).toList()
+        );
+
+        // Sort descending and limit
+        resultList = hubFactory.listPaginatedPeripherals(new PageControl(1, 2, "fqdn", true));
+        assertNotEmpty(resultList);
+        assertEquals(
+            List.of("gamma", "epsilon"),
+            resultList.stream().map(ph -> ph.getFqdn().split("-")[0]).toList()
+        );
+
+        // Filter, sort ascending and limit
+        resultList = hubFactory.listPaginatedPeripherals(new PageControl(1, 2, "fqdn", false, "fqdn", "local"));
+        assertNotEmpty(resultList);
+        assertEquals(
+            List.of("alpha", "beta"),
+            resultList.stream().map(ph -> ph.getFqdn().split("-")[0]).toList()
+        );
+
+        // Filter, sort descending and limit, getting second page
+        resultList = hubFactory.listPaginatedPeripherals(new PageControl(2, 1, "fqdn", true, "fqdn", "03"));
+        assertNotEmpty(resultList);
+        assertEquals(
+            List.of("epsilon"),
+            resultList.stream().map(ph -> ph.getFqdn().split("-")[0]).toList()
+        );
+    }
+
+    private void createPeripherals() {
+        Stream.of(
+            new IssPeripheral("alpha-01.dev.local"),
+            new IssPeripheral("beta-03.test.local"),
+            new IssPeripheral("gamma-03.prod.aws"),
+            new IssPeripheral("delta-01.test.aws"),
+            new IssPeripheral("epsilon-03.dev.local")
+        ).forEach(ph -> hubFactory.save(ph));
     }
 
     private static String getRandomFqdn() {


### PR DESCRIPTION
## What does this PR change?

This PR changes the way the dynamic query to extract the peripheral list is implemented. It replaces the current string concatenation approach with a `CriteriaQuery`. This is an attempt to fix the SonarCloud issue "Database queries should not be vulnerable to injection attacks" currently reported in https://github.com/uyuni-project/uyuni/pull/10118.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
