### PR TITLE
download.suse.de is unreacheable from SLC1

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -67,13 +67,13 @@ Then(/^it should be possible to use the custom download endpoint$/) do
 end
 
 Then(/^it should be possible to reach the build sources$/) do
-  if product == 'Uyuni'
-    # TODO: move that internal resource to some other external location
-    log 'Sanity check not implemented, move resource to external network first'
-  else
-    url = 'http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/media.1/products.key'
-    get_target('server').run("curl --insecure --location #{url} --output /dev/null")
-  end
+  example_product =
+    if product == 'Uyuni'
+      'distribution/leap-micro/5.5/product/repo/Leap-Micro-5.5-x86_64-Media1/media.1/products'
+    else
+      'ibs/SUSE/Products/SLE-Product-SLES/15-SP6/x86_64/product/media.1/products'
+    end
+  get_target('server').run("curl --insecure --location http://#{$build_sources}/#{example_product} --output /dev/null")
 end
 
 Then(/^it should be possible to reach the Docker profiles$/) do

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -51,6 +51,7 @@ $private_net = ENV.fetch('PRIVATENET', nil) if ENV['PRIVATENET']
 $mirror = ENV.fetch('MIRROR', nil)
 $server_http_proxy = ENV.fetch('SERVER_HTTP_PROXY', nil) if ENV['SERVER_HTTP_PROXY']
 $custom_download_endpoint = ENV.fetch('CUSTOM_DOWNLOAD_ENDPOINT', nil) if ENV['CUSTOM_DOWNLOAD_ENDPOINT']
+$build_sources = ENV.fetch('BUILD_SOURCES', nil) if ENV['BUILD_SOURCES']
 $no_auth_registry = ENV.fetch('NO_AUTH_REGISTRY', nil) if ENV['NO_AUTH_REGISTRY']
 $auth_registry = ENV.fetch('AUTH_REGISTRY', nil) if ENV['AUTH_REGISTRY']
 $current_user = 'admin'


### PR DESCRIPTION
## What does this PR change?

Use download.nue.suse.com instead of download.suse.de. It's same site, but it's filtered differently by our firewalls.

**IMPORTANT NOTE**: I have searched other occurrences of download.suse.de in our test suite. There's quite a bit of them, but none should have an importance on the tests in SLC1.

In particular, in the Kiwi and Docker profiles, `download.suse.de` gets changed into the domain name of the closest mirror anyways.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were added

- [x] **DONE**


## Links

Port(s):
 * 5.0: https://github.com/SUSE/spacewalk/pull/27022
 * 4.3: https://github.com/SUSE/spacewalk/pull/27023

- [ ] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
