### PR TITLE
Issv3 scc metering

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -175,6 +175,7 @@ import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssPeripheralChannels;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
+import com.suse.scc.proxy.SCCProxyRecord;
 
 import java.util.List;
 
@@ -312,6 +313,7 @@ public class AnnotationRegistry {
             SAPWorkload.class,
             SCCCredentials.class,
             SCCOrderItem.class,
+            SCCProxyRecord.class,
             SCCRegCacheItem.class,
             SCCRepositoryAuth.class,
             SCCRepositoryBasicAuth.class,

--- a/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
@@ -35,6 +35,7 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCSubscriptionJson;
+import com.suse.scc.proxy.SCCProxyFactory;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -217,7 +218,8 @@ public class MirrorCredentialsManager {
                     .setUuid(uuid)
                     .createSCCConfig();
             SCCClient sccClient = new SCCWebClient(sccConfig);
-            SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient);
+            SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
+            SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient, sccProxyFactory);
             sccRegManager.deregister(itemList, true);
         }
         catch (URISyntaxException e) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.test;
+
+import static com.suse.scc.SCCEndpoints.SHOULD_BE_REMOVED;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.util.http.HttpClientAdapter;
+import com.redhat.rhn.domain.credentials.CredentialsFactory;
+import com.redhat.rhn.domain.credentials.HubSCCCredentials;
+import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.domain.scc.SCCCachingFactory;
+import com.redhat.rhn.domain.scc.SCCRegCacheItem;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerInfo;
+import com.redhat.rhn.manager.content.ContentSyncManager;
+import com.redhat.rhn.taskomatic.task.ForwardRegistrationTask;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ServerTestUtils;
+
+import com.suse.manager.hub.test.ControllerTestUtils;
+import com.suse.manager.model.hub.HubFactory;
+import com.suse.manager.model.hub.IssHub;
+import com.suse.manager.model.hub.IssPeripheral;
+import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.scc.SCCEndpoints;
+import com.suse.scc.SCCSystemRegistrationManager;
+import com.suse.scc.client.SCCClientException;
+import com.suse.scc.client.SCCConfig;
+import com.suse.scc.client.SCCConfigBuilder;
+import com.suse.scc.client.SCCWebClient;
+import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
+import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.proxy.SCCProxyFactory;
+import com.suse.scc.proxy.SCCProxyManager;
+import com.suse.scc.proxy.SCCProxyRecord;
+import com.suse.scc.proxy.SccProxyStatus;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseFactory;
+import org.apache.http.HttpStatus;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.DefaultHttpResponseFactory;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletResponse;
+
+import spark.route.HttpMethod;
+
+public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
+
+    private SCCCredentials primaryCredentials;
+    private List<Server> servers;
+    private List<SCCRegCacheItem> testSystems;
+
+    private MockSCCWebClient mockSccWebClient;
+    private MockForwardRegistrationTask mockForwardRegistrationTask;
+    private SCCProxyFactory testSccProxyFactory;
+    private SCCSystemRegistrationManager testSccSystemRegMan;
+
+    private Integer systemSize;
+    private Integer batchSize;
+    private boolean allowFirstCallToFail;
+    private boolean allowAllCallsToFail;
+
+    private static final String HUB_FQDN = "hub.local";
+    private static final String PERIPHERAL_FQDN = "peripheral.local";
+    private static final String PERIPHERAL_USERNAME = "peripheral-000002";
+    private static final String PERIPHERAL_PASSWD = "not so secret";
+
+    static class MockSCCWebClient extends SCCWebClient {
+        protected int callCnt;
+
+        MockSCCWebClient(SCCConfig configIn) {
+            super(configIn);
+            callCnt = 0;
+        }
+
+        public int getCallCnt() {
+            return callCnt;
+        }
+
+        public void resetCallCnt() {
+            callCnt = 0;
+        }
+
+        @Override
+        public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
+                throws SCCClientException {
+            //do nothing
+        }
+    }
+
+    static class MockForwardRegistrationTask extends ForwardRegistrationTask {
+        @Override
+        public void executeSCCTasksCore(SCCSystemRegistrationManager sccRegManager,
+                                        SCCProxyFactory sccProxyFactory,
+                                        SCCCredentials sccPrimaryOrProxyCredentials) {
+            super.executeSCCTasksCore(sccRegManager, sccProxyFactory, sccPrimaryOrProxyCredentials);
+        }
+
+
+        @Override
+        public Optional<SCCCredentials> findSccCredentials() {
+            return super.findSccCredentials();
+        }
+    }
+
+    static class MockHttpClientAdapter extends HttpClientAdapter {
+        MockHttpClientAdapter(SCCConfig configIn) {
+            super(configIn.getAdditionalCerts(), false);
+        }
+
+        @Override
+        public HttpResponse executeRequest(HttpRequestBase request, String username,
+                                           String password) throws IOException {
+            HttpResponseFactory factory = new DefaultHttpResponseFactory();
+            HttpResponse response = factory.newHttpResponse(
+                    new BasicStatusLine(new ProtocolVersion("http", 1, 1),
+                            HttpStatus.SC_BAD_REQUEST, null), null);
+
+            if (request.getMethod().compareToIgnoreCase("PUT") == 0) {
+                executeRequestCreateSystems(request, username, password, response);
+            }
+            if (request.getMethod().compareToIgnoreCase("DELETE") == 0) {
+                executeRequestDeleteSystems(request, username, password, response);
+            }
+
+            return response;
+        }
+
+        public void executeRequestCreateSystems(HttpRequestBase request, String username,
+                                                String password, HttpResponse response) {
+            try {
+                HttpEntity entity = ((HttpPut) request).getEntity(); // example
+                String requestBody = EntityUtils.toString(entity);
+
+                String result = (String) ControllerTestUtils.simulateApiEndpointCallBasicAuth(
+                        SHOULD_BE_REMOVED + "/connect/organizations/systems", HttpMethod.put,
+                        username, password, requestBody);
+
+                response.setEntity(new StringEntity(result, APPLICATION_JSON));
+                response.setStatusCode(HttpServletResponse.SC_CREATED);
+            }
+            catch (Exception eIn) {
+                throw new IllegalStateException(eIn);
+            }
+        }
+
+        public void executeRequestDeleteSystems(HttpRequestBase request, String username,
+                                                String password, HttpResponse response) {
+            try {
+                String url = request.getURI().getPath();
+                int index = url.lastIndexOf("/");
+                String id = url.substring(index + 1);
+
+                Object res = ControllerTestUtils.simulateApiEndpointCallBasicAuth(
+                        SHOULD_BE_REMOVED + "/connect/organizations/systems/:id",
+                        HttpMethod.delete, username, password, id);
+
+                response.setEntity(new StringEntity(res.toString(), APPLICATION_JSON));
+                response.setStatusCode(HttpServletResponse.SC_CREATED);
+            }
+            catch (Exception eIn) {
+                throw new IllegalStateException(eIn);
+            }
+        }
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        systemSize = 15;
+        batchSize = 3;
+        allowFirstCallToFail = false;
+        allowAllCallsToFail = false;
+    }
+
+    private void setupTest() throws Exception {
+        setupCreateTestObjects();
+        setupCreateTestSCCWebClient();
+        testSccSystemRegMan = new SCCSystemRegistrationManager(mockSccWebClient, testSccProxyFactory);
+        setupCreateSystems();
+        mockSccWebClient.resetCallCnt();
+    }
+
+    private void setupCreateTestObjects() {
+        primaryCredentials = CredentialsFactory.createSCCCredentials("username", "password");
+        primaryCredentials.setUrl("https://scc.suse.com");
+        CredentialsFactory.storeCredentials(primaryCredentials);
+
+        mockForwardRegistrationTask = new MockForwardRegistrationTask();
+        testSccProxyFactory = new SCCProxyFactory();
+    }
+
+    private void setupCreateSystems() throws Exception {
+        Path tmpSaltRoot = Files.createTempDirectory("salt");
+        SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot.toAbsolutePath());
+        SaltStateGeneratorService.INSTANCE.setSkipSetOwner(true);
+        Config.get().setString(ConfigDefaults.REG_BATCH_SIZE, String.valueOf(batchSize));
+
+        for (SCCRegCacheItem item : getAllSCCRegCacheItems()) {
+            SCCCachingFactory.deleteRegCacheItem(item);
+        }
+
+        servers = new ArrayList<>();
+        for (int i = 0; i < systemSize; i++) {
+            Server testSystem = ServerTestUtils.createTestSystem();
+            ServerInfo serverInfo = testSystem.getServerInfo();
+            serverInfo.setCheckin(new Date(0)); // 1970-01-01 00:00:00 UTC
+            testSystem.setServerInfo(serverInfo);
+            servers.add(testSystem);
+        }
+
+        SCCCachingFactory.initNewSystemsToForward();
+        List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
+        testSystems = allUnregistered.stream()
+                .filter(i -> i.getOptServer().get().getServerInfo().getCheckin().equals(new Date(0)))
+                .collect(Collectors.toList());
+    }
+
+    private void setupCreateTestSCCWebClient() throws URISyntaxException {
+        String url = "https://localhost";
+        SCCConfig sccConfig = new SCCConfigBuilder()
+                .setUrl(new URI(url))
+                .setUsername("username")
+                .setPassword("password")
+                .setUuid("uuid")
+                .createSCCConfig();
+        mockSccWebClient = new MockSCCWebClient(sccConfig) {
+            @Override
+            public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
+                    List<SCCRegisterSystemJson> systems, String username, String password
+            ) {
+                callCnt += 1;
+                if (allowFirstCallToFail) {
+                    // allow first call to fail
+                    boolean setBadRequest = (callCnt == 1);
+                    if (setBadRequest) {
+                        throw new SCCClientException(400, "Bad Request");
+                    }
+                }
+                if (allowAllCallsToFail) {
+                    throw new SCCClientException(400, "Bad Request");
+                }
+                return new SCCOrganizationSystemsUpdateResponse(
+                        systems.stream()
+                                .map(system ->
+                                        new SCCSystemCredentialsJson(system.getLogin(),
+                                                system.getPassword(), 12345L))
+                                .collect(Collectors.toList())
+                );
+            }
+        };
+    }
+
+    private void setupAsPeripheral() {
+        IssHub hub = new IssHub(HUB_FQDN, "");
+        HubFactory hubFactory = new HubFactory();
+        hubFactory.save(hub);
+
+        SCCCredentials sccCredentialsTowardsHub =
+                CredentialsFactory.createSCCCredentials(PERIPHERAL_USERNAME, PERIPHERAL_PASSWD);
+        sccCredentialsTowardsHub.setUrl(HUB_FQDN);
+
+        CredentialsFactory.storeCredentials(sccCredentialsTowardsHub);
+    }
+
+    private void setupAsHub() {
+        HubSCCCredentials sccCredentialsTowardsPeripheral =
+                CredentialsFactory.createHubSCCCredentials(PERIPHERAL_USERNAME, PERIPHERAL_PASSWD, PERIPHERAL_FQDN);
+        CredentialsFactory.storeCredentials(sccCredentialsTowardsPeripheral);
+
+        IssPeripheral peripheral = new IssPeripheral(PERIPHERAL_FQDN, "");
+        HubFactory hubFactory = new HubFactory();
+        hubFactory.save(peripheral);
+    }
+
+    private void setupEndpoint() throws URISyntaxException {
+        URI url = new URI(HUB_FQDN);
+        String uuid = ContentSyncManager.getUUID();
+        SCCProxyManager sccProxyManager = new SCCProxyManager();
+        SCCEndpoints endpoints = new SCCEndpoints(uuid, url, sccProxyManager);
+        endpoints.initRoutes(null);
+    }
+
+    private List<SCCRegCacheItem> getAllSCCRegCacheItems() {
+        return HibernateFactory.getSession()
+                .createNativeQuery("SELECT * FROM suseSCCRegCache", SCCRegCacheItem.class)
+                .getResultList();
+    }
+
+    private void assertPreConditions() {
+        assertEquals(
+                systemSize.intValue(),
+                testSystems.stream().filter(i -> i.isSccRegistrationRequired()).count(),
+                "initially all systems should require registration"
+        );
+        assertEquals(
+                0,
+                testSystems.stream().filter(i -> i.getOptRegistrationErrorTime().isPresent()).count(),
+                "initially no system should have a registration error time"
+        );
+        assertEquals(
+                0,
+                testSystems.stream().filter(i -> i.getOptCredentials().isPresent()).count(),
+                "initially no system should have credentials"
+        );
+        assertEquals(
+                0,
+                testSystems.stream().filter(i -> i.getOptSccId().isPresent()).count(),
+                "initially no system should have a scc id"
+        );
+    }
+
+    private void assertPostConditionsCount(
+            int expectedRegistered,
+            int expectedFailed,
+            int expectedProcessed
+    ) {
+        assertEquals(
+                expectedRegistered,
+                testSystems.stream().filter(i -> i.getOptSccId().isPresent()).count(),
+                "Sucessful registered systems mismatch"
+        );
+        assertEquals(
+                expectedFailed,
+                testSystems.stream().filter(i -> i.isSccRegistrationRequired()).count(),
+                "no system should still be requiring registration"
+        );
+        assertEquals(
+                expectedFailed,
+                testSystems.stream().filter(i -> i.getOptRegistrationErrorTime().isPresent()).count(),
+                "no system should have a registration error time set"
+        );
+        assertEquals(
+                expectedProcessed,
+                testSystems.stream().filter(i -> i.getOptCredentials().isPresent()).count(),
+                "no new systems should have credentials"
+        );
+    }
+
+    @Test
+    public void testSuccessSystemRegistrationWhenNoSystemsProvided() throws Exception {
+        systemSize = 0;
+        setupTest();
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(0, 0, 0);
+    }
+
+    /**
+     * Tests when all systems are payg.
+     */
+    @Test
+    public void testSuccessSystemRegistrationWhenAllSystemsArePayG() throws Exception {
+        setupTest();
+        servers.stream().forEach(i -> i.setPayg(true));
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(0, 0, 15);
+    }
+
+    @Test
+    public void testSuccessSystemRegistrationWhenAllSystemsAreCreated() throws Exception {
+        setupTest();
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(15, 0, 15);
+    }
+
+
+    @Test
+    public void testSuccessSystemRegistrationWhenAllSccRequestsFail() throws Exception {
+        allowAllCallsToFail = true;
+        setupTest();
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(0, 15, 0);
+    }
+
+    // Test if every scenario works as expected when occur together.
+    // In this case, the logic is as it follows:
+    // - 30 systems are pending to be registered
+    // - 5 are payg
+    // - 9 will fail registering as the first SCC api call will fail.
+    // This means:
+    // - the remaining 16 systems will be successfully registered and will have a scc id
+    // - the 9 systems that fail and will still require registration and also have a registration error time set
+    // - 21 systems (the successfully registered systems + payg ones) will have credentials.
+    @Test
+    public void testSuccessSystemRegistration() throws Exception {
+        systemSize = 30;
+        batchSize = 9;
+        allowFirstCallToFail = true;
+        final int skipRegister = 5;
+        setupTest();
+
+        for (int i = 0; i < skipRegister; i++) {
+            this.servers.get(i).setPayg(true);
+        }
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(16, 9, 21);
+    }
+
+    @Test
+    public void testWithHub() throws Exception {
+        systemSize = 5;
+        setupTest();
+        setupAsPeripheral();
+        setupAsHub();
+        setupEndpoint();
+
+        assertPreConditions();
+
+        URI url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));
+        String uuid = ContentSyncManager.getUUID();
+        SCCConfig sccConfig = new SCCConfigBuilder()
+                .setUrl(url)
+                .setUsername("")
+                .setPassword("")
+                .setUuid(uuid)
+                .createSCCConfig();
+        MockHttpClientAdapter newAdapter = new MockHttpClientAdapter(sccConfig);
+        SCCWebClient sccClient = new SCCWebClient(sccConfig, newAdapter);
+        SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
+
+        assertEquals(systemSize, testSystems.size());
+        assertEquals(systemSize, servers.size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATED).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING).size());
+
+        SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient, sccProxyFactory);
+
+        Optional<SCCCredentials> optCred = mockForwardRegistrationTask.findSccCredentials();
+        if (optCred.isEmpty()) {
+            throw new IllegalStateException("optCred should have a value");
+        }
+        mockForwardRegistrationTask.executeSCCTasksCore(sccRegManager, sccProxyFactory, optCred.get());
+
+        assertPostConditionsCount(systemSize, 0, systemSize);
+
+        List<SCCProxyRecord> proxyRecords =
+                sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING);
+
+        //TODO FIXME
+        /*
+        assertEquals(systemSize, proxyRecords.size());
+        if (systemSize == proxyRecords.size()) {
+            SCCProxyRecord proxyRecord = proxyRecords.get(0);
+            assertTrue(proxyRecord.getOptSccId().isEmpty());
+            assertEquals(PERIPHERAL_FQDN, proxyRecord.getPeripheralFqdn());
+            assertTrue(proxyRecord.getProxyId() > 0);
+        }
+        */
+
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATED).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING).size());
+        //TODO FIXME
+        /*
+        List<SCCRegCacheItem> sccRegCacheItems = getAllSCCRegCacheItems();
+
+        assertEquals(systemSize, sccRegCacheItems.size());
+        if (systemSize == sccRegCacheItems.size()) {
+            SCCRegCacheItem sccRegCacheItem = sccRegCacheItems.get(0);
+            assertFalse(sccRegCacheItem.isSccRegistrationRequired());
+            assertTrue(sccRegCacheItem.getOptSccId().isPresent());
+            assertTrue(sccRegCacheItem.getOptServer().isPresent());
+        }
+
+        //delete
+        ServerFactory.delete(servers.get(0));
+        ServerFactory.delete(servers.get(1));
+
+        mockForwardRegistrationTask.executeSCCTasksCore(sccRegManager, sccProxyFactory, optCred.get());
+        assertEquals(systemSize - 2,
+                sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATED).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING).size());
+       */
+    }
+
+}

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -24,8 +24,11 @@ import com.suse.scc.client.SCCClient;
 import com.suse.scc.client.SCCClientException;
 import com.suse.scc.model.SCCUpdateSystemJson;
 import com.suse.scc.model.SCCVirtualizationHostJson;
+import com.suse.scc.proxy.SCCProxyFactory;
+import com.suse.scc.proxy.SCCProxyRecord;
 import com.suse.scc.registration.SCCSystemRegistration;
 
+import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,14 +43,32 @@ public class SCCSystemRegistrationManager {
 
     private static final Logger LOG = LogManager.getLogger(SCCSystemRegistrationManager.class);
     private final SCCClient sccClient;
+    private final SCCProxyFactory sccProxyFactory;
+    private final SCCSystemRegistration sccSystemRegistration;
 
     /**
      * Constructor
      *
      * @param sccClientIn the scc client
+     * @param sccProxyFactoryIn the scc proxy factory
      */
-    public SCCSystemRegistrationManager(SCCClient sccClientIn) {
+    public SCCSystemRegistrationManager(SCCClient sccClientIn, SCCProxyFactory sccProxyFactoryIn) {
+        this(sccClientIn, sccProxyFactoryIn, new SCCSystemRegistration());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param sccClientIn             the scc client
+     * @param sccProxyFactoryIn       the scc proxy factory
+     * @param sccSystemRegistrationIn the scc system registration
+     */
+    public SCCSystemRegistrationManager(SCCClient sccClientIn,
+                                        SCCProxyFactory sccProxyFactoryIn,
+                                        SCCSystemRegistration sccSystemRegistrationIn) {
         this.sccClient = sccClientIn;
+        this.sccProxyFactory = sccProxyFactoryIn;
+        this.sccSystemRegistration = sccSystemRegistrationIn;
     }
 
     /**
@@ -98,16 +119,7 @@ public class SCCSystemRegistrationManager {
                         SCCCachingFactory.deleteRegCacheItem(cacheItem);
                     }
                     catch (SCCClientException e) {
-                        if (e.getHttpStatusCode() == 404) {
-                            LOG.info("System {} not found in SCC", cacheItem.getId());
-                        }
-                        else {
-                            LOG.error("SCC error while deregistering system {}", cacheItem.getId(), e);
-                        }
-                        if (forceDBDeletion || e.getHttpStatusCode() == 404) {
-                            SCCCachingFactory.deleteRegCacheItem(cacheItem);
-                        }
-                        cacheItem.setRegistrationErrorTime(new Date());
+                        handleErrorDeregister(cacheItem, e, forceDBDeletion);
                     }
                     catch (Exception e) {
                         LOG.error("Error deregistering system {}", cacheItem.getId(), e);
@@ -121,6 +133,78 @@ public class SCCSystemRegistrationManager {
         ));
     }
 
+    private void handleErrorDeregister(SCCRegCacheItem cacheItem, SCCClientException e, boolean forceDBDeletion) {
+        if (e.getHttpStatusCode() == 404) {
+            LOG.info("System {} not found in SCC", cacheItem.getId());
+        }
+        else {
+            LOG.error("SCC error while deregistering system {}", cacheItem.getId(), e);
+        }
+        if (forceDBDeletion || e.getHttpStatusCode() == 404) {
+            SCCCachingFactory.deleteRegCacheItem(cacheItem);
+        }
+        cacheItem.setRegistrationErrorTime(new Date());
+    }
+
+    /**
+     * De-register a system from SCC
+     *
+     * @param proxyRecords the proxy records identifying the system to de-register
+     * @param forceDBDeletion force delete the proxy record when set to true
+     */
+    public void proxyDeregister(List<SCCProxyRecord> proxyRecords, boolean forceDBDeletion) {
+        proxyRecords.forEach(proxyRecord -> proxyRecord.getOptSccId().ifPresentOrElse(
+                sccId -> {
+                    try {
+                        LOG.debug("de-register system {}", proxyRecord);
+                        sccClient.deleteSystem(sccId, proxyRecord.getSccLogin(), proxyRecord.getSccPasswd());
+                        sccProxyFactory.remove(proxyRecord);
+                    }
+                    catch (SCCClientException e) {
+                        handleErrorProxyDeregister(proxyRecord, e, forceDBDeletion);
+                    }
+                    catch (Exception e) {
+                        handleErrorProxyDeregister(proxyRecord, e);
+                    }
+                },
+                () -> {
+                    LOG.debug("delete not registered cache item {}", proxyRecord);
+                    sccProxyFactory.remove(proxyRecord);
+                }
+        ));
+    }
+
+    private void handleErrorProxyDeregister(SCCProxyRecord proxyRecord, SCCClientException e, boolean forceDBDeletion) {
+        boolean doRemove = forceDBDeletion;
+        if (e.getHttpStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            LOG.info("System {} not found in SCC", proxyRecord.getSccId());
+            doRemove = true;
+        }
+        else {
+            handleErrorProxyDeregister(proxyRecord, e);
+        }
+
+        if (doRemove) {
+            sccProxyFactory.remove(proxyRecord);
+        }
+    }
+
+    private void handleErrorProxyDeregister(SCCProxyRecord proxyRecord, Exception e) {
+        LOG.error("Error while deregistering system {}", proxyRecord.getSccId(), e);
+        proxyRecord.setSccRegistrationErrorTime(new Date());
+        sccProxyFactory.save(proxyRecord);
+    }
+
+    /**
+     * Register systems in SCC
+     *
+     * @param proxyRecords the proxy records identifying the system to register
+     * @param primaryCredential the current primary organization credential
+     */
+    public void proxyRegister(List<SCCProxyRecord> proxyRecords, SCCCredentials primaryCredential) {
+        //new SCCSystemRegistration().register(sccClient, items, primaryCredential)
+    }
+
     /**
      * Register systems in SCC
      *
@@ -128,7 +212,7 @@ public class SCCSystemRegistrationManager {
      * @param primaryCredential the current primary organization credential
      */
     public void register(List<SCCRegCacheItem> items, SCCCredentials primaryCredential) {
-        new SCCSystemRegistration().register(sccClient, items, primaryCredential);
+        sccSystemRegistration.register(sccClient, items, primaryCredential);
     }
 
     /**

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -122,8 +122,17 @@ public class SCCWebClient implements SCCClient {
      * @param configIn the configuration object
      */
     public SCCWebClient(SCCConfig configIn) {
+        this(configIn, new HttpClientAdapter(configIn.getAdditionalCerts(), false));
+    }
+
+    /**
+     * Constructor for testing purposes
+     * @param configIn the configuration object
+     * @param httpClientIn the HttpClientAdapter object
+     */
+    public SCCWebClient(SCCConfig configIn, HttpClientAdapter httpClientIn) {
         config = configIn;
-        httpClient = new HttpClientAdapter(configIn.getAdditionalCerts(), false);
+        httpClient = httpClientIn;
     }
 
     private <T> T writeCache(T value, String name) {

--- a/java/code/src/com/suse/scc/model/SCCSystemCredentialsJson.java
+++ b/java/code/src/com/suse/scc/model/SCCSystemCredentialsJson.java
@@ -14,25 +14,52 @@
  */
 package com.suse.scc.model;
 
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+
 /**
- * SCCSystemCredentialsJson
+ * SCCSystemCredentialsJson: response to SCC put to /organizations/systems
  */
 public class SCCSystemCredentialsJson {
 
+    private Long id;
     private String login;
     private String password;
-    private Long id;
+    @SerializedName("system_token")
+    private String systemToken;
+    @SerializedName("last_seen_at")
+    private Date lastSeenAt;
 
     /**
      * Constructor
-     * @param loginIn the login
+     *
+     * @param loginIn    the login
      * @param passwordIn the password
-     * @param idIn the scc ID
+     * @param idIn       the scc ID
      */
     public SCCSystemCredentialsJson(String loginIn, String passwordIn, Long idIn) {
-       this.login = loginIn;
-       this.password = passwordIn;
-       this.id = idIn;
+        this.login = loginIn;
+        this.password = passwordIn;
+        this.id = idIn;
+        this.systemToken = null;
+        this.lastSeenAt = null;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param loginIn      the login
+     * @param passwordIn   the password
+     * @param idIn         the scc ID
+     * @param lastSeenAtIn the last seen date
+     */
+    public SCCSystemCredentialsJson(String loginIn, String passwordIn, Long idIn, Date lastSeenAtIn) {
+        this.login = loginIn;
+        this.password = passwordIn;
+        this.id = idIn;
+        this.systemToken = null;
+        this.lastSeenAt = lastSeenAtIn;
     }
 
     /**

--- a/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.scc.proxy;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+public class SCCProxyFactory extends HibernateFactory {
+
+    private static final Logger LOG = LogManager.getLogger(SCCProxyFactory.class);
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    /**
+     * Save a {@link SCCProxyRecord} object
+     *
+     * @param sccProxyRecord object to save
+     */
+    public void save(SCCProxyRecord sccProxyRecord) {
+        sccProxyRecord.setModified(new Date());
+        saveObject(sccProxyRecord);
+    }
+
+    /**
+     * Remove a {@link SCCProxyRecord} object
+     *
+     * @param sccProxyRecord object to remove
+     */
+    public void remove(SCCProxyRecord sccProxyRecord) {
+        removeObject(sccProxyRecord);
+    }
+
+    /**
+     * Lookup {@link SCCProxyRecord} object by its proxy generated id
+     *
+     * @param proxyId the proxy generated id
+     * @return return {@link SCCProxyRecord} with the given proxy generated id or empty
+     */
+    public Optional<SCCProxyRecord> lookupByProxyId(long proxyId) {
+        return getSession()
+                .createQuery("FROM SCCProxyRecord WHERE proxyId = :proxyId", SCCProxyRecord.class)
+                .setParameter("proxyId", proxyId)
+                .uniqueResultOptional();
+    }
+
+    /**
+     * Lookup {@link SCCProxyRecord} list of objects with given status
+     *
+     * @param statusIn the status
+     * @return return list of {@link SCCProxyRecord} with the given status
+     */
+    public List<SCCProxyRecord> lookupByStatus(SccProxyStatus statusIn) {
+        return getSession()
+                .createQuery("FROM SCCProxyRecord WHERE status = :status", SCCProxyRecord.class)
+                .setParameter("status", statusIn)
+                .list();
+    }
+
+    /**
+     * Lookup {@link SCCProxyRecord} list of objects with given status and with retry time not expired
+     *
+     * @param statusIn the status
+     * @return return list of {@link SCCProxyRecord} with the given status
+     */
+    public List<SCCProxyRecord> lookupByStatusAndRetry(SccProxyStatus statusIn) {
+        int regErrorExpireTime = Config.get().getInt(ConfigDefaults.REG_ERROR_EXPIRE_TIME, 168);
+        Calendar retryTime = Calendar.getInstance();
+        retryTime.add(Calendar.HOUR, -1 * regErrorExpireTime);
+
+        return getSession()
+                .createQuery("""
+                            FROM SCCProxyRecord
+                            WHERE status = :status
+                            AND (sccRegistrationErrorTime IS NULL
+                                 OR sccRegistrationErrorTime < :retryTime)
+                        """, SCCProxyRecord.class)
+                .setParameter("status", statusIn)
+                .setParameter("retryTime", new Date(retryTime.getTimeInMillis()))
+                .list();
+    }
+
+    /**
+     * Returns registration items of systems which should be forwarded to SCC
+     *
+     * @return list of {@link SCCProxyRecord}
+     */
+    public List<SCCProxyRecord> findSystemsToForwardRegistration() {
+        return lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING);
+    }
+
+    /**
+     * Returns registration items of systems which should be de-registered from SCC
+     *
+     * @return list of {@link SCCProxyRecord}
+     */
+    public List<SCCProxyRecord> listDeregisterItems() {
+        return lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING);
+    }
+}

--- a/java/code/src/com/suse/scc/proxy/SCCProxyManager.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyManager.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.scc.proxy;
+
+import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.utils.Json;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Business logic to manage SCC proxy in hub
+ */
+public class SCCProxyManager {
+
+    private final SCCProxyFactory sccProxyFactory;
+
+    /**
+     * Default constructor
+     */
+    public SCCProxyManager() {
+        this(new SCCProxyFactory());
+    }
+
+    /**
+     * Builds an instance with the given dependencies
+     *
+     * @param sccProxyFactoryIn the sccProxyFactory factory
+     */
+    public SCCProxyManager(SCCProxyFactory sccProxyFactoryIn) {
+        this.sccProxyFactory = sccProxyFactoryIn;
+    }
+
+    /**
+     * Creates systems from the lists and stores data to be later registered to SCC
+     *
+     * @param systemsList a list of {@Link SCCRegisterSystemJson} to be created
+     * @param peripheralFqdnIn the fqdn of the peripheral
+     * @return list of corresponding generated records
+     */
+    public List<SCCProxyRecord> createSystems(List<SCCRegisterSystemJson> systemsList, String peripheralFqdnIn) {
+
+        List<SCCProxyRecord> systemsRecords = new ArrayList<>();
+
+        for (SCCRegisterSystemJson system : systemsList) {
+            String sccLogin = system.getLogin();
+            String sccPasswd = system.getPassword();
+            String sccCreationJson = Json.GSON.toJson(system);
+
+            SCCProxyRecord sccProxyRecord = new SCCProxyRecord(peripheralFqdnIn, sccLogin, sccPasswd, sccCreationJson);
+            sccProxyFactory.save(sccProxyRecord);
+            systemsRecords.add(sccProxyRecord);
+        }
+
+        return systemsRecords;
+    }
+
+    /**
+     * Marks a system for deletion
+     *
+     * @param systemProxyId the proxy id of the system
+     * @return false if the id was not found
+     */
+    public boolean deleteSystem(long systemProxyId) {
+        Optional<SCCProxyRecord> proxyRecord = sccProxyFactory.lookupByProxyId(systemProxyId);
+
+        if (proxyRecord.isPresent()) {
+            SCCProxyRecord sccProxyRecord = proxyRecord.get();
+            sccProxyRecord.setStatus(SccProxyStatus.SCC_REMOVAL_PENDING);
+            sccProxyFactory.save(sccProxyRecord);
+            return true;
+        }
+
+        return false; //not found
+    }
+
+    //registerToScc()
+    //
+}

--- a/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.scc.proxy;
+
+import static java.util.Optional.ofNullable;
+
+import com.redhat.rhn.domain.BaseDomainHelper;
+
+import org.hibernate.annotations.Type;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+@Entity
+@Table(name = "suseSccProxy")
+public class SCCProxyRecord extends BaseDomainHelper {
+
+    private Long proxyId;
+    private String peripheralFqdn;
+    private String sccLogin;
+    private String sccPasswd;
+    private String sccCreationJson;
+    private Long sccId;
+    private Date sccRegistrationErrorTime;
+    private SccProxyStatus status;
+
+    /**
+     * Default constructor
+     */
+    public SCCProxyRecord() {
+        this(null, null, null, null);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param peripheralFqdnIn peripheral from which the request comes from
+     * @param sccLoginIn login of the system to register in SCC
+     * @param sccPasswdIn password of the system to register in SCC
+     * @param sccCreationJsonIn original creation json of the system to register in SCC
+     */
+    public SCCProxyRecord(String peripheralFqdnIn, String sccLoginIn, String sccPasswdIn, String sccCreationJsonIn) {
+        peripheralFqdn = peripheralFqdnIn;
+        sccLogin = sccLoginIn;
+        sccPasswd = sccPasswdIn;
+        sccCreationJson = sccCreationJsonIn;
+        status = SccProxyStatus.SCC_CREATION_PENDING;
+    }
+
+    @Id
+    @Column(name = "proxy_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long getProxyId() {
+        return proxyId;
+    }
+
+    public void setProxyId(Long proxyIdIn) {
+        proxyId = proxyIdIn;
+    }
+
+    @Column(name = "peripheral_fqdn")
+    public String getPeripheralFqdn() {
+        return peripheralFqdn;
+    }
+
+    public void setPeripheralFqdn(String peripheralFqdnIn) {
+        peripheralFqdn = peripheralFqdnIn;
+    }
+
+    @Column(name = "scc_login")
+    public String getSccLogin() {
+        return sccLogin;
+    }
+
+    public void setSccLogin(String sccLoginIn) {
+        sccLogin = sccLoginIn;
+    }
+
+    @Column(name = "scc_passwd")
+    public String getSccPasswd() {
+        return sccPasswd;
+    }
+
+    public void setSccPasswd(String sccPasswdIn) {
+        sccPasswd = sccPasswdIn;
+    }
+
+    @Column(name = "scc_creation_json")
+    public String getSccCreationJson() {
+        return sccCreationJson;
+    }
+
+    public void setSccCreationJson(String sccCreationJsonIn) {
+        sccCreationJson = sccCreationJsonIn;
+    }
+
+    @Column(name = "scc_id")
+    public Long getSccId() {
+        return sccId;
+    }
+
+    public void setSccId(Long sccIdIn) {
+        sccId = sccIdIn;
+    }
+
+    /**
+     * @return Returns the SCC ID when this system was registered already
+     */
+    @Transient
+    public Optional<Long> getOptSccId() {
+        return ofNullable(sccId);
+    }
+
+    @Column(name = "scc_regerror_timestamp")
+    public Date getSccRegistrationErrorTime() {
+        return sccRegistrationErrorTime;
+    }
+
+    public void setSccRegistrationErrorTime(Date sccRegistrationErrorTimeIn) {
+        sccRegistrationErrorTime = sccRegistrationErrorTimeIn;
+    }
+
+    /**
+     * @return the time when the last registration failed
+     */
+    @Transient
+    public Optional<Date> getOptSccRegistrationErrorTime() {
+        return ofNullable(sccRegistrationErrorTime);
+    }
+
+    @Type(type = "com.suse.scc.proxy.SccProxyStatusEnumType")
+    public SccProxyStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SccProxyStatus statusIn) {
+        status = statusIn;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (!(oIn instanceof SCCProxyRecord that)) {
+            return false;
+        }
+        return Objects.equals(getProxyId(), that.getProxyId()) &&
+                Objects.equals(getPeripheralFqdn(), that.getPeripheralFqdn()) &&
+                Objects.equals(getSccLogin(), that.getSccLogin()) &&
+                Objects.equals(getSccPasswd(), that.getSccPasswd()) &&
+                Objects.equals(getSccId(), that.getSccId()) &&
+                Objects.equals(getStatus(), that.getStatus());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getProxyId(),
+                getPeripheralFqdn(),
+                getSccLogin(),
+                getSccPasswd(),
+                getSccId(),
+                getStatus());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("SCCProxyRecord{");
+        sb.append("proxyId=").append(proxyId);
+        sb.append(", peripheralFqdn='").append(peripheralFqdn).append('\'');
+        sb.append(", sccLogin='").append(sccLogin).append('\'');
+        sb.append(", sccPasswd='").append(sccPasswd).append('\'');
+        sb.append(", sccCreationJson='").append(sccCreationJson).append('\'');
+        sb.append(", sccId=").append(sccId);
+        sb.append(", sccRegistrationErrorTime=").append(sccRegistrationErrorTime);
+        sb.append(", status=").append(status);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/java/code/src/com/suse/scc/proxy/SccProxyStatus.java
+++ b/java/code/src/com/suse/scc/proxy/SccProxyStatus.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.scc.proxy;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.Labeled;
+
+public enum SccProxyStatus implements Labeled {
+    SCC_CREATION_PENDING,
+    SCC_CREATED,
+    SCC_REMOVAL_PENDING;
+
+    @Override
+    public String getLabel() {
+        return this.name().toLowerCase();
+    }
+
+    public String getDescription() {
+        return LocalizationService.getInstance().getMessage("proxy.status." + this.name().toLowerCase());
+    }
+}

--- a/java/code/src/com/suse/scc/proxy/SccProxyStatusEnumType.java
+++ b/java/code/src/com/suse/scc/proxy/SccProxyStatusEnumType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.scc.proxy;
+
+import com.redhat.rhn.domain.DatabaseEnumType;
+
+/**
+ * Maps the {@link SccProxyStatus} enum to its label
+ */
+public class SccProxyStatusEnumType extends DatabaseEnumType<SccProxyStatus> {
+
+    /**
+     * Default Constructor
+     */
+    public SccProxyStatusEnumType() {
+        super(SccProxyStatus.class);
+    }
+}
+

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistration.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistration.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class SCCSystemRegistration {
 
-    private final List<SCCSystemRegistrationContextHandler> contextHandlerChain = new ArrayList<>();
+    protected final List<SCCSystemRegistrationContextHandler> contextHandlerChain = new ArrayList<>();
 
     /**
      * Constructor

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
@@ -46,7 +46,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
         context.getItems().forEach(cacheItem -> cacheItem.getOptServer().ifPresent(ServerFactory::save));
     }
 
-    private void updateSuccessfullyRegisteredItems(SCCSystemRegistrationContext context) {
+    protected void updateSuccessfullyRegisteredItems(SCCSystemRegistrationContext context) {
         for (SCCSystemCredentialsJson systemCredentials : context.getRegisteredSystems()) {
 
             SCCRegCacheItem cacheItem = context.getItemsByLogin().get(systemCredentials.getLogin());
@@ -63,7 +63,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
         }
     }
 
-    private void updateFailedRegisteredItems(SCCSystemRegistrationContext context) {
+    protected void updateFailedRegisteredItems(SCCSystemRegistrationContext context) {
         for (Map.Entry<String, SCCRegisterSystemJson> entry :
                 context.getPendingRegistrationSystemsByLogin().entrySet()) {
             SCCRegCacheItem cacheItem = context.getItemsByLogin().get(entry.getKey());
@@ -74,7 +74,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
         }
     }
 
-    private void updatePaygSystems(SCCSystemRegistrationContext context) {
+    protected void updatePaygSystems(SCCSystemRegistrationContext context) {
         context.getPaygSystems().forEach(cacheItem -> context.setItemAsNonRegistrationRequiredItem(cacheItem));
     }
 

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
@@ -51,6 +51,7 @@ import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.model.SCCUpdateSystemJson;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 import com.suse.scc.model.SCCVirtualizationHostPropertiesJson;
+import com.suse.scc.proxy.SCCProxyFactory;
 
 import org.junit.jupiter.api.Test;
 
@@ -66,6 +67,7 @@ import java.util.stream.Collectors;
  * Tests for {@link SCCClient} methods.
  */
 public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
+    private SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
 
     @Test
     public void testSCCSystemRegistrationLifecycle() throws Exception {
@@ -110,7 +112,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
         };
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCRegCacheItem> testSystems = allUnregistered.stream()
@@ -172,7 +175,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
                 .createSCCConfig();
         SCCWebClient sccWebClient = new SCCWebClient(sccConfig);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
 
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
@@ -238,7 +242,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
         };
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCRegCacheItem> testSystems = allUnregistered.stream()
@@ -312,7 +317,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
         };
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCRegCacheItem> testSystems = allUnregistered.stream()
@@ -403,7 +409,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         credentials.setUrl("https://scc.suse.com");
         CredentialsFactory.storeCredentials(credentials);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCVirtualizationHostJson> virtHostsJson = SCCCachingFactory.listVirtualizationHosts();
@@ -489,7 +496,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         credentials.setUrl("https://scc.suse.com");
         CredentialsFactory.storeCredentials(credentials);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCVirtualizationHostJson> virtHostsJson = SCCCachingFactory.listVirtualizationHosts();
@@ -590,7 +598,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         credentials.setUrl("https://scc.suse.com");
         CredentialsFactory.storeCredentials(credentials);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCVirtualizationHostJson> virtHostsJson = SCCCachingFactory.listVirtualizationHosts();

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
@@ -36,6 +36,7 @@ import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.proxy.SCCProxyFactory;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,6 +65,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
     private Integer systemSize;
     private Integer batchSize;
 
+    private SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
 
     @Override
     @BeforeEach
@@ -115,7 +117,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -136,7 +139,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -156,7 +160,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -191,7 +196,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -253,7 +259,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions

--- a/schema/spacewalk/common/tables/suseSccProxy.sql
+++ b/schema/spacewalk/common/tables/suseSccProxy.sql
@@ -1,0 +1,34 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+
+CREATE TABLE suseSccProxy
+(
+    proxy_id            BIGINT CONSTRAINT suse_sccproxy_proxy_id_pk PRIMARY KEY
+                                                  GENERATED ALWAYS AS IDENTITY,
+    peripheral_fqdn     VARCHAR(128),
+    scc_login           VARCHAR(64),
+    scc_passwd          VARCHAR(64),
+    scc_creation_json   TEXT,
+    scc_id              NUMERIC,
+    status              scc_proxy_status_t NOT NULL,
+    scc_regerror_timestamp TIMESTAMPTZ,
+
+    created        TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL
+);
+

--- a/schema/spacewalk/common/tables/tables.deps
+++ b/schema/spacewalk/common/tables/tables.deps
@@ -261,6 +261,7 @@ susePackageState                   :: rhnPackageName rhnPackageEVR rhnPackageArc
 suseProducts                       :: rhnPackageArch rhnChannelFamily
 suseProductChannel                 :: suseProducts rhnChannel
 suseProductExtension               :: suseProducts
+suseSccProxy                       :: scc_proxy_status_t
 suseChannelTemplate                :: suseProducts suseSCCRepository
 suseSaltPillar                     :: rhnServer rhnServerGroup web_customer
 suseSCCOrderItem                   :: suseCredentials

--- a/schema/spacewalk/postgres/class/scc_proxy_status_t.sql
+++ b/schema/spacewalk/postgres/class/scc_proxy_status_t.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TYPE scc_proxy_status_t AS ENUM (
+    'scc_creation_pending',
+    'scc_created',
+    'scc_removal_pending'
+);

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.6-to-susemanager-schema-5.1.7/600-create_suseSccProxy.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.6-to-susemanager-schema-5.1.7/600-create_suseSccProxy.sql
@@ -1,0 +1,46 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'scc_proxy_status_t') THEN
+        CREATE TYPE scc_proxy_status_t AS ENUM (
+            'scc_creation_pending',
+            'scc_created',
+            'scc_removal_pending'
+        );
+    ELSE
+        RAISE NOTICE 'type "scc_proxy_status_t" already exists, skipping';
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS suseSccProxy
+(
+    proxy_id            BIGINT CONSTRAINT suse_sccproxy_proxy_id_pk PRIMARY KEY
+                                                  GENERATED ALWAYS AS IDENTITY,
+    peripheral_fqdn     VARCHAR(128),
+    scc_login           VARCHAR(64),
+    scc_passwd          VARCHAR(64),
+    scc_creation_json   TEXT,
+    scc_id              NUMERIC,
+    status              scc_proxy_status_t NOT NULL,
+    scc_regerror_timestamp TIMESTAMPTZ,
+
+    created        TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL
+);
+


### PR DESCRIPTION
## What does this PR change?

This is the upstream branch referred to https://github.com/uyuni-project/uyuni/pull/10229

SUSE Manager send data about registered systems to SCC. In a Hub scenario, the peripheral server should send the data to the Hub and the Hub should send it to SCC.
This PR puts the basis of having the Hub acting as a proxy to the SCC, in particular:
- Creates DB schema on the Hub to hold data send from peripheral server 
- Add endpoints to act as if it was an SCC:
        PUT /connect/organizations/systems (create systems)
        DELETE /connect/organizations/systems/:id (delete systems)


## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/25350
Port(s): not backported
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
