### PR TITLE
Upload Cucumber JSON Reports For PR Acceptance Tests

### DIFF
--- a/.github/workflows/acceptance_tests_base.yml
+++ b/.github/workflows/acceptance_tests_base.yml
@@ -213,6 +213,20 @@ jobs:
       - name: Run acceptance tests
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
         run: ./testsuite/podman_runner/${{ inputs.tests }}
+      
+      - name: Upload Cucumber JSON Reports
+        if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 #v4.6.1
+        with:
+          name: cucumber-json-reports
+          path: ./testsuite/results/**/*.json
+          if-no-files-found: warn
+          # Duration after which the artifact will expire in days.
+          # The maximum is 90 days.
+          retention-days: 90 
+          # Default compression level is '6', the same as GNU Gzip.
+          # For more details: https://github.com/actions/upload-artifact?tab=readme-ov-file#altering-compressions-level-speed-v-size
+          compression-level: 6
 
       - name: Get server logs
         if: ${{ failure() && !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true'}}


### PR DESCRIPTION
## What does this PR change?

This PR adds a GitHub Actions step to upload Cucumber JSON reports as a GitHub Actions Artifact after running PR acceptance tests. Having these reports uploaded as artifacts ensures we retain valuable test result data tied to specific code changes. This data is useful for long-term analysis and especially for the [AI-Driven Test Selection](https://github.com/openSUSE/mentoring/issues/244) project proposed for Google Summer of Code 2025.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No links.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
