### PR TITLE
Fix old supportutils functions

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
+++ b/susemanager-utils/supportutils-plugin-susemanager-client/susemanagerclient
@@ -5,7 +5,7 @@
 #              about a SUSE Manager Client
 # License:     GPLv2
 # Author:      Michael Calmer <mc@suse.de>
-# Modified:    2024 February 03
+# Modified:    2025 May 06
 #############################################################
 
 SVER=5.0.0
@@ -102,7 +102,7 @@ SERVICES="
 "
 
 for SERVICE in $SERVICES; do
-    check_service $OF $SERVICE
+    log_cmd $OF "systemctl status $SERVICE"
 done
 
 CONTAINERS="

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager
@@ -6,10 +6,10 @@
 # License:     GPLv2
 # Author:      Stefan Bogner <sbogner@suse.com>
 #              Michael Calmer <mc@suse.com>
-# Modified:    2024 February 03
+# Modified:    2025 May 06
 #############################################################
 
-SVER=5.0.0
+SVER=5.0.1
 RCFILE="/usr/lib/supportconfig/resources/supportconfig.rc"
 OF='plugin-susemanager.txt'
 
@@ -93,17 +93,17 @@ log_entry $OF note "Cloud / PAYG"
 if [ -x /usr/bin/instance-flavor-check ]; then
         log_cmd $OF "/usr/bin/instance-flavor-check"
         if [ $(/usr/bin/instance-flavor-check) == "PAYG" ]; then
-                validate_rpm "python-instance-billing-flavor-check"
-                validate_rpm "billing-data-service"
-                validate_rpm "csp-billing-adapter-service"
-                validate_rpm "python311-csp-billing-adapter"
-                validate_rpm "python311-csp-billing-adapter-local"
-                validate_rpm "python311-csp-billing-adapter-amazon"
-                validate_rpm "suma-amazon-adapter-config-llc"
-                validate_rpm "suma-amazon-adapter-config-ltd"
-                validate_rpm "python311-csp-billing-adapter-azure"
-                validate_rpm "suma-azure-adapter-config-llc"
-                validate_rpm "suma-azure-adapter-config-ltd"
+                rpm_verify $OF "python-instance-billing-flavor-check"
+                rpm_verify $OF "billing-data-service"
+                rpm_verify $OF "csp-billing-adapter-service"
+                rpm_verify $OF "python311-csp-billing-adapter"
+                rpm_verify $OF "python311-csp-billing-adapter-local"
+                rpm_verify $OF "python311-csp-billing-adapter-amazon"
+                rpm_verify $OF "suma-amazon-adapter-config-llc"
+                rpm_verify $OF "suma-amazon-adapter-config-ltd"
+                rpm_verify $OF "python311-csp-billing-adapter-azure"
+                rpm_verify $OF "suma-azure-adapter-config-llc"
+                rpm_verify $OF "suma-azure-adapter-config-ltd"
         else
                 log_write $OF "Not a PAYG Instance"
         fi


### PR DESCRIPTION
## What does this PR change?
Replaces the obsolete `validate_rpm` function with `rpm_verify` provided by supportutils.
Replace the removed `check_service` function bsc#1216231

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- No tests
- [x] **DONE**

## Links
None
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
