### PR TITLE
Avoid steps inside steps

### DIFF
--- a/testsuite/documentation/guidelines.md
+++ b/testsuite/documentation/guidelines.md
@@ -129,9 +129,10 @@ product's feature, not how you want to test it. This is the role of the scenario
 * Don't fall in the case where same step can trigger two different regular expressions
 
 In the implementation:
+* Try to avoid calling steps from inside the Ruby code, use Ruby functions instead
 * We are phasing out minitest assertions like ```assert_equal```, use `fail` instead
 * Don't use global variables, prefer member variables
-* Inside a step definition use `log` instead of `puts`, as the `puts` method will not be capture by Cucumber.
+* Use `log` instead of `puts`, as the `puts` method will not be captured by Cucumber.
 
 ## Other
 


### PR DESCRIPTION
## What does this PR change?

Cucumber guidelines: avoid steps inside steps

## GUI diff

No difference.

- [x] **DONE**


## Documentation

This is an internal documentation PR.

- [x] **DONE**


## Test coverage

Doc only.

- [x] **DONE**


## Links

No ports to 4.3 nor 5.0, feeling too lazy.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
