### PR TITLE
Fix ReportDB tests

### DIFF
--- a/testsuite/features/secondary/srv_reportdb.feature
+++ b/testsuite/features/secondary/srv_reportdb.feature
@@ -1,11 +1,11 @@
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2022-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 @skip_if_github_validation
 @scope_reportdb
-Feature: ReportDB
+Feature: Report database
   In order to use reporting tools
   As an authorized user
-  I want to be able to access and use the Report Database named "reportdb"
+  I want to access and use the report database named "ReportDB"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
@@ -14,8 +14,8 @@ Feature: ReportDB
     When I schedule a task to update ReportDB
 
   Scenario: Connect to the ReportDB on the server with admin user
-    Given I can connect to the ReportDB on the Server
-    And I have a user allowed to create roles on the ReportDB
+    Then I should be able to connect to the ReportDB on the server
+    And there should be a user allowed to create roles on the ReportDB
 
   Scenario: Create read-only user
     When I create a read-only user for the ReportDB

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1368,13 +1368,13 @@ end
 
 # ReportDB
 
-Given(/^I can connect to the ReportDB on the Server$/) do
+Then(/^I should be able to connect to the ReportDB on the server$/) do
   # connect and quit database
   _result, return_code = get_target('server').run(reportdb_server_query('\\q'))
   raise SystemCallError, 'Couldn\'t connect to the ReportDB on the server' unless return_code.zero?
 end
 
-Given(/^I have a user allowed to create roles on the ReportDB$/) do
+Then(/^there should be a user allowed to create roles on the ReportDB $/) do
   users_and_permissions, return_code = get_target('server').run(reportdb_server_query('\\du'))
   raise SystemCallError, 'Couldn\'t connect to the ReportDB on the server' unless return_code.zero?
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1419,11 +1419,9 @@ end
 
 When(/^I connect to the ReportDB with read-only user from external machine$/) do
   node = get_target('server')
-  output, _code = node.run_local('dig +short reportdb A')
-  reportdb_ip = output.strip
 
   # connection from the controller to the reportdb in the server
-  $reportdb_ro_conn = PG.connect(host: reportdb_ip, port: 5432, dbname: 'reportdb', user: $reportdb_ro_user, password: 'linux')
+  $reportdb_ro_conn = PG.connect(host: node.public_ip, port: 5432, dbname: 'reportdb', user: $reportdb_ro_user, password: 'linux')
 end
 
 Then(/^I should be able to query the ReportDB$/) do
@@ -1462,21 +1460,17 @@ end
 
 Then(/^I should be able to connect to the ReportDB with the ReportDB admin user$/) do
   node = get_target('server')
-  output, _code = node.run_local('dig +short reportdb A')
-  reportdb_ip = output.strip
 
   # connection from the controller to the reportdb in the server
-  reportdb_admin_conn = PG.connect(host: reportdb_ip, port: 5432, dbname: 'reportdb', user: $reportdb_admin_user, password: $reportdb_admin_password)
+  reportdb_admin_conn = PG.connect(host: node.public_ip, port: 5432, dbname: 'reportdb', user: $reportdb_admin_user, password: $reportdb_admin_password)
   raise SystemCallError, 'Couldn\'t connect to ReportDB with admin from external machine' unless reportdb_admin_conn.status.zero?
 end
 
 Then(/^I should not be able to connect to product database with the ReportDB admin user$/) do
   node = get_target('server')
-  output, _code = node.run_local('dig +short db A')
-  db_ip = output.strip
 
   dbname = 'susemanager'
-  reportdb_admin_conn = PG.connect(host: db_ip, port: 5432, dbname: dbname, user: $reportdb_admin_user, password: $reportdb_admin_password)
+  reportdb_admin_conn = PG.connect(host: node.public_ip, port: 5432, dbname: dbname, user: $reportdb_admin_user, password: $reportdb_admin_password)
   assert_raises PG::InsufficientPrivilege do
     reportdb_admin_conn.exec('select * from rhnserver;')
   end


### PR DESCRIPTION
## What does this PR change?

The ReportDB tests must be adapted to the separated container situation.


## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

Cucumber tests were modified

- [x] **DONE**

## Links

No ports, 5.1+ only.

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
