### PR TITLE
SonarCloud error reduction fix, rules 1110, 4349, 1149, 2696, 4719, 6213

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/ModeFactory.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/ModeFactory.java
@@ -56,11 +56,13 @@ public class ModeFactory implements ManifestFactoryBuilder {
     @Override
     public Object createObject(Map params) {
         try {
-            if (parser == null) {
-                parser = XMLReaderFactory.createXMLReader(DEFAULT_PARSER_NAME);
+            synchronized (this) {
+                if (parser == null) {
+                    parser = XMLReaderFactory.createXMLReader(DEFAULT_PARSER_NAME);
 
-                ContentHandler handler = new DataSourceParserHelper();
-                parser.setContentHandler(handler);
+                    ContentHandler handler = new DataSourceParserHelper();
+                    parser.setContentHandler(handler);
+                }
             }
             String filename = (String)params.get("filename");
             if (filename == null) {

--- a/java/code/src/com/redhat/rhn/common/security/acl/SystemAclHandler.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/SystemAclHandler.java
@@ -147,10 +147,10 @@ public class SystemAclHandler extends BaseHandler {
             return false;
         }
         try {
-            SystemRecord record = SystemRecord.lookupById(
+            SystemRecord systemRecord = SystemRecord.lookupById(
                                     CobblerXMLRPCHelper.getConnection(user),
                                                     server.getCobblerId());
-            return record != null;
+            return systemRecord != null;
         }
         catch (Exception e) {
             log.error("Cobbler connection errored out for Id{}", server.getCobblerId(), e);

--- a/java/code/src/com/redhat/rhn/common/validator/StringConstraint.java
+++ b/java/code/src/com/redhat/rhn/common/validator/StringConstraint.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -55,23 +55,11 @@ public class StringConstraint extends RequiredIfConstraint {
     }
 
     private boolean lengthLessThan(String str, Number length) {
-        try {
-            return str.getBytes("UTF8").length <= length.intValue();
-        }
-        catch (UnsupportedEncodingException use) {
-            LOG.warn("Couldn;t convert to UTF8-> [{}]", str);
-            return str.length() < length.intValue();
-        }
+        return str.getBytes(StandardCharsets.UTF_8).length <= length.intValue();
     }
 
     private boolean lengthGreaterThan(String str, Number length) {
-        try {
-            return str.getBytes("UTF8").length >= length.intValue();
-        }
-        catch (UnsupportedEncodingException use) {
-            LOG.warn("Couldn;t convert to UTF8-> [{}]", str);
-            return str.length() >= length.intValue();
-        }
+        return str.getBytes(StandardCharsets.UTF_8).length >= length.intValue();
     }
 
     /** {@inheritDoc} */

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/PowerManagementAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/PowerManagementAction.java
@@ -135,8 +135,8 @@ public class PowerManagementAction extends RhnAction {
                     if (context.wasDispatched(
                         "kickstart.powermanagement.jsp.get_status")) {
                         try {
-                            SystemRecord record = getSystemRecord(user, server);
-                            request.setAttribute(POWER_STATUS_ON, record.getPowerStatus());
+                            SystemRecord systemRecord = getSystemRecord(user, server);
+                            request.setAttribute(POWER_STATUS_ON, systemRecord.getPowerStatus());
                             addMessage(request, "kickstart.powermanagement.saved");
                         }
                         catch (XmlRpcException e) {
@@ -213,17 +213,17 @@ public class PowerManagementAction extends RhnAction {
         SortedMap<String, String> types = setUpPowerTypes(request, strutsDelegate, errors);
 
         if (!types.isEmpty()) {
-            SystemRecord record = getSystemRecord(user, server);
+            SystemRecord systemRecord = getSystemRecord(user, server);
 
-            if (record == null) {
+            if (systemRecord == null) {
                 request.setAttribute(POWER_TYPE, types.get(types.firstKey()));
             }
             else {
-                request.setAttribute(POWER_TYPE, record.getPowerType());
-                request.setAttribute(POWER_ADDRESS, record.getPowerAddress());
-                request.setAttribute(POWER_USERNAME, record.getPowerUsername());
-                request.setAttribute(POWER_PASSWORD, record.getPowerPassword());
-                request.setAttribute(POWER_ID, record.getPowerId());
+                request.setAttribute(POWER_TYPE, systemRecord.getPowerType());
+                request.setAttribute(POWER_ADDRESS, systemRecord.getPowerAddress());
+                request.setAttribute(POWER_USERNAME, systemRecord.getPowerUsername());
+                request.setAttribute(POWER_PASSWORD, systemRecord.getPowerPassword());
+                request.setAttribute(POWER_ID, systemRecord.getPowerId());
             }
         }
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/ssm/test/SsmKSScheduleActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/ssm/test/SsmKSScheduleActionTest.java
@@ -203,8 +203,8 @@ public class SsmKSScheduleActionTest extends RhnMockStrutsTestCase {
 
         assertEquals(302, getMockResponse().getStatusCode());
 
-        SystemRecord record = SystemRecord.lookupById(connection, server.getCobblerId());
-        assertNotNull(record);
-        assertNotSame(profile.getId(), record.getProfile().getId());
+        SystemRecord systemRecord = SystemRecord.lookupById(connection, server.getCobblerId());
+        assertNotNull(systemRecord);
+        assertNotSame(profile.getId(), systemRecord.getProfile().getId());
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/PowerManagementActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/PowerManagementActionTest.java
@@ -152,13 +152,13 @@ public class PowerManagementActionTest extends RhnMockStrutsTestCase {
         verifyActionMessage("kickstart.powermanagement.saved");
 
         CobblerConnection connection = CobblerXMLRPCHelper.getConnection(user);
-        SystemRecord record = SystemRecord.lookupById(connection, server.getCobblerId());
+        SystemRecord systemRecord = SystemRecord.lookupById(connection, server.getCobblerId());
 
-        assertEquals(EXPECTED_TYPE, record.getPowerType());
-        assertEquals(EXPECTED_ADDRESS, record.getPowerAddress());
-        assertEquals(EXPECTED_USERNAME, record.getPowerUsername());
-        assertEquals(EXPECTED_PASSWORD, record.getPowerPassword());
-        assertEquals(EXPECTED_ID, record.getPowerId());
+        assertEquals(EXPECTED_TYPE, systemRecord.getPowerType());
+        assertEquals(EXPECTED_ADDRESS, systemRecord.getPowerAddress());
+        assertEquals(EXPECTED_USERNAME, systemRecord.getPowerUsername());
+        assertEquals(EXPECTED_PASSWORD, systemRecord.getPowerPassword());
+        assertEquals(EXPECTED_ID, systemRecord.getPowerId());
     }
 
     /**
@@ -235,12 +235,12 @@ public class PowerManagementActionTest extends RhnMockStrutsTestCase {
         assertEquals(EXPECTED_ID_2, request.getAttribute(PowerManagementAction.POWER_ID));
 
         CobblerConnection connection = CobblerXMLRPCHelper.getConnection(user);
-        SystemRecord record = SystemRecord.lookupById(connection, server.getCobblerId());
+        SystemRecord systemRecord = SystemRecord.lookupById(connection, server.getCobblerId());
 
-        assertEquals(EXPECTED_ADDRESS_2, record.getPowerAddress());
-        assertEquals(EXPECTED_USERNAME_2, record.getPowerUsername());
-        assertEquals(EXPECTED_PASSWORD_2, record.getPowerPassword());
-        assertEquals(EXPECTED_ID_2, record.getPowerId());
+        assertEquals(EXPECTED_ADDRESS_2, systemRecord.getPowerAddress());
+        assertEquals(EXPECTED_USERNAME_2, systemRecord.getPowerUsername());
+        assertEquals(EXPECTED_PASSWORD_2, systemRecord.getPowerPassword());
+        assertEquals(EXPECTED_ID_2, systemRecord.getPowerId());
         verifyNoActionErrors();
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/test/PowerManagementConfigurationActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/test/PowerManagementConfigurationActionTest.java
@@ -96,16 +96,16 @@ public class PowerManagementConfigurationActionTest extends RhnMockStrutsTestCas
         actionPerform();
 
         for (Server server : servers) {
-            SystemRecord record = SystemRecord
+            SystemRecord systemRecord = SystemRecord
                 .lookupById(connection, server.getCobblerId());
-            assertEquals(PowerManagementActionTest.EXPECTED_TYPE, record.getPowerType());
+            assertEquals(PowerManagementActionTest.EXPECTED_TYPE, systemRecord.getPowerType());
             assertEquals(PowerManagementActionTest.EXPECTED_ADDRESS,
-                record.getPowerAddress());
+                    systemRecord.getPowerAddress());
             assertEquals(PowerManagementActionTest.EXPECTED_USERNAME,
-                record.getPowerUsername());
+                    systemRecord.getPowerUsername());
             assertEquals(PowerManagementActionTest.EXPECTED_PASSWORD,
-                record.getPowerPassword());
-            assertEquals(PowerManagementActionTest.EXPECTED_ID, record.getPowerId());
+                    systemRecord.getPowerPassword());
+            assertEquals(PowerManagementActionTest.EXPECTED_ID, systemRecord.getPowerId());
         }
 
         // In SSM empty string means "do not change"
@@ -120,16 +120,16 @@ public class PowerManagementConfigurationActionTest extends RhnMockStrutsTestCas
         actionPerform();
 
         for (Server server : servers) {
-            SystemRecord record = SystemRecord
+            SystemRecord systemRecord = SystemRecord
                 .lookupById(connection, server.getCobblerId());
-            assertEquals(PowerManagementActionTest.EXPECTED_TYPE, record.getPowerType());
+            assertEquals(PowerManagementActionTest.EXPECTED_TYPE, systemRecord.getPowerType());
             assertEquals(PowerManagementActionTest.EXPECTED_ADDRESS,
-                record.getPowerAddress());
+                    systemRecord.getPowerAddress());
             assertEquals(PowerManagementActionTest.EXPECTED_USERNAME_2,
-                record.getPowerUsername());
+                    systemRecord.getPowerUsername());
             assertEquals(PowerManagementActionTest.EXPECTED_PASSWORD_2,
-                record.getPowerPassword());
-            assertEquals(PowerManagementActionTest.EXPECTED_ID, record.getPowerId());
+                    systemRecord.getPowerPassword());
+            assertEquals(PowerManagementActionTest.EXPECTED_ID, systemRecord.getPowerId());
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletRequest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/RhnHttpServletRequest.java
@@ -20,9 +20,10 @@ import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Locale;
-import java.util.Vector;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -34,7 +35,7 @@ public class RhnHttpServletRequest extends HttpServletRequestWrapper {
 
     private static final String ACTIVE_LANG_ATTR = "rhnActiveLang";
 
-    private Vector<Locale> locales = new Vector<>();
+    private ArrayList<Locale> locales = new ArrayList<>();
 
     /**
      * Constructs a new RhnHttpServletRequest based on the given parameters.
@@ -182,7 +183,7 @@ public class RhnHttpServletRequest extends HttpServletRequestWrapper {
      */
     @Override
     public Enumeration<Locale> getLocales() {
-        return this.locales.elements();
+        return Collections.enumeration(this.locales);
     }
 
     /**
@@ -200,12 +201,12 @@ public class RhnHttpServletRequest extends HttpServletRequestWrapper {
      */
     @Override
     public Enumeration<String> getAttributeNames() {
-        Vector<String> tmp = new Vector<>();
+        ArrayList<String> tmp = new ArrayList<>();
         tmp.add(ACTIVE_LANG_ATTR);
         for (Enumeration<String> e = super.getAttributeNames(); e.hasMoreElements();) {
             tmp.add(e.nextElement());
         }
-        return tmp.elements();
+        return Collections.enumeration(tmp);
     }
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -220,7 +220,7 @@ public class ContentSyncManager {
      * Set the channel_family.json {@link File} to a different path.
      * @param file the channel_family.json
      */
-    public void setChannelFamiliesJson(File file) {
+    public static void setChannelFamiliesJson(File file) {
         channelFamiliesJson = file;
     }
 
@@ -236,7 +236,7 @@ public class ContentSyncManager {
      * Set the additional_products.json {@link File} to read from.
      * @param file the add additional_products.json file
      */
-    public void setAdditionalProductsJson(File file) {
+    public static void setAdditionalProductsJson(File file) {
         additionalProductsJson = file;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerPaygTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerPaygTest.java
@@ -164,8 +164,9 @@ public class ContentSyncManagerPaygTest extends RhnBaseTestCase {
 
             // download the product data from Cloud RMT
             ContentSyncManager csm = new ContentSyncManager(tmpLogDir, mgr);
-            csm.setChannelFamiliesJson(new File(TestUtils.findTestData(CHANNEL_FAMILY).getPath()));
-            csm.setAdditionalProductsJson(new File(TestUtils.findTestData(ADDITIONAL_PRODUCTS).getPath()));
+            ContentSyncManager.setChannelFamiliesJson(new File(TestUtils.findTestData(CHANNEL_FAMILY).getPath()));
+            ContentSyncManager.setAdditionalProductsJson(
+                    new File(TestUtils.findTestData(ADDITIONAL_PRODUCTS).getPath()));
             csm.updateChannelFamilies(csm.readChannelFamilies());
             csm.updateSUSEProducts(csm.getProducts());
             csm.updateRepositories(null);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -132,11 +132,13 @@ public class ForwardRegistrationTask extends RhnJavaJob {
             sccRegManager.deregister(deregister, false);
             sccRegManager.register(forwardRegistration, primaryCredentials);
             sccRegManager.virtualInfo(virtHosts, primaryCredentials);
-            if (LocalDateTime.now().isAfter(nextLastSeenUpdateRun)) {
-                sccRegManager.updateLastSeen(primaryCredentials);
-                // next run in 22 - 26 hours
-                nextLastSeenUpdateRun = nextLastSeenUpdateRun.plusMinutes(
-                        ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
+            synchronized (this) {
+                if (LocalDateTime.now().isAfter(nextLastSeenUpdateRun)) {
+                    sccRegManager.updateLastSeen(primaryCredentials);
+                    // next run in 22 - 26 hours
+                    nextLastSeenUpdateRun = nextLastSeenUpdateRun.plusMinutes(
+                            ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
+                }
             }
         }
         catch (URISyntaxException e) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/CompressingDigestOutputWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/CompressingDigestOutputWriter.java
@@ -73,6 +73,16 @@ public class CompressingDigestOutputWriter extends OutputStream {
     }
 
     /**
+     * write stream with byte
+     * @param b byte
+     * @throws IOException ioexception
+     */
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        bufferedStream.write(b, off, len);
+    }
+
+    /**
      * flush stream
      * @throws IOException ioexception
      */

--- a/java/code/src/com/suse/manager/webui/services/ConfigChannelSaltManager.java
+++ b/java/code/src/com/suse/manager/webui/services/ConfigChannelSaltManager.java
@@ -32,13 +32,13 @@ import com.redhat.rhn.domain.config.ConfigRevision;
 import com.suse.manager.webui.utils.YamlHelper;
 import com.suse.utils.Opt;
 
-import org.apache.commons.codec.CharEncoding;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -214,7 +214,7 @@ public class ConfigChannelSaltManager {
             throws IOException {
         assertStateInOrgDir(channelDir, outFile);
         outFile.getParentFile().mkdirs();
-        FileUtils.writeStringToFile(outFile, content, CharEncoding.UTF_8);
+        FileUtils.writeStringToFile(outFile, content, StandardCharsets.UTF_8);
      }
 
     /**

--- a/java/code/src/org/cobbler/Profile.java
+++ b/java/code/src/org/cobbler/Profile.java
@@ -728,10 +728,10 @@ public class Profile extends CobblerObject {
         // FIXME: The inheritance in Cobbler should not be broken with this method. Thus it should be completely
         //        removed.
         super.syncRedHatManagementKeys(keysToRemove, keysToAdd);
-        for (SystemRecord record :
+        for (SystemRecord systemRecord :
                 SystemRecord.listByAssociatedProfile(client, this.getName())) {
-            record.syncRedHatManagementKeys(keysToRemove, keysToAdd);
-            record.save();
+            systemRecord.syncRedHatManagementKeys(keysToRemove, keysToAdd);
+            systemRecord.save();
         }
     }
 


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rules:

[ java:S1110 Redundant pairs of parentheses should be removed](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1110&rule_key=java%3AS1110)
[ java:S4349 write(byte[],int,int) should be overridden](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS4349&rule_key=java%3AS4349)
[ java:S1149 Synchronized class Vector should not be used](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1149&rule_key=java%3AS1149)
[ java:S2696 Instance methods should not write to static fields](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS2696&rule_key=java%3AS2696)
[ java:S4719 StandardCharsets constants should be preferred](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS4719&rule_key=java%3AS4719)
[ java:S6213 Restricted Identifiers should not be used as Identifiers](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS6213&rule_key=java%3AS6213)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): not backported
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

