### PR TITLE
Remove unneeded parentheses in Java code

### DIFF
--- a/java/code/src/com/redhat/rhn/common/client/ClientCertificate.java
+++ b/java/code/src/com/redhat/rhn/common/client/ClientCertificate.java
@@ -216,7 +216,7 @@ public class ClientCertificate {
             if (!m.getName().equals(FIELDS)) {
                 String[] values = m.getValues();
                 struct.addBody(createStringMember(m.getName(),
-                        (values != null && values.length > 0) ? values[0] : ""));
+                        values != null && values.length > 0 ? values[0] : ""));
             }
             else {
                 struct.addBody(createFieldMember(m.getName(), m.getValues()));

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -607,7 +607,7 @@ public class ConfigDefaults {
      * @return boolean if this sat is disconnected or not
      */
     public boolean isDisconnected() {
-        return (Config.get().getBoolean(DISCONNECTED));
+        return Config.get().getBoolean(DISCONNECTED);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/db/NamedPreparedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/NamedPreparedStatement.java
@@ -54,14 +54,14 @@ public final class NamedPreparedStatement {
             if (inQuotes) {
                 continue;
             }
-            if (c == ':' && (query.charAt(i + 1) == ':')) {
+            if (c == ':' && query.charAt(i + 1) == ':') {
                 i++;
                 continue;
             }
             // The Oracle PL/SQL syntax uses := to indicate that a function
             // should return a value.  Since, we do not want to replace := with
             // a ?, just skip this : if the next char is a =.
-            if (c == ':' && (query.charAt(i + 1) != '=')) {
+            if (c == ':' && query.charAt(i + 1) != '=') {
                 return i;
             }
         }

--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -690,7 +690,7 @@ public class CachedStatement implements Serializable {
                         obj = currentResults.get(pos);
                     }
                     // if pointers are null, we are doing an elaborator.
-                    addToObject(columns, rs, obj, (pointers != null));
+                    addToObject(columns, rs, obj, pointers != null);
                     // bug 141664: Don't add to the DataResult if we are
                     // elaborating the data.
                     if (pointers == null) {
@@ -854,12 +854,12 @@ public class CachedStatement implements Serializable {
         // this : August 23, 2005 12:00:00 AM PDT
         // vs the real date: August 23, 2005 1:36:12 PM PDT
         if (columnValue instanceof Date ||
-                ("oracle.sql.TIMESTAMPLTZ"
-                     .equals(columnValue.getClass().getCanonicalName())) ||
-                ("oracle.sql.TIMESTAMP"
-                     .equals(columnValue.getClass().getCanonicalName())) ||
-                ("oracle.sql.TIMESTAMPTZ"
-                     .equals(columnValue.getClass().getCanonicalName()))) {
+                "oracle.sql.TIMESTAMPLTZ"
+                     .equals(columnValue.getClass().getCanonicalName()) ||
+                "oracle.sql.TIMESTAMP"
+                     .equals(columnValue.getClass().getCanonicalName()) ||
+                "oracle.sql.TIMESTAMPTZ"
+                     .equals(columnValue.getClass().getCanonicalName())) {
             return rs.getTimestamp(columnName);
         }
         else if (columnValue instanceof BigDecimal) {

--- a/java/code/src/com/redhat/rhn/common/db/datasource/DataSourceParserHelper.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/DataSourceParserHelper.java
@@ -322,10 +322,10 @@ class DataSourceParserHelper implements ContentHandler, Serializable {
             }
 
             String column = parsedAttributes.getValue("column");
-            elaboratorJoinColumn = (column == null) ? "id" : column.toLowerCase();
+            elaboratorJoinColumn = column == null ? "id" : column.toLowerCase();
 
             String mult = parsedAttributes.getValue("multiple");
-            multiple = (mult != null && mult.equals("t"));
+            multiple = mult != null && mult.equals("t");
 
             parameterList = new ArrayList<>();
             String parameters = parsedAttributes.getValue("params");

--- a/java/code/src/com/redhat/rhn/common/db/datasource/test/DataListTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/test/DataListTest.java
@@ -142,7 +142,7 @@ public class DataListTest extends RhnBaseTestCase {
         }
 
         public boolean isElaborated() {
-            return (elaborated > 0);
+            return elaborated > 0;
         }
 
         public int getElaborated() {

--- a/java/code/src/com/redhat/rhn/common/db/datasource/test/DataSourceParserTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/test/DataSourceParserTest.java
@@ -154,9 +154,9 @@ public class DataSourceParserTest extends RhnBaseTestCase {
         /* Don't do plans for queries that use system tables or for
          * dummy queries.
          */
-        return (m != null && m.getParsedQuery() != null &&
+        return m != null && m.getParsedQuery() != null &&
                 (m.getName().equals("tablespace_overview") ||
-                 m.getParsedQuery().getSqlStatement().trim().startsWith("--")));
+                 m.getParsedQuery().getSqlStatement().trim().startsWith("--"));
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/common/filediff/RhnPatchDiffWriter.java
+++ b/java/code/src/com/redhat/rhn/common/filediff/RhnPatchDiffWriter.java
@@ -157,7 +157,7 @@ public class RhnPatchDiffWriter implements DiffVisitor, DiffWriter {
         }
 
         //skip all the lines outside of our context.
-        while ((numLines - counter) > contextLines) {
+        while (numLines - counter > contextLines) {
             lines.next();
             counter++;
         }

--- a/java/code/src/com/redhat/rhn/common/filediff/Trace.java
+++ b/java/code/src/com/redhat/rhn/common/filediff/Trace.java
@@ -93,7 +93,7 @@ public class Trace {
      */
     public int bestPossible() {
         int shortest = currentLineOld > currentLineNew ? currentLineNew : currentLineOld;
-        return (matches + shortest + 1); //currentLine* is an index, so we must add one.
+        return matches + shortest + 1; //currentLine* is an index, so we must add one.
     }
 
     private void fork() {

--- a/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/MessageQueue.java
@@ -253,7 +253,7 @@ public class MessageQueue {
      * @return boolean true if MessageQueue is running.
      */
     public static boolean isMessaging() {
-        return (dispatcher != null && !dispatcher.isStopped());
+        return dispatcher != null && !dispatcher.isStopped();
     }
 
 

--- a/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
+++ b/java/code/src/com/redhat/rhn/common/messaging/SmtpMail.java
@@ -273,7 +273,7 @@ public class SmtpMail implements Mail {
         if (addrs != null) {
             for (int x = 0; x < addrs.length; x++) {
                 buf.append(addrs[x].toString());
-                if (addrs.length > 1 && x < (addrs.length - 1)) {
+                if (addrs.length > 1 && x < addrs.length - 1) {
                     buf.append(",");
                 }
             }

--- a/java/code/src/com/redhat/rhn/common/security/CSRFTokenValidator.java
+++ b/java/code/src/com/redhat/rhn/common/security/CSRFTokenValidator.java
@@ -85,7 +85,7 @@ public final class CSRFTokenValidator {
 
         String header = request.getHeader("X-CSRF-Token");
         String parameter = request.getParameter(tokenKey);
-        String token = parameter != null ? parameter : (header != null ? header : null);
+        String token = parameter != null ? parameter : header != null ? header : null;
 
         if (token == null) {
             throw new CSRFTokenException("Request does not contain a CSRF security token");

--- a/java/code/src/com/redhat/rhn/common/security/HMAC.java
+++ b/java/code/src/com/redhat/rhn/common/security/HMAC.java
@@ -42,8 +42,8 @@ public class HMAC {
         int hn, ln, cx;
         StringBuilder buf = new StringBuilder(a.length * 2);
         for (cx = 0; cx < a.length; cx++) {
-            hn = ((a[cx]) & 0x00ff) / 16;
-            ln = (a[cx]) & 0x000f;
+            hn = (a[cx] & 0x00ff) / 16;
+            ln = a[cx] & 0x000f;
             buf.append(HEXCHARS.charAt(hn));
             buf.append(HEXCHARS.charAt(ln));
         }

--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -184,7 +184,7 @@ public class Access extends BaseHandler {
         queryParams.put("label", label);
         queryParams.put("org_id", user.getOrg().getId());
         DataResult<Row> dr = m.execute(queryParams);
-        return (!dr.isEmpty());
+        return !dr.isEmpty();
     }
 
     /**
@@ -201,7 +201,7 @@ public class Access extends BaseHandler {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("org_id", user.getOrg().getId());
         DataResult<OrgProxyServer> dr = m.execute(queryParams);
-        return (!dr.isEmpty());
+        return !dr.isEmpty();
     }
 
     /**
@@ -450,7 +450,7 @@ public class Access extends BaseHandler {
      */
     public boolean aclUserAuthenticated(Map<String, Object> ctx, String[] params) {
         User user = (User)ctx.get("user");
-        return (user != null);
+        return user != null;
     }
 
     /**
@@ -462,7 +462,7 @@ public class Access extends BaseHandler {
      * @return true if the system is a satellite and has any users.
      */
     public boolean aclNeedFirstUser(Map<String, Object> ctx, String[] p) {
-        return !(UserFactory.satelliteHasUsers());
+        return !UserFactory.satelliteHasUsers();
     }
 
     /**
@@ -499,7 +499,7 @@ public class Access extends BaseHandler {
         User user = (User) ctx.get("user");
         if (user != null) {
             List<ChannelPerms> chans = UserManager.channelManagement(user, null);
-            return (user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN)) || !chans.isEmpty();
+            return user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN) || !chans.isEmpty();
         }
 
         return false;

--- a/java/code/src/com/redhat/rhn/common/security/acl/ChannelAclHandler.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/ChannelAclHandler.java
@@ -91,7 +91,7 @@ public class ChannelAclHandler extends BaseHandler {
         User usr = (User)ctx.get(USER);
         Channel chan = getChannel(usr, ctx);
         if (chan != null) {
-            String p0 = (params.length > 0 ? params[0] : null);
+            String p0 = params.length > 0 ? params[0] : null;
             boolean subscribable = ChannelFactory.isGloballySubscribable(usr.getOrg(),
                     chan);
             if (NOT_GLOBAL_SUBSCRIBE.equals(p0)) {
@@ -154,7 +154,7 @@ public class ChannelAclHandler extends BaseHandler {
         Channel chan = getChannel(usr, ctx);
         if (chan != null) {
             Set<ChannelVersion> vers = ChannelManager.getChannelVersions(chan);
-            return (vers != null && vers.contains(ChannelVersion.RHEL5));
+            return vers != null && vers.contains(ChannelVersion.RHEL5);
         }
         return false;
 

--- a/java/code/src/com/redhat/rhn/common/security/acl/ConfigAclHandler.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/ConfigAclHandler.java
@@ -121,7 +121,7 @@ public class ConfigAclHandler extends BaseHandler {
         //somewhat slow because it loads up every file instead of justing
         //finding one and then bailing.
         ConfigChannel cc = getChannel(ctx, params);
-        return (!cc.getConfigFiles().isEmpty());
+        return !cc.getConfigFiles().isEmpty();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/security/acl/SystemAclHandler.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/SystemAclHandler.java
@@ -87,7 +87,7 @@ public class SystemAclHandler extends BaseHandler {
         queryParams.put("label", label);
         queryParams.put("sid", sid);
         DataResult<Row> dr = m.execute(queryParams);
-        return (!dr.isEmpty());
+        return !dr.isEmpty();
     }
 
     /**
@@ -103,7 +103,7 @@ public class SystemAclHandler extends BaseHandler {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("sid", sid);
         DataResult<Row> dr = m.execute(queryParams);
-        return (!dr.isEmpty());
+        return !dr.isEmpty();
     }
 
     /**
@@ -119,7 +119,7 @@ public class SystemAclHandler extends BaseHandler {
         Map<String, Object> queryParams = new HashMap<>();
         queryParams.put("sid", sid);
         DataResult<Row> dr = m.execute(queryParams);
-        return (!dr.isEmpty());
+        return !dr.isEmpty();
     }
 
     /**
@@ -130,7 +130,7 @@ public class SystemAclHandler extends BaseHandler {
      */
     public boolean aclSystemKickstartSessionExists(Map<String, Object> ctx, String[] params) {
         Long sid = getAsLong(ctx.get("sid"));
-        return (KickstartFactory.lookupKickstartSessionByServer(sid) != null);
+        return KickstartFactory.lookupKickstartSessionByServer(sid) != null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/translation/Translator.java
+++ b/java/code/src/com/redhat/rhn/common/translation/Translator.java
@@ -50,7 +50,7 @@ public class Translator extends Translations {
      * @return Returns the string representation of i
      */
     public static String int2String(Integer i) {
-        return (i == null) ? "" : i.toString();
+        return i == null ? "" : i.toString();
     }
 
     /**
@@ -72,7 +72,7 @@ public class Translator extends Translations {
      * @return Returns the boolean representation of i
      */
     public static boolean int2Boolean(Integer i) {
-        return (i != null) && i.equals(1);
+        return i != null && i.equals(1);
     }
 
     /**
@@ -81,7 +81,7 @@ public class Translator extends Translations {
      * @return Returns the boolean representation of i
      */
     public static boolean long2Boolean(Long i) {
-        return (i != null) && i == 1;
+        return i != null && i == 1;
     }
 
     /** Convert from Integer to User
@@ -97,7 +97,7 @@ public class Translator extends Translations {
      * @return The resulting long
      */
     public static long long2Objlong(Long l) {
-        return (l == null) ? 0 : l;
+        return l == null ? 0 : l;
     }
 
     /**
@@ -106,7 +106,7 @@ public class Translator extends Translations {
      * @return Integer version of the Long.
      */
     public static Integer long2Integer(Long l) {
-        return (l == null) ? null : l.intValue();
+        return l == null ? null : l.intValue();
     }
 
     /**
@@ -115,7 +115,7 @@ public class Translator extends Translations {
      * @return int version of the Long.
      */
     public static int long2Int(Long l) {
-        return (l == null) ? 0 : l.intValue();
+        return l == null ? 0 : l.intValue();
     }
 
     /** Convert from BigDecimal to int
@@ -123,7 +123,7 @@ public class Translator extends Translations {
      * @return The resulting int
      */
     public static int bigDecimal2Int(BigDecimal bd) {
-        return (bd == null) ? 0 : bd.intValue();
+        return bd == null ? 0 : bd.intValue();
     }
 
     /** Convert from BigDecimal to Integer
@@ -131,7 +131,7 @@ public class Translator extends Translations {
      * @return The resulting Integer
      */
     public static Integer bigDecimal2IntObject(BigDecimal bd) {
-        return (bd == null) ? Integer.valueOf(0) : Integer.valueOf(bd.intValue());
+        return bd == null ? Integer.valueOf(0) : Integer.valueOf(bd.intValue());
     }
 
     /** Convert from BigDecimal to long
@@ -139,7 +139,7 @@ public class Translator extends Translations {
      * @return The resulting long
      */
     public static long bigDecimal2Long(BigDecimal bd) {
-        return (bd == null) ? 0 : bd.longValue();
+        return bd == null ? 0 : bd.longValue();
     }
 
     /**
@@ -148,7 +148,7 @@ public class Translator extends Translations {
      * @return The resulting Long
      */
     public static Long bigDecimal2LongObj(BigDecimal bd) {
-        return (bd == null) ? null : bd.longValue();
+        return bd == null ? null : bd.longValue();
     }
 
     /**
@@ -173,7 +173,7 @@ public class Translator extends Translations {
      * @return The resulting string.
      */
     public static String double2String(Double d) {
-        return (d == null) ? "0" : d.toString();
+        return d == null ? "0" : d.toString();
     }
 
     /**
@@ -182,7 +182,7 @@ public class Translator extends Translations {
      * @return List.toString()
      */
     public static String list2String(List<Object> l) {
-        return (l == null) ? "" : l.toString();
+        return l == null ? "" : l.toString();
     }
 
     /**
@@ -191,7 +191,7 @@ public class Translator extends Translations {
      * @return map.toString()
      */
     public static String map2String(Map<?, ?> m) {
-        return (m == null) ? "" : m.toString();
+        return m == null ? "" : m.toString();
     }
 
     /**
@@ -200,7 +200,7 @@ public class Translator extends Translations {
      * @return The resulting string.
      */
     public static String boolean2String(Boolean b) {
-        return (b == null) ? Boolean.FALSE.toString() : b.toString();
+        return b == null ? Boolean.FALSE.toString() : b.toString();
     }
 
     /**
@@ -210,7 +210,7 @@ public class Translator extends Translations {
      * @return Resulting string
      */
     public static String date2String(Date d) {
-        return (d == null) ? "" : d.toString();
+        return d == null ? "" : d.toString();
     }
 
     /**
@@ -219,6 +219,6 @@ public class Translator extends Translations {
      * @return a boolean primitive
      */
     public static boolean boolean2boolean(Boolean b) {
-        return (b != null) && b;
+        return b != null && b;
     }
 }

--- a/java/code/src/com/redhat/rhn/common/util/CryptHelper.java
+++ b/java/code/src/com/redhat/rhn/common/util/CryptHelper.java
@@ -90,7 +90,7 @@ public class CryptHelper {
         StringBuilder out = new StringBuilder();
 
         while (length > 0) {
-            out.append(b64t.substring((value & 0x3f), (value & 0x3f) + 1));
+            out.append(b64t.substring(value & 0x3f, (value & 0x3f) + 1));
             --length;
             value >>= 6;
         }

--- a/java/code/src/com/redhat/rhn/common/util/DatePicker.java
+++ b/java/code/src/com/redhat/rhn/common/util/DatePicker.java
@@ -584,7 +584,7 @@ public class DatePicker {
             (SimpleDateFormat) DateFormat.getDateTimeInstance(DateFormat.SHORT,
                     DateFormat.SHORT, locale);
         String pattern = sdf.toPattern();
-        isLatin = (pattern.indexOf('a') >= 0);
+        isLatin = pattern.indexOf('a') >= 0;
         // HACK: check whether month or date comes first
         isDayBeforeMonth = pattern.indexOf('d') < pattern.indexOf('M');
     }

--- a/java/code/src/com/redhat/rhn/common/util/DebVersionComparator.java
+++ b/java/code/src/com/redhat/rhn/common/util/DebVersionComparator.java
@@ -112,7 +112,7 @@ public class DebVersionComparator implements Comparator<String> {
         while (i < a.length || j < b.length) {
             int firstDiff = 0;
 
-            while ((i < a.length && !Character.isDigit(a[i])) || (j < b.length && !Character.isDigit(b[j]))) {
+            while (i < a.length && !Character.isDigit(a[i]) || j < b.length && !Character.isDigit(b[j])) {
                 int ac = i >= a.length ? 0 : order(a[i]);
                 int bc = j >= b.length ? 0 : order(b[j]);
 
@@ -129,7 +129,7 @@ public class DebVersionComparator implements Comparator<String> {
             while (j < b.length && b[j] == '0') {
                 j++;
             }
-            while (i < a.length && j < b.length && Character.isDigit(a[i]) && Character.isDigit((b[j]))) {
+            while (i < a.length && j < b.length && Character.isDigit(a[i]) && Character.isDigit(b[j])) {
                 if (firstDiff == 0) {
                     firstDiff = a[i] - b[j];
                 }

--- a/java/code/src/com/redhat/rhn/common/util/MethodUtil.java
+++ b/java/code/src/com/redhat/rhn/common/util/MethodUtil.java
@@ -145,7 +145,7 @@ public class MethodUtil {
                     Object curr = params[j];
                     if (log.isDebugEnabled()) {
                         log.debug("Trying to translate from: {} to: {} isInstance: {}",
-                                (curr == null) ? null : curr.getClass(), types[j], types[j].isInstance(curr));
+                                curr == null ? null : curr.getClass(), types[j], types[j].isInstance(curr));
                     }
                     if (curr != null && curr.getClass().isPrimitive() &&
                             types[j].isPrimitive()) {
@@ -154,7 +154,7 @@ public class MethodUtil {
                         }
                         converted[j] = curr;
                     }
-                    if ((curr == null && !types[j].isPrimitive()) ||
+                    if (curr == null && !types[j].isPrimitive() ||
                             types[j].isInstance(curr)) {
                         if (log.isDebugEnabled()) {
                             log.debug("same type");
@@ -187,8 +187,8 @@ public class MethodUtil {
                            " in class: " + o.getClass().getName() + " with params: [";
             for (int i = 0; i < params.length; i++) {
                 if (params[i] != null) {
-                    message = message + ("type: " + params[i].getClass().getName() +
-                              ", value: " + params[i]);
+                    message = message + "type: " + params[i].getClass().getName() +
+                            ", value: " + params[i];
                     if (i < params.length - 1) {
                         message = message + ", ";
                     }

--- a/java/code/src/com/redhat/rhn/common/util/RpmVersionComparator.java
+++ b/java/code/src/com/redhat/rhn/common/util/RpmVersionComparator.java
@@ -114,7 +114,7 @@ public class RpmVersionComparator implements Comparator<String> {
                 return -1;  /* arbitrary */
             }
             if (b2 == e2) {
-                return (isnum ? 1 : -1);
+                return isnum ? 1 : -1;
             }
 
             if (isnum) {
@@ -138,7 +138,7 @@ public class RpmVersionComparator implements Comparator<String> {
             String seg2 = str2.substring(b2, e2);
             int rc = seg1.compareTo(seg2);
             if (rc != 0) {
-                return  (rc < 0) ? -1 : 1;
+                return  rc < 0 ? -1 : 1;
             }
             //  Reinitilize
             b1 = e1;
@@ -200,6 +200,6 @@ public class RpmVersionComparator implements Comparator<String> {
     }
 
     private char xchar(String s, int i) {
-        return (i < s.length() ? s.charAt(i) : '\0');
+        return i < s.length() ? s.charAt(i) : '\0';
     }
 }

--- a/java/code/src/com/redhat/rhn/common/util/StringUtil.java
+++ b/java/code/src/com/redhat/rhn/common/util/StringUtil.java
@@ -409,20 +409,20 @@ public class StringUtil {
         endChars.add('.');
         endChars.add(',');
 
-        if (space == -1 || (space > line && line != -1)) {
+        if (space == -1 || space > line && line != -1) {
             end = line;
         }
         else {
             end = space;
         }
 
-        if (end == -1 || (end > tag && tag != -1)) {
+        if (end == -1 || end > tag && tag != -1) {
             end = tag;
         }
 
         // dot before the end
-        if (end > 0 && (endChars.contains(
-                entireToken.charAt(end - 1)))) {
+        if (end > 0 && endChars.contains(
+                entireToken.charAt(end - 1))) {
             end--;
         }
         // dot at the end
@@ -460,13 +460,13 @@ public class StringUtil {
         LocalizationService ls = LocalizationService.getInstance();
         String number = null;
         String type = null;
-        if (bytes >= (1024 * 1024)) { // show in megabytes (with two decimals)
+        if (bytes >= 1024 * 1024) { // show in megabytes (with two decimals)
             number = ls.formatNumber(bytes / (1024.0 * 1024),
-                    (wholeNum ? 0 : 2));
+                    wholeNum ? 0 : 2);
             type = "mb";
         }
         else if (bytes >= 1024) { // show in kilobytes (with one decimal)
-            number = ls.formatNumber(bytes / 1024.0, (wholeNum ? 0 : 1));
+            number = ls.formatNumber(bytes / 1024.0, wholeNum ? 0 : 1);
             type = "kb";
         }
         else { // show in bytes (with no decimals)
@@ -512,7 +512,7 @@ public class StringUtil {
     public static String categorizeTime(long target, int maxUnit, int minUnit) {
         checkUnits(maxUnit, minUnit);
         long now = System.currentTimeMillis();
-        long elapsedTime = (now > target ? (now - target) : (target - now));
+        long elapsedTime = now > target ? now - target : target - now;
 
         // Start by filling an array with the number of "whole units"
         // for each of the units requested, from max to min.
@@ -524,7 +524,7 @@ public class StringUtil {
                 unitValues[currUnit] = elapsedTime / MILLIS_PER_UNIT[currUnit];
             }
             else {
-                elapsedTime -= (unitValues[currUnit + 1] * MILLIS_PER_UNIT[currUnit + 1]);
+                elapsedTime -= unitValues[currUnit + 1] * MILLIS_PER_UNIT[currUnit + 1];
                 unitValues[currUnit] = elapsedTime / MILLIS_PER_UNIT[currUnit];
             }
         }
@@ -565,7 +565,7 @@ public class StringUtil {
         long valInMaxUnits;
 
         long now = System.currentTimeMillis();
-        long elapsedTime = (now > target ? (now - target) : (target - now));
+        long elapsedTime = now > target ? now - target : target - now;
         int theUnit = findMaximumUnitFor(elapsedTime, maxUnit);
 
         // maxUnit is now one of entered-value,
@@ -578,8 +578,8 @@ public class StringUtil {
         // If the remainder > half a unit, round up.
         // Note: we don't round seconds
         if (theUnit != SECONDS_UNITS &&
-                remainder >= (MILLIS_PER_UNIT[theUnit - 1] *
-                        (UNITS_PER_NEXT[theUnit - 1] / 2))) {
+                remainder >= MILLIS_PER_UNIT[theUnit - 1] *
+                        (UNITS_PER_NEXT[theUnit - 1] / 2)) {
             valInMaxUnits++;
         }
 
@@ -663,7 +663,7 @@ public class StringUtil {
      * other kinds of non-Linux EOLs, so we can use it on uploaded files as well
      */
     public static String webToLinux(String inWebStr) {
-        return (inWebStr == null ? null : inWebStr.replace("\r\n", "\n"));
+        return inWebStr == null ? null : inWebStr.replace("\r\n", "\n");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/util/TimeUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/TimeUtils.java
@@ -34,7 +34,7 @@ public class TimeUtils {
      * @return the current system time in seconds.
      */
     public static long currentTimeSeconds() {
-        return (System.currentTimeMillis() / 1000);
+        return System.currentTimeMillis() / 1000;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/util/test/StringUtilTest.java
+++ b/java/code/src/com/redhat/rhn/common/util/test/StringUtilTest.java
@@ -194,10 +194,10 @@ public class StringUtilTest  {
 
     @Test
     public void testCategorizeTime3() {
-        long oneWeek = (1000 * 60 * 60 * 24 * 7);
-        long oneDay = (1000 * 60 * 60 * 24);
-        long oneHour = (1000 * 60 * 60);
-        long oneMinute = (1000 * 60);
+        long oneWeek = 1000 * 60 * 60 * 24 * 7;
+        long oneDay = 1000 * 60 * 60 * 24;
+        long oneHour = 1000 * 60 * 60;
+        long oneMinute = 1000 * 60;
 
         // The tests want to know an exact string.
         // If the system we're running on is slow enough, there may (or may not!) be
@@ -231,7 +231,7 @@ public class StringUtilTest  {
         result = StringUtil.categorizeTime(testDate, maxUnit, minUnit);
         assertEquals("47 hours 1 minute ago", result);
         // 600 minutes ago
-        testDate = System.currentTimeMillis() - (600 * oneMinute);
+        testDate = System.currentTimeMillis() - 600 * oneMinute;
         maxUnit = StringUtil.MINUTES_UNITS;
         minUnit = StringUtil.MINUTES_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit, minUnit);
@@ -245,31 +245,31 @@ public class StringUtilTest  {
 
         // 5 weeks 5 days 5 hours and 5 minutes from now
         testDate = System.currentTimeMillis() +
-            (5 * oneWeek + 5 * oneDay + 5 * oneHour + 5 * oneMinute + slop);
+                5 * oneWeek + 5 * oneDay + 5 * oneHour + 5 * oneMinute + slop;
         maxUnit = StringUtil.WEEKS_UNITS;
         minUnit = StringUtil.MINUTES_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit, minUnit);
         assertEquals("5 weeks 5 days 5 hours 5 minutes from now", result);
         // 0 weeks 0 days 1 hour from now
-        testDate = System.currentTimeMillis() + (oneHour + slop);
+        testDate = System.currentTimeMillis() + oneHour + slop;
         maxUnit = StringUtil.WEEKS_UNITS;
         minUnit = StringUtil.HOURS_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit, minUnit);
         assertEquals("0 weeks 0 days 1 hour from now", result);
          // 25 days 5 hours from now
-        testDate = System.currentTimeMillis() + (25 * oneDay + 5 * oneHour + slop);
+        testDate = System.currentTimeMillis() + 25 * oneDay + 5 * oneHour + slop;
         maxUnit = StringUtil.DAYS_UNITS;
         minUnit = StringUtil.HOURS_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit, minUnit);
         assertEquals("25 days 5 hours from now", result);
         // 47 hours and 1 minute from now
-        testDate = System.currentTimeMillis() + (47 * oneHour + oneMinute + slop);
+        testDate = System.currentTimeMillis() + 47 * oneHour + oneMinute + slop;
         maxUnit = StringUtil.HOURS_UNITS;
         minUnit = StringUtil.MINUTES_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit, minUnit);
         assertEquals("47 hours 1 minute from now", result);
         // 600 minutes from now
-        testDate = System.currentTimeMillis() + (600 * oneMinute + slop);
+        testDate = System.currentTimeMillis() + 600 * oneMinute + slop;
         maxUnit = StringUtil.MINUTES_UNITS;
         minUnit = StringUtil.MINUTES_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit, minUnit);
@@ -278,10 +278,10 @@ public class StringUtilTest  {
 
     @Test
     public void testCategorizeTime2() {
-        long oneWeek = (1000 * 60 * 60 * 24 * 7);
-        long oneDay = (1000 * 60 * 60 * 24);
-        long oneHour = (1000 * 60 * 60);
-        long oneMinute = (1000 * 60);
+        long oneWeek = 1000 * 60 * 60 * 24 * 7;
+        long oneDay = 1000 * 60 * 60 * 24;
+        long oneHour = 1000 * 60 * 60;
+        long oneMinute = 1000 * 60;
 
         long testDate;
         int maxUnit;
@@ -296,7 +296,7 @@ public class StringUtilTest  {
         assertEquals("6 weeks ago", result);
 
         // 10 sec ago
-        testDate = System.currentTimeMillis() - (20 * 1000);
+        testDate = System.currentTimeMillis() - 20 * 1000;
         maxUnit = StringUtil.WEEKS_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit);
         assertEquals("20 seconds ago", result);
@@ -320,7 +320,7 @@ public class StringUtilTest  {
         assertEquals("47 hours ago", result);
 
         // 600 minutes ago
-        testDate = System.currentTimeMillis() - (600 * oneMinute);
+        testDate = System.currentTimeMillis() - 600 * oneMinute;
         maxUnit = StringUtil.MINUTES_UNITS;
         result = StringUtil.categorizeTime(testDate, maxUnit);
         assertEquals("600 minutes ago", result);
@@ -334,7 +334,7 @@ public class StringUtilTest  {
 
     @Test
     public void testCategorizeTimeWeekAndYear() {
-        long oneDay = (1000 * 60 * 60 * 24);
+        long oneDay = 1000 * 60 * 60 * 24;
         long oneWeek = oneDay * 7;
         long oneMonth = oneWeek * 4;
         long oneYear = oneMonth * 12;

--- a/java/code/src/com/redhat/rhn/common/util/test/TimeUtilsTest.java
+++ b/java/code/src/com/redhat/rhn/common/util/test/TimeUtilsTest.java
@@ -27,7 +27,7 @@ public class TimeUtilsTest  {
 
     @Test
     public void testCurrentTimeSeconds() {
-        assertTrue(timeEquals((System.currentTimeMillis() / 1000),
+        assertTrue(timeEquals(System.currentTimeMillis() / 1000,
                      TimeUtils.currentTimeSeconds()));
     }
 
@@ -41,6 +41,6 @@ public class TimeUtilsTest  {
      */
     public static boolean timeEquals(long timeOne, long timeTwo) {
         //how about within two units of time
-        return (timeTwo > (timeOne - 2) && timeTwo < (timeOne + 2));
+        return timeTwo > timeOne - 2 && timeTwo < timeOne + 2;
     }
 }

--- a/java/code/src/com/redhat/rhn/common/validator/RequiredIfConstraint.java
+++ b/java/code/src/com/redhat/rhn/common/validator/RequiredIfConstraint.java
@@ -88,8 +88,8 @@ public class RequiredIfConstraint extends ParsedConstraint {
                  */
                 // required tag doesn't contain a value
                 if ((fieldValue == null || fieldValue.isEmpty()) &&
-                            // but something is in the required field
-                            (requiredIfValue != null && !requiredIfValue.isEmpty())) {
+                        // but something is in the required field
+                        requiredIfValue != null && !requiredIfValue.isEmpty()) {
                     required = true; // set this required = true
                 }
                 else if (requiredIfValue.equals(fieldValue)) {

--- a/java/code/src/com/redhat/rhn/common/validator/StringConstraint.java
+++ b/java/code/src/com/redhat/rhn/common/validator/StringConstraint.java
@@ -89,7 +89,7 @@ public class StringConstraint extends RequiredIfConstraint {
         // Validate String length
         if (hasMaxLength()) {
             LOG.debug("HasMaxlength ..");
-            if (!(lengthLessThan(strValue, getMaxLength()))) {
+            if (!lengthLessThan(strValue, getMaxLength())) {
                 LOG.debug("Above max length: {} data: {}max length: {}", strValue.length(), strValue, getMaxLength());
                 Object[] args = new Object[2];
                 args[0] = localizedIdentifier;
@@ -105,7 +105,7 @@ public class StringConstraint extends RequiredIfConstraint {
                 args[0] = localizedIdentifier;
                 return new ValidatorError("errors.required", args);
             }
-            if (!(lengthGreaterThan(strValue, getMinLength()))) {
+            if (!lengthGreaterThan(strValue, getMinLength())) {
                 LOG.debug("Below min length: {} data: {}", strValue.length(), strValue);
                 Object[] args = new Object[2];
                 args[0] = localizedIdentifier;

--- a/java/code/src/com/redhat/rhn/common/validator/Validator.java
+++ b/java/code/src/com/redhat/rhn/common/validator/Validator.java
@@ -134,7 +134,7 @@ public class Validator {
             throw new ValidatorException(errorMessage, e);
         }
         // TODO: Get rid of the toString and determine the type
-        String data = (value == null) ? null : value.toString();
+        String data = value == null ? null : value.toString();
 
         ValidatorError validationMessage;
 
@@ -142,7 +142,7 @@ public class Validator {
         log.debug("Constraint: {}", constraint);
 
         boolean required = !constraint.getOptional() ||
-                (value != null && !value.equals(""));
+                value != null && !value.equals("");
         if (required) {
             boolean checkConstraint = true;
             if (constraint instanceof RequiredIfConstraint reqIfConst) {
@@ -194,7 +194,7 @@ public class Validator {
         String identifier =
             LocalizationService.getInstance().getMessage(constraint.getIdentifier());
 
-        if ((dataType.equals("int")) || (dataType.equals("java.lang.Integer"))) {
+        if (dataType.equals("int") || dataType.equals("java.lang.Integer")) {
             try {
                 Integer.parseInt(data);
             }
@@ -228,7 +228,7 @@ public class Validator {
                 }
             }
         }
-        else if ((dataType.equals("float")) || (dataType.equals("java.lang.Float"))) {
+        else if (dataType.equals("float") || dataType.equals("java.lang.Float")) {
             try {
                 Float.parseFloat(data);
             }
@@ -244,7 +244,7 @@ public class Validator {
                 }
             }
         }
-        else if ((dataType.equals("double")) || (dataType.equals("java.lang.Double"))) {
+        else if (dataType.equals("double") || dataType.equals("java.lang.Double")) {
             try {
                 Double.parseDouble(data);
             }
@@ -263,8 +263,8 @@ public class Validator {
         }
 
         else if (dataType.equals("java.lang.Boolean") &&
-                !((data.equalsIgnoreCase("true")) || (data.equalsIgnoreCase("false")) ||
-                (data.equalsIgnoreCase("yes")) || (data.equalsIgnoreCase("no")))) {
+                !(data.equalsIgnoreCase("true") || data.equalsIgnoreCase("false") ||
+                        data.equalsIgnoreCase("yes") || data.equalsIgnoreCase("no"))) {
                 validationMessage = new ValidatorError("errors.invalid", identifier);
             }
 

--- a/java/code/src/com/redhat/rhn/domain/action/ActionChainFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChainFactory.java
@@ -385,9 +385,9 @@ public class ActionChainFactory extends HibernateFactory {
      * @return if the action chains contains any minion
      */
     public static boolean isActionChainTargettingMinions(final ActionChain actionChain) {
-        return ((Long)singleton.lookupObjectByNamedQuery("ActionChain.countMinionsInActionChain",
+        return (Long)singleton.lookupObjectByNamedQuery("ActionChain.countMinionsInActionChain",
             Map.of("actionchain_id", actionChain.getId())
-        ) > 0);
+        ) > 0;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -302,7 +302,7 @@ public class ActionFactory extends HibernateFactory {
         query.setParameter("serverId", serverId);
         query.setParameter("label", "kickstart.initiate");
         List<ServerAction> retval = query.list();
-        return (retval != null && !retval.isEmpty());
+        return retval != null && !retval.isEmpty();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigUploadActionFormatter.java
@@ -74,14 +74,14 @@ public class ConfigUploadActionFormatter extends ActionFormatter {
         HtmlTag strong = new HtmlTag("strong");
         strong.addBody(LocalizationService.getInstance()
                 .getMessage(transKey));
-        return (strong.render() + "<br />");
+        return strong.render() + "<br />";
     }
 
     private String renderFileName(ConfigFileName name) {
         //paths can have pretty much any character including newlines,
         //spaces, and control characters. Escaping html here is only
         //going to work happily for file names that make some kind of sense.
-        return (StringEscapeUtils.escapeHtml4(name.getPath()) + "<br />");
+        return StringEscapeUtils.escapeHtml4(name.getPath()) + "<br />";
     }
 
     private void displayChannels(StringBuilder buffy, Set<ConfigChannelAssociation> channelSet) {

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeChannelTask.java
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeChannelTask.java
@@ -78,8 +78,8 @@ public class DistUpgradeChannelTask extends BaseDomainHelper implements Serializ
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((channel == null) ? 0 : channel.hashCode());
-        result = prime * result + ((details == null) ? 0 : details.hashCode());
+        result = prime * result + (channel == null ? 0 : channel.hashCode());
+        result = prime * result + (details == null ? 0 : details.hashCode());
         result = prime * result + task;
         return result;
     }

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageActionDetails.java
@@ -166,10 +166,10 @@ public class PackageActionDetails extends ActionChild {
         if (!(other instanceof PackageActionDetails castOther)) {
             return false;
         }
-        return new EqualsBuilder().append((getParentAction() == null ? null :
-                                       getParentAction().getId()),
-                                       (castOther.getParentAction() == null ? null :
-                                       castOther.getParentAction().getId()))
+        return new EqualsBuilder().append(getParentAction() == null ? null :
+                                       getParentAction().getId(),
+                        castOther.getParentAction() == null ? null :
+                        castOther.getParentAction().getId())
                                   .append(packageId, castOther.getPackageId())
                                   .append(parameter, castOther.getParameter())
                                   .append(packageName, castOther.getPackageName())
@@ -182,8 +182,8 @@ public class PackageActionDetails extends ActionChild {
     @Override
     public int hashCode() {
         int result = 37 * (getParentAction() == null ? 0 :
-                          (getParentAction().getId() == null ? 0 :
-                           getParentAction().getId().intValue()));
+                getParentAction().getId() == null ? 0 :
+                 getParentAction().getId().intValue());
         result += 37 * (packageId == null ? 0 : packageId.intValue());
         result += 37 * (parameter == null ? 0 : parameter.hashCode());
         result += 37 * (packageName == null ? 0 : packageName.hashCode());

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionDetailsTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionDetailsTest.java
@@ -166,9 +166,9 @@ public class PackageActionDetailsTest extends RhnBaseTestCase {
         pad.setParameter("upgrade");
         Long testid = 100L;
 
-        pad.setArch((HibernateFactory.getSession().createNativeQuery("""
+        pad.setArch(HibernateFactory.getSession().createNativeQuery("""
                 SELECT p.* from rhnPackageArch as p WHERE p.id = :id
-                """, PackageArch.class).setParameter("id", testid).getSingleResult()));
+                """, PackageArch.class).setParameter("id", testid).getSingleResult());
         pad.setPackageName(PackageNameTest.createTestPackageName());
 
         ((PackageAction) parent).addDetail(pad);

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -653,7 +653,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @return true if this channel is considered a base channel.
      */
     public boolean isBaseChannel() {
-        return (getParentChannel() == null);
+        return getParentChannel() == null;
     }
 
     /**
@@ -901,7 +901,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      */
     public String getChecksumTypeLabel() {
 
-        if ((checksumType == null) || (checksumType.getLabel() == null)) {
+        if (checksumType == null || checksumType.getLabel() == null) {
             // each channel shall have set checksumType
             return null;
         }

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -702,7 +702,7 @@ public class ChannelFactory extends HibernateFactory {
             return false;
         }
         Object o = singleton.lookupObjectByNamedQuery("Channel.verifyLabel", Map.of(LABEL, label), false);
-        return (o != null);
+        return o != null;
     }
 
     /**
@@ -716,7 +716,7 @@ public class ChannelFactory extends HibernateFactory {
             return false;
         }
         Object o = singleton.lookupObjectByNamedQuery("Channel.verifyName", Map.of("name", name), false);
-        return (o != null);
+        return o != null;
     }
 
     /**
@@ -1572,11 +1572,11 @@ public class ChannelFactory extends HibernateFactory {
             channelInfo.setPeripheralOrgId(peripheralOrgId);
         }
 
-        String parentChannelLabel = (null == channel.getParentChannel()) ? null :
+        String parentChannelLabel = null == channel.getParentChannel() ? null :
                 channel.getParentChannel().getLabel();
         channelInfo.setParentChannelLabel(parentChannelLabel);
 
-        String channelArchLabel = (null == channel.getChannelArch()) ? null :
+        String channelArchLabel = null == channel.getChannelArch() ? null :
                 channel.getChannelArch().getLabel();
         channelInfo.setChannelArchLabel(channelArchLabel);
 
@@ -1585,7 +1585,7 @@ public class ChannelFactory extends HibernateFactory {
         channelInfo.setSummary(channel.getSummary());
         channelInfo.setDescription(channel.getDescription());
 
-        String productNameLabel = (null == channel.getProductName()) ? null :
+        String productNameLabel = null == channel.getProductName() ? null :
                 channel.getProductName().getLabel();
         channelInfo.setProductNameLabel(productNameLabel);
 
@@ -1597,10 +1597,10 @@ public class ChannelFactory extends HibernateFactory {
         channelInfo.setEndOfLifeDate(channel.getEndOfLife());
         channelInfo.setChecksumTypeLabel(channel.getChecksumTypeLabel());
 
-        String channelProductProduct = (null == channel.getProduct()) ? null :
+        String channelProductProduct = null == channel.getProduct() ? null :
                 channel.getProduct().getProduct();
         channelInfo.setChannelProductProduct(channelProductProduct);
-        String channelProductVersion = (null == channel.getProduct()) ? null :
+        String channelProductVersion = null == channel.getProduct() ? null :
                 channel.getProduct().getVersion();
         channelInfo.setChannelProductVersion(channelProductVersion);
 
@@ -1839,7 +1839,7 @@ public class ChannelFactory extends HibernateFactory {
         Org org = null;
         if (null != modifyChannelInfo.getPeripheralOrgId()) {
             org = OrgFactory.lookupById(modifyChannelInfo.getPeripheralOrgId());
-            if ((null != modifyChannelInfo.getPeripheralOrgId()) && (null == org)) {
+            if (null != modifyChannelInfo.getPeripheralOrgId() && null == org) {
                 throw new IllegalArgumentException("No org id to modify [" +
                         modifyChannelInfo.getPeripheralOrgId() +
                         "] for channel [" + modifyChannelInfo.getLabel() + "]");
@@ -1885,8 +1885,8 @@ public class ChannelFactory extends HibernateFactory {
         setValueIfNotNull(channel, modifyChannelInfo.getGpgKeyFp(), Channel::setGPGKeyFp);
         setValueIfNotNull(channel, modifyChannelInfo.getEndOfLifeDate(), Channel::setEndOfLife);
 
-        if ((null != modifyChannelInfo.getChannelProductProduct()) &&
-                (null != modifyChannelInfo.getChannelProductVersion())) {
+        if (null != modifyChannelInfo.getChannelProductProduct() &&
+                null != modifyChannelInfo.getChannelProductVersion()) {
             channel.setProduct(MgrSyncUtils.findOrCreateChannelProduct(
                     modifyChannelInfo.getChannelProductProduct(),
                     modifyChannelInfo.getChannelProductVersion()));

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelVersion.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelVersion.java
@@ -114,8 +114,8 @@ public class ChannelVersion {
     public static ChannelVersion getChannelVersionForDistChannelMap(
             DistChannelMap dcm) {
         if (DIST_CHANNEL_MAP_TO_CHANNEL_VERSION.containsKey(dcm.getRelease())) {
-            return (DIST_CHANNEL_MAP_TO_CHANNEL_VERSION.get(
-                    dcm.getRelease()));
+            return DIST_CHANNEL_MAP_TO_CHANNEL_VERSION.get(
+                    dcm.getRelease());
         }
         return ChannelVersion.LEGACY;
     }

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigRevision.java
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigRevision.java
@@ -177,7 +177,7 @@ public class ConfigRevision extends BaseDomainHelper {
      * @return true if file-type is 'file'
      */
     public boolean isFile() {
-        return (configFileType != null && configFileType.getLabel().equals("file"));
+        return configFileType != null && configFileType.getLabel().equals("file");
     }
 
     /**
@@ -185,7 +185,7 @@ public class ConfigRevision extends BaseDomainHelper {
      * @return true if file-type is 'sls'
      */
     public boolean isSls() {
-        return (configFileType != null && configFileType.getLabel().equals("sls"));
+        return configFileType != null && configFileType.getLabel().equals("sls");
     }
 
     /**
@@ -201,7 +201,7 @@ public class ConfigRevision extends BaseDomainHelper {
      * @return true if file-type is 'directory'
      */
     public boolean isDirectory() {
-        return (configFileType != null && configFileType.getLabel().equals("directory"));
+        return configFileType != null && configFileType.getLabel().equals("directory");
     }
 
     /**
@@ -209,7 +209,7 @@ public class ConfigRevision extends BaseDomainHelper {
      * @return true if file-type is 'symlink'
      */
     public boolean isSymlink() {
-        return (configFileType != null && configFileType.getLabel().equals("symlink"));
+        return configFileType != null && configFileType.getLabel().equals("symlink");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/config/ConfigurationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/config/ConfigurationFactory.java
@@ -613,7 +613,7 @@ public class ConfigurationFactory extends HibernateFactory {
         inParams.put("username_in", user);
         inParams.put("groupname_in", group);
         inParams.put("filemode_in", filemode);
-        if ((selinuxCtx == null) || (selinuxCtx.isEmpty())) {
+        if (selinuxCtx == null || selinuxCtx.isEmpty()) {
             inParams.put("selinuxCtx_in", null);
         }
         else {
@@ -922,7 +922,7 @@ public class ConfigurationFactory extends HibernateFactory {
             // mark and reset stream, so that stream can be re-read later
             stream.mark(size.intValue());
             do {
-                read = stream.read(foo, offset, (foo.length - offset));
+                read = stream.read(foo, offset, foo.length - offset);
                 offset += read;
             } while (read > 0 && offset < foo.length);
             stream.reset();
@@ -963,7 +963,7 @@ public class ConfigurationFactory extends HibernateFactory {
         if (results == null) {
             return 1L;
         }
-        return ((Long) results.get("revision")) + 1;
+        return (Long) results.get("revision") + 1;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -194,7 +194,7 @@ public class ContentProjectFactory extends HibernateFactory {
         consume(
                 predecessor,
                 () -> insertFirstEnvironment(newEnv),
-                (pred) -> appendEnvironment(newEnv, pred));
+                pred -> appendEnvironment(newEnv, pred));
     }
 
     private static void insertFirstEnvironment(ContentEnvironment newEnv) {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -108,13 +108,13 @@ public class PackageFilter extends ContentFilter<Package> {
         if (field.equals("nevr")) {
             int relIdx = value.lastIndexOf('-');
             int verIdx = value.lastIndexOf('-', relIdx - 1);
-            return (verIdx > 0) && value.substring(0, verIdx).equals(pack.getPackageName().getName());
+            return verIdx > 0 && value.substring(0, verIdx).equals(pack.getPackageName().getName());
         }
         else if (field.equals("nevra")) {
             int relIdx = value.lastIndexOf('-');
             int verIdx = value.lastIndexOf('-', relIdx - 1);
             int archIdx = value.lastIndexOf('.');
-            return (verIdx > 0) && (archIdx > 0) &&
+            return verIdx > 0 && archIdx > 0 &&
                    value.substring(0, verIdx).equals(pack.getPackageName().getName()) &&
                    value.substring(archIdx + 1).equals(pack.getPackageArch().getLabel());
         }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/PeripheralServerEntitlement.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/PeripheralServerEntitlement.java
@@ -60,7 +60,7 @@ public class PeripheralServerEntitlement extends Entitlement {
             return false;
         }
         return super.isAllowedOnServer(server) &&
-                ((server.getBaseEntitlement() instanceof SaltEntitlement) ||
-                 (server.getBaseEntitlement() instanceof ForeignEntitlement));
+                (server.getBaseEntitlement() instanceof SaltEntitlement ||
+                        server.getBaseEntitlement() instanceof ForeignEntitlement);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/ProxyEntitlement.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/ProxyEntitlement.java
@@ -58,8 +58,8 @@ public class ProxyEntitlement extends Entitlement {
     @Override
     public boolean isAllowedOnServer(Server server) {
         return  super.isAllowedOnServer(server) &&
-                ((server.getBaseEntitlement() instanceof SaltEntitlement) ||
-                 (server.getBaseEntitlement() instanceof ForeignEntitlement));
+                (server.getBaseEntitlement() instanceof SaltEntitlement ||
+                        server.getBaseEntitlement() instanceof ForeignEntitlement);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -932,7 +932,7 @@ public class ErrataFactory extends HibernateFactory {
         // only update the cache if exactly one of patches is retracted
         if (previousAdvisoryStatus != cloned.getAdvisoryStatus() &&
                 (previousAdvisoryStatus == RETRACTED || cloned.getAdvisoryStatus() == RETRACTED)) {
-            boolean retract = (cloned.getAdvisoryStatus() == RETRACTED);
+            boolean retract = cloned.getAdvisoryStatus() == RETRACTED;
             cloned.getChannels().forEach(c -> {
                 processRetracted(cloned.getId(), c.getId(), retract);
                 ChannelFactory.refreshNewestPackageCache(c, "sync errata");

--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -452,8 +452,8 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
         Package pkg = clonedErratum.getPackages().iterator().next();
         InstalledPackage installedPackage = PackageTestUtils.createInstalledPackage(pkg);
         PackageEvr evr = pkg.getPackageEvr();
-        installedPackage.setEvr((PackageEvrFactory.lookupOrCreatePackageEvr(
-                evr.getEpoch(), "0.1.0", evr.getRelease(), pkg.getPackageType()))); // older version
+        installedPackage.setEvr(PackageEvrFactory.lookupOrCreatePackageEvr(
+                evr.getEpoch(), "0.1.0", evr.getRelease(), pkg.getPackageType())); // older version
         // assumption
         assertTrue(pkg.getPackageEvr().compareTo(installedPackage.getEvr()) > 0);
         installedPackage.setServer(server);

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -779,7 +779,7 @@ public class FormulaFactory {
                                     .map(Map.class::cast)
                                     .orElseGet(Collections::emptyMap)))
                     .filter(ExporterConfig::isEnabled)
-                    .filter(e -> (proxyEnabled && proxyPort.isPresent()) || (!proxyEnabled && e.getPort().isPresent()))
+                    .filter(e -> proxyEnabled && proxyPort.isPresent() || !proxyEnabled && e.getPort().isPresent())
                     .map(exporterConfig -> new EndpointInfo(
                             formulaData.getSystemID(),
                             exporterConfig.getEndpointNameOrFallback(),

--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfoFactory.java
@@ -100,8 +100,8 @@ public class ImageInfoFactory extends HibernateFactory {
         boolean isDocker = profile.asDockerfileProfile().isPresent();
         boolean isKiwi = profile.asKiwiProfile().isPresent();
 
-        if ((!server.hasContainerBuildHostEntitlement() && isDocker) ||
-                (!server.hasOSImageBuildHostEntitlement() && isKiwi)) {
+        if (!server.hasContainerBuildHostEntitlement() && isDocker ||
+                !server.hasOSImageBuildHostEntitlement() && isKiwi) {
             throw new IllegalArgumentException("Server is not a build host.");
         }
 
@@ -185,8 +185,8 @@ public class ImageInfoFactory extends HibernateFactory {
             throws TaskomaticApiException {
         MinionServer server = image.getBuildServer();
 
-        if ((!server.hasContainerBuildHostEntitlement() && image.getImageType().equals(ImageProfile.TYPE_DOCKERFILE)) ||
-                (!server.hasOSImageBuildHostEntitlement() && image.getImageType().equals(ImageProfile.TYPE_KIWI))) {
+        if (!server.hasContainerBuildHostEntitlement() && image.getImageType().equals(ImageProfile.TYPE_DOCKERFILE) ||
+                !server.hasOSImageBuildHostEntitlement() && image.getImageType().equals(ImageProfile.TYPE_KIWI)) {
             throw new IllegalArgumentException("Server is not a build host.");
         }
 

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -580,7 +580,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
 
         assertFalse(user.getOrg().getPillars().stream()
-              .filter(item -> (category.equals(item.getCategory())))
+              .filter(item -> category.equals(item.getCategory()))
               .findAny().isPresent());
 
     }

--- a/java/code/src/com/redhat/rhn/domain/iss/IssMaster.java
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssMaster.java
@@ -253,7 +253,7 @@ public class IssMaster extends BaseDto {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/iss/IssMasterOrg.java
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssMasterOrg.java
@@ -119,8 +119,8 @@ public class IssMasterOrg extends BaseDto {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((masterOrgId == null) ? 0 : masterOrgId.hashCode());
-        result = prime * result + ((masterOrgName == null) ? 0 : masterOrgName.hashCode());
+        result = prime * result + (masterOrgId == null ? 0 : masterOrgId.hashCode());
+        result = prime * result + (masterOrgName == null ? 0 : masterOrgName.hashCode());
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/iss/IssSlave.java
+++ b/java/code/src/com/redhat/rhn/domain/iss/IssSlave.java
@@ -191,7 +191,7 @@ public class IssSlave extends BaseDto {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.java
@@ -800,7 +800,7 @@ public class KickstartData {
      */
     public boolean isRhel7OrGreater() {
         if (getInstallType() != null) {
-            return (getInstallType().isRhel7OrGreater() || getInstallType().isFedora());
+            return getInstallType().isRhel7OrGreater() || getInstallType().isFedora();
         }
         return false;
     }
@@ -810,7 +810,7 @@ public class KickstartData {
      */
     public boolean isRhel9OrGreater() {
         if (getInstallType() != null) {
-            return (getInstallType().isRhel9OrGreater() || getInstallType().isFedora());
+            return getInstallType().isRhel9OrGreater() || getInstallType().isFedora();
         }
         return false;
     }
@@ -820,8 +820,8 @@ public class KickstartData {
      */
     public boolean isRhel6OrGreater() {
         if (getInstallType() != null) {
-            return (getInstallType().isRhel6OrGreater() ||
-                    getInstallType().isFedora());
+            return getInstallType().isRhel6OrGreater() ||
+                    getInstallType().isFedora();
         }
         return false;
     }
@@ -855,7 +855,7 @@ public class KickstartData {
      */
     public boolean isSLES11OrGreater() {
         if (getInstallType() != null) {
-            return (getInstallType().isSLES11OrGreater());
+            return getInstallType().isSLES11OrGreater();
         }
         return false;
     }
@@ -866,7 +866,7 @@ public class KickstartData {
      */
     public boolean isSLES12OrGreater() {
         if (getInstallType() != null) {
-            return (getInstallType().isSLES12OrGreater());
+            return getInstallType().isSLES12OrGreater();
         }
         return false;
     }
@@ -877,7 +877,7 @@ public class KickstartData {
      */
     public boolean isSLES15OrGreater() {
         if (getInstallType() != null) {
-            return (getInstallType().isSLES15OrGreater());
+            return getInstallType().isSLES15OrGreater();
         }
         return false;
     }

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartInstallType.java
@@ -52,21 +52,21 @@ public class KickstartInstallType extends BaseDomainHelper {
      * @return if this installer type is rhel 9 or greater
      */
     public boolean isRhel9OrGreater() {
-        return (isRhel8OrGreater() && !isRhel8());
+        return isRhel8OrGreater() && !isRhel8();
     }
 
     /**
      * @return if this installer type is rhel 8 or greater
      */
     public boolean isRhel8OrGreater() {
-        return (isRhel7OrGreater() && !isRhel7());
+        return isRhel7OrGreater() && !isRhel7();
     }
 
     /**
      * @return if this installer type is rhel 7 or greater (for rhel8)
      */
     public boolean isRhel7OrGreater() {
-        return (!isRhel6());
+        return !isRhel6();
     }
 
     /**
@@ -172,21 +172,21 @@ public class KickstartInstallType extends BaseDomainHelper {
      * @return if this installer type is SLES 15 or greater (for SLES 15+)
      */
     public boolean isSLES15OrGreater() {
-        return (isSLES12OrGreater() && !isSLES12());
+        return isSLES12OrGreater() && !isSLES12();
     }
 
     /**
      * @return if this installer type is SLES 12 or greater (for SLES 15)
      */
     public boolean isSLES12OrGreater() {
-        return (isSLES11OrGreater() && !isSLES11());
+        return isSLES11OrGreater() && !isSLES11();
     }
 
     /**
      * @return if this installer type is SLES 11 or greater (for SLES 12)
      */
     public boolean isSLES11OrGreater() {
-        return (isSLES10OrGreater() && !isSLES10());
+        return isSLES10OrGreater() && !isSLES10();
     }
 
     /**
@@ -194,7 +194,7 @@ public class KickstartInstallType extends BaseDomainHelper {
      */
     public boolean isSLES10OrGreater() {
         // we need to reverse logic here
-        return (!isRhel() && !isFedora() && !isGeneric() && isSLES());
+        return !isRhel() && !isFedora() && !isGeneric() && isSLES();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartableTree.java
@@ -240,8 +240,8 @@ public class KickstartableTree extends BaseDomainHelper {
      */
     public boolean basePathIsUrl() {
         String defaultLocation = this.getBasePath().toLowerCase();
-        return (defaultLocation.startsWith("http://") ||
-                defaultLocation.startsWith("ftp://"));
+        return defaultLocation.startsWith("http://") ||
+                defaultLocation.startsWith("ftp://");
     }
 
 

--- a/java/code/src/com/redhat/rhn/domain/kickstart/builder/KickstartBuilder.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/builder/KickstartBuilder.java
@@ -235,7 +235,7 @@ public class KickstartBuilder {
         }
 
         // Make sure the first line starts with %packages for sanity:
-        if (!(lines.get(0)).startsWith("%packages")) {
+        if (!lines.get(0).startsWith("%packages")) {
             throw new KickstartParsingException("Packages section didn't start with " +
                     "%packages tag.");
         }
@@ -281,7 +281,7 @@ public class KickstartBuilder {
             return;
         }
 
-        if (!(lines.get(0)).startsWith(prefix)) {
+        if (!lines.get(0).startsWith(prefix)) {
             throw new KickstartParsingException("Pre section didn't start with " +
                     "%pre tag.");
         }

--- a/java/code/src/com/redhat/rhn/domain/kickstart/builder/test/KickstartBuilderTest.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/builder/test/KickstartBuilderTest.java
@@ -87,7 +87,7 @@ public class KickstartBuilderTest extends BaseTestCaseWithUser {
         KickstartParser parser = createKickstartParser("samplekickstart1.ks");
         assertEquals(27, parser.getOptionLines().size());
         assertEquals(102, parser.getPackageLines().size());
-        assertTrue((parser.getPackageLines().get(0)).startsWith("%packages"));
+        assertTrue(parser.getPackageLines().get(0).startsWith("%packages"));
         assertEquals(40, parser.getPreScriptLines().size());
         assertEquals(0, parser.getPostScriptLines().size());
     }

--- a/java/code/src/com/redhat/rhn/domain/org/Org.java
+++ b/java/code/src/com/redhat/rhn/domain/org/Org.java
@@ -506,8 +506,8 @@ public class Org extends BaseDomainHelper implements SaltConfigurable {
             if (!sgt.isBase()) {
                 Entitlement ent = EntitlementManager.getByName(sgt.getLabel());
                 if (ent != null) {
-                    if ((EntitlementManager.OSIMAGE_BUILD_HOST_ENTITLED.equals(ent.getLabel()) &&
-                            !Config.get().getBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED)) ||
+                    if (EntitlementManager.OSIMAGE_BUILD_HOST_ENTITLED.equals(ent.getLabel()) &&
+                            !Config.get().getBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED) ||
                             EntitlementManager.ANSIBLE_MANAGED_ENTITLED.equals(ent.getLabel())) {
                         continue;
                     }
@@ -565,7 +565,7 @@ public class Org extends BaseDomainHelper implements SaltConfigurable {
      * @return default token, null if none exists.
      */
     public Token getToken() {
-        return (regTokenOrgDefault != null) ? regTokenOrgDefault.getToken() : null;
+        return regTokenOrgDefault != null ? regTokenOrgDefault.getToken() : null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupImpl.java
+++ b/java/code/src/com/redhat/rhn/domain/org/usergroup/UserGroupImpl.java
@@ -177,7 +177,7 @@ public class UserGroupImpl extends BaseDomainHelper implements UserGroup {
      */
     @Override
     public boolean isAssociatedRole(Role rin) {
-        return (rin.equals(role));
+        return rin.equals(role);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductUpgrade.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductUpgrade.java
@@ -95,11 +95,11 @@ public class SUSEProductUpgrade extends BaseDomainHelper implements Serializable
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((details == null) ? 0 : details.hashCode());
+        result = prime * result + (details == null ? 0 : details.hashCode());
         result = prime * result +
-                ((fromProduct == null) ? 0 : fromProduct.hashCode());
+                (fromProduct == null ? 0 : fromProduct.hashCode());
         result = prime * result +
-                ((toProduct == null) ? 0 : toProduct.hashCode());
+                (toProduct == null ? 0 : toProduct.hashCode());
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -638,7 +638,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.getChannelTemplates()
         .stream()
         .filter(pr -> pr.getRootProduct().equals(root))
-        .filter(pr -> (mandatory && pr.isMandatory()) || optionalChannelIds.contains(pr.getRepository().getSccId()))
+        .filter(pr -> mandatory && pr.isMandatory() || optionalChannelIds.contains(pr.getRepository().getSccId()))
         .forEach(pr -> {
             try {
                 if (pr.getParentChannelLabel() != null &&

--- a/java/code/src/com/redhat/rhn/domain/recurringactions/OrgRecurringAction.java
+++ b/java/code/src/com/redhat/rhn/domain/recurringactions/OrgRecurringAction.java
@@ -81,7 +81,7 @@ public class OrgRecurringAction extends RecurringAction {
      */
     @Override
     public boolean canAccess(User user) {
-        return (user.hasRole(RoleFactory.ORG_ADMIN) && user.getOrg().equals(getOrg())) ||
+        return user.hasRole(RoleFactory.ORG_ADMIN) && user.getOrg().equals(getOrg()) ||
                 user.hasRole(RoleFactory.SAT_ADMIN);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
+++ b/java/code/src/com/redhat/rhn/domain/server/NetworkInterface.java
@@ -298,7 +298,7 @@ Serializable {
             isPub = isPub && !addr6.getAddress().equals("::1");
         }
 
-        return (isPub && hasAddress);
+        return isPub && hasAddress;
     }
 
     /**
@@ -317,13 +317,12 @@ Serializable {
      * @return true if the nic is a container network
      */
     public boolean isContainerNetwork() {
-        return (
-            "bridge".equals(module) && (
-                    getName().startsWith("docker") ||
-                    getName().startsWith("cni-podman") ||
-                    getName().startsWith("podman") ||
-                    getName().startsWith("cni")
-            ) || getName().startsWith("flannel"));
+        return "bridge".equals(module) && (
+                getName().startsWith("docker") ||
+                getName().startsWith("cni-podman") ||
+                getName().startsWith("podman") ||
+                getName().startsWith("cni")
+        ) || getName().startsWith("flannel");
     }
 
     /**
@@ -331,7 +330,7 @@ Serializable {
      * @return true if the nic is a virtual bridge, false otherwise
      */
     public boolean isVirtBridge() {
-        return ("bridge".equals(module) && getName().startsWith("virbr"));
+        return "bridge".equals(module) && getName().startsWith("virbr");
     }
 
     /**
@@ -416,7 +415,7 @@ Serializable {
         if (addrs == null) {
             addrs = findServerNetAddress6ByScope("host");
         }
-        return ((addrs != null && addrs.iterator().hasNext()) ?
-                addrs.iterator().next() : "::1");
+        return addrs != null && addrs.iterator().hasNext() ?
+                addrs.iterator().next() : "::1";
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -789,7 +789,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * @return contact method label
      */
     public Optional<String> getContactMethodLabel() {
-        String label = (this.contactMethod == null) ? null : this.contactMethod.getLabel();
+        String label = this.contactMethod == null ? null : this.contactMethod.getLabel();
         return Optional.ofNullable(label);
     }
 
@@ -942,7 +942,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
      */
     public Device getDevice(String dev) {
         for (Device d : getDevices()) {
-            if ((d.getDevice() != null) && (d.getDevice().equals(dev))) {
+            if (d.getDevice() != null && d.getDevice().equals(dev)) {
                 return d;
             }
         }
@@ -1182,7 +1182,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * @return Returns the primary hostname for this server
      */
     public String getDecodedHostname() {
-        return (hostname == null) ? null : IDN.toUnicode(hostname);
+        return hostname == null ? null : IDN.toUnicode(hostname);
     }
 
     /**
@@ -1600,7 +1600,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * @return true if the system is a virtual host
      */
     public boolean isVirtualHost() {
-        return (SystemManager.isVirtualHost(getOrg().getId(), getId())) ||
+        return SystemManager.isVirtualHost(getOrg().getId(), getId()) ||
                 hasVirtualizationEntitlement();
     }
 
@@ -1879,11 +1879,11 @@ public class Server extends BaseDomainHelper implements Identifiable {
      */
     public boolean isInactive() {
         Date lastCheckin = this.getLastCheckin();
-        long millisInDay = (1000 * 60 * 60 * 24);
+        long millisInDay = 1000 * 60 * 60 * 24;
         RhnConfigurationFactory factory = RhnConfigurationFactory.getSingleton();
         long threshold = factory.getLongConfiguration(RhnConfiguration.KEYS.SYSTEM_CHECKIN_THRESHOLD).getValue();
         Date yesterday = new Timestamp(System.currentTimeMillis() -
-                (millisInDay * threshold));
+                millisInDay * threshold);
         return lastCheckin.before(yesterday);
     }
 
@@ -2451,8 +2451,8 @@ public class Server extends BaseDomainHelper implements Identifiable {
      * @return <code>true</code> if OS supports CoCo Attestation
      */
     public boolean doesOsSupportCoCoAttestation() {
-        return (isSLES15() && getRelease().equals("15.6")) ||
-            (isLeap15() && getRelease().equals("15.6"));
+        return isSLES15() && getRelease().equals("15.6") ||
+                isLeap15() && getRelease().equals("15.6");
     }
 
     /**
@@ -2699,7 +2699,7 @@ public class Server extends BaseDomainHelper implements Identifiable {
     public boolean isConvertibleToProxy() {
         return !isProxy() && (
                 ConfigDefaults.get().isUyuni() || isSLEMicro5() || isSEMicro6() ||
-                        (isSLES() && (getRelease().equals("15.6") || getRelease().equals("15.7")))
+                        isSLES() && (getRelease().equals("15.6") || getRelease().equals("15.7"))
         );
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -264,8 +264,8 @@ public class ServerFactory extends HibernateFactory {
     public static Map<String, Long> getMinionIdMap(Long id) {
         List<Object[]> result = SINGLETON.listObjectsByNamedQuery("Server.listMinionIdMappings", Map.of("user_id", id));
         return result.stream().collect(toMap(
-                row -> (String)(row[0]),
-                row -> (Long)(row[1]))
+                row -> (String) row[0],
+                row -> (Long) row[1])
         );
     }
 
@@ -1107,7 +1107,7 @@ public class ServerFactory extends HibernateFactory {
 
         List<ServerSnapshot> snaps = null;
 
-        if ((startDate != null) && (endDate != null)) {
+        if (startDate != null && endDate != null) {
             params.put("start_date", startDate);
             params.put("end_date", endDate);
             snaps = SINGLETON.listObjectsByNamedQuery("ServerSnapshot.findBetweenDates", params);
@@ -1166,7 +1166,7 @@ public class ServerFactory extends HibernateFactory {
      */
     public static void deleteSnapshots(Org org, Date startDate, Date endDate) {
 
-        if ((startDate != null) && (endDate != null)) {
+        if (startDate != null && endDate != null) {
             HibernateFactory.getSession()
             .getNamedQuery("ServerSnapshot.deleteBetweenDates")
             .setParameter("org", org)
@@ -1209,7 +1209,7 @@ public class ServerFactory extends HibernateFactory {
     public static void deleteSnapshots(Org org, Server server,
             Date startDate, Date endDate) {
 
-        if ((startDate != null) && (endDate != null)) {
+        if (startDate != null && endDate != null) {
             HibernateFactory.getSession()
             .getNamedQuery("ServerSnapshot.deleteForServerBetweenDates")
             .setParameter("org", org)

--- a/java/code/src/com/redhat/rhn/domain/token/TokenPackageFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/token/TokenPackageFactory.java
@@ -71,7 +71,7 @@ public class TokenPackageFactory extends HibernateFactory {
      * @return list of token packages found
      */
     public static List<TokenPackage> lookupPackages(Token tokenIn, PackageName nameIn) {
-        if ((tokenIn == null) || (nameIn == null)) {
+        if (tokenIn == null || nameIn == null) {
             return null;
         }
 
@@ -103,7 +103,7 @@ public class TokenPackageFactory extends HibernateFactory {
     public static TokenPackage lookupPackage(Token tokenIn, PackageName nameIn,
             PackageArch archIn) {
 
-        if ((tokenIn == null) || (nameIn == null) || (archIn == null)) {
+        if (tokenIn == null || nameIn == null || archIn == null) {
             return null;
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/AuditSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/AuditSearchAction.java
@@ -63,7 +63,7 @@ public class AuditSearchAction extends RhnAction {
         String startDisp;
 
         if (startMilli != null && startMilli >= 0) {
-            startDisp = (new Date(startMilli)).toString();
+            startDisp = new Date(startMilli).toString();
         }
         else {
             yesterday = Calendar.getInstance();
@@ -84,7 +84,7 @@ public class AuditSearchAction extends RhnAction {
         String endDisp;
 
         if (endMilli != null && endMilli > 0 && endMilli != Long.MAX_VALUE) {
-            endDisp = (new Date(endMilli)).toString();
+            endDisp = new Date(endMilli).toString();
         }
         else {
             endMilli = Calendar.getInstance().getTime().getTime();
@@ -185,7 +185,7 @@ public class AuditSearchAction extends RhnAction {
         // should we look at the DatePickers?
         parseDates = dform.get("parseDates") != null;
         // did we receive a form with some checkboxes checked?
-        submitted = (autypes != null && autypes.length > 0);
+        submitted = autypes != null && autypes.length > 0;
         // can we mark this section reviewed?
         unrev = dform.get("unreviewable") != null;
         // get the "page creation time" to determine cache usage
@@ -232,7 +232,7 @@ public class AuditSearchAction extends RhnAction {
                     cacheSeqno.compareTo(seqno) >= 0) {
                 log.debug("actual search");
                 result = AuditManager.getAuditLogs(autypes, machine, start, end);
-                session.setAttribute("auditCacheSeqno", (new Date()).getTime());
+                session.setAttribute("auditCacheSeqno", new Date().getTime());
                 session.setAttribute("auditResultCache", result);
             }
             else {
@@ -271,7 +271,7 @@ public class AuditSearchAction extends RhnAction {
 
         // set the page creation time
         // + 1 so that it's greater than the auditCacheSeqno above
-        request.setAttribute("seqno", (new Date()).getTime() + 1);
+        request.setAttribute("seqno", new Date().getTime() + 1);
 
         // add any accumulated messages to be displayed
         addMessages(request, amsgs);

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfDiffSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfDiffSubmitAction.java
@@ -119,6 +119,6 @@ public class XccdfDiffSubmitAction extends RhnAction implements Listable<RuleRes
 
     private String getView(HttpServletRequest request) {
         String view = request.getParameter(VIEW);
-        return (view == null || "".equals(view)) ? FULL : view;
+        return view == null || "".equals(view) ? FULL : view;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/ChannelDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/ChannelDetailsAction.java
@@ -64,11 +64,11 @@ public class ChannelDetailsAction extends RhnAction {
         Channel chan = ChannelManager.lookupByIdAndUser(cid, user);
 
         if (isSubmitted(form) && (
-                (chan.getOrg() == null && user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN)) ||
+                chan.getOrg() == null && user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN) ||
                     UserManager.verifyChannelAdmin(user, chan))) {
             String global = (String)form.get("global");
-            chan.setGloballySubscribable((global != null) &&
-                    ("all".equals(global)), user.getOrg());
+            chan.setGloballySubscribable(global != null &&
+                    "all".equals(global), user.getOrg());
 
             chan.setGPGCheck(BooleanUtils.isTrue((Boolean)form.get("gpg_check")));
 
@@ -114,7 +114,7 @@ public class ChannelDetailsAction extends RhnAction {
 
         request.setAttribute("gpg_check", chan.isGPGCheck());
 
-        if ((chan.getOrg() == null && user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN)) ||
+        if (chan.getOrg() == null && user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN) ||
                 UserManager.verifyChannelAdmin(user, chan)) {
             request.setAttribute("has_access", true);
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/ConfirmErrataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/ConfirmErrataAction.java
@@ -90,7 +90,7 @@ public class ConfirmErrataAction extends RhnListAction {
         Long sourceCid = null;
         Channel srcChan = null;
         String selChannel = request.getParameter(SELECTED_CHANNEL);
-        if ((selChannel != null) && (!selChannel.equals(""))) {
+        if (selChannel != null && !selChannel.equals("")) {
             sourceCid = Long.parseLong(selChannel);
             srcChan = ChannelFactory.lookupByIdAndUser(sourceCid, user);
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/DeleteChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/DeleteChannelAction.java
@@ -74,7 +74,7 @@ public class DeleteChannelAction extends RhnAction {
                 SystemManager.countSubscribedToChannelWithoutOrg(channel.getOrg().getId(), channelId));
 
         if (context.isSubmitted()) {
-            if ((request.getParameter("unsubscribeSystems") != null) || subscribedSystemsCount == 0) {
+            if (request.getParameter("unsubscribeSystems") != null || subscribedSystemsCount == 0) {
                 DataResult<PackageOverview> dr;
                 try {
                     dr = PackageManager.listCustomPackageForChannel(channelId, user.getOrg().getId(), false);

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/EditChannelAction.java
@@ -411,8 +411,8 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
         try {
             updated = ucc.update(ctx.getParamAsLong("cid"));
             String sharing = (String) form.get(SUBSCRIPTIONS);
-            updated.setGloballySubscribable((sharing != null) &&
-                    ("all".equals(sharing)), loggedInUser.getOrg());
+            updated.setGloballySubscribable(sharing != null &&
+                    "all".equals(sharing), loggedInUser.getOrg());
             updated = HibernateFactory.reload(updated);
             ServerFactory.listMinionsByChannel(updated.getId()).stream()
                     .forEach(ms -> MinionPillarManager.INSTANCE.generatePillar(ms, false, Collections.emptySet()));
@@ -473,7 +473,7 @@ public class EditChannelAction extends RhnAction implements Listable<OrgTrust> {
         command.setSupportPolicy(StringUtil.nullIfEmpty(form.getString(SUPPORT_POLICY)));
         command.setAccess(form.getString(ORG_SHARING));
         String sharing = form.getString(SUBSCRIPTIONS);
-        command.setGloballySubscribable((sharing != null) && ("all".equals(sharing)));
+        command.setGloballySubscribable(sharing != null && "all".equals(sharing));
 
 
         try {

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
@@ -250,8 +250,8 @@ public class SyncRepositoriesAction extends RhnAction implements Listable<Conten
                 for (String line : lines) {
                     // Packages are downloaded
                     if (line.contains("No new packages to sync.") ||
-                            (line.contains("Linking packages to channel.")) ||
-                            (line.contains("Sync completed."))) {
+                            line.contains("Linking packages to channel.") ||
+                            line.contains("Sync completed.")) {
                         syncingRepo.put("progress", "100");
                         // Mark as finished when all repos are synced
                         syncingRepo.put("finished", !inProgress);

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DateRangePicker.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DateRangePicker.java
@@ -115,8 +115,8 @@ public class DateRangePicker {
         }
         req.setAttribute("start", start);
         req.setAttribute("end", end);
-        assert (start.getDate() != null);
-        assert (end.getDate() != null);
+        assert start.getDate() != null;
+        assert end.getDate() != null;
         return retval;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -662,8 +662,8 @@ public class DownloadFile extends DownloadAction {
         }
         // Update kickstart session
         if (ksession != null &&
-                (!(ksession.getState().getLabel().equals(KickstartSessionState.COMPLETE) ||
-                        ksession.getState().getLabel().equals(KickstartSessionState.FAILED)))) {
+                !(ksession.getState().getLabel().equals(KickstartSessionState.COMPLETE) ||
+                        ksession.getState().getLabel().equals(KickstartSessionState.FAILED))) {
             ksession.setState(newState);
             if (ksession.getPackageFetchCount() == null) {
                 ksession.setPackageFetchCount(0L);

--- a/java/code/src/com/redhat/rhn/frontend/action/common/test/BaseSetOperateOnDiffActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/test/BaseSetOperateOnDiffActionTest.java
@@ -50,8 +50,8 @@ public class BaseSetOperateOnDiffActionTest extends RhnPostMockStrutsTestCase {
             ActivationKeyFactory.save(key);
             TestUtils.flushAndEvict(key);
         }
-        assertTrue((ksdata.getDefaultRegTokens() == null ||
-                ksdata.getDefaultRegTokens().isEmpty()));
+        assertTrue(ksdata.getDefaultRegTokens() == null ||
+                ksdata.getDefaultRegTokens().isEmpty());
         setRequestPathInfo("/kickstart/ActivationKeysSubmit");
         addSelectedItem(ActivationKeyTest.createTestActivationKey(user,
                 ServerFactoryTest.createTestServer(user)).getId());
@@ -64,8 +64,8 @@ public class BaseSetOperateOnDiffActionTest extends RhnPostMockStrutsTestCase {
         addDispatchCall(ActivationKeysSubmitAction.UPDATE_METHOD);
         actionPerform();
         verifyActionMessage("kickstart_activation_keys.added");
-        assertTrue((ksdata.getDefaultRegTokens() != null &&
-                !ksdata.getDefaultRegTokens().isEmpty()));
+        assertTrue(ksdata.getDefaultRegTokens() != null &&
+                !ksdata.getDefaultRegTokens().isEmpty());
 
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigFileForm.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigFileForm.java
@@ -201,9 +201,9 @@ public class ConfigFileForm extends ScrubbingDynaActionForm {
      * @return true IFF the above conditions are true
      */
     protected boolean canDisplayContent(ConfigRevision cr) {
-        return (cr.isFile() || cr.isSls() &&
+        return cr.isFile() || cr.isSls() &&
                 !cr.getConfigContent().isBinary() &&
-                cr.getConfigContent().getFileSize() < MAX_EDITABLE_SIZE);
+                cr.getConfigContent().getFileSize() < MAX_EDITABLE_SIZE;
     }
 
     private boolean isUpload() {

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/DiffAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/DiffAction.java
@@ -121,8 +121,8 @@ public class DiffAction extends RhnAction {
         else if (other.isSymlink()) {
             ConfigFileName target = info.getTargetFileName();
             ConfigFileName otarget = oinfo.getTargetFileName();
-            if ((target == null  && otarget != null) ||
-                   (target != null  && otarget == null) ||
+            if (target == null  && otarget != null ||
+                    target != null  && otarget == null ||
                    !otarget.equals(target)) {
                 request.setAttribute("difftargetpath", "true");
             }
@@ -130,8 +130,8 @@ public class DiffAction extends RhnAction {
 
         if (!revision.getConfigFileType().getLabel()
                 .equals(other.getConfigFileType().getLabel()) ||
-                (revision.isFile() && revision.getConfigContent().isBinary() !=
-                    other.getConfigContent().isBinary())) {
+                revision.isFile() && revision.getConfigContent().isBinary() !=
+                    other.getConfigContent().isBinary()) {
             request.setAttribute("difftype", "true");
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/overview/ManagedSystemsList.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/overview/ManagedSystemsList.java
@@ -65,7 +65,7 @@ public class ManagedSystemsList extends RhnListAction {
 
         // if submitted get checkbox status
         if (requestContext.isSubmitted()) {
-            managedSystemsOnly = (request.getParameter(checkboxName) != null);
+            managedSystemsOnly = request.getParameter(checkboxName) != null;
         }
         // if checkbox is "on", filter data to show systems containing
         // at least one locally or centrally managed file only
@@ -75,7 +75,7 @@ public class ManagedSystemsList extends RhnListAction {
             // iterate through list
             for (ConfigSystemDto o : dtos) {
                 // if there is no local and no global file
-                if ((o.getGlobalFileCount() + o.getLocalFileCount()) <= 0) {
+                if (o.getGlobalFileCount() + o.getLocalFileCount() <= 0) {
                     // delete system from list
                     dr.remove(o);
                     total--;

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ChannelSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ChannelSetupAction.java
@@ -85,8 +85,8 @@ public class ChannelSetupAction extends RhnListAction {
             }
             //Else we check and see if the original channel was listed in
             //      the original errata
-            else if (e != null && (e.isCloned() && errataInChannel(((ClonedErrata) e).getOriginal(),
-                    channel.getOriginalId()))) {
+            else if (e != null && e.isCloned() && errataInChannel(((ClonedErrata) e).getOriginal(),
+                    channel.getOriginalId())) {
                 pkgs = ChannelManager.relevantPackages(channel.getId(), e);
             } //if it wasn't then no packages are listed
             else {

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
@@ -167,11 +167,11 @@ public class ErrataSearchAction extends BaseSearchAction {
         }
 
         Boolean eTypeBug =
-            (form.get(ERRATA_BUG) == null ? Boolean.FALSE : (Boolean)form.get(ERRATA_BUG));
+                form.get(ERRATA_BUG) == null ? Boolean.FALSE : (Boolean)form.get(ERRATA_BUG);
         Boolean eTypeSec =
-            (form.get(ERRATA_SEC) == null ? Boolean.FALSE : (Boolean)form.get(ERRATA_SEC));
+                form.get(ERRATA_SEC) == null ? Boolean.FALSE : (Boolean)form.get(ERRATA_SEC);
         Boolean eTypeEnh =
-            (form.get(ERRATA_ENH) == null ? Boolean.FALSE : (Boolean)form.get(ERRATA_ENH));
+                form.get(ERRATA_ENH) == null ? Boolean.FALSE : (Boolean)form.get(ERRATA_ENH);
 
         // If no errata-type is set, set them all
         if (!(eTypeBug || eTypeSec || eTypeEnh)) {
@@ -243,7 +243,7 @@ public class ErrataSearchAction extends BaseSearchAction {
             args.add(preprocessSearchString(searchString, mode));
         }
 
-        if ((dateSearch && StringUtils.isBlank(searchString)) || OPT_CVE.equals(mode)) {
+        if (dateSearch && StringUtils.isBlank(searchString) || OPT_CVE.equals(mode)) {
             // Tells search server to search the database
             path = "db.search";
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/EditGroupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/EditGroupAction.java
@@ -177,8 +177,8 @@ public class EditGroupAction extends RhnAction {
         // Ugly condition for two error cases:
         //     creating page + group name exists
         //     editing page + group name exists except our group
-        if (((sgid == null) && (newGroup != null)) ||
-                (sgid != null) && (newGroup != null) && (!sgid.equals(newGroup.getId()))) {
+        if (sgid == null && newGroup != null ||
+                sgid != null && newGroup != null && !sgid.equals(newGroup.getId())) {
             errors.add(ActionMessages.GLOBAL_MESSAGE,
                     new ActionMessage("systemgroup.create.alreadyexists"));
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
@@ -220,8 +220,8 @@ public class ForgotCredentialsAction extends RhnAction {
 
         // Time has not elapsed for last user
         if (prevRequest != null &&
-                ((now - prevRequest) < timeout * 1000) &&
-                (user.toUpperCase().equals(prevRequestUser))) {
+                now - prevRequest < timeout * 1000 &&
+                user.toUpperCase().equals(prevRequestUser)) {
             log.debug("Unsuccessful try to request email for {}", user);
             return false;
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/EditPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/EditPackagesAction.java
@@ -151,8 +151,8 @@ public class EditPackagesAction extends RhnAction {
 
                 // if noBase is checked and the current package is @base, ignore it
                 PackageName pn = PackageFactory.lookupOrCreatePackageByName(pkg);
-                if ((pn.getName().toLowerCase().replaceAll("\\s", "")
-                        .equals("@base")) && (ksdata.getNoBase())) {
+                if (pn.getName().toLowerCase().replaceAll("\\s", "")
+                        .equals("@base") && ksdata.getNoBase()) {
                     continue;
                 }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartAdvancedOptionsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartAdvancedOptionsAction.java
@@ -93,8 +93,8 @@ public class KickstartAdvancedOptionsAction extends RhnAction {
             //lets first make sure all required params are set
             for (Object valueIn : cmd.getRequiredOptions()) {
                 KickstartCommandName cn = (KickstartCommandName) valueIn;
-                if ((request.getParameter(cn.getName()) == null) ||
-                        (request.getParameter(cn.getName().concat("_txt")).equals(""))) {
+                if (request.getParameter(cn.getName()) == null ||
+                        request.getParameter(cn.getName().concat("_txt")).equals("")) {
                     messages.add(ActionMessages.GLOBAL_MESSAGE,
                             new ActionMessage("errors.required", cn.getName()));
                 }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeAction.java
@@ -156,14 +156,14 @@ public class KickstartIpRangeAction extends RhnAction {
 
         ValidatorError retval = null;
 
-        Long [] octet1 = { ((Long)form.get(OCTET1A)),
-                           ((Long)form.get(OCTET1B)),
-                           ((Long)form.get(OCTET1C)),
-                           ((Long)form.get(OCTET1D)), };
-        Long [] octet2 = { ((Long)form.get(OCTET2A)),
-                           ((Long)form.get(OCTET2B)),
-                           ((Long)form.get(OCTET2C)),
-                           ((Long)form.get(OCTET2D)), };
+        Long [] octet1 = {(Long)form.get(OCTET1A),
+                (Long)form.get(OCTET1B),
+                (Long)form.get(OCTET1C),
+                (Long)form.get(OCTET1D), };
+        Long [] octet2 = {(Long)form.get(OCTET2A),
+                (Long)form.get(OCTET2B),
+                (Long)form.get(OCTET2C),
+                (Long)form.get(OCTET2D), };
 
         if (!cmd.validateIpRange(octet1, octet2)) {
             retval = new ValidatorError("kickstart.iprange_validate.failure");

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeDeleteAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartIpRangeDeleteAction.java
@@ -64,9 +64,9 @@ public class KickstartIpRangeDeleteAction extends RhnAction {
                     ctx.getCurrentUser());
 
         // make sure get params came across request
-        if ((request.getParameter(MIN)) == null ||
-                (request.getParameter(MAX)) == null ||
-                (ctx.getRequiredParam(RequestContext.KICKSTART_ID) == null)) {
+        if (request.getParameter(MIN) == null ||
+                request.getParameter(MAX) == null ||
+                ctx.getRequiredParam(RequestContext.KICKSTART_ID) == null) {
             throw new BadParameterException("Missing min, max and/or ksid for ks ip range");
         }
         // make sure org has permission

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartSoftwareEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartSoftwareEditAction.java
@@ -93,7 +93,7 @@ public class KickstartSoftwareEditAction extends BaseKickstartEditAction {
                 kstree = trees.get(trees.size() - 1);
                 form.set(TREE, kstree.getId());
             }
-            if (kstree == null && (trees != null && !trees.isEmpty())) {
+            if (kstree == null && trees != null && !trees.isEmpty()) {
                 kstree = KickstartFactory.lookupKickstartTreeByIdAndOrg(tree.getId(),
                         ctx.getCurrentUser().getOrg());
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/ScheduleKickstartWizardAction.java
@@ -547,7 +547,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
             }
             else {
                 ctx.getRequest().setAttribute("distro_kernel_params",
-                        (distro.getKernelOptions().get() instanceof Map) ?
+                        distro.getKernelOptions().get() instanceof Map ?
                             distro.convertOptionsMap(distro.getKernelOptions().get()) :
                             distro.getKernelOptions().get());
             }
@@ -557,7 +557,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
             }
             else {
                 ctx.getRequest().setAttribute("distro_post_kernel_params",
-                        (distro.getKernelOptionsPost().get() instanceof Map) ?
+                        distro.getKernelOptionsPost().get() instanceof Map ?
                             distro.convertOptionsMap(distro.getKernelOptionsPost().get()) :
                             distro.getKernelOptionsPost().get());
             }
@@ -571,7 +571,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
             }
             else {
                 ctx.getRequest().setAttribute("profile_kernel_params",
-                        (profile.getKernelOptions().get() instanceof Map) ?
+                        profile.getKernelOptions().get() instanceof Map ?
                              profile.convertOptionsMap(profile.getKernelOptions().get()) :
                              profile.getKernelOptions().get());
             }
@@ -581,7 +581,7 @@ public class ScheduleKickstartWizardAction extends RhnWizardAction {
             }
             else {
                 ctx.getRequest().setAttribute("profile_post_kernel_params",
-                        (profile.getKernelOptionsPost().get() instanceof Map) ?
+                        profile.getKernelOptionsPost().get() instanceof Map ?
                              profile.convertOptionsMap(profile.getKernelOptionsPost().get()) :
                              profile.getKernelOptionsPost().get());
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/ExtGroupDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/ExtGroupDetailAction.java
@@ -153,18 +153,18 @@ public class ExtGroupDetailAction extends RhnAction {
             String label = role.getLabel();
             if (UserFactory.IMPLIEDROLES.contains(role)) {
                 // channel, config, system group, activation key
-                boolean hasOrgAdmin = extGroup != null && extGroup.getRoles().contains((RoleFactory.ORG_ADMIN));
+                boolean hasOrgAdmin = extGroup != null && extGroup.getRoles().contains(RoleFactory.ORG_ADMIN);
                 SelectableLabelValueBean bean = new SelectableLabelValueBean(
                         LocalizationService.getInstance().getMessage(label),
                         label,
                         hasOrgAdmin ||
-                            (extGroup != null && extGroup.getRoles().contains(role)),
+                                extGroup != null && extGroup.getRoles().contains(role),
                         hasOrgAdmin && UserFactory.IMPLIEDROLES.contains(role));
                 regularRoles.add(bean);
             }
             else {
                 // org and satellite admin
-                boolean hasSatAdmin = extGroup != null && extGroup.getRoles().contains((RoleFactory.SAT_ADMIN));
+                boolean hasSatAdmin = extGroup != null && extGroup.getRoles().contains(RoleFactory.SAT_ADMIN);
                 SelectableLabelValueBean bean = new SelectableLabelValueBean(
                         LocalizationService.getInstance().getMessage(label),
                         label,

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/SatUserListAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/SatUserListAction.java
@@ -53,9 +53,9 @@ public class SatUserListAction extends RhnAction {
 
         DataList<MultiOrgAllUserOverview> result = OrgManager.allUsers();
 
-        Long canModify =  (user.getOrg().getId().longValue() ==
-            oid.longValue()) &&
-           (user.hasRole(RoleFactory.ORG_ADMIN)) ? 1L : 0L;
+        Long canModify =  user.getOrg().getId().longValue() ==
+            oid.longValue() &&
+                user.hasRole(RoleFactory.ORG_ADMIN) ? 1L : 0L;
 
         request.setAttribute("canModify", canModify);
         request.setAttribute("userOrgId", oid);

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/UserListSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/UserListSetupAction.java
@@ -52,9 +52,9 @@ public class UserListSetupAction extends RhnAction {
         Org org = OrgFactory.lookupById(oid);
         String name = org.getName();
 
-        Long canModify =  (user.getOrg().getId().longValue() ==
-                           oid.longValue()) &&
-                          (user.hasRole(RoleFactory.ORG_ADMIN)) ? 1L : 0L;
+        Long canModify =  user.getOrg().getId().longValue() ==
+                           oid.longValue() &&
+                user.hasRole(RoleFactory.ORG_ADMIN) ? 1L : 0L;
         DataList result = OrgManager.activeUsers(oid);
 
         request.setAttribute("canModify", canModify);

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/PackageListSetupAction.java
@@ -39,7 +39,7 @@ public class PackageListSetupAction extends BaseSystemPackagesAction {
         // Master ptf will be selectable only if unistallation is supported by the package manager
         boolean ptfUninstallationSupported = ServerFactory.isPtfUninstallationSupported(server);
         result.stream()
-              .filter(p -> p.isPartOfPtf() || (!ptfUninstallationSupported && p.isMasterPtfPackage()))
+              .filter(p -> p.isPartOfPtf() || !ptfUninstallationSupported && p.isMasterPtfPackage())
               .forEach(p -> p.setSelectable(false));
 
         return result;

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/CreateProfileAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/CreateProfileAction.java
@@ -86,7 +86,7 @@ public class CreateProfileAction extends RhnAction {
                     params.put("sid", request.getParameter("sid"));
                     forward = strutsDelegate.forwardParams(mapping.findForward("created"),
                             params);
-                    if (log.isDebugEnabled() && (forward != null)) {
+                    if (log.isDebugEnabled() && forward != null) {
                         log.debug("Where are we going [{}]", forward);
                     }
                 }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/DeleteProfileAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/DeleteProfileAction.java
@@ -83,7 +83,7 @@ public class DeleteProfileAction extends RhnAction {
             }
             forward = strutsDelegate.forwardParams(mapping.findForward("deleted"),
                     params);
-            if (log.isDebugEnabled() && (forward != null)) {
+            if (log.isDebugEnabled() && forward != null) {
                 log.debug("Where are we going [{}]", forward);
             }
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/ShowProfileAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/profile/ShowProfileAction.java
@@ -89,7 +89,7 @@ public class ShowProfileAction extends RhnAction {
 
     private boolean buttonPressed(String btnName, DynaActionForm form) {
         String btn = (String) form.get(btnName);
-        return (btn != null && !"".equals(btn));
+        return btn != null && !"".equals(btn);
     }
 
     private ActionForward compareSystems(ActionMapping mapping,

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/RestartAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/RestartAction.java
@@ -49,7 +49,7 @@ public class RestartAction extends RhnAction {
         RequestContext ctx = new RequestContext(request);
 
         if (isSubmitted(form)) {
-            Boolean restart = ((Boolean) form.get(RESTART));
+            Boolean restart = (Boolean) form.get(RESTART);
             if (BooleanUtils.toBooleanDefaultIfNull(restart, false)) {
                 RestartSatelliteEvent event = new
                     RestartSatelliteEvent(ctx.getCurrentUser());

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/LockUnlockSystemAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/LockUnlockSystemAction.java
@@ -75,7 +75,7 @@ public class LockUnlockSystemAction extends RhnListAction {
                 for (Long longIn : set.getElementValues()) {
                     Server server = SystemManager.lookupByIdAndUser(
                             longIn, context.getCurrentUser());
-                    if (lck && (server.getLock() == null)) {
+                    if (lck && server.getLock() == null) {
                         if (reason == null) {
                             reason = LocalizationService.getInstance()
                                     .getMessage("sdc.details.overview.lock.reason");
@@ -85,7 +85,7 @@ public class LockUnlockSystemAction extends RhnListAction {
                                 server, reason);
                         locledSys++;
                     }
-                    else if (unlck && (server.getLock() != null)) {
+                    else if (unlck && server.getLock() != null) {
                         SystemManager.unlockServer(context.getCurrentUser(), server);
                         unlockedSys++;
                     }

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
@@ -304,8 +304,8 @@ public class ProvisioningRemoteCommand extends RhnAction implements
         String[] scriptShellTokens = script.trim().split("\n").clone()[0].split("/");
         String scriptType = scriptShellTokens[scriptShellTokens.length - 1];
         scriptType = scriptType.length() > 1 ?
-                     (scriptType.substring(0, 1).toUpperCase() +
-                      scriptType.substring(1).toLowerCase()) :
+                scriptType.substring(0, 1).toUpperCase() +
+                 scriptType.substring(1).toLowerCase() :
                       scriptType.toUpperCase();
 
         StringBuilder summary = new StringBuilder();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
@@ -96,7 +96,7 @@ public class ErrataSetupAction extends RhnAction implements Listable<ErrataOverv
             zyppPluginInstalled = PackageFactory.lookupByNameAndServer(
                     ZYPP_PLUGIN, server) != null;
         }
-        request.setAttribute("supported", (isSUSEMinion || zyppPluginInstalled));
+        request.setAttribute("supported", isSUSEMinion || zyppPluginInstalled);
 
         ListRhnSetHelper help = new ListRhnSetHelper(this, request, getSetDecl(sid));
         help.setListName(LIST_NAME);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemRemoteCommandAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemRemoteCommandAction.java
@@ -263,7 +263,7 @@ public class SystemRemoteCommandAction extends RhnAction implements MaintenanceW
         return ActionChainManager.scheduleScriptRuns(
                 user,
                 servers,
-                (label != null ? label : MessageFormat.format(msg, server.getName())),
+                label != null ? label : MessageFormat.format(msg, server.getName()),
                 ActionManager.createScript(form.getString(FormData.UID),
                         form.getString(FormData.GID),
                         form.get(FormData.TIMEOUT) == null ?

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
@@ -214,7 +214,7 @@ public class SystemSearchAction extends BaseSearchAction implements Listable<Sys
 
         List results = (List) request.getAttribute(getDataSetName());
        LOG.debug("SystemSearch results.size() = {}", results != null ? results.size() : "null results");
-        if ((results != null) && (results.size() == 1)) {
+        if (results != null && results.size() == 1) {
             SystemSearchResult s = (SystemSearchResult) results.get(0);
             return StrutsDelegate.getInstance().forwardParam(mapping.findForward("single"),
                             "sid", s.getId().toString());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
@@ -282,7 +282,7 @@ public class SystemSearchHelper {
             Integer numDays = Integer.parseInt(terms);
             Calendar startDate = Calendar.getInstance();
             // SearchRange:  [TargetDate - NOW]
-            startDate.add(Calendar.DATE, (-1 * numDays) - 1);
+            startDate.add(Calendar.DATE, -1 * numDays - 1);
             query = "registered:{\"" + formatDateString(startDate.getTime()) +
                 "\" TO \"" + formatDateString(
                 Calendar.getInstance().getTime()) +
@@ -770,7 +770,7 @@ public class SystemSearchHelper {
 
             Map<String, Object> sMap1 = results.get(serverId1);
             Map<String, Object> sMap2 = results.get(serverId2);
-            if ((sMap1 == null) && (sMap2 == null)) {
+            if (sMap1 == null && sMap2 == null) {
                 return compareByNameAndSID(sys1, sys2);
             }
 
@@ -782,9 +782,9 @@ public class SystemSearchHelper {
                 return S1_FIRST;
             }
 
-            Double score1 = (sMap1.containsKey(SCORE) ? (Double) sMap1.get(SCORE) : null);
-            Double score2 = (sMap2.containsKey(SCORE) ? (Double) sMap2.get(SCORE) : null);
-            if ((score1 == null) && (score2 == null)) {
+            Double score1 = sMap1.containsKey(SCORE) ? (Double) sMap1.get(SCORE) : null;
+            Double score2 = sMap2.containsKey(SCORE) ? (Double) sMap2.get(SCORE) : null;
+            if (score1 == null && score2 == null) {
                 return compareByNameAndSID(sys1, sys2);
             }
             if (score1 == null) {
@@ -817,7 +817,7 @@ public class SystemSearchHelper {
         // Sort by profile-name if there is one, then by reverse-sid-order
         private int compareByNameAndSID(SystemOverview sys1, SystemOverview sys2) {
 
-            if ((sys1.getName() == null) && (sys2.getName() == null)) {
+            if (sys1.getName() == null && sys2.getName() == null) {
                 return sys2.getId().compareTo(sys1.getId());
             }
 
@@ -877,7 +877,7 @@ public class SystemSearchHelper {
             }
             Map<String, Object> sMap1 = results.get(serverId1);
             Map<String, Object> sMap2 = results.get(serverId2);
-            if ((sMap1 == null) && (sMap2 == null)) {
+            if (sMap1 == null && sMap2 == null) {
                 return 0;
             }
             if (sMap1 == null) {
@@ -888,7 +888,7 @@ public class SystemSearchHelper {
             }
             String val1 = (String)sMap1.get(MATCHING_FIELD_VALUE);
             String val2 = (String)sMap2.get(MATCHING_FIELD_VALUE);
-            if ((val1 == null) && (val2 == null)) {
+            if (val1 == null && val2 == null) {
                 return 0;
             }
             if (val1 == null) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/XccdfDeleteConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/XccdfDeleteConfirmAction.java
@@ -90,7 +90,7 @@ public class XccdfDeleteConfirmAction extends RhnAction {
                RhnSetFactory.cleanup(set);
            }
            Long retainedCount = result.size() - removedCount;
-           ActionMessages msg = (removedCount == 0) ?
+           ActionMessages msg = removedCount == 0 ?
                new ActionErrors() : new ActionMessages();
            String[] messageParams = {removedCount.toString(), retainedCount.toString()};
            msg.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
@@ -104,7 +104,7 @@ public class SystemEntitlementsSubmitAction extends
         String entType = form.getString(SystemEntitlementsSetupAction.ADDON_ENTITLEMENT);
 
         Entitlement ent = EntitlementManager.getByName(entType);
-        return (ent == null || ent.isBase()) ? null : ent;
+        return ent == null || ent.isBase() ? null : ent;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotRollbackAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotRollbackAction.java
@@ -86,8 +86,8 @@ public class SnapshotRollbackAction extends RhnAction {
 
         InvalidSnapshotReason reason = snapshot.getInvalidReason();
         params.put(SNAPSHOT_NAME, snapshot.getName());
-        params.put(INVALID_REASON_LABEL, (reason != null ? reason.getLabel() : ""));
-        params.put(INVALID_REASON_NAME, (reason != null ? reason.getName() : ""));
+        params.put(INVALID_REASON_LABEL, reason != null ? reason.getLabel() : "");
+        params.put(INVALID_REASON_NAME, reason != null ? reason.getName() : "");
         params.put(GROUP_CHANGES,   snapshot.groupDiffs(sid));
         params.put(CHANNEL_CHANGES, snapshot.channelDiffs(sid));
         params.put(PACKAGE_CHANGES, snapshot.packageDiffs(sid));

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemMigrateAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemMigrateAction.java
@@ -92,8 +92,8 @@ public class SystemMigrateAction extends RhnAction {
 
                 // unless the user is a satellite admin, they are not permitted to migrate
                 // systems from an org that they do not belong to
-                if ((!user.hasRole(RoleFactory.SAT_ADMIN)) &&
-                    (!user.getOrg().equals(s.getOrg()))) {
+                if (!user.hasRole(RoleFactory.SAT_ADMIN) &&
+                        !user.getOrg().equals(s.getOrg())) {
                     ValidatorError err = new ValidatorError("system.migrate.user_no_perms");
                     getStrutsDelegate().saveMessages(request,
                             RhnValidationHelper.validatorErrorToActionErrors(err));

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -133,9 +133,9 @@ public class SystemOverviewAction extends RhnAction {
 
         //Order entitlements
         List<Entitlement> entitlements = s.getEntitlements().stream().sorted(
-                (e1, e2) -> (e1.isBase() && e2.isBase()) || (!e1.isBase() && !e2.isBase()) ?
+                (e1, e2) -> e1.isBase() && e2.isBase() || !e1.isBase() && !e2.isBase() ?
                         e1.getHumanReadableLabel().compareTo(e2.getHumanReadableLabel()) :
-                        (e1.isBase() ? -1 : 1))
+                        e1.isBase() ? -1 : 1)
                 .collect(Collectors.toList());
 
         request.setAttribute("rebootRequired", rebootRequired);

--- a/java/code/src/com/redhat/rhn/frontend/action/tasko/DeleteScheduleAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/tasko/DeleteScheduleAction.java
@@ -49,7 +49,7 @@ public class DeleteScheduleAction extends RhnAction {
         User loggedInUser = ctx.getCurrentUser();
 
         if (ctx.hasParam("schid")) {
-            Long scheduleId = ctx.getParamAsLong(("schid"));
+            Long scheduleId = ctx.getParamAsLong("schid");
             TaskomaticApi tapi = new TaskomaticApi();
             Map<String, Object> schedule = new HashMap<>();
             try {

--- a/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
@@ -57,7 +57,7 @@ public class ScheduleDetailAction extends RhnAction {
         Map<String, Object> params = makeParamMap(request);
         RequestContext ctx = new RequestContext(request);
         User loggedInUser = ctx.getCurrentUser();
-        Long scheduleId = ctx.getParamAsLong(("schid"));
+        Long scheduleId = ctx.getParamAsLong("schid");
 
         if (ctx.hasParam("schid")) {
             params.put("schid", scheduleId);
@@ -197,7 +197,7 @@ public class ScheduleDetailAction extends RhnAction {
                 Map<String, Object> bunch = tapi.lookupBunchByName(loggedInUser, bunchName);
                 request.setAttribute("bunchdescription", bunch.get("description"));
                 RecurringEventPicker.prepopulatePicker(request, "date",
-                        (String) schedule.get(("cron_expr")));
+                        (String) schedule.get("cron_expr"));
             }
             catch (TaskomaticApiException e) {
                 createErrorMessage(request,

--- a/java/code/src/com/redhat/rhn/frontend/action/test/YourRhnActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/test/YourRhnActionTest.java
@@ -31,7 +31,7 @@ public class YourRhnActionTest extends RhnMockStrutsTestCase {
 
         setRequestPathInfo("/YourRhn");
         actionPerform();
-         assertTrue(((Boolean) request.getAttribute("anyListsSelected")));
+         assertTrue((Boolean) request.getAttribute("anyListsSelected"));
 
          assertNotNull(request.getAttribute("inactiveSystems"));
          assertNotNull(request.getAttribute("tasks"));

--- a/java/code/src/com/redhat/rhn/frontend/action/user/ResetPasswordSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/ResetPasswordSubmitAction.java
@@ -68,7 +68,7 @@ public class ResetPasswordSubmitAction extends UserEditActionHelper {
         DynaActionForm form = (DynaActionForm) formIn;
         Map<String, Object> params = makeParamMap(request);
 
-        String token = (form.get("token") == null ? null : form.get("token").toString());
+        String token = form.get("token") == null ? null : form.get("token").toString();
         ResetPassword rp = ResetPasswordFactory.lookupByToken(token);
         ActionErrors errors = ResetPasswordFactory.findErrors(rp);
 

--- a/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
@@ -57,7 +57,7 @@ public abstract class UserEditActionHelper extends RhnAction {
                     new ActionMessage("error.password_mismatch"));
         }
 
-        Boolean readOnly = (form.get("readonly") != null);
+        Boolean readOnly = form.get("readonly") != null;
         if (!targetUser.isReadOnly()) {
             if (readOnly && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
                     targetUser.getOrg().numActiveOrgAdmins() < 2) {

--- a/java/code/src/com/redhat/rhn/frontend/action/user/UserEditSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/UserEditSetupAction.java
@@ -148,7 +148,7 @@ public class UserEditSetupAction extends RhnAction {
             // and disable the item in the UI.
             if (UserFactory.IMPLIEDROLES.contains(currRole) &&
                     targetUser.hasPermanentRole(RoleFactory.ORG_ADMIN)) {
-                uilabel = uilabel + (" - [ " + LocalizationService.getInstance().getMessage("Admin Access") + " ]");
+                uilabel = uilabel + " - [ " + LocalizationService.getInstance().getMessage("Admin Access") + " ]";
 
                 disabled = true;
                 log.debug("2");

--- a/java/code/src/com/redhat/rhn/frontend/dto/ActivationKeyDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ActivationKeyDto.java
@@ -64,7 +64,7 @@ public class ActivationKeyDto extends BaseDto {
      * @param value 1 if the key is disabled
      */
     public void setKeyDisabled(Integer value) {
-        this.keyDisabled = value != null && (value.equals(1));
+        this.keyDisabled = value != null && value.equals(1);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/ChannelPerms.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ChannelPerms.java
@@ -38,7 +38,7 @@ public class ChannelPerms {
      * @param value 1 if the channel is globally subscribable.
      */
     public void setGloballySubscribable(Integer value) {
-        if (value == null || (!value.equals(1))) {
+        if (value == null || !value.equals(1)) {
             this.globallySubscribable = false;
             return;
         }
@@ -58,7 +58,7 @@ public class ChannelPerms {
      * @param value 1 if the user has permissions to this channel
      */
     public void setHasPerm(Integer value) {
-        if (value == null || (!value.equals(1))) {
+        if (value == null || !value.equals(1)) {
             this.hasPerm = false;
             return;
         }

--- a/java/code/src/com/redhat/rhn/frontend/dto/EssentialChannelDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/EssentialChannelDto.java
@@ -199,7 +199,7 @@ public class EssentialChannelDto extends BaseDto {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + (id == null ? 0 : id.hashCode());
         return result;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/dto/OrgIdWrapper.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/OrgIdWrapper.java
@@ -51,6 +51,6 @@ public class OrgIdWrapper {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return (orgId == null) ? null : orgId.toString();
+        return orgId == null ? null : orgId.toString();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/dto/OrgTrustOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/OrgTrustOverview.java
@@ -79,6 +79,6 @@ public class OrgTrustOverview extends BaseDto {
      * @param trustedIn whether the org is trusted.
      */
     public void setTrusted(Integer trustedIn) {
-        trusted = (trustedIn != 0);
+        trusted = trustedIn != 0;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageDto.java
@@ -306,8 +306,8 @@ public class PackageDto extends BaseDto {
         SimpleDateFormat dateFormatGMT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
         dateFormatGMT.setTimeZone(TimeZone.getTimeZone("GMT"));
         try {
-            this.buildTime = (buildTimeIn == null ?
-                        null : dateFormatGMT.parse(buildTimeIn.toString()));
+            this.buildTime = buildTimeIn == null ?
+                        null : dateFormatGMT.parse(buildTimeIn.toString());
         }
         catch (ParseException e) {
             throw new RhnRuntimeException(e);

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
@@ -111,8 +111,8 @@ public class PackageListItem extends IdComboDto {
         }
 
         if (lockedStatus != null &&
-            (!lockedStatus.equals(PackageManager.PKG_PENDING_LOCK) &&
-             (!lockedStatus.equals(PackageManager.PKG_PENDING_UNLOCK)))) {
+                !lockedStatus.equals(PackageManager.PKG_PENDING_LOCK) &&
+                !lockedStatus.equals(PackageManager.PKG_PENDING_UNLOCK)) {
             throw new Exception(String.format("Unknown lock status: %s", lockedStatus));
         }
 
@@ -570,9 +570,9 @@ public class PackageListItem extends IdComboDto {
      * @return String representation of package's NEVR
      */
     public String getNevr() {
-        String e = (this.getEpoch() != null) ? this.getEpoch() : "0";
-        String v = (this.getVersion() != null) ? this.getVersion() : "0";
-        String r = (this.getRelease() != null) ? this.getRelease() : "0";
+        String e = this.getEpoch() != null ? this.getEpoch() : "0";
+        String v = this.getVersion() != null ? this.getVersion() : "0";
+        String r = this.getRelease() != null ? this.getRelease() : "0";
         return this.getName() + "-" + e + ":" + v + "-" + r;
     }
 
@@ -582,10 +582,10 @@ public class PackageListItem extends IdComboDto {
      * @return String representation of package's NEVRA
      */
     public String getNevra() {
-        String e = (this.getEpoch() != null) ? this.getEpoch() : "0";
-        String v = (this.getVersion() != null) ? this.getVersion() : "0";
-        String r = (this.getRelease() != null) ? this.getRelease() : "0";
-        String a = (this.getArch() != null) ? this.getArch() : "0";
+        String e = this.getEpoch() != null ? this.getEpoch() : "0";
+        String v = this.getVersion() != null ? this.getVersion() : "0";
+        String r = this.getRelease() != null ? this.getRelease() : "0";
+        String a = this.getArch() != null ? this.getArch() : "0";
         return this.getName() + "-" + e + ":" + v + "-" + r + "." + a;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/ScheduledAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ScheduledAction.java
@@ -196,7 +196,7 @@ public class ScheduledAction extends BaseDto implements RowCallback {
      * @return the number of actions which are in progress.
      */
     public long getInProgress() {
-        return (pickedUp + queued);
+        return pickedUp + queued;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/SnapshotTagDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SnapshotTagDto.java
@@ -115,7 +115,7 @@ public class SnapshotTagDto extends BaseDto {
     * null if not selectable
     */
    public void setSelectable(Integer selectableIn) {
-       selectable = (selectableIn != null);
+       selectable = selectableIn != null;
    }
 
    /**
@@ -123,7 +123,7 @@ public class SnapshotTagDto extends BaseDto {
     * null if not selectable
     */
    public void setSelectable(Long selectableIn) {
-       selectable = (selectableIn != null);
+       selectable = selectableIn != null;
    }
 
    /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/StringDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/StringDto.java
@@ -64,7 +64,7 @@ public class StringDto {
      */
     @Override
     public int hashCode() {
-        return (value == null) ? 0 : value.hashCode();
+        return value == null ? 0 : value.hashCode();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemCompareDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemCompareDto.java
@@ -101,7 +101,7 @@ public class SystemCompareDto {
         for (List list : lists) {
             List<Item> itemized = new LinkedList<>();
             for (Object o : list) {
-                String s = (o != null) ? String.valueOf(o).trim() : "";
+                String s = o != null ? String.valueOf(o).trim() : "";
                 Item i = new Item();
                 i.value = s;
                 itemized.add(i);
@@ -131,7 +131,7 @@ public class SystemCompareDto {
         List<Item> compared = new LinkedList<>();
         Map<String, Integer> similarity = new HashMap<>();
         for (Object o : strings) {
-            String s = (o != null) ? String.valueOf(o).trim() : "";
+            String s = o != null ? String.valueOf(o).trim() : "";
             Item i = new Item();
             i.value = s;
             compared.add(i);

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemOverview.java
@@ -765,7 +765,7 @@ public class SystemOverview extends BaseTupleDto implements Serializable {
      * null if not selectable
      */
     public void setSelectable(Integer selectableIn) {
-        selectable = (selectableIn != null);
+        selectable = selectableIn != null;
     }
 
     /**
@@ -886,7 +886,7 @@ public class SystemOverview extends BaseTupleDto implements Serializable {
      *  system is not a virtual host. Sets isVirtualHost to true or false.
      */
     public void setVirtualHost(Object host) {
-        isVirtualHost = (host != null);
+        isVirtualHost = host != null;
     }
 
     /**
@@ -894,7 +894,7 @@ public class SystemOverview extends BaseTupleDto implements Serializable {
      * system is not a virtual guest. Sets isVirtualGuest to true or false.
      */
     public void setVirtualGuest(Object guest) {
-        isVirtualGuest = (guest != null);
+        isVirtualGuest = guest != null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemSearchResult.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemSearchResult.java
@@ -72,7 +72,7 @@ public class SystemSearchResult extends SystemOverview {
         String field = getMatchingField();
         log.info("Will look up field <{}> to determine why this matched", field);
         try {
-            if ((field != null) && (!StringUtils.isBlank(field))) {
+            if (field != null && !StringUtils.isBlank(field)) {
                 value = BeanUtils.getProperty(this, field);
                 log.info("SystemSearchResult.Id = {} BeanUtils.getProperty(sr, {}) = {}", getId(), field, value);
             }
@@ -155,7 +155,7 @@ public class SystemSearchResult extends SystemOverview {
       * @return the hostname in IDN encoding
       */
     public String getDecodedHostname() {
-        return (hostname == null) ? null : IDN.toUnicode(hostname);
+        return hostname == null ? null : IDN.toUnicode(hostname);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/VirtualSystemOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/VirtualSystemOverview.java
@@ -288,7 +288,7 @@ public class VirtualSystemOverview extends SystemOverview {
      * @return whether the current system is UI isVirtualHost
      */
     public boolean getIsVirtualHost() {
-        return (this.getUuid() == null);
+        return this.getUuid() == null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/VisibleSystems.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/VisibleSystems.java
@@ -82,7 +82,7 @@ public class VisibleSystems extends BaseDto {
      * null if not selectable
      */
     public void setSelectable(Integer selectableIn) {
-       selectable = (selectableIn != null);
+       selectable = selectableIn != null;
     }
 
     /**
@@ -90,7 +90,7 @@ public class VisibleSystems extends BaseDto {
      * one if selectable, null if not selectable
      */
     public void setSelectable(Long selectableIn) {
-        selectable = (selectableIn != null);
+        selectable = selectableIn != null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/XccdfTestResultCounts.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/XccdfTestResultCounts.java
@@ -186,7 +186,7 @@ public abstract class XccdfTestResultCounts extends BaseDto {
 
     private Long getCountOf(String resultLabel) {
         Long result = getCountMap().get(resultLabel);
-        return (result != null) ? result : 0;
+        return result != null ? result : 0;
     }
 
     private Map<String, Long> getCountMap() {

--- a/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartOptionValue.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartOptionValue.java
@@ -160,7 +160,7 @@ public class KickstartOptionValue implements Comparable<KickstartOptionValue> {
     @Override
     public int hashCode() {
         int result;
-        result = (name != null ? name.hashCode() : 0);
+        result = name != null ? name.hashCode() : 0;
         result = 31 * result + (arg != null ? arg.hashCode() : 0);
         result = 31 * result + (enabled != null ? enabled.hashCode() : 0);
         return result;

--- a/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartOverviewSystemsDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/kickstart/KickstartOverviewSystemsDto.java
@@ -157,7 +157,7 @@ public class KickstartOverviewSystemsDto extends BaseDto {
      * @return whether or not the current system is a bare metal
      */
     public boolean getIsBareMetal() {
-        return (getOldServerId() == null && getNewServerId() == null);
+        return getOldServerId() == null && getNewServerId() == null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/test/RendererHelperTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/test/RendererHelperTest.java
@@ -48,7 +48,7 @@ public class RendererHelperTest extends RhnBaseTestCase {
     private static final int PAGE_SIZE = 5;
 
     private static final int TOTAL_SERVERS_COUNT = PAGE_SIZE + 5;
-    private static final int EQUAL_SERVERS_COUNT = TOTAL_SERVERS_COUNT - (PAGE_SIZE / 2);
+    private static final int EQUAL_SERVERS_COUNT = TOTAL_SERVERS_COUNT - PAGE_SIZE / 2;
 
     @Test
     public void testSortOverviews() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/AlignSoftwareTargetAction.java
@@ -80,7 +80,7 @@ public class AlignSoftwareTargetAction implements MessageAction {
 
     @Override
     public Consumer<Exception> getExceptionHandler() {
-        return (e) -> {
+        return e -> {
             if (e instanceof AlignSoftwareTargetException exc) {
                 LOG.error("Error aligning target {}", exc.getTarget().getId(), e);
                 exc.getTarget().setStatus(Status.FAILED);

--- a/java/code/src/com/redhat/rhn/frontend/filter/StringMatcher.java
+++ b/java/code/src/com/redhat/rhn/frontend/filter/StringMatcher.java
@@ -34,10 +34,10 @@ class StringMatcher implements Matcher {
                     StringUtils.isBlank(filterColumn)) {
             return true; ///show all if I entered a blank value
         }
-        String value = ((String)MethodUtil.callMethod(obj,
+        String value = (String)MethodUtil.callMethod(obj,
                 StringUtil.beanify("get " +
                                     filterColumn),
-                                new Object[0]));
+                                new Object[0]);
         if (!StringUtils.isBlank(value)) {
             return value.toUpperCase().contains(filterData.toUpperCase());
         }

--- a/java/code/src/com/redhat/rhn/frontend/html/BaseTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/html/BaseTag.java
@@ -128,7 +128,7 @@ public abstract class BaseTag {
             ret.append("\"");
         }
         if (selfClosing) {
-            ret.append((spaceBeforeEndTag ? " />" : "/>"));
+            ret.append(spaceBeforeEndTag ? " />" : "/>");
         }
         else {
             ret.append(">");
@@ -183,7 +183,7 @@ public abstract class BaseTag {
      * @return true if this tag has a body defined.
      */
     public boolean hasBody() {
-        return (!body.isEmpty());
+        return !body.isEmpty();
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/nav/NavTreeIndex.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/NavTreeIndex.java
@@ -306,7 +306,7 @@ public class NavTreeIndex {
     private boolean canViewUrl(NavNode node, int depth) {
         AclGuard guard = tree.getGuard();
         // purposefully an or, not an and
-        return (guard == null || guard.canRender(node, depth));
+        return guard == null || guard.canRender(node, depth);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/nav/RenderEngine.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/RenderEngine.java
@@ -78,7 +78,7 @@ public class RenderEngine {
             if (i == 0) {
                 node.setFirst(true);
             }
-            else if (i == (size - 1)) {
+            else if (i == size - 1) {
                 node.setLast(true);
             }
 

--- a/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/PxtAuthenticationService.java
@@ -143,9 +143,9 @@ public class PxtAuthenticationService extends BaseAuthenticationService {
     }
 
     private boolean isAuthenticationRequired(HttpServletRequest request) {
-        return (!pxtDelegate.isPxtSessionKeyValid(request) ||
+        return !pxtDelegate.isPxtSessionKeyValid(request) ||
                pxtDelegate.isPxtSessionExpired(request) ||
-               pxtDelegate.getWebUserId(request) == null);
+               pxtDelegate.getWebUserId(request) == null;
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthenticationFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthenticationFilter.java
@@ -68,7 +68,7 @@ public class AuthenticationFilter implements Filter {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("ENTER AuthFilter.doFilter: {} [{}] ({})", request.getRemoteAddr(), new Date(),
-                    ((HttpServletRequest) (request)).getRequestURI());
+                    ((HttpServletRequest) request).getRequestURI());
         }
 
         if (authenticationService.validate((HttpServletRequest) request, (HttpServletResponse) response)) {

--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthorizationFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthorizationFilter.java
@@ -67,7 +67,7 @@ public class AuthorizationFilter implements Filter {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("ENTER AuthorizationFilter.doFilter: {} [{}] ({})", request.getRemoteAddr(), new Date(),
-                    ((HttpServletRequest) (request)).getRequestURI());
+                    ((HttpServletRequest) request).getRequestURI());
         }
 
         HttpServletRequest hreq = new RhnHttpServletRequest((HttpServletRequest) request);

--- a/java/code/src/com/redhat/rhn/frontend/servlets/OvalServlet.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/OvalServlet.java
@@ -109,8 +109,8 @@ public class OvalServlet extends HttpServlet {
 
     private String getFormat(HttpServletRequest request) {
         String format = request.getParameter("format");
-        if (format == null || (!format.equalsIgnoreCase("xml") &&
-                !format.equals("zip"))) {
+        if (format == null || !format.equalsIgnoreCase("xml") &&
+                !format.equals("zip")) {
             format = "xml";
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/servlets/PxtSessionDelegateImpl.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/PxtSessionDelegateImpl.java
@@ -71,7 +71,7 @@ public class PxtSessionDelegateImpl implements PxtSessionDelegate {
     @Override
     public Long getWebUserId(HttpServletRequest request) {
         WebSession session = getPxtSessionIfExists(request);
-        return ((session == null) ? null : session.getWebUserId());
+        return session == null ? null : session.getWebUserId();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/servlets/SetCharacterEncodingFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SetCharacterEncodingFilter.java
@@ -85,7 +85,7 @@ public class SetCharacterEncodingFilter implements Filter {
            throws IOException, ServletException {
 
         // Conditionally select and set the character encoding to be used
-        if ((request.getCharacterEncoding() == null)) {
+        if (request.getCharacterEncoding() == null) {
             String encodingIn = selectEncoding(request);
             if (encoding != null) {
                 request.setCharacterEncoding(encodingIn);
@@ -121,7 +121,7 @@ public class SetCharacterEncodingFilter implements Filter {
      * @return character encoding to use
      */
     protected String selectEncoding(ServletRequest request) {
-        return (this.encoding);
+        return this.encoding;
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/servlets/ajax/AjaxHandlerServlet.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/ajax/AjaxHandlerServlet.java
@@ -148,7 +148,7 @@ public class AjaxHandlerServlet extends HttpServlet {
             ActionChainEntriesDto dto = parseBody(req, ActionChainEntriesDto.class);
             return actionChainEntryRenderer.renderAsync(req, resp, dto.getActionChainId(), dto.getSortOrder());
         });
-        HANDLERS.put("action-chain-save", ((req, resp) -> {
+        HANDLERS.put("action-chain-save", (req, resp) -> {
             ActionChainSaveDto dto = parseBody(req, ActionChainSaveDto.class);
             return actionChainSaveAction.save(
                 dto.getActionChainId(),
@@ -158,7 +158,7 @@ public class AjaxHandlerServlet extends HttpServlet {
                 dto.getReorderedSortOrders(),
                 req
             );
-        }));
+        });
 
         // The following handler is used in all the pages using the rl:selectablecolumn custom tag
         HANDLERS.put("item-selector", (req, resp) -> {

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/SystemDetailsMessageFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/SystemDetailsMessageFilterTest.java
@@ -72,7 +72,7 @@ public class SystemDetailsMessageFilterTest extends MockObjectTestCase {
         SystemDetailsMessageFilter filter = new SystemDetailsMessageFilter();
         filter.processSystemMessages(request, minionServer);
         ActionMessages messages =
-                ((ActionMessages) request.getSession().getAttribute("org.apache.struts.action.ERROR"));
+                (ActionMessages) request.getSession().getAttribute("org.apache.struts.action.ERROR");
         assertNull(messages);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
@@ -198,7 +198,7 @@ public class RequestContext {
         PxtSessionDelegateFactory factory = PxtSessionDelegateFactory.getInstance();
         PxtSessionDelegate pxtDelegate = factory.newPxtSessionDelegate();
         Long uid = pxtDelegate.getWebUserId(request);
-        return ((uid == null) ? null : UserFactory.lookupById(uid));
+        return uid == null ? null : UserFactory.lookupById(uid);
     }
 
     /**
@@ -423,7 +423,7 @@ public class RequestContext {
      * @return True if the named parameter is in the request.
      */
     public boolean hasParam(String name) {
-        return (request.getParameter(name) != null);
+        return request.getParameter(name) != null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/struts/RhnValidationHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RhnValidationHelper.java
@@ -303,7 +303,7 @@ public class RhnValidationHelper {
      */
     public static boolean getFailedValidation(HttpServletRequest request) {
         String failed = (String) request.getAttribute(FAILED_KEY);
-        return (failed != null && failed.equals("true"));
+        return failed != null && failed.equals("true");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
@@ -192,7 +192,7 @@ public class StrutsDelegate {
     public void saveMessages(HttpServletRequest request, ActionMessages messages) {
         HttpSession session = request.getSession();
 
-        if ((messages == null) || messages.isEmpty()) {
+        if (messages == null || messages.isEmpty()) {
             session.removeAttribute(Globals.ERROR_KEY);
             session.removeAttribute(Globals.MESSAGE_KEY);
             return;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/AddressTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/AddressTag.java
@@ -239,7 +239,7 @@ public class AddressTag extends TagSupport {
             throw new JspException("IO error writing to JSP file:", ioe);
         }
 
-        return (SKIP_BODY);
+        return SKIP_BODY;
     }
 
     // man this is a hack.

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ColumnTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ColumnTag.java
@@ -407,7 +407,7 @@ public class ColumnTag extends TagSupport {
      * @return true if the header needs to be displayed.
      */
     private boolean showHeader() {
-        return (pageContext.getAttribute("current") == null);
+        return pageContext.getAttribute("current") == null;
     }
 
     /**
@@ -597,7 +597,7 @@ public class ColumnTag extends TagSupport {
     }
 
     private boolean showUrl() {
-        return ((getUrl() != null) && isRenderUrl());
+        return getUrl() != null && isRenderUrl();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
@@ -199,7 +199,7 @@ public class DateTimePickerTag extends TagSupport {
         out.append(createHiddenInput("minute", String.valueOf(data.getMinute())).render());
         if (data.isLatin()) {
             out.append(createHiddenInput("am_pm",
-                    String.valueOf((data.getHourOfDay() >= 12) ? 1 : 0)).render());
+                    String.valueOf(data.getHourOfDay() >= 12 ? 1 : 0)).render());
         }
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
@@ -243,7 +243,7 @@ public class FormatDateTag extends TagSupport {
         catch (IOException ioe) {
             throw new JspException("IO error writing to JSP file:", ioe);
         }
-        return (SKIP_BODY);
+        return SKIP_BODY;
     }
 
     /**
@@ -287,10 +287,10 @@ public class FormatDateTag extends TagSupport {
     }
 
     protected boolean isFormatCustomized() {
-        return (getPattern() != null ||
+        return getPattern() != null ||
                 getType() != null ||
                 getDateStyle() != null ||
-                getTimeStyle() != null);
+                getTimeStyle() != null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ListDisplayTag.java
@@ -525,7 +525,7 @@ public class ListDisplayTag extends ListDisplayTagBase {
         out.append(LocalizationService.getInstance()
                     .getMessage("message.range", args));
 
-        if ((set != null) && (!RhnSetDecl.SYSTEMS.getLabel().equals(set.getLabel()))) {
+        if (set != null && !RhnSetDecl.SYSTEMS.getLabel().equals(set.getLabel())) {
             if (top) {
                 out.append(" <strong><span id=\"pagination_selcount_top\">");
             }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/LocalizedSubmitTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/LocalizedSubmitTag.java
@@ -50,7 +50,7 @@ public class LocalizedSubmitTag extends SubmitTag {
     @Override
     public String getStyleClass() {
         if (super.getStyleClass() != null) {
-            return (super.getStyleClass());
+            return super.getStyleClass();
         }
         return "btn btn-primary";
     }
@@ -62,7 +62,7 @@ public class LocalizedSubmitTag extends SubmitTag {
     public int doStartTag() throws JspException {
         this.setValue(LocalizationService.getInstance().getMessage(getValueKey()));
         super.doStartTag();
-        return (SKIP_BODY);
+        return SKIP_BODY;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/MessagesTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/MessagesTag.java
@@ -49,7 +49,7 @@ public class MessagesTag extends TagSupport {
             baseTag.setAttribute("class", "alert alert-info");
 
             out.print(baseTag.renderOpenTag());
-            return (EVAL_BODY_INCLUDE);
+            return EVAL_BODY_INCLUDE;
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);
@@ -66,7 +66,7 @@ public class MessagesTag extends TagSupport {
             out = pageContext.getOut();
             out.print(baseTag.renderCloseTag());
             removeMessagesFromSession();
-            return (EVAL_PAGE);
+            return EVAL_PAGE;
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
@@ -63,7 +63,7 @@ public class NavDialogMenuTag extends TagSupport {
             throw new JspException("Error writing to JSP file:", e);
         }
 
-        return (SKIP_BODY);
+        return SKIP_BODY;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/RequireTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/RequireTag.java
@@ -105,10 +105,10 @@ public class RequireTag extends TagSupport {
                 // acl methods must be in the following form
                 // aclXxxYyy(Object context, String[] params) and invoked
                 // xxx_yyy(param);
-                return (EVAL_BODY_INCLUDE);
+                return EVAL_BODY_INCLUDE;
             }
 
-            return (SKIP_BODY);
+            return SKIP_BODY;
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/SystemTimeMessageTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/SystemTimeMessageTag.java
@@ -55,7 +55,7 @@ public class SystemTimeMessageTag extends TagSupport {
         try {
             out = pageContext.getOut();
             out.print(getMessage());
-            return (EVAL_PAGE);
+            return EVAL_PAGE;
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);
@@ -71,10 +71,10 @@ public class SystemTimeMessageTag extends TagSupport {
 
         Date now = new Date();
         Date lastCheckIn = server.getLastCheckin();
-        Date expectedCheckIn = new Date(lastCheckIn.getTime() + (1000 * 60 * 60 * 2));
+        Date expectedCheckIn = new Date(lastCheckIn.getTime() + 1000 * 60 * 60 * 2);
         //expected check in is two hours after last check in, regardless of threshold
         long checkInAgo = now.getTime() - lastCheckIn.getTime();
-        Long days = (((checkInAgo / 1000) / 60) / 60) / 24;
+        Long days = checkInAgo / 1000 / 60 / 60 / 24;
         RhnConfigurationFactory factory = RhnConfigurationFactory.getSingleton();
         boolean awol = days.intValue() >
                 factory.getIntegerConfiguration(RhnConfiguration.KEYS.SYSTEM_CHECKIN_THRESHOLD).getValue();

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/ToolbarTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/ToolbarTag.java
@@ -602,7 +602,7 @@ public class ToolbarTag extends TagSupport {
             buf.append(renderIcon());
 
             out.print(buf.toString());
-            return (EVAL_BODY_INCLUDE);
+            return EVAL_BODY_INCLUDE;
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);
@@ -625,7 +625,7 @@ public class ToolbarTag extends TagSupport {
             buf.append(baseTag.renderCloseTag());
 
             out.print(buf.toString());
-            return (EVAL_PAGE);
+            return EVAL_PAGE;
         }
         catch (Exception e) {
             throw new JspException("Error writing to JSP file:", e);
@@ -783,7 +783,7 @@ public class ToolbarTag extends TagSupport {
     }
 
     private boolean assertNotEmpty(String str) {
-        return (str != null && !"".equals(str));
+        return str != null && !"".equals(str);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/UnpagedListDisplayTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/UnpagedListDisplayTag.java
@@ -212,7 +212,7 @@ public class UnpagedListDisplayTag extends ListDisplayTagBase {
      * @return true if parent-string, false else
      */
     public boolean isParent(String s) {
-        return (s != null && s.startsWith("p"));
+        return s != null && s.startsWith("p");
     }
 
     /**
@@ -221,7 +221,7 @@ public class UnpagedListDisplayTag extends ListDisplayTagBase {
      * @return true if child-string, false else
      */
     public boolean isChild(String s) {
-        return (s != null && s.startsWith("c"));
+        return s != null && s.startsWith("c");
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/ListViewHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/ListViewHelper.java
@@ -164,12 +164,12 @@ public class ListViewHelper {
             tmp.setFilter(true);
             this.filteredResult = tmp;
             this.filteredResult.setStart(start);
-            this.filteredResult.setEnd((start + this.filteredResult.size()) - 1);
+            this.filteredResult.setEnd(start + this.filteredResult.size() - 1);
         }
         else {
             this.result = this.result.slice(start - 1, end - 1);
             this.result.setStart(start);
-            this.result.setEnd((start + this.result.size()) - 1);
+            this.result.setEnd(start + this.result.size() - 1);
         }
     }
 
@@ -242,12 +242,12 @@ public class ListViewHelper {
         boolean retval = false;
         String prevFilter = getPreviousFilterParam();
         String currentFilter = getFilterParam();
-        if ((prevFilter != null && currentFilter != null) &&
+        if (prevFilter != null && currentFilter != null &&
                 !prevFilter.equals(currentFilter)) {
             retval = true;
 
         }
-        else if ((prevFilter == null && currentFilter != null) || prevFilter != null &&
+        else if (prevFilter == null && currentFilter != null || prevFilter != null &&
                 currentFilter == null) {
             retval = true;
         }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/BaseListFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/BaseListFilter.java
@@ -53,7 +53,7 @@ public abstract class BaseListFilter implements ListFilter {
         criteria = criteria.toLowerCase();
         if (methodName != null) {
             String value = ListTagUtil.getBeanValue(object, methodName);
-            return (value != null) &&
+            return value != null &&
                     value.toLowerCase().contains(criteria);
         }
         return false;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/CSVTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/CSVTag.java
@@ -147,7 +147,7 @@ public class CSVTag extends BodyTagSupport {
     @Override
     public int doEndTag() throws JspException {
         setupPageData();
-        if ((null != exportColumns) && (null != pageData)) {
+        if (null != exportColumns && null != pageData) {
             renderExport();
         }
         release();

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ColumnTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ColumnTag.java
@@ -210,7 +210,7 @@ public class ColumnTag extends BodyTagSupport {
     }
 
     protected void renderHeader() throws JspException {
-        if ((headerKey == null) && (headerText == null)) {
+        if (headerKey == null && headerText == null) {
             return;
         }
         ListTagUtil.write(pageContext, "<th");
@@ -330,7 +330,7 @@ public class ColumnTag extends BodyTagSupport {
         ListCommand command = ListTagUtil.getCurrentCommand(this, pageContext);
 
         if (styleClass != null ||
-                (isCurrColumnSorted() && command != ListCommand.COL_HEADER)) {
+                isCurrColumnSorted() && command != ListCommand.COL_HEADER) {
             ListTagUtil.write(pageContext, " class=\"");
             if (styleClass != null) {
                 ListTagUtil.write(pageContext, styleClass);

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/DataSetManipulator.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/DataSetManipulator.java
@@ -211,7 +211,7 @@ public class DataSetManipulator {
             }
         }
         else {
-            if ((getCurrentPageNumber() * pageSize) + pageSize < (totalDataSetSize)) {
+            if (getCurrentPageNumber() * pageSize + pageSize < totalDataSetSize) {
                 retval = getCurrentPageNumber() + 1;
             }
         }
@@ -225,7 +225,7 @@ public class DataSetManipulator {
     public int getPrevPageNumber() {
         int retval = -1;
         if (getCurrentPageNumber() > 0) {
-            if (((getCurrentPageNumber() * pageSize) - pageSize) > -1) {
+            if (getCurrentPageNumber() * pageSize - pageSize > -1) {
                 retval = getCurrentPageNumber() - 1;
             }
         }
@@ -245,7 +245,7 @@ public class DataSetManipulator {
      * @return answer to that burning question
      */
     public boolean isLastPage() {
-        int maxPage = (dataset.size() / pageSize) - 1;
+        int maxPage = dataset.size() / pageSize - 1;
         // Add a page for overflow, since the dataset is not
         // evenly divisible by the pagesize
         if (dataset.size() % pageSize > 0) {

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTag.java
@@ -663,7 +663,7 @@ public class ListTag extends BodyTagSupport {
 
         pageContext.pushBody(footLinksContent);
         // if there is reference links, put them as a panel footer
-        if ((refLink != null) && (!isEmpty())) {
+        if (refLink != null && !isEmpty()) {
 
             ListTagUtil.write(pageContext, "<a href=\"" + refLink + "\" >");
             /* Here we render the reflink and its key. If the key hasn't been set
@@ -749,7 +749,7 @@ public class ListTag extends BodyTagSupport {
 
         ListTagUtil.write(pageContext, "<!-- START LIST " + getUniqueName() + " -->");
 
-        String listId = (getStyleId() != null) ? getStyleId() : getUniqueName();
+        String listId = getStyleId() != null ? getStyleId() : getUniqueName();
 
         setupManipulator();
         manip.sort();

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
@@ -650,9 +650,9 @@ public class ListTagUtil {
                 "name=\"%s\" value=\"%s\" class=\"form-control\" placeholder=\"%s\" " +
                 "onkeypress=\"return enterKeyHandler(event, jQuery('button[name=%s]'))\"/>",
                                 filterValueKey,
-                                (filterValue != null ?
-                                 StringEscapeUtils.escapeHtml4(filterValue) :
-                                 ""),
+                filterValue != null ?
+                 StringEscapeUtils.escapeHtml4(filterValue) :
+                 "",
                                  StringEscapeUtils.escapeHtml4(placeHolder),
                                  filterName
                                  ));
@@ -679,7 +679,7 @@ public class ListTagUtil {
     public static void renderFilterSubmit(PageContext pageContext,
             String uniqueName) throws JspException {
         String filterName = makeFilterNameByLabel(uniqueName);
-        String result = (String.format("<input type=\"hidden\" name=\"%s\">", filterName));
+        String result = String.format("<input type=\"hidden\" name=\"%s\">", filterName);
         ListTagUtil.write(pageContext, result);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/decorators/ElaborationDecorator.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/decorators/ElaborationDecorator.java
@@ -44,7 +44,7 @@ public class ElaborationDecorator extends BaseListDecorator {
         Elaborator elab = TagHelper.lookupElaboratorFor(getCurrentList().
                                                                   getUniqueName(),
                                     getCurrentList().getContext().getRequest());
-        if ((data == null) || (data.isEmpty())) {
+        if (data == null || data.isEmpty()) {
             return;
         }
         if (elab == null) {

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/helper/ListSetHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/helper/ListSetHelper.java
@@ -192,7 +192,7 @@ public abstract class ListSetHelper extends ListHelper {
 
     private void syncSelections(List dataSet,
                     HttpServletRequest request) {
-        if ((dataSet != null) && (!dataSet.isEmpty())) {
+        if (dataSet != null && !dataSet.isEmpty()) {
             if (dataSet.get(0) instanceof Selectable) {
                 syncSelections(dataSet);
             }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/BaseTestToolbarTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/BaseTestToolbarTag.java
@@ -75,7 +75,7 @@ public abstract class BaseTestToolbarTag extends RhnBaseTestCase {
         }
 
         public boolean aclIsFoo(Map<String, Object> ctx, String[] params) {
-            return (params[0].equals("foo"));
+            return params[0].equals("foo");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/RequireTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/RequireTagTest.java
@@ -185,7 +185,7 @@ public class RequireTagTest extends RhnBaseTestCase {
         }
 
         public boolean aclIsFoo(Map<String, Object> ctx, String[] params) {
-            return (params[0].equals("foo"));
+            return params[0].equals("foo");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -320,7 +320,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
             " in class: " + this.getClass().getName() + " with params: [";
             for (Iterator iter = params.iterator(); iter.hasNext();) {
                 Object param = iter.next();
-                message += (param.getClass().getName());
+                message += param.getClass().getName();
                     if (iter.hasNext()) {
                         message = message + ", ";
                     }
@@ -445,7 +445,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
     protected void validateEntitlements(List<Entitlement> entitlements) {
 
         for (Entitlement ent : entitlements) {
-            if ((ent == null) || (ent.isPermanent())) {
+            if (ent == null || ent.isPermanent()) {
                 throw new InvalidEntitlementException();
             }
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/MissingErrataAttributeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/MissingErrataAttributeException.java
@@ -29,7 +29,7 @@ public class MissingErrataAttributeException extends FaultException {
      */
     public MissingErrataAttributeException(String attribute) {
         super(2609, "invalidActionType", LocalizationService.getInstance().
-                getMessage("api.errata.missingerrataaction", (attribute)));
+                getMessage("api.errata.missingerrataaction", attribute));
     }
 
     /**
@@ -41,6 +41,6 @@ public class MissingErrataAttributeException extends FaultException {
      */
     public MissingErrataAttributeException(String attribute, Throwable cause) {
         super(2609, "invalidActionType", LocalizationService.getInstance().
-                getMessage("api.errata.missingerrataaction", (attribute)), cause);
+                getMessage("api.errata.missingerrataaction", attribute), cause);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcLoggingInvocationProcessor.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/XmlRpcLoggingInvocationProcessor.java
@@ -80,7 +80,7 @@ public class XmlRpcLoggingInvocationProcessor extends LoggingInvocationProcessor
         // HACK ALERT!  We need the caller, would be better in
         // the postProcess, but that works for ALL methods except
         // logout.  So we do it here.
-        if ((arguments != null) && (!arguments.isEmpty())) {
+        if (arguments != null && !arguments.isEmpty()) {
             if (arguments.get(0) instanceof User u) {
                 setCaller(u);
             }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
@@ -455,7 +455,7 @@ public class ActivationKeyHandler extends BaseHandler {
         }
 
         if (details.containsKey("usage_limit")) {
-            Long usageLimit = Long.valueOf(((Integer) details.get("usage_limit")));
+            Long usageLimit = Long.valueOf((Integer) details.get("usage_limit"));
             aKey.setUsageLimit(usageLimit);
         }
 
@@ -1179,6 +1179,6 @@ public class ActivationKeyHandler extends BaseHandler {
        */
       public int checkConfigDeployment(User loggedInUser, String key) {
           ActivationKey ac = lookupKey(key, loggedInUser);
-          return (ac.getDeployConfigs() ? 1 : 0);
+          return ac.getDeployConfigs() ? 1 : 0;
       }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
@@ -670,23 +670,23 @@ public class ActivationKeyHandlerTest extends BaseHandlerTestCase {
         boolean foundPkg1 = false, foundPkg2 = false, foundPkg3 = false;
 
         for (TokenPackage pkg : activationKey.getPackages()) {
-            if ((pkg.getPackageName() != null) &&
+            if (pkg.getPackageName() != null &&
                 pkg.getPackageName().getName().equals("pkg1")) {
 
-                if ((pkg.getPackageArch() != null) &&
+                if (pkg.getPackageArch() != null &&
                     pkg.getPackageArch().getLabel().equals("i386")) {
 
                     foundPkg1 = true;
                 }
             }
-            else if ((pkg.getPackageName() != null) &&
+            else if (pkg.getPackageName() != null &&
                      pkg.getPackageName().getName().equals("pkg2")) {
 
                 if (pkg.getPackageArch() == null) {
                     foundPkg2 = true;
                 }
             }
-            else if ((pkg.getPackageName() != null) &&
+            else if (pkg.getPackageName() != null &&
                      pkg.getPackageName().getName().equals("pkg3")) {
 
                 if (pkg.getPackageArch() == null) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/ApiHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/api/ApiHandler.java
@@ -191,8 +191,8 @@ public class ApiHandler extends BaseHandler {
         if (classType.equals(String.class)) {
             return "string";
         }
-        else if ((classType.equals(Integer.class)) ||
-                 (classType.equals(int.class))) {
+        else if (classType.equals(Integer.class) ||
+                classType.equals(int.class)) {
             return "int";
         }
         else if (classType.equals(Date.class)) {
@@ -205,10 +205,10 @@ public class ApiHandler extends BaseHandler {
         else if (classType.equals(Map.class)) {
             return "struct";
         }
-        else if ((classType.equals(List.class)) ||
-                 (classType.equals(Set.class)) ||
-                 (classType.toString().contains("class [L")) ||
-                 (classType.toString().contains("class [I"))) {
+        else if (classType.equals(List.class) ||
+                classType.equals(Set.class) ||
+                classType.toString().contains("class [L") ||
+                classType.toString().contains("class [I")) {
             return "array";
         }
         else if (classType.toString().contains("class [B")) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/chain/test/ActionChainHandlerTest.java
@@ -426,7 +426,7 @@ public class ActionChainHandlerTest extends BaseHandlerTestCase {
                 this.admin, CHAIN_LABEL).isEmpty());
         assertTrue(this.ach.removeAction(
                 this.admin, CHAIN_LABEL,
-                ((Long) (this.ach.listChainActions(this.admin, CHAIN_LABEL).get(0))
+                ((Long) this.ach.listChainActions(this.admin, CHAIN_LABEL).get(0)
                         .get("id")).intValue()) > 0);
         assertTrue(this.ach.listChainActions(this.admin, CHAIN_LABEL).isEmpty());
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/access/ChannelAccessHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/access/ChannelAccessHandler.java
@@ -57,7 +57,7 @@ public class ChannelAccessHandler extends BaseHandler {
 
         Channel channel = lookupChannelByLabel(loggedInUser, channelLabel);
         // This can be set for null-org channels by channel admin
-        if ((channel.getOrg() != null) || (!loggedInUser.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN))) {
+        if (channel.getOrg() != null || !loggedInUser.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN)) {
             verifyChannelAdmin(loggedInUser, channel);
         }
 
@@ -89,7 +89,7 @@ public class ChannelAccessHandler extends BaseHandler {
 
         Channel channel = lookupChannelByLabel(loggedInUser, channelLabel);
         // This can be set for null-org channels by channel admin
-        if ((channel.getOrg() != null) || (!loggedInUser.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN))) {
+        if (channel.getOrg() != null || !loggedInUser.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN)) {
             verifyChannelAdmin(loggedInUser, channel);
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -721,7 +721,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
         ccc.setGpgKeyFp(gpgKey.get("fingerprint"));
         ccc.setGpgCheck(gpgCheck);
 
-        return (ccc.create() != null) ? 1 : 0;
+        return ccc.create() != null ? 1 : 0;
     }
     /**
      * Creates a software channel, parent_channel_label can be empty string
@@ -1550,7 +1550,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
     }
 
     private void scheduleErrataCacheUpdate(Org org, Channel channel, long delay) {
-        delay /= (24 * 60 * 60);
+        delay /= 24 * 60 * 60;
 
         Task task = TaskFactory.lookup(org, ErrataCacheWorker.BY_CHANNEL, channel.getId());
         if (task == null) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -341,9 +341,9 @@ public class ErrataHandler extends BaseHandler {
         }
         if (details.containsKey("advisory_type")) {
             String pea = "Product Enhancement Advisory"; // hack for checkstyle
-            if (!(details.get("advisory_type")).equals("Security Advisory") &&
-            !(details.get("advisory_type")).equals(pea) &&
-            !(details.get("advisory_type")).equals("Bug Fix Advisory")) {
+            if (!details.get("advisory_type").equals("Security Advisory") &&
+            !details.get("advisory_type").equals(pea) &&
+            !details.get("advisory_type").equals("Bug Fix Advisory")) {
                 throw new InvalidParameterException("Invalid advisory type");
             }
             errata.setAdvisoryType((String)details.get("advisory_type"));
@@ -688,7 +688,7 @@ public class ErrataHandler extends BaseHandler {
             Package pkg = PackageManager.lookupByIdAndUser(Long.valueOf(packageId),
                     loggedInUser);
 
-            if ((pkg != null) && (!errata.getPackages().contains(pkg))) {
+            if (pkg != null && !errata.getPackages().contains(pkg)) {
                 errata.addPackage(pkg);
                 packagesAdded++;
             }
@@ -734,7 +734,7 @@ public class ErrataHandler extends BaseHandler {
             Package pkg = PackageManager.lookupByIdAndUser(Long.valueOf(packageId),
                     loggedInUser);
 
-            if ((pkg != null) && (errata.getPackages().contains(pkg))) {
+            if (pkg != null && errata.getPackages().contains(pkg)) {
                 errata.removePackage(pkg);
                 packagesRemoved++;
             }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/test/ErrataHandlerTest.java
@@ -747,7 +747,7 @@ public class ErrataHandlerTest extends BaseHandlerTestCase {
         Set<Channel> channels = cloned.getChannels();
         assertEquals(1, channels.size());
 
-        Channel sameChannel = ((Channel)channels.toArray()[0]);
+        Channel sameChannel = (Channel)channels.toArray()[0];
         assertEquals(channel, sameChannel);
 
         Set<Package> packs = sameChannel.getPackages();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
@@ -513,8 +513,8 @@ public class ProfileHandler extends BaseHandler {
         if (preScripts.size() != myPreScripts.size()) {
             throw new IllegalArgumentException("Too many pre script IDs.");
         }
-        if ((postScriptsBeforeRegistration.size() + postScriptsAfterRegistration.size() !=
-                myPostScripts.size())) {
+        if (postScriptsBeforeRegistration.size() + postScriptsAfterRegistration.size() !=
+                myPostScripts.size()) {
             throw new IllegalArgumentException("Too many post script IDs.");
         }
 
@@ -992,7 +992,7 @@ public class ProfileHandler extends BaseHandler {
 
                // the following is a workaround to ensure that the options are rendered
                // on the UI on separate lines.
-               if (i < (options.size() - 1)) {
+               if (i < options.size() - 1) {
                    option += "\r";
                }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
@@ -495,8 +495,8 @@ public class OrgHandler extends BaseHandler {
 
             // unless the user is a satellite admin, they are not permitted to transfer
             // systems from an org that they do not belong to
-            if ((!loggedInUser.hasRole(RoleFactory.SAT_ADMIN)) &&
-                    (!loggedInUser.getOrg().equals(server.getOrg()))) {
+            if (!loggedInUser.hasRole(RoleFactory.SAT_ADMIN) &&
+                    !loggedInUser.getOrg().equals(server.getOrg())) {
                 throw new PermissionCheckFailureException(server);
             }
 
@@ -623,7 +623,7 @@ public class OrgHandler extends BaseHandler {
         Map<String, Object> result = new HashMap<>();
         result.put("enabled", retentionPeriod != null);
         result.put("retention_period",
-                (retentionPeriod != null) ? retentionPeriod : Long.valueOf(0));
+                retentionPeriod != null ? retentionPeriod : Long.valueOf(0));
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/PackageHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/packages/PackageHelper.java
@@ -111,10 +111,10 @@ public class PackageHelper {
         addEntry(pkgMap, "part_of_retracted_patch",
                     pkg.isPartOfRetractedPatch());
         Long sz = pkg.getPackageSize();
-        addEntry(pkgMap, "size", (sz == null) ? "" : String.valueOf(sz));
+        addEntry(pkgMap, "size", sz == null ? "" : String.valueOf(sz));
 
         sz = pkg.getPayloadSize();
-        addEntry(pkgMap, "payload_size", (sz == null) ? "" : String.valueOf(sz));
+        addEntry(pkgMap, "payload_size", sz == null ? "" : String.valueOf(sz));
 
         return pkgMap;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/preferences/locale/PreferencesLocaleHandler.java
@@ -151,7 +151,7 @@ public class PreferencesLocaleHandler extends BaseHandler {
         @Override
         public boolean evaluate(Object object) {
             RhnTimeZone tz = (RhnTimeZone) object;
-            return (tz.getTimeZoneId() == id);
+            return tz.getTimeZoneId() == id;
         }
     }
 
@@ -173,7 +173,7 @@ public class PreferencesLocaleHandler extends BaseHandler {
         /** {@inheritDoc} */
         @Override
         public boolean evaluate(Object object) {
-            return (object.equals(locale));
+            return object.equals(locale);
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/ProxyHandler.java
@@ -119,7 +119,7 @@ public class ProxyHandler extends BaseHandler {
     public int isProxy(String clientcert)
         throws MethodInvalidParamException {
         Server server = validateClientCertificate(clientcert);
-        return (server.isProxy() ? 1 : 0);
+        return server.isProxy() ? 1 : 0;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/RecurringActionHandler.java
@@ -169,7 +169,7 @@ public class RecurringActionHandler extends BaseHandler {
         if (!actionProps.containsKey("id")) {
             throw new InvalidArgsException("No action id provided");
         }
-        RecurringAction action = lookupById(user, ((Integer) actionProps.get("id")));
+        RecurringAction action = lookupById(user, (Integer) actionProps.get("id"));
         // detach the object and prevent hibernate from auto flushing when fields become dirty
         HibernateFactory.getSession().evict(action);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SslContentSourceSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SslContentSourceSerializer.java
@@ -47,9 +47,9 @@ public class SslContentSourceSerializer extends ApiResponseSerializer<SslContent
         SslCryptoKey key = src.getClientKey();
 
         return new SerializationBuilder()
-                .add("sslCaDesc", (ca != null) ? ca.getDescription() : "")
-                .add("sslCertDesc", (cert != null) ? cert.getDescription() : "")
-                .add("sslKeyDesc", (key != null) ? key.getDescription() : "")
+                .add("sslCaDesc", ca != null ? ca.getDescription() : "")
+                .add("sslCertDesc", cert != null ? cert.getDescription() : "")
+                .add("sslKeyDesc", key != null ? key.getDescription() : "")
                 .build();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -688,7 +688,7 @@ public class SystemHandler extends BaseHandler {
 
         List<EssentialChannelDto> list = ChannelManager.listBaseChannelsForSystem(loggedInUser, server);
         for (EssentialChannelDto ch : list) {
-            Boolean currentBase = (baseChannel != null) &&
+            Boolean currentBase = baseChannel != null &&
                     baseChannel.getId().equals(ch.getId());
             returnList.add(createChannelMap(ch, currentBase));
         }
@@ -768,8 +768,8 @@ public class SystemHandler extends BaseHandler {
         }
         int offsetHrs = offset / 1000 / 60 / 60;
         int offsetMins = offset / 1000 / 60 % 60;
-        c.add(Calendar.HOUR_OF_DAY, (-offsetHrs));
-        c.add(Calendar.MINUTE, (-offsetMins));
+        c.add(Calendar.HOUR_OF_DAY, -offsetHrs);
+        c.add(Calendar.MINUTE, -offsetMins);
         c.set(Calendar.MILLISECOND, 0);
         return c.getTime();
     }
@@ -1234,7 +1234,7 @@ public class SystemHandler extends BaseHandler {
             String pkgEpoch = StringUtils.trim((String) pkg.get("epoch"));
             // If epoch is null, we arrived here from the isNvreInstalled(...n,v,r) method;
             // therefore, just skip the comparison
-            if ((epoch != null) && !pkgEpoch.equals(StringUtils.trim(epoch))) {
+            if (epoch != null && !pkgEpoch.equals(StringUtils.trim(epoch))) {
                 continue;
             }
 
@@ -2451,8 +2451,8 @@ public class SystemHandler extends BaseHandler {
             if (action.getArchived() != null) {
                 result.put("archived", action.getArchived());
             }
-            if ((action.getSchedulerUser() != null) &&
-                    (action.getSchedulerUser().getLogin() != null)) {
+            if (action.getSchedulerUser() != null &&
+                    action.getSchedulerUser().getLogin() != null) {
                 result.put("scheduler_user", action.getSchedulerUser().getLogin());
             }
             if (action.getPrerequisite() != null) {
@@ -5881,7 +5881,7 @@ public class SystemHandler extends BaseHandler {
         }
 
         // put a more intelligible exception
-        if ((server.getBaseEntitlement() == null) && (!addOnEnts.isEmpty())) {
+        if (server.getBaseEntitlement() == null && !addOnEnts.isEmpty()) {
             throw new InvalidEntitlementException("Base entitlement missing");
         }
 
@@ -6751,7 +6751,7 @@ public class SystemHandler extends BaseHandler {
                 preferIpv6Gateway, ksDistro);
 
         rec.setHostName(hostName);
-        rec.setGateway((preferIpv6Gateway) ? gw6 : gw4);
+        rec.setGateway(preferIpv6Gateway ? gw6 : gw4);
         rec.setNameServers(Optional.of(nameservers));
         meta.put(KickstartFormatter.STATIC_NETWORK_VAR, command);
         rec.setKsMeta(Optional.of(meta));
@@ -7291,7 +7291,7 @@ public class SystemHandler extends BaseHandler {
      */
     public int tagLatestSnapshot(User loggedInUser, Integer sid, String tagName) {
         Server server = lookupServer(loggedInUser, sid);
-        if (!(server.hasEntitlement(EntitlementManager.MANAGEMENT))) {
+        if (!server.hasEntitlement(EntitlementManager.MANAGEMENT)) {
             throw new FaultException(-2, "provisionError",
                     "System does not support snapshots");
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/custominfo/CustomInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/custominfo/CustomInfoHandler.java
@@ -51,7 +51,7 @@ public class CustomInfoHandler extends BaseHandler {
     public int createKey(User loggedInUser, String keyLabel,
                 String keyDescription) throws FaultException {
 
-        if ((keyLabel.length() < 2) || (keyDescription.length() < 2)) {
+        if (keyLabel.length() < 2 || keyDescription.length() < 2) {
             throw new FaultException(-1, "labelOrDescriptionTooShort",
                     "Label and description must be at least two characters long");
         }
@@ -96,7 +96,7 @@ public class CustomInfoHandler extends BaseHandler {
                     "A custom key with label: " + keyLabel + "does not exist.");
         }
 
-        if ((keyDescription.length() < 2)) {
+        if (keyDescription.length() < 2) {
             throw new FaultException(-1, "labelOrDescriptionTooShort",
                     "Label and description must be at least two characters long");
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1525,7 +1525,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         List<ShortSystemInfo> sysList = handler.searchByName(admin, "ydjdk1");
         assertEquals(1, sysList.size());
         SystemOverview result = sysList.get(0);
-        assertEquals(server.getId().intValue(), (result.getId().intValue()));
+        assertEquals(server.getId().intValue(), result.getId().intValue());
         assertEquals("ydjdk1234", result.getName());
         assertNotNull(result.getLastCheckin());
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
@@ -124,8 +124,8 @@ public class ServerGroupHandler extends BaseHandler {
         String admins = null;
         for (String login : loginNames) {
             User user = UserFactory.lookupByLogin(login);
-            if ((user != null) && ((user.hasRole(RoleFactory.SAT_ADMIN) ||
-                (user.hasRole(RoleFactory.ORG_ADMIN))))) {
+            if (user != null && (user.hasRole(RoleFactory.SAT_ADMIN) ||
+                    user.hasRole(RoleFactory.ORG_ADMIN))) {
                 if (admins == null) {
                     admins = login;
                 }

--- a/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
+++ b/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
@@ -80,6 +80,6 @@ public class AclManager {
             context.put("user", user);
         }
 
-        return (aclObj.evalAcl(context, acl));
+        return aclObj.evalAcl(context, acl);
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/acl/test/AclManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/acl/test/AclManagerTest.java
@@ -89,7 +89,7 @@ public class AclManagerTest extends RhnBaseTestCase {
         }
 
         public boolean aclIsFoo(Map<String, Object> ctx, String[] params) {
-            return (params[0].equals("foo"));
+            return params[0].equals("foo");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -198,7 +198,7 @@ public class ActionManager extends BaseManager {
         }
         Date now = Calendar.getInstance().getTime();
         if (serverAction.getStatus().equals(ActionFactory.STATUS_QUEUED) ||
-                serverAction.getStatus().equals((ActionFactory.STATUS_PICKED_UP))) {
+                serverAction.getStatus().equals(ActionFactory.STATUS_PICKED_UP)) {
             serverAction.setStatus(ActionFactory.STATUS_FAILED);
             serverAction.setResultMsg(message);
             serverAction.setCompletionTime(now);
@@ -631,7 +631,7 @@ public class ActionManager extends BaseManager {
             addConfigurationRevisionsToAction(user, revisions, a, server);
         }
         Set<ServerAction> sa = a.getServerActions();
-        if ((sa == null) || (sa.isEmpty())) {
+        if (sa == null || sa.isEmpty()) {
             return null;
         }
         ActionFactory.save(a);
@@ -1139,7 +1139,7 @@ public class ActionManager extends BaseManager {
      */
     public static PackageAction schedulePackageRefresh(User scheduler, Server server)
         throws TaskomaticApiException {
-        return (schedulePackageRefresh(scheduler, server, new Date()));
+        return schedulePackageRefresh(scheduler, server, new Date());
     }
 
     /**
@@ -2184,9 +2184,9 @@ public class ActionManager extends BaseManager {
                                                      server,
                                                      ActionFactory.TYPE_REBOOT,
                                                      ActionFactory.TYPE_REBOOT.getName(),
-                                                     (earliestAction == null ?
-                                                      new Date() :
-                                                      earliestAction));
+                earliestAction == null ?
+                 new Date() :
+                 earliestAction);
         ActionFactory.save(action);
         taskomaticApi.scheduleActionExecution(action);
         return action;
@@ -2212,7 +2212,7 @@ public class ActionManager extends BaseManager {
                         server,
                         ActionFactory.TYPE_CLIENTCERT_UPDATE_CLIENT_CERT,
                         ActionFactory.TYPE_CLIENTCERT_UPDATE_CLIENT_CERT.getName(),
-                        (earliestAction == null ? new Date() : earliestAction));
+                earliestAction == null ? new Date() : earliestAction);
         ActionFactory.save(action);
         taskomaticApi.scheduleActionExecution(action);
         return action;

--- a/java/code/src/com/redhat/rhn/manager/audit/AuditChannelInfo.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/AuditChannelInfo.java
@@ -122,7 +122,7 @@ public class AuditChannelInfo {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + (int) (id ^ (id >>> 32));
+        result = prime * result + (int) (id ^ id >>> 32);
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/audit/AuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/AuditManager.java
@@ -68,8 +68,8 @@ public class AuditManager /* extends BaseManager */ {
      */
     public static void markReviewed(String machine, Long start, Long end, String username) throws IOException {
         try (FileWriter fwr = new FileWriter(reviewFile, true)) { // append!
-            fwr.write(machine + "," + (start / 1000) + "," + (end / 1000) + "," +
-                username + "," + (new Date().getTime() / 1000) + "\n");
+            fwr.write(machine + "," + start / 1000 + "," + end / 1000 + "," +
+                username + "," + new Date().getTime() / 1000 + "\n");
         }
     }
 
@@ -99,8 +99,8 @@ public class AuditManager /* extends BaseManager */ {
 
                 File auditLog = new File(
                     logDirStr + File.separator + aureview.getName() + "/audit/audit-" +
-                    (fileStart / 1000) + "-" +
-                    (fileEnd / 1000) + ".parsed");
+                            fileStart / 1000 + "-" +
+                            fileEnd / 1000 + ".parsed");
 
                 dr.addAll(readAuditFile(auditLog, types, start, end));
             }
@@ -359,7 +359,7 @@ public class AuditManager /* extends BaseManager */ {
         String str, part1, reviewedBy = null;
         String[] revInfo;
 
-        part1 = machine + "," + (start / 1000) + "," + (end / 1000) + ",";
+        part1 = machine + "," + start / 1000 + "," + end / 1000 + ",";
 
         try (BufferedReader brdr = new BufferedReader(new FileReader(reviewFile))) {
 

--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -1082,10 +1082,10 @@ public class CVEAuditManager {
             // channels, they might be partly patched. To cover this case, check if a newer patch is available in the
             // same channel, or the original channel if this is a clone.
             Optional<CVEPatchStatus> newerPatch = packageResults.stream()
-                    .filter(r -> instChannel.getId().equals(r.getChannelId().get()) || (instChannel.isCloned() &&
+                    .filter(r -> instChannel.getId().equals(r.getChannelId().get()) || instChannel.isCloned() &&
                             instChannel.asCloned().map(ClonedChannel::getOriginal)
                                     .map(Channel::getId)
-                                    .stream().anyMatch(id -> id.equals(r.getChannelId().get()))))
+                                    .stream().anyMatch(id -> id.equals(r.getChannelId().get())))
                     .filter(r -> li.getPackageEvr().get().compareTo(r.getPackageEvr().get()) < 0)
                     .max(evrComparator);
 

--- a/java/code/src/com/redhat/rhn/manager/audit/ErrataIdAdvisoryPair.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ErrataIdAdvisoryPair.java
@@ -79,7 +79,7 @@ public class ErrataIdAdvisoryPair {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + (int) (id ^ (id >>> 32));
+        result = prime * result + (int) (id ^ id >>> 32);
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/audit/ServerChannelIdPair.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ServerChannelIdPair.java
@@ -98,8 +98,8 @@ public class ServerChannelIdPair {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + (int) (cid ^ (cid >>> 32));
-        result = prime * result + (int) (sid ^ (sid >>> 32));
+        result = prime * result + (int) (cid ^ cid >>> 32);
+        result = prime * result + (int) (sid ^ sid >>> 32);
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/audit/scap/RuleResultComparator.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/scap/RuleResultComparator.java
@@ -84,9 +84,9 @@ public class RuleResultComparator {
      * either on xccdf:idents or result of evaluation
      */
     public Boolean getDiffers() {
-        return (first == null || second == null ||
+        return first == null || second == null ||
                 !first.getLabel().equals(second.getLabel()) ||
-                !first.getIdentsString().equals(second.getIdentsString()));
+                !first.getIdentsString().equals(second.getIdentsString());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2206,7 +2206,7 @@ public class ChannelManager extends BaseManager {
      * @return list of compatible package arches.
      */
     public static List<String> listCompatiblePackageArches(String[] channelArchLabels) {
-        if (channelArchLabels == null || (channelArchLabels.length < 1)) {
+        if (channelArchLabels == null || channelArchLabels.length < 1) {
             return new ArrayList<>();
         }
 
@@ -2499,7 +2499,7 @@ public class ChannelManager extends BaseManager {
                 TaskConstants.TASK_QUERY_REPOMD_DETAILS_QUERY);
         Map<String, Object> params = new HashMap<>();
         params.put("channel_label", channel);
-        return (!selector.execute(params).isEmpty());
+        return !selector.execute(params).isEmpty();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -1009,7 +1009,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
 
         List<PackageDto> list = ChannelManager.listErrataPackages(c, e);
         assertEquals(list.size(), 1);
-        assertEquals(list.get(0).getId(), (bothP.getId()));
+        assertEquals(list.get(0).getId(), bothP.getId());
 
 
     }

--- a/java/code/src/com/redhat/rhn/manager/configuration/ConfigFileBuilder.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/ConfigFileBuilder.java
@@ -89,7 +89,7 @@ public class ConfigFileBuilder {
                 lookupConfigFile(user, cc.getId(), path);
         }
 
-        return (file != null);
+        return file != null;
     }
 
     /**
@@ -145,7 +145,7 @@ public class ConfigFileBuilder {
             }
         }
         else {
-            if ((prevRevision != null) &&
+            if (prevRevision != null &&
                     form.matchesRevision(prevRevision)) {
                 return prevRevision;
             }

--- a/java/code/src/com/redhat/rhn/manager/configuration/ConfigurationManager.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/ConfigurationManager.java
@@ -2060,7 +2060,7 @@ public class ConfigurationManager extends BaseManager {
 
         Map<String, Object> result = m.execute(inParams, outParams);
         int access = ((Long)result.get("access")).intValue();
-        return (access == 1);
+        return access == 1;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/configuration/ConfigurationValidation.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/ConfigurationValidation.java
@@ -180,7 +180,7 @@ public class ConfigurationValidation {
         boolean valid = false;
         try {
             int i = Integer.parseInt(in);
-            valid = (i > 0);
+            valid = i > 0;
         }
         catch (Exception e) {
             valid = false;
@@ -195,7 +195,7 @@ public class ConfigurationValidation {
      * @return true if valid, false otherwise
      */
     public static boolean validateUserOrGroup(String in) {
-        return (in != null && in.matches("^[a-zA-Z0-9_][a-zA-Z0-9_\\-]*$"));
+        return in != null && in.matches("^[a-zA-Z0-9_][a-zA-Z0-9_\\-]*$");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/configuration/file/ConfigFileData.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/file/ConfigFileData.java
@@ -437,7 +437,7 @@ public abstract class ConfigFileData {
                getOwner().equals(cInfo.getUsername()) &&
                getGroup().equals(cInfo.getGroupname()) &&
                Long.valueOf(getPermissions()).equals(cInfo.getFilemode()) &&
-               ((StringUtils.isEmpty(cfdSelinuxCtx) && StringUtils.isEmpty(crSelinuxCtx)) ||
+               (StringUtils.isEmpty(cfdSelinuxCtx) && StringUtils.isEmpty(crSelinuxCtx) ||
                        cfdSelinuxCtx.equals(crSelinuxCtx));
     }
  }

--- a/java/code/src/com/redhat/rhn/manager/configuration/file/SLSFileData.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/file/SLSFileData.java
@@ -124,7 +124,7 @@ public class SLSFileData extends ConfigFileData {
         if (!super.matchesRevision(cRevision)) {
             return Boolean.FALSE;
         }
-        return (isBinary() == cRevision.getConfigContent().isBinary()) &&
+        return isBinary() == cRevision.getConfigContent().isBinary() &&
                 getContents().equals(cRevision.getConfigContent().getContentsString());
     }
 

--- a/java/code/src/com/redhat/rhn/manager/configuration/file/TextFileData.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/file/TextFileData.java
@@ -151,7 +151,7 @@ public class TextFileData extends ConfigFileData {
         if (!super.matchesRevision(cRevision)) {
             return Boolean.FALSE;
         }
-        return (isBinary() == cRevision.getConfigContent().isBinary()) &&
+        return isBinary() == cRevision.getConfigContent().isBinary() &&
                 getContents().equals(cRevision.getConfigContent().getContentsString());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1345,7 +1345,7 @@ public class ContentSyncManager {
         List<String> urls = new LinkedList<>();
 
         // Debian repo
-        if (repo.getDistroTarget() != null && (List.of("amd64", "arm64").contains(repo.getDistroTarget()))) {
+        if (repo.getDistroTarget() != null && List.of("amd64", "arm64").contains(repo.getDistroTarget())) {
             // There is not only 1 file we can test.
             // https://wiki.debian.org/DebianRepository/Format
             relFiles.add("Packages.xz");
@@ -2635,7 +2635,7 @@ public class ContentSyncManager {
                 int status = MgrSyncUtils.sendHeadRequest(uri.toString(),
                         user, password).getStatusLine().getStatusCode();
                 LOG.debug("accessibleUrl: {} returned status {}", uri, status);
-                return (status == HttpURLConnection.HTTP_OK);
+                return status == HttpURLConnection.HTTP_OK;
             }
         }
         catch (IOException e) {

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -337,7 +337,7 @@ public class MgrSyncUtils {
                 // Our CDN tokens use this key
                 queryParam.startsWith("dlauth=") ||
                 // typical Akamai token values
-                (queryParam.contains("exp=") && queryParam.contains("hmac="));
+                queryParam.contains("exp=") && queryParam.contains("hmac=");
         LOG.debug("{} isAuthToken: {}", queryParam, ret);
         return ret;
     }

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1525,7 +1525,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
 
         int newFamilyNumbers = ChannelFamilyFactory.getAllChannelFamilies().size();
         // 2 families added with suffix none, alpha and beta
-        assertEquals(familynumbers + (3 * 2), newFamilyNumbers);
+        assertEquals(familynumbers + 3 * 2, newFamilyNumbers);
 
         // Change the name
         for (ChannelFamilyJson cf : channelFamilies) {
@@ -1536,7 +1536,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         csm.updateChannelFamilies(channelFamilies);
 
         newFamilyNumbers = ChannelFamilyFactory.getAllChannelFamilies().size();
-        assertEquals(familynumbers + (3 * 2), newFamilyNumbers);
+        assertEquals(familynumbers + 3 * 2, newFamilyNumbers);
 
         // Assert everything is as expected
         for (ChannelFamilyJson cf : channelFamilies) {
@@ -1912,7 +1912,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         // different mirror has no effect as you cannot overwrite fromdir option
         assertFalse(csm.isRefreshNeeded("https://mirror.example.com/"));
 
-        ManagerInfoFactory.setLastMgrSyncRefresh(System.currentTimeMillis() - (48 * 60 * 60 * 1000));
+        ManagerInfoFactory.setLastMgrSyncRefresh(System.currentTimeMillis() - 48 * 60 * 60 * 1000);
         assertTrue(csm.isRefreshNeeded(null));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -324,7 +324,7 @@ public class ContentManager {
     public int removeEnvironment(String envLabel, String projectLabel, User user) {
         ensureOrgAdmin(user);
         return lookupEnvironment(envLabel, projectLabel, user)
-                .map((env) -> {
+                .map(env -> {
                     ContentProjectFactory.removeEnvironment(env);
                     return 1;
                 })
@@ -398,7 +398,7 @@ public class ContentManager {
     public void detachSource(String projectLabel, Type sourceType, String sourceLabel, User user) {
         ensureOrgAdmin(user);
         ProjectSource src = lookupProjectSource(projectLabel, sourceType, sourceLabel, user)
-                .orElseThrow(() -> (new EntityNotExistsException(sourceLabel)));
+                .orElseThrow(() -> new EntityNotExistsException(sourceLabel));
         if (src.getState() == ATTACHED) {
             src.getContentProject().removeSource(src);
         }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1711,10 +1711,10 @@ public class ErrataManager extends BaseManager {
         // throw Exception if that's not the case
         if (onlyRelevant) {
             boolean allRelevant = errataIds.isEmpty() ||
-                    (errataIds.stream()
+                    errataIds.stream()
                     .allMatch(eid -> serverApplicableErrataMap.values().stream()
                     .allMatch(eids -> eids.contains(eid))) &&
-                    !serverApplicableErrataMap.isEmpty());
+                    !serverApplicableErrataMap.isEmpty();
 
             if (!allRelevant) {
                 throw new InvalidErrataException();

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/ErrataCacheManager.java
@@ -78,7 +78,7 @@ public class ErrataCacheManager extends HibernateFactory {
             return 0;
         }
         Long cnt = (Long) dr.get(0).get("num_items");
-        return (cnt != null) ? cnt.intValue() : 0;
+        return cnt != null ? cnt.intValue() : 0;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -147,7 +147,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
         Channel channel = ChannelTestUtils.createTestChannel(user);
         searchByPackagesIdsHelper(
                 Optional.of(channel),
-                (pids) -> ErrataManager.searchByPackageIdsWithOrg(pids, user.getOrg()));
+                pids -> ErrataManager.searchByPackageIdsWithOrg(pids, user.getOrg()));
     }
 
     private void searchByPackagesIdsHelper(Optional<Channel> channel,

--- a/java/code/src/com/redhat/rhn/manager/kickstart/IpAddressRange.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/IpAddressRange.java
@@ -174,8 +174,8 @@ public class IpAddressRange {
      * @return is this IPaddress contained in this range
      */
     public boolean isIpAddressContained(IpAddress addrIn) {
-        return (addrIn.getNumber() >= this.min.getNumber() &&
-                addrIn.getNumber() <= this.max.getNumber());
+        return addrIn.getNumber() >= this.min.getNumber() &&
+                addrIn.getNumber() <= this.max.getNumber();
     }
 
     /**
@@ -184,7 +184,7 @@ public class IpAddressRange {
      * @return if this range is before the other
      */
     public boolean isRangeBefore(IpAddressRange rangeIn) {
-        return (this.max.getNumber() < rangeIn.min.getNumber());
+        return this.max.getNumber() < rangeIn.min.getNumber();
     }
 
     /**
@@ -193,7 +193,7 @@ public class IpAddressRange {
      * @return if this range is after the other
      */
     public boolean isRangeAfter(IpAddressRange rangeIn) {
-        return (this.min.getNumber() > rangeIn.max.getNumber());
+        return this.min.getNumber() > rangeIn.max.getNumber();
     }
 
     /**
@@ -202,7 +202,7 @@ public class IpAddressRange {
      * @return is this range is disjoint from the other
      */
     public boolean isDisjoint(IpAddressRange rangeIn) {
-        return (this.isRangeBefore(rangeIn) || this.isRangeAfter(rangeIn));
+        return this.isRangeBefore(rangeIn) || this.isRangeAfter(rangeIn);
     }
 
     /**
@@ -211,8 +211,8 @@ public class IpAddressRange {
      * @return is this range a subset of the other
      */
     public boolean isSubset(IpAddressRange rangeIn) {
-        return (this.min.getNumber() >= rangeIn.min.getNumber() &&
-                this.max.getNumber() <= rangeIn.max.getNumber());
+        return this.min.getNumber() >= rangeIn.min.getNumber() &&
+                this.max.getNumber() <= rangeIn.max.getNumber();
     }
 
     /**
@@ -221,8 +221,8 @@ public class IpAddressRange {
      * @return does this range contain the other range
      */
     public boolean isSuperset(IpAddressRange rangeIn) {
-        return (this.min.getNumber() <= rangeIn.min.getNumber() &&
-                this.max.getNumber() >= rangeIn.max.getNumber());
+        return this.min.getNumber() <= rangeIn.min.getNumber() &&
+                this.max.getNumber() >= rangeIn.max.getNumber();
     }
 
     /**
@@ -231,8 +231,8 @@ public class IpAddressRange {
      * @return can this range coexist with other ranges in org
      */
     public boolean canCoexist(IpAddressRange rangeIn) {
-        return ((this.isDisjoint(rangeIn) || this.isSubset(rangeIn) ||
-                this.isSuperset(rangeIn)) && !this.equals(rangeIn));
+        return (this.isDisjoint(rangeIn) || this.isSubset(rangeIn) ||
+                this.isSuperset(rangeIn)) && !this.equals(rangeIn);
 
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartIpCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartIpCommand.java
@@ -102,7 +102,7 @@ public class KickstartIpCommand extends BaseKickstartCommand {
      * @return whether this range is valid (octets are 0-255)
      */
     public boolean validateIpRange(long[] oct1In, long[] oct2In) {
-        return (validateIp(oct1In) && validateIp(oct2In));
+        return validateIp(oct1In) && validateIp(oct2In);
     }
 
     /**
@@ -112,7 +112,7 @@ public class KickstartIpCommand extends BaseKickstartCommand {
      * @return whether this range is valid (octets are 0-255)
      */
     public boolean validateIpRange(Long [] oct1In, Long[] oct2In) {
-        return (validateIp(convertLongArr(oct1In)) && validateIp(convertLongArr(oct2In)));
+        return validateIp(convertLongArr(oct1In)) && validateIp(convertLongArr(oct2In));
     }
 
     /**
@@ -145,8 +145,8 @@ public class KickstartIpCommand extends BaseKickstartCommand {
      */
     private boolean validateIp(long [] ipIn) {
         boolean retval = true;
-        for (int i = 0; (i < ipIn.length) && retval; i++) {
-            retval = (ipIn[i] >= MIN_OCTET) && (ipIn[i] <= MAX_OCTET);
+        for (int i = 0; i < ipIn.length && retval; i++) {
+            retval = ipIn[i] >= MIN_OCTET && ipIn[i] <= MAX_OCTET;
         }
         return retval;
     }
@@ -171,10 +171,10 @@ public class KickstartIpCommand extends BaseKickstartCommand {
         long max = iprIn.getMax().getNumber();
         long min = iprIn.getMin().getNumber();
         List l = KickstartFactory.lookupRangeByOrg(this.ksdata.getOrg());
-        for (Iterator itr = l.iterator(); (itr.hasNext() && !found);) {
+        for (Iterator itr = l.iterator(); itr.hasNext() && !found;) {
             KickstartIpRange ksr = (KickstartIpRange) itr.next();
-            found = ((ksr.getMax() <= max) && (ksr.getMax() >= min)) ||
-                ((ksr.getMin() <= max) && (ksr.getMin() >= min));
+            found = ksr.getMax() <= max && ksr.getMax() >= min ||
+                    ksr.getMin() <= max && ksr.getMin() >= min;
         }
 
         return found;

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartManager.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartManager.java
@@ -233,13 +233,13 @@ public class KickstartManager extends BaseManager {
                     range.getMax().longValue(),
                     range.getId().longValue());
             //seed range if null
-            bestRange = (bestRange == null) ? iprange : bestRange;
+            bestRange = bestRange == null ? iprange : bestRange;
             if (iprange.isSubset(bestRange)) {
                 bestRange = iprange;
             }
         }
 
-        return (bestRange == null) ? KickstartFactory.lookupOrgDefault(orgIn) :
+        return bestRange == null ? KickstartFactory.lookupOrgDefault(orgIn) :
             KickstartFactory.lookupKickstartDataByIdAndOrg(orgIn, bestRange.getKsid());
     }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
@@ -134,7 +134,7 @@ public class KickstartOptionsCommand  extends BaseKickstartCommand {
             v.setEnabled(mapIn.containsKey(name));
 
             String[] s = (String[]) mapIn.get(name + "_txt");
-            if ((s != null) && (v.getEnabled())) {
+            if (s != null && v.getEnabled()) {
                 v.setArg(s[0]);
             }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -305,7 +305,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         this.setScheduleDate(scheduleDateIn);
         if (data != null) {
             this.setKsdata(data);
-            assert (this.getKsdata() != null);
+            assert this.getKsdata() != null;
         }
 
         this.setKickstartServerName(kickstartServerNameIn);
@@ -351,7 +351,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
 
         Server hServer =
                 ServerFactory.lookupByIdAndOrg(selectedHostServerId, userIn.getOrg());
-        assert (hServer != null);
+        assert hServer != null;
         this.setHostServer(hServer);
 
         // There may or may not be a target server present.  If so, then look it up in

--- a/java/code/src/com/redhat/rhn/manager/kickstart/ProvisionVirtualInstanceCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/ProvisionVirtualInstanceCommand.java
@@ -194,7 +194,7 @@ public class ProvisionVirtualInstanceCommand extends KickstartScheduleCommand {
         throws TaskomaticApiException {
 
         KickstartSession ksSession = getKickstartSession();
-        Long sessionId = (ksSession != null) ? ksSession.getId() : null;
+        Long sessionId = ksSession != null ? ksSession.getId() : null;
         //TODO -- It feels a little dirty to pass in this & this.getExtraOptions,
         //but I don't know that I understand the implications of making getExtraOptions
         //a public method.

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileEditCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileEditCommand.java
@@ -92,7 +92,7 @@ public class CobblerProfileEditCommand extends CobblerProfileCommand {
             String cobFileName = ksData.buildCobblerFileName();
             if (!cobName.equals(prof.getName()) ||
                     !cobFileName.equals(ksData.getCobblerFileName()) ||
-                    !(new File(cobFileName)).exists()) {
+                    !new File(cobFileName).exists()) {
                 // delete current cfg file
                 KickstartFactory.removeKickstartTemplatePath(ksData);
                 // create new cfg file

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -230,7 +230,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
             if (event.getSummary().equals(String.format("System migration scheduled by %s", origOrgAdmin.getLogin())) &&
                 event.getDetails().contains("From organization: " + origOrg.getName()) &&
                 event.getDetails().contains("To organization: " + destOrg.getName()) &&
-                (event.getCreated() != null)) {
+                    event.getCreated() != null) {
                 migrationRecorded = true;
             }
         }
@@ -269,7 +269,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
             if (event.getSummary().equals(String.format("System migration scheduled by %s", origOrgAdmin.getLogin())) &&
                 event.getDetails().contains("From organization: " + origOrg.getName()) &&
                 event.getDetails().contains("To organization: " + destOrg.getName()) &&
-                (event.getCreated() != null)) {
+                    event.getCreated() != null) {
                 migrationRecorded = true;
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/profile/ProfileManager.java
+++ b/java/code/src/com/redhat/rhn/manager/profile/ProfileManager.java
@@ -127,7 +127,7 @@ public class ProfileManager extends BaseManager {
     }
 
     private static boolean isNameInUse(String name, Long orgid) {
-        return (ProfileFactory.findByNameAndOrgId(name, orgid) != null);
+        return ProfileFactory.findByNameAndOrgId(name, orgid) != null;
     }
 
     /**
@@ -256,7 +256,7 @@ public class ProfileManager extends BaseManager {
                                 // if the arch of the packages doesn't match, we don't
                                 // need to compare the EVR; therefore, if at end of the
                                 // list, add both packages to the result
-                                if ((j + 1) == plist.size()) {
+                                if (j + 1 == plist.size()) {
                                     PackageMetadata pm = createPackageMetadata(
                                             syspkgitem, null,
                                             PackageMetadata.KEY_THIS_ONLY, param);
@@ -279,7 +279,7 @@ public class ProfileManager extends BaseManager {
                                 if (pm.getComparisonAsInt() !=
                                         PackageMetadata.KEY_NO_DIFF) {
 
-                                    if ((j + 1) == plist.size()) {
+                                    if (j + 1 == plist.size()) {
                                         // this is the last entry in plist; therefore,
                                         // this must be a difference between pkgs
                                         log.debug("Adding to cm: {} comp: {}", evrKey, pm.getComparison());
@@ -421,12 +421,12 @@ public class ProfileManager extends BaseManager {
      * @return returns 0 if arch are equal; otherwise, return 1
      */
     private static int compareArch(String a1, String a2) {
-        if (((a1 == null) && (a2 != null)) ||
-                ((a1 != null) && (a2 == null))) {
+        if (a1 == null && a2 != null ||
+                a1 != null && a2 == null) {
             return 1;
         }
 
-        if (((a1 == null) && (a2 == null)) || (a1.equals(a2))) {
+        if (a1 == null && a2 == null || a1.equals(a2)) {
             return 0;
         }
         return 1;

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/StateConfigFactory.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/StateConfigFactory.java
@@ -87,7 +87,7 @@ public class StateConfigFactory {
         return RecurringActionFactory.lookupInternalStateByName(stateName)
                 .map(state -> (RecurringStateConfig) new RecurringInternalState(state, position))
                 .or(() -> Optional.ofNullable(configManager.lookupGlobalConfigChannel(user, stateName))
-                        .map((channel) -> this.getRecurringState(channel, position)))
+                        .map(channel -> this.getRecurringState(channel, position)))
                 .orElseThrow();
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/satellite/ConfigureSatelliteCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/ConfigureSatelliteCommand.java
@@ -104,7 +104,7 @@ public class ConfigureSatelliteCommand extends BaseConfigureCommand
         if (logger.isDebugEnabled()) {
             logger.debug("getCommandArguments(String, Iterator) - end - return value={}", (Object)returnStringArray);
         }
-        return (anythingChanged ? returnStringArray : null);
+        return anythingChanged ? returnStringArray : null;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/satellite/test/ImportCustomStatesTest.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/test/ImportCustomStatesTest.java
@@ -328,6 +328,6 @@ public class ImportCustomStatesTest extends BaseTestCaseWithUser {
 
     private void assertTaskDoesNotExist(String taskName) {
         List<Task> tasks = TaskFactory.getTaskListByNameLike(taskName);
-        assertTrue((tasks == null || tasks.isEmpty()));
+        assertTrue(tasks == null || tasks.isEmpty());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/satellite/test/UpgradeCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/test/UpgradeCommandTest.java
@@ -59,6 +59,6 @@ public class UpgradeCommandTest extends BaseTestCaseWithUser {
         assertNotNull(ksession);
 
         List<Task> tasks = TaskFactory.getTaskListByNameLike(UpgradeCommand.UPGRADE_KS_PROFILES);
-        assertTrue((tasks == null || tasks.isEmpty()));
+        assertTrue(tasks == null || tasks.isEmpty());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/session/SessionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/session/SessionManager.java
@@ -290,7 +290,7 @@ public class SessionManager extends BaseManager {
                                                SEC_PARM_TOKENIZER_CHAR + vals[1]);
         long currTime = Calendar.getInstance().getTimeInMillis();
         long timeStamped = Long.parseLong(vals[1]);
-        if ((currTime - timeStamped) <= TIMEOUT_VAL &&
+        if (currTime - timeStamped <= TIMEOUT_VAL &&
                 newEncoded.equals(vals[2])) {
             if (logger.isDebugEnabled()) {
                 logger.debug("isValidTimestampedParamString(String[])" +

--- a/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsDto.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsDto.java
@@ -121,8 +121,8 @@ public class MirrorCredentialsDto extends BaseDto {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((password == null) ? 0 : password.hashCode());
-        result = prime * result + ((user == null) ? 0 : user.hashCode());
+        result = prime * result + (password == null ? 0 : password.hashCode());
+        result = prime * result + (user == null ? 0 : user.hashCode());
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
@@ -140,7 +140,7 @@ public class MirrorCredentialsManager {
         // Check if the supplied user name already exists in stored credentials
         for (SCCCredentials existingCred : CredentialsFactory.listSCCCredentials()) {
             if (existingCred.getUsername().equals(creds.getUser()) &&
-                    (!Objects.equals(existingCred.getId(), creds.getId()))) {
+                    !Objects.equals(existingCred.getId(), creds.getId())) {
                 throw new MirrorCredentialsNotUniqueException("Username already exists");
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/setup/ProductSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/ProductSyncManager.java
@@ -253,7 +253,7 @@ public class ProductSyncManager {
 
             Date lastSyncDate = channelStatus.getLastSyncDate();
             if (maxLastSyncDate == null ||
-                    (lastSyncDate != null && lastSyncDate.after(maxLastSyncDate))) {
+                    lastSyncDate != null && lastSyncDate.after(maxLastSyncDate)) {
                 maxLastSyncDate = lastSyncDate;
             }
         }
@@ -275,7 +275,7 @@ public class ProductSyncManager {
         else {
             syncStatus = new SyncStatus(SyncStatus.SyncStage.IN_PROGRESS);
             int totalChannels = product.getMandatoryChannels().size();
-            syncStatus.setSyncProgress((finishedCounter * 100) / totalChannels);
+            syncStatus.setSyncProgress(finishedCounter * 100 / totalChannels);
         }
 
         return syncStatus;

--- a/java/code/src/com/redhat/rhn/manager/setup/SubscriptionDto.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/SubscriptionDto.java
@@ -136,9 +136,9 @@ public class SubscriptionDto {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((endDate == null) ? 0 : endDate.hashCode());
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((startDate == null) ? 0 : startDate.hashCode());
+        result = prime * result + (endDate == null ? 0 : endDate.hashCode());
+        result = prime * result + (name == null ? 0 : name.hashCode());
+        result = prime * result + (startDate == null ? 0 : startDate.hashCode());
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/setup/test/ProductSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/test/ProductSyncManagerTest.java
@@ -237,7 +237,7 @@ public class ProductSyncManagerTest extends BaseTestCaseWithUser {
             // Check the product sync status
             SyncStatus status = getProductSyncStatus(product, channelByLabel);
             assertEquals(SyncStatus.SyncStage.FINISHED, status.getStage());
-            assertNotNull((status.getLastSyncDate()));
+            assertNotNull(status.getLastSyncDate());
         }
         finally {
             // Clean up and restore the old cache path

--- a/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/SsmManager.java
@@ -289,7 +289,7 @@ public class SsmManager {
                                                         Server srv,
                                                         ChannelChangeDto srvChange) {
         boolean baseChange =
-                (currentBase.isPresent() && !currentBase.get().getId().equals(srvChange.getNewBaseId().orElse(null))) ||
+                currentBase.isPresent() && !currentBase.get().getId().equals(srvChange.getNewBaseId().orElse(null)) ||
                 !(currentBase.isPresent() && srvChange.getNewBaseId().isPresent());
 
         boolean newBaseIsCompatible = true;

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -150,7 +150,7 @@ public class ServerGroupManager implements Serializable {
      */
     public void validateAccessCredentials(User user,
                                     ServerGroup group, String groupIdentifier) {
-        if (group == null || (group.isManaged() && !canAccess(user, group))) {
+        if (group == null || group.isManaged() && !canAccess(user, group)) {
             LocalizationService ls = LocalizationService.getInstance();
             throw new LookupException("Unable to locate or access server group: " + groupIdentifier,
                     ls.getMessage("lookup.servergroup.title"),

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2498,7 +2498,7 @@ public class SystemManager extends BaseManager {
 
         // Grab the host from the first guest in the list:
         Long firstGuestId = guestIds.get(0);
-        Server host = (viFactory.lookupById(firstGuestId)).
+        Server host = viFactory.lookupById(firstGuestId).
                 getHostSystem();
 
         VirtualInstanceState running = VirtualInstanceFactory.getInstance().
@@ -3059,7 +3059,7 @@ public class SystemManager extends BaseManager {
                                                                 List<String> ignored, Long inactiveHours) {
 
         Calendar cal = Calendar.getInstance();
-        cal.add(Calendar.HOUR, (0 - inactiveHours.intValue()));
+        cal.add(Calendar.HOUR, 0 - inactiveHours.intValue());
 
         SelectMode ipMode = ModeFactory.getMode("System_queries",
                 query);
@@ -3748,7 +3748,7 @@ public class SystemManager extends BaseManager {
             throw new IllegalArgumentException(pkgName.getName() + " :not available in assigned channels of " +
                     minion.getId());
         }
-        else if ((isAvailable && pkgState == PackageStates.INSTALLED) || pkgState == PackageStates.REMOVED) {
+        else if (isAvailable && pkgState == PackageStates.INSTALLED || pkgState == PackageStates.REMOVED) {
             pkgStates.removeIf(ps -> ps.getName().equals(pkgName));
             PackageState packageState = new PackageState();
             packageState.setStateRevision(stateRev);

--- a/java/code/src/com/redhat/rhn/manager/system/UpdateBaseChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/system/UpdateBaseChannelCommand.java
@@ -62,8 +62,8 @@ public class UpdateBaseChannelCommand extends BaseUpdateChannelCommand {
         Channel newChannel = null;
 
         // if new channel equals old, there's nothing to do
-        if ((oldChannel == null && baseChannelId == -1) ||
-            (oldChannel != null && oldChannel.getId() == baseChannelId.longValue())) {
+        if (oldChannel == null && baseChannelId == -1 ||
+                oldChannel != null && oldChannel.getId() == baseChannelId.longValue()) {
             return null;
         }
 

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
@@ -157,7 +157,7 @@ public class VirtualInstanceManager extends BaseManager {
                     vinst.lookupVirtualInstanceByUuid(guid);
 
             Map<String, String> vmData = optionalVmData.get(name);
-            VirtualInstanceState st = (vmData != null && vmData.get("vmState") != null) ?
+            VirtualInstanceState st = vmData != null && vmData.get("vmState") != null ?
                     vinst.getState(vmData.get("vmState"))
                             .orElse(vinst.getUnknownState()) : vinst.getUnknownState();
 

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -133,7 +133,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         UserTestUtils.addVirtualization(user.getOrg());
 
         Server guest =
-            (host.getGuests().iterator().next()).getGuestSystem();
+            host.getGuests().iterator().next().getGuestSystem();
         guest.addChannel(ChannelTestUtils.createBaseChannel(user));
         ServerTestUtils.addVirtualization(user, guest);
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -359,7 +359,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                 "testOrg" + this.getClass().getSimpleName());
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server host = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
-        Server guest = (host.getGuests().iterator().next()).
+        Server guest = host.getGuests().iterator().next().
             getGuestSystem();
         Long sid = guest.getId();
 
@@ -386,7 +386,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                 "testOrg" + this.getClass().getSimpleName());
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server host = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
-        Server guest = (host.getGuests().iterator().next()).
+        Server guest = host.getGuests().iterator().next().
             getGuestSystem();
         Long sid = guest.getId();
 
@@ -1006,7 +1006,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                 assertEquals(2, result1Packages.size());
             }
             else if (map.get("id").equals(server2.getId())) {
-                assertEquals(server2.getName(), (map.get("system_name")));
+                assertEquals(server2.getName(), map.get("system_name"));
 
                 assertInstanceOf(List.class, map.get("elaborator0"));
                 List result2Packages = (List)map.get("elaborator0");
@@ -1031,7 +1031,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         server = ServerFactory.lookupById(server.getId());
         int sizeAfter = server.getNotes().size();
-        assertEquals(sizeAfter, (sizeBefore + 1));
+        assertEquals(sizeAfter, sizeBefore + 1);
 
         Note deleteMe = server.getNotes().iterator().next();
 
@@ -1060,7 +1060,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         server = ServerFactory.lookupById(server.getId());
         int sizeAfter = server.getNotes().size();
-        assertEquals(sizeAfter, (sizeBefore + 4));
+        assertEquals(sizeAfter, sizeBefore + 4);
 
         // Test
         SystemManager.deleteNotes(admin, server.getId());
@@ -1177,7 +1177,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(5, dr.size());
         assertTrue(dr.iterator().hasNext());
 
-        SystemOverview m = (dr.iterator().next());
+        SystemOverview m = dr.iterator().next();
         assertNotNull(m.getName());
     }
 

--- a/java/code/src/com/redhat/rhn/manager/token/ActivationKeyManager.java
+++ b/java/code/src/com/redhat/rhn/manager/token/ActivationKeyManager.java
@@ -156,8 +156,8 @@ public class ActivationKeyManager {
     public ActivationKey createNewReActivationKey(User user, Server server,
             String key, String note, Long usageLimit, Channel baseChannel,
             boolean universalDefault, KickstartSession session) {
-        if ((server == null && session == null) || (server != null &&
-                SystemManager.lookupByIdAndUser(server.getId(), user) == null)) {
+        if (server == null && session == null || server != null &&
+                SystemManager.lookupByIdAndUser(server.getId(), user) == null) {
             throw new IllegalArgumentException("Either server or session can be null, " +
                     "but not both, otherwise use createNewActivationKey");
         }

--- a/java/code/src/com/redhat/rhn/manager/token/test/ActivationKeyPackagesCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/token/test/ActivationKeyPackagesCommandTest.java
@@ -95,7 +95,7 @@ public class ActivationKeyPackagesCommandTest extends BaseTestCaseWithUser {
                 foundPkg1 = true;
             }
             else if (pkg.getPackageName().getName().equals("pkg2") &&
-                     (pkg.getPackageArch() == null) &&
+                    pkg.getPackageArch() == null &&
                      pkg.getToken().equals(key.getToken())) {
                 foundPkg2 = true;
             }

--- a/java/code/src/com/redhat/rhn/manager/user/UserManager.java
+++ b/java/code/src/com/redhat/rhn/manager/user/UserManager.java
@@ -128,7 +128,7 @@ public class UserManager extends BaseManager {
          * package (org the package doesn't exist), nothing will be returned from the query
          * and we will end up with an empty DataResult object.
          */
-        return (!dr.isEmpty());
+        return !dr.isEmpty();
     }
 
     /**
@@ -148,7 +148,7 @@ public class UserManager extends BaseManager {
          * package (org the package doesn't exist), nothing will be returned from the query
          * and we will end up with an empty DataResult object.
          */
-        return (!dr.isEmpty());
+        return !dr.isEmpty();
     }
 
     /**
@@ -992,7 +992,7 @@ public class UserManager extends BaseManager {
      * @return true if user can administer system group
      */
     public static boolean canAdministerSystemGroup(User user, ManagedServerGroup group) {
-        return (user != null && group != null && SERVER_GROUP_MANAGER.canAccess(user, group));
+        return user != null && group != null && SERVER_GROUP_MANAGER.canAccess(user, group);
     }
 
     /**
@@ -1074,7 +1074,7 @@ public class UserManager extends BaseManager {
         boolean permittedAction = false;
         Iterator<Channel> channels = user.getOrg().getAccessibleChannels().iterator();
         while (!permittedAction && channels.hasNext()) {
-            if ((channels.next()).getId().equals(cid)) {
+            if (channels.next().getId().equals(cid)) {
                 permittedAction = true;
             }
         }
@@ -1171,7 +1171,7 @@ public class UserManager extends BaseManager {
     public static String roleNames(Set<Role> rolesIn) {
         String roleNames = null;
         for (Role role : rolesIn) {
-            roleNames = (roleNames == null) ? role.getName() :
+            roleNames = roleNames == null ? role.getName() :
                 roleNames + ", " + role.getName();
         }
         if (roleNames == null) {
@@ -1188,7 +1188,7 @@ public class UserManager extends BaseManager {
     public static String serverGroupsName(Set<ServerGroup> serverGroupsIn) {
         String serverGroupsName = null;
         for (ServerGroup sg : serverGroupsIn) {
-            serverGroupsName = (serverGroupsName == null) ? sg.getName() :
+            serverGroupsName = serverGroupsName == null ? sg.getName() :
                 serverGroupsName + ", " + sg.getName();
         }
         return Objects.requireNonNullElse(serverGroupsName, "(none)");

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
@@ -394,7 +394,7 @@ public class TaskoFactory extends HibernateFactory {
     public static TaskoRun lookupRunByOrgAndId(Integer orgId, Integer runId)
         throws InvalidParamException {
         TaskoRun run = lookupRunById(runId.longValue());
-        if ((run == null) || (!runBelongToOrg(orgId, run))) {
+        if (run == null || !runBelongToOrg(orgId, run)) {
             throw new InvalidParamException("No such run id");
         }
         return run;
@@ -476,7 +476,7 @@ public class TaskoFactory extends HibernateFactory {
 
     private static boolean runBelongToOrg(Integer orgId, TaskoRun run) {
         if (orgId == null) {
-            return (run.getOrgId() == null);
+            return run.getOrgId() == null;
         }
         return orgId.equals(run.getOrgId());
     }
@@ -534,8 +534,8 @@ public class TaskoFactory extends HibernateFactory {
         String jobLabel = "single-" + bunchName + "-";
         int count = 0;
         while (!TaskoFactory.listSchedulesByOrgAndLabel(orgId, jobLabel + count).isEmpty() ||
-                (SchedulerKernel.getScheduler() != null && SchedulerKernel.getScheduler()
-                        .getTrigger(triggerKey(jobLabel + count, TaskoQuartzHelper.getGroupName(orgId))) != null)) {
+                SchedulerKernel.getScheduler() != null && SchedulerKernel.getScheduler()
+                        .getTrigger(triggerKey(jobLabel + count, TaskoQuartzHelper.getGroupName(orgId))) != null) {
             count++;
         }
         return jobLabel + count;

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
@@ -258,7 +258,7 @@ public class TaskoQuartzHelper {
     }
 
     private static boolean isCronExpressionEmpty(String cronExpr) {
-        return (cronExpr == null || cronExpr.isEmpty());
+        return cronExpr == null || cronExpr.isEmpty();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoXmlRpcHandler.java
@@ -237,7 +237,7 @@ public class TaskoXmlRpcHandler {
         // check for inconsistencies
         // quartz unschedules job after trigger end time
         // so better handle quartz and schedules separately
-        if ((scheduleList.isEmpty()) && (trigger == null)) {
+        if (scheduleList.isEmpty() && trigger == null) {
             log.error("Unscheduling of bunch {} failed: no such job label", jobLabel);
             return 0;
         }
@@ -581,8 +581,8 @@ public class TaskoXmlRpcHandler {
     private void isAlreadyScheduled(Integer orgId, String jobLabel) throws SchedulerException, InvalidParamException {
 
         if (!TaskoFactory.listActiveSchedulesByOrgAndLabel(orgId, jobLabel).isEmpty() ||
-                (SchedulerKernel.getScheduler().getTrigger(triggerKey(jobLabel,
-                        TaskoQuartzHelper.getGroupName(orgId))) != null)) {
+                SchedulerKernel.getScheduler().getTrigger(triggerKey(jobLabel,
+                        TaskoQuartzHelper.getGroupName(orgId))) != null) {
             throw new InvalidParamException("jobLabel already in use");
         }
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -845,7 +845,7 @@ public class TaskomaticApi {
     public void scheduleSingleRootCaCertUpdate(Map<String, String> filenameToRootCaCertMap)
             throws TaskomaticApiException {
 
-        if ((null == filenameToRootCaCertMap) || filenameToRootCaCertMap.isEmpty()) {
+        if (null == filenameToRootCaCertMap || filenameToRootCaCertMap.isEmpty()) {
             return; // nothing to do: avoid invoke call, to spare a potential exception
         }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoSchedule.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/domain/TaskoSchedule.java
@@ -71,7 +71,7 @@ public class TaskoSchedule {
         data = serializeMap(dataIn);
         setCronExpr(cronExprIn);
         setActiveFrom(Objects.requireNonNullElseGet(activeFromIn, Date::new));
-        if ((cronExprIn == null) || (cronExprIn.isEmpty())) {
+        if (cronExprIn == null || cronExprIn.isEmpty()) {
             // set activeFrom for single runs
             setActiveTill(getActiveFrom());
         }
@@ -86,7 +86,7 @@ public class TaskoSchedule {
      */
     public void sanityCheckForPredefinedSchedules() {
         if (getActiveTill() == null) {
-            if ((cronExpr == null) || (cronExpr.isEmpty())) {
+            if (cronExpr == null || cronExpr.isEmpty()) {
                 // set activeTill for single runs
                 setActiveTill(new Date());
                 HibernateFactory.commitTransaction();
@@ -295,6 +295,6 @@ public class TaskoSchedule {
      * @return true, if it's a cron schedule
      */
     public boolean isCronSchedule() {
-        return (cronExpr != null) && !cronExpr.isEmpty();
+        return cronExpr != null && !cronExpr.isEmpty();
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
@@ -129,7 +129,7 @@ public class CobblerSyncTask extends RhnJavaJob {
             CobblerProfileSyncCommand profSync = new CobblerProfileSyncCommand();
             profSync.store();
 
-            LAST_UPDATED.set((new Date()).getTime() / 1000 + 1);
+            LAST_UPDATED.set(new Date().getTime() / 1000 + 1);
         }
         catch (RuntimeException re) {
             log.error("RuntimeExceptionError trying to sync to cobbler: {}", re.getMessage(), re);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -416,8 +416,8 @@ public class DailySummary extends RhnJavaJob {
 
         hdr.append(StringUtils.repeat(" ", longestActionLength));
         for (String status : statusSet) {
-            hdr.append(status + StringUtils.repeat(" ", (longestStatusLength +
-                    ERRATA_SPACER) - status.length()));
+            hdr.append(status + StringUtils.repeat(" ", longestStatusLength +
+                    ERRATA_SPACER - status.length()));
         }
 
         if (!errataActions.isEmpty()) {
@@ -453,7 +453,7 @@ public class DailySummary extends RhnJavaJob {
         StringBuffer formattedActions = new StringBuffer();
         for (String actionName : actionTree.keySet()) {
             formattedActions.append(actionName +
-                   StringUtils.repeat(" ", (longestActionLength - (actionName.length()))));
+                   StringUtils.repeat(" ", longestActionLength - actionName.length()));
             for (String status : statusSet) {
                 Map<String, Integer> counts = actionTree.get(actionName);
                 Integer theCount = counts.get(status);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataMailer.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataMailer.java
@@ -238,12 +238,12 @@ public class ErrataMailer extends RhnJavaJob {
         for (Row row : servers) {
             String release = (String) row.get("release");
             printWriter.print(release);
-            for (int i = 0; i < (11 - release.length()); i++) {
+            for (int i = 0; i < 11 - release.length(); i++) {
                 printWriter.print(' ');
             }
             String arch = (String) row.get("arch");
             printWriter.print(arch);
-            for (int i = 0; i < (11 - arch.length()); i++) {
+            for (int i = 0; i < 11 - arch.length(); i++) {
                 printWriter.print(' ');
             }
             printWriter.println((String) row.get("name"));

--- a/java/code/src/com/redhat/rhn/taskomatic/task/KickstartFileSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/KickstartFileSyncTask.java
@@ -57,7 +57,7 @@ public class KickstartFileSyncTask extends RhnJavaJob {
                 Profile p = Profile.lookupById(cc, ks.getCobblerId());
                 if (p != null) {
                     String ksFilePath = ks.buildCobblerFileName();
-                    if (!(new File(ksFilePath)).exists() ||
+                    if (!new File(ksFilePath).exists() ||
                             !ksFilePath.equals(p.getKickstart())) {
                         log.info("Syncing {}", ks.getLabel());
                         CobblerProfileEditCommand cpec = new CobblerProfileEditCommand(ks);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ReportDBHelper.java
@@ -293,7 +293,7 @@ public class ReportDBHelper {
         //just to be sure that user doesn't have any permission, because in that case the drop role might fails
         revokeDBUser(session, dbName, username);
 
-        session.createNativeQuery(("GRANT %1$s TO current_user").formatted(username)).executeUpdate();
+        session.createNativeQuery("GRANT %1$s TO current_user".formatted(username)).executeUpdate();
         session.createNativeQuery("REASSIGN OWNED BY %1$s TO current_user".formatted(username)).executeUpdate();
         session.createNativeQuery("DROP OWNED BY %1$s".formatted(username)).executeUpdate();
         session.createNativeQuery("DROP ROLE %1$s".formatted(username)).executeUpdate();

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SessionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SessionCleanup.java
@@ -46,7 +46,7 @@ public class SessionCleanup extends RhnJavaJob {
         //retrieves info from user preferences
         long window = c.getInt("web.session_database_lifetime");
 
-        long bound = (System.currentTimeMillis() / 1000) - (2 * window);
+        long bound = System.currentTimeMillis() / 1000 - 2 * window;
 
         log.debug("session_cleanup: starting delete of stale sessions");
         if (log.isDebugEnabled()) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SystemProfileRefreshTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SystemProfileRefreshTask.java
@@ -63,8 +63,8 @@ public class SystemProfileRefreshTask extends RhnJavaJob {
 
             Set<Long> sids = ServerFactory.listOrgSystems(org.getId()).stream()
                     .filter(s -> !s.isInactive())
-                    .filter(s -> (s.hasEntitlement(EntitlementManager.SALT) ||
-                                s.hasEntitlement(EntitlementManager.MANAGEMENT)))
+                    .filter(s -> s.hasEntitlement(EntitlementManager.SALT) ||
+                                s.hasEntitlement(EntitlementManager.MANAGEMENT))
                     .map(Server::getId)
                     .collect(Collectors.toSet());
             if (sids.isEmpty()) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/checkin/SystemSummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/checkin/SystemSummary.java
@@ -183,8 +183,8 @@ public class SystemSummary {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + (int) (id ^ (id >>> 32));
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + (int) (id ^ id >>> 32);
+        result = prime * result + (name == null ? 0 : name.hashCode());
         return result;
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/PrimaryXmlWriter.java
@@ -318,7 +318,7 @@ public class PrimaryXmlWriter extends RepomdWriter {
             String[] parts = evr.split(":");
             String vr;
             if (parts.length != 1) {
-                if (parts[0] != null && !(parts[0].isEmpty())) {
+                if (parts[0] != null && !parts[0].isEmpty()) {
                     map.put("epoch", parts[0]);
                 }
                 vr = parts[1];
@@ -416,6 +416,6 @@ public class PrimaryXmlWriter extends RepomdWriter {
      *         are enabled, otherwise false.
      */
     private boolean hasPreFlag(long senseIn) {
-        return (senseIn & ((1 << 6) | (1 << 9) | (1 << 10) | (1 << 24))) > 0;
+        return (senseIn & (1 << 6 | 1 << 9 | 1 << 10 | 1 << 24)) > 0;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceDriver.java
@@ -204,8 +204,8 @@ public class SSHServiceDriver extends AbstractQueueDriver<SystemSummary> {
     private boolean isDefaultSchedule() {
         List<TaskoSchedule> schedules =
                 TaskoFactory.listActiveSchedulesByOrgAndLabel(null, JOB_LABEL);
-        return (schedules.size() == 1) &&
-                (schedules.get(0).getCronExpr().equals("0 * * * * ?"));
+        return schedules.size() == 1 &&
+                schedules.get(0).getCronExpr().equals("0 * * * * ?");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/CheckinCandidatesSimulationTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/CheckinCandidatesSimulationTest.java
@@ -242,6 +242,6 @@ public class CheckinCandidatesSimulationTest  {
      * Calculate percentage value.
      */
     private double getPercentage(long number, long total) {
-        return ((double) number / (double) total) * 100;
+        return (double) number / (double) total * 100;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/SessionCleanupTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/SessionCleanupTest.java
@@ -43,7 +43,7 @@ public class SessionCleanupTest extends RhnBaseTestCase {
         /* we set the expire time of our test websession to an insanely large negative
         number this ensures that we do not accidentally delete real entries in the
         database */
-        s.setExpires((System.currentTimeMillis() / 1000) * -2);
+        s.setExpires(System.currentTimeMillis() / 1000 * -2);
         WebSessionFactory.save(s);
         assertNotNull(s.getId());
         Config c = Config.get();

--- a/java/code/src/com/redhat/rhn/testing/ForwardWrapper.java
+++ b/java/code/src/com/redhat/rhn/testing/ForwardWrapper.java
@@ -161,7 +161,7 @@ public class ForwardWrapper extends ActionForward {
      */
     public Long getLongParam(String pname) {
         String v = getParam(pname);
-        return (v == null) ? null : Long.valueOf(v);
+        return v == null ? null : Long.valueOf(v);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/TestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/TestUtils.java
@@ -308,7 +308,7 @@ public class TestUtils {
             elements = e.getStackTrace();
         }
         // Only show 10 lines of the trace
-        for (int i = 0; ((i < elements.length) && i < depth); i++) {
+        for (int i = 0; i < elements.length && i < depth; i++) {
             System.out.println("Stack: [" + i + "]: " + elements[i].getClassName() +
                                "." + elements[i].getMethodName() + " : " +
                                elements[i].getLineNumber());
@@ -441,8 +441,8 @@ public class TestUtils {
                 IllegalArgumentException("java.l10n_debug is set to false.  " +
                         "This test doesnt mean anything if its set to false. ");
         }
-        return (checkMe.startsWith(
-            Config.get().getString("java.l10n_debug_marker", "$$$")));
+        return checkMe.startsWith(
+            Config.get().getString("java.l10n_debug_marker", "$$$"));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/httpservermock/HttpServerMock.java
+++ b/java/code/src/com/redhat/rhn/testing/httpservermock/HttpServerMock.java
@@ -45,7 +45,7 @@ public class HttpServerMock {
          */
         port = (int) (
                 10000 +
-                (System.currentTimeMillis() % 100) * 100 +
+                System.currentTimeMillis() % 100 * 100 +
                 new Random().nextInt(100));
     }
 

--- a/java/code/src/com/suse/manager/api/RouteFactory.java
+++ b/java/code/src/com/suse/manager/api/RouteFactory.java
@@ -329,6 +329,6 @@ public class RouteFactory {
     private int compareSerializerHierarchy(ApiResponseSerializer<?> a, ApiResponseSerializer<?> b) {
         Class<?> aClass = a.getSupportedClass();
         Class<?> bClass = b.getSupportedClass();
-        return aClass.isAssignableFrom(bClass) ? -1 : (bClass.isAssignableFrom(aClass) ? 1 : 0);
+        return aClass.isAssignableFrom(bClass) ? -1 : bClass.isAssignableFrom(aClass) ? 1 : 0;
     }
 }

--- a/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
+++ b/java/code/src/com/suse/manager/attestation/test/AttestationManagerTest.java
@@ -241,7 +241,7 @@ public class AttestationManagerTest extends JMockBaseTestCaseWithUser {
     public void testFilterListReports() throws InterruptedException {
         mgr.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
 
-        long epochStart = (new Date().getTime() / 1000);
+        long epochStart = new Date().getTime() / 1000;
         for (int i = 10; i > 0; i--) {
             createFakeAttestationReport(user, server);
             HibernateFactory.getSession().flush();

--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -316,8 +316,8 @@ public class HubController {
         List<ChannelInfoJson> allChannelsInfo = hubManager.collectAllChannels(token)
                 .stream()
                 .map(ch -> new ChannelInfoJson(ch.getId(), ch.getName(), ch.getLabel(), ch.getSummary(),
-                        ((null == ch.getOrg()) ? null : ch.getOrg().getId()),
-                        (null == ch.getParentChannel()) ? null : ch.getParentChannel().getId()))
+                        null == ch.getOrg() ? null : ch.getOrg().getId(),
+                        null == ch.getParentChannel() ? null : ch.getParentChannel().getId()))
                 .toList();
 
         return success(response, allChannelsInfo);

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -754,7 +754,7 @@ public class HubManager {
             // Send the local GPG key used to sign metadata, if configured.
             // This force metadata checking on the peripheral server when mirroring from the Hub
             String localGpgKey =
-                    (ConfigDefaults.get().isMetadataSigningEnabled()) ? CertificateUtils.loadGpgKey() : null;
+                    ConfigDefaults.get().isMetadataSigningEnabled() ? CertificateUtils.loadGpgKey() : null;
 
             // Register this server on the remote with the hub role
             internalApi.registerHub(localAccessToken.getSerializedForm(), localRootCA, localGpgKey);
@@ -1472,7 +1472,7 @@ public class HubManager {
             Stream.iterate(channel, Objects::nonNull, Channel::getParentChannel).forEach(allChannels::add);
 
             for (Channel ch : allChannels) {
-                if (ch.isCustom() && (peripheralOrgIdWhenCustomChannel == null)) {
+                if (ch.isCustom() && peripheralOrgIdWhenCustomChannel == null) {
                     throw new IllegalArgumentException(
                             String.format("A peripheral OrgID must be specified for custom channel with label [%s]",
                                     channelLabel));

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -166,11 +166,11 @@ public class ControllerTestUtils {
 
         RouteImpl routeImpl = (RouteImpl) routeMatch.get().getTarget();
 
-        Map<String, String> httpHeaders = (null == authBearerToken) ?
+        Map<String, String> httpHeaders = null == authBearerToken ?
                 new HashMap<>() :
                 Map.of("Authorization", "Bearer " + authBearerToken);
 
-        Request dummyTestRequest = (null == body) ?
+        Request dummyTestRequest = null == body ?
                 SparkTestUtils.createMockRequestWithParams(apiEndpoint, new HashMap<>(), httpHeaders) :
                 SparkTestUtils.createMockRequestWithBody(apiEndpoint, httpHeaders, body);
 
@@ -237,7 +237,7 @@ public class ControllerTestUtils {
         GregorianCalendar cal = new GregorianCalendar();
         Date nowDate = createDateUtil(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH));
 
-        return (dateIn.getTime() - nowDate.getTime() < 24L * 60L * 60L * 1000L);
+        return dateIn.getTime() - nowDate.getTime() < 24L * 60L * 60L * 1000L;
     }
 
     public ChannelInfoDetailsJson createChannelInfoDetailsJson(Long orgId,

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -139,15 +139,15 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     }
 
     private static Stream<Arguments> onlyGetApis() {
-        return allApiEndpoints().filter(e -> (HttpMethod.get == e.get()[0]));
+        return allApiEndpoints().filter(e -> HttpMethod.get == e.get()[0]);
     }
 
     private static Stream<Arguments> onlyPostApis() {
-        return allApiEndpoints().filter(e -> (HttpMethod.post == e.get()[0]));
+        return allApiEndpoints().filter(e -> HttpMethod.post == e.get()[0]);
     }
 
     private static Stream<Arguments> onlyHubApis() {
-        return allApiEndpoints().filter(e -> (IssRole.HUB == e.get()[2]));
+        return allApiEndpoints().filter(e -> IssRole.HUB == e.get()[2]);
     }
 
     private static boolean noHubApis() {
@@ -155,7 +155,7 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     }
 
     private static Stream<Arguments> onlyPeripheralApis() {
-        return allApiEndpoints().filter(e -> (IssRole.PERIPHERAL == e.get()[2]));
+        return allApiEndpoints().filter(e -> IssRole.PERIPHERAL == e.get()[2]);
     }
 
     private static boolean noPeripheralApis() {
@@ -414,13 +414,13 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
         assertTrue(allOrgs.size() >= 3, "All 3 test test orgs are not listed");
         assertTrue(allOrgs.stream()
-                        .anyMatch(e -> (e.getOrgId() == org1.getId()) && (e.getOrgName().startsWith("org1"))),
+                        .anyMatch(e -> e.getOrgId() == org1.getId() && e.getOrgName().startsWith("org1")),
                 apiUnderTest + " API call not listing test organization [org1]");
         assertTrue(allOrgs.stream()
-                        .anyMatch(e -> (e.getOrgId() == org2.getId()) && (e.getOrgName().startsWith("org2"))),
+                        .anyMatch(e -> e.getOrgId() == org2.getId() && e.getOrgName().startsWith("org2")),
                 apiUnderTest + " API call not listing test organization [org2]");
         assertTrue(allOrgs.stream()
-                        .anyMatch(e -> (e.getOrgId() == org3.getId()) && (e.getOrgName().startsWith("org3"))),
+                        .anyMatch(e -> e.getOrgId() == org3.getId() && e.getOrgName().startsWith("org3")),
                 apiUnderTest + " API call not listing test organization [org3]");
     }
 

--- a/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
+++ b/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
@@ -126,7 +126,7 @@ public class KubernetesManager {
                             imgBuildRevision = Optional.of(imageInfo.getRevisionNumber());
                             usage = Optional.of(imgToUsage.computeIfAbsent(
                                     imageInfo.getId(),
-                                    (infoId) -> new ImageUsage(imageInfo)));
+                                    infoId -> new ImageUsage(imageInfo)));
                         }
                         else {
                             LOG.debug("Image build history not found for digest: {} (maybe the image was not " +

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -749,8 +749,8 @@ public class MaintenanceManager {
                 return false;
             })
             .filter(Opt.fold(calendarOpt,
-                    () -> (sa -> true),
-                    c -> (sa -> !isActionInMaintenanceWindow(sa.getParentAction(), schedule, calendarOpt))))
+                    () -> sa -> true,
+                    c -> sa -> !isActionInMaintenanceWindow(sa.getParentAction(), schedule, calendarOpt)))
             .collect(Collectors.groupingBy(ServerAction::getParentAction,
                     Collectors.mapping(ServerAction::getServer, toList())));
 

--- a/java/code/src/com/suse/manager/maintenance/test/IcalUtilsTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/IcalUtilsTest.java
@@ -135,12 +135,12 @@ public class IcalUtilsTest  {
         // dates in the tests are readable my human eyes too
         List<Pair<String, String>> nycEvents = icalUtils.calculateUpcomingPeriods(
                 multiZonesCal, of("Maint. windows - NYC - weekdays"), datetime.toInstant(), 3)
-                .map(pair -> Pair.of(formatNY(pair.getLeft()), formatNY((pair.getRight()))))
+                .map(pair -> Pair.of(formatNY(pair.getLeft()), formatNY(pair.getRight())))
                 .collect(Collectors.toList());
 
         List<Pair<String, String>> sriLankaEvts = icalUtils.calculateUpcomingPeriods(
                 multiZonesCal, of("Maint. windows-Sri Lanka"), datetime.toInstant(), 3)
-                .map(pair -> Pair.of(formatSriLanka(pair.getLeft()), formatSriLanka((pair.getRight()))))
+                .map(pair -> Pair.of(formatSriLanka(pair.getLeft()), formatSriLanka(pair.getRight())))
                 .collect(Collectors.toList());
 
         List<Pair<Instant, Instant>> listNoEvts = icalUtils.calculateUpcomingPeriods(

--- a/java/code/src/com/suse/manager/reactor/hardware/CpuArchUtil.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/CpuArchUtil.java
@@ -53,8 +53,8 @@ public class CpuArchUtil {
      * @return Check if the given cpuarch is X86 (32 or 64 bit)
      */
     public static boolean isX86(String cpuarch) {
-        return (cpuarch.startsWith("i") &&
-                StringUtils.substring(cpuarch, -2, cpuarch.length()).equals("86")) ||
+        return cpuarch.startsWith("i") &&
+                StringUtils.substring(cpuarch, -2, cpuarch.length()).equals("86") ||
                 "x86_64".equals(cpuarch);
     }
 

--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -497,8 +497,8 @@ public class HardwareMapper {
             zhost.updateServerInfo();
 
             CPU hostcpu = zhost.getCpu();
-            if (hostcpu == null || (hostcpu.getNrsocket() != null &&
-                    hostcpu.getNrsocket().longValue() != totalIfls)) {
+            if (hostcpu == null || hostcpu.getNrsocket() != null &&
+                    hostcpu.getNrsocket().longValue() != totalIfls) {
                 LOG.debug("Update host cpu: {}", totalIfls);
                 hostcpu = Optional.ofNullable(hostcpu).orElseGet(CPU::new);
                 hostcpu.setNrCPU(totalIfls);
@@ -582,7 +582,7 @@ public class HardwareMapper {
                 grains.getValueAsString("virtual"));
         String virtSubtype = grains.getValueAsString("virtual_subtype");
         String instanceId = grains.getValueAsString("instance_id");
-        String virtUuid = (StringUtils.isEmpty(instanceId)) ? grains.getValueAsString("uuid") : instanceId;
+        String virtUuid = StringUtils.isEmpty(instanceId) ? grains.getValueAsString("uuid") : instanceId;
         int vCPUs = grains.getValueAsLong("total_num_cpus").orElse(0L).intValue();
         long memory = grains.getValueAsLong("mem_total").orElse(0L);
 
@@ -1155,7 +1155,7 @@ public class HardwareMapper {
 
         if (subsys.equals("block")) {
             if (StringUtils.isNotBlank(attrs.getValueAsString("ID_CDROM")) ||
-                    (attrs.getValueAsString("ID_TYPE").equals("cd"))) {
+                    attrs.getValueAsString("ID_TYPE").equals("cd")) {
                 return Device.CLASS_CDROM;
             }
             else {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -136,7 +136,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
      */
     @Override
     public void execute(EventMessage msg) {
-        RegisterMinionEventMessage registerMinionEventMessage = ((RegisterMinionEventMessage) msg);
+        RegisterMinionEventMessage registerMinionEventMessage = (RegisterMinionEventMessage) msg;
         Optional<MinionStartupGrains> startupGrainsOpt = Opt.or(registerMinionEventMessage.getMinionStartupGrains(),
                 () -> saltApi.getGrains(registerMinionEventMessage.getMinionId(),
                         new TypeToken<MinionStartupGrains>() { }, "machine_id", "saltboot_initrd", "susemanager"));

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -510,8 +510,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals("livepatch_2_2_1", minion.getKernelLiveVersion());
 
         // Verify Uptime is set
-        Date bootTime = new Date(System.currentTimeMillis() - (600 * 1000));
-        assertEquals((long) minion.getLastBoot(), (bootTime.getTime() / 1000));
+        Date bootTime = new Date(System.currentTimeMillis() - 600 * 1000);
+        assertEquals((long) minion.getLastBoot(), bootTime.getTime() / 1000);
 
         //Switch back from live patching
         message = new JobReturnEventMessage(JobReturnEvent
@@ -714,7 +714,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateX86NoDmi()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.nodmi.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.nodmi.x86.json", server -> {
             assertNotNull(server);
             assertNotNull(server.getCpu());
             assertNotNull(server.getVirtualInstance());
@@ -730,7 +730,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateDockerNoDmiUdev()  throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.docker.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.docker.json", server -> {
             assertNotNull(server);
             assertNotNull(server.getCpu());
             assertNull(server.getVirtualInstance());
@@ -745,7 +745,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testHardwareProfileUpdateX86() throws Exception {
-        testHardwareProfileUpdate("hardware.profileupdate.x86.json", (server) -> {
+        testHardwareProfileUpdate("hardware.profileupdate.x86.json", server -> {
             assertNotNull(server);
             assertNotNull(server.getCpu());
             assertEquals(Long.valueOf(1), server.getCpu().getNrsocket());
@@ -1730,7 +1730,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ActivationKey key = ImageTestUtils.createActivationKey(user);
         ImageProfile profile = ImageTestUtils.createKiwiImageProfile("my-kiwi-image", key, user);
 
-        ImageInfo image = doTestKiwiImageBuild(server, profile, "image.build.kiwi.json", (info) -> {
+        ImageInfo image = doTestKiwiImageBuild(server, profile, "image.build.kiwi.json", info -> {
             // name and version is updated from the Kiwi build result
             assertEquals("POS_Image_JeOS7", info.getName());
             assertEquals("7.0.0", info.getVersion());
@@ -1788,7 +1788,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ActivationKey key = ImageTestUtils.createActivationKey(user);
         ImageProfile profile = ImageTestUtils.createKiwiImageProfile("my-kiwi-image", key, user);
 
-        ImageInfo image = doTestKiwiImageBuild(server, profile, "image.build.bundle.kiwi.json", (info) -> {
+        ImageInfo image = doTestKiwiImageBuild(server, profile, "image.build.bundle.kiwi.json", info -> {
             // name and version is updated from the Kiwi build result
             assertEquals("POS_Image_JeOS7", info.getName());
             assertEquals("7.0.0", info.getVersion());
@@ -1877,7 +1877,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
 
         assertFalse(user.getOrg().getPillars().stream()
-                   .filter(item -> (("Image" + image.getId()).equals(item.getCategory())))
+                   .filter(item -> ("Image" + image.getId()).equals(item.getCategory()))
                    .findAny().isPresent());
     }
 
@@ -1906,7 +1906,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ActivationKey key = ImageTestUtils.createActivationKey(user);
         ImageProfile profile = ImageTestUtils.createKiwiImageProfile("my-kiwi-image", key, user);
 
-        doTestKiwiImageInspect(server, profile, "image.inspect.kiwi_compressed.json", (info) -> {
+        doTestKiwiImageInspect(server, profile, "image.inspect.kiwi_compressed.json", info -> {
             assertNotNull(info.getInspectAction().getId());
             assertEquals(286, info.getPackages().size());
 

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -173,7 +173,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
     }
 
-    private ExpectationsFunction SLES_EXPECTATIONS = (key) ->
+    private ExpectationsFunction SLES_EXPECTATIONS = key ->
             new Expectations() {{
                 allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                 will(returnValue(getSystemInfo(MINION_ID, null, key)));
@@ -181,7 +181,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
             }};
 
-    private ExpectationsFunction SLES_EXPECTATIONS_NO_STARTUPGRAINS = (key) ->
+    private ExpectationsFunction SLES_EXPECTATIONS_NO_STARTUPGRAINS = key ->
             new Expectations() {{
                 allowing(saltServiceMock)
                         .getGrains(with(any(String.class)), with(any(TypeToken.class)), with(any(String[].class)));
@@ -192,13 +192,13 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
             }};
 
-    private ExpectationsFunction SLES_EXPECTATIONS_ALREADY_REGISTERED = (key) ->
+    private ExpectationsFunction SLES_EXPECTATIONS_ALREADY_REGISTERED = key ->
             new Expectations() {{
                 allowing(saltServiceMock).updateSystemInfo(with(any(MinionList.class)));
             }};
 
     @SuppressWarnings("unchecked")
-    private final ExpectationsFunction SLES_NO_AK_EXPECTATIONS = (key) ->
+    private final ExpectationsFunction SLES_NO_AK_EXPECTATIONS = key ->
             new Expectations() {{
                 allowing(saltServiceMock)
                         .getGrains(with(any(String.class)), with(any(TypeToken.class)), with(any(String[].class)));
@@ -209,7 +209,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 will(returnValue(Optional.empty()));
             }};
 
-    private ActivationKeySupplier ACTIVATION_KEY_SUPPLIER = (contactMethod) -> {
+    private ActivationKeySupplier ACTIVATION_KEY_SUPPLIER = contactMethod -> {
         Channel baseChannel = ChannelFactoryTest.createBaseChannel(user, "channel-x86_64");
         ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
         key.setBaseChannel(baseChannel);
@@ -268,7 +268,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         }
     };
 
-    private Consumer<Void> CLEANUP = (arg) -> MinionServerFactory.findByMachineId(MACHINE_ID)
+    private Consumer<Void> CLEANUP = arg -> MinionServerFactory.findByMachineId(MACHINE_ID)
             .ifPresent(ServerFactory::delete);
 
     @Override
@@ -544,7 +544,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         server2.setMachineId(MACHINE_ID);
         server2.setHostname(server2.getName());
         try {
-            executeTest((key) -> new Expectations() {{
+            executeTest(key -> new Expectations() {{
                 allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                 will(returnValue(getSystemInfo(MINION_ID, null, key)));
                 allowing(saltServiceMock).removeSaltSSHKnownHost(with(any(String.class)));
@@ -573,7 +573,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     public void testAlreadyRegisteredMinionWithNewMinionId() throws Exception {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         server.setMachineId(MACHINE_ID);
-        executeTest((key) -> new Expectations() {{
+        executeTest(key -> new Expectations() {{
             allowing(saltServiceMock).updateSystemInfo(with(any(MinionList.class)));
             exactly(1).of(saltServiceMock).deleteKey(server.getMinionId());
         }}, null, (minion, machineId, key) -> assertTrue(MinionServerFactory.findByMinionId(MINION_ID).isPresent()),
@@ -584,7 +584,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     public void testWithMissingMachineIdStartUpGrains() throws Exception {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         server.setMinionId(MINION_ID);
-        executeTest((key) -> new Expectations(),
+        executeTest(key -> new Expectations(),
                 null,
                 (minion, machineId, key) -> assertFalse(MinionServerFactory.findByMachineId(MACHINE_ID).isPresent()),
                 null, DEFAULT_CONTACT_METHOD, Optional.of(new MinionStartupGrains()));
@@ -602,7 +602,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
                 .machineId(MACHINE_ID).saltbootInitrd(true)
                 .createMinionStartUpGrains();
-        executeTest((key) -> new Expectations() {{
+        executeTest(key -> new Expectations() {{
             allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
             will(returnValue(getSystemInfo(MINION_ID, null, key)));
         }}, null, (minion, machineId, key) -> assertTrue(MinionServerFactory.findByMinionId(MINION_ID).isPresent()),
@@ -683,7 +683,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ServerFactory.save(minion);
 
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     MinionStartupGrains.SuseManagerGrain suseManagerGrain =
                             new MinionStartupGrains.SuseManagerGrain(Optional.of(key));
                     MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
@@ -697,7 +697,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getProducts(with(any(String.class)));
                     will(returnValue(Optional.empty()));
                 }},
-                (contactMethod) -> {
+                contactMethod -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     // setting a server makes it a re-activation key
                     key.setServer(minion);
@@ -719,7 +719,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .machineId(MACHINE_ID).saltbootInitrd(false)
                 .createMinionStartUpGrains();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock)
                             .getGrains(with(any(String.class)), with(any(TypeToken.class)), with(any(String[].class)));
                     will(returnValue(Optional.of(minionStartUpGrains)));
@@ -736,7 +736,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getProducts(with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (contactMethod) -> null,
+                contactMethod -> null,
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -754,7 +754,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         Channel baseChannelX8664 = setupBaseAndRequiredChannels(channelFamily, product);
         HibernateFactory.getSession().flush();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, null)));
                     List<ProductInfo> pil = new ArrayList<>();
@@ -768,7 +768,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getProducts(with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (contactMethod) -> null,
+                contactMethod -> null,
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -794,7 +794,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         MinionStartupGrains.SuseManagerGrain suseManagerGrain =
                 new MinionStartupGrains.SuseManagerGrain(Optional.of("non-existent-key"));
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, "non-existent-key")));
                     List<ProductInfo> pil = new ArrayList<>();
@@ -810,7 +810,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                              with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (contactMethod) -> {
+                contactMethod -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setOrg(user.getOrg());
                     ActivationKeyFactory.save(key);
@@ -844,7 +844,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .machineId(MACHINE_ID).saltbootInitrd(false).susemanagerGrain(suseManagerGrain)
                 .createMinionStartUpGrains();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, "non-existent-key")));
                     List<ProductInfo> pil = new ArrayList<>();
@@ -860,7 +860,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                              with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                (contactMethod) -> {
+                contactMethod -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setBaseChannel(baseChannelX8664);
                     key.setOrg(user.getOrg());
@@ -897,7 +897,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 "Config channel 1", "config-channel-1");
         HibernateFactory.getSession().flush();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     MinionStartupGrains.SuseManagerGrain suseManagerGrain =
                             new MinionStartupGrains.SuseManagerGrain(Optional.of(key));
                     MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
@@ -909,7 +909,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, key)));
                 }},
-                (contactMethod) -> {
+                contactMethod -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     key.setBaseChannel(baseChannelX8664);
                     baseChannelX8664.getAccessibleChildrenFor(user)
@@ -962,7 +962,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 SUSEProductTestUtils.createTestSUSEProduct(channelFamilyOther);
         Channel baseChannelX8664Other =
                 setupBaseAndRequiredChannels(channelFamilyOther, productOther);
-        executeTest((key) -> new Expectations() {
+        executeTest(key -> new Expectations() {
 
             {
                 allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
@@ -976,7 +976,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 allowing(saltServiceMock).getProducts(with(any(String.class)));
                 will(returnValue(Optional.of(pil)));
             }
-        }, (contactMethod) -> {
+        }, contactMethod -> {
             ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
             key.setBaseChannel(null);
             // Channels unrelated to the product added as child channels in the
@@ -1048,7 +1048,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .createMinionStartUpGrains();
         try {
             executeTest(
-                    (key) -> new Expectations() {{
+                    key -> new Expectations() {{
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         will(returnValue(getSystemInfo(MINION_ID, testCase.productName.toLowerCase(),
                                 baseChannel != null ? key : null)));
@@ -1066,7 +1066,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                                 Optional.of(testCase.sllProvider)
                         ))));
                     }},
-                    baseChannel != null ? (contactMethod) -> {
+                    baseChannel != null ? contactMethod -> {
                         ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                         key.setBaseChannel(baseChannel);
                         key.setOrg(user.getOrg());
@@ -1115,7 +1115,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         try {
             executeTest(
                     SLES_NO_AK_EXPECTATIONS,
-                    (cm) -> null,
+                    cm -> null,
                     (minion, machineId, key) -> assertEquals(creator.getOrg(), minion.get().getOrg()),
                     DEFAULT_CONTACT_METHOD
                     );
@@ -1167,7 +1167,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .machineId(MACHINE_ID).saltbootInitrd(true)
                 .createMinionStartUpGrains();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     // Notice product name has spaces in the string. It is intentional to test hw string preprocessing
                     Map<String, Object> mods = new HashMap<>();
@@ -1180,7 +1180,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             with(any(LocalCall.class)),
                             with(any(String.class)));
                 }},
-                (contactMethod) -> null, // no AK
+                contactMethod -> null, // no AK
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -1205,7 +1205,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .createMinionStartUpGrains();
         try {
             executeTest(
-                    (key) -> new Expectations() {{
+                    key -> new Expectations() {{
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         Map<String, Object> mods = new HashMap<>();
                         mods.put("saltboot_initrd", true);
@@ -1217,7 +1217,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                                 with(any(LocalCall.class)),
                                 with(any(String.class)));
                     }},
-                    (contactMethod) -> null, // no AK
+                    contactMethod -> null, // no AK
                     (optMinion, machineId, key) -> assertTrue(optMinion.isPresent()),
                     DEFAULT_CONTACT_METHOD,
                     Optional.of(minionStartUpGrains));
@@ -1246,7 +1246,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .createMinionStartUpGrains();
         try {
             executeTest(
-                    (key) -> new Expectations() {{
+                    key -> new Expectations() {{
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         Map<String, Object> mods = new HashMap<>();
                         mods.put("saltboot_initrd", true);
@@ -1256,7 +1256,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         will(returnValue(getSystemInfo(MINION_ID, null, "non-existent-key", null, mods)));
                         // no call to state.apply saltboot
                     }},
-                    (contactMethod) -> null, // no AK
+                    contactMethod -> null, // no AK
                     (optMinion, machineId, key) -> {
                         assertTrue(optMinion.isPresent());
                         MinionServer minion = optMinion.get();
@@ -1287,7 +1287,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .machineId(MACHINE_ID).saltbootInitrd(true)
                 .createMinionStartUpGrains();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     Map<String, Object> mods = new HashMap<>();
                     mods.put("saltboot_initrd", true);
@@ -1299,7 +1299,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             with(any(LocalCall.class)),
                             with(any(String.class)));
                 }},
-                (contactMethod) -> null, // no AK
+                contactMethod -> null, // no AK
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -1332,7 +1332,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .machineId(MACHINE_ID).saltbootInitrd(true)
                 .createMinionStartUpGrains();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     Map<String, Object> mods = new HashMap<>();
                     mods.put("saltboot_initrd", true);
@@ -1347,7 +1347,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             with(any(LocalCall.class)),
                             with(any(String.class)));
                 }},
-                (contactMethod) -> null, // no AK
+                contactMethod -> null, // no AK
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -1384,7 +1384,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
         try {
             executeTest(
-                    (key) -> new Expectations() {{
+                    key -> new Expectations() {{
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         Map<String, Object> mods = new HashMap<>();
                         mods.put("saltboot_initrd", true);
@@ -1396,7 +1396,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                                 with(any(LocalCall.class)),
                                 with(any(String.class)));
                     }},
-                    (contactMethod) -> null, // no AK
+                    contactMethod -> null, // no AK
                     (optMinion, machineId, key) -> {
                         assertTrue(optMinion.isPresent());
                         MinionServer minion = optMinion.get();
@@ -1432,7 +1432,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
         try {
             executeTest(
-                    (key) -> new Expectations() {{
+                    key -> new Expectations() {{
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         Map<String, Object> mods = new HashMap<>();
                         mods.put("saltboot_initrd", true);
@@ -1442,7 +1442,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         will(returnValue(getSystemInfo(MINION_ID, null, "non-existent-key", null, mods)));
                         // no call to state.apply saltboot
                     }},
-                    (contactMethod) -> null, // no AK
+                    contactMethod -> null, // no AK
                     (optMinion, machineId, key) -> {
                         assertTrue(optMinion.isPresent());
                         MinionServer minion = optMinion.get();
@@ -1482,7 +1482,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .createMinionStartUpGrains();
 
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     Map<String, Object> mods = new HashMap<>();
                     mods.put("saltboot_initrd", true);
@@ -1495,7 +1495,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             with(any(LocalCall.class)),
                             with(any(String.class)));
                 }},
-                (contactMethod) -> null, // no AK
+                contactMethod -> null, // no AK
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -1518,7 +1518,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .machineId(MACHINE_ID).saltbootInitrd(false)
                 .createMinionStartUpGrains();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     Map<String, Object> mods = new HashMap<>();
                     mods.put("saltboot_initrd", false);
@@ -1533,7 +1533,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             with(any(LocalCall.class)),
                             with(any(String.class)));
                 }},
-                (contactMethod) -> null, // no AK
+                contactMethod -> null, // no AK
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -1575,12 +1575,12 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         server.setMachineId(MACHINE_ID);
         server.addChannel(assignedChannel);
         ServerFactory.save(server);
-        executeTest((key) -> new Expectations() {
+        executeTest(key -> new Expectations() {
             {
                 allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                 will(returnValue(getSystemInfo(MINION_ID, null, key)));
             }
-        }, (contactMethod) -> {
+        }, contactMethod -> {
             ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
             key.setBaseChannel(akBaseChannel);
             key.addChannel(akChildChannel);
@@ -1626,12 +1626,12 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         server.addChannel(akBaseChannel);
         server.addChannel(assignedChildChannel);
         ServerFactory.save(server);
-        executeTest((key) -> new Expectations() {
+        executeTest(key -> new Expectations() {
             {
                 allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                 will(returnValue(getSystemInfo(MINION_ID, null, key)));
             }
-        }, (contactMethod) -> {
+        }, contactMethod -> {
             ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
             key.setBaseChannel(akBaseChannel);
             key.addChannel(akChildChannel);
@@ -1673,12 +1673,12 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         server.addChannel(assignedChannel);
         server.addChannel(assignedChildChannel);
         ServerFactory.save(server);
-        executeTest((key) -> new Expectations() {
+        executeTest(key -> new Expectations() {
             {
                 allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                 will(returnValue(getSystemInfo(MINION_ID, null, key)));
             }
-        }, (contactMethod) -> null,
+        }, contactMethod -> null,
         (optMinion, machineId, key) -> {
             assertTrue(optMinion.isPresent());
             MinionServer minion = optMinion.get();
@@ -1710,7 +1710,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ChannelFamily channelFamily = createTestChannelFamily();
         HibernateFactory.getSession().flush();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     MinionStartupGrains.SuseManagerGrain suseManagerGrain =
                             new MinionStartupGrains.SuseManagerGrain(Optional.of(key));
                     MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
@@ -1722,7 +1722,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, null, key)));
                 }},
-                (contactMethod) -> {
+                contactMethod -> {
                     ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
                     // setting a server makes it a re-activation key
                     key.setServer(oldMinion);
@@ -1764,7 +1764,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         oldMinion.addChannel(assignedChildChannel);
         ServerFactory.save(oldMinion);
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     MinionStartupGrains.SuseManagerGrain suseManagerGrain =
                             new MinionStartupGrains.SuseManagerGrain(Optional.of(key));
                     MinionStartupGrains minionStartUpGrains =  new MinionStartupGrains.MinionStartupGrainsBuilder()
@@ -1776,7 +1776,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, null, key)));
                 }},
-                (contactMethod) -> "1-re-already-used",
+                contactMethod -> "1-re-already-used",
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -1809,11 +1809,11 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 .machineId(MACHINE_ID).saltbootInitrd(true).susemanagerGrain(suseManagerGrain)
                 .createMinionStartUpGrains();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, null, key)));
                 }},
-                (contactMethod) -> "1-re-already-used",
+                contactMethod -> "1-re-already-used",
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     MinionServer minion = optMinion.get();
@@ -1837,7 +1837,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         product.setFree(false);
         try {
             executeTest(
-                    (key) -> new Expectations() {{
+                    key -> new Expectations() {{
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         will(returnValue(getSystemInfo(MINION_ID, "byos", key)));
                         allowing(saltServiceMock).getInstanceFlavor(MINION_ID);
@@ -1881,7 +1881,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         product.setFree(false);
         try {
             executeTest(
-                    (key) -> new Expectations() {{
+                    key -> new Expectations() {{
                         allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                         will(returnValue(getSystemInfo(MINION_ID, null, key)));
                         allowing(saltServiceMock).getInstanceFlavor(MINION_ID);
@@ -1923,7 +1923,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         SUSEProduct product = SUSEProductTestUtils.createTestSUSEProduct(channelFamily);
         product.setFree(true);
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, key)));
                     allowing(saltServiceMock).getInstanceFlavor(MINION_ID);
@@ -1966,7 +1966,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         SUSEProductFactory.save(product);
 
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, null, key)));
                     allowing(saltServiceMock).getInstanceFlavor(MINION_ID);
@@ -1998,7 +1998,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     public void testRegisterMinionPAYGonPAYG() throws Exception {
         cloudManager4Test = new TestCloudPaygManagerBuilder().withPaygInstance().build();
         executeTest(
-                (key) -> new Expectations() {{
+                key -> new Expectations() {{
                     allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                     will(returnValue(getSystemInfo(MINION_ID, "slespayg", key)));
                     allowing(saltServiceMock).getInstanceFlavor(MINION_ID);

--- a/java/code/src/com/suse/manager/utils/PagedSqlQueryBuilder.java
+++ b/java/code/src/com/suse/manager/utils/PagedSqlQueryBuilder.java
@@ -298,7 +298,7 @@ public class PagedSqlQueryBuilder {
         FilterWithValue filter = Optional.ofNullable(filterParser).map(parser -> parser.apply(pageControl)).
                 orElse(FilterWithValue.NO_FILTER);
         if (!"".equals(filter.getValue())) {
-            whereWithFilter = (where != null) ?
+            whereWithFilter = where != null ?
                     String.format("(%s) AND %s", where, filter.getFilter()) :
                     filter.getFilter();
         }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -352,8 +352,8 @@ public class SaltUtils {
                 e.getKey().endsWith("-release") ||
                 // Live patching requires refresh to fetch the updated LP version
                 e.getKey().startsWith("kernel-livepatch-") ||
-                (e.getValue().getNewValue().isLeft() &&
-                 e.getValue().getOldValue().isLeft())
+                        e.getValue().getNewValue().isLeft() &&
+                         e.getValue().getOldValue().isLeft()
         );
 
         if (fullRefreshNeeded) {
@@ -1700,7 +1700,7 @@ public class SaltUtils {
         InstalledPackage pkg = new InstalledPackage();
         pkg.setEvr(packageEvr);
         pkg.setInstallTime(pkgInfo.getInstallDateUnixTime()
-                .map(time -> new Date((time * 1000)))
+                .map(time -> new Date(time * 1000))
                 .orElse(null));
         pkg.setName(packageName);
         pkg.setServer(server);
@@ -2170,7 +2170,7 @@ public class SaltUtils {
             return;
         }
         Date bootTime = new Date(
-                System.currentTimeMillis() - (uptimeSeconds * 1000));
+                System.currentTimeMillis() - uptimeSeconds * 1000);
         LOG.debug("Set last boot for {} to {}", minion.getMinionId(), bootTime);
         minion.setLastBoot(bootTime.getTime() / 1000);
 

--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -586,8 +586,8 @@ public class DownloadController {
             }
             halt(HttpStatus.SC_FORBIDDEN, String.format("You need a token to access %s", request.pathInfo()));
         }
-        if ((queryParams.size() > 1 && header == null) ||
-                (!queryParams.isEmpty() && header != null)) {
+        if (queryParams.size() > 1 && header == null ||
+                !queryParams.isEmpty() && header != null) {
             LOG.info("Bad Request: Only one token is accepted");
             halt(HttpStatus.SC_BAD_REQUEST, "Only one token is accepted");
         }

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -210,7 +210,7 @@ public class MinionsAPI {
         Map<String, Long> visibleToUser = MinionServerFactory.lookupVisibleToUser(user)
                 .collect(Collectors.toMap(MinionServer::getMinionId, MinionServer::getId));
 
-        Predicate<String> isVisible = (minionId) ->
+        Predicate<String> isVisible = minionId ->
             visibleToUser.containsKey(minionId) || !serverIdMapping.containsKey(minionId);
 
         var minions = SaltMinionJson.fromFingerprints(fingerprints, visibleToUser, isVisible);

--- a/java/code/src/com/suse/manager/webui/controllers/RecurringActionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/RecurringActionController.java
@@ -472,7 +472,7 @@ public class RecurringActionController {
         else if (action.getRecurringActionType() instanceof RecurringState stateType) {
             stateType.setTestMode(details.isTest());
             if (json.getRecurringActionId() == null ||
-                    (json.getRecurringActionId() != null && details.getStates() != null)) {
+                    json.getRecurringActionId() != null && details.getStates() != null) {
                 Set<RecurringStateConfig> newConfig = getStateConfigFromJson(details.getStates(), action.getCreator());
                 ((RecurringState) action.getRecurringActionType()).saveStateConfig(newConfig);
             }

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -244,15 +244,15 @@ public class StatesAPI {
 
         // Lookup assigned states
         List<ConfigChannel> assignedStates = handleTarget(type, id,
-                (serverId) -> {
+                serverId -> {
                     MinionServer server = getEntityIfExists(MinionServerFactory.lookupById(id));
                     return StateFactory.latestConfigChannels(server);
                 },
-                (groupId) -> {
+                groupId -> {
                     ServerGroup group = getEntityIfExists(ServerGroupFactory.lookupByIdAndOrg(id, user.getOrg()));
                     return StateFactory.latestConfigChannels(group);
                 },
-                (orgId) -> {
+                orgId -> {
                     Org org = getEntityIfExists(OrgFactory.lookupById(id));
                     return StateFactory.latestConfigChannels(org);
                 }
@@ -294,18 +294,18 @@ public class StatesAPI {
 
         try {
             SaltConfigurable entity = handleTarget(json.getTargetType(), json.getTargetId(),
-                (serverId) -> {
+                    serverId -> {
                         MinionServer server = getEntityIfExists(MinionServerFactory.lookupById(serverId));
                         checkUserHasPermissionsOnServer(server, user);
                         return server;
                 },
-                (groupId) -> {
+                    groupId -> {
                         ServerGroup group =
                                 getEntityIfExists(ServerGroupFactory.lookupByIdAndOrg(groupId, user.getOrg()));
                         checkUserHasPermissionsOnServerGroup(user, group);
                         return group;
                 },
-                (orgId) -> {
+                    orgId -> {
                         Org org = getEntityIfExists(OrgFactory.lookupById(json.getTargetId()));
                         checkUserHasPermissionsOnOrg(org);
                         return org;
@@ -480,7 +480,7 @@ public class StatesAPI {
         try {
             ApplyStatesAction scheduledAction = handleTarget(json.getTargetType(),
                     json.getTargetId(),
-                    (serverId) -> {
+                    serverId -> {
                         MinionServer server = getEntityIfExists(MinionServerFactory.lookupById(json.getTargetId()));
                         checkUserHasPermissionsOnServer(server, user);
                         ApplyStatesAction action = ActionManager.scheduleApplyStates(user,
@@ -488,7 +488,7 @@ public class StatesAPI {
                                 getScheduleDate(json));
                         return action;
                     },
-                    (groupId) -> {
+                    groupId -> {
                         ServerGroup group = getEntityIfExists(
                                 ServerGroupFactory.lookupByIdAndOrg(json.getTargetId(), user.getOrg()));
                         checkUserHasPermissionsOnServerGroup(user, group);
@@ -510,7 +510,7 @@ public class StatesAPI {
 
                         return action;
                     },
-                    (orgId) -> {
+                    orgId -> {
                         Org org = getEntityIfExists(OrgFactory.lookupById(json.getTargetId()));
                         checkUserHasPermissionsOnOrg(org);
                         List<Long> minionServerIds = MinionServerFactory

--- a/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/VirtualHostManagerController.java
@@ -277,7 +277,7 @@ public class VirtualHostManagerController {
      * @return the json response
      */
     public static String update(Request request, Response response, User user) {
-        return withVirtualHostManager(request, response, user, (vhm) -> {
+        return withVirtualHostManager(request, response, user, vhm -> {
             List<String> errors = new LinkedList<>();
             Map<String, String> gathererModuleParams =
                     paramsFromQueryMap(request.queryMap().toMap());
@@ -376,7 +376,7 @@ public class VirtualHostManagerController {
      */
     public static String getKubeconfigContexts(Request request,
                                                Response response, User user) {
-        return withVirtualHostManager(request, response, user, (vhm) -> {
+        return withVirtualHostManager(request, response, user, vhm -> {
             String kubeconfigPath = vhm.getConfigs().stream()
                     .filter(cfg -> CONFIG_KUBECONFIG.equals(cfg.getParameter()))
                     .map(VirtualHostManagerConfig::getValue)
@@ -612,7 +612,7 @@ public class VirtualHostManagerController {
      * @return dummy string to satisfy spark
      */
     public static Object refresh(Request request, Response response, User user) {
-        return withVirtualHostManager(request, response, user, (vhm) -> {
+        return withVirtualHostManager(request, response, user, vhm -> {
             String label = vhm.getLabel();
             String message = null;
             Map<String, String> params = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/controllers/activationkeys/ActivationKeysController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/activationkeys/ActivationKeysController.java
@@ -83,7 +83,7 @@ public class ActivationKeysController {
      * @return the json response
      */
     public static String getChannels(Request request, Response response, User user) {
-        return withActivationKey(request, response, user, (activationKey) -> result(response,
+        return withActivationKey(request, response, user, activationKey -> result(response,
                 success(ChannelsJson.fromChannelSet(activationKey.getChannels())), new TypeToken<>() { }));
     }
 
@@ -139,7 +139,7 @@ public class ActivationKeysController {
             return result(response, success(jsonChannels), new TypeToken<>() { });
         }
         else {
-            return withChannel(request, response, user, (base) -> {
+            return withChannel(request, response, user, base -> {
                 jsonChannels.add(generateChannelJson(base, user));
                 return result(response, success(jsonChannels), new TypeToken<>() { });
             });

--- a/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -164,7 +164,7 @@ public abstract class AbstractMinionBootstrapper {
         LOG.debug("Salt SSH Dir test output: {}", commandOutput);
 
         try {
-            boolean ownerCanReadWrite = ("rw").equals(commandOutput.substring(1, 3));
+            boolean ownerCanReadWrite = "rw".equals(commandOutput.substring(1, 3));
             boolean userAndGroupSet = commandOutput.contains("salt salt");
 
             LOG.debug("User can read/write: {} user and group correct: {}", ownerCanReadWrite, userAndGroupSet);

--- a/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/AnsibleControllerTest.java
@@ -148,7 +148,7 @@ public class AnsibleControllerTest extends BaseTestCaseWithUser {
     @Test
     public void testParseInventoryAndGetHostnames() {
         List<InventoryTestCase> testCases = getTestInventories();
-        testCases.stream().forEach((testCase) -> {
+        testCases.stream().forEach(testCase -> {
             Set<String> gotHostnames = AnsibleManager.parseInventoryAndGetHostnames(testCase.getInventory());
             assertEquals(gotHostnames, testCase.getExpectedResult());
         });

--- a/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/DownloadControllerTest.java
@@ -494,7 +494,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
      */
     @Test
     public void testCorrectChannelWithTokenInUrl() throws Exception {
-        testCorrectChannel((tokenChannel) -> {
+        testCorrectChannel(tokenChannel -> {
             Map<String, String> params = new HashMap<>();
             params.put(tokenChannel, "");
             return getMockRequestWithParams(params);
@@ -509,7 +509,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
      */
     @Test
     public void testCorrectChannelWithTokenInHeader() throws Exception {
-        testCorrectChannel((tokenChannel) -> {
+        testCorrectChannel(tokenChannel -> {
             Map<String, String> headers = new HashMap<>();
             headers.put("X-Mgr-Auth", tokenChannel);
             return getMockRequestWithParamsAndHeaders(Collections.emptyMap(), headers);
@@ -518,7 +518,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
 
     @Test
     public void testDownloadDebPackage() throws Exception {
-        testCorrectChannel(() -> debPackageFile, (tokenChannel) -> {
+        testCorrectChannel(() -> debPackageFile, tokenChannel -> {
             Map<String, String> headers = new HashMap<>();
             headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(tokenChannel.getBytes()));
             return getMockRequestWithParamsAndHeaders(Collections.emptyMap(), headers, debUriFile);
@@ -527,7 +527,7 @@ public class DownloadControllerTest extends BaseTestCaseWithUser {
 
     @Test
     public void testParseDebPackageVersion() throws Exception {
-        testCorrectChannel(() -> debPackageFile2, (tokenChannel) -> {
+        testCorrectChannel(() -> debPackageFile2, tokenChannel -> {
             Map<String, String> headers = new HashMap<>();
             headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(tokenChannel.getBytes()));
             return getMockRequestWithParamsAndHeaders(Collections.emptyMap(), headers, debUriFile2);

--- a/java/code/src/com/suse/manager/webui/services/ConfigChannelSaltManager.java
+++ b/java/code/src/com/suse/manager/webui/services/ConfigChannelSaltManager.java
@@ -483,7 +483,7 @@ public class ConfigChannelSaltManager {
      * @return the channel relative path
      */
     private Path getChannelRelativePath(Long orgId, String channelLabel) {
-        return Paths.get((getOrgNamespace(orgId)))
+        return Paths.get(getOrgNamespace(orgId))
                 .resolve(channelLabel);
     }
 

--- a/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
@@ -531,8 +531,8 @@ public class SaltActionChainGeneratorService {
      * @return the file name
      */
     public static String getActionChainSLSFileName(Long actionChainId, MinionSummary minionServer, int chunk) {
-        return (ACTIONCHAIN_SLS_FILE_PREFIX + actionChainId +
-                "_" + minionServer.getMachineId() + "_" + chunk + ".sls");
+        return ACTIONCHAIN_SLS_FILE_PREFIX + actionChainId +
+                "_" + minionServer.getMachineId() + "_" + chunk + ".sls";
     }
 
     private void saveChunkSLS(List<SaltState> states, MinionSummary minion, long actionChainId, int chunk) {

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -632,7 +632,7 @@ public class SaltServerActionService {
                 failActionChain(minionId, firstChunkActionId, Optional.of("No action chain result"));
             }
             else if (!stateApplyResult.isResult() && (stateApplyResult.getChanges() == null ||
-                    (stateApplyResult.getChanges().isJsonObject()) &&
+                    stateApplyResult.getChanges().isJsonObject() &&
                             ((JsonObject)stateApplyResult.getChanges()).size() == 0)) {
                 LOG.error("Error handling action chain execution: {}", stateApplyResult.getComment());
                 failActionChain(minionId, firstChunkActionId, Optional.of(stateApplyResult.getComment()));
@@ -738,7 +738,7 @@ public class SaltServerActionService {
         catch (JsonSyntaxException e) {
             LOG.error("Unexpected response: {}", stateChanges, e);
             String msg = stateChanges.toString();
-            if ((stateChanges.isJsonObject()) &&
+            if (stateChanges.isJsonObject() &&
                     ((JsonObject)stateChanges).get("ret") != null) {
                 msg = ((JsonObject)stateChanges).get("ret").toString();
             }
@@ -1976,7 +1976,7 @@ public class SaltServerActionService {
                             // SSH login is blocked when a reboot is ongoing. Reschedule this action later again
                             LOG.info("System is going down. Configure re-try in 3 minutes");
                             sa.setStatus(STATUS_QUEUED);
-                            sa.setRemainingTries((sa.getRemainingTries() - 1L));
+                            sa.setRemainingTries(sa.getRemainingTries() - 1L);
                             sa.setPickupTime(null);
                             sa.setCompletionTime(null);
                             action.setEarliestAction(Date.from(Instant.now().plus(3, ChronoUnit.MINUTES)));

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -840,8 +840,8 @@ public class SaltSSHService {
             return future.handle((applyResult, err) -> {
                 if (applyResult != null) {
                     List<String> result = applyResult.fold(
-                        (saltErr) -> singletonList(SaltUtils.decodeSaltErr(saltErr).getMessage()),
-                        (saltRes) -> saltRes.values().stream()
+                            saltErr -> singletonList(SaltUtils.decodeSaltErr(saltErr).getMessage()),
+                            saltRes -> saltRes.values().stream()
                                             .filter(value -> !value.isResult())
                                             .map(StateApplyResult::getComment)
                                             .collect(Collectors.toList())

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -85,7 +85,7 @@ public class SubscriptionMatchProcessor {
                     // see https://github.com/SUSE/spacewalk/wiki/
                     // Subscription-counting#definitions
                     s.getPhysical() ?
-                        (s.getVirtualHost() ? "virtualHost" : "nonVirtual") :
+                            s.getVirtualHost() ? "virtualHost" : "nonVirtual" :
                         "virtualGuest",
                     output.getMatches().stream()
                         .filter(m -> m.getSystemId().equals(s.getId()))

--- a/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
@@ -435,12 +435,12 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
                                 .getActionChainSLSFileName(actionChain.getId(), minionSummary1, 2))
                         .toFile());
 
-        assertEquals(("pkg_installed:\n" +
+        assertEquals("pkg_installed:\n" +
                         "    pkg.installed:\n" +
                         "    -   refresh: true\n" +
                         "    -   pkgs:\n" +
                         "        -   salt.x86_64: 2018.3.0-4.1\n" +
-                        "        -   salt-minion.x86_64: 2018.3.0-4.1\n"), fileContent);
+                        "        -   salt-minion.x86_64: 2018.3.0-4.1\n", fileContent);
     }
 
     @Test

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -498,7 +498,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                                             Object pillarValue, LocalCall<?> call) {
         assertEquals("state", call.getModuleName());
         assertEquals("apply", call.getFunctionName());
-        Map<String, Object> kwargs = ((Map<String, Object>)call.getPayload().get("kwarg"));
+        Map<String, Object> kwargs = (Map<String, Object>)call.getPayload().get("kwarg");
         assertTrue(((List<String>)kwargs.get("mods")).contains(expectedState),
                 "State does not call: " + expectedState);
         if (pillarEntry != null) {
@@ -996,7 +996,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         context().checking(new Expectations() { {
             oneOf(saltServiceMock).callAsync(
                 with(any(LocalCall.class)),
-                with((new MinionListMatcher(List.of(secondMinion.getMinionId())))),
+                with(new MinionListMatcher(List.of(secondMinion.getMinionId()))),
                 with(any(Optional.class))
             );
             LocalAsyncResult<?> result = new LocalAsyncResult<>() {

--- a/java/code/src/com/suse/manager/webui/services/test/ThrottlingServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/ThrottlingServiceTest.java
@@ -58,7 +58,7 @@ public class ThrottlingServiceTest {
 
     @Test
     public void testMultipleResources() {
-        ThrowingConsumer<String> call = (res) -> service.call(1, res, 1, ThrottlingService.DEF_THROTTLE_PERIOD_SECS);
+        ThrowingConsumer<String> call = res -> service.call(1, res, 1, ThrottlingService.DEF_THROTTLE_PERIOD_SECS);
 
         assertDoesNotThrow(() -> call.accept("/resource/one"), "Call must be allowed");
         assertThrows(TooManyCallsException.class, () -> call.accept("/resource/one"), "Call must not be allowed");
@@ -67,7 +67,7 @@ public class ThrottlingServiceTest {
 
     @Test
     public void testMultipleUsers() {
-        ThrowingConsumer<Long> call = (uid) -> service.call(uid, "/my/resource", 1,
+        ThrowingConsumer<Long> call = uid -> service.call(uid, "/my/resource", 1,
                 ThrottlingService.DEF_THROTTLE_PERIOD_SECS);
 
         assertDoesNotThrow(() -> call.accept(1L), "Call must be allowed");

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -460,7 +460,7 @@ public class SparkApplicationHelper {
             boolean committed = false;
             try {
                 //Checking if the response is valid should fix rollback for failing responses (e.g. from controllers)
-                boolean isValidResponse = (responseIn.status() == HttpStatus.SC_OK);
+                boolean isValidResponse = responseIn.status() == HttpStatus.SC_OK;
                 if (isValidResponse && HibernateFactory.inTransaction()) {
                     HibernateFactory.commitTransaction();
                 }

--- a/java/code/src/com/suse/manager/webui/utils/gson/ChannelsJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ChannelsJson.java
@@ -200,7 +200,7 @@ public class ChannelsJson {
      */
     public void setChildren(Stream<Channel> childrenIn) {
         this.children = childrenIn.map(
-                (c) -> new ChannelJson(c.getId(), c.getLabel(), c.getName(), c.isCustom(), true,
+                        c -> new ChannelJson(c.getId(), c.getLabel(), c.getName(), c.isCustom(), true,
                         c.isCloned(), c.getChannelArch().getLabel()))
                 .collect(Collectors.toList());
     }
@@ -210,7 +210,7 @@ public class ChannelsJson {
      * @param recommendedFlags the map of channels with recommended flag value
      */
     public void setChildrenWithRecommendedAndArch(Stream<Channel> childrenIn, Map<Long, Boolean> recommendedFlags) {
-        this.children = childrenIn.map((c) -> {
+        this.children = childrenIn.map(c -> {
             ChannelJson channelWithArch = new ChannelJson(
                     c.getId(),
                     c.getLabel(),

--- a/java/code/src/com/suse/manager/webui/utils/gson/ImageInfoJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ImageInfoJson.java
@@ -297,7 +297,7 @@ public class ImageInfoJson {
         }
 
         this.customData = customDataIn.stream().collect(Collectors.toMap(
-                (cd) -> cd.getKey().getLabel(), ImageInfoCustomDataValue::getValue));
+                cd -> cd.getKey().getLabel(), ImageInfoCustomDataValue::getValue));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/gson/test/SaltMinionTestJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/test/SaltMinionTestJson.java
@@ -72,7 +72,7 @@ public class SaltMinionTestJson extends MockObjectTestCase {
         registered.put("m2", 2L);
         registered.put("m4", 4L); // registered not visible
 
-        Predicate<String> isVisible = (minionId) -> visibleToUser.containsKey(minionId) ||
+        Predicate<String> isVisible = minionId -> visibleToUser.containsKey(minionId) ||
                 !registered.containsKey(minionId);
 
         List<SaltMinionJson> minions = SaltMinionJson.fromFingerprints(fingerprints, visibleToUser, isVisible);

--- a/java/code/src/com/suse/manager/xmlrpc/iss/test/HubHandlerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/iss/test/HubHandlerTest.java
@@ -101,7 +101,7 @@ public class HubHandlerTest extends BaseHandlerTestCase {
     @BeforeEach
     public void setupTest() {
         context.setThreadingPolicy(new Synchroniser());
-        context.setImposteriser((ByteBuddyClassImposteriser.INSTANCE));
+        context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         hubManagerMock = context.mock(HubManager.class);
         migratorFactoryMock = context.mock(IssMigratorFactory.class);
@@ -519,7 +519,7 @@ public class HubHandlerTest extends BaseHandlerTestCase {
     }
 
     private static Map<String, String> mapWithNull(String... keyValuePairs) {
-        if (keyValuePairs == null || (keyValuePairs.length % 2) != 0) {
+        if (keyValuePairs == null || keyValuePairs.length % 2 != 0) {
             throw new IllegalArgumentException();
         }
 

--- a/java/code/src/com/suse/oval/OVALCleaner.java
+++ b/java/code/src/com/suse/oval/OVALCleaner.java
@@ -164,7 +164,7 @@ public class OVALCleaner {
      */
     private static void convertDebianTestRefs(BaseCriteria root, String osVersion) {
         if (root instanceof CriteriaType criteriaType) {
-            for (BaseCriteria criteria : (criteriaType).getChildren()) {
+            for (BaseCriteria criteria : criteriaType.getChildren()) {
                 convertDebianTestRefs(criteria, osVersion);
             }
         }

--- a/java/code/src/com/suse/oval/vulnerablepkgextractor/CriteriaTreeBasedExtractor.java
+++ b/java/code/src/com/suse/oval/vulnerablepkgextractor/CriteriaTreeBasedExtractor.java
@@ -100,7 +100,7 @@ public abstract class CriteriaTreeBasedExtractor implements VulnerablePackagesEx
             if (currentLevel > maxNestingLevel) {
                 return;
             }
-            for (BaseCriteria child : ((CriteriaType) (criteria)).getChildren()) {
+            for (BaseCriteria child : ((CriteriaType) criteria).getChildren()) {
                 collectCriterionsHelper(child, currentLevel + 1, maxNestingLevel, criterions);
             }
         }
@@ -122,7 +122,7 @@ public abstract class CriteriaTreeBasedExtractor implements VulnerablePackagesEx
             matches.add(criteria);
         }
         if (criteria instanceof CriteriaType criteriaCast) {
-            for (BaseCriteria childCriteria : (criteriaCast).getChildren()) {
+            for (BaseCriteria childCriteria : criteriaCast.getChildren()) {
                 walkCriteriaTreeHelper(childCriteria, matches);
             }
         }

--- a/java/code/src/com/suse/utils/CertificateUtils.java
+++ b/java/code/src/com/suse/utils/CertificateUtils.java
@@ -139,7 +139,7 @@ public final class CertificateUtils {
      * @throws JobExecutionException if there was an error
      */
     public static void saveAndUpdateCertificates(Map<String, String> filenameToRootCaCertMap) {
-        if ((null == filenameToRootCaCertMap) || filenameToRootCaCertMap.isEmpty()) {
+        if (null == filenameToRootCaCertMap || filenameToRootCaCertMap.isEmpty()) {
             return; // nothing to do
         }
 
@@ -148,7 +148,7 @@ public final class CertificateUtils {
     }
 
     private static void saveCertificates(Map<String, String> filenameToRootCaCertMap) {
-        if ((null == filenameToRootCaCertMap) || filenameToRootCaCertMap.isEmpty()) {
+        if (null == filenameToRootCaCertMap || filenameToRootCaCertMap.isEmpty()) {
             return; // nothing to do
         }
 

--- a/java/code/src/com/suse/utils/Ip.java
+++ b/java/code/src/com/suse/utils/Ip.java
@@ -75,9 +75,9 @@ public class Ip {
         byte[] addr = new byte[size];
         int b = 0;
         for (int i = 0; i < mask; i++) {
-            b += 1 << (7 - i % Byte.SIZE);
+            b += 1 << 7 - i % Byte.SIZE;
             if (i % Byte.SIZE == 7 || i == mask - 1) {
-                addr[(i / Byte.SIZE)] = (byte)b;
+                addr[i / Byte.SIZE] = (byte)b;
                 b = 0;
             }
         }

--- a/java/code/src/com/suse/utils/Predicates.java
+++ b/java/code/src/com/suse/utils/Predicates.java
@@ -37,7 +37,7 @@ public final class Predicates {
      * @return true if the object does not contain meaningful content
      */
     public static boolean isAbsent(Object value) {
-        return !(isProvided(value));
+        return !isProvided(value);
     }
 
     /**
@@ -126,7 +126,7 @@ public final class Predicates {
      * @return true if none of the elements in the collection are considered provided, otherwise false
      */
     public static boolean noneProvided(Collection<?> collection) {
-        if ((collection == null) || collection.isEmpty()) {
+        if (collection == null || collection.isEmpty()) {
             return true;
         }
         return !isProvided(collection);
@@ -139,7 +139,7 @@ public final class Predicates {
      * @return true if any of the elements in the collection are considered provided, otherwise false
      */
     public static boolean anyProvided(Collection<?> collection) {
-        return !(noneProvided(collection));
+        return !noneProvided(collection);
     }
 
     /**

--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -933,7 +933,7 @@ public abstract class CobblerObject {
             return new HashSet<>();
         }
         String keys = StringUtils.defaultString(key.get());
-        String[] sets = (keys).split(",");
+        String[] sets = keys.split(",");
         return new HashSet<>(Arrays.asList(sets));
     }
 

--- a/java/code/src/org/cobbler/SystemRecord.java
+++ b/java/code/src/org/cobbler/SystemRecord.java
@@ -538,7 +538,7 @@ public class SystemRecord extends CobblerObject {
      */
     public boolean isNetbootEnabled() {
         return Boolean.TRUE.toString().
-                equalsIgnoreCase((String.valueOf(dataMap.get(NETBOOT_ENABLED))));
+                equalsIgnoreCase(String.valueOf(dataMap.get(NETBOOT_ENABLED)));
     }
 
     /**

--- a/java/code/src/org/cobbler/test/MockConnection.java
+++ b/java/code/src/org/cobbler/test/MockConnection.java
@@ -158,7 +158,7 @@ public class MockConnection extends CobblerConnection {
                 modifyItem(profiles, (String) args[0], (String) args[1], args[2]);
                 break;
             case "get_profile":
-                return getItem(profiles, (String) args[0], (args.length == 3 && (boolean) args[2]));
+                return getItem(profiles, (String) args[0], args.length == 3 && (boolean) args[2]);
             case "get_profile_handle":
                 return getItemHandle((String) args[0], profiles);
             case "remove_profile":
@@ -177,7 +177,7 @@ public class MockConnection extends CobblerConnection {
                 modifyItem(distros, (String) args[0], (String) args[1], args[2]);
                 break;
             case "get_distro":
-                return getItem(distros, (String) args[0], (args.length == 3 && (boolean) args[2]));
+                return getItem(distros, (String) args[0], args.length == 3 && (boolean) args[2]);
             case "rename_distro":
                 log.debug("DISTRO: Rename w/ handle{}", args[0]);
                 renameItem((String) args[0], (String) args[2], distros);
@@ -200,7 +200,7 @@ public class MockConnection extends CobblerConnection {
                 modifyItem(systems, (String) args[0], (String) args[1], args[2]);
                 break;
             case "get_system":
-                return getItem(systems, (String) args[0], (args.length == 3 && (boolean) args[2]));
+                return getItem(systems, (String) args[0], args.length == 3 && (boolean) args[2]);
             case "get_system_handle":
                 return getItemHandle((String) args[0], systems);
             case "remove_system":
@@ -246,7 +246,7 @@ public class MockConnection extends CobblerConnection {
                 renameItem((String) args[0], (String) args[2], images);
                 return "";
             case "get_image":
-                return getItem(images, (String) args[0], (args.length == 3 && (boolean) args[2]));
+                return getItem(images, (String) args[0], args.length == 3 && (boolean) args[2]);
             case "get_image_handle":
                 return getItemHandle((String) args[0], images);
             case "remove_image":


### PR DESCRIPTION
## What does this PR change?

Use IntelliJ mass autofix to remove all the unneeded parentheses in the Java code.
This should fix a number of sonarcloud issues around parentheses.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: code formatting
- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
