### PR TITLE
Fix: Correctly register and deregister with multiple roles

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9151,6 +9151,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="hub.unexpected_error" xml:space="preserve">
         <source>Registration of the remote server failed due to an unexpected error. Please check the server logs.</source>
       </trans-unit>
+      <trans-unit id="hub.error_peripheral_not_registrable" xml:space="preserve">
+        <source>The server {0} cannot be registered as a peripheral of this hub</source>
+      </trans-unit>
       <trans-unit id="hub.invalid_token_id" xml:space="preserve">
         <source>The specified access token does not exist.</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -173,6 +173,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(MigrationResultSerializer.class);
         SERIALIZER_CLASSES.add(AccessGroupSerializer.class);
         SERIALIZER_CLASSES.add(NamespaceSerializer.class);
+        SERIALIZER_CLASSES.add(ServerInfoJsonSerializer.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ServerInfoJsonSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ServerInfoJsonSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.suse.manager.api.ApiResponseSerializer;
+import com.suse.manager.api.SerializationBuilder;
+import com.suse.manager.api.SerializedApiResponse;
+import com.suse.manager.model.hub.ServerInfoJson;
+
+/**
+ * Converts a ServerInfoJson to an XMLRPC &lt;struct&gt;.
+ *
+ * @apidoc.doc
+ *  #struct_begin("server info")
+ *      #prop_desc("boolean", "isHub", "true if server is a hub")
+ *      #prop_desc("boolean", "isPeripheral", "true if server is a peripheral")
+ *  #struct_end()
+ */
+public class ServerInfoJsonSerializer extends ApiResponseSerializer<ServerInfoJson> {
+
+    @Override
+    public Class<ServerInfoJson> getSupportedClass() {
+        return ServerInfoJson.class;
+    }
+
+    @Override
+    public SerializedApiResponse serialize(ServerInfoJson src) {
+        return new SerializationBuilder()
+                .add("isHub", src.isHub())
+                .add("isPeripheral", src.isPeripheral())
+                .build();
+    }
+}

--- a/java/code/src/com/suse/manager/hub/DefaultHubInternalClient.java
+++ b/java/code/src/com/suse/manager/hub/DefaultHubInternalClient.java
@@ -19,6 +19,7 @@ import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
 import com.suse.manager.model.hub.RegisterJson;
 import com.suse.manager.model.hub.SCCCredentialsJson;
+import com.suse.manager.model.hub.ServerInfoJson;
 import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
 
 import com.google.gson.Gson;
@@ -129,6 +130,11 @@ public class DefaultHubInternalClient implements HubInternalClient {
     @Override
     public void deleteIssV1Master() throws IOException {
         invokePost("hub/sync/migrate/v1", "deleteMaster", null);
+    }
+
+    @Override
+    public ServerInfoJson getServerInfo() throws IOException {
+        return invokeGet("hub", "serverInfo", ServerInfoJson.class);
     }
 
     private <R> R invokeGet(String namespace, String apiMethod, Type responseType)

--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -44,6 +44,7 @@ import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
 import com.suse.manager.model.hub.RegisterJson;
 import com.suse.manager.model.hub.SCCCredentialsJson;
+import com.suse.manager.model.hub.ServerInfoJson;
 import com.suse.manager.model.hub.UpdatableServerData;
 import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
 import com.suse.manager.webui.utils.token.TokenBuildingException;
@@ -104,6 +105,7 @@ public class HubController {
         post("/hub/ping", asJson(usingTokenAuthentication(this::ping)));
         post("/hub/sync/deregister", asJson(usingTokenAuthentication(onlyFromRegistered(this::deregister))));
         post("/hub/sync/registerHub", asJson(usingTokenAuthentication(onlyFromUnregistered(this::registerHub))));
+        get("/hub/serverInfo", asJson(usingTokenAuthentication(this::getServerInfo)));
         post("/hub/sync/replaceTokens", asJson(usingTokenAuthentication(onlyFromHub(this::replaceTokens))));
         post("/hub/sync/storeCredentials", asJson(usingTokenAuthentication(onlyFromHub(this::storeCredentials))));
         post("/hub/sync/setHubDetails", asJson(usingTokenAuthentication(onlyFromHub(this::setHubDetails))));
@@ -288,6 +290,11 @@ public class HubController {
             LOGGER.error("Unable to schedule root CA certificate update {}", token.getServerFqdn(), ex);
             return internalServerError(response, "Unable to schedule root CA certificate update");
         }
+    }
+
+    private String getServerInfo(Request request, Response response, IssAccessToken token) {
+        ServerInfoJson serverInfoJson = hubManager.getServerInfo(token);
+        return success(response, serverInfoJson);
     }
 
     private String storeCredentials(Request request, Response response, IssAccessToken token) {

--- a/java/code/src/com/suse/manager/hub/HubInternalClient.java
+++ b/java/code/src/com/suse/manager/hub/HubInternalClient.java
@@ -15,6 +15,7 @@ import com.suse.manager.model.hub.ChannelInfoDetailsJson;
 import com.suse.manager.model.hub.ChannelInfoJson;
 import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
+import com.suse.manager.model.hub.ServerInfoJson;
 
 import java.io.IOException;
 import java.util.List;
@@ -103,4 +104,12 @@ public interface HubInternalClient {
      * Deletes the ISSv1 Master
      */
     void deleteIssV1Master() throws IOException;
+
+    /**
+     * checks if the server can be registered as peripheral
+     *
+     * @return information about the server
+     * @throws IOException when the communication fails
+     */
+    ServerInfoJson getServerInfo() throws IOException;
 }

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -55,6 +55,7 @@ import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.IssServer;
 import com.suse.manager.model.hub.ManagerInfoJson;
 import com.suse.manager.model.hub.OrgInfoJson;
+import com.suse.manager.model.hub.ServerInfoJson;
 import com.suse.manager.model.hub.TokenType;
 import com.suse.manager.model.hub.UpdatableServerData;
 import com.suse.manager.webui.controllers.ProductsController;
@@ -231,6 +232,18 @@ public class HubManager {
     }
 
     /**
+     * Checks if the server can be registered as peripheral
+     * @param accessToken the access token granting access and identifying the caller
+     * @return return {@link ServerInfoJson}
+     */
+    public ServerInfoJson getServerInfo(IssAccessToken accessToken) {
+        ensureValidToken(accessToken);
+
+        return new ServerInfoJson(hubFactory.countPeripherals() > 0,
+                hubFactory.lookupIssHub().isPresent());
+    }
+
+    /**
      * Save the given remote server as hub or peripheral depending on the specified role
      * @param accessToken the access token granting access and identifying the caller
      * @param role the role of the server
@@ -257,8 +270,54 @@ public class HubManager {
     public void deregister(User user, String fqdn, boolean onlyLocal) throws CertificateException, IOException {
         ensureSatAdmin(user);
 
-        IssRole remoteRole = hubFactory.isISSPeripheral() ? IssRole.HUB : IssRole.PERIPHERAL;
-        IssServer server = findServer(user, fqdn, remoteRole);
+        boolean thisIsISSHub = hubFactory.isISSHub();
+        boolean thisIsISSPeripheral = hubFactory.isISSPeripheral();
+        IssRole serverRole = null;
+
+        if (!thisIsISSHub && thisIsISSPeripheral) {
+            serverRole = IssRole.HUB;
+        }
+        if (thisIsISSHub && !thisIsISSPeripheral) {
+            serverRole = IssRole.PERIPHERAL;
+        }
+        if (thisIsISSHub && thisIsISSPeripheral) {
+            //this is both hub and peripheral: whose server do I have to deregister from?
+
+            //try deregister a peripheral
+            serverRole = IssRole.PERIPHERAL;
+            IssServer server = findServer(user, fqdn, serverRole);
+            if (null == server) {
+                //try deregister a hub
+                serverRole = IssRole.HUB;
+                server = findServer(user, fqdn, serverRole);
+                if (null == server) {
+                    LOG.error("Cannot deregister: server {} not found (neither hub nor peripheral)", fqdn);
+                    throw new IllegalStateException(
+                            "Cannot deregister: server %s not found (neither hub nor peripheral)".formatted(fqdn));
+                }
+            }
+        }
+        if (!thisIsISSHub && !thisIsISSPeripheral) {
+            return; //nothing to do: probably a race condition
+        }
+
+        deregister(user, fqdn, serverRole, onlyLocal);
+    }
+
+    /**
+     * Deregister the server with the given FQDN. The de-registration can be optionally performed also on the
+     * remote server.
+     * @param user the user
+     * @param fqdn the FQDN
+     * @param serverRole the server role (HUB or PERIPHERAL)
+     * @param onlyLocal specify if the de-registration has to be performed also on the remote server
+     * @throws CertificateException when it's not possible to use remote server certificate
+     * @throws IOException when the connection with the remote server fails
+     */
+    public void deregister(User user, String fqdn, IssRole serverRole, boolean onlyLocal)
+            throws CertificateException, IOException {
+        ensureSatAdmin(user);
+        IssServer server = findServer(user, fqdn, serverRole);
 
         if (null == server) {
             return;
@@ -270,7 +329,7 @@ public class HubManager {
             internalClient.deregister();
         }
 
-        switch (remoteRole) {
+        switch (serverRole) {
             case HUB -> deleteHub(fqdn);
             case PERIPHERAL -> deletePeripheral(fqdn);
             default -> throw new IllegalStateException("Role should either be HUB or PERIPHERAL");
@@ -285,13 +344,21 @@ public class HubManager {
      */
     public IssRole deleteIssServerLocal(IssAccessToken accessToken, String fqdn) {
         ensureValidToken(accessToken);
-        if (hubFactory.isISSPeripheral()) {
-            deleteHub(fqdn);
+
+        Optional<IssPeripheral> issPeripheral = hubFactory.lookupIssPeripheralByFqdn(fqdn);
+        if (issPeripheral.isPresent()) {
+            deletePeripheral(issPeripheral.get());
+            return IssRole.PERIPHERAL;
+        }
+
+        Optional<IssHub> issHub = hubFactory.lookupIssHubByFqdn(fqdn);
+        if (issHub.isPresent()) {
+            deleteHub(issHub.get());
             return IssRole.HUB;
         }
 
-        deletePeripheral(fqdn);
-        return IssRole.PERIPHERAL;
+        LOG.info("Peripheral Server with name {} not found", fqdn);
+        return IssRole.PERIPHERAL; //default value?
     }
 
     private void deletePeripheral(String peripheralFqdn) {
@@ -737,9 +804,36 @@ public class HubManager {
                 reportDbName, reportDbHost, reportDbPort);
     }
 
+    private void checkIfRegistrableAsPeripheral(ServerInfoJson serverInfo) throws PeripheralRegistrationException {
+        // if server is already a peripheral, then it has already a hub.
+        // multiple hubs are not allowed: replacing the hub could lead to circular dependencies
+        if (serverInfo.isPeripheral()) {
+            throw new PeripheralRegistrationException(
+                    "Candidate peripheral server already registered to a hub. Deregister it first");
+        }
+
+        // To avoid circular dependencies:
+        // if the server is not a hub (has no peripherals), it can be safely registered
+        // if current node is not subscribed to a hub, it can safely register any server (regardless of it already
+        // having peripherals)
+        if (serverInfo.isHub() && hubFactory.lookupIssHub().isPresent()) {
+            // how can we be sure the server is not our ancestor? Are forests allowed?
+            // with the following throw:
+            // PRO: we avoid mistakenly registering our tree root
+            // CON: we do not allow to register the root of another tree of a forest
+            throw new PeripheralRegistrationException(
+                    "Candidate peripheral server already owns peripherals. Cannot register another server tree");
+        }
+    }
+
     private IssPeripheral registerWithToken(User user, String remoteServer, String rootCA, String remoteToken)
         throws TokenParsingException, CertificateException, TokenBuildingException, IOException,
             TaskomaticApiException {
+
+        var internalApi = clientFactory.newInternalClient(remoteServer, remoteToken, rootCA);
+        ServerInfoJson serverInfo = internalApi.getServerInfo();
+        checkIfRegistrableAsPeripheral(serverInfo);
+
         parseAndSaveToken(remoteServer, remoteToken);
 
         IssServer registeredServer = createServer(IssRole.PERIPHERAL, remoteServer, rootCA, null, user);

--- a/java/code/src/com/suse/manager/hub/PeripheralRegistrationException.java
+++ b/java/code/src/com/suse/manager/hub/PeripheralRegistrationException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.hub;
+
+import java.io.IOException;
+
+public class PeripheralRegistrationException extends IOException {
+
+    /**
+     * Creates a new instance
+     */
+    public PeripheralRegistrationException() {
+        super();
+    }
+
+    /**
+     * Creates a new instance with the given error message
+     * @param message the error message
+     */
+    public PeripheralRegistrationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance with the given error message and cause
+     * @param message the error message
+     * @param cause what cause this invalid response exception
+     */
+    public PeripheralRegistrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/java/code/src/com/suse/manager/hub/migration/IssMigrator.java
+++ b/java/code/src/com/suse/manager/hub/migration/IssMigrator.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.hub.HubManager;
 import com.suse.manager.model.hub.ChannelInfoJson;
+import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.migration.MigrationItem;
 import com.suse.manager.model.hub.migration.MigrationMessageLevel;
 import com.suse.manager.model.hub.migration.MigrationResult;
@@ -300,7 +301,7 @@ public class IssMigrator {
 
         try {
             LOGGER.debug("Peripheral {} was not correctly migrated. Deregistering.", item.peripheral());
-            hubManager.deregister(user, item.fqdn(), false);
+            hubManager.deregister(user, item.fqdn(), IssRole.PERIPHERAL, false);
         }
         catch (Exception ex) {
             LOGGER.error("Unable to deregister peripheral {}", item.peripheral(), ex);

--- a/java/code/src/com/suse/manager/hub/migration/test/IssMigratorTest.java
+++ b/java/code/src/com/suse/manager/hub/migration/test/IssMigratorTest.java
@@ -55,6 +55,7 @@ import com.suse.manager.model.hub.IssAccessToken;
 import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssPeripheralChannels;
 import com.suse.manager.model.hub.IssRole;
+import com.suse.manager.model.hub.ServerInfoJson;
 import com.suse.manager.model.hub.migration.MigrationMessage;
 import com.suse.manager.model.hub.migration.MigrationResult;
 import com.suse.manager.model.hub.migration.MigrationResultCode;
@@ -706,6 +707,8 @@ public class IssMigratorTest extends JMockBaseTestCaseWithUser {
             will(returnValue(null));
 
             allowing(internalClientMock).scheduleProductRefresh();
+            allowing(internalClientMock).getServerInfo();
+            will(returnValue(new ServerInfoJson()));
         }
 
         private void failingRegistration(SlaveMigrationData data, HubInternalClient internalClientMock)
@@ -724,6 +727,9 @@ public class IssMigratorTest extends JMockBaseTestCaseWithUser {
                 with(anyOf(nullValue(String.class), any(String.class)))
             );
             will(throwException(new IOException("Remote failure")));
+
+            allowing(internalClientMock).getServerInfo();
+            will(returnValue(new ServerInfoJson()));
         }
 
         private void allowChannelSetup(HubInternalClient internalClientMock,

--- a/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubManagerTest.java
@@ -58,6 +58,7 @@ import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssRole;
 import com.suse.manager.model.hub.IssServer;
 import com.suse.manager.model.hub.ManagerInfoJson;
+import com.suse.manager.model.hub.ServerInfoJson;
 import com.suse.manager.model.hub.TokenType;
 import com.suse.manager.model.hub.UpdatableServerData;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -641,7 +642,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
             allowing(internalClient).deregister();
         }});
 
-        hubManager.deregister(satAdmin, fqdn, false);
+        hubManager.deregister(satAdmin, fqdn, IssRole.HUB, false);
 
         assertNull(hubFactory.lookupAccessTokenFor(fqdn));
         assertNull(hubFactory.lookupIssuedToken(fqdn));
@@ -652,7 +653,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     @Test
     public void canDeregisterHubLocalOnly() throws Exception {
         String fqdn = LOCAL_SERVER_FQDN;
-        hubManager.deregister(satAdmin, fqdn, true);
+        hubManager.deregister(satAdmin, fqdn, IssRole.HUB, true);
 
         assertNull(hubFactory.lookupAccessTokenFor(fqdn));
         assertNull(hubFactory.lookupIssuedToken(fqdn));
@@ -673,7 +674,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
             allowing(internalClient).deregister();
         }});
 
-        hubManager.deregister(satAdmin, fqdn, false);
+        hubManager.deregister(satAdmin, fqdn, IssRole.PERIPHERAL, false);
 
         assertNull(hubFactory.lookupAccessTokenFor(fqdn));
         assertNull(hubFactory.lookupIssuedToken(fqdn));
@@ -685,7 +686,7 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
     public void canDeregisterPeripheralLocalOnly() throws Exception {
         String fqdn = LOCAL_SERVER_FQDN;
 
-        hubManager.deregister(satAdmin, fqdn, true);
+        hubManager.deregister(satAdmin, fqdn, IssRole.PERIPHERAL, true);
 
         assertNull(hubFactory.lookupAccessTokenFor(fqdn));
         assertNull(hubFactory.lookupIssuedToken(fqdn));
@@ -766,6 +767,9 @@ public class HubManagerTest extends JMockBaseTestCaseWithUser {
             allowing(internalClient).storeReportDbCredentials(with(any(String.class)), with(any(String.class)));
 
             allowing(internalClient).scheduleProductRefresh();
+
+            allowing(internalClient).getServerInfo();
+            will(returnValue(new ServerInfoJson()));
         }});
 
         // Register the remote server as PERIPHERAL for this local server

--- a/java/code/src/com/suse/manager/model/hub/ServerInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/ServerInfoJson.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.model.hub;
+
+import java.util.Objects;
+
+public class ServerInfoJson {
+
+    private final boolean isHub;
+
+    private final boolean isPeripheral;
+
+    /**
+     * Default constructor
+     */
+    public ServerInfoJson() {
+        isHub = false;
+        isPeripheral = false;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param isHubIn true if server is registered to a hub
+     * @param isPeripheralIn true if server has registered peripherals
+     */
+    public ServerInfoJson(boolean isHubIn, boolean isPeripheralIn) {
+        isHub = isHubIn;
+        isPeripheral = isPeripheralIn;
+    }
+
+    public boolean isHub() {
+        return isHub;
+    }
+
+    public boolean isPeripheral() {
+        return isPeripheral;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (!(oIn instanceof ServerInfoJson that)) {
+            return false;
+        }
+        return isHub() == that.isHub() && isPeripheral() == that.isPeripheral();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isHub(), isPeripheral());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ServerInfoJson{");
+        sb.append("isHub=").append(isHub);
+        sb.append(", isPeripheral=").append(isPeripheral);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/HubApiController.java
@@ -29,6 +29,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.hub.HubManager;
 import com.suse.manager.hub.InvalidResponseException;
+import com.suse.manager.hub.PeripheralRegistrationException;
 import com.suse.manager.hub.migration.IssMigrator;
 import com.suse.manager.hub.migration.IssMigratorFactory;
 import com.suse.manager.model.hub.AccessTokenDTO;
@@ -290,6 +291,12 @@ public class HubApiController {
             LOGGER.error("Invalid response received from the remote server {}", remoteServer, ex);
             return internalServerError(response, LOC.getMessage("hub.invalid_remote_response"));
         }
+        catch (PeripheralRegistrationException ex) {
+            LOGGER.error("{} cannot be registered as a peripheral from this hub: {}",
+                    remoteServer, ex.getMessage());
+            return internalServerError(response, LOC.getMessage("hub.error_peripheral_not_registrable",
+                    remoteServer));
+        }
         catch (IOException ex) {
             LOGGER.error("Error while attempting to connect to remote server {}", remoteServer, ex);
             return internalServerError(response, LOC.getMessage("hub.error_connecting_remote"));
@@ -404,7 +411,7 @@ public class HubApiController {
         }
 
         try {
-            hubManager.deregister(user, server.getFqdn(), false);
+            hubManager.deregister(user, server.getFqdn(), issRole, false);
         }
         catch (IOException | CertificateException ex) {
             LOGGER.error("Unable to register: error to connect with the remote server {}", server.getFqdn(), ex);

--- a/java/code/src/com/suse/manager/xmlrpc/iss/test/HubHandlerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/test/HubHandlerTest.java
@@ -40,6 +40,7 @@ import com.suse.manager.hub.migration.IssMigratorFactory;
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssHub;
 import com.suse.manager.model.hub.IssPeripheral;
+import com.suse.manager.model.hub.ServerInfoJson;
 import com.suse.manager.model.hub.migration.MigrationResult;
 import com.suse.manager.model.hub.migration.MigrationResultCode;
 import com.suse.manager.model.hub.migration.SlaveMigrationData;
@@ -385,6 +386,8 @@ public class HubHandlerTest extends BaseHandlerTestCase {
             will(throwException(new SSLHandshakeException(sshFailureErrorString)));
 
             allowing(mockDefaultHubInternalClient).deregister();
+            allowing(mockDefaultHubInternalClient).getServerInfo();
+            will(returnValue(new ServerInfoJson()));
         }});
 
         String dummyToken = newHubHandler.generateAccessToken(satAdmin, ConfigDefaults.get().getHostname());

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-overregister
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-overregister
@@ -1,0 +1,2 @@
+- Fix: Correctly register and deregister hubs and peripherals
+  with multiple roles

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -19,6 +19,9 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('', '/hub/sync/registerHub', 'POST', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/hub/serverInfo', 'GET', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/hub/sync/replaceTokens', 'POST', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)

--- a/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-fix-overregister
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-fix-overregister
@@ -1,0 +1,1 @@
+- Added RBAC info for endpoint /hub/serverInfo

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.6-to-susemanager-schema-5.1.7/100-rbac-endpoint.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.6-to-susemanager-schema-5.1.7/100-rbac-endpoint.sql
@@ -1,0 +1,14 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/hub/serverInfo', 'GET', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/hub/serverInfo' AND http_method = 'GET');


### PR DESCRIPTION
## What does this PR change?

## WARNING: PLEASE REBASE THIS ON https://github.com/uyuni-project/uyuni/pull/10148
## The first commit is from https://github.com/uyuni-project/uyuni/pull/10148, only the last commit is new

This fix avoid that peripherals already taken (subscribed to a hub) could be registered from a different hub.
Furthermore, it correctly deregister when a server is both hub and peripheral



## GUI diff
Before:
![before](https://github.com/user-attachments/assets/80a786e5-3f4c-438c-b68f-c53ea5be009e)

After:
![Uploading after.png…]()


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): 
Port(s): 
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

