### PR TITLE
SonarCloud fix: java:S5411 Avoid using boxed "Boolean" types directly in boolean expressions

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
@@ -139,7 +139,7 @@ public class ContentPropertiesValidator {
      * @param label label to validate
      * @return true if label is valid
      */
-    public static Boolean isLabelValid(String label) {
+    public static boolean isLabelValid(String label) {
         return Pattern.compile(CreateChannelCommand.CHANNEL_LABEL_REGEX).matcher(label).find() &&
                 Pattern.compile(CreateChannelCommand.CHANNEL_NAME_REGEX).matcher(label).find();
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfSearchAction.java
@@ -93,7 +93,7 @@ public class XccdfSearchAction extends BaseSearchAction {
         return null;
     }
 
-    private Boolean getOptionScanDateSearch(HttpServletRequest request) {
+    private boolean getOptionScanDateSearch(HttpServletRequest request) {
         Object dateSrch = request.getAttribute(SCAN_DATE_SEARCH);
         if (dateSrch instanceof Boolean bool) {
             return bool;

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataSearchAction.java
@@ -45,6 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 
@@ -98,7 +99,7 @@ public class ErrataSearchAction extends BaseSearchAction {
                 "erratasearch.jsp.start_date",
                 "erratasearch.jsp.end_date");
         DatePickerResults dates = null;
-        Boolean dateSearch = getOptionIssueDateSearch(request);
+        boolean dateSearch = getOptionIssueDateSearch(request);
 
         /*
          * If search/viewmode aren't null, we need to search and set
@@ -399,29 +400,19 @@ public class ErrataSearchAction extends BaseSearchAction {
         }
         List<ErrataOverview> filteredByType = new ArrayList<>();
         for (ErrataOverview eo : unfiltered) {
-            Boolean type = null;
             if (eo.isBugFix()) {
-                type = (Boolean)formIn.get(ERRATA_BUG);
-                if (type != null) {
-                    if (type) {
-                            filteredByType.add(eo);
-                    }
+                if (Optional.ofNullable((Boolean)formIn.get(ERRATA_BUG)).orElse(false)) {
+                    filteredByType.add(eo);
                 }
             }
             if (eo.isSecurityAdvisory()) {
-                type = (Boolean)formIn.get(ERRATA_SEC);
-                if (type != null) {
-                    if (type) {
-                        filteredByType.add(eo);
-                    }
+                if (Optional.ofNullable((Boolean)formIn.get(ERRATA_SEC)).orElse(false)) {
+                    filteredByType.add(eo);
                 }
             }
             if (eo.isProductEnhancement()) {
-                type = (Boolean)formIn.get(ERRATA_ENH);
-                if (type != null) {
-                    if (type) {
-                        filteredByType.add(eo);
-                    }
+                if (Optional.ofNullable((Boolean)formIn.get(ERRATA_ENH)).orElse(false)) {
+                    filteredByType.add(eo);
                 }
             }
         }
@@ -524,7 +515,7 @@ public class ErrataSearchAction extends BaseSearchAction {
         return queryIn.replace(":", "\\:");
     }
 
-    private Boolean getOptionIssueDateSearch(HttpServletRequest request) {
+    private boolean getOptionIssueDateSearch(HttpServletRequest request) {
         Object dateSrch = request.getAttribute(OPT_ISSUE_DATE);
         if (dateSrch == null) {
             return false;

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartLocaleEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartLocaleEditAction.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.manager.kickstart.BaseKickstartCommand;
 import com.redhat.rhn.manager.kickstart.KickstartLocaleCommand;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.struts.action.DynaActionForm;
 
 import java.util.List;
@@ -77,17 +78,13 @@ public class KickstartLocaleEditAction extends BaseKickstartEditAction {
                                         "validation.timezone.invalid");
         }
 
-        Boolean useUtc = (Boolean) form.get(USE_UTC);
+        boolean useUtc = BooleanUtils.isTrue((Boolean)form.get(USE_UTC));
 
-        if (useUtc == null) {
-            useUtc = Boolean.FALSE;
-        }
-
-        if (localeCmd.getKickstartData().isUsingUtc() &&
+        if (BooleanUtils.isTrue(localeCmd.getKickstartData().isUsingUtc()) &&
             !useUtc) {
             localeCmd.doNotUseUtc();
         }
-        else if (!localeCmd.getKickstartData().isUsingUtc() &&
+        else if (BooleanUtils.isNotTrue(localeCmd.getKickstartData().isUsingUtc()) &&
                 useUtc) {
             localeCmd.useUtc();
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgConfigAction.java
@@ -111,7 +111,7 @@ public class OrgConfigAction extends RhnAction {
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
     }
 
-    private Boolean getOptionScapRetentionPeriodSet(HttpServletRequest request) {
+    private boolean getOptionScapRetentionPeriodSet(HttpServletRequest request) {
         String strRetentionSet = request.getParameter(SCAP_RETENTION_SET);
         return "on".equals(strRetentionSet);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.manager.SatManager;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionMessage;
 import org.apache.struts.action.ActionMessages;
@@ -57,7 +58,7 @@ public abstract class UserEditActionHelper extends RhnAction {
                     new ActionMessage("error.password_mismatch"));
         }
 
-        Boolean readOnly = (form.get("readonly") != null);
+        boolean readOnly = (form.get("readonly") != null);
         if (!targetUser.isReadOnly()) {
             if (readOnly && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
                     targetUser.getOrg().numActiveOrgAdmins() < 2) {
@@ -65,7 +66,7 @@ public abstract class UserEditActionHelper extends RhnAction {
                         new ActionMessage("error.readonly_org_admin",
                                 targetUser.getOrg().getName()));
             }
-            if (readOnly && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
+            if (BooleanUtils.isTrue(readOnly) && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
                     SatManager.getActiveSatAdmins().size() < 2) {
                 errors.add(ActionMessages.GLOBAL_MESSAGE,
                         new ActionMessage("error.readonly_sat_admin",

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
@@ -58,6 +58,7 @@ import com.suse.manager.webui.utils.token.DownloadTokenBuilder;
 import com.suse.manager.webui.utils.token.Token;
 import com.suse.manager.webui.utils.token.TokenBuildingException;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -462,7 +463,7 @@ public class ActivationKeyHandler extends BaseHandler {
         // Check if we need to override the usage_limit and set to unlimited:
         if (details.containsKey("unlimited_usage_limit")) {
             Boolean unlimited = (Boolean)details.get("unlimited_usage_limit");
-            if (unlimited) {
+            if (BooleanUtils.isTrue(unlimited)) {
                 aKey.setUsageLimit(null);
             }
         }
@@ -1080,13 +1081,13 @@ public class ActivationKeyHandler extends BaseHandler {
          List<ConfigChannel> channels = configHelper.
                               lookupGlobals(loggedInUser, configChannelLabels);
          ConfigChannelListProcessor proc = new ConfigChannelListProcessor();
-         if (addToTop) {
+         if (BooleanUtils.isTrue(addToTop)) {
              Collections.reverse(channels);
          }
 
          for (ActivationKey key : activationKeys) {
              for (ConfigChannel chan : channels) {
-                 if (addToTop) {
+                 if (BooleanUtils.isTrue(addToTop)) {
                      proc.add(key.getConfigChannelsFor(loggedInUser), chan, 0);
                  }
                  else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/ProfileHandler.java
@@ -675,7 +675,7 @@ public class ProfileHandler extends BaseHandler {
         script.setData(contents.getBytes());
         script.setInterpreter(interpreter.equals("") ? null : interpreter);
         script.setScriptType(type);
-        script.setChroot(chroot ? "Y" : "N");
+        script.setChroot(BooleanUtils.isTrue(chroot) ? "Y" : "N");
         script.setRaw(!template);
         script.setErrorOnFail(erroronfail);
         script.setKsdata(ksData);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/profile/system/SystemDetailsHandler.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.manager.kickstart.SystemDetailsCommand;
 
 import com.suse.manager.api.ReadOnly;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
@@ -293,7 +294,7 @@ public class SystemDetailsHandler extends BaseHandler {
         }
 
         command.setTimezone(locale);
-        if (useUtc) {
+        if (BooleanUtils.isTrue(useUtc)) {
             command.useUtc();
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/OrgHandler.java
@@ -52,6 +52,7 @@ import com.redhat.rhn.manager.user.UserManager;
 
 import com.suse.manager.api.ReadOnly;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -177,7 +178,7 @@ public class OrgHandler extends BaseHandler {
         cmd.setPrefix(prefix);
 
         String pamAuthService = Config.get().getString(ConfigDefaults.WEB_PAM_AUTH_SERVICE);
-        if (usePamAuth) {
+        if (BooleanUtils.isTrue(usePamAuth)) {
             if (pamAuthService != null && !pamAuthService.trim().isEmpty()) {
                 cmd.setUsePam(usePamAuth);
             }
@@ -220,7 +221,7 @@ public class OrgHandler extends BaseHandler {
             throw new ValidationException(e.getMessage());
         }
 
-        if (!usePamAuth && StringUtils.isEmpty(password)) {
+        if (BooleanUtils.isNotTrue(usePamAuth) && StringUtils.isEmpty(password)) {
             throw new FaultException(-501, "passwordRequiredOrUsePam",
                     "Password is required if not using PAM authentication");
         }
@@ -659,7 +660,7 @@ public class OrgHandler extends BaseHandler {
         ensureUserRole(loggedInUser, RoleFactory.SAT_ADMIN);
         OrgConfig orgConfig = verifyOrgExists(orgId).getOrgConfig();
         if (newSettings.containsKey("enabled")) {
-            if ((Boolean) newSettings.get("enabled")) {
+            if (BooleanUtils.isTrue((Boolean) newSettings.get("enabled"))) {
                 orgConfig.setScapRetentionPeriodDays(90L);
             }
             else {
@@ -828,7 +829,7 @@ public class OrgHandler extends BaseHandler {
                                      Boolean enable) {
         ensureUserRole(loggedInUser, RoleFactory.SAT_ADMIN);
         Org org = verifyOrgExists(orgId);
-        if (enable) {
+        if (BooleanUtils.isTrue(enable)) {
             org.getOrgConfig().setStagingContentEnabled(enable);
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ConfigRevisionSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ConfigRevisionSerializer.java
@@ -24,6 +24,7 @@ import com.suse.manager.api.SerializationBuilder;
 import com.suse.manager.api.SerializedApiResponse;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.BooleanUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
@@ -129,7 +130,7 @@ public class ConfigRevisionSerializer extends ApiResponseSerializer<ConfigRevisi
     protected void addFileContent(ConfigRevision rev, SerializationBuilder builder) {
         if (!rev.getConfigContent().isBinary()) {
             String content = rev.getConfigContent().getContentsString();
-            if (!StringUtil.containsInvalidXmlChars2(content)) {
+            if (BooleanUtils.isFalse(StringUtil.containsInvalidXmlChars2(content))) {
                 builder.add(CONTENTS, content);
                 builder.add(CONTENTS_ENC64, Boolean.FALSE);
             }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ScriptResultSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ScriptResultSerializer.java
@@ -22,6 +22,7 @@ import com.suse.manager.api.SerializationBuilder;
 import com.suse.manager.api.SerializedApiResponse;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.BooleanUtils;
 
 import java.nio.charset.StandardCharsets;
 
@@ -57,7 +58,7 @@ public class ScriptResultSerializer extends ApiResponseSerializer<ScriptResult> 
                 .add("returnCode", src.getReturnCode());
 
         String outputContents = src.getOutputContents();
-        if (StringUtil.containsInvalidXmlChars2(outputContents)) {
+        if (BooleanUtils.isTrue(StringUtil.containsInvalidXmlChars2(outputContents))) {
             builder.add("output_enc64", Boolean.TRUE);
             builder.add("output", new String(Base64.encodeBase64(outputContents
                     .getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -201,6 +201,7 @@ import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.xmlrpc.NoSuchHistoryEventException;
 import com.suse.manager.xmlrpc.dto.SystemEventDetailsDto;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -887,7 +888,7 @@ public class SystemHandler extends BaseHandler {
         ret.put("id", channel.getId());
         ret.put("name", channel.getName());
         ret.put("label", channel.getLabel());
-        ret.put("current_base", currentBase ? Integer.valueOf(1) : Integer.valueOf(0));
+        ret.put("current_base", BooleanUtils.isTrue(currentBase) ? Integer.valueOf(1) : Integer.valueOf(0));
         return ret;
     }
 
@@ -1945,7 +1946,7 @@ public class SystemHandler extends BaseHandler {
             List<Server> servers = new ArrayList<>(1);
             servers.add(server);
 
-            if (member) {
+            if (BooleanUtils.isTrue(member)) {
                 //add to server group
                 serverGroupManager.addServers(group, servers, loggedInUser);
             }
@@ -3909,7 +3910,7 @@ public class SystemHandler extends BaseHandler {
             .map(Integer::longValue)
             .collect(toList());
 
-        if (!allowModules) {
+        if (BooleanUtils.isNotTrue(allowModules)) {
             for (Long sid : serverIds) {
                 Server server = SystemManager.lookupByIdAndUser(sid, loggedInUser);
                 for (Channel channel : server.getChannels()) {
@@ -4217,7 +4218,7 @@ public class SystemHandler extends BaseHandler {
 
         List<Long> actionIds = new ArrayList<>();
 
-        if (!allowModules) {
+        if (BooleanUtils.isNotTrue(allowModules)) {
             boolean hasModules = false;
             for (Integer sid : sids) {
                 Server server = SystemManager.lookupByIdAndUser(sid.longValue(), loggedInUser);
@@ -5713,7 +5714,7 @@ public class SystemHandler extends BaseHandler {
         if (details.containsKey("auto_errata_update")) {
             Boolean autoUpdate = (Boolean)details.get("auto_errata_update");
 
-            if (autoUpdate) {
+            if (BooleanUtils.isTrue(autoUpdate)) {
                 server.setAutoUpdate("Y");
             }
             else {
@@ -5812,7 +5813,7 @@ public class SystemHandler extends BaseHandler {
                     server);
         }
         else {
-            if (lockStatus) {
+            if (BooleanUtils.isTrue(lockStatus)) {
                 // lock the server, if it isn't already locked.
                 if (server.getLock() == null) {
                     SystemManager.lockServer(loggedInUser, server,
@@ -7411,7 +7412,7 @@ public class SystemHandler extends BaseHandler {
             String interfaceName) {
         Server server = lookupServer(loggedInUser, sid);
 
-        if (!server.existsActiveInterfaceWithName(interfaceName)) {
+        if (BooleanUtils.isNotTrue(server.existsActiveInterfaceWithName(interfaceName))) {
             throw new NoSuchNetworkInterfaceException("No such network interface: " +
                     interfaceName);
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/XmlRpcSystemHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/XmlRpcSystemHelper.java
@@ -31,7 +31,6 @@ import com.suse.manager.webui.utils.gson.BootstrapParameters;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * XmlRpcSystemHelper
@@ -149,14 +148,13 @@ public class XmlRpcSystemHelper {
      */
     public int bootstrap(User user, BootstrapParameters params, boolean saltSSH)
             throws BootstrapException {
-        BootstrapResult result = Stream.of(saltSSH).map(ssh -> {
-            if (ssh) {
-                return sshMinionBootstrapper.bootstrap(params, user, ContactMethodUtil.getSSHMinionDefault());
-            }
-            else {
-                return regularMinionBootstrapper.bootstrap(params, user, ContactMethodUtil.getRegularMinionDefault());
-            }
-        }).findAny().orElseThrow(() -> new BootstrapException("No result for " + params.getHost()));
+        BootstrapResult result;
+        if (saltSSH) {
+            result = sshMinionBootstrapper.bootstrap(params, user, ContactMethodUtil.getSSHMinionDefault());
+        }
+        else {
+            result = regularMinionBootstrapper.bootstrap(params, user, ContactMethodUtil.getRegularMinionDefault());
+        }
 
         // Determine the result, throw BootstrapException in case of failure
         if (!result.isSuccess()) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/ServerConfigHandler.java
@@ -46,6 +46,8 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.api.ReadOnly;
 import com.suse.manager.utils.MinionServerUtils;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -110,7 +112,7 @@ public class ServerConfigHandler extends BaseHandler {
             Integer sid, Boolean listLocal) {
         ConfigurationManager cm = ConfigurationManager.getInstance();
         Server server = xmlRpcSystemHelper.lookupServer(loggedInUser, sid);
-        if (listLocal) {
+        if (BooleanUtils.isTrue(listLocal)) {
             return cm.listFileNamesForSystemQuick(loggedInUser, server, null);
         }
         List<ConfigFileNameDto> files = new LinkedList<>();
@@ -197,7 +199,7 @@ public class ServerConfigHandler extends BaseHandler {
         validKeys.add(ConfigRevisionSerializer.PERMISSIONS);
         validKeys.add(ConfigRevisionSerializer.REVISION);
         validKeys.add(ConfigRevisionSerializer.SELINUX_CTX);
-        if (!isDir) {
+        if (BooleanUtils.isNotTrue(isDir)) {
             validKeys.add(ConfigRevisionSerializer.CONTENTS);
             validKeys.add(ConfigRevisionSerializer.CONTENTS_ENC64);
             validKeys.add(ConfigRevisionSerializer.MACRO_START);
@@ -209,7 +211,7 @@ public class ServerConfigHandler extends BaseHandler {
         Server server = xmlRpcSystemHelper.lookupServer(loggedInUser, sid);
         checkIfLocalPermissible(server);
         ConfigChannel channel;
-        if (commitToLocal) {
+        if (BooleanUtils.isTrue(commitToLocal)) {
             channel = server.getLocalOverride();
         }
         else {
@@ -217,7 +219,7 @@ public class ServerConfigHandler extends BaseHandler {
         }
         XmlRpcConfigChannelHelper configHelper = XmlRpcConfigChannelHelper.getInstance();
         return configHelper.createOrUpdatePath(loggedInUser, channel, path,
-                isDir ? ConfigFileType.dir() : ConfigFileType.file(), data);
+                BooleanUtils.isTrue(isDir) ? ConfigFileType.dir() : ConfigFileType.file(), data);
     }
 
 
@@ -273,7 +275,7 @@ public class ServerConfigHandler extends BaseHandler {
         Server server = xmlRpcSystemHelper.lookupServer(loggedInUser, sid);
         checkIfLocalPermissible(server);
         ConfigChannel channel;
-        if (commitToLocal) {
+        if (BooleanUtils.isTrue(commitToLocal)) {
             channel = server.getLocalOverride();
         }
         else {
@@ -321,7 +323,7 @@ public class ServerConfigHandler extends BaseHandler {
         List<ConfigRevision> revisions = new LinkedList<>();
         for (String path : paths) {
             ConfigFile cf;
-            if (searchLocal) {
+            if (BooleanUtils.isTrue(searchLocal)) {
                 cf = cm.lookupConfigFile(loggedInUser,
                         server.getLocalOverride().getId(), path);
 
@@ -375,7 +377,7 @@ public class ServerConfigHandler extends BaseHandler {
         List<ConfigFile> cfList = new ArrayList<>();
         for (String path : paths) {
             ConfigFile cf;
-            if (deleteFromLocal) {
+            if (BooleanUtils.isTrue(deleteFromLocal)) {
                 cf = cm.lookupConfigFile(loggedInUser,
                         server.getLocalOverride().getId(), path);
             }
@@ -513,7 +515,7 @@ public class ServerConfigHandler extends BaseHandler {
             if (channels.equals(server.getConfigChannelList())) {
                 continue;
             }
-            if (addToTop) {
+            if (BooleanUtils.isTrue(addToTop)) {
                 // Add the existing subscriptions to the end so they will be resubscribed
                 // and their ranks will be overridden
                 channelsToAdd = Stream

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
@@ -45,6 +45,8 @@ import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.api.ReadOnly;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -213,7 +215,7 @@ public class ServerGroupHandler extends BaseHandler {
 
         List servers = xmlRpcSystemHelper.lookupServers(loggedInUser, serverIds);
 
-        if (add) {
+        if (BooleanUtils.isTrue(add)) {
             serverGroupManager.addServers(group, servers, loggedInUser);
         }
         else {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
@@ -947,7 +947,7 @@ public class UserHandler extends BaseHandler {
             String login, List<String> sgNames, Boolean setDefault) {
         ensureUserRole(loggedInUser, RoleFactory.ORG_ADMIN);
 
-        if (setDefault) {
+        if (BooleanUtils.isTrue(setDefault)) {
             removeDefaultSystemGroups(loggedInUser, login, sgNames);
          }
 
@@ -1070,7 +1070,7 @@ public class UserHandler extends BaseHandler {
         UserManager.grantServerGroupPermission(targetUser.getId(), groupIds);
 
         // Follow up with a call to addDefaultSystemGroups if setDefault is true:
-        if (setDefault) {
+        if (BooleanUtils.isTrue(setDefault)) {
             addDefaultSystemGroups(loggedInUser, login, sgNames);
         }
 
@@ -1153,12 +1153,12 @@ public class UserHandler extends BaseHandler {
                 loggedInUser, login);
 
         if (!targetUser.isReadOnly()) {
-            if (readOnly && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
+            if (BooleanUtils.isTrue(readOnly) && targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
                     targetUser.getOrg().numActiveOrgAdmins() < 2) {
                 throw new InvalidOperationException("error.readonly_org_admin",
                         targetUser.getOrg().getName());
             }
-            if (readOnly && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
+            if (BooleanUtils.isTrue(readOnly) && targetUser.hasRole(RoleFactory.SAT_ADMIN) &&
                     SatManager.getActiveSatAdmins().size() < 2) {
                 throw new InvalidOperationException("error.readonly_sat_admin");
             }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -364,7 +364,7 @@ public class ActionChainManager {
 
         Set<Long> sidSet = new HashSet<>(sids);
 
-        String summary = "Apply highstate" + (test.isPresent() && test.get() ? " in test-mode" : "");
+        String summary = "Apply highstate" + (test.orElse(false) ? " in test-mode" : "");
         Set<Action> result = createActions(user, ActionFactory.TYPE_APPLY_STATES, summary,
                 earliest, actionChain, null, sidSet);
         for (Action action : result) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -668,7 +668,7 @@ public class ContentManager {
     }
 
     // helper method to determine if given environment is BUILDING
-    private Boolean isEnvironmentBuilding(Optional<ContentEnvironment> env) {
+    private boolean isEnvironmentBuilding(Optional<ContentEnvironment> env) {
         return env.flatMap(e -> e.computeStatus().map(status -> status.equals(EnvironmentTarget.Status.BUILDING)))
                 .orElse(false);
     }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartOptionsCommand.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.kickstart.KickstartOptionValue;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -134,7 +135,7 @@ public class KickstartOptionsCommand  extends BaseKickstartCommand {
             v.setEnabled(mapIn.containsKey(name));
 
             String[] s = (String[]) mapIn.get(name + "_txt");
-            if ((s != null) && (v.getEnabled())) {
+            if ((s != null) && (BooleanUtils.isTrue(v.getEnabled()))) {
                 v.setArg(s[0]);
             }
 

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/TreeDeleteOperation.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/TreeDeleteOperation.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class TreeDeleteOperation extends BaseTreeEditOperation {
 
-    private Boolean deleteProfiles = Boolean.FALSE;
+    private boolean deleteProfiles = false;
 
     /**
      * Default constructor: DONT USE

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -137,6 +137,7 @@ import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.xmlrpc.dto.SystemEventDetailsDto;
 import com.suse.utils.Opt;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -3578,7 +3579,7 @@ public class SystemManager extends BaseManager {
             params = new HashMap<>();
             params.put("user_id", user.getId());
             params.put("pref", preference);
-            params.put("value", value ? 1 : 0);
+            params.put("value", BooleanUtils.isTrue(value) ? 1 : 0);
             mode.execute(params, new HashMap<>());
         }
     }
@@ -3606,7 +3607,7 @@ public class SystemManager extends BaseManager {
                 "set_auto_update_bulk");
         Map<String, Object> params = new HashMap<>();
         params.put("user_id", user.getId());
-        params.put("value", value ? "Y" : "N");
+        params.put("value", BooleanUtils.isTrue(value) ? "Y" : "N");
         mode.execute(params, new HashMap<>());
     }
 

--- a/java/code/src/com/suse/manager/api/HttpApiRegistry.java
+++ b/java/code/src/com/suse/manager/api/HttpApiRegistry.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.frontend.xmlrpc.HandlerFactory;
 
 import com.suse.manager.webui.controllers.login.LoginController;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -94,7 +95,7 @@ public class HttpApiRegistry {
             methodsByName.forEach((groupKey, methodList) -> {
                 String path = HTTP_API_ROOT + namespace.replace('.', '/') + '/' + groupKey.getLeft();
                 Route route = routeFactory.createRoute(methodList, handler);
-                if (groupKey.getRight()) {
+                if (BooleanUtils.isTrue(groupKey.getRight())) {
                     registrationHelper.addGetRoute(path, route);
                 }
                 else {
@@ -108,7 +109,7 @@ public class HttpApiRegistry {
                             groupKey.getLeft(),
                             methodList.size() > 1 ?
                                     MessageFormat.format(" ({0} overloads)", methodList.size()) : "",
-                            groupKey.getRight() ? " (Read-only)" : ""));
+                            BooleanUtils.isTrue(groupKey.getRight()) ? " (Read-only)" : ""));
                 }
                 methodCount[0] += 1;
             });

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -149,6 +149,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
@@ -1005,7 +1006,7 @@ public class SaltUtils {
                             Map<Boolean, String> moveRes = saltApi.storeMinionScapFiles(
                                     minion, openscapResult.getUploadDir(), action.getId());
                             moveRes.entrySet().stream().findFirst().ifPresent(moved -> {
-                                if (moved.getKey()) {
+                                if (BooleanUtils.isTrue(moved.getKey())) {
                                     Path resultsFile = Paths.get(moved.getValue(),
                                             "results.xml");
                                     try (InputStream resultsFileIn =

--- a/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/channels/ChannelsApiController.java
@@ -32,6 +32,8 @@ import com.suse.manager.webui.utils.gson.ResultJson;
 
 import com.google.gson.reflect.TypeToken;
 
+import org.apache.commons.lang3.BooleanUtils;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -72,7 +74,7 @@ public class ChannelsApiController {
         return doWithoutAutoFlushing(() -> {
             Boolean filterClm = Boolean.parseBoolean(req.queryParams("filterClm"));
             Set<Long> filterOutIds = new HashSet<>();
-            if (filterClm) {
+            if (BooleanUtils.isTrue(filterClm)) {
                 // filtering Content Lifecycle Management target channels
                 filterOutIds.addAll(ContentProjectFactory.listSoftwareEnvironmentTarget().stream()
                         .map(tgt -> tgt.getChannel().getId())

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -63,6 +63,7 @@ import com.suse.manager.webui.utils.SaltConfigChannelState;
 import com.suse.manager.webui.utils.SaltPillar;
 import com.suse.manager.webui.utils.salt.custom.OSImageInspectSlsResult;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -224,7 +225,7 @@ public enum SaltStateGeneratorService {
                 bootImage.getKernel().getFilename());
 
         bootImagePillarSync.put("local_path", bootLocalPath);
-        if (isBundle) {
+        if (BooleanUtils.isTrue(isBundle)) {
             bootImagePillarSync.put("kernel_link", "../../" + systemLocalPath + '/' +
                     bootImage.getKernel().getFilename());
             bootImagePillarSync.put("initrd_link", "../../" + systemLocalPath + '/' +

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -30,6 +30,9 @@ import com.suse.matcher.json.MatchJson;
 import com.suse.matcher.json.MessageJson;
 import com.suse.matcher.json.OutputJson;
 import com.suse.matcher.json.ProductJson;
+import com.suse.matcher.json.SystemJson;
+
+import org.apache.commons.lang3.BooleanUtils;
 
 import java.util.Collections;
 import java.util.Date;
@@ -75,6 +78,15 @@ public class SubscriptionMatchProcessor {
         }
     }
 
+    private String getType(SystemJson s) {
+        if (BooleanUtils.isTrue(s.getPhysical())) {
+            return (BooleanUtils.isTrue(s.getVirtualHost()) ? "virtualHost" : "nonVirtual");
+        }
+        else {
+            return "virtualGuest";
+        }
+    }
+
     private Map<String, System> systems(InputJson input, OutputJson output) {
         return input.getSystems().stream()
                 .map(s -> new System(
@@ -84,9 +96,7 @@ public class SubscriptionMatchProcessor {
                     s.getProductIds(),
                     // see https://github.com/SUSE/spacewalk/wiki/
                     // Subscription-counting#definitions
-                    s.getPhysical() ?
-                        (s.getVirtualHost() ? "virtualHost" : "nonVirtual") :
-                        "virtualGuest",
+                        getType(s),
                     output.getMatches().stream()
                         .filter(m -> m.getSystemId().equals(s.getId()))
                         .map(MatchJson::getSubscriptionId)

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -46,6 +46,7 @@ import com.redhat.rhn.manager.user.UserManager;
 import com.suse.manager.utils.DiskCheckHelper;
 import com.suse.manager.utils.DiskCheckSeverity;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
@@ -136,7 +137,7 @@ public class LoginHelper {
                 RhnConfigurationFactory factory = RhnConfigurationFactory.getSingleton();
                 Boolean useOrgUnit =
                         factory.getBooleanConfiguration(RhnConfiguration.KEYS.EXTAUTH_USE_ORGUNIT).getValue();
-                if (useOrgUnit) {
+                if (BooleanUtils.isTrue(useOrgUnit)) {
                     String orgUnitString =
                             (String) request.getAttribute("REMOTE_USER_ORGUNIT");
                     newUserOrg = OrgFactory.lookupByName(orgUnitString);


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rule java:S5411 Avoid using boxed "Boolean" types directly in boolean expressions

When boxed type java.lang.Boolean is used as an expression to determine the control flow (as described in [Java Language Specification §4.2.5 The boolean Type and boolean Values](https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.2.5)) it will throw a NullPointerException if the value is null (as defined in [Java Language Specification §5.1.8 Unboxing Conversion](https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.8)).

It is safer to avoid such conversion altogether and handle the null value explicitly.

Note, however, that no issues will be raised for Booleans that have already been null-checked or are marked @NonNull/@NotNull

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878, https://github.com/uyuni-project/uyuni/issues/9941
Port(s): not backported
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

