### PR TITLE
Bv fix issue add mu slmicro6x

### DIFF
--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -488,16 +488,31 @@ When(/^I create the MU repositories for "([^"]*)"$/) do |client|
       log "The MU repository #{unique_repo_name} was already created, we will reuse it."
     else
       content_type = deb_host?(client) ? 'deb' : 'yum'
-      steps %(
-        When I follow the left menu "Software > Manage > Repositories"
-        And I follow "Create Repository"
-        And I enter "#{unique_repo_name}" as "label"
-        And I enter "#{repo_url.strip}" as "url"
-        And I select "#{content_type}" from "contenttype"
-        And I click on "Create Repository"
-        Then I should see a "Repository created successfully" text or "The repository label '#{unique_repo_name}' is already in use" text
-        And I should see "metadataSigned" as checked
-      )
+      node = get_target(client)
+      if node.os_family.include?('sl-micro') && node.os_version.include?('6')
+        steps %(
+          When I follow the left menu "Software > Manage > Repositories"
+          And I follow "Create Repository"
+          And I enter "#{unique_repo_name}" as "label"
+          And I enter "#{repo_url.strip}" as "url"
+          And I select "#{content_type}" from "contenttype"
+          And I uncheck "metadataSigned"
+          And I click on "Create Repository"
+          Then I should see a "Repository created successfully" text or "The repository label '#{unique_repo_name}' is already in use" text
+          And I should see "metadataSigned" as unchecked
+        )
+      else
+        steps %(
+          When I follow the left menu "Software > Manage > Repositories"
+          And I follow "Create Repository"
+          And I enter "#{unique_repo_name}" as "label"
+          And I enter "#{repo_url.strip}" as "url"
+          And I select "#{content_type}" from "contenttype"
+          And I click on "Create Repository"
+          Then I should see a "Repository created successfully" text or "The repository label '#{unique_repo_name}' is already in use" text
+          And I should see "metadataSigned" as checked
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## What does this PR change?

Currently, when running BV with slmicro6X minions, the add MU step is failing because the MU repositories for those minions are not signed by SUSE authority. (see: https://suse.slack.com/archives/C02CLBJ5RGF/p1744337596069169)
To solve this issue, uncheck the metadata check when we have a slmicro minion.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port(s):
 - 4.3: https://github.com/SUSE/spacewalk/pull/27018
 - 5.0: https://github.com/SUSE/spacewalk/pull/27017

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
