### PR TITLE
Fix the health check of the container (bsc#1240604)

### DIFF
--- a/containers/server-attestation-image/Dockerfile
+++ b/containers/server-attestation-image/Dockerfile
@@ -13,7 +13,7 @@ RUN zypper --gpg-auto-import-keys --non-interactive install --auto-agree-with-li
     uyuni-coco-attestation-core \
     uyuni-coco-attestation-module-secureboot \
     ${ARCH_SPECIFIC_MODULES} \
-    javassist apache-commons-ognl
+    javassist apache-commons-ognl procps
 
 ARG PRODUCT=Uyuni
 ARG VENDOR="Uyuni project"

--- a/containers/server-attestation-image/server-attestation-image.changes.mcalmer.coco-fix
+++ b/containers/server-attestation-image/server-attestation-image.changes.mcalmer.coco-fix
@@ -1,0 +1,1 @@
+- Fix the health check of the container (bsc#1240604)


### PR DESCRIPTION
## What does this PR change?

procps was removed from the base container. To use pgrep we need to install it now in our container.
This fix the health check

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- TBD

- [ ] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/27160

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
