### PR TITLE
QE: Modifiying some problems in checking and unchecking checkboxes

### DIFF
--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -16,33 +16,47 @@ Feature: Assign child channel to a system
     Given I am authorized
 
 @susemanager
-  Scenario: Check the system is still subscribed to old channels before channel change completes
+  Scenario: Pre-requisite: unsubscribe from old channels
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
+    And I check radio button "SLE-Product-SLES15-SP4-Pool for x86_64"
     Then radio button "SLE-Product-SLES15-SP4-Pool for x86_64" should be checked
     And I wait until I do not see "Loading..." text
+    When I uncheck "SLE15-SP4-Installer-Updates for x86_64"
     And I should see "SLE15-SP4-Installer-Updates for x86_64" as unchecked
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
 
 @uyuni
-  Scenario: Check the system is still subscribed to old channels before channel change completes
+  Scenario: Pre-requisite: unsubscribe from old channels
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
+    And I check radio button "openSUSE Leap 15.6 (x86_64)"
     Then radio button "openSUSE Leap 15.6 (x86_64)" should be checked
-    And I wait until I do not see "Loading..." text
-    And I should see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" as unchecked
+    When I wait until I do not see "Loading..." text
+    And I uncheck "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" by label
+    Then I should see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" as unchecked
+    When I uncheck "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)" by label
+    Then I should see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)" as unchecked
+    When I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
 
 @susemanager
-  Scenario: Check via API old channels are still the same on the system before channel change completes
+  Scenario: Pre-requisite: check via API that the system is unsubscribed from old channels
     When I refresh the metadata for "sle_minion"
     Then channel "SLE-Product-SLES15-SP4-Pool for x86_64" should be enabled on "sle_minion"
     And channel "SLE15-SP4-Installer-Updates for x86_64" should be disabled on "sle_minion"
 
 @uyuni
-  Scenario: Check via API old channels are still the same on the system before channel change completes
+  Scenario: Pre-requisite: check via API that the system is unsubscribed from old channels
     When I refresh the metadata for "sle_minion"
     Then channel "openSUSE Leap 15.6 (x86_64)" should be enabled on "sle_minion"
     And channel "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" should be disabled on "sle_minion"
@@ -69,11 +83,12 @@ Feature: Assign child channel to a system
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     Then radio button "openSUSE Leap 15.6 (x86_64)" should be checked
-    And I wait until I do not see "Loading..." text
-    And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)"
-    And I click on "Next"
+    When I wait until I do not see "Loading..." text
+    And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" by label
+    Then I should see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" as checked
+    When I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
-    And I click on "Confirm"
+    When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
@@ -142,13 +157,15 @@ Feature: Assign child channel to a system
     Then radio button "openSUSE Leap 15.6 (x86_64)" should be checked
     And I wait until I do not see "Loading..." text
     And I wait until I see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" text
-    And I uncheck "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)"
-    And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)"
-    And I check "Fake-RPM-SUSE-Channel"
+    And I uncheck "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" by label
+    Then I should see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" as unchecked
+    When I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)" by label
+    Then I should see "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)" as checked
+    When I check "Fake-RPM-SUSE-Channel"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
-    Then I should see a "Changing the channels has been scheduled." text
-    When I follow "scheduled" in the content area
+    And I wait until I see "Changing the channels has been scheduled." text
+    And I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
     Then channel "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64)" should be disabled on "sle_minion"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -161,6 +161,17 @@ When(/^I uncheck "([^"]*)"$/) do |identifier|
   raise ScriptError, "Checkbox #{identifier} not unchecked." if has_checked_field?(identifier)
 end
 
+When(/^I (check|uncheck) "([^"]*)" by label$/) do |action, label|
+  checkbox = find(:xpath, "//label[text()='#{label}']/preceding-sibling::input[@type='checkbox']")
+  if action == 'check'
+    checkbox.set(true)
+    raise ScriptError, "Checkbox #{label} not checked." unless has_checked_field?(label)
+  elsif action == 'uncheck'
+    checkbox.set(false)
+    raise ScriptError, "Checkbox #{label} not unchecked." unless has_unchecked_field?(label)
+  end
+end
+
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
   if has_select?(field, with_options: [option], wait: 1)
     select(option, from: field)


### PR DESCRIPTION
## What does this PR change?

This PR introduces a new method for checking and unchecking checkboxes to address an issue encountered on the `min_change_software_channels.feature` screen. The problem occurs when multiple checkboxes share the same base name with differing suffixes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed.

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): None, something found during the rrtg tasks
Port(s): 
 - Manager 5.0:
 - Manager 4.3:

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
