### PR TITLE
ISSV3 Fix: failures to deregister peripheral servers (bsc#1240396)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -39,7 +39,9 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.taskomatic.domain.TaskoSchedule;
 import com.redhat.rhn.taskomatic.task.RepoSyncTask;
 
+import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.utils.MinionServerUtils;
+import com.suse.utils.CertificateUtils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -827,6 +829,20 @@ public class TaskomaticApi {
     /**
      * Schedule one root ca certificate update
      *
+     * @param issRoleIn server role: one of HUB, PERIPHERAL
+     * @param fqdn fully qualified domain name of the server
+     * @param rootCaCertContent root ca certificate actual content
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSingleRootCaCertUpdate(IssRole issRoleIn, String fqdn, String rootCaCertContent)
+            throws TaskomaticApiException {
+        String filename = CertificateUtils.computeRootCaFileName(issRoleIn.getLabel(), fqdn);
+        scheduleSingleRootCaCertUpdate(filename, rootCaCertContent);
+    }
+
+    /**
+     * Schedule one root ca certificate update
+     *
      * @param fileName          filename of the ca certificate
      * @param rootCaCertContent root ca certificate actual content
      * @throws TaskomaticApiException if there was an error
@@ -863,6 +879,20 @@ public class TaskomaticApi {
         Map<String, Object> paramList = new HashMap<>();
         paramList.put("filename_to_root_ca_cert_map", sanitisedFilenameToRootCaCertMap);
         invoke(SCHEDULE_SINGLE_SAT_BUNCH_RUN, "root-ca-cert-update-bunch", paramList);
+    }
+
+
+    /**
+     * Schedule one root ca certificate delete
+     *
+     * @param issRoleIn server role: one of HUB, PERIPHERAL
+     * @param fqdn fully qualified domain name of the server
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSingleRootCaCertDelete(IssRole issRoleIn, String fqdn)
+            throws TaskomaticApiException {
+        String filename = CertificateUtils.computeRootCaFileName(issRoleIn.getLabel(), fqdn);
+        scheduleSingleRootCaCertDelete(filename);
     }
 
     /**

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -890,8 +890,10 @@ public class HubManager {
 
     private IssServer createServer(IssRole role, String serverFqdn, String rootCA, String gpgKey, User user)
             throws TaskomaticApiException {
-        String filename = CertificateUtils.computeRootCaFileName(role.getLabel(), serverFqdn);
-        taskomaticApi.scheduleSingleRootCaCertUpdate(filename, rootCA);
+        if (StringUtils.isNotEmpty(rootCA)) {
+            String filename = CertificateUtils.computeRootCaFileName(role.getLabel(), serverFqdn);
+            taskomaticApi.scheduleSingleRootCaCertUpdate(filename, rootCA);
+        }
         return switch (role) {
             case HUB -> {
                 IssHub hub = new IssHub(serverFqdn, rootCA);

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -311,6 +311,13 @@ public class HubManager {
         }
         hubFactory.remove(peripheral);
         hubFactory.removeAccessTokensFor(peripheral.getFqdn());
+        try {
+            taskomaticApi.scheduleSingleRootCaCertDelete(IssRole.PERIPHERAL, peripheral.getFqdn());
+        }
+        catch (TaskomaticApiException ex) {
+            //if unable to delete ca certificate, just log a warning
+            LOG.warn("Cannot remove ca certificate for peripheral {}", peripheral.getFqdn());
+        }
     }
 
     private void deleteHub(String hubFqdn) {
@@ -333,6 +340,13 @@ public class HubManager {
         }
         hubFactory.remove(hub);
         hubFactory.removeAccessTokensFor(hub.getFqdn());
+        try {
+            taskomaticApi.scheduleSingleRootCaCertDelete(IssRole.HUB, hub.getFqdn());
+        }
+        catch (TaskomaticApiException ex) {
+            //if unable to delete ca certificate, just log a warning
+            LOG.warn("Cannot remove ca certificate for peripheral {}", hub.getFqdn());
+        }
     }
 
     /**
@@ -660,8 +674,7 @@ public class HubManager {
         });
 
         if (data.hasRootCA()) {
-            String filename = CertificateUtils.computeRootCaFileName(role.getLabel(), fqdn);
-            taskomaticApi.scheduleSingleRootCaCertUpdate(filename, data.getRootCA());
+            taskomaticApi.scheduleSingleRootCaCertUpdate(role, fqdn, data.getRootCA());
         }
     }
 
@@ -891,8 +904,7 @@ public class HubManager {
     private IssServer createServer(IssRole role, String serverFqdn, String rootCA, String gpgKey, User user)
             throws TaskomaticApiException {
         if (StringUtils.isNotEmpty(rootCA)) {
-            String filename = CertificateUtils.computeRootCaFileName(role.getLabel(), serverFqdn);
-            taskomaticApi.scheduleSingleRootCaCertUpdate(filename, rootCA);
+            taskomaticApi.scheduleSingleRootCaCertUpdate(role, serverFqdn, rootCA);
         }
         return switch (role) {
             case HUB -> {

--- a/java/code/src/com/suse/manager/model/hub/HubFactory.java
+++ b/java/code/src/com/suse/manager/model/hub/HubFactory.java
@@ -127,8 +127,11 @@ public class HubFactory extends HibernateFactory {
      * @return return {@link IssHub}
      */
     public Optional<IssHub> lookupIssHub() {
-        return getSession().createQuery("FROM IssHub", IssHub.class)
-                .uniqueResultOptional();
+        Query<IssHub> query = getSession().createQuery("FROM IssHub", IssHub.class);
+        if (query.stream().count() > 1) {
+            LOG.error("Duplicate hub in IssHub: a peripheral server should have not more than 1 Hub");
+        }
+        return query.stream().findFirst();
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
@@ -408,7 +408,7 @@ public class HubApiController {
         }
         catch (IOException | CertificateException ex) {
             LOGGER.error("Unable to register: error to connect with the remote server {}", server.getFqdn(), ex);
-            internalServerError(response, LOC.getMessage("hub.unable_to_deregister"));
+            return internalServerError(response, LOC.getMessage("hub.unable_to_deregister"));
         }
 
         return success(response);

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -684,6 +684,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String success(Response response) {
+        response.status(HttpStatus.SC_OK);
         return json(response, ResultJson.success(), new TypeToken<>() { });
     }
 
@@ -695,6 +696,7 @@ public class SparkApplicationHelper {
      * @param <T> the type of data
      */
     public static <T> String success(Response response, T data) {
+        response.status(HttpStatus.SC_OK);
         return json(response, data, new TypeToken<>() { });
     }
 


### PR DESCRIPTION
## What does this PR change?
This PR fixes bugs when deregistering the peripheral servers.
They should be removed from the Hub's list of peripherals and, on their end, should no longer display the Hub's data in the Hub Configuration > Hub Details UI page.
The de-registering must be correctly been done both from the Hub and the Peripheral side

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: tested manually
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/26845
Port(s): no backports (issv3)
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

