### PR TITLE
Remove bootloader linux and initrd files from spacewalk-debug

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -515,6 +515,10 @@ find $DIR -name "server.key*" -delete
 find $DIR -name "server.pem*" -delete
 find $DIR -name "rhn-org-httpd-ssl*" -delete
 
+# Remove bootloader linux+initrd files
+find $DIR/salt-states/generated-sls/bootloader/ -type f -exec truncate -s 0 {} \;
+touch $DIR/salt-states/generated-sls/bootloader/DATA_GOT_TRUNCATED_VIA_SUPPORTCONFIG
+
 # fix permissions
 chmod -R 700 $DIR
 

--- a/python/spacewalk/spacewalk-backend.changes.wtmpx.spacewalk-debug
+++ b/python/spacewalk/spacewalk-backend.changes.wtmpx.spacewalk-debug
@@ -1,0 +1,1 @@
+- Remove bootloader linux and initrd files from spacewalk-debug


### PR DESCRIPTION
## What does this PR change?

Remove bootloader linux and initrd files from spacewalk-debug

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/27091

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
