### PR TITLE
fix ISSv3 channel sync API bug: a custom channel cannot be re-assigned to a different peripheral organization

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1812,6 +1812,15 @@ public class ChannelFactory extends HibernateFactory {
                 }
                 orgSet.add(orgId);
             }
+
+            Channel channel = ChannelFactory.lookupByLabel(channelInfo.getLabel());
+            if ((null != channel) && (channel.isCustom())) {
+                if (!orgId.equals(channel.getOrg().getId())) {
+                    throw new IllegalArgumentException("Unable to modify org from [" + channel.getOrg().getId() +
+                            "] to [" + orgId +
+                            "] for channel [" + channelInfo.getLabel() + "]");
+                }
+            }
         }
     }
 
@@ -1836,12 +1845,16 @@ public class ChannelFactory extends HibernateFactory {
                     modifyChannelInfo.getLabel() + "]");
         }
 
-        Org org = null;
         if (null != modifyChannelInfo.getPeripheralOrgId()) {
-            org = OrgFactory.lookupById(modifyChannelInfo.getPeripheralOrgId());
-            if ((null != modifyChannelInfo.getPeripheralOrgId()) && (null == org)) {
+            Org org = OrgFactory.lookupById(modifyChannelInfo.getPeripheralOrgId());
+            if (null == org) {
                 throw new IllegalArgumentException("No org id to modify [" +
                         modifyChannelInfo.getPeripheralOrgId() +
+                        "] for channel [" + modifyChannelInfo.getLabel() + "]");
+            }
+            if (!org.equals(channel.getOrg())) {
+                throw new IllegalArgumentException("Unable to modify org from [" + channel.getOrg().getName() +
+                        "] to [" + org.getName() +
                         "] for channel [" + modifyChannelInfo.getLabel() + "]");
             }
         }
@@ -1862,11 +1875,6 @@ public class ChannelFactory extends HibernateFactory {
             }
 
             channel.asCloned().get().setOriginal(originalChannel);
-        }
-
-        //null field = do not modify
-        if (null != modifyChannelInfo.getPeripheralOrgId()) {
-            channel.setOrg(org);
         }
 
         setValueIfNotNull(channel, modifyChannelInfo.getBaseDir(), Channel::setBaseDir);

--- a/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
+++ b/java/code/src/com/suse/manager/hub/test/ControllerTestUtils.java
@@ -411,7 +411,7 @@ public class ControllerTestUtils {
         assertEquals(modifyInfo.getLabel(), ch.getLabel());
 
         if (null != modifyInfo.getPeripheralOrgId()) {
-            checkMethod.accept(modifyInfo.getPeripheralOrgId(), ch.getOrg().getId());
+            assertEquals(modifyInfo.getPeripheralOrgId(), ch.getOrg().getId());
         }
 
         checkMethod.accept(modifyInfo.getOriginalChannelLabel(), ch.getOriginal().getLabel());
@@ -438,10 +438,10 @@ public class ControllerTestUtils {
         checkMethod.accept(modifyInfo.isInstallerUpdates(), ch.isInstallerUpdates());
     }
 
-    public void createTestChannel(ChannelInfoDetailsJson modifyInfo, User userIn) throws Exception {
+    public void createTestChannel(ChannelInfoDetailsJson modifyInfo, Org orgIn) throws Exception {
         ChannelFamily cfam = ChannelFamilyFactoryTest.createTestChannelFamily();
         String query = "ChannelArch.findById";
         ChannelArch arch = (ChannelArch) TestUtils.lookupFromCacheById(500L, query);
-        ChannelFactoryTest.createTestChannel(modifyInfo.getName(), modifyInfo.getLabel(), userIn.getOrg(), arch, cfam);
+        ChannelFactoryTest.createTestChannel(modifyInfo.getName(), modifyInfo.getLabel(), orgIn, arch, cfam);
     }
 }

--- a/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
+++ b/java/code/src/com/suse/manager/hub/test/HubControllerTest.java
@@ -34,6 +34,7 @@ import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.iss.IssFactory;
 import com.redhat.rhn.domain.iss.IssMaster;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.channel.software.ChannelSoftwareHandler;
 import com.redhat.rhn.manager.channel.ChannelManager;
@@ -884,11 +885,9 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
 
 
         Date anotherEndOfLifeDate = testUtils.createDateUtil(2042, 4, 2);
-        User anotherPeripheralUser = UserTestUtils.findNewUser(
-                "another_peripheral_user_", "another_peripheral_org_", true);
 
         ChannelInfoDetailsJson modifyInfo = ChannelFactory.toChannelInfo(
-                cloneProdCh, anotherPeripheralUser.getOrg().getId(), Optional.of("cloneDevelCh"));
+                cloneProdCh, cloneProdChInfo.getPeripheralOrgId(), Optional.of("cloneDevelCh"));
 
         modifyInfo.setBaseDir("baseDir_diff");
         modifyInfo.setName("name_diff");
@@ -924,7 +923,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @Test
     public void ensureNotThrowingWhenModifyingDataIsValid() throws Exception {
         ChannelInfoDetailsJson modifyInfo = testUtils.createValidCustomChInfo("customCh");
-        testUtils.createTestChannel(modifyInfo, user);
+        Org org = OrgFactory.lookupById(modifyInfo.getPeripheralOrgId());
+        testUtils.createTestChannel(modifyInfo, org);
 
         testUtils.checkSyncChannelsApiNotThrowing(DUMMY_SERVER_FQDN, List.of(modifyInfo));
     }
@@ -932,7 +932,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @Test
     public void ensureThrowsWhenModifyingMissingPeriperhalOrg() throws Exception {
         ChannelInfoDetailsJson modifyInfo = testUtils.createValidCustomChInfo("customCh");
-        testUtils.createTestChannel(modifyInfo, user);
+        Org org = OrgFactory.lookupById(modifyInfo.getPeripheralOrgId());
+        testUtils.createTestChannel(modifyInfo, org);
 
         modifyInfo.setPeripheralOrgId(75842L);
 
@@ -942,7 +943,8 @@ public class HubControllerTest extends JMockBaseTestCaseWithUser {
     @Test
     public void ensureThrowsWhenModifyingMissingOriginalChannelInClonedChannels() throws Exception {
         ChannelInfoDetailsJson modifyInfo = testUtils.createValidCustomChInfo("customCh");
-        testUtils.createTestChannel(modifyInfo, user);
+        Org org = OrgFactory.lookupById(modifyInfo.getPeripheralOrgId());
+        testUtils.createTestChannel(modifyInfo, org);
 
         modifyInfo.setOriginalChannelLabel(modifyInfo.getLabel() + "MISSING");
 

--- a/java/spacewalk-java.changes.carlo.uyuni-ch-reassign-org-fix
+++ b/java/spacewalk-java.changes.carlo.uyuni-ch-reassign-org-fix
@@ -1,0 +1,2 @@
+- Fix ISSv3 channel sync API bug: a custom channel cannot be
+  re-assigned to a different peripheral organization


### PR DESCRIPTION
## What does this PR change?
Once a custom channel is assigned to a specific peripheral org, it cannot be just re-assigned to a different peripheral organization: this has to be avoided when making **an API call**

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/27186
Port(s): no ports needed (ISSV3)
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
