### PR TITLE
WIP: testsuite: add feature to run health check tool

### DIFF
--- a/testsuite/features/secondary/srv_health_check_supportconfig.feature
+++ b/testsuite/features/secondary/srv_health_check_supportconfig.feature
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@scope_salt
+Feature: Health Check tool based on a supportconfig
+  A supportconfig generated from the Uyuni server
+  should be able to be parsed by Health Check tool.
+
+  Scenario: A supportconfig is taken from the server
+    When I generate a supportconfig for the server
+    Then I obtain and extract the supportconfig from the server
+
+  Scenario: Install health check tool
+    When I setup a health check environment on the controller
+    Then file "/usr/lib/python3.11/site-packages/health_check/config.toml" should exist on "localhost"
+    And I run "mgr-health-check --help" on "localhost"
+
+  Scenario: Execute health check tool with server supportconfig
+    When I run "mgr-health-check -v -s /root/server-supportconfig/uyuni-server-supportconfig/ start" on "localhost"
+    Then I run "test $(podman ps | grep health-check | wc -l) == 4" on "localhost"
+
+  Scenario: Health Check containers are healthy and running
+    When I run "curl -s localhost:9000 -o /dev/null" on "localhost"
+    Then I run "curl -s localhost:3100 -o /dev/null" on "localhost"
+    And I run "curl -s localhost:9081 -o /dev/null" on "localhost"
+    And I run "curl -s localhost:3000 -o /dev/null" on "localhost"
+
+  Scenario: Health Check containers are exposing metrics
+    When I run "curl -s localhost:9000/metrics.json | python3 -c 'import sys, json; print(json.load(sys.stdin).keys())'" on "localhost"
+
+  Scenario: Cleanup: Remove health check tool
+    When I run "mgr-health-check clean" on "localhost"
+    And I clean the health check environment on the controller
+    Then file "/usr/lib/python3.11/site-packages/health_check/config.toml" should not exist on "localhost"
+    And I run "rm /root/server-supportconfig* -rf" on "localhost"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -639,6 +639,14 @@ When(/^the controller stops mocking a Redfish host$/) do
   `rm -rf /root/DSP2043_2019.1*`
 end
 
+When(/^I setup a health check environment on the controller$/) do
+  `sh #{File.dirname(__FILE__)}/../upload_files/health_check_setup.sh setup`
+end
+
+When(/^I clean the health check environment on the controller$/) do
+  `sh #{File.dirname(__FILE__)}/../upload_files/health_check_setup.sh clean`
+end
+
 When(/^I install a user-defined state for "([^"]*)" on the server$/) do |host|
   system_name = get_system_name(host)
   # copy state file to server
@@ -1054,6 +1062,22 @@ end
 When(/I copy the distribution inside the container on the server$/) do
   node = get_target('server')
   node.run('mgradm distro copy /tmp/tftpboot-installation/SLE-15-SP4-x86_64 SLE-15-SP4-TFTP', runs_in_container: false)
+end
+
+When(/I generate a supportconfig for the server$/) do
+  node = get_target('server')
+  node.run('mgradm support config', runs_in_container: false)
+  node.run('mv /root/scc_*.tar.gz /root/server-supportconfig.tar.gz', runs_in_container: false)
+end
+
+When(/I obtain and extract the supportconfig from the server$/) do
+  supportconfig_path = "/root/server-supportconfig.tar.gz"
+  test_runner_file = "/root/server-supportconfig.tar.gz"
+  get_target('server').scp_download(supportconfig_path, test_runner_file)
+  `mkdir /root/server-supportconfig && tar xzvf /root/server-supportconfig.tar.gz -C /root/server-supportconfig`
+  `mv /root/server-supportconfig/scc_* /root/server-supportconfig/test-server`
+  `tar xJvf /root/server-supportconfig/test-server/uyuni-server-supportconfig.txz -C /root/server-supportconfig`
+  `mv /root/server-supportconfig/scc_suse_*/ /root/server-supportconfig/uyuni-server-supportconfig/`
 end
 
 When(/I remove the autoinstallation files from the server$/) do

--- a/testsuite/features/upload_files/health_check_setup.sh
+++ b/testsuite/features/upload_files/health_check_setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+HEALTH_CHECK_PACKAGE="python311-mgr-health-check"
+HEALTH_CHECK_REPO="https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/healthcheck/15.6/"
+HEALTH_CHECK_CONFIG="/usr/lib/python3.11/site-packages/health_check/config.toml"
+
+set -e
+
+if [ "$1" == "setup" ]; then
+        echo "PREPARING HEALTH CHECK TOOL ENVIRONMENT"
+        echo
+	echo "---> Configuring OBS health check repository ($HEALTH_CHECK_REPO)"
+        zypper ar $HEALTH_CHECK_REPO health_check_master_repo
+        echo "---> Installing $HEALTH_CHECK_PACKAGE package"
+	zypper in -y $HEALTH_CHECK_PACKAGE
+        echo "---> Using devel health check containers instead of stable ones"
+        sed -i 's/healthcheck\/stable/healthcheck/g' $HEALTH_CHECK_CONFIG
+        echo "---> Display health check config.toml"
+        cat $HEALTH_CHECK_CONFIG
+        echo "---> Done!"
+fi
+
+if [ "$1" == "clean" ]; then
+	echo "Removing health check tool and disable repository"
+        zypper rr $HEALTH_CHECK_REPO
+	zypper rm -y $HEALTH_CHECK_PACKAGE
+fi

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -76,5 +76,6 @@
 - features/secondary/srv_cobbler_distro.feature
 - features/secondary/srv_cobbler_buildiso.feature
 - features/secondary/srv_cobbler_profile.feature
+- features/secondary/srv_health_check_supportconfig.feature
 
 ## Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

This PR adds a new testsuite feature to run health check tool against a generated supportconfig.

It does some minimal checks to verify that health check is working properly and extracting metrics from the supportconfig as expected.
 
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24380

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
