### PR TITLE
Remove unneeded debug log message

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
@@ -708,7 +708,6 @@ public class KickstartData {
                 }
             }
         }
-        logger.debug("returning: {}", retval);
         return Collections.unmodifiableSet(retval);
     }
 

--- a/java/spacewalk-java.changes.cbosdo.log-sanitizing
+++ b/java/spacewalk-java.changes.cbosdo.log-sanitizing
@@ -1,0 +1,1 @@
+- Remove unneeded debug message


### PR DESCRIPTION
## What does this PR change?

Fixes a Sonarcloud issue with potential user controlled data being logged, and that debug message isn't that useful.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: logging removed

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26928
Port(s): https://github.com/SUSE/spacewalk/pull/27026 https://github.com/SUSE/spacewalk/pull/27025

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
