### PR TITLE
Add Amazon 2023 to BV testsuite

### DIFF
--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -243,6 +243,20 @@ Feature: Sanity checks
     And "alma9_ssh_minion" should communicate with the server using public interface
     And the clock from "alma9_ssh_minion" should be exact
 
+@amazon2023_minion
+  Scenario: The Amazon 2023 Salt minion is healthy
+    Then "amazon2023_minion" should have a FQDN
+    And reverse resolution should work for "amazon2023_minion"
+    And "amazon2023_minion" should communicate with the server using public interface
+    And the clock from "amazon2023_minion" should be exact
+
+@amazon2023_ssh_minion
+  Scenario: The Amazon 2023 Salt SSH minion is healthy
+    Then "amazon2023_ssh_minion" should have a FQDN
+    And reverse resolution should work for "amazon2023_ssh_minion"
+    And "amazon2023_ssh_minion" should communicate with the server using public interface
+    And the clock from "amazon2023_ssh_minion" should be exact
+
 @centos7_minion
   Scenario: The CentOS 7 Salt minion is healthy
     Then "centos7_minion" should have a FQDN

--- a/testsuite/features/build_validation/init_clients/amazon2023_minion.feature
+++ b/testsuite/features/build_validation/init_clients/amazon2023_minion.feature
@@ -1,0 +1,43 @@
+# Copyright (c) 2025 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new Amazon 2023 minion
+#  2) subscribe it to a base channel for testing
+
+@amazon2023_minion
+Feature: Bootstrap a Amazon 2023 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a Amazon 2023 Salt minion
+    When I perform a full salt minion cleanup on "amazon2023_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a Amazon 2023 Salt minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "amazon2023_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select "1-amazon2023_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    And I wait until I see "Bootstrap process initiated." text
+    And I wait until onboarding is completed for "amazon2023_minion"
+
+@proxy
+  Scenario: Check connection from Amazon 2023 Salt minion to proxy
+    Given I am on the Systems overview page of this "amazon2023_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of Amazon 2023 Salt minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "amazon2023_minion" hostname
+
+  Scenario: Check events history for failures on Amazon 2023 Salt minion
+    Given I am on the Systems overview page of this "amazon2023_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/amazon2023_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/amazon2023_ssh_minion.feature
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new Amazon 2023 minion via salt-ssh
+#  2) subscribe it to a base channel for testing
+
+@amazon2023_ssh_minion
+Feature: Bootstrap a Amazon 2023 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a Amazon 2023 Salt SSH minion
+    When I perform a full salt minion cleanup on "amazon2023_ssh_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a Amazon 2023 Salt SSH minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I enter the hostname of "amazon2023_ssh_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select "1-amazon2023_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies" if present
+    And I click on "Bootstrap"
+    # workaround for bsc#1222108
+    And I wait at most 480 seconds until I see "Bootstrap process initiated." text
+    And I wait until onboarding is completed for "amazon2023_ssh_minion"
+
+@proxy
+  Scenario: Check connection from Amazon 2023 Salt SSH minion to proxy
+    Given I am on the Systems overview page of this "amazon2023_ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of Amazon 2023 Salt SSH minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "amazon2023_ssh_minion" hostname
+
+  Scenario: Check events history for failures on Amazon 2023 Salt SSH minion
+    Given I am on the Systems overview page of this "amazon2023_ssh_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -532,6 +532,26 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until all synchronized channels for "almalinux9" have finished
 
 @susemanager
+@amazon2023_minion
+  Scenario: Add Amazon Linux 2023
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "currently running" text
+    And I wait until I do not see "Loading" text
+    And I enter "Amazon Linux 2023" as the filtered product description
+    And I select "Amazon Linux 2023 x86_64" as a product
+    Then I should see the "Amazon Linux 2023 x86_64" selected
+    When I click the Add Product button
+    And I wait until I see "Amazon Linux 2023 x86_64" product has been added
+    And I wait until all synchronized channels for "amazonlinux2023" have finished
+
+@uyuni
+@amazon2023_minion
+  Scenario: Add Amazon Linux 2023
+    When I use spacewalk-common-channel to add all "amazonlinux2023" channels with arch "x86_64"
+    And I wait until all synchronized channels for "amazonlinux2023" have finished
+
+@susemanager
 @centos7_minion
   Scenario: Add SUSE Liberty Linux 7
     Given I am authorized for the "Admin" section

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -7,7 +7,7 @@ Feature: Sanity checks
 
   Scenario: The server is healthy
     Then "server" should have a FQDN
-    Then reverse resolution should work for "server"
+    And reverse resolution should work for "server"
     And the clock from "server" should be exact
     And service "apache2" is enabled on "server"
     And service "apache2" is active on "server"

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -44,6 +44,8 @@ ENV_VAR_BY_HOST = {
   'alma8_ssh_minion' => 'ALMA8_SSHMINION',
   'alma9_minion' => 'ALMA9_MINION',
   'alma9_ssh_minion' => 'ALMA9_SSHMINION',
+  'amazon2023_minion' => 'AMAZON2023_MINION',
+  'amazon2023_ssh_minion' => 'AMAZON2023_SSHMINION',
   'centos7_minion' => 'CENTOS7_MINION',
   'centos7_ssh_minion' => 'CENTOS7_SSHMINION',
   'liberty9_minion' => 'LIBERTY9_MINION',
@@ -188,6 +190,8 @@ PACKAGE_BY_CLIENT = {
   'alma8_ssh_minion' => 'autoconf',
   'alma9_minion' => 'autoconf',
   'alma9_ssh_minion' => 'autoconf',
+  'amazon2023_minion' => 'autoconf',
+  'amazon2023_ssh_minion' => 'autoconf',
   'centos7_minion' => 'autoconf',
   'centos7_ssh_minion' => 'autoconf',
   'liberty9_minion' => 'autoconf',
@@ -267,6 +271,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'alma8_ssh_minion' => 'almalinux8 for x86_64',
     'alma9_minion' => 'almalinux9 for x86_64',
     'alma9_ssh_minion' => 'almalinux9 for x86_64',
+    'amazon2023_minion' => 'amazonlinux2023 for x86_64',
+    'amazon2023_ssh_minion' => 'amazonlinux2023 for x86_64',
     'centos7_minion' => 'RHEL x86_64 Server 7',
     'centos7_ssh_minion' => 'RHEL x86_64 Server 7',
     'liberty9_minion' => 'EL9-Pool for x86_64',
@@ -338,6 +344,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'alma8_ssh_minion' => 'AlmaLinux 8 (x86_64)',
     'alma9_minion' => 'AlmaLinux 9 (x86_64)',
     'alma9_ssh_minion' => 'AlmaLinux 9 (x86_64)',
+    'amazon2023_minion' => 'Amazon Linux 2023 x86_64',
+    'amazon2023_ssh_minion' => 'Amazon Linux 2023 x86_64',
     'centos7_minion' => 'CentOS 7 (x86_64)',
     'centos7_ssh_minion' => 'CentOS 7 (x86_64)',
     'liberty9_minion' => 'EL9-Pool for x86_64',
@@ -397,6 +405,7 @@ LABEL_BY_BASE_CHANNEL = {
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
     'almalinux8 for x86_64' => 'almalinux8-x86_64',
     'almalinux9 for x86_64' => 'almalinux9-x86_64',
+    'amazonlinux2023 for x86_64' => 'amazonlinux2023-x86_64',
     'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
     'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
     'EL9-Pool for x86_64' => 'el9-pool-x86_64',
@@ -427,6 +436,7 @@ LABEL_BY_BASE_CHANNEL = {
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
     'AlmaLinux 8 (x86_64)' => 'almalinux8-x86_64',
     'AlmaLinux 9 (x86_64)' => 'almalinux9-x86_64',
+    'Amazon Linux 2023 x86_64' => 'amazonlinux2023-x86_64',
     'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
     'CentOS 7 (x86_64)' => 'centos7-x86_64',
     'EL9-Pool for x86_64' => 'el9-pool-x86_64',
@@ -464,6 +474,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SL-Micro-6.1-Pool for x86_64' => 'SL-MICRO-6.1-x86_64',
     'almalinux8 for x86_64' => 'almalinux-8-x86_64',
     'almalinux9 for x86_64' => 'almalinux-9-x86_64',
+    'amazonlinux2023 for x86_64' => 'amazonlinux-2023-x86_64',
     'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
     'RHEL x86_64 Server 7' => 'RES7-x86_64',
     'EL9-Pool for x86_64' => 'SUSE-LibertyLinux9-x86_64',
@@ -496,6 +507,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SL-Micro-6.1-Pool for x86_64' => 'SL-MICRO-6.1-x86_64',
     'AlmaLinux 8 (x86_64)' => 'almalinux-8-x86_64-uyuni',
     'AlmaLinux 9 (x86_64)' => 'almalinux-9-x86_64-uyuni',
+    'Amazon Linux 2023 x86_64' => 'amazonlinux-2023-x86_64-uyuni',
     'Fake-Base-Channel-SUSE-like' => 'fake-base-channel-suse-like',
     'CentOS 7 (x86_64)' => 'centos-7-x86_64-uyuni',
     'EL9-Pool for x86_64' => 'SUSE-LibertyLinux9-x86_64',
@@ -534,6 +546,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
     'almalinux8 for x86_64' => nil,
     'almalinux9 for x86_64' => nil,
+    'amazonlinux2023 for x86_64' => nil,
     'Fake-Base-Channel-SUSE-like' => nil,
     'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
     'EL9-Pool for x86_64' => 'el9-pool-x86_64',
@@ -563,8 +576,9 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SLE-Micro-5.5-Pool for x86_64' => 'sle-micro-5.5-pool-x86_64',
     'SL-Micro-6.0-Pool for x86_64' => 'sl-micro-6.0-pool-x86_64',
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
-    'almalinux8 for x86_64' => nil,
-    'almalinux9 for x86_64' => nil,
+    'AlmaLinux 8 (x86_64)' => nil,
+    'AlmaLinux 9 (x86_64)' => nil,
+    'Amazon Linux 2023 x86_64' => nil,
     'Fake-Base-Channel-SUSE-like' => nil,
     'CentOS 7 (x86_64)' => 'centos-7-x86_64-uyuni',
     'EL9-Pool for x86_64' => 'el9-pool-x86_64',
@@ -616,6 +630,8 @@ PKGARCH_BY_CLIENT = {
   'alma8_ssh_minion' => 'x86_64',
   'alma9_minion' => 'x86_64',
   'alma9_ssh_minion' => 'x86_64',
+  'amazon2023_minion' => 'x86_64',
+  'amazon2023_ssh_minion' => 'x86_64',
   'centos7_minion' => 'x86_64',
   'centos7_ssh_minion' => 'x86_64',
   'liberty9_minion' => 'x86_64',
@@ -670,15 +686,31 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sle-module-containers15-sp4-updates-x86_64
         sle-product-sles15-sp4-ltss-updates-x86_64
       ],
-    'almalinux8' =>
+    'almalinux8' => # CHECKED
       %w[
         almalinux8-x86_64
         almalinux8-appstream-x86_64
+        managertools-el8-pool-x86_64-alma
+        managertools-el8-updates-x86_64-alma
+        managertools-beta-el8-pool-x86_64-alma
+        managertools-beta-el8-updates-x86_64-alma
       ],
     'almalinux9' => # CHECKED
       %w[
         almalinux9-x86_64
         almalinux9-appstream-x86_64
+        managertools-el9-pool-x86_64-alma
+        managertools-el9-updates-x86_64-alma
+        managertools-beta-el9-pool-x86_64-alma
+        managertools-beta-el9-updates-x86_64-alma
+      ],
+    'amazonlinux2023' => # CHECKED
+      %w[
+        amazonlinux2023-x86_64
+        managertools-el9-pool-x86_64-amazon
+        managertools-el9-updates-x86_64-amazon
+        managertools-beta-el9-pool-x86_64-amazon
+        managertools-beta-el9-updates-x86_64-amazon
       ],
     'debian-12' => # CHECKED
       %w[
@@ -1014,6 +1046,11 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         almalinux9-x86_64-extras
         almalinux9-uyuni-client-devel-x86_64
       ],
+    'amazonlinux2023' =>
+      %w[
+        amazonlinux2023-x86_64
+        amazonlinux2023-uyuni-client-devel-x86_64
+      ],
     'centos7' => # CHECKED
       %w[
         centos7-x86_64
@@ -1314,9 +1351,9 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
 # Formula: (end date - startup date) * 2, rounded to upper 60 seconds
 # Please keep this list sorted alphabetically
 TIMEOUT_BY_CHANNEL_NAME = {
-  'almalinux8-appstream-x86_64' => 480,
+  'almalinux8-appstream-x86_64' => 1260,
   'almalinux8-uyuni-client-devel-x86_64' => 60,
-  'almalinux8-x86_64' => 420,
+  'almalinux8-x86_64' => 540,
   'almalinux8-x86_64-appstream' => 1740,
   'almalinux8-x86_64-extras' => 60,
   'almalinux9-appstream-x86_64' => 480,
@@ -1324,6 +1361,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'almalinux9-x86_64' => 120,
   'almalinux9-x86_64-appstream' => 720,
   'almalinux9-x86_64-extras' => 60,
+  'amazonlinux2023-x86_64' => 1980,
+  'amazonlinux2023-uyuni-client-devel-x86_64' => 60,
   'centos-7-iso' => 300,
   'centos7-uyuni-client-devel-x86_64' => 60,
   'centos7-x86_64' => 960,
@@ -1347,8 +1386,14 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'fake-child-channel-suse-like' => 240,
   'fake-rpm-suse-channel' => 120,
   'fake-rpm-terminal-channel' => 360,
+  'managertools-beta-el8-pool-x86_64-alma' => 60,
+  'managertools-beta-el9-pool-x86_64-amazon' => 60,
+  'managertools-beta-el8-updates-x86_64-alma' => 60,
+  'managertools-beta-el9-updates-x86_64-amazon' => 60,
   'managertools-beta-el9-pool-x86_64' => 60,
+  'managertools-beta-el9-pool-x86_64-alma' => 60,
   'managertools-beta-el9-updates-x86_64' => 60,
+  'managertools-beta-el9-updates-x86_64-alma' => 60,
   'managertools-beta-sle15-pool-x86_64-sp4' => 60,
   'managertools-beta-sle15-updates-x86_64-sp4' => 60,
   'managertools-beta-ubuntu2204-updates-amd64' => 60,
@@ -1358,10 +1403,16 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'managertools-el7-pool-x86_64-lbt7' => 60,
   'managertools-el7-updates-x86_64-lbt7' => 60,
   'managertools-el8-pool-x86_64' => 60,
+  'managertools-el8-pool-x86_64-alma' => 60,
   'managertools-el8-updates-x86_64' => 60,
+  'managertools-el8-updates-x86_64-alma' => 60,
   'managertools-el9-pool-x86_64' => 60,
+  'managertools-el9-pool-x86_64-alma' => 60,
+  'managertools-el9-pool-x86_64-amazon' => 60,
   'managertools-el9-pool-x86_64-rocky' => 60,
   'managertools-el9-updates-x86_64' => 60,
+  'managertools-el9-updates-x86_64-alma' => 60,
+  'managertools-el9-updates-x86_64-amazon' => 60,
   'managertools-el9-updates-x86_64-rocky' => 60,
   'managertools-sle12-pool-x86_64-sp5' => 60,
   'managertools-sle12-updates-x86_64-sp5' => 60,

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -331,6 +331,14 @@ Before('@alma9_ssh_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['alma9_ssh_minion']
 end
 
+Before('@amazon2023_minion') do
+  skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['amazon2023_minion']
+end
+
+Before('@amazon2023_ssh_minion') do
+  skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['amazon2023_ssh_minion']
+end
+
 Before('@centos7_minion') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['centos7_minion']
 end


### PR DESCRIPTION
## What does this PR change?

Add Amazon 2023 to BV testsuite


## GUI diff

No difference.

- [x] **DONE**


## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

No ports: only 5.1 and later.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
