### PR TITLE
Fix saltboot endpoint access (bsc#1242069)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/AuthorizationFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/AuthorizationFilter.java
@@ -155,6 +155,10 @@ public class AuthorizationFilter implements Filter {
     }
 
     private void handleSparkAccess(HttpServletRequest hreq, Set<String> noAuthEndpoints) {
+        if (!authenticationService.requestURIRequiresAuthentication(hreq)) {
+            // The request URI doesn't require authentication.
+            return;
+        }
         RouteMatch route = ServletRoutes.get().find(
                 HttpMethod.get(hreq.getMethod().toLowerCase()),
                 hreq.getServletPath(), hreq.getContentType());
@@ -163,9 +167,8 @@ public class AuthorizationFilter implements Filter {
             throw new PermissionException("Route not found to verify authorization for: " + hreq.getRequestURI());
         }
 
-        // Check if the request URI needs authentication. If so, also check if the URI needs authorization as well.
-        if (!authenticationService.requestURIRequiresAuthentication(hreq) ||
-                noAuthEndpoints.contains(route.getMatchUri())) {
+        if (noAuthEndpoints.contains(route.getMatchUri())) {
+            // The request URI doesn't require authorization.
             return;
         }
 

--- a/java/spacewalk-java.changes.cbbayburt.bsc1242069
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1242069
@@ -1,0 +1,1 @@
+- Fix saltboot endpoint access (bsc#1242069)


### PR DESCRIPTION
As part of the filtering process, RBAC looks up requested URIs in Spark's route list. However, since saltboot `HEAD` requests are not handled by Spark or tomcat, but by apache, RBAC cannot find a corresponding Spark route and blocks access.

Saltboot URIs are unauthenticated, so RBAC can be bypassed for them.

This PR bypasses Spark route lookup for unauthenticated URIs.

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1242069

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
