### PR TITLE
QE: Swapping a step that checks if a text disappears for one that waits

### DIFF
--- a/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
@@ -117,14 +117,14 @@ Feature: PXE boot a terminal with Cobbler and containerized proxy
     And I follow "15-sp4-cobbler"
     And I follow "Delete Autoinstallation"
     And I click on "Delete Autoinstallation"
-    Then I should not see a "15-sp4-cobbler" text
+    And I wait until I do not see "15-sp4-cobbler" text
 
   Scenario: Cleanup: remove the auto installation distribution
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "SLE-15-SP4-TFTP"
     And I follow "Delete Distribution"
     And I click on "Delete Distribution"
-    Then I should not see a "SLE-15-SP4-TFTP" text
+    And I wait until I do not see "SLE-15-SP4-TFTP" text
 
   Scenario: Cleanup: remove the auto installation files
     When I remove packages "tftpboot-installation-SLE-15-SP4-x86_64 expect" from this "build_host"


### PR DESCRIPTION
until it disappears

## What does this PR change?

Changes a step for another one better for waiting for the disappearance of a text independently of how much time the product takes in doing a task

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): None, somthing that was found during the RRTG task
Port(s): None, it happens in principle just in uyuni

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
