### PR TITLE
Fix query for Server by machineId (bsc#1240409)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -1502,7 +1502,7 @@ public class ServerFactory extends HibernateFactory {
      */
     public static Optional<Server> findByMachineId(String machineId) {
         return getSession().createNativeQuery("""
-                                      SELECT * from rhnServer
+                                      SELECT *, 0 as clazz_ from rhnServer
                                       WHERE machine_id = :machine
                                       """, Server.class)
                 .setParameter("machine", machineId, StandardBasicTypes.STRING)

--- a/java/spacewalk-java.changes.mcalmer.fix-query-for-server
+++ b/java/spacewalk-java.changes.mcalmer.fix-query-for-server
@@ -1,0 +1,1 @@
+- Fix query for Server by machineId (bsc#1240409)


### PR DESCRIPTION
## What does this PR change?

Fix SQL query to resolve error:

```
2025-04-02 13:54:35,403 [salt-event-thread-4] WARN  org.hibernate.engine.jdbc.spi.SqlExceptionHelper - SQL Error: 0, SQLState: 42703
2025-04-02 13:54:35,403 [salt-event-thread-4] ERROR org.hibernate.engine.jdbc.spi.SqlExceptionHelper - The column name clazz_ was not found in this ResultSet.
2025-04-02 13:54:35,403 [salt-event-thread-4] ERROR com.suse.manager.reactor.PGEventListener - Unexpected exception while executing a MessageAction
javax.persistence.PersistenceException: org.hibernate.exception.SQLGrammarException: could not execute query
        at org.hibernate.internal.ExceptionConverterImpl.convert(ExceptionConverterImpl.java:154) ~[hibernate5_hibernate-core.jar:5.3.25.Final]
        at org.hibernate.query.internal.AbstractProducedQuery.list(AbstractProducedQuery.java:1575) ~[hibernate5_hibernate-core.jar:5.3.25.Final]
        at org.hibernate.query.internal.AbstractProducedQuery.uniqueResult(AbstractProducedQuery.java:1608) ~[hibernate5_hibernate-core.jar:5.3.25.Final]
        at org.hibernate.query.internal.AbstractProducedQuery.uniqueResultOptional(AbstractProducedQuery.java:1559) ~[hibernate5_hibernate-core.jar:5.3.25.Final]
        at com.redhat.rhn.domain.server.ServerFactory.findByMachineId(ServerFactory.java:1509) ~[rhn.jar:?]
        at com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction.lambda$registerMinion$18(RegisterMinionEventMessageAction.java:238) ~[rhn.jar:?]
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26913
Port(s): no ports needed - change was introduced in 5.1/master

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
