### PR TITLE
QE: Removing copyright message test

### DIFF
--- a/testsuite/features/secondary/srv_mainpage.feature
+++ b/testsuite/features/secondary/srv_mainpage.feature
@@ -19,23 +19,6 @@ Feature: Main landing page options and preferences
     And I follow "API Documentation"
     Then I should see a "API Overview" text
 
-# TODO: We need to refactor this to navigate to a doc page
-
-@skip
-  Scenario: Access the Copyright Notice
-    Given I am not authorized
-    When I go to the home page
-    And I follow "Copyright Notice"
-    Then I should see a "Copyright (c) 2011 - 2025 SUSE LLC." text
-
-@susemanager
-  Scenario: Access the EULA
-    Given I am not authorized
-    When I go to the home page
-    And I follow "Copyright Notice"
-    And I follow "SUSE Multi-Linux Manager License Agreement"
-    Then I should see a "SUSE Multi-Linux Manager License Agreement" text
-
   Scenario: Log into Uyuni
     Given I am not authorized
     When I go to the home page


### PR DESCRIPTION
## What does this PR change?

Removing the EULA test that ensures that the copyright message is in the main page because is not necessary anymore. It's not necessary anymore because this message was deleted from the front page in this pr:https://github.com/uyuni-project/uyuni/pull/8588 and it applies to the current uyuni HEAD and to Manager 5.1.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were removed

- [x] **DONE**

## Links

Issue(s): None
Port(s): None because it has been modified just in uyuni HEAD and in manager 5.1 beta2.

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
