### PR TITLE
Remove trailing && \ in server-image Dockerfile

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -70,7 +70,7 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
     rm /etc/krb5.conf.d/crypto-policies && \
     ln -s /etc/crypto-policies/back-ends/krb5.config /etc/krb5.conf.d/crypto-policies && \
     mv "/etc/krb5.conf.d" "/etc/rhn/krb5.conf.d" && \
-    ln -s "/etc/rhn/krb5.conf.d" "/etc/krb5.conf.d" && \
+    ln -s "/etc/rhn/krb5.conf.d" "/etc/krb5.conf.d"
 
 ADD --chown=root:root root.tar.gz /
 


### PR DESCRIPTION
## What does this PR change?

trailing && \ in RUN directive may break the docker image build.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: build failure fix
- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
