### PR TITLE
Replace server hostname in chained proxy tftp container (bsc#1236166)

### DIFF
--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.nadvornik.replace_fqdns
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.nadvornik.replace_fqdns
@@ -1,0 +1,1 @@
+- Replace server hostname in chained proxy config (bsc#1236166)

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -84,10 +84,11 @@ class HttpResponseDataFiltered(HttpResponseData):
     """
 
     # pylint: disable-next=super-init-not-called
-    def __init__(self, url, capath, proxy_fqdn, server_fqdn):
+    def __init__(self, url, capath, proxy_fqdn, server_fqdn, replace_fqdns):
         # request file by url and store it
         self._proxy_fqdn = proxy_fqdn
         self._server_fqdn = server_fqdn
+        self._replace_fqdns = replace_fqdns
         self._request = requests.get(url, stream=True, verify=capath)
         if self._request.status_code == 404:
             raise FileNotFoundError()
@@ -133,11 +134,18 @@ class HttpResponseDataFilteredPXE(HttpResponseDataFiltered):
                         entry += f"ONTIMEOUT {entry_name}\n"
                         saltboot_content += entry
                     else:
-                        cobbler_content += re.sub(
+                        filtered_entry = re.sub(
                             r"\b" + re.escape(self._server_fqdn) + r"\b",
                             self._proxy_fqdn,
                             entry,
                         )
+                        for fqdn in self._replace_fqdns:
+                            filtered_entry = re.sub(
+                                r"\b" + re.escape(fqdn) + r"\b",
+                                self._proxy_fqdn,
+                                filtered_entry,
+                            )
+                        cobbler_content += filtered_entry
                     entry = ""
             if not in_entry:
                 if line.startswith("LABEL"):
@@ -182,11 +190,18 @@ class HttpResponseDataFilteredGrub(HttpResponseDataFiltered):
                         saltboot_content += entry
                         saltboot_content += f"set default={entry_name}\n"
                     else:
-                        cobbler_content += re.sub(
+                        filtered_entry = re.sub(
                             r"\b" + re.escape(self._server_fqdn) + r"\b",
                             self._proxy_fqdn,
                             entry,
                         )
+                        for fqdn in self._replace_fqdns:
+                            filtered_entry = re.sub(
+                                r"\b" + re.escape(fqdn) + r"\b",
+                                self._proxy_fqdn,
+                                filtered_entry,
+                            )
+                        cobbler_content += filtered_entry
                     entry = ""
             else:
                 if line.startswith("menuentry"):
@@ -216,12 +231,14 @@ class TFTPHandler(BaseHandler):
         proxy_fqdn,
         server_fqdn,
         capath,
+        replace_fqdns,
     ):
         self._root = root
         self._http_host = http_host
         self._proxy_fqdn = proxy_fqdn
         self._server_fqdn = server_fqdn
         self._capath = capath
+        self._replace_fqdns = replace_fqdns
         super().__init__(server_addr, peer, path, options, stats)
 
     def get_response_data(self):
@@ -236,18 +253,30 @@ class TFTPHandler(BaseHandler):
             # request specific system configuration
             logging.debug("Got request for system PXE %s, filtering HTTP", path)
             return HttpResponseDataFilteredPXE(
-                f"{target}/tftp/{path}", capath, self._proxy_fqdn, self._server_fqdn
+                f"{target}/tftp/{path}",
+                capath,
+                self._proxy_fqdn,
+                self._server_fqdn,
+                self._replace_fqdns,
             )
         elif path.startswith("grub/system"):
             logging.debug("Got request for system GRUB %s, filtering HTTP", path)
             return HttpResponseDataFilteredGrub(
-                f"{target}/tftp/{path}", capath, self._proxy_fqdn, self._server_fqdn
+                f"{target}/tftp/{path}",
+                capath,
+                self._proxy_fqdn,
+                self._server_fqdn,
+                self._replace_fqdns,
             )
         elif path.startswith("pxelinux.cfg/default"):
             # server local default
             logging.debug("Got request for %s, filtering HTTP", path)
             return HttpResponseDataFilteredPXE(
-                f"{target}/tftp/{path}", capath, self._proxy_fqdn, self._server_fqdn
+                f"{target}/tftp/{path}",
+                capath,
+                self._proxy_fqdn,
+                self._server_fqdn,
+                self._replace_fqdns,
             )
         elif path.startswith("pxelinux.cfg/"):
             # ignore other pxelinux.cfg files
@@ -256,7 +285,11 @@ class TFTPHandler(BaseHandler):
         elif path.startswith("grub/") and path.endswith("_menu_items.cfg"):
             logging.debug("Got request for %s, filtering HTTP", path)
             return HttpResponseDataFilteredGrub(
-                f"{target}/tftp/{path}", capath, self._proxy_fqdn, self._server_fqdn
+                f"{target}/tftp/{path}",
+                capath,
+                self._proxy_fqdn,
+                self._server_fqdn,
+                self._replace_fqdns,
             )
         # The rest get from http
         logging.debug("Got request for %s, forwarding to HTTP", path)
@@ -277,6 +310,7 @@ class TFTPServer(BaseServer):
         proxy_fqdn,
         server_fqdn,
         capath,
+        replace_fqdns,
     ):
         self._root = root
         if capath is None or http_host == "localhost":
@@ -289,6 +323,7 @@ class TFTPServer(BaseServer):
         self._proxy_fqdn = proxy_fqdn
         self._server_fqdn = server_fqdn
         self._capath = capath
+        self._replace_fqdns = replace_fqdns
         super().__init__(address, port, retries, timeout, None)
 
     def get_handler(self, server_addr, peer, path, options):
@@ -302,6 +337,7 @@ class TFTPServer(BaseServer):
             self._proxy_fqdn,
             self._server_fqdn,
             self._capath,
+            self._replace_fqdns,
         )
 
 
@@ -365,6 +401,13 @@ def get_arguments():
         default="/usr/share/uyuni/ca.crt",
         help="Path to CA certificate",
     )
+    parser.add_argument(
+        "--replaceFqdns",
+        nargs="*",
+        type=str,
+        dest="replace_fqdns",
+        help="Replace additional FQDNs with proxy hostname in cobbler menu files",
+    )
     return parser.parse_args()
 
 
@@ -377,6 +420,7 @@ def main():
             config = yaml.safe_load(source)
             args.proxy_fqdn = config["proxy_fqdn"]
             args.server_fqdn = config["server"]
+            args.replace_fqdns = config.get("replace_fqdns", [])
             log_level = (
                 logging.DEBUG if config.get("log_level", 1) == 5 else logging.INFO
             )
@@ -388,11 +432,16 @@ def main():
         logging.error("Invalid configuration file passed, missing %s", str(err))
         exit(1)
 
+    if not isinstance(args.replace_fqdns, list):
+        logging.error("Invalid configuration file passed, replace_fqdns is not a list")
+        exit(1)
+
     logging.info("Starting TFTP proxy:")
     logging.info("HTTP endpoint: %s", args.http_host)
     logging.info("Server FQDN: %s", args.server_fqdn)
     logging.info("Proxy FQDN: %s", args.proxy_fqdn)
     logging.info("CA path: %s", args.caPath)
+    logging.info("Replace FQDNs: %s", args.replace_fqdns)
 
     server = TFTPServer(
         args.ip,
@@ -404,6 +453,7 @@ def main():
         args.proxy_fqdn,
         args.server_fqdn,
         args.caPath,
+        args.replace_fqdns,
     )
 
     try:

--- a/java/code/src/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateGenerateFileMaps.java
+++ b/java/code/src/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateGenerateFileMaps.java
@@ -15,8 +15,10 @@
 
 package com.redhat.rhn.manager.system.proxycontainerconfig;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +35,8 @@ public class ProxyContainerConfigCreateGenerateFileMaps implements ProxyContaine
         context.getConfigMap().put("server_version", ConfigDefaults.get().getProductVersion());
         context.getConfigMap().put("proxy_fqdn", context.getProxyFqdn());
         context.getConfigMap().put("ca_crt", context.getRootCaCert());
+        String cobblerFqdn = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
+        context.getConfigMap().put("replace_fqdns", Collections.singletonList(cobblerFqdn));
 
         // httpd.yaml
         Map<String, Object> httpdConfig = new HashMap<>();

--- a/java/code/src/com/suse/proxy/test/ProxyConfigUpdateFileAcquisitorTest.java
+++ b/java/code/src/com/suse/proxy/test/ProxyConfigUpdateFileAcquisitorTest.java
@@ -111,7 +111,8 @@ public class ProxyConfigUpdateFileAcquisitorTest extends BaseTestCaseWithUser {
                         "server_ssh_key_pub", "dummyServerSshKeyPub",
                         "server_ssh_push", "dummyServerSshPush",
                         "server_ssh_push_pub", "dummyServerSshPushPub"
-                )
+                ),
+                "replace_fqdns", List.of("masterFqdn")
         );
         mockProxyContainerConfigCreateFacadeMockCreateFiles(expectedProxyConfigFiles);
 
@@ -130,7 +131,8 @@ public class ProxyConfigUpdateFileAcquisitorTest extends BaseTestCaseWithUser {
                 "proxy container configuration did not generate required entry: ca_crt",
                 "proxy container configuration did not generate required entry: server",
                 "proxy container configuration did not generate required entry: httpd",
-                "proxy container configuration did not generate required entry: email"
+                "proxy container configuration did not generate required entry: email",
+                "proxy container configuration did not generate required entry: replace_fqdns"
         };
 
         ProxyConfigUpdateContext proxyConfigUpdateContext = getProxyConfigUpdateContext();
@@ -181,7 +183,8 @@ public class ProxyConfigUpdateFileAcquisitorTest extends BaseTestCaseWithUser {
                         "server_crt", "dummyServerCrt",
                         "server_key", Map.of("unexpected", "map")
                 ),
-                "ssh", "not_a_map"
+                "ssh", "not_a_map",
+                "replace_fqdns", List.of("masterFqdn")
         );
         mockProxyContainerConfigCreateFacadeMockCreateFiles(expectedProxyConfigFiles);
 

--- a/java/code/src/com/suse/proxy/update/ProxyConfigUpdateFileAcquisitor.java
+++ b/java/code/src/com/suse/proxy/update/ProxyConfigUpdateFileAcquisitor.java
@@ -29,6 +29,7 @@ import com.suse.manager.webui.utils.gson.ProxyConfigUpdateJson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -52,7 +53,8 @@ public class ProxyConfigUpdateFileAcquisitor implements ProxyConfigUpdateContext
                     "server_ssh_key_pub", String.class,
                     "server_ssh_push", String.class,
                     "server_ssh_push_pub", String.class
-            )
+            ),
+            "replace_fqdns", List.of(String.class)
     );
     private static final Logger LOG = LogManager.getLogger(ProxyConfigUpdateFileAcquisitor.class);
     private static final String ERROR_MESSAGE_MISSING_ENTRY =

--- a/java/spacewalk-java.changes.nadvornik.replace_fqdns
+++ b/java/spacewalk-java.changes.nadvornik.replace_fqdns
@@ -1,0 +1,1 @@
+- Replace server hostname in chained proxy config (bsc#1236166)

--- a/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
+++ b/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
@@ -28,6 +28,7 @@ mgrpxy_installed:
         max_cache_size_mb: {{ pillar['max_cache_size_mb']|int }}
         server_version: "{{ pillar['server_version'] }}"
         email: {{ pillar['email'] }}
+        replace_fqdns: {{ pillar['replace_fqdns'] }}
 
 /etc/uyuni/proxy/httpd.yaml:
   file.managed:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.replace_fqdns
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.nadvornik.replace_fqdns
@@ -1,0 +1,1 @@
+- Replace server hostname in chained proxy config (bsc#1236166)


### PR DESCRIPTION
## What does this PR change?

This PR adds `replace_fqdns` entry to proxy config and uses it to replace server fqdn in chained proxy configuration.
This is a forward-port of https://github.com/SUSE/spacewalk/pull/26299 with added new code for the simplified proxy onboarding.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were updated

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26066
https://github.com/SUSE/spacewalk/issues/26279
https://bugzilla.suse.com/show_bug.cgi?id=1236166
Port(s):  https://github.com/SUSE/spacewalk/pull/26299

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
