### PR TITLE
Fix filtering of notification messages (bsc#1242141)

### DIFF
--- a/java/buildconf/test/rhn.conf.postgresql-example
+++ b/java/buildconf/test/rhn.conf.postgresql-example
@@ -165,3 +165,6 @@ server.susemanager.scc_backup_srv_usr = 52156f60-8aa2-4165-8645-367efdc2a510
 
 # Disable remote commands from UI
 java.disable_remote_commands_from_ui = false
+
+# disable ChannelSyncFinished for a test
+java.notifications_type_disabled = ChannelSyncFinished

--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -118,7 +118,7 @@ public class UserNotificationFactory extends HibernateFactory {
     public static boolean isNotificationTypeDisabled(NotificationMessage notificationIn) {
         List<String> disableNotificationsBy = ConfigDefaults.get().getNotificationsTypeDisabled();
 
-        return disableNotificationsBy.contains(notificationIn.getType().name());
+        return disableNotificationsBy.contains(notificationIn.getType().getLabel());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.domain.access.AccessGroupFactory;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotification;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
+import com.redhat.rhn.domain.notification.types.ChannelSyncFinished;
 import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.notification.types.StateApplyFailed;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
@@ -88,6 +89,23 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
         assertEquals(1, UserNotificationFactory.unreadUserNotificationsSize(user));
         assertEquals(1, UserNotificationFactory.listUnreadByUser(user).size());
         assertEquals(1, UserNotificationFactory.listAllByUser(user).size());
+        mailer.verify();
+    }
+
+    @Test
+    public final void testUserDisabledNotification() {
+        mailer.setExpectedSendCount(0);
+        UserNotificationFactory.setMailer(mailer);
+        user.setEmailNotify(0);
+
+        assertEquals(0, UserNotificationFactory.unreadUserNotificationsSize(user));
+        NotificationMessage msg = UserNotificationFactory.createNotificationMessage(
+                new ChannelSyncFinished(1L, "dumma-channel"));
+        UserNotificationFactory.storeNotificationMessageFor(msg);
+
+        assertEquals(0, UserNotificationFactory.unreadUserNotificationsSize(user));
+        assertEquals(0, UserNotificationFactory.listUnreadByUser(user).size());
+        assertEquals(0, UserNotificationFactory.listAllByUser(user).size());
         mailer.verify();
     }
 

--- a/java/spacewalk-java.changes.mcalmer.fix-notification-filter
+++ b/java/spacewalk-java.changes.mcalmer.fix-notification-filter
@@ -1,0 +1,1 @@
+- Fix filtering of notification messages (bsc#1242141)


### PR DESCRIPTION
## What does this PR change?

Since we use Labeled class, name is different now.
To compare with the list of disabled notifications we need to use the "label".

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit test added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27132
Port(s): none - only 5.1+ issue

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
