### PR TITLE
Increase timeout to sync channel when code coverage enabled

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -430,6 +430,7 @@ When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
     timeout = 60
   else
     timeout = TIMEOUT_BY_CHANNEL_NAME[channel]
+    timeout *= 2 if $code_coverage_mode
   end
   begin
     repeat_until_timeout(timeout: timeout, message: 'Channel not fully synced') do
@@ -462,6 +463,7 @@ When(/^I wait until all synchronized channels for "([^"]*)" have finished$/) do 
       timeout += 60
     else
       timeout += TIMEOUT_BY_CHANNEL_NAME[channel]
+      timeout += TIMEOUT_BY_CHANNEL_NAME[channel] if $code_coverage_mode
     end
   end
   begin


### PR DESCRIPTION
## What does this PR change?

Increase timeout to sync channel when code coverage enabled

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
