### PR TITLE
get virtual instance info from physical hosts using salt virt.vm_info

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -671,6 +671,24 @@ public class ActionFactory extends HibernateFactory {
     }
 
     /**
+     * List all pending server actions of the given types
+     * @param typesIn the types to look for
+     * @return return a list of server actions
+     */
+    public static List<ServerAction> listPendingServerActionsByTypes(List<ActionType> typesIn) {
+        return getSession().createQuery("""
+            SELECT sa.*
+              FROM rhnAction a
+              JOIN rhnserveraction sa ON a.id = sa.action_id
+             WHERE a.action_type IN (:types)
+               AND sa.status in (0, 1)
+               AND a.earliest_action <= current_timestamp
+            """, ServerAction.class)
+                .setParameterList("types", typesIn.stream().map(ActionType::getId).toList())
+                .list();
+    }
+
+    /**
      * Lookup a List of ServerAction objects for a given Server.
      * @param serverIn you want to limit the list of Actions to
      * @return List of ServerAction objects
@@ -1253,5 +1271,10 @@ public class ActionFactory extends HibernateFactory {
      * The constant representing "Refresh Ansible inventories" [ID:525]
      */
     public static final ActionType TYPE_INVENTORY = lookupActionTypeByLabel("ansible.inventory");
+
+    /**
+     * The constant representing "Refresh Virtual Machine list" [ID:527]
+     */
+    public static final ActionType TYPE_VIRT_PROFILE_REFRESH = lookupActionTypeByLabel("virt.refresh_list");
 }
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -376,6 +376,12 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                         outer-join="false" cascade="all" property-ref="parentAction"/>
         </subclass>
 
+        <!-- Refresh virtual instance information -->
+        <subclass
+                name="com.redhat.rhn.domain.action.VirtualInstanceRefreshAction"
+                discriminator-value="527" lazy="true">
+        </subclass>
+
     </class>
     <query name="Action.findByIdandOrgId">
         <![CDATA[from com.redhat.rhn.domain.action.Action as a where a.id = :aid and org_id = :orgId]]>

--- a/java/code/src/com/redhat/rhn/domain/action/VirtualInstanceRefreshAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/VirtualInstanceRefreshAction.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.domain.action;
+
+
+/**
+ * VirtualInstanceRefreshAction
+ */
+public class VirtualInstanceRefreshAction extends Action {
+
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/GathererJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/GathererJob.java
@@ -16,9 +16,19 @@
 package com.redhat.rhn.taskomatic.task.gatherer;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.util.TimeUtils;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManager;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerFactory;
+import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.taskomatic.task.RhnJavaJob;
+import com.redhat.rhn.taskomatic.task.TaskHelper;
 
 import com.suse.manager.gatherer.GathererRunner;
 import com.suse.manager.gatherer.HostJson;
@@ -29,6 +39,8 @@ import org.quartz.JobExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Taskomatic job for running gatherer on all Virtual Host Managers and
@@ -58,6 +70,7 @@ public class GathererJob extends RhnJavaJob {
         if (StringUtils.isEmpty(vhmLabel)) {
             managers.addAll(VirtualHostManagerFactory.getInstance()
                     .listVirtualHostManagers());
+            gatherVmInfoFromPhysicalSystems();
         }
         else {
             managers.add(VirtualHostManagerFactory.getInstance().lookupByLabel(vhmLabel));
@@ -96,6 +109,33 @@ public class GathererJob extends RhnJavaJob {
         }
         finally {
             HibernateFactory.closeSession();
+        }
+    }
+
+    private void gatherVmInfoFromPhysicalSystems() {
+        for (Org org : OrgFactory.lookupAllOrgs()) {
+
+            Set<Long> sids = TimeUtils.logTime(log, "Find physical systems",
+                    () -> ServerFactory.listOrgSystems(org.getId()).stream()
+                            .filter(s -> !s.isInactive())
+                            .filter(s -> (s.hasEntitlement(EntitlementManager.SALT)))
+                            .filter(s -> !s.isVirtualGuest())
+                            .map(Server::getId)
+                            .collect(Collectors.toSet()));
+            if (sids.isEmpty()) {
+                continue;
+            }
+
+            Action act = ActionFactory.createAction(ActionFactory.TYPE_VIRT_PROFILE_REFRESH);
+            // set up needed fields for the action
+            act.setName(act.getActionType().getName());
+            act.setOrg(org);
+            ActionFactory.save(act);
+
+            ActionManager.scheduleForExecution(act, sids);
+            TaskHelper.scheduleActionExecution(act);
+
+            log.info("  schedule Virt profile refresh for {} systems in org {}", sids.size(), org.getName());
         }
     }
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
@@ -36,6 +36,7 @@ public class ApplyStatesEventMessage implements EventDatabaseMessage {
     public static final String PACKAGES = "packages";
     public static final String PACKAGES_PROFILE_UPDATE = "packages.profileupdate";
     public static final String HARDWARE_PROFILE_UPDATE = "hardware.profileupdate";
+    public static final String VIRTUAL_PROFILE_UPDATE = "hardware.virtprofile";
     public static final String CHANNELS = "channels";
     public static final String SALT_MINION_SERVICE = "services.salt-minion";
     public static final String REPORTDB_USER = "services.reportdb-user";

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/VmInfoSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/VmInfoSlsResult.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ */
+package com.suse.manager.webui.utils.salt.custom;
+
+import com.suse.salt.netapi.results.Ret;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import com.google.gson.annotations.SerializedName;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class VmInfoSlsResult {
+
+    private static final Logger LOG = LogManager.getLogger(VmInfoSlsResult.class);
+
+    @SerializedName(value = "mgrcompat_|-mgr_virt_profile_|-virt.vm_info_|-module_run")
+    private StateApplyResult<Ret<Map<String, Map<String, Object>>>> vminfo;
+
+    /**
+     * @return return virtual machine informations
+     */
+    public Map<String, Map<String, Object>> getVmInfos() {
+        if (vminfo == null) {
+            LOG.info("No virtual machines found");
+            return Collections.emptyMap();
+        }
+        return vminfo.getChanges().getRet();
+    }
+}

--- a/java/spacewalk-java.changes.mcalmer.gather-virtualization-data
+++ b/java/spacewalk-java.changes.mcalmer.gather-virtualization-data
@@ -1,0 +1,2 @@
+- Get virtual instance info from physical hosts using salts
+  vm_info in the virt module

--- a/schema/spacewalk/common/data/rhnActionType.sql
+++ b/schema/spacewalk/common/data/rhnActionType.sql
@@ -71,5 +71,6 @@ insert into rhnActionType values (506, 'channels.subscribe', 'Subscribe to chann
 insert into rhnActionType values (521, 'ansible.playbook', 'Execute an Ansible playbook', 'N', 'N', 'N');
 insert into rhnActionType values (523, 'coco.attestation', 'Confidential Compute Attestation', 'N', 'N', 'N');
 insert into rhnActionType values (524, 'appstreams.configure', 'Configure AppStreams in a system', 'N', 'N', 'N');
-commit;
 insert into rhnActionType values (525, 'ansible.inventory', 'Refresh Ansible inventories', 'N', 'N', 'N');
+insert into rhnActionType values (527, 'virt.refresh_list', 'Refresh virtual instance information', 'N', 'N', 'N');
+commit;

--- a/schema/spacewalk/susemanager-schema.changes.mcalmer.gather-virtualization-data
+++ b/schema/spacewalk/susemanager-schema.changes.mcalmer.gather-virtualization-data
@@ -1,0 +1,1 @@
+- Add action type to refresh virtual instance data

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/010-add-virt-refresh_list-actiontype.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/010-add-virt-refresh_list-actiontype.sql
@@ -1,0 +1,3 @@
+insert into rhnActionType 
+select 527, 'virt.refresh_list', 'Refresh virtual instance information', 'N', 'N', 'N'
+where not exists (select 1 from rhnActionType where id = 527);

--- a/susemanager-utils/susemanager-sls/salt/hardware/virtprofile.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/virtprofile.sls
@@ -1,0 +1,4 @@
+mgr_virt_profile:
+  mgrcompat.module_run:
+    - name: virt.vm_info
+

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.gather-virtualization-data
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.gather-virtualization-data
@@ -1,0 +1,1 @@
+- Add state to get virtual instance info from physical hosts


### PR DESCRIPTION
## What does this PR change?

After removing the virtualization feature we need to take care to still get the virtual host <=> guest relation for
SCC reporting.
This PR use salt virt.vm_info execution module to get the virtual instances running on physical systems.
The gatherer taskomatic job execute this one time per day only on physical salt managed nodes to get up to date data.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): SUSE/spacewalk#25437

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
