### PR TITLE
Ensure selinuxenabled exists before executing it (bsc#1241060)

### DIFF
--- a/uyuni/uyuni-storage-setup/scripts/susemanager-storage-setup-functions.sh
+++ b/uyuni/uyuni-storage-setup/scripts/susemanager-storage-setup-functions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Copyright (c) 2019--2024 SUSE Linux GmbH
-# Copyright (c) 2024 SUSE LLC
+# Copyright (c) 2019--2025 SUSE Linux GmbH
+# Copyright (c) 2024--2025 SUSE LLC
 #
 # This file is part of uyuni-storage-setup.
 #
@@ -77,10 +77,10 @@ check_mountpoint() {
     # check if mount_point exists
     if [ ! -d $mount_point ]; then
         mkdir $mount_point || die "Unable to create $mount_point"
-	chmod 0700 $mount_point
-	if /usr/sbin/selinuxenabled; then
+        chmod 0700 $mount_point
+        if [ -x /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
             chcon --reference=$mount_point/.. $mount_point || die "Unable to set selinux context to $mount_point"
-	fi
+        fi
     fi
 }
 
@@ -136,7 +136,7 @@ mount_storage() {
     local mount_point=$2
     mkdir -p $mount_point
     chmod 0700 $mount_point
-    if /usr/sbin/selinuxenabled; then
+    if [ -x /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
         chcon --reference=$mount_point/.. $mount_point || die "Unable to set selinux context to $mount_point"
     fi
     local result=$(mount $part $mount_point 2>&1)
@@ -171,7 +171,7 @@ remount_storage() {
     if [ ! -d $mount_point ]; then
         mkdir -p $mount_point
         chmod 0700 $mount_point
-        if /usr/sbin/selinuxenabled; then
+        if [ -x /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
             chcon --reference=$mount_point/.. $mount_point || die "Unable to set selinux context to $mount_point"
         fi
     fi

--- a/uyuni/uyuni-storage-setup/uyuni-storage-setup.changes.mackdk.5.0-fix-storage-setup-selinux
+++ b/uyuni/uyuni-storage-setup/uyuni-storage-setup.changes.mackdk.5.0-fix-storage-setup-selinux
@@ -1,0 +1,1 @@
+- Ensure selinuxenabled exists before executing it (bsc#1241060)


### PR DESCRIPTION
## What does this PR change?

This PR adds a check to ensure that selinuxenabled before executing it. In fact, in SLE S it is not installed by default and this results on an error, even if the script works correctly.

Port of https://github.com/SUSE/spacewalk/pull/27014

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26982

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
