### PR TITLE
Test: fix filter tests when list is empty

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -105,8 +105,8 @@ namespace :utils do
     filtered_tests = input_tests.select { |test| filter_tests.include?(test) }
 
     if filtered_tests.empty?
-        filtered_tests = ["features/finishing/srv_debug.feature"]
-        puts "Filtered tests is empty, selecting debug test"
+        filtered_tests = ["features/secondary/srv_users.feature"]
+        puts "Filtered tests is empty, selecting only the users test"
     end
 
     # Log for debugging

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -104,6 +104,11 @@ namespace :utils do
     # Intersect filter_tests with input_tests to create the filtered set
     filtered_tests = input_tests.select { |test| filter_tests.include?(test) }
 
+    if filtered_tests.empty?
+        filtered_tests = input_tests
+        puts "Filtered tests is empty, selecting all tests"
+    end
+
     # Log for debugging
     puts "Filtered Tests: #{filtered_tests}"
 

--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -105,8 +105,8 @@ namespace :utils do
     filtered_tests = input_tests.select { |test| filter_tests.include?(test) }
 
     if filtered_tests.empty?
-        filtered_tests = input_tests
-        puts "Filtered tests is empty, selecting all tests"
+        filtered_tests = ["features/finishing/srv_debug.feature"]
+        puts "Filtered tests is empty, selecting debug test"
     end
 
     # Log for debugging


### PR DESCRIPTION
## What does this PR change?

If the filter tests is empty, select all tests.

## GUI diff

No difference.



- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests
- [ ] **DONE**

## Links
N/A

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
