### PR TITLE
ISSv3: Set correct SCC proxy endpoints

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.taskomatic.task.test;
 
-import static com.suse.scc.SCCEndpoints.SHOULD_BE_REMOVED;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -173,7 +172,7 @@ public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
                 String requestBody = EntityUtils.toString(entity);
 
                 String result = (String) ControllerTestUtils.simulateApiEndpointCallBasicAuth(
-                        SHOULD_BE_REMOVED + "/connect/organizations/systems", HttpMethod.put,
+                        "/hub/scc/connect/organizations/systems", HttpMethod.put,
                         username, password, requestBody);
 
                 response.setEntity(new StringEntity(result, APPLICATION_JSON));
@@ -192,7 +191,7 @@ public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
                 String id = url.substring(index + 1);
 
                 Object res = ControllerTestUtils.simulateApiEndpointCallBasicAuth(
-                        SHOULD_BE_REMOVED + "/connect/organizations/systems/:id",
+                        "/hub/scc/connect/organizations/systems/:id",
                         HttpMethod.delete, username, password, id);
 
                 response.setEntity(new StringEntity(res.toString(), APPLICATION_JSON));

--- a/java/code/src/com/suse/scc/SCCEndpoints.java
+++ b/java/code/src/com/suse/scc/SCCEndpoints.java
@@ -147,8 +147,6 @@ public class SCCEndpoints {
         };
     }
 
-    public static final String SHOULD_BE_REMOVED = "/hub/scc";
-
     /**
      * Initialize routs
      * @param jade jade
@@ -159,9 +157,8 @@ public class SCCEndpoints {
         get("/hub/scc/connect/organizations/subscriptions", asJson(withSCCAuth(this::subscriptions)));
         get("/hub/scc/connect/organizations/orders", asJson(withSCCAuth(this::orders)));
         get("/hub/scc/suma/product_tree.json", asJson(this::productTree));
-        //
-        put(SHOULD_BE_REMOVED + "/connect/organizations/systems", asJson(withSCCAuth(this::createSystems)));
-        delete(SHOULD_BE_REMOVED + "/connect/organizations/systems/:id", asJson(withSCCAuth(this::deleteSystem)));
+        put("/hub/scc/connect/organizations/systems", asJson(withSCCAuth(this::createSystems)));
+        delete("/hub/scc/connect/organizations/systems/:id", asJson(withSCCAuth(this::deleteSystem)));
     }
 
     private final Gson gson = new GsonBuilder()


### PR DESCRIPTION
## What does this PR change?
Make sure that correct SCC proxy endpoints are set, when coming from the hub (e.g. "/hub/scc/connect/organizations/systems")

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/27055
Port(s): # no backports
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
