### PR TITLE
Fail the external PR labeler GH action if the API call fails

### DIFF
--- a/.github/workflows/external_pr_labeler.yml
+++ b/.github/workflows/external_pr_labeler.yml
@@ -12,15 +12,23 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - id: generate-token
+        name: Generate an access token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.EXTERNAL_PR_LABELER_APP_ID }}
+          private-key: ${{ secrets.EXTERNAL_PR_LABELER_PK }}
+
       - id: is_member
         name: Check if author is an org member
         env:
-          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # The following API call returns 404 if user is not a member of the uyuni-project org
           # See: https://docs.github.com/rest/orgs/members#check-organization-membership-for-a-user--status-codes
           RESULT=`gh api orgs/uyuni-project/members/${{ github.actor }} -i | head -1 | awk '{ print $2 }'`
           echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
       - name: Label the PR
         # If not a member of org
         if: ${{ steps.is_member.outputs.result == 404 }}

--- a/.github/workflows/external_pr_labeler.yml
+++ b/.github/workflows/external_pr_labeler.yml
@@ -29,6 +29,11 @@ jobs:
           RESULT=`gh api orgs/uyuni-project/members/${{ github.actor }} -i | head -1 | awk '{ print $2 }'`
           echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
+          # Fail the job if the API call didn't return 204 (member) or 404 (not member)
+          if [[ "$RESULT" != "204" && "$RESULT" != "404" ]]; then
+            echo "Error: Failed to check organization membership. Status code: $RESULT"
+          fi
+
       - name: Label the PR
         # If not a member of org
         if: ${{ steps.is_member.outputs.result == 404 }}


### PR DESCRIPTION
This PR modifies the action to use a GitHub App installation key instead of a personal access token for authorization, as recommended by GitHub.

The API call in the action requires an additional permission (read org members). A GitHub app installation key is used to provide it.

See also: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow 

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
