### PR TITLE
Fix broken /etc/rhn/krb5.conf.d/crypto-policies symlink

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -68,7 +68,11 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         sssd-krb5 \
         sssd-tools && \
     systemctl enable prometheus-node_exporter && \
-    systemctl enable sssd
+    systemctl enable sssd && \
+    rm /etc/krb5.conf.d/crypto-policies && \
+    ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies && \
+    mv "/etc/krb5.conf.d" "/etc/rhn/krb5.conf.d" && \
+    ln -s "/etc/rhn/krb5.conf.d" "/etc/krb5.conf.d" && \
 
 # Initialize environments to sync configuration and package files to persistent volumes
 RUN systemctl enable timezone_alignment && \

--- a/containers/server-image/root/etc/krb5.conf.d
+++ b/containers/server-image/root/etc/krb5.conf.d
@@ -1,1 +1,0 @@
-/etc/rhn/krb5.conf.d

--- a/containers/server-image/server-image.changes.cbosdo.5.0-krb-symlink
+++ b/containers/server-image/server-image.changes.cbosdo.5.0-krb-symlink
@@ -1,0 +1,2 @@
+- Fix broken /etc/rhn/krb5.conf.d/crypto-policies symlink
+  (bsc#1237938)


### PR DESCRIPTION
## What does this PR change?

The /etc/krb5.conf.d/crypto-policies symlink being relative it doesn't work with the `/etc/rhn/krb5.conf.d` location. Using an absolute symlink to make everyone happy. bsc#1237938

Also fix a regression introduced with the move to the tarball files: /etc/rhn/krb5.conf.d should be a symlink to /etc/krb5.conf.d

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: AD integration is not automatically tested

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26563
Port(s): https://github.com/SUSE/spacewalk/pull/26951

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
