### PR TITLE
--no-rpm option has been removed from command rhn-ssl-tool

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -617,7 +617,7 @@ When(/^the controller starts mocking a Redfish host$/) do
     # On kubernetes, the server has no clue about certificates
     crt_path, key_path, _ca_path = generate_certificate('controller', hostname)
   else
-    get_target('server').run("mgr-ssl-tool --gen-server -d /root/ssl-build --no-rpm -p spacewalk --set-hostname #{hostname} --server-cert=controller.crt --server-key=controller.key")
+    get_target('server').run("mgr-ssl-tool --gen-server -d /root/ssl-build -p spacewalk --set-hostname #{hostname} --server-cert=controller.crt --server-key=controller.key")
     key_path, _err = get_target('server').run('ls /root/ssl-build/*/controller.key')
     crt_path, _err = get_target('server').run('ls /root/ssl-build/*/controller.crt')
   end


### PR DESCRIPTION
## What does this PR change?

This PR lets the redfish tests pass after these changes:
- https://github.com/uyuni-project/uyuni/pull/9622
- https://github.com/uyuni-project/uyuni-tools/pull/572

## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

Cucumber tests were modified.

- [x] **DONE**

## Links

No ports, needed only in HEAD.

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
