### PR TITLE
remove dropped tool spacewalk-sync-setup from filelist

### DIFF
--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -107,7 +107,6 @@ popd
 %attr(755,root,root) %{_bindir}/spacewalk-clone-by-date
 %attr(755,root,root) %{_bindir}/spacewalk-hostname-rename
 %attr(755,root,root) %{_bindir}/spacewalk-manage-channel-lifecycle
-%attr(755,root,root) %{_bindir}/spacewalk-sync-setup
 %attr(755,root,root) %{_bindir}/taskotop
 %attr(755,root,root) %{_bindir}/spacewalk-watch-channel-sync.sh
 %config %{_sysconfdir}/rhn/spacewalk-common-channels.ini
@@ -121,7 +120,6 @@ popd
 %{python3_sitelib}/utils/__pycache__/depsolver.*
 %{_mandir}/man8/spacewalk-clone-by-date.8%{?ext_man}
 %{_mandir}/man8/spacewalk-hostname-rename.8%{?ext_man}
-%{_mandir}/man8/spacewalk-sync-setup.8%{?ext_man}
 %{_mandir}/man8/taskotop.8%{?ext_man}
 
 


### PR DESCRIPTION
## What does this PR change?

Remove spacewalk-sync-setup also from the filelist in the spec file.
Follow-up  of https://github.com/uyuni-project/uyuni/pull/10163

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
