### PR TITLE
SonarCloud fix: java:S125 Sections of code should not be commented out

### DIFF
--- a/java/code/src/com/redhat/rhn/common/client/test/ClientCertificateDigesterTest.java
+++ b/java/code/src/com/redhat/rhn/common/client/test/ClientCertificateDigesterTest.java
@@ -50,7 +50,6 @@ public class ClientCertificateDigesterTest extends RhnBaseTestCase {
         assertNotNull(cert, "SystemId is null");
 
         // hardcoded key from test system
-        //cert.validate("3050cf46ac0417297e2dd964fdaac1ae");
         cert.validate("h13MzDNjItVNsXd2YOU7etBUh8EefWdKouUM7DETP5ISYWxXAa9vnWYZV7LD7EuM");
     }
 

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -405,7 +405,6 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
         assertEquals(3, infoList.size());
         infoList.forEach(i -> assertEquals("suma-3.1-base", i.getName()));
-        //assertFalse(infoList.get(0).getVersion().equals(infoList.get(1).getVersion()));
 
         info = ImageInfoFactory.lookupByName("suma-3.1-base", "v2.0", store.getId()).get();
 

--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -394,7 +394,6 @@ public class SUSEProductTestUtils extends HibernateFactory {
         product.setFriendlyName("SUSE CaaS Platform 4.0");
         product.setArch(PackageFactory.lookupPackageArchByLabel("x86_64"));
         product.setProductId(1340);
-        //product.setChannelFamily(cfsles);
         product.setBase(false);
         product.setReleaseStage(ReleaseStage.released);
         TestUtils.saveAndFlush(product);

--- a/java/code/src/com/redhat/rhn/domain/server/test/MgrServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/MgrServerTest.java
@@ -39,7 +39,7 @@ public class MgrServerTest extends RhnBaseTestCase {
         Server server = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
                 ServerFactoryTest.TYPE_SERVER_MGR);
-        //flushAndEvict(server);
+
         Server s = ServerFactory.lookupById(server.getId());
         assertNotNull(s, "Server not found");
         assertInstanceOf(MinionServer.class, s, "Server object returned is NOT a MgrServer");

--- a/java/code/src/com/redhat/rhn/domain/server/test/ProxyServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ProxyServerTest.java
@@ -37,7 +37,7 @@ public class ProxyServerTest extends RhnBaseTestCase {
         Server server = ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeEnterpriseEntitled(),
                 ServerFactoryTest.TYPE_SERVER_PROXY);
-        //flushAndEvict(server);
+
         Server s = ServerFactory.lookupById(server.getId());
         assertNotNull(s, "Server not found");
         assertFalse(s.isMgrServer());

--- a/java/code/src/com/redhat/rhn/domain/session/test/WebSessionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/session/test/WebSessionFactoryTest.java
@@ -137,9 +137,7 @@ public class WebSessionFactoryTest extends RhnBaseTestCase {
             assertNotNull(u);
             assertEquals(userId, u.getId());
             lastId = userId;
-            // s.setWebUserId(null);
             WebSessionFactory.save(s);
-            // flushAndEvict(s);
             s = (WebSession) reload(s);
             TestCaseHelper.tearDownHelper();
         }

--- a/java/code/src/com/redhat/rhn/domain/test/TestImpl.java
+++ b/java/code/src/com/redhat/rhn/domain/test/TestImpl.java
@@ -60,7 +60,6 @@ public class TestImpl implements TestInterface {
     }
 
     public void setHidden(String hideIn) {
-        // Thread.dumpStack();
         hidden = hideIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/user/test/UserTest.java
+++ b/java/code/src/com/redhat/rhn/domain/user/test/UserTest.java
@@ -138,7 +138,6 @@ public class UserTest extends RhnBaseTestCase {
         usr.setLogin(foo);
         assertEquals(foo, usr.getLogin());
 
-        //usr.setOrgId(id);
         assertNotNull(usr.getOrg());
 
         usr.setPassword(foo);

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/test/EditChannelActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/test/EditChannelActionTest.java
@@ -27,11 +27,6 @@ public class EditChannelActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void testExecute() {
-    /*
-        setRequestPathInfo("/channel/manage/EditChannel");
-        actionPerform();
-        assertNotNull(request.getAttribute(RhnHelper.TARGET_USER));
-        */
         System.out.println("JESUSR PLEASE FIX THIS TEST");
         assertTrue(true);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/common/test/DownloadActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/test/DownloadActionTest.java
@@ -90,7 +90,6 @@ public class DownloadActionTest extends RhnMockStrutsTestCase {
         addRequestParameter("url", "/ks/dist/" + tree.getLabel() + "/Server/" + fileName);
         request.setQueryString("url=/ks/dist/" + tree.getLabel() + "/Server/" + fileName);
         actionPerform();
-        // assertEquals("/kickstart/DownloadFile.do", getActualForward());
         assertNotNull(request.getAttribute("params"));
         // https://dhcp77-150.rhndev.redhat.com/
         // download/package/4ad2199e64aa756a21b9a33fe6f4faf355586b70/

--- a/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
@@ -64,7 +64,6 @@ public class RhnSetActionTest extends RhnBaseTestCase {
 
     @Test
     public void testUpdateList() throws Exception {
-        //TestAction action = new TestAction();
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action);
         sah.setupClampListBounds();

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/EditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/EditActionTest.java
@@ -59,7 +59,6 @@ public class EditActionTest extends RhnBaseTestCase {
         RhnMockHttpServletRequest request = TestUtils.getRequestWithSessionAndUser();
         RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
         RhnMockDynaActionForm form = new RhnMockDynaActionForm("errataEditForm");
-        //request.setSession(session);
         request.setupServerName("mymachine.rhndev.redhat.com");
 
         RequestContext requestContext = new RequestContext(request);

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartPreservationListTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartPreservationListTest.java
@@ -67,9 +67,7 @@ public class KickstartPreservationListTest extends BaseKickstartEditTestCase {
         addSelectedItem(list2.getId());
         addDispatchCall(KickstartPreservationListSubmitAction.UPDATE_METHOD);
         setRequestPathInfo("/kickstart/KickstartFilePreservationListsSubmit");
-        //        assertTrue(ksdata.getCryptoKeys() == null);
         actionPerform();
-        //        assertTrue(ksdata.getCryptoKeys().size() == 1);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/test/TreeActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/tree/test/TreeActionTest.java
@@ -202,8 +202,6 @@ public class TreeActionTest extends RhnPostMockStrutsTestCase {
 
     public String executeSubmit(String path, Channel c) {
         String newLabel = "somelabel" + TestUtils.randomString();
-        //KickstartableTree tree = KickstartableTreeTest.createTestKickstartableTree();
-        //tree.setLabel(newLabel);
 
         addRequestParameter(RhnAction.SUBMITTED, Boolean.TRUE.toString());
         setRequestPathInfo(path);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -73,8 +73,6 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
         setRequestPathInfo("/systems/details/Edit");
         TestUtils.saveAndFlush(user.getOrg());
 
-        /*s = ServerFactoryTest.createTestServer(user, true,
-                ServerConstants.getServerGroupTypeEnterpriseEntitled());*/
         s = ServerTestUtils.createTestSystem(user);
         ChannelTestUtils.setupBaseChannelForVirtualization(user, s.getBaseChannel());
 

--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -335,8 +335,6 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
                     this.getClass().getSimpleName()));
 
         assertNotEquals(e1.getId(), e2.getId()); //make sure adv names are different
-        //assertTrue(ErrataManager.advisoryNameIsUnique(e2.getId(), e2.getAdvisoryName()));
-        //assertFalse(ErrataManager.advisoryNameIsUnique(e2.getId(), e1.getAdvisoryName()));
     }
 
     // Don't need this test to actually run right now.  Its experimental.

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartManagerTest.java
@@ -112,7 +112,7 @@ public class KickstartManagerTest extends BaseTestCaseWithUser {
 
     /*
      * Test where 'eth0' doesn't match anything, but there should be a default
-     *  Kickstart set;
+     *  Kickstart set
      */
     @Test
     public void testFindProfileForIpAddressDefault() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartUrlHelperTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartUrlHelperTest.java
@@ -141,7 +141,6 @@ public class KickstartUrlHelperTest extends BaseKickstartCommandTestCase {
         String expected = "http://spacewalk.example.com/" +
             "ty/" + "";
         String url = helper.getKickstartMediaSessionUrl(session);
-        // "http://spacewalk.example.com/ty/weOyQenH";
         String token = url.substring(url.lastIndexOf("/"));
         token = token.split("/")[1];
         TinyUrl ty = CommonFactory.lookupTinyUrl(token);
@@ -166,7 +165,6 @@ public class KickstartUrlHelperTest extends BaseKickstartCommandTestCase {
         String encodedId = SessionSwap.encodeData(session.getId().toString());
         String expected = "/ty/" + "";
         String url = helper.getKickstartMediaPath(session, new Date());
-        // "/ty/weOyQenH";
         String token = url.substring(url.lastIndexOf("/"));
         token = token.split("/")[1];
         TinyUrl ty = CommonFactory.lookupTinyUrl(token);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartWizardHelperTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartWizardHelperTest.java
@@ -39,7 +39,6 @@ public class KickstartWizardHelperTest extends BaseTestCaseWithUser {
         String origConfig = Config.get().getString(ConfigDefaults.PRODUCT_NAME);
         Config.get().setString(ConfigDefaults.PRODUCT_NAME, ConfigDefaults.SPACEWALK.get(0));
         // applies to SUSE Manager too
-        // assertTrue(ConfigDefaults.get().isSpacewalk());
         List types = helper.getVirtualizationTypes();
         assertNotNull(types);
         boolean found = false;

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/test/TreeLabelTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/test/TreeLabelTest.java
@@ -41,7 +41,6 @@ public class TreeLabelTest extends BaseTestCaseWithUser {
         // ^([1-zA-Z0-1@.\s]{1,255})$
         // a-zA-Z\d\-\._
         // qr/^[a-zA-Z\d\-\._]*$/
-        // PatternCompiler compiler = new Perl5Compiler();
 
         String regEx = BaseTreeEditOperation.VALIDATE_LABEL_REGEX;
         Pattern pattern = Pattern.compile(regEx);

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -143,7 +143,6 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
         migrationManager.removeOrgRelationships(origOrgAdmins.iterator().next(), server);
         server = ServerFactory.lookupById(server.getId());
 
-        //serverGroup1 = (ManagedServerGroup) reload(serverGroup1);
         assertEquals(0, serverGroup1.getCurrentMembers().intValue());
 
         assertEquals(0, server.getManagedGroups().size());

--- a/java/code/src/com/redhat/rhn/manager/profile/test/ProfileManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/profile/test/ProfileManagerTest.java
@@ -218,10 +218,6 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
 
     @Test
     public void testTwoVsOneKernelPackages()  {
-        /*
-         *     public static List comparePackageLists(DataResult profiles,
-            DataResult systems, String param) {
-         */
 
         List<PackageListItem> a = new ArrayList<>();
         PackageListItem pli = new PackageListItem();
@@ -267,7 +263,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         assertEquals(1, diff.size());
         PackageMetadata pm = (PackageMetadata) diff.get(0);
         assertNotNull(pm);
-        // assertEquals(PackageMetadata.KEY_OTHER_NEWER, pm.getComparisonAsInt());
+        // assertEquals(PackageMetadata.KEY_OTHER_NEWER, pm.getComparisonAsInt())
         // Changed this to KEY_OTHER_ONLY because for systems with multiple revs of
         // same package we are now
         assertEquals(PackageMetadata.KEY_OTHER_ONLY, pm.getComparisonAsInt());
@@ -610,7 +606,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
 
         List<PackageMetadata> diff = ProfileManager.comparePackageLists(new DataResult<>(a),
                 new DataResult<>(b), "foo");
-        // This used to assert: assertEquals(0, diff.size());
+        // This used to assert: assertEquals(0, diff.size())
         // but we now support showing what older packages exist on a system
         assertEquals(2, diff.size());
 
@@ -669,7 +665,6 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         assertNotNull(pm);
         assertEquals("kernel-2.6.9-22.EL", pm.getOther().getEvr());
         assertEquals(PackageMetadata.KEY_OTHER_ONLY, pm.getComparisonAsInt());
-        // assertEquals("kernel-2.4.21-27.EL", pm.getSystem().getEvr());
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
@@ -630,7 +630,6 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
         tmpHandler.endElement("package");
         tmpHandler.endDocument();
 
-        //st.flush();
         String test = st.toString();
         System.out.println(test);
 

--- a/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
@@ -1027,7 +1027,7 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         server1.addChannel(parent1);
         server1.addChannel(child11);
 
-        Channel parent2 = ChannelFactoryTest.createTestChannel(org2); //ChannelFactoryTest.createTestChannel(user);
+        Channel parent2 = ChannelFactoryTest.createTestChannel(org2);
         parent2.setParentChannel(null);
         Channel child21 = ChannelFactoryTest.createTestChannel(user);
         child21.setParentChannel(parent2);

--- a/java/code/src/com/redhat/rhn/manager/ssm/test/SsmOperationDataPopulatorTest.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/test/SsmOperationDataPopulatorTest.java
@@ -46,7 +46,7 @@ public class SsmOperationDataPopulatorTest extends RhnBaseTestCase {
     @Override
     @AfterEach
     public void tearDown() {
-        // Override so the base class' tearDown doesn't rollback the transaction;
+        // Override so the base class' tearDown doesn't rollback the transaction
         // for this class we want the data to be persisted and remain there
     }
 

--- a/java/code/src/com/redhat/rhn/testing/TestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/TestUtils.java
@@ -340,7 +340,7 @@ public class TestUtils {
         session.flush();
         /*
          * In hibernate 3, the following doesn't work:
-         * Object obj = session.load(objClass, id);
+         * Object obj = session.load(objClass, id)
          * load returns the proxy class instead of the persisted class, ie,
          * Filter$$EnhancerByCGLIB$$9bcc734d_2 instead of Filter.
          * session.get is set to not return the proxy class, so that is what we'll use.


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rule java:S125 Sections of code should not be commented out

Commented-out code distracts the focus from the actual executed code. It creates a noise that increases maintenance code. And because it is never executed, it quickly becomes out of date and invalid.

Commented-out code should be deleted and can be retrieved from source control history if required.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): not backported
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
