### PR TITLE
Fix typo in RBAC ACL 'authorized_for' in system details header (bsc#1241697)

### DIFF
--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -157,8 +157,8 @@
 
     <rhn-tab name="Power Management" url="/rhn/systems/details/kickstart/PowerManagement.do" acl="system_feature(ftr_kickstart)" node-id="power_management" />
 
-    <rhn-tab name="Snapshots" acl="authoized_for(systems.snapshots); client_capable(packages.runTransaction) or client_capable(configfiles.deploy); system_feature(ftr_snapshotting)" url="/rhn/systems/details/history/snapshots/Index.do" showChildrenIfActive="0">
-      <rhn-tab name="Rollback" acl="authoized_for(systems.snapshots, W); " url="/rhn/systems/details/history/snapshots/Rollback.do" />
+    <rhn-tab name="Snapshots" acl="authorized_for(systems.snapshots); client_capable(packages.runTransaction) or client_capable(configfiles.deploy); system_feature(ftr_snapshotting)" url="/rhn/systems/details/history/snapshots/Index.do" showChildrenIfActive="0">
+      <rhn-tab name="Rollback" acl="authorized_for(systems.snapshots, W); " url="/rhn/systems/details/history/snapshots/Rollback.do" />
       <rhn-tab name="Groups" url="/rhn/systems/details/history/snapshots/Groups.do" />
       <rhn-tab name="Channels" url="/rhn/systems/details/history/snapshots/Channels.do" />
       <rhn-tab name="Packages" url="/rhn/systems/details/history/snapshots/Packages.do">
@@ -170,7 +170,7 @@
         <rhn-tab-url>/rhn/systems/details/history/snapshots/SnapshotTagCreate.do</rhn-tab-url>
       </rhn-tab>
     </rhn-tab>
-    <rhn-tab name="Snapshot Tags" acl="authoized_for(systems.snapshots); client_capable(packages.runTransaction) or client_capable(configfiles.deploy); system_feature(ftr_snapshotting)">
+    <rhn-tab name="Snapshot Tags" acl="authorized_for(systems.snapshots); client_capable(packages.runTransaction) or client_capable(configfiles.deploy); system_feature(ftr_snapshotting)">
       <rhn-tab-url>/rhn/systems/details/history/snapshots/Tags.do</rhn-tab-url>
       <rhn-tab-url>/rhn/systems/details/history/snapshots/TagCreate.do</rhn-tab-url>
     </rhn-tab>

--- a/java/spacewalk-java.changes.cbbayburt.bsc1241697
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1241697
@@ -1,0 +1,1 @@
+- Fix typo in the ACLs in system details header (bsc#1241697)


### PR DESCRIPTION
A typo in RBAC ACLs causes ISE on some system pages.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/27069
https://bugzilla.suse.com/show_bug.cgi?id=1241697

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
