### PR TITLE
Fix layout issues in product page (bsc#1240131)

### DIFF
--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.module.scss
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.module.scss
@@ -1,0 +1,11 @@
+:global(.old-theme),
+:global(.new-theme) {
+  .taskList {
+    list-style: none;
+    margin-bottom: 1.5em;
+
+    :global(.fa) {
+      margin-left: -1em;
+    }
+  }
+}

--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
@@ -5,6 +5,8 @@ import { Messages, MessageType } from "components/messages/messages";
 
 import Network from "utils/network";
 
+import styles from "./products-scc-dialog.module.scss";
+
 const messageMap = {
   // Nothing for now
 };
@@ -149,7 +151,7 @@ class SCCDialog extends React.Component<Props> {
         <hr />
         <div className="d-block">
           <Messages items={this.state.errors} />
-          <ul id="scc-task-list" className="fa-ul">
+          <ul id="scc-task-list" className={styles.taskList}>
             {this.state.steps.map((s) => {
               return (
                 <li key={s.id}>
@@ -157,11 +159,11 @@ class SCCDialog extends React.Component<Props> {
                     className={
                       s.success != null
                         ? s.success
-                          ? "fa fa-li fa-check text-success"
-                          : "fa fa-li fa-exclamation-triangle text-warning"
+                          ? "fa fa-check text-success"
+                          : "fa fa-exclamation-triangle text-warning"
                         : s.inProgress
-                        ? "fa fa-li fa-spinner fa-spin"
-                        : "fa fa-li fa-circle-o text-muted"
+                        ? "fa fa-spinner fa-spin"
+                        : "fa fa-circle-o text-muted"
                     }
                   />
                   <span>{s.label}</span>

--- a/web/spacewalk-web.changes.eth.bsc1240131
+++ b/web/spacewalk-web.changes.eth.bsc1240131
@@ -1,0 +1,1 @@
+- Fix layout issues in product page (bsc#1240131)


### PR DESCRIPTION
## What does this PR change?

The product page sidebar was not using the updated font due to being overwritten by the icon font styles.

## GUI diff

<img width="406" alt="Screenshot 2025-04-08 at 10 03 05" src="https://github.com/user-attachments/assets/289b857b-50c8-40f2-b7be-c082abf3d00b" />

<img width="404" alt="Screenshot 2025-04-08 at 10 03 11" src="https://github.com/user-attachments/assets/d8a437ab-3a38-44bb-9d0c-ff18936d32e6" />


- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: bugfix

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1240131

Fixes https://github.com/SUSE/spacewalk/issues/26808

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
