### PR TITLE
Uyuni fix deregister

### DIFF
--- a/java/code/src/com/suse/manager/hub/migration/test/IssMigratorTest.java
+++ b/java/code/src/com/suse/manager/hub/migration/test/IssMigratorTest.java
@@ -54,6 +54,7 @@ import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssPeripheralChannels;
+import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.migration.MigrationMessage;
 import com.suse.manager.model.hub.migration.MigrationResult;
 import com.suse.manager.model.hub.migration.MigrationResultCode;
@@ -685,7 +686,9 @@ public class IssMigratorTest extends JMockBaseTestCaseWithUser {
         private void allowRegistration(SlaveMigrationData data, HubInternalClient internalClientMock)
             throws TaskomaticApiException, CertificateException, IOException {
             allowing(taskomaticApi)
-                .scheduleSingleRootCaCertUpdate("peripheral_" + data.fqdn() + "_root_ca.pem", data.rootCA());
+                    .scheduleSingleRootCaCertUpdate(IssRole.PERIPHERAL, data.fqdn(), data.rootCA());
+            allowing(taskomaticApi)
+                    .scheduleSingleRootCaCertDelete(IssRole.PERIPHERAL, data.fqdn());
 
             allowing(hubClientFactory).newInternalClient(data.fqdn(), data.token(), data.rootCA());
             will(returnValue(internalClientMock));
@@ -708,7 +711,9 @@ public class IssMigratorTest extends JMockBaseTestCaseWithUser {
         private void failingRegistration(SlaveMigrationData data, HubInternalClient internalClientMock)
             throws TaskomaticApiException, CertificateException, IOException {
             allowing(taskomaticApi)
-                .scheduleSingleRootCaCertUpdate("peripheral_" + data.fqdn() + "_root_ca.pem", data.rootCA());
+                    .scheduleSingleRootCaCertUpdate(IssRole.PERIPHERAL, data.fqdn(), data.rootCA());
+            allowing(taskomaticApi)
+                    .scheduleSingleRootCaCertDelete(IssRole.PERIPHERAL, data.fqdn());
 
             allowing(hubClientFactory).newInternalClient(data.fqdn(), data.token(), data.rootCA());
             will(returnValue(internalClientMock));

--- a/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
@@ -511,17 +511,17 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
         mockTaskomaticApi.verifyTaskoCall();
 
         mockTaskomaticApi.resetTaskomaticCall();
-        mockTaskomaticApi.setExpectations(1,
-                List.of("tasko.scheduleSingleSatBunchRun"),
-                List.of("root-ca-cert-update-bunch"),
+        mockTaskomaticApi.setExpectations(0,
+                List.of(),
+                List.of(),
                 "hub_dummy2.hub.fqdn_root_ca.pem", "", "");
         hubManager.saveNewServer(getValidToken("dummy2.hub.fqdn"), IssRole.HUB, "", "");
         mockTaskomaticApi.verifyTaskoCall();
 
         mockTaskomaticApi.resetTaskomaticCall();
-        mockTaskomaticApi.setExpectations(1,
-                List.of("tasko.scheduleSingleSatBunchRun"),
-                List.of("root-ca-cert-update-bunch"),
+        mockTaskomaticApi.setExpectations(0,
+                List.of(),
+                List.of(),
                 "hub_dummy3.hub.fqdn_root_ca.pem", "", "");
         hubManager.saveNewServer(getValidToken("dummy3.hub.fqdn"), IssRole.HUB, null, null);
         mockTaskomaticApi.verifyTaskoCall();
@@ -537,17 +537,17 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
         mockTaskomaticApi.verifyTaskoCall();
 
         mockTaskomaticApi.resetTaskomaticCall();
-        mockTaskomaticApi.setExpectations(1,
-                List.of("tasko.scheduleSingleSatBunchRun"),
-                List.of("root-ca-cert-update-bunch"),
+        mockTaskomaticApi.setExpectations(0,
+                List.of(),
+                List.of(),
                 "peripheral_dummy2.periph.fqdn_root_ca.pem", "", "");
         hubManager.saveNewServer(getValidToken("dummy2.periph.fqdn"), IssRole.PERIPHERAL, "", "");
         mockTaskomaticApi.verifyTaskoCall();
 
         mockTaskomaticApi.resetTaskomaticCall();
-        mockTaskomaticApi.setExpectations(1,
-                List.of("tasko.scheduleSingleSatBunchRun"),
-                List.of("root-ca-cert-update-bunch"),
+        mockTaskomaticApi.setExpectations(0,
+                List.of(),
+                List.of(),
                 "peripheral_dummy3.periph.fqdn_root_ca.pem", "", "");
         hubManager.saveNewServer(getValidToken("dummy3.periph.fqdn"), IssRole.PERIPHERAL, null, null);
         mockTaskomaticApi.verifyTaskoCall();

--- a/java/code/src/com/suse/manager/model/hub/HubFactory.java
+++ b/java/code/src/com/suse/manager/model/hub/HubFactory.java
@@ -127,8 +127,11 @@ public class HubFactory extends HibernateFactory {
      * @return return {@link IssHub}
      */
     public Optional<IssHub> lookupIssHub() {
-        return getSession().createQuery("FROM IssHub", IssHub.class)
-                .uniqueResultOptional();
+        Query<IssHub> query = getSession().createQuery("FROM IssHub", IssHub.class);
+        if (query.stream().count() > 1) {
+            LOG.error("Duplicate hub in IssHub: a peripheral server should have not more than 1 Hub");
+        }
+        return query.stream().findFirst();
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
@@ -408,7 +408,7 @@ public class HubApiController {
         }
         catch (IOException | CertificateException ex) {
             LOGGER.error("Unable to register: error to connect with the remote server {}", server.getFqdn(), ex);
-            internalServerError(response, LOC.getMessage("hub.unable_to_deregister"));
+            return internalServerError(response, LOC.getMessage("hub.unable_to_deregister"));
         }
 
         return success(response);

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -662,6 +662,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String success(Response response) {
+        response.status(HttpStatus.SC_OK);
         return json(response, ResultJson.success(), new TypeToken<>() { });
     }
 
@@ -673,6 +674,7 @@ public class SparkApplicationHelper {
      * @param <T> the type of data
      */
     public static <T> String success(Response response, T data) {
+        response.status(HttpStatus.SC_OK);
         return json(response, data, new TypeToken<>() { });
     }
 

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-deregister
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-deregister
@@ -1,0 +1,1 @@
+- Fix: failures to deregister peripheral servers (bsc#1240396)


### PR DESCRIPTION
## What does this PR change?

This PR fixes bugs when deregistering the peripheral servers.
They should be removed from the Hub's list of peripherals and, on their end, should no longer display the Hub's data in the Hub Configuration > Hub Details UI page.
The de-registering must be correctly been done both from the Hub and the Peripheral side

Substitutes closed PR (https://github.com/uyuni-project/uyuni/pull/10147)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26845
Port(s): no backports (issv3)
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

