### PR TITLE
SonarCloud fix: java:S1192 String literals should not be duplicated

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
@@ -248,8 +248,8 @@ public abstract class BaseSearchAction extends RhnAction {
                     boolean flag) {
         LocalizationService ls = LocalizationService.getInstance();
         Map<String, String> selection = new HashMap<>();
-        selection.put("display", (flag ? "*" : "") + ls.getMessage(key));
-        selection.put("value", StringEscapeUtils.escapeHtml4(value));
+        selection.put(DISPLAY_KEY, (flag ? "*" : "") + ls.getMessage(key));
+        selection.put(VALUE_KEY, StringEscapeUtils.escapeHtml4(value));
         options.add(selection);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListTagUtil.java
@@ -48,6 +48,7 @@ import javax.servlet.jsp.tagext.TagSupport;
 public class ListTagUtil {
     private static final String HIDDEN_TEXT = "<input type=\"hidden\" " +
                                                 "name=\"%s\" value=\"%s\"/>";
+    private static final String LIST_PREFIX = "list_";
     private ListTagUtil() {
 
     }
@@ -243,7 +244,7 @@ public class ListTagUtil {
      * @return the url key for sort direction
      */
     public static String makeSortDirLabel(String listName) {
-        return "list_" + listName + "_sortdir";
+        return LIST_PREFIX + listName + "_sortdir";
     }
 
     /**
@@ -252,7 +253,7 @@ public class ListTagUtil {
      * @return the url key for sort label
      */
     public static String makeSortByLabel(String listName) {
-        return "list_" + listName + "_sortby";
+        return LIST_PREFIX + listName + "_sortby";
     }
 
     /**
@@ -261,7 +262,7 @@ public class ListTagUtil {
      * @return the url key for sort direction
      */
     public static String makeSortDirId(String listName) {
-        return "list_" + listName + "_sortdir_id";
+        return LIST_PREFIX + listName + "_sortdir_id";
     }
 
     /**
@@ -270,7 +271,7 @@ public class ListTagUtil {
      * @return the url key for sort label
      */
     public static String makeSortById(String listName) {
-        return "list_" + listName + "_sortby_id";
+        return LIST_PREFIX + listName + "_sortby_id";
     }
 
     /**
@@ -279,7 +280,7 @@ public class ListTagUtil {
      * @return the url key for filter label
      */
     public static String makeFilterByLabel(String listName) {
-        return "list_" + listName + "_filterby";
+        return LIST_PREFIX + listName + "_filterby";
     }
 
     /**
@@ -288,7 +289,7 @@ public class ListTagUtil {
      * @return the url key for filter value label
      */
     public static String makeFilterValueByLabel(String listName) {
-        return "list_" + listName + "_filterval";
+        return LIST_PREFIX + listName + "_filterval";
     }
 
     /**
@@ -297,7 +298,7 @@ public class ListTagUtil {
      * @return the url key for filter value label
      */
     public static String makeFilterAttributeByLabel(String listName) {
-        return "list_" + listName + "_filterattr";
+        return LIST_PREFIX + listName + "_filterattr";
     }
 
 
@@ -307,7 +308,7 @@ public class ListTagUtil {
      * @return the url key for filter value label
      */
     public static String makeImageNameByLabel(String listName) {
-        return "list_" + listName + "_filterattr";
+        return LIST_PREFIX + listName + "_filterattr";
     }
 
 
@@ -317,7 +318,7 @@ public class ListTagUtil {
      * @return the key for filter name label
      */
     public static String makeFilterNameByLabel(String listName) {
-        return "list_" + listName + "_filtername";
+        return LIST_PREFIX + listName + "_filtername";
     }
 
     /**
@@ -326,7 +327,7 @@ public class ListTagUtil {
      * @return the url key for filter value label
      */
     public static String makeOldFilterValueByLabel(String listName) {
-        return "list_" + listName + "_oldfilterval";
+        return LIST_PREFIX + listName + "_oldfilterval";
     }
 
     /**
@@ -335,7 +336,7 @@ public class ListTagUtil {
      * @return the filter class label
      */
     public static String makeFilterClassLabel(String listName) {
-        return "list_" + listName + "_filterclass";
+        return LIST_PREFIX + listName + "_filterclass";
     }
 
     /**
@@ -346,7 +347,7 @@ public class ListTagUtil {
      * @return the label of the select action
      */
     public static String makeSelectActionName(String listName) {
-        return "list_" + listName + "_selectAction";
+        return LIST_PREFIX + listName + "_selectAction";
     }
 
     /**
@@ -355,7 +356,7 @@ public class ListTagUtil {
      * @return the label of the select action
      */
     public static String makeExtraButtonName(String listName) {
-        return "list_" + listName + "_" + ExtraButtonDecorator.EXTRA_BUTTON;
+        return LIST_PREFIX + listName + "_" + ExtraButtonDecorator.EXTRA_BUTTON;
     }
 
 
@@ -366,7 +367,7 @@ public class ListTagUtil {
      * @return the label of the select amount attribute
      */
     public static String makeSelectedAmountName(String listName) {
-        return "list_" + listName + "_selected_amt";
+        return LIST_PREFIX + listName + "_selected_amt";
     }
 
     /**
@@ -375,7 +376,7 @@ public class ListTagUtil {
      * @return the name of selected items
      */
     public static String makeSelectedItemsName(String listName) {
-        return "list_" + listName + "_sel";
+        return LIST_PREFIX + listName + "_sel";
     }
 
     /**
@@ -384,7 +385,7 @@ public class ListTagUtil {
      * @return the name of attribute holding all the row items in the page
      */
     public static String makePageItemsName(String listName) {
-        return "list_" + listName + "_items";
+        return LIST_PREFIX + listName + "_items";
     }
 
     /**
@@ -393,7 +394,7 @@ public class ListTagUtil {
      * @return the  name of the attribute that holds the current page number.
      */
     public static String makePageNumberName(String listName) {
-        return "list_" + listName + "_page";
+        return LIST_PREFIX + listName + "_page";
     }
     /**
      * Make first page link
@@ -577,7 +578,7 @@ public class ListTagUtil {
      * @return the label of the parent is an element attribute
      */
     public static String makeParentIsAnElementLabel(String listName) {
-        return "list_" + listName + "_parent_is_an_element";
+        return LIST_PREFIX + listName + "_parent_is_an_element";
     }
 
     /**
@@ -692,7 +693,7 @@ public class ListTagUtil {
         else {
             url += "&";
         }
-        url += "list_" + listName;
+        url += LIST_PREFIX + listName;
         url += "_page=" + page;
         return url;
 

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -73,6 +73,7 @@ public class SparkApplicationHelper {
             .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
             .create();
     private static final ThrottlingService THROTTLER = GlobalInstanceHolder.THROTTLING_SERVICE;
+    private static final String APPLICATION_JSON = "application/json";
 
     /**
      * Private constructor.
@@ -384,7 +385,7 @@ public class SparkApplicationHelper {
      */
     public static Route asJson(Route route) {
         return (request, response) -> {
-            response.type("application/json");
+            response.type(APPLICATION_JSON);
             return route.handle(request, response);
         };
     }
@@ -433,7 +434,7 @@ public class SparkApplicationHelper {
      * @return true if the content type is application/json
      */
     public static boolean isJson(Response response) {
-        return response.type().contains("application/json");
+        return response.type().contains(APPLICATION_JSON);
     }
 
     /**
@@ -498,7 +499,7 @@ public class SparkApplicationHelper {
             if (request.headers("accept").contains("json") || isJson(response)) {
                 Map<String, Object> exc = new HashMap<>();
                 exc.put("message", e.getMessage());
-                response.type("application/json");
+                response.type(APPLICATION_JSON);
                 response.body(GSON.toJson(exc));
                 response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
             }
@@ -534,7 +535,7 @@ public class SparkApplicationHelper {
      */
     @Deprecated
     public static String json(Response response, Object result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result);
     }
 
@@ -547,7 +548,7 @@ public class SparkApplicationHelper {
      */
     @Deprecated
     public static String json(Response response, Map<String, Object> result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result);
     }
 
@@ -562,7 +563,7 @@ public class SparkApplicationHelper {
      */
     @Deprecated
     public static String json(Response response, int httpStatusCode, Object result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(httpStatusCode);
         return GSON.toJson(result);
     }
@@ -577,7 +578,7 @@ public class SparkApplicationHelper {
      */
     @Deprecated
     public static String json(Gson gson, Response response, Object result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return gson.toJson(result);
     }
 
@@ -587,7 +588,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String jsonNull(Response response) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(null);
     }
 
@@ -598,7 +599,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String json(Response response, JsonElement result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result);
     }
 
@@ -609,7 +610,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String json(Response response, boolean result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result);
     }
 
@@ -620,7 +621,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String json(Response response, int result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result);
     }
 
@@ -631,7 +632,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String json(Response response, String result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result);
     }
 
@@ -642,7 +643,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String json(Response response, List<String> result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result);
     }
 
@@ -687,7 +688,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static <T> String json(Response response, T result, TypeToken<T> type) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return GSON.toJson(result, type.getType());
     }
 
@@ -701,7 +702,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static <T> String json(Response response, int httpStatusCode, T result, TypeToken<T> type) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(httpStatusCode);
         return GSON.toJson(result, type.getType());
     }
@@ -715,7 +716,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static <T> String result(Response response, ResultJson<T> result, TypeToken<T> type) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         ParameterizedType parameterizedType = new ParameterizedTypeImpl(null, ResultJson.class, type.getType());
         return GSON.toJson(result, parameterizedType);
     }
@@ -739,7 +740,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String json(Gson gson, Response response, long result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return gson.toJson(result);
     }
 
@@ -753,7 +754,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static <T> String json(Gson gson, Response response, T result, TypeToken<T> type) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         return gson.toJson(result, type.getType());
     }
 
@@ -768,7 +769,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static <T> String result(Response response, int httpStatusCode, ResultJson<T> result, TypeToken<T> type) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(httpStatusCode);
         ParameterizedType parameterizedType = new ParameterizedTypeImpl(null, ResultJson.class, type.getType());
         return GSON.toJson(result, parameterizedType);
@@ -782,7 +783,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String badRequest(Response response, String... messages) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(HttpStatus.SC_BAD_REQUEST);
         return GSON.toJson(ResultJson.error(messages));
     }
@@ -795,7 +796,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String notFound(Response response, String... messages) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(HttpStatus.SC_NOT_FOUND);
         return GSON.toJson(ResultJson.error(messages));
     }
@@ -808,7 +809,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String internalServerError(Response response, String... messages) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         return GSON.toJson(ResultJson.error(messages));
     }
@@ -821,7 +822,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String forbidden(Response response, String... messages) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(HttpStatus.SC_FORBIDDEN);
         return GSON.toJson(ResultJson.error(messages));
     }
@@ -837,7 +838,7 @@ public class SparkApplicationHelper {
      */
     @Deprecated
     public static String jsonError(Response response, int httpStatusCode, String result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(httpStatusCode);
         return GSON.toJson(result);
     }
@@ -854,7 +855,7 @@ public class SparkApplicationHelper {
      */
     @Deprecated
     public static String json(Gson gson, Response response, int httpStatusCode, Object result) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(httpStatusCode);
         return gson.toJson(result);
     }
@@ -871,7 +872,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static <T> String json(Gson gson, Response response, int httpStatusCode, T result, TypeToken<T> type) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(httpStatusCode);
         return gson.toJson(result, type.getType());
     }
@@ -889,7 +890,7 @@ public class SparkApplicationHelper {
      */
     public static <T> String result(Gson gson, Response response, int httpStatusCode, ResultJson<T> result,
                                     TypeToken<T> type) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(httpStatusCode);
         ParameterizedType parameterizedType = new ParameterizedTypeImpl(null, ResultJson.class, type.getType());
         return gson.toJson(result, parameterizedType);


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rule java:S1192 String literals should not be duplicated
Duplicated string literals make the process of refactoring complex and error-prone, as any change would need to be propagated on all occurrences.
Exceptions: To prevent generating some false-positives, literals having less than 5 characters are excluded.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): not backported
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
