### PR TITLE
call product refresh after the channel sync call

### DIFF
--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -334,11 +334,17 @@ public class HubController {
 
         try {
             hubManager.syncChannels(token, channelInfoList);
+            Date earliest = Date.from(Instant.now().plus(10, ChronoUnit.SECONDS));
+            taskomaticApi.scheduleProductRefresh(earliest, false);
             return success(response);
         }
         catch (IllegalArgumentException ex) {
             LOGGER.error("Illegal arguments in syncChannels", ex);
             return badRequest(response, ex.getMessage());
+        }
+        catch (TaskomaticApiException ex) {
+            LOGGER.error("Scheduling a product refresh failed. ", ex);
+            return internalServerError(response, "Scheduling product refresh failed");
         }
         catch (Exception e) {
             LOGGER.error("Internal server error in syncChannels", e);

--- a/java/spacewalk-java.changes.mcalmer.issv3-call-refresh
+++ b/java/spacewalk-java.changes.mcalmer.issv3-call-refresh
@@ -1,0 +1,2 @@
+- Call product refresh after the channel sync call to finish the
+  setup on the peripheral server


### PR DESCRIPTION
## What does this PR change?

To finish a channel sync from hub to peripheral, we need to call the product refresh.
This PR schedule a refresh with a delay of 10 seconds to have all the changes comited to the DB.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27020

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
