### PR TITLE
Use the new names for the Manager tools

### DIFF
--- a/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/salt_migration_minion_migration.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 SUSE LLC
+# Copyright (c) 2023-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # This feature depends on
@@ -32,8 +32,8 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     And I wait until I do not see "Loading..." text
     And I check radio button "SLE-Product-SLES15-SP5-Pool for x86_64"
     And I wait until I see "SLE-Module-Basesystem15-SP5-Pool for x86_64" text
-    And I check "SLE-Manager-Tools15-Pool for x86_64 SP5"
-    And I check "SLE-Manager-Tools15-Updates for x86_64 SP5"
+    And I check "ManagerTools-SLE15-Pool for x86_64 SP5"
+    And I check "ManagerTools-SLE15-Updates for x86_64 SP5"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_minion_migration.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 SUSE LLC
+# Copyright (c) 2022-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @slemicro54_minion
@@ -43,10 +43,10 @@ Feature: Migrate a SLE Micro 5.4 Salt minion to SLE Micro 5.5
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "unselected"
-    When I select the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5"
-    Then I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "selected"
-    And I click on "Next"
+    Then I should see the child channel "ManagerTools-SLE-Micro5-Pool for x86_64 5.5" "unselected"
+    When I select the child channel "ManagerTools-SLE-Micro5-Pool for x86_64 5.5"
+    Then I should see the child channel "ManagerTools-SLE-Micro5-Pool for x86_64 5.5" "selected"
+    When I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text

--- a/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
+++ b/testsuite/features/build_validation/migration/slemicro54_ssh_minion_migration.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2024 SUSE LLC
+# Copyright (c) 2022-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @slemicro54_ssh_minion
@@ -44,10 +44,10 @@ Feature: Migrate a SLE Micro 5.4 Salt SSH minion to SLE Micro 5.5
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "unselected"
-    When I select the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5"
-    Then I should see the child channel "SLE-Manager-Tools-For-Micro5-Pool for x86_64 5.5" "selected"
-    And I click on "Next"
+    Then I should see the child channel "ManagerTools-SLE-Micro5-Pool for x86_64 5.5" "unselected"
+    When I select the child channel "ManagerTools-SLE-Micro5-Pool for x86_64 5.5"
+    Then I should see the child channel "ManagerTools-SLE-Micro5-Pool for x86_64 5.5" "selected"
+    When I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -145,7 +145,7 @@ Feature: Update activation keys
     And I select the parent channel for the "proxy_nontransactional" from "selectedBaseChannel"
     And I wait for child channels to appear
     And I include the recommended child channels
-    And I wait until "SLE-Manager-Tools15-Pool for x86_64 SP7" has been checked
+    And I wait until "ManagerTools-SLE15-Pool for x86_64 SP7" has been checked
     And I check "SUSE-Manager-Proxy-5.1-Pool for x86_64"
     And I check "SUSE-Manager-Proxy-5.1-Updates for x86_64"
     And I click on "Update Activation Key"


### PR DESCRIPTION
## What does this PR change?

Use the new names for the Manager tools instead of the old names.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

Cucumber tests were changed

- [x] **DONE**

## Links

Port(s): no ports, 5.1+ only!

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
