### PR TITLE
CI: fix buildhost docker tests

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -4,7 +4,6 @@
 # This feature depends on:
 # - features/secondary/min_docker_api.feature
 
-@skip_if_github_validation
 @build_host
 @scope_building_container_images
 @auth_registry
@@ -33,8 +32,6 @@ Feature: Build image with authenticated registry
     And I click on "create-btn"
     Then I wait until I see "auth_registry_profile" text
 
-# This test fails for unknown reason
-@skip_if_github_validation
   @scc_credentials
   Scenario: Build an image in the authenticated image store
     When I follow the left menu "Images > Build"
@@ -44,7 +41,7 @@ Feature: Build image with authenticated registry
     And I click on "submit-btn"
     Then I wait until I see "auth_registry_profile" text
     # Verify the status of images in the authenticated image store
-    When I wait at most 660 seconds until image "auth_registry_profile" with version "latest" is built successfully via API
+    When I wait at most 900 seconds until image "auth_registry_profile" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "auth_registry_profile" with version "latest" is inspected successfully via API
     And I wait until no Salt job is running on "build_host"
     And I refresh the page

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -12,7 +12,6 @@
 # - features/secondary/min_salt_install_with_staging.feature
 # Due to the images listed in the CVE Audit images
 
-@skip_if_github_validation
 @build_host
 @scope_building_container_images
 @scope_cve_audit
@@ -65,7 +64,7 @@ Feature: Build container images and CVE audit them
     And I wait at most 660 seconds until event "Image Build suse_key scheduled" is completed
     # We should see the same result via API.
     # Also, check that all inspect actions are finished:
-    And I wait at most 600 seconds until image "suse_key" with version "latest" is built successfully via API
+    And I wait at most 900 seconds until image "suse_key" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "latest" is inspected successfully via API
 
 @skip_if_github_validation
@@ -77,7 +76,7 @@ Feature: Build container images and CVE audit them
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_simple" via API calls
     And I wait at most 660 seconds until event "Image Build suse_simple scheduled" is completed
-    And I wait at most 600 seconds until image "suse_simple" with version "latest" is built successfully via API
+    And I wait at most 900 seconds until image "suse_simple" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "latest" is inspected successfully via API
 
 @skip_if_github_validation
@@ -90,7 +89,7 @@ Feature: Build container images and CVE audit them
     When I schedule the build of image "suse_real_key" via API calls
     And I wait at most 660 seconds until event "Image Build suse_real_key scheduled" is completed
     And I wait at most 60 seconds until all "3" container images are built correctly on the Image List page
-    And I wait at most 600 seconds until image "suse_real_key" with version "latest" is built successfully via API
+    And I wait at most 900 seconds until image "suse_real_key" with version "latest" is built successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "latest" is inspected successfully via API
     When I wait until no Salt job is running on "build_host"
 
@@ -101,7 +100,7 @@ Feature: Build container images and CVE audit them
 @scc_credentials
   Scenario: Build suse_key images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
-    And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
+    And I wait at most 900 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     When I wait until no Salt job is running on "build_host"
 
@@ -111,7 +110,7 @@ Feature: Build container images and CVE audit them
 
   Scenario: Build suse_simple image with different versions
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
-    And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
+    And I wait at most 900 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     When I wait until no Salt job is running on "build_host"
 
@@ -132,7 +131,7 @@ Feature: Build container images and CVE audit them
 
   Scenario: Rebuild suse_simple image
     When I schedule the build of image "suse_simple" with version "Latest_simple" via API calls
-    And I wait at most 600 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
+    And I wait at most 900 seconds until image "suse_simple" with version "Latest_simple" is built successfully via API
     And I wait at most 300 seconds until image "suse_simple" with version "Latest_simple" is inspected successfully via API
     When I wait until no Salt job is running on "build_host"
 
@@ -143,7 +142,7 @@ Feature: Build container images and CVE audit them
 @scc_credentials
   Scenario: Rebuild suse_key image
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via API calls
-    And I wait at most 600 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
+    And I wait at most 900 seconds until image "suse_key" with version "Latest_key-activation1" is built successfully via API
     And I wait at most 300 seconds until image "suse_key" with version "Latest_key-activation1" is inspected successfully via API
     When I wait until no Salt job is running on "build_host"
 
@@ -160,7 +159,7 @@ Feature: Build container images and CVE audit them
     And I click on "submit-btn"
     And I wait until no Salt job is running on "build_host"
     Then I wait until I see "GUI_BUILT_IMAGE" text
-    And I wait at most 600 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is built successfully via API
+    And I wait at most 900 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is built successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "GUI_BUILT_IMAGE" is inspected successfully via API
 
 @scc_credentials
@@ -173,7 +172,7 @@ Feature: Build container images and CVE audit them
     And I click on "submit-btn"
     And I wait until no Salt job is running on "build_host"
     Then I wait until I see "GUI_DOCKERADMIN" text
-    And I wait at most 600 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is built successfully via API
+    And I wait at most 900 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is built successfully via API
     And I wait at most 300 seconds until image "suse_real_key" with version "GUI_DOCKERADMIN" is inspected successfully via API
 
 @scc_credentials


### PR DESCRIPTION
## What does this PR change?

The build of docker images in the buildhost takes longer than before. Could be that the performance of the buildhost is worse. Given the buildhost is not part of the product, we will just wait a bit more for the build to finish.

## GUI diff

No difference.


- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [ ] **DONE**

## Links



- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
