### PR TITLE
Improve uyuni configfiles sync

### DIFF
--- a/containers/server-image/root/usr/bin/uyuni-configfiles-sync
+++ b/containers/server-image/root/usr/bin/uyuni-configfiles-sync
@@ -167,22 +167,24 @@ sync() {
                     else
                         CHECKSUM=""
                     fi
-                    if [ ! -z "$CHECKSUM" ] && [ "$CHECKSUM" = "$(sha256sum $SOURCE_FILE | awk '{print $1}')" ]; then
-                        # Checksum are equal between new defaults and cached defaults
-                        # this mean changes are made by the user
-                        sync_file $SOURCE_FILE $TARGET_FILE
-                    elif [ ! -z "$CHECKSUM" ] && [ ! "$CHECKSUM" = "$(sha256sum $SOURCE_FILE | awk '{print $1}')" ]; then
-                        # Checksum are different between new defaults and cached defaults checksums
-                        # Meaning changes in file due an upgrade or local user changes
-                        if [ "$CHECKSUM" = "$(sha256sum $TARGET_FILE | awk '{print $1}')" ]; then
-                            # Checksum is equal between cached defaults and target file
-                            # Meaning no local changes and changes are due an upgrade
-                            echo "    - $TARGET_FILE - No local modifications but new changes coming from a package upgrade, replacing file"
-                            rsync -a $SOURCE_FILE $TARGET_FILE
+		    if [ ! -z "$CHECKSUM" ]; then
+                        if [ ! "$CHECKSUM" = "$(sha256sum $SOURCE_FILE | awk '{print $1}')" ]; then
+                            # Checksum are different between new defaults and cached defaults checksums
+                            # Meaning changes in file due an upgrade or local user changes
+                            if [ "$CHECKSUM" = "$(sha256sum $TARGET_FILE | awk '{print $1}')" ]; then
+                                # Checksum is equal between cached defaults and target file
+                                # Meaning no local changes and changes are due an upgrade
+                                echo "    - $TARGET_FILE - No local modifications but new changes coming from a package upgrade, replacing file"
+                                rsync -a $SOURCE_FILE $TARGET_FILE
+                            else
+                                # Local changes made by the user.
+                                sync_file $SOURCE_FILE $TARGET_FILE
+                            fi
                         else
-                            # Local changes made by the user.
-                            sync_file $SOURCE_FILE $TARGET_FILE
-                        fi
+                            # User has changed the file, but the checksum between new defaults and cached defaults
+                            # are the same. This means the original file in the image has not changed. No need to sync or backup
+                            echo "    - $TARGET_FILE - Local modifications, but file has not changed in the image. Keeping"
+			fi
                     else
                         # First sync - no checksums stored yet. Syncing
                         sync_file $SOURCE_FILE $TARGET_FILE

--- a/containers/server-image/root/usr/bin/uyuni-configfiles-sync
+++ b/containers/server-image/root/usr/bin/uyuni-configfiles-sync
@@ -133,7 +133,7 @@ sync() {
             RSYNC_ARGS="--exclude={$LIST_FILES_TO_EXCLUDE}"
         fi
         # Synchronize package files from source excluding (configuration files)
-        CMD="rsync -ab $RSYNC_ARGS --exclude=".pv" --suffix ".rpmsave" $SOURCES $PV"
+        CMD="rsync -a $RSYNC_ARGS --exclude=".pv" $SOURCES $PV"
         eval $CMD
         echo "done!"
 

--- a/containers/server-image/server-image.changes.mcalmer.Manager-5.0-improve-uyuni-configfiles-sync
+++ b/containers/server-image/server-image.changes.mcalmer.Manager-5.0-improve-uyuni-configfiles-sync
@@ -1,0 +1,4 @@
+- No sync when a user modified file was not changed between
+  2 image versions
+- No backup for files which would be replaced directly from
+  RPM as well


### PR DESCRIPTION
## What does this PR change?
- No sync when a user modified file was not changed between 2 image versions
- No backup for files which would be replaced directly from RPM as well

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/26737

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
