### PR TITLE
Improve change channel performance (bsc#1239154)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -1893,23 +1893,13 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * is just a convenience method.  Basically the channels associated with this
      * server that are not base channels.
      *
-     * @return Set of Child Channels.  null of none found.
+     * @return Set of Child Channels.
      */
     public Set<Channel> getChildChannels() {
-        // Make sure we return NULL if none are found
         if (this.getChannels() != null) {
-            Set<Channel> retval = new HashSet<>();
-            for (Channel c : this.getChannels()) {
-                // add non base channels (children)
-                // to return set.
-                if (!c.isBaseChannel()) {
-                    retval.add(c);
-                }
-            }
-            if (retval.isEmpty()) {
-                return new HashSet<>();
-            }
-            return retval;
+            return this.getChannels().stream()
+                    .filter(c -> !c.isBaseChannel())
+                    .collect(Collectors.toSet());
         }
         return new HashSet<>();
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemChannelsAction.java
@@ -180,11 +180,9 @@ public class SystemChannelsAction extends RhnLookupDispatchAction {
         List<Channel> currentPreservedChildChans = new LinkedList<>();
         List<Channel> currentUnpreservedChildChans = new LinkedList<>();
 
-        if (s.getChildChannels() != null) {
-            for (Channel childChan : s.getChildChannels()) {
-                log.debug("   {}", childChan.getName());
-                currentChildChans.add(childChan);
-            }
+        for (Channel childChan : s.getChildChannels()) {
+            log.debug("   {}", childChan.getName());
+            currentChildChans.add(childChan);
         }
 
         Long newBaseChannelId = (Long) ((DynaActionForm) formIn).get(NEW_BASE_CHANNEL_ID);

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemCompareDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemCompareDto.java
@@ -260,11 +260,9 @@ public class SystemCompareDto {
         for (Server system : servers) {
             List keys = new LinkedList<>();
             Set<Channel> childChannels = system.getChildChannels();
-            if (childChannels != null) {
-                for (Channel channel : childChannels) {
-                    keys.add(channel.getName());
-                    idMap.put(channel.getName(), channel.getId().toString());
-                }
+            for (Channel channel : childChannels) {
+                keys.add(channel.getName());
+                idMap.put(channel.getName(), channel.getId().toString());
             }
             ret.add(keys);
         }
@@ -335,11 +333,9 @@ public class SystemCompareDto {
                 keys.add(system.getBaseChannel().getChannelFamily().getName());
             }
 
-            if (system.getChildChannels() != null) {
-                for (Channel channel : system.getChildChannels()) {
-                    if (!channel.isCustom()) {
-                        keys.add(channel.getChannelFamily().getName());
-                    }
+            for (Channel channel : system.getChildChannels()) {
+                if (!channel.isCustom()) {
+                    keys.add(channel.getChannelFamily().getName());
                 }
             }
             ret.add(keys);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3399,11 +3399,6 @@ public class SystemHandler extends BaseHandler {
     public List<Channel> listSubscribedChildChannels(User loggedInUser, Integer sid) {
         Server server = lookupServer(loggedInUser, sid);
         Set<Channel> childChannels = server.getChildChannels();
-
-        if (childChannels == null) {
-            return new ArrayList<>();
-        }
-
         return new ArrayList<>(childChannels);
     }
 

--- a/java/code/src/com/redhat/rhn/manager/ssm/ChannelChangeAction.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/ChannelChangeAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.manager.ssm;
+
+/**
+ * What to do with a channel.
+ */
+public enum ChannelChangeAction {
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+    NO_CHANGE
+}

--- a/java/code/src/com/redhat/rhn/manager/ssm/ChannelChangeDto.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/ChannelChangeDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) 2018--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.redhat.rhn.manager.ssm;
@@ -24,19 +20,10 @@ import java.util.Optional;
  */
 public class ChannelChangeDto {
 
-    /**
-     * What to do with a channel.
-     */
-    public enum ChannelAction {
-        SUBSCRIBE,
-        UNSUBSCRIBE,
-        NO_CHANGE
-    }
-
     private Optional<Long> oldBaseId;
     private Optional<Long> newBaseId;
     private boolean newBaseDefault;
-    private Map<Long, ChannelAction> childChannelActions = new HashMap<>();
+    private Map<Long, ChannelChangeAction> childChannelActions = new HashMap<>();
 
     /**
      * @return oldBaseId to get
@@ -83,14 +70,14 @@ public class ChannelChangeDto {
     /**
      * @return childChannels to get
      */
-    public Map<Long, ChannelAction> getChildChannelActions() {
+    public Map<Long, ChannelChangeAction> getChildChannelActions() {
         return childChannelActions;
     }
 
     /**
      * @param childChannelsIn to set
      */
-    public void setChildChannelActions(Map<Long, ChannelAction> childChannelsIn) {
+    public void setChildChannelActions(Map<Long, ChannelChangeAction> childChannelsIn) {
         this.childChannelActions = childChannelsIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
@@ -236,11 +236,11 @@ public class SsmManager {
         Server srv = ServerFactory.lookupById(srvDto.getId());
 
         if (defaultBaseChange(srvChanges)) {
-            return handleDefaultBaseChannelChange(earliest, user, srv, srvChanges);
+            return handleDefaultBaseChannelChange(earliest, user, srv, srvChanges, new HashMap<>());
         }
         else if (explicitChange(srvChanges)) {
             return handleExplicitBaseChannelChange(earliest, user, Optional.empty(), srv,
-                    srvChanges.stream().findFirst().get());
+                    srvChanges.stream().findFirst().get(), new HashMap<>());
         }
         // no child-only changes possible in case of systems without a base channel
         return null;
@@ -258,23 +258,34 @@ public class SsmManager {
                     .filter(ch -> ch.getOldBaseId().map(currentBase.getId()::equals).orElse(false))
                     .collect(Collectors.toSet());
 
+            Map<String, List<Channel>> accessibleChildsByBase =
+                    oldBaseServers.stream()
+                            .map(Server::getBaseChannel)
+                            .distinct()
+                            .collect(Collectors.toMap(Channel::getLabel,
+                                    bc -> ChannelFactory.getAccessibleChildChannels(bc, user)));
+
             return oldBaseServers.stream()
-                    .map(srv -> handleSingleSystemChannelChange(srvChanges, earliest, user, currentBase, srv));
+                    .map(srv -> handleSingleSystemChannelChange(srvChanges, earliest, user, currentBase, srv,
+                            accessibleChildsByBase));
         });
     }
 
-    private static ChannelSelectionResult handleSingleSystemChannelChange(Set<ChannelChangeDto> srvChanges,
-            Date earliest, User user, Channel currentBase, Server srv) {
+    private static ChannelSelectionResult handleSingleSystemChannelChange(
+            Set<ChannelChangeDto> srvChanges, Date earliest, User user, Channel currentBase,
+            Server srv, Map<String, List<Channel>> accessibleChildsByBase) {
+
         if (defaultBaseChange(srvChanges)) {
-            return handleDefaultBaseChannelChange(earliest, user, srv, srvChanges);
+            return handleDefaultBaseChannelChange(earliest, user, srv, srvChanges, accessibleChildsByBase);
         }
         else if (explicitChange(srvChanges)) {
             return handleExplicitBaseChannelChange(earliest, user,  Optional.of(currentBase), srv,
-                    srvChanges.stream().findFirst().get());
+                    srvChanges.stream().findFirst().get(), accessibleChildsByBase);
         }
         else if (onlyChildChannelsChange(srvChanges)) {
             ChannelChangeDto srvChange = srvChanges.stream().findFirst().get();
-            Set<Channel> childChannels = getChildChannelsForChange(user, srv, srvChange, srv.getBaseChannel());
+            Set<Channel> childChannels = getChildChannelsForChange(user, srv, srvChange, srv.getBaseChannel(),
+                    accessibleChildsByBase);
 
             return new ChannelSelectionResult(srv, new ChannelSelection(Optional.empty(), childChannels));
         }
@@ -285,9 +296,9 @@ public class SsmManager {
     }
 
     private static ChannelSelectionResult handleExplicitBaseChannelChange(Date earliest, User user,
-                                                        Optional<Channel> currentBase,
-                                                        Server srv,
-                                                        ChannelChangeDto srvChange) {
+            Optional<Channel> currentBase, Server srv, ChannelChangeDto srvChange,
+            Map<String, List<Channel>> accessibleChildsByBase) {
+
         boolean baseChange =
                 (currentBase.isPresent() && !currentBase.get().getId().equals(srvChange.getNewBaseId().orElse(null))) ||
                 !(currentBase.isPresent() && srvChange.getNewBaseId().isPresent());
@@ -319,14 +330,16 @@ public class SsmManager {
         }
         else {
             Channel newBaseChannel = ChannelFactory.lookupById(srvChange.getNewBaseId().get());
-            Set<Channel> childChannels = getChildChannelsForChange(user, srv, srvChange, newBaseChannel);
+            Set<Channel> childChannels = getChildChannelsForChange(user, srv, srvChange, newBaseChannel,
+                    accessibleChildsByBase);
 
             return new ChannelSelectionResult(srv, new ChannelSelection(Optional.of(newBaseChannel), childChannels));
         }
     }
 
     private static ChannelSelectionResult handleDefaultBaseChannelChange(Date earliest, User user,
-                                                       Server srv, Set<ChannelChangeDto> srvChanges) {
+            Server srv, Set<ChannelChangeDto> srvChanges, Map<String, List<Channel>> accessibleChildsByBase) {
+
         Optional<Channel> guessedChannel =
                 ChannelManager.guessServerBaseChannel(user, srv.getId());
         if (!guessedChannel.isPresent()) {
@@ -336,7 +349,8 @@ public class SsmManager {
         Optional<ChannelChangeDto> srvChange = getChangeByDefaultBase(srvChanges, guessedChannel.get());
         if (srvChange.isPresent()) {
             Channel newBaseChannel = ChannelFactory.lookupById(srvChange.get().getNewBaseId().get());
-            Set<Channel> childChannels = getChildChannelsForChange(user, srv, srvChange.get(), newBaseChannel);
+            Set<Channel> childChannels = getChildChannelsForChange(user, srv, srvChange.get(), newBaseChannel,
+                    accessibleChildsByBase);
 
             return new ChannelSelectionResult(srv, new ChannelSelection(Optional.of(newBaseChannel), childChannels));
         }
@@ -347,11 +361,8 @@ public class SsmManager {
     }
 
     private static Set<ScheduleChannelChangesResultDto> scheduleSubscribeChannelsAction(
-                                                                                   List<ChannelSelectionResult> results,
-                                                                                   Optional<Channel> baseChannel,
-                                                                                   Set<Channel> childChannels,
-                                                                                   User user, Date earliest,
-                                                                                   ActionChain actionChain) {
+            List<ChannelSelectionResult> results, Optional<Channel> baseChannel, Set<Channel> childChannels,
+            User user, Date earliest, ActionChain actionChain) {
         try {
             Set<Action> actions = ActionChainManager.scheduleSubscribeChannelsAction(
                     user,
@@ -376,8 +387,11 @@ public class SsmManager {
     }
 
     private static Set<Channel> getChildChannelsForChange(User user, Server server, ChannelChangeDto change,
-                                                           Channel newBaseChannel) {
-        List<Channel> accessibleChildren = ChannelFactory.getAccessibleChildChannels(newBaseChannel, user);
+            Channel newBaseChannel, Map<String, List<Channel>> accessibleChildsByBase) {
+
+        List<Channel> accessibleChildren =
+                accessibleChildsByBase.computeIfAbsent(newBaseChannel.getLabel(),
+                        k -> ChannelFactory.getAccessibleChildChannels(newBaseChannel, user));
         Set<Channel> availableChildChannels = server.getChildChannels();
 
         Set<Channel> result = new HashSet<>();

--- a/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
@@ -200,11 +200,11 @@ public class SsmManager {
     }
 
     private static List<ScheduleChannelChangesResultDto> scheduleChannelChanges(User user, Date earliest,
-            ActionChain actionChain, Map<ChannelSelection, List<ChannelSelectionResult>> succeded,
+            ActionChain actionChain, Map<ChannelSelection, List<ChannelSelectionResult>> succeeded,
             Map<String, List<ChannelSelectionResult>> errored) {
-        Stream<ScheduleChannelChangesResultDto> succededResults =
-                succeded.entrySet().stream().map(e ->
-                           scheduleSubscribeChannelsAction(succeded.get(e.getKey()),
+        Stream<ScheduleChannelChangesResultDto> succeededResults =
+                succeeded.entrySet().stream().map(e ->
+                           scheduleSubscribeChannelsAction(succeeded.get(e.getKey()),
                                                            e.getKey().getNewBaseChannel(),
                                                            e.getKey().getChildChannels(),
                                                            user, earliest, actionChain)
@@ -216,7 +216,7 @@ public class SsmManager {
                 )
         ).flatMap(Function.identity());
 
-        return Stream.concat(succededResults, erroredResults).collect(Collectors.toList());
+        return Stream.concat(succeededResults, erroredResults).collect(Collectors.toList());
     }
 
     private static Stream<ChannelSelectionResult> handleChannelChangesForSystemsWithNoBaseChannel(
@@ -251,7 +251,7 @@ public class SsmManager {
                     .filter(ch -> ch.getOldBaseId().map(currentBase.getId()::equals).orElse(false))
                     .collect(Collectors.toSet());
 
-            Map<String, List<Channel>> accessibleChildsByBase =
+            Map<String, List<Channel>> accessibleChildrenByBase =
                     oldBaseServers.stream()
                             .map(Server::getBaseChannel)
                             .distinct()
@@ -260,16 +260,16 @@ public class SsmManager {
 
             return oldBaseServers.stream()
                     .map(srv -> handleSingleSystemChannelChange(srvChanges, user, currentBase, srv,
-                            accessibleChildsByBase));
+                            accessibleChildrenByBase));
         });
     }
 
     private static ChannelSelectionResult handleSingleSystemChannelChange(
             Set<ChannelChangeDto> srvChanges, User user, Channel currentBase,
-            Server srv, Map<String, List<Channel>> accessibleChildsByBase) {
+            Server srv, Map<String, List<Channel>> accessibleChildrenByBase) {
 
         return ChannelChangeFactory.parseChanges(srvChanges, currentBase)
-            .map(channelChange -> channelChange.handleChange(user, srv, accessibleChildsByBase))
+            .map(channelChange -> channelChange.handleChange(user, srv, accessibleChildrenByBase))
             .orElseGet(() -> {
                 LOG.error("Invalid channel change for serverId={}", srv.getId());
                 return new ChannelSelectionResult(srv, "invalid_change");

--- a/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
@@ -378,7 +378,8 @@ public class SsmManager {
     private static Set<Channel> getChildChannelsForChange(User user, Server server, ChannelChangeDto change,
                                                            Channel newBaseChannel) {
         List<Channel> accessibleChildren = ChannelFactory.getAccessibleChildChannels(newBaseChannel, user);
-        // TODO ChannelManager.verifyChannelSubscribe() for base and children ?
+        Set<Channel> availableChildChannels = server.getChildChannels();
+
         Set<Channel> result = new HashSet<>();
         change.getChildChannelActions().forEach((cid, action) -> {
             final long childId = cid;
@@ -395,7 +396,7 @@ public class SsmManager {
                 }
             }
             else if (action == ChannelChangeDto.ChannelAction.NO_CHANGE) {
-                server.getChildChannels().stream()
+                availableChildChannels.stream()
                         .filter(cc -> cc.getId() == childId)
                         .findFirst()
                         .ifPresent(result::add);

--- a/java/code/src/com/redhat/rhn/manager/ssm/channelchange/AbstractChannelChange.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/channelchange/AbstractChannelChange.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.manager.ssm.channelchange;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.ssm.ChannelChangeAction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Abstract base class for all the type of channel changes
+ */
+abstract class AbstractChannelChange implements ChannelChange {
+
+    private static final Logger LOGGER = LogManager.getLogger(AbstractChannelChange.class);
+
+    /**
+     * Retrieves all the child channels allowed for the specified change
+     * @param user the user performing the operation
+     * @param childChannelActionsMap the actions map
+     * @param server the server affected by the change
+     * @param newBaseChannel the new base channel
+     * @param childrenByBaseMap the map of the child channels allowed for the current base
+     * @return the set of relevant child channels
+     */
+    protected Set<Channel> getChildChannelsForChange(User user, Map<Long, ChannelChangeAction> childChannelActionsMap,
+                                                     Server server, Channel newBaseChannel,
+                                                     Map<String, List<Channel>> childrenByBaseMap) {
+        Set<Channel> result = new HashSet<>();
+
+        childChannelActionsMap.forEach((childId, action) -> {
+            if (action == ChannelChangeAction.SUBSCRIBE) {
+                List<Channel> accessibleChildren = childrenByBaseMap.computeIfAbsent(
+                    newBaseChannel.getLabel(),
+                    k -> ChannelFactory.getAccessibleChildChannels(newBaseChannel, user)
+                );
+
+                // Find the accessible child with a matching id
+                accessibleChildren.stream()
+                    .filter(ac -> ac.getId().equals(childId))
+                    .findFirst()
+                    .ifPresentOrElse(
+                        result::add,
+                        () -> LOGGER.warn("Child channel id={} not found in accessible children of {} for user={}",
+                            childId, newBaseChannel.getName(), user.getLogin())
+                    );
+            }
+            else if (action == ChannelChangeAction.NO_CHANGE) {
+                // Find the server child channel with a matching id
+                server.getChildChannels().stream()
+                    .filter(cc -> cc.getId().equals(childId))
+                    .findFirst()
+                    .ifPresent(result::add);
+            }
+        });
+
+        return result;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/ssm/channelchange/ChannelChange.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/channelchange/ChannelChange.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.manager.ssm.channelchange;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.ssm.ChannelSelectionResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for handling a channel change
+ */
+@FunctionalInterface
+public interface ChannelChange {
+
+    /**
+     * Handle the current change on the given server,
+     * @param user the user performing the operation
+     * @param server the server
+     * @param childrenByBaseMap the child channels allowed for the current base
+     * @return a {@link ChannelSelectionResult} describing the result of the operation
+     */
+    ChannelSelectionResult handleChange(User user, Server server, Map<String, List<Channel>> childrenByBaseMap);
+}

--- a/java/code/src/com/redhat/rhn/manager/ssm/channelchange/ChannelChangeFactory.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/channelchange/ChannelChangeFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.manager.ssm.channelchange;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.manager.ssm.ChannelChangeDto;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Factory for creating {@link ChannelChange}
+ */
+public final class ChannelChangeFactory {
+
+    private ChannelChangeFactory() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Creates the {@link ChannelChange} corresponding to the given set of {@link ChannelChangeDto}.
+     * @param changes the set of changes
+     * @return the {@link ChannelChange} represented by the set of {@link ChannelChangeDto}, empty otherwise.
+     */
+    public static Optional<ChannelChange> parseChanges(Set<ChannelChangeDto> changes) {
+        return parseChanges(changes, null);
+    }
+
+    /**
+     * Creates the {@link ChannelChange} corresponding to the given set of {@link ChannelChangeDto}.
+     * @param changes the set of changes
+     * @param baseChannel  the current base channel, or null if no base is currently defined.
+     * @return the {@link ChannelChange} represented by the set of {@link ChannelChangeDto}, empty otherwise.
+     */
+    public static Optional<ChannelChange> parseChanges(Set<ChannelChangeDto> changes, Channel baseChannel) {
+        // First check if it's a change from a default base
+        return defaultBaseChange(changes)
+            // then try an explicit base change from the given base channel
+            .or(() -> explicitBaseChange(changes, baseChannel))
+            // child channels changes are only possible in case the system has a base channel
+            .or(() -> baseChannel != null ? onlyChildChannelsChange(changes) : Optional.empty());
+    }
+
+    private static Optional<ChannelChange> defaultBaseChange(Set<ChannelChangeDto> changes) {
+        DefaultBaseChange defaultBaseChange = new DefaultBaseChange();
+
+        boolean allMatch = changes.stream()
+            .allMatch(ch -> {
+                if (ch.getNewBaseId().isPresent() && ch.isNewBaseDefault()) {
+                    defaultBaseChange.addChange(ch.getNewBaseId().get(), ch.getChildChannelActions());
+                    return true;
+                }
+
+                return false;
+            });
+
+        return allMatch ? Optional.of(defaultBaseChange) : Optional.empty();
+    }
+
+    private static Optional<ChannelChange> explicitBaseChange(Set<ChannelChangeDto> changes, Channel base) {
+        if (changes.size() != 1) {
+            return Optional.empty();
+        }
+
+        return changes.stream()
+            .filter(ch -> ch.getNewBaseId().isPresent() && !ch.isNewBaseDefault())
+            .map(ch -> new ExplicitBaseChange(base, ch.getNewBaseId().orElseThrow(), ch.getChildChannelActions()))
+            .map(ChannelChange.class::cast)
+            .findFirst();
+    }
+
+    private static Optional<ChannelChange> onlyChildChannelsChange(Set<ChannelChangeDto> changes) {
+        if (changes.size() != 1) {
+            return Optional.empty();
+        }
+
+        return changes.stream()
+            .filter(ch -> ch.getNewBaseId().isPresent() && ch.getOldBaseId().isPresent() &&
+                          ch.getOldBaseId().get().equals(ch.getNewBaseId().get())
+            )
+            .map(ch -> new OnlyChildChannelsChange(ch.getChildChannelActions()))
+            .map(ChannelChange.class::cast)
+            .findFirst();
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/ssm/channelchange/DefaultBaseChange.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/channelchange/DefaultBaseChange.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.manager.ssm.channelchange;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.ssm.ChannelChangeAction;
+import com.redhat.rhn.manager.ssm.ChannelSelection;
+import com.redhat.rhn.manager.ssm.ChannelSelectionResult;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Represent a channel change where the base changes from the default base to an explicit new base
+ */
+public class DefaultBaseChange extends AbstractChannelChange {
+    private static final Logger LOGGER = LogManager.getLogger(DefaultBaseChange.class);
+
+    private final Set<PossibleChange> baseChangeSet;
+
+    DefaultBaseChange() {
+        this.baseChangeSet = new HashSet<>();
+    }
+
+    /**
+     * Add a possible change
+     * @param newBaseId the new base id
+     * @param childChannelActions the map of actions applied to the children
+     */
+    public void addChange(long newBaseId, Map<Long, ChannelChangeAction> childChannelActions) {
+        this.baseChangeSet.add(new PossibleChange(newBaseId, childChannelActions));
+    }
+
+    @Override
+    public ChannelSelectionResult handleChange(User user, Server server, Map<String, List<Channel>> childrenByBaseMap) {
+
+        // Figure out the base channel
+        Channel guessedChannel = ChannelManager.guessServerBaseChannel(user, server.getId()).orElse(null);
+        if (guessedChannel == null) {
+            LOGGER.error("Could not guess base channel for serverId={} user={}", server.getId(), user.getLogin());
+            return new ChannelSelectionResult(server, "no_base_channel_guess");
+        }
+
+        // Extract the change to apply from the available
+        PossibleChange actualChange = selectChangeByDefaultBase(guessedChannel);
+        if (actualChange == null) {
+            LOGGER.warn("No base channel change found for serverId={}", server.getId());
+            return new ChannelSelectionResult(server, "no_base_change_found");
+        }
+
+        Channel newBaseChannel = ChannelFactory.lookupById(actualChange.newBaseId());
+        Map<Long, ChannelChangeAction> childChannelActionsMap = actualChange.childChannelActions();
+
+        Set<Channel> childChannels = super.getChildChannelsForChange(user, childChannelActionsMap, server,
+            newBaseChannel, childrenByBaseMap);
+
+        return new ChannelSelectionResult(server, new ChannelSelection(Optional.of(newBaseChannel), childChannels));
+    }
+
+    private PossibleChange selectChangeByDefaultBase(Channel guessedChannel) {
+        return baseChangeSet.stream()
+            .filter(change -> change.newBaseId() == guessedChannel.getId())
+            .findFirst()
+            .orElse(null);
+    }
+
+    private record PossibleChange(long newBaseId, Map<Long, ChannelChangeAction> childChannelActions) { }
+}

--- a/java/code/src/com/redhat/rhn/manager/ssm/channelchange/ExplicitBaseChange.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/channelchange/ExplicitBaseChange.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.manager.ssm.channelchange;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.ssm.ChannelChangeAction;
+import com.redhat.rhn.manager.ssm.ChannelSelection;
+import com.redhat.rhn.manager.ssm.ChannelSelectionResult;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Represent a channel change where the base changes from the given current base to a new base
+ */
+public class ExplicitBaseChange extends AbstractChannelChange {
+
+    private static final Logger LOGGER = LogManager.getLogger(ExplicitBaseChange.class);
+
+    private final Channel currentBase;
+
+    private final long newBaseId;
+
+    private final Map<Long, ChannelChangeAction> childChannelActions;
+
+    /**
+     * Default constructor, used by {@link ChannelChangeFactory}
+     * @param currentBaseIn the current base
+     * @param newBaseIdIn the new base id
+     * @param childChannelActionsIn the map of actions applied to the children
+     */
+    ExplicitBaseChange(Channel currentBaseIn, long newBaseIdIn, Map<Long, ChannelChangeAction> childChannelActionsIn) {
+        this.currentBase = currentBaseIn;
+        this.newBaseId = newBaseIdIn;
+        this.childChannelActions = childChannelActionsIn;
+    }
+
+    @Override
+    public ChannelSelectionResult handleChange(User user, Server server, Map<String, List<Channel>> childrenByBaseMap) {
+        if (!isNewBaseIsCompatible(user, server)) {
+            String baseId = Optional.ofNullable(server.getBaseChannel()).map(b -> b.getId() + "").orElse("none");
+            Long serverId = server.getId();
+
+            LOGGER.error("New base id={} not compatible with base id={} for serverId={}", newBaseId, baseId, serverId);
+
+            return new ChannelSelectionResult(server, "incompatible_base");
+        }
+
+        Channel newBaseChannel = ChannelFactory.lookupById(newBaseId);
+        Set<Channel> childChannels = super.getChildChannelsForChange(user, childChannelActions, server, newBaseChannel,
+            childrenByBaseMap);
+
+        return new ChannelSelectionResult(server, new ChannelSelection(Optional.of(newBaseChannel), childChannels));
+    }
+
+    private boolean isNewBaseIsCompatible(User user, Server srv) {
+        // If it's the same id it's compatible
+        if (currentBase != null && currentBase.getId().equals(newBaseId)) {
+            return true;
+        }
+
+        // If the system doesn't currently have a base
+        if (currentBase == null) {
+            // Check if the possible base channels for the system contains the new id
+            return ChannelManager.listBaseChannelsForSystem(user, srv).stream()
+                .anyMatch(abc -> abc.getId().equals(newBaseId));
+        }
+
+        // Otherwise verify if the new base is among the compatible channels list
+        return ChannelManager.listCompatibleBaseChannelsForChannel(user, currentBase).stream()
+            .anyMatch(cbc -> cbc.getId().equals(newBaseId));
+
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/manager/ssm/channelchange/OnlyChildChannelsChange.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/channelchange/OnlyChildChannelsChange.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.redhat.rhn.manager.ssm.channelchange;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.ssm.ChannelChangeAction;
+import com.redhat.rhn.manager.ssm.ChannelSelection;
+import com.redhat.rhn.manager.ssm.ChannelSelectionResult;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Represent a channel change where the base stays the same and only the children change
+ */
+public class OnlyChildChannelsChange extends AbstractChannelChange {
+
+    private final Map<Long, ChannelChangeAction> childChannelActions;
+
+    /**
+     * Default constructor, used by {@link ChannelChangeFactory}
+     * @param childChannelActionsIn the map of actions applied to the children
+     */
+    OnlyChildChannelsChange(Map<Long, ChannelChangeAction> childChannelActionsIn) {
+       this.childChannelActions = childChannelActionsIn;
+    }
+
+    @Override
+    public ChannelSelectionResult handleChange(User user, Server server, Map<String, List<Channel>> childrenByBaseMap) {
+        Set<Channel> childChannels = super.getChildChannelsForChange(user, childChannelActions, server,
+            server.getBaseChannel(), childrenByBaseMap);
+        return new ChannelSelectionResult(server, new ChannelSelection(Optional.empty(), childChannels));
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) 2018--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.redhat.rhn.manager.ssm.test;
@@ -45,6 +41,7 @@ import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
+import com.redhat.rhn.manager.ssm.ChannelChangeAction;
 import com.redhat.rhn.manager.ssm.ChannelChangeDto;
 import com.redhat.rhn.manager.ssm.ScheduleChannelChangesResultDto;
 import com.redhat.rhn.manager.ssm.SsmAllowedChildChannelsDto;
@@ -609,8 +606,8 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change1.setOldBaseId(Optional.of(server1.getBaseChannel().getId()));
         change1.setNewBaseDefault(true);
         change1.setNewBaseId(Optional.of(baseChannel.getId()));
-        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
-        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeDto.ChannelAction.NO_CHANGE);
+        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeAction.SUBSCRIBE);
+        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeAction.NO_CHANGE);
         changes.add(change1);
         Date earliest = new Date();
 
@@ -670,16 +667,16 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change1.setOldBaseId(Optional.of(server1.getBaseChannel().getId()));
         change1.setNewBaseDefault(true);
         change1.setNewBaseId(Optional.of(baseChannel.getId()));
-        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
-        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeDto.ChannelAction.NO_CHANGE);
+        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeAction.SUBSCRIBE);
+        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeAction.NO_CHANGE);
         changes.add(change1);
 
         ChannelChangeDto change2 = new ChannelChangeDto();
         change2.setOldBaseId(Optional.of(server2.getBaseChannel().getId()));
         change2.setNewBaseDefault(true);
         change2.setNewBaseId(Optional.of(baseChannel2.getId()));
-        change2.getChildChannelActions().put(childChannel2_1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
-        change2.getChildChannelActions().put(childChannel2_2.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
+        change2.getChildChannelActions().put(childChannel2_1.getId(), ChannelChangeAction.SUBSCRIBE);
+        change2.getChildChannelActions().put(childChannel2_2.getId(), ChannelChangeAction.SUBSCRIBE);
         changes.add(change2);
 
         Date earliest = new Date();
@@ -776,15 +773,15 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change1.setOldBaseId(Optional.of(server1.getBaseChannel().getId()));
         change1.setNewBaseDefault(true);
         change1.setNewBaseId(Optional.of(baseChannel.getId()));
-        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
-        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeDto.ChannelAction.NO_CHANGE);
+        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeAction.SUBSCRIBE);
+        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeAction.NO_CHANGE);
         changes.add(change1);
 
         ChannelChangeDto change2 = new ChannelChangeDto();
         change2.setOldBaseId(Optional.of(server2.getBaseChannel().getId()));
         change2.setNewBaseDefault(false);
         change2.setNewBaseId(Optional.of(parent2.getId()));
-        change2.getChildChannelActions().put(child21.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
+        change2.getChildChannelActions().put(child21.getId(), ChannelChangeAction.SUBSCRIBE);
         changes.add(change2);
 
         Date earliest = new Date();
@@ -852,15 +849,15 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change1.setOldBaseId(Optional.of(server1.getBaseChannel().getId()));
         change1.setNewBaseDefault(true);
         change1.setNewBaseId(Optional.of(baseChannel.getId()));
-        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
-        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeDto.ChannelAction.NO_CHANGE);
+        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeAction.SUBSCRIBE);
+        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeAction.NO_CHANGE);
         changes.add(change1);
 
         ChannelChangeDto change2 = new ChannelChangeDto();
         change2.setOldBaseId(Optional.of(server2.getBaseChannel().getId()));
         change2.setNewBaseDefault(false);
         change2.setNewBaseId(Optional.of(customBase.getId()));
-        change2.getChildChannelActions().put(customBaseChild1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
+        change2.getChildChannelActions().put(customBaseChild1.getId(), ChannelChangeAction.SUBSCRIBE);
         changes.add(change2);
 
         Date earliest = new Date();
@@ -953,15 +950,15 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change1.setOldBaseId(Optional.empty());
         change1.setNewBaseDefault(true);
         change1.setNewBaseId(Optional.of(baseChannel.getId()));
-        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
-        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeDto.ChannelAction.NO_CHANGE);
+        change1.getChildChannelActions().put(childChannel1.getId(), ChannelChangeAction.SUBSCRIBE);
+        change1.getChildChannelActions().put(childChannel2.getId(), ChannelChangeAction.NO_CHANGE);
         changes.add(change1);
 
         ChannelChangeDto change2 = new ChannelChangeDto();
         change2.setOldBaseId(Optional.of(server2.getBaseChannel().getId()));
         change2.setNewBaseDefault(false);
         change2.setNewBaseId(Optional.of(customBase.getId()));
-        change2.getChildChannelActions().put(customBaseChild1.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
+        change2.getChildChannelActions().put(customBaseChild1.getId(), ChannelChangeAction.SUBSCRIBE);
         changes.add(change2);
 
         Date earliest = new Date();
@@ -1046,7 +1043,7 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change.setOldBaseId(Optional.of(server1.getBaseChannel().getId()));
         change.setNewBaseDefault(false);
         change.setNewBaseId(Optional.of(parent2.getId()));
-        change.getChildChannelActions().put(child21.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
+        change.getChildChannelActions().put(child21.getId(), ChannelChangeAction.SUBSCRIBE);
         changes.add(change);
 
         Date earliest = new Date();
@@ -1091,7 +1088,7 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change.setOldBaseId(Optional.empty());
         change.setNewBaseDefault(false);
         change.setNewBaseId(Optional.of(parent2.getId()));
-        change.getChildChannelActions().put(child21.getId(), ChannelChangeDto.ChannelAction.SUBSCRIBE);
+        change.getChildChannelActions().put(child21.getId(), ChannelChangeAction.SUBSCRIBE);
         changes.add(change);
 
         Date earliest = new Date();

--- a/java/spacewalk-java.changes.mcalmer.improve-channel-change-performance
+++ b/java/spacewalk-java.changes.mcalmer.improve-channel-change-performance
@@ -1,0 +1,2 @@
+- Improve performance when changing channels on multiple system
+  through SSM (bsc#1239154)


### PR DESCRIPTION
## What does this PR change?

This PR improves the performance of the change channel operation. This was currently too slow when executed on many systems through SSM and it was causing issue in the UI.

Port of https://github.com/SUSE/spacewalk/pull/26720

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26642

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
