### PR TITLE
Issv3 proxy registration data for SCC on the Hub

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -175,6 +175,7 @@ import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.model.hub.IssPeripheralChannels;
 import com.suse.manager.model.maintenance.MaintenanceCalendar;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
+import com.suse.scc.proxy.SCCProxyRecord;
 
 import java.util.List;
 
@@ -312,6 +313,7 @@ public class AnnotationRegistry {
             SAPWorkload.class,
             SCCCredentials.class,
             SCCOrderItem.class,
+            SCCProxyRecord.class,
             SCCRegCacheItem.class,
             SCCRepositoryAuth.class,
             SCCRepositoryBasicAuth.class,

--- a/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/MirrorCredentialsManager.java
@@ -35,6 +35,7 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCSubscriptionJson;
+import com.suse.scc.proxy.SCCProxyFactory;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -217,7 +218,8 @@ public class MirrorCredentialsManager {
                     .setUuid(uuid)
                     .createSCCConfig();
             SCCClient sccClient = new SCCWebClient(sccConfig);
-            SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient);
+            SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
+            SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient, sccProxyFactory);
             sccRegManager.deregister(itemList, true);
         }
         catch (URISyntaxException e) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -140,7 +140,14 @@ public class ForwardRegistrationTask extends RhnJavaJob {
     // Do SCC related tasks like insert, update and delete system in SCC
     protected void executeSCCTasks(SCCCredentials credentialsIn) {
         try {
-            URI url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));
+            IssHub issHub = credentialsIn.getIssHub();
+            URI url;
+            if (null == issHub) {
+                url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));
+            }
+            else {
+                url = new URI("https://%1$s/rhn/hub/scc/".formatted(issHub.getFqdn()));
+            }
             String uuid = ContentSyncManager.getUUID();
             SCCCachingFactory.initNewSystemsToForward();
             SCCConfig sccConfig = new SCCConfigBuilder()

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -192,7 +192,11 @@ public class ForwardRegistrationTask extends RhnJavaJob {
         List<SCCProxyRecord> proxyDeregister = sccProxyFactory.listDeregisterItems();
         log.debug("{} ProxyRecords found to delete", proxyDeregister.size());
 
+        List<SCCProxyRecord> proxyVirtHosts = sccProxyFactory.findVirtualizationHosts();
+        log.debug("{} VirtHosts ProxyRecords found to send", proxyVirtHosts.size());
+
         sccRegManager.proxyDeregister(proxyDeregister, false);
         sccRegManager.proxyRegister(proxyForwardRegistration, sccPrimaryOrProxyCredentials);
+        sccRegManager.proxyVirtualInfo(proxyVirtHosts, sccPrimaryOrProxyCredentials);
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -54,6 +54,11 @@ public class ForwardRegistrationTask extends RhnJavaJob {
     private static LocalDateTime nextLastSeenUpdateRun = LocalDateTime.now().plusMinutes(
             ThreadLocalRandom.current().nextInt(30, 3 * 60));
 
+    //task setup
+    protected Optional<SCCCredentials> taskConfigSccCredentials = Optional.empty();
+    protected URI taskConfigSccUrl = null;
+    protected boolean taskConfigIsSccProxy = false;
+
     @Override
     public String getConfigNamespace() {
         return "forward_registration";
@@ -82,37 +87,50 @@ public class ForwardRegistrationTask extends RhnJavaJob {
             }
         }
         if (Config.get().getString(ContentSyncManager.RESOURCE_PATH) == null) {
+            setupTaskConfiguration();
 
-            Optional<SCCCredentials> optPrimCred = findSccCredentials();
-            if (optPrimCred.isEmpty()) {
-                return;
-            }
-            int waitTimeSec = ThreadLocalRandom.current().nextInt(0, 15 * 60);
-            if (log.isDebugEnabled()) {
-                // no waiting when debug is on
-                waitTimeSec = 1;
-            }
-            try {
-                Thread.sleep(Duration.ofSeconds(waitTimeSec).toMillis());
-            }
-            catch (InterruptedException e) {
-                log.debug("Sleep interrupted", e);
-                Thread.currentThread().interrupt();
-            }
-            optPrimCred.ifPresent(credentials -> executeSCCTasks(credentials));
+            taskConfigSccCredentials.ifPresent(credentials -> {
+                waitRandomTimeWithinMinutes(15);
+                executeSCCTasks(credentials);
+            });
         }
     }
 
-    protected Optional<SCCCredentials> findSccCredentials() {
+    protected void setupTaskConfiguration() {
         HubFactory hubFactory = new HubFactory();
         Optional<IssHub> optHub = hubFactory.lookupIssHub();
-        return optHub.flatMap(this::getSCCCredentialsWhenHub).or(this::getSCCCredentials);
+        taskConfigSccCredentials = optHub.flatMap(this::getSCCCredentialsWhenPeripheral).or(this::getSCCCredentials);
+
+        try {
+            taskConfigSccUrl = new URI(optHub.map(h -> "https://%s/rhn/hub/scc".formatted(h.getFqdn()))
+                    .orElse(Config.get().getString(ConfigDefaults.SCC_URL)));
+        }
+        catch (URISyntaxException e) {
+            log.error("Unable to define a valid URI for the SCC url", e);
+        }
+
+        taskConfigIsSccProxy = optHub.isPresent();
+    }
+
+    private void waitRandomTimeWithinMinutes(int minutes) {
+        int waitTimeSec = ThreadLocalRandom.current().nextInt(0, minutes * 60);
+        if (log.isDebugEnabled()) {
+            // no waiting when debug is on
+            waitTimeSec = 1;
+        }
+        try {
+            Thread.sleep(Duration.ofSeconds(waitTimeSec).toMillis());
+        }
+        catch (InterruptedException e) {
+            log.debug("Sleep interrupted", e);
+            Thread.currentThread().interrupt();
+        }
     }
 
     protected Optional<SCCCredentials> getSCCCredentials() {
         List<SCCCredentials> credentials = CredentialsFactory.listSCCCredentials();
         Optional<SCCCredentials> optPrimCred = credentials.stream()
-                .filter(c -> c.isPrimary())
+                .filter(SCCCredentials::isPrimary)
                 .findFirst();
         if (log.isDebugEnabled() && optPrimCred.isEmpty()) {
             // We cannot update SCC without credentials
@@ -123,7 +141,7 @@ public class ForwardRegistrationTask extends RhnJavaJob {
         return optPrimCred;
     }
 
-    protected Optional<SCCCredentials> getSCCCredentialsWhenHub(IssHub hub) {
+    protected Optional<SCCCredentials> getSCCCredentialsWhenPeripheral(IssHub hub) {
         List<SCCCredentials> credentials = CredentialsFactory.listSCCCredentials();
         Optional<SCCCredentials> optHubCredential = credentials.stream()
                 .filter(c -> hub.getFqdn().equals(c.getUrl()))
@@ -139,38 +157,27 @@ public class ForwardRegistrationTask extends RhnJavaJob {
 
     // Do SCC related tasks like insert, update and delete system in SCC
     protected void executeSCCTasks(SCCCredentials credentialsIn) {
-        try {
-            IssHub issHub = credentialsIn.getIssHub();
-            URI url;
-            if (null == issHub) {
-                url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));
-            }
-            else {
-                url = new URI("https://%1$s/rhn/hub/scc/".formatted(issHub.getFqdn()));
-            }
-            String uuid = ContentSyncManager.getUUID();
-            SCCCachingFactory.initNewSystemsToForward();
-            SCCConfig sccConfig = new SCCConfigBuilder()
-                    .setUrl(url)
-                    .setUsername("")
-                    .setPassword("")
-                    .setUuid(uuid)
-                    .createSCCConfig();
-            SCCClient sccClient = new SCCWebClient(sccConfig);
-            SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
+        String uuid = ContentSyncManager.getUUID();
+        SCCCachingFactory.initNewSystemsToForward();
+        SCCConfig sccConfig = new SCCConfigBuilder()
+                .setUrl(taskConfigSccUrl)
+                .setUsername("")
+                .setPassword("")
+                .setUuid(uuid)
+                .createSCCConfig();
+        SCCClient sccClient = new SCCWebClient(sccConfig);
+        SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
 
-            SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient, sccProxyFactory);
+        SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient, sccProxyFactory);
 
-            executeSCCTasksCore(sccRegManager, sccProxyFactory, credentialsIn);
-        }
-        catch (URISyntaxException e) {
-            log.error(e.getMessage(), e);
+        executeSCCTasksAsServer(sccRegManager, credentialsIn);
+        if (taskConfigIsSccProxy) {
+            executeSCCTasksAsProxy(sccRegManager, credentialsIn);
         }
     }
 
-    // core execution routine
-    protected void executeSCCTasksCore(SCCSystemRegistrationManager sccRegManager,
-                                       SCCProxyFactory sccProxyFactory,
+    // normal server tasks: direct to SCC
+    protected void executeSCCTasksAsServer(SCCSystemRegistrationManager sccRegManager,
                                        SCCCredentials sccPrimaryOrProxyCredentials) {
         List<SCCRegCacheItem> forwardRegistration = SCCCachingFactory.findSystemsToForwardRegistration();
         log.debug("{} RegCacheItems found to forward", forwardRegistration.size());
@@ -192,6 +199,12 @@ public class ForwardRegistrationTask extends RhnJavaJob {
                         ThreadLocalRandom.current().nextInt(22 * 60, 26 * 60));
             }
         }
+    }
+
+    // tasks acting as proxy for peripherals
+    protected void executeSCCTasksAsProxy(SCCSystemRegistrationManager sccRegManager,
+            SCCCredentials sccPrimaryOrProxyCredentials) {
+        SCCProxyFactory sccProxyFactory = sccRegManager.getSccProxyFactory();
 
         List<SCCProxyRecord> proxyForwardRegistration = sccProxyFactory.findSystemsToForwardRegistration();
         log.debug("{} ProxyRecords found to forward", proxyForwardRegistration.size());

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task.test;
+
+import static com.suse.scc.SCCEndpoints.SHOULD_BE_REMOVED;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.util.http.HttpClientAdapter;
+import com.redhat.rhn.domain.credentials.CredentialsFactory;
+import com.redhat.rhn.domain.credentials.HubSCCCredentials;
+import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.domain.scc.SCCCachingFactory;
+import com.redhat.rhn.domain.scc.SCCRegCacheItem;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerInfo;
+import com.redhat.rhn.manager.content.ContentSyncManager;
+import com.redhat.rhn.taskomatic.task.ForwardRegistrationTask;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ServerTestUtils;
+
+import com.suse.manager.hub.test.ControllerTestUtils;
+import com.suse.manager.model.hub.HubFactory;
+import com.suse.manager.model.hub.IssHub;
+import com.suse.manager.model.hub.IssPeripheral;
+import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.scc.SCCEndpoints;
+import com.suse.scc.SCCSystemRegistrationManager;
+import com.suse.scc.client.SCCClientException;
+import com.suse.scc.client.SCCConfig;
+import com.suse.scc.client.SCCConfigBuilder;
+import com.suse.scc.client.SCCWebClient;
+import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
+import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.proxy.SCCProxyFactory;
+import com.suse.scc.proxy.SCCProxyManager;
+import com.suse.scc.proxy.SCCProxyRecord;
+import com.suse.scc.proxy.SccProxyStatus;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseFactory;
+import org.apache.http.HttpStatus;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.DefaultHttpResponseFactory;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletResponse;
+
+import spark.route.HttpMethod;
+
+public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
+
+    private SCCCredentials primaryCredentials;
+    private List<Server> servers;
+    private List<SCCRegCacheItem> testSystems;
+
+    private MockSCCWebClient mockSccWebClient;
+    private MockForwardRegistrationTask mockForwardRegistrationTask;
+    private SCCProxyFactory testSccProxyFactory;
+    private SCCSystemRegistrationManager testSccSystemRegMan;
+
+    private Integer systemSize;
+    private Integer batchSize;
+    private boolean allowFirstCallToFail;
+    private boolean allowAllCallsToFail;
+
+    private static final String HUB_FQDN = "hub.local";
+    private static final String PERIPHERAL_FQDN = "peripheral.local";
+    private static final String PERIPHERAL_USERNAME = "peripheral-000002";
+    private static final String PERIPHERAL_PASSWD = "not so secret";
+
+    static class MockSCCWebClient extends SCCWebClient {
+        protected int callCnt;
+
+        MockSCCWebClient(SCCConfig configIn) {
+            super(configIn);
+            callCnt = 0;
+        }
+
+        public int getCallCnt() {
+            return callCnt;
+        }
+
+        public void resetCallCnt() {
+            callCnt = 0;
+        }
+
+        @Override
+        public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
+                throws SCCClientException {
+            //do nothing
+        }
+    }
+
+    static class MockForwardRegistrationTask extends ForwardRegistrationTask {
+        @Override
+        public void executeSCCTasksCore(SCCSystemRegistrationManager sccRegManager,
+                                        SCCProxyFactory sccProxyFactory,
+                                        SCCCredentials sccPrimaryOrProxyCredentials) {
+            super.executeSCCTasksCore(sccRegManager, sccProxyFactory, sccPrimaryOrProxyCredentials);
+        }
+
+
+        @Override
+        public Optional<SCCCredentials> findSccCredentials() {
+            return super.findSccCredentials();
+        }
+    }
+
+    static class MockHttpClientAdapter extends HttpClientAdapter {
+        MockHttpClientAdapter(SCCConfig configIn) {
+            super(configIn.getAdditionalCerts(), false);
+        }
+
+        @Override
+        public HttpResponse executeRequest(HttpRequestBase request, String username,
+                                           String password) throws IOException {
+            HttpResponseFactory factory = new DefaultHttpResponseFactory();
+            HttpResponse response = factory.newHttpResponse(
+                    new BasicStatusLine(new ProtocolVersion("http", 1, 1),
+                            HttpStatus.SC_BAD_REQUEST, null), null);
+
+            if (request.getMethod().compareToIgnoreCase("PUT") == 0) {
+                executeRequestCreateSystems(request, username, password, response);
+            }
+            if (request.getMethod().compareToIgnoreCase("DELETE") == 0) {
+                executeRequestDeleteSystems(request, username, password, response);
+            }
+
+            return response;
+        }
+
+        public void executeRequestCreateSystems(HttpRequestBase request, String username,
+                                                String password, HttpResponse response) {
+            try {
+                HttpEntity entity = ((HttpPut) request).getEntity(); // example
+                String requestBody = EntityUtils.toString(entity);
+
+                String result = (String) ControllerTestUtils.simulateApiEndpointCallBasicAuth(
+                        SHOULD_BE_REMOVED + "/connect/organizations/systems", HttpMethod.put,
+                        username, password, requestBody);
+
+                response.setEntity(new StringEntity(result, APPLICATION_JSON));
+                response.setStatusCode(HttpServletResponse.SC_CREATED);
+            }
+            catch (Exception eIn) {
+                throw new IllegalStateException(eIn);
+            }
+        }
+
+        public void executeRequestDeleteSystems(HttpRequestBase request, String username,
+                                                String password, HttpResponse response) {
+            try {
+                String url = request.getURI().getPath();
+                int index = url.lastIndexOf("/");
+                String id = url.substring(index + 1);
+
+                Object res = ControllerTestUtils.simulateApiEndpointCallBasicAuth(
+                        SHOULD_BE_REMOVED + "/connect/organizations/systems/:id",
+                        HttpMethod.delete, username, password, id);
+
+                response.setEntity(new StringEntity(res.toString(), APPLICATION_JSON));
+                response.setStatusCode(HttpServletResponse.SC_CREATED);
+            }
+            catch (Exception eIn) {
+                throw new IllegalStateException(eIn);
+            }
+        }
+    }
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        systemSize = 15;
+        batchSize = 3;
+        allowFirstCallToFail = false;
+        allowAllCallsToFail = false;
+    }
+
+    private void setupTest() throws Exception {
+        setupCreateTestObjects();
+        setupCreateTestSCCWebClient();
+        testSccSystemRegMan = new SCCSystemRegistrationManager(mockSccWebClient, testSccProxyFactory);
+        setupCreateSystems();
+        mockSccWebClient.resetCallCnt();
+    }
+
+    private void setupCreateTestObjects() {
+        primaryCredentials = CredentialsFactory.createSCCCredentials("username", "password");
+        primaryCredentials.setUrl("https://scc.suse.com");
+        CredentialsFactory.storeCredentials(primaryCredentials);
+
+        mockForwardRegistrationTask = new MockForwardRegistrationTask();
+        testSccProxyFactory = new SCCProxyFactory();
+    }
+
+    private void setupCreateSystems() throws Exception {
+        Path tmpSaltRoot = Files.createTempDirectory("salt");
+        SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot.toAbsolutePath());
+        SaltStateGeneratorService.INSTANCE.setSkipSetOwner(true);
+        Config.get().setString(ConfigDefaults.REG_BATCH_SIZE, String.valueOf(batchSize));
+
+        for (SCCRegCacheItem item : getAllSCCRegCacheItems()) {
+            SCCCachingFactory.deleteRegCacheItem(item);
+        }
+
+        servers = new ArrayList<>();
+        for (int i = 0; i < systemSize; i++) {
+            Server testSystem = ServerTestUtils.createTestSystem();
+            ServerInfo serverInfo = testSystem.getServerInfo();
+            serverInfo.setCheckin(new Date(0)); // 1970-01-01 00:00:00 UTC
+            testSystem.setServerInfo(serverInfo);
+            servers.add(testSystem);
+        }
+
+        SCCCachingFactory.initNewSystemsToForward();
+        List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
+        testSystems = allUnregistered.stream()
+                .filter(i -> i.getOptServer().get().getServerInfo().getCheckin().equals(new Date(0)))
+                .collect(Collectors.toList());
+    }
+
+    private void setupCreateTestSCCWebClient() throws URISyntaxException {
+        String url = "https://localhost";
+        SCCConfig sccConfig = new SCCConfigBuilder()
+                .setUrl(new URI(url))
+                .setUsername("username")
+                .setPassword("password")
+                .setUuid("uuid")
+                .createSCCConfig();
+        mockSccWebClient = new MockSCCWebClient(sccConfig) {
+            @Override
+            public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
+                    List<SCCRegisterSystemJson> systems, String username, String password
+            ) {
+                callCnt += 1;
+                if (allowFirstCallToFail) {
+                    // allow first call to fail
+                    boolean setBadRequest = (callCnt == 1);
+                    if (setBadRequest) {
+                        throw new SCCClientException(400, "Bad Request");
+                    }
+                }
+                if (allowAllCallsToFail) {
+                    throw new SCCClientException(400, "Bad Request");
+                }
+                return new SCCOrganizationSystemsUpdateResponse(
+                        systems.stream()
+                                .map(system ->
+                                        new SCCSystemCredentialsJson(system.getLogin(),
+                                                system.getPassword(), 12345L))
+                                .collect(Collectors.toList())
+                );
+            }
+        };
+    }
+
+    private void setupAsPeripheral() {
+        IssHub hub = new IssHub(HUB_FQDN, "");
+        HubFactory hubFactory = new HubFactory();
+        hubFactory.save(hub);
+
+        SCCCredentials sccCredentialsTowardsHub =
+                CredentialsFactory.createSCCCredentials(PERIPHERAL_USERNAME, PERIPHERAL_PASSWD);
+        sccCredentialsTowardsHub.setUrl(HUB_FQDN);
+
+        CredentialsFactory.storeCredentials(sccCredentialsTowardsHub);
+    }
+
+    private void setupAsHub() {
+        HubSCCCredentials sccCredentialsTowardsPeripheral =
+                CredentialsFactory.createHubSCCCredentials(PERIPHERAL_USERNAME, PERIPHERAL_PASSWD, PERIPHERAL_FQDN);
+        CredentialsFactory.storeCredentials(sccCredentialsTowardsPeripheral);
+
+        IssPeripheral peripheral = new IssPeripheral(PERIPHERAL_FQDN, "");
+        HubFactory hubFactory = new HubFactory();
+        hubFactory.save(peripheral);
+    }
+
+    private void setupEndpoint() throws URISyntaxException {
+        URI url = new URI(HUB_FQDN);
+        String uuid = ContentSyncManager.getUUID();
+        SCCProxyManager sccProxyManager = new SCCProxyManager();
+        SCCEndpoints endpoints = new SCCEndpoints(uuid, url, sccProxyManager);
+        endpoints.initRoutes(null);
+    }
+
+    private List<SCCRegCacheItem> getAllSCCRegCacheItems() {
+        return HibernateFactory.getSession()
+                .createNativeQuery("SELECT * FROM suseSCCRegCache", SCCRegCacheItem.class)
+                .getResultList();
+    }
+
+    private void assertPreConditions() {
+        assertEquals(
+                systemSize.intValue(),
+                testSystems.stream().filter(i -> i.isSccRegistrationRequired()).count(),
+                "initially all systems should require registration"
+        );
+        assertEquals(
+                0,
+                testSystems.stream().filter(i -> i.getOptRegistrationErrorTime().isPresent()).count(),
+                "initially no system should have a registration error time"
+        );
+        assertEquals(
+                0,
+                testSystems.stream().filter(i -> i.getOptCredentials().isPresent()).count(),
+                "initially no system should have credentials"
+        );
+        assertEquals(
+                0,
+                testSystems.stream().filter(i -> i.getOptSccId().isPresent()).count(),
+                "initially no system should have a scc id"
+        );
+    }
+
+    private void assertPostConditionsCount(
+            int expectedRegistered,
+            int expectedFailed,
+            int expectedProcessed
+    ) {
+        assertEquals(
+                expectedRegistered,
+                testSystems.stream().filter(i -> i.getOptSccId().isPresent()).count(),
+                "Sucessful registered systems mismatch"
+        );
+        assertEquals(
+                expectedFailed,
+                testSystems.stream().filter(i -> i.isSccRegistrationRequired()).count(),
+                "no system should still be requiring registration"
+        );
+        assertEquals(
+                expectedFailed,
+                testSystems.stream().filter(i -> i.getOptRegistrationErrorTime().isPresent()).count(),
+                "no system should have a registration error time set"
+        );
+        assertEquals(
+                expectedProcessed,
+                testSystems.stream().filter(i -> i.getOptCredentials().isPresent()).count(),
+                "no new systems should have credentials"
+        );
+    }
+
+    @Test
+    public void testSuccessSystemRegistrationWhenNoSystemsProvided() throws Exception {
+        systemSize = 0;
+        setupTest();
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(0, 0, 0);
+    }
+
+    /**
+     * Tests when all systems are payg.
+     */
+    @Test
+    public void testSuccessSystemRegistrationWhenAllSystemsArePayG() throws Exception {
+        setupTest();
+        servers.stream().forEach(i -> i.setPayg(true));
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(0, 0, 15);
+    }
+
+    @Test
+    public void testSuccessSystemRegistrationWhenAllSystemsAreCreated() throws Exception {
+        setupTest();
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(15, 0, 15);
+    }
+
+
+    @Test
+    public void testSuccessSystemRegistrationWhenAllSccRequestsFail() throws Exception {
+        allowAllCallsToFail = true;
+        setupTest();
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(0, 15, 0);
+    }
+
+    // Test if every scenario works as expected when occur together.
+    // In this case, the logic is as it follows:
+    // - 30 systems are pending to be registered
+    // - 5 are payg
+    // - 9 will fail registering as the first SCC api call will fail.
+    // This means:
+    // - the remaining 16 systems will be successfully registered and will have a scc id
+    // - the 9 systems that fail and will still require registration and also have a registration error time set
+    // - 21 systems (the successfully registered systems + payg ones) will have credentials.
+    @Test
+    public void testSuccessSystemRegistration() throws Exception {
+        systemSize = 30;
+        batchSize = 9;
+        allowFirstCallToFail = true;
+        final int skipRegister = 5;
+        setupTest();
+
+        for (int i = 0; i < skipRegister; i++) {
+            this.servers.get(i).setPayg(true);
+        }
+
+        assertPreConditions();
+        mockForwardRegistrationTask.executeSCCTasksCore(testSccSystemRegMan, testSccProxyFactory, primaryCredentials);
+        assertPostConditionsCount(16, 9, 21);
+    }
+
+    @Test
+    public void testWithHub() throws Exception {
+        systemSize = 5;
+        setupTest();
+        setupAsPeripheral();
+        setupAsHub();
+        setupEndpoint();
+
+        assertPreConditions();
+
+        URI url = new URI(Config.get().getString(ConfigDefaults.SCC_URL));
+        String uuid = ContentSyncManager.getUUID();
+        SCCConfig sccConfig = new SCCConfigBuilder()
+                .setUrl(url)
+                .setUsername("")
+                .setPassword("")
+                .setUuid(uuid)
+                .createSCCConfig();
+        MockHttpClientAdapter newAdapter = new MockHttpClientAdapter(sccConfig);
+        SCCWebClient sccClient = new SCCWebClient(sccConfig, newAdapter);
+        SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
+
+        assertEquals(systemSize, testSystems.size());
+        assertEquals(systemSize, servers.size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATED).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING).size());
+
+        SCCSystemRegistrationManager sccRegManager = new SCCSystemRegistrationManager(sccClient, sccProxyFactory);
+
+        Optional<SCCCredentials> optCred = mockForwardRegistrationTask.findSccCredentials();
+        if (optCred.isEmpty()) {
+            throw new IllegalStateException("optCred should have a value");
+        }
+        mockForwardRegistrationTask.executeSCCTasksCore(sccRegManager, sccProxyFactory, optCred.get());
+
+        assertPostConditionsCount(systemSize, 0, systemSize);
+
+        List<SCCProxyRecord> proxyRecords =
+                sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING);
+
+        //TODO FIXME
+        /*
+        assertEquals(systemSize, proxyRecords.size());
+        if (systemSize == proxyRecords.size()) {
+            SCCProxyRecord proxyRecord = proxyRecords.get(0);
+            assertTrue(proxyRecord.getOptSccId().isEmpty());
+            assertEquals(PERIPHERAL_FQDN, proxyRecord.getPeripheralFqdn());
+            assertTrue(proxyRecord.getProxyId() > 0);
+        }
+        */
+
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATED).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING).size());
+        //TODO FIXME
+        /*
+        List<SCCRegCacheItem> sccRegCacheItems = getAllSCCRegCacheItems();
+
+        assertEquals(systemSize, sccRegCacheItems.size());
+        if (systemSize == sccRegCacheItems.size()) {
+            SCCRegCacheItem sccRegCacheItem = sccRegCacheItems.get(0);
+            assertFalse(sccRegCacheItem.isSccRegistrationRequired());
+            assertTrue(sccRegCacheItem.getOptSccId().isPresent());
+            assertTrue(sccRegCacheItem.getOptServer().isPresent());
+        }
+
+        //delete
+        ServerFactory.delete(servers.get(0));
+        ServerFactory.delete(servers.get(1));
+
+        mockForwardRegistrationTask.executeSCCTasksCore(sccRegManager, sccProxyFactory, optCred.get());
+        assertEquals(systemSize - 2,
+                sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATED).size());
+        assertEquals(0, sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING).size());
+       */
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/ForwardRegistrationTaskTest.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.taskomatic.task.test;
 
-import static com.suse.scc.SCCEndpoints.SHOULD_BE_REMOVED;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -173,7 +172,7 @@ public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
                 String requestBody = EntityUtils.toString(entity);
 
                 String result = (String) ControllerTestUtils.simulateApiEndpointCallBasicAuth(
-                        SHOULD_BE_REMOVED + "/connect/organizations/systems", HttpMethod.put,
+                        "/hub/scc/connect/organizations/systems", HttpMethod.put,
                         username, password, requestBody);
 
                 response.setEntity(new StringEntity(result, APPLICATION_JSON));
@@ -192,7 +191,7 @@ public class ForwardRegistrationTaskTest extends BaseTestCaseWithUser {
                 String id = url.substring(index + 1);
 
                 Object res = ControllerTestUtils.simulateApiEndpointCallBasicAuth(
-                        SHOULD_BE_REMOVED + "/connect/organizations/systems/:id",
+                        "/hub/scc/connect/organizations/systems/:id",
                         HttpMethod.delete, username, password, id);
 
                 response.setEntity(new StringEntity(res.toString(), APPLICATION_JSON));

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -802,6 +802,19 @@ public class SparkApplicationHelper {
 
     /**
      * Serialize the result and set the response content type to JSON
+     * and the http status code to bad request.
+     * @param response the http response
+     * @param messages messages
+     * @return a JSON string
+     */
+    public static String unprocessableEntity(Response response, String... messages) {
+        response.type("application/json");
+        response.status(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+        return GSON.toJson(ResultJson.error(messages).toSccResult());
+    }
+
+    /**
+     * Serialize the result and set the response content type to JSON
      * and the http status code to internal server error.
      * @param response the http response
      * @param messages messages

--- a/java/code/src/com/suse/manager/webui/utils/gson/ResultJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ResultJson.java
@@ -169,4 +169,14 @@ public class ResultJson<T> {
     public T getData() {
         return data;
     }
+
+    /**
+     * @return return the special json structure defined by the SCC API
+     */
+    public Map<String, Object> toSccResult() {
+        if (isSuccess()) {
+            return Map.of("success", Boolean.TRUE);
+        }
+        return Map.of("type", "error", "error", String.join(" ", getMessages()));
+    }
 }

--- a/java/code/src/com/suse/scc/SCCEndpoints.java
+++ b/java/code/src/com/suse/scc/SCCEndpoints.java
@@ -39,7 +39,7 @@ import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCFileClient;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.model.SCCVirtualizationHostJson;
@@ -160,7 +160,7 @@ public class SCCEndpoints {
         get("/hub/scc/connect/organizations/subscriptions", asJson(withSCCAuth(this::subscriptions)));
         get("/hub/scc/connect/organizations/orders", asJson(withSCCAuth(this::orders)));
         get("/hub/scc/suma/product_tree.json", asJson(this::productTree));
-        put("/hub/scc/connect/organizations/systems", asJson(withSCCAuth(this::createSystems)));
+        put("/hub/scc/connect/organizations/systems", asJson(withSCCAuth(this::createOrUpdateSystems)));
         delete("/hub/scc/connect/organizations/systems/:id", asJson(withSCCAuth(this::deleteSystem)));
         put("/hub/scc/connect/organizations/virtualization_hosts", asJson(withSCCAuth(this::setVirtualizationHosts)));
     }
@@ -349,17 +349,17 @@ public class SCCEndpoints {
      * @param credentials
      * @return a {@Link SCCOrganizationSystemsUpdateResponse} json object
      */
-    public String createSystems(Request request, Response response, HubSCCCredentials credentials) {
+    public String createOrUpdateSystems(Request request, Response response, HubSCCCredentials credentials) {
         try {
-            TypeToken<Map<String, List<SCCRegisterSystemJson>>> typeToken = new TypeToken<>() { };
-            Map<String, List<SCCRegisterSystemJson>> payload = gson.fromJson(request.body(), typeToken.getType());
+            TypeToken<Map<String, List<SCCRegisterSystemItem>>> typeToken = new TypeToken<>() { };
+            Map<String, List<SCCRegisterSystemItem>> payload = gson.fromJson(request.body(), typeToken.getType());
             if (!payload.containsKey("systems")) {
                 return badRequest(response, "wrong json input: missing systems key");
             }
 
-            List<SCCRegisterSystemJson> systemsList = payload.get("systems");
+            List<SCCRegisterSystemItem> systemsList = payload.get("systems");
 
-            List<SCCSystemCredentialsJson> systemsResponse = sccProxyManager.createSystems(systemsList,
+            List<SCCSystemCredentialsJson> systemsResponse = sccProxyManager.createOrUpdateSystems(systemsList,
                             credentials.getPeripheralUrl())
                     .stream()
                     .map(r -> new SCCSystemCredentialsJson(

--- a/java/code/src/com/suse/scc/SCCEndpoints.java
+++ b/java/code/src/com/suse/scc/SCCEndpoints.java
@@ -11,7 +11,11 @@
 package com.suse.scc;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.asJson;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.badRequest;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.internalServerError;
+import static spark.Spark.delete;
 import static spark.Spark.get;
+import static spark.Spark.put;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.Channel;
@@ -33,11 +37,18 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCFileClient;
 import com.suse.scc.client.SCCWebClient;
+import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
+import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.model.SCCRepositoryJson;
+import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.proxy.SCCProxyManager;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 
+import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -47,6 +58,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -72,14 +86,29 @@ public class SCCEndpoints {
 
     private static final Logger LOG = LogManager.getLogger(SCCEndpoints.class);
 
+    private final SCCProxyManager sccProxyManager;
+
     /**
      * Constructor
-     * @param uuidIn the UUID
+     *
+     * @param uuidIn   the UUID
      * @param sccUrlIn the SCC URL
      */
     public SCCEndpoints(String uuidIn, URI sccUrlIn) {
+        this(uuidIn, sccUrlIn, new SCCProxyManager());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param uuidIn   the UUID
+     * @param sccUrlIn the SCC URL
+     * @param sccProxyManagerIn the SCC proxy manager
+     */
+    public SCCEndpoints(String uuidIn, URI sccUrlIn, SCCProxyManager sccProxyManagerIn) {
         this.uuid = uuidIn;
         this.sccUrl = sccUrlIn;
+        this.sccProxyManager = sccProxyManagerIn;
     }
 
     private Route withSCCAuth(RouteWithSCCAuth route) {
@@ -119,6 +148,8 @@ public class SCCEndpoints {
         };
     }
 
+    public static final String SHOULD_BE_REMOVED = "/hub/scc";
+
     /**
      * Initialize routs
      * @param jade jade
@@ -129,11 +160,19 @@ public class SCCEndpoints {
         get("/hub/scc/connect/organizations/subscriptions", asJson(withSCCAuth(this::subscriptions)));
         get("/hub/scc/connect/organizations/orders", asJson(withSCCAuth(this::orders)));
         get("/hub/scc/suma/product_tree.json", asJson(this::productTree));
+        //
+        put(SHOULD_BE_REMOVED + "/connect/organizations/systems", asJson(withSCCAuth(this::createSystems)));
+        delete(SHOULD_BE_REMOVED + "/connect/organizations/systems/:id", asJson(withSCCAuth(this::deleteSystem)));
     }
 
     private final Gson gson = new GsonBuilder()
             .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
             .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
+            .create();
+
+    private final Gson gsonSccProxy = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+            .serializeNulls()
             .create();
 
     /**
@@ -299,5 +338,71 @@ public class SCCEndpoints {
      */
     public String productTree(Request request, Response response) {
         return serveEndpoint(SCCClient::productTree);
+    }
+
+    /**
+     * SCC proxy endpoint: register a list of system (put /connect/organizations/systems)
+     *
+     * @param request
+     * @param response
+     * @param credentials
+     * @return a {@Link SCCOrganizationSystemsUpdateResponse} json object
+     */
+    public String createSystems(Request request, Response response, HubSCCCredentials credentials) {
+        try {
+            TypeToken<Map<String, List<SCCRegisterSystemJson>>> typeToken = new TypeToken<>() { };
+            Map<String, List<SCCRegisterSystemJson>> payload = gson.fromJson(request.body(), typeToken.getType());
+            if (!payload.containsKey("systems")) {
+                return badRequest(response, "wrong json input: missing systems key");
+            }
+
+            List<SCCRegisterSystemJson> systemsList = payload.get("systems");
+
+            List<SCCSystemCredentialsJson> systemsResponse = sccProxyManager.createSystems(systemsList,
+                            credentials.getPeripheralUrl())
+                    .stream()
+                    .map(r -> new SCCSystemCredentialsJson(
+                            r.getSccLogin(),
+                            r.getSccPasswd(),
+                            r.getProxyId(),
+                            new Date(0)))
+                    .toList();
+
+            response.status(HttpStatus.SC_CREATED);
+            return gsonSccProxy.toJson(new SCCOrganizationSystemsUpdateResponse(systemsResponse));
+        }
+        catch (JsonSyntaxException eIn) {
+            return badRequest(response, eIn.getMessage());
+        }
+        catch (Exception ex) {
+            return internalServerError(response, ex.getMessage());
+        }
+    }
+
+    /**
+     * SCC proxy endpoint: delete a system (delete /connect/organizations/systems/id)
+     *
+     * @param request
+     * @param response
+     * @param credentials
+     * @return empty body and http status code 204 (successfully deleted) or 404 (not found)
+     */
+    public String deleteSystem(Request request, Response response, HubSCCCredentials credentials) {
+        try {
+            long systemProxyId = Long.parseLong(request.params("id"));
+
+            if (sccProxyManager.deleteSystem(systemProxyId)) {
+                response.status(HttpStatus.SC_NO_CONTENT); //204
+                return "";
+            }
+            response.status(HttpStatus.SC_NOT_FOUND); //404
+            return "";
+        }
+        catch (NumberFormatException ex) {
+            return badRequest(response, "wrong input: invalid id (%s)".formatted(request.params("id")));
+        }
+        catch (Exception ex) {
+            return internalServerError(response, ex.getMessage());
+        }
     }
 }

--- a/java/code/src/com/suse/scc/SCCEndpoints.java
+++ b/java/code/src/com/suse/scc/SCCEndpoints.java
@@ -148,8 +148,6 @@ public class SCCEndpoints {
         };
     }
 
-    public static final String SHOULD_BE_REMOVED = "/hub/scc";
-
     /**
      * Initialize routs
      * @param jade jade
@@ -160,9 +158,8 @@ public class SCCEndpoints {
         get("/hub/scc/connect/organizations/subscriptions", asJson(withSCCAuth(this::subscriptions)));
         get("/hub/scc/connect/organizations/orders", asJson(withSCCAuth(this::orders)));
         get("/hub/scc/suma/product_tree.json", asJson(this::productTree));
-        //
-        put(SHOULD_BE_REMOVED + "/connect/organizations/systems", asJson(withSCCAuth(this::createSystems)));
-        delete(SHOULD_BE_REMOVED + "/connect/organizations/systems/:id", asJson(withSCCAuth(this::deleteSystem)));
+        put("/hub/scc/connect/organizations/systems", asJson(withSCCAuth(this::createSystems)));
+        delete("/hub/scc/connect/organizations/systems/:id", asJson(withSCCAuth(this::deleteSystem)));
     }
 
     private final Gson gson = new GsonBuilder()

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -24,8 +24,11 @@ import com.suse.scc.client.SCCClient;
 import com.suse.scc.client.SCCClientException;
 import com.suse.scc.model.SCCUpdateSystemJson;
 import com.suse.scc.model.SCCVirtualizationHostJson;
+import com.suse.scc.proxy.SCCProxyFactory;
+import com.suse.scc.proxy.SCCProxyRecord;
 import com.suse.scc.registration.SCCSystemRegistration;
 
+import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,14 +43,32 @@ public class SCCSystemRegistrationManager {
 
     private static final Logger LOG = LogManager.getLogger(SCCSystemRegistrationManager.class);
     private final SCCClient sccClient;
+    private final SCCProxyFactory sccProxyFactory;
+    private final SCCSystemRegistration sccSystemRegistration;
 
     /**
      * Constructor
      *
      * @param sccClientIn the scc client
+     * @param sccProxyFactoryIn the scc proxy factory
      */
-    public SCCSystemRegistrationManager(SCCClient sccClientIn) {
+    public SCCSystemRegistrationManager(SCCClient sccClientIn, SCCProxyFactory sccProxyFactoryIn) {
+        this(sccClientIn, sccProxyFactoryIn, new SCCSystemRegistration());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param sccClientIn             the scc client
+     * @param sccProxyFactoryIn       the scc proxy factory
+     * @param sccSystemRegistrationIn the scc system registration
+     */
+    public SCCSystemRegistrationManager(SCCClient sccClientIn,
+                                        SCCProxyFactory sccProxyFactoryIn,
+                                        SCCSystemRegistration sccSystemRegistrationIn) {
         this.sccClient = sccClientIn;
+        this.sccProxyFactory = sccProxyFactoryIn;
+        this.sccSystemRegistration = sccSystemRegistrationIn;
     }
 
     /**
@@ -98,16 +119,7 @@ public class SCCSystemRegistrationManager {
                         SCCCachingFactory.deleteRegCacheItem(cacheItem);
                     }
                     catch (SCCClientException e) {
-                        if (e.getHttpStatusCode() == 404) {
-                            LOG.info("System {} not found in SCC", cacheItem.getId());
-                        }
-                        else {
-                            LOG.error("SCC error while deregistering system {}", cacheItem.getId(), e);
-                        }
-                        if (forceDBDeletion || e.getHttpStatusCode() == 404) {
-                            SCCCachingFactory.deleteRegCacheItem(cacheItem);
-                        }
-                        cacheItem.setRegistrationErrorTime(new Date());
+                        handleErrorDeregister(cacheItem, e, forceDBDeletion);
                     }
                     catch (Exception e) {
                         LOG.error("Error deregistering system {}", cacheItem.getId(), e);
@@ -121,6 +133,78 @@ public class SCCSystemRegistrationManager {
         ));
     }
 
+    private void handleErrorDeregister(SCCRegCacheItem cacheItem, SCCClientException e, boolean forceDBDeletion) {
+        if (e.getHttpStatusCode() == 404) {
+            LOG.info("System {} not found in SCC", cacheItem.getId());
+        }
+        else {
+            LOG.error("SCC error while deregistering system {}", cacheItem.getId(), e);
+        }
+        if (forceDBDeletion || e.getHttpStatusCode() == 404) {
+            SCCCachingFactory.deleteRegCacheItem(cacheItem);
+        }
+        cacheItem.setRegistrationErrorTime(new Date());
+    }
+
+    /**
+     * De-register a system from SCC
+     *
+     * @param proxyRecords the proxy records identifying the system to de-register
+     * @param forceDBDeletion force delete the proxy record when set to true
+     */
+    public void proxyDeregister(List<SCCProxyRecord> proxyRecords, boolean forceDBDeletion) {
+        proxyRecords.forEach(proxyRecord -> proxyRecord.getOptSccId().ifPresentOrElse(
+                sccId -> {
+                    try {
+                        LOG.debug("de-register system {}", proxyRecord);
+                        sccClient.deleteSystem(sccId, proxyRecord.getSccLogin(), proxyRecord.getSccPasswd());
+                        sccProxyFactory.remove(proxyRecord);
+                    }
+                    catch (SCCClientException e) {
+                        handleErrorProxyDeregister(proxyRecord, e, forceDBDeletion);
+                    }
+                    catch (Exception e) {
+                        handleErrorProxyDeregister(proxyRecord, e);
+                    }
+                },
+                () -> {
+                    LOG.debug("delete not registered cache item {}", proxyRecord);
+                    sccProxyFactory.remove(proxyRecord);
+                }
+        ));
+    }
+
+    private void handleErrorProxyDeregister(SCCProxyRecord proxyRecord, SCCClientException e, boolean forceDBDeletion) {
+        boolean doRemove = forceDBDeletion;
+        if (e.getHttpStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            LOG.info("System {} not found in SCC", proxyRecord.getSccId());
+            doRemove = true;
+        }
+        else {
+            handleErrorProxyDeregister(proxyRecord, e);
+        }
+
+        if (doRemove) {
+            sccProxyFactory.remove(proxyRecord);
+        }
+    }
+
+    private void handleErrorProxyDeregister(SCCProxyRecord proxyRecord, Exception e) {
+        LOG.error("Error while deregistering system {}", proxyRecord.getSccId(), e);
+        proxyRecord.setSccRegistrationErrorTime(new Date());
+        sccProxyFactory.save(proxyRecord);
+    }
+
+    /**
+     * Register systems in SCC
+     *
+     * @param proxyRecords the proxy records identifying the system to register
+     * @param primaryCredential the current primary organization credential
+     */
+    public void proxyRegister(List<SCCProxyRecord> proxyRecords, SCCCredentials primaryCredential) {
+        //new SCCSystemRegistration().register(sccClient, items, primaryCredential)
+    }
+
     /**
      * Register systems in SCC
      *
@@ -128,7 +212,7 @@ public class SCCSystemRegistrationManager {
      * @param primaryCredential the current primary organization credential
      */
     public void register(List<SCCRegCacheItem> items, SCCCredentials primaryCredential) {
-        new SCCSystemRegistration().register(sccClient, items, primaryCredential);
+        sccSystemRegistration.register(sccClient, items, primaryCredential);
     }
 
     /**

--- a/java/code/src/com/suse/scc/SCCTaskManager.java
+++ b/java/code/src/com/suse/scc/SCCTaskManager.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.scc;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.credentials.Credentials;
+import com.redhat.rhn.domain.credentials.CredentialsFactory;
+import com.redhat.rhn.domain.credentials.SCCCredentials;
+import com.redhat.rhn.domain.scc.SCCCachingFactory;
+import com.redhat.rhn.domain.scc.SCCRegCacheItem;
+import com.redhat.rhn.manager.content.ContentSyncManager;
+
+import com.suse.manager.model.hub.HubFactory;
+import com.suse.manager.model.hub.IssHub;
+import com.suse.scc.client.SCCConfig;
+import com.suse.scc.client.SCCConfigBuilder;
+import com.suse.scc.client.SCCWebClient;
+import com.suse.scc.model.SCCUpdateSystemItem;
+import com.suse.scc.model.SCCVirtualizationHostJson;
+import com.suse.scc.proxy.SCCProxyFactory;
+import com.suse.scc.proxy.SCCProxyRecord;
+import com.suse.scc.proxy.SccProxyStatus;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class SCCTaskManager {
+    protected Logger log = LogManager.getLogger(getClass());
+
+    private final HubFactory hubFactory;
+    private final SCCProxyFactory sccProxyFactory;
+
+    /**
+     * Default constructor
+     */
+    public SCCTaskManager() {
+        this(new HubFactory(), new SCCProxyFactory());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param hubFactoryIn      the hub factory
+     * @param sccProxyFactoryIn the proxy factory
+     */
+    public SCCTaskManager(HubFactory hubFactoryIn, SCCProxyFactory sccProxyFactoryIn) {
+        hubFactory = hubFactoryIn;
+        sccProxyFactory = sccProxyFactoryIn;
+    }
+
+    private void waitRandomTimeWithinMinutes(int minutes) {
+        int waitTimeSec = ThreadLocalRandom.current().nextInt(0, minutes * 60);
+        if (log.isDebugEnabled()) {
+            // no waiting when debug is on
+            waitTimeSec = 1;
+        }
+        try {
+            Thread.sleep(Duration.ofSeconds(waitTimeSec).toMillis());
+        }
+        catch (InterruptedException e) {
+            log.debug("Sleep interrupted", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * get scc credentials
+     */
+    protected Optional<SCCCredentials> getSCCCredentials() {
+        Optional<IssHub> optHub = hubFactory.lookupIssHub();
+        return optHub.flatMap(this::getSCCCredentialsPeripheralCase).or(this::getSCCCredentialsStandardCase);
+    }
+
+    protected Optional<SCCCredentials> getSCCCredentialsStandardCase() {
+        List<SCCCredentials> credentials = CredentialsFactory.listSCCCredentials();
+        Optional<SCCCredentials> optPrimCred = credentials.stream()
+                .filter(SCCCredentials::isPrimary)
+                .findFirst();
+
+        if (log.isDebugEnabled() && optPrimCred.isEmpty()) {
+            // We cannot update SCC without credentials
+            // Standard Uyuni case
+            log.debug("No SCC Credentials - skipping forwarding registration");
+        }
+
+        return optPrimCred;
+    }
+
+    protected Optional<SCCCredentials> getSCCCredentialsPeripheralCase(IssHub hub) {
+        List<SCCCredentials> credentials = CredentialsFactory.listSCCCredentials();
+        Optional<SCCCredentials> optHubCredential = credentials.stream()
+                .filter(c -> hub.getFqdn().equals(c.getUrl()))
+                .findFirst();
+
+        if (optHubCredential.isEmpty()) {
+            log.warn("No Hub SCC Credentials for {} - skipping forwarding registration", hub.getFqdn());
+        }
+
+        return optHubCredential;
+    }
+
+    /**
+     * get scc url
+     */
+    protected String getSCCUrl() {
+        Optional<IssHub> optHub = hubFactory.lookupIssHub();
+        return optHub.map(this::getUrlPeripheralCase).orElse(getUrlStandardCase());
+    }
+
+    protected String getUrlStandardCase() {
+        return Config.get().getString(ConfigDefaults.SCC_URL);
+    }
+
+    protected String getUrlPeripheralCase(IssHub hub) {
+        return "https://%s/rhn/hub/scc".formatted(hub.getFqdn());
+    }
+
+    /**
+     * true if acting as SCC proxy
+     */
+    protected boolean isSCCProxy() {
+        return hubFactory.isISSHub();
+    }
+
+    /**
+     * create SCCSystemRegistrationManager
+     */
+    protected SCCSystemRegistrationManager getSCCSystemRegistrationManager() {
+        return getSCCSystemRegistrationManager(getSCCUrl());
+    }
+
+    protected SCCSystemRegistrationManager getSCCSystemRegistrationManager(String sccUrl) {
+        URI sccURI = null;
+        try {
+            sccURI = new URI(sccUrl);
+        }
+        catch (URISyntaxException e) {
+            log.error("Unable to define a valid URI for the SCC url", e);
+        }
+
+        SCCConfig sccConfig = new SCCConfigBuilder()
+                .setUrl(sccURI)
+                .setUsername("")
+                .setPassword("")
+                .setUuid(ContentSyncManager.getUUID())
+                .createSCCConfig();
+
+        SCCWebClient sccClient = new SCCWebClient(sccConfig);
+        return new SCCSystemRegistrationManager(sccClient, sccProxyFactory);
+    }
+
+    /**
+     * Execute SCC related tasks like insert, update and delete system in SCC
+     *
+     * @param minutes               number of minutes within whom task execution is done
+     * @param nextLastSeenUpdateRun timestamp of next "last seen update" run
+     * @return true if updateLastSeen has been performed
+     */
+    public boolean executeSCCTasksWithinRandomMinutes(int minutes, LocalDateTime nextLastSeenUpdateRun) {
+        if (minutes > 0) {
+            waitRandomTimeWithinMinutes(minutes);
+        }
+        return executeSCCTasks(nextLastSeenUpdateRun);
+    }
+
+    /**
+     * Execute SCC related tasks like insert, update and delete system in SCC
+     */
+    protected boolean executeSCCTasks(LocalDateTime nextLastSeenUpdateRun) {
+        boolean updateLastSeenRun = executeSCCTasksAsServer(nextLastSeenUpdateRun);
+        if (isSCCProxy()) {
+            executeSCCTasksAsProxy();
+        }
+        return updateLastSeenRun;
+    }
+
+    /**
+     * Execute normal server tasks: direct to SCC
+     */
+    protected boolean executeSCCTasksAsServer(LocalDateTime nextLastSeenUpdateRun) {
+        SCCCachingFactory.initNewSystemsToForward();
+
+        boolean updateLastSeenRun = getSCCCredentials().isPresent() &&
+                (LocalDateTime.now().isAfter(nextLastSeenUpdateRun));
+
+        getSCCCredentials().ifPresent(sccPrimaryCredentials -> {
+            SCCSystemRegistrationManager sccRegManager = getSCCSystemRegistrationManager();
+            List<SCCRegCacheItem> forwardRegistration = SCCCachingFactory.findSystemsToForwardRegistration();
+            log.debug("{} RegCacheItems found to forward", forwardRegistration.size());
+
+            List<SCCRegCacheItem> deregister = SCCCachingFactory.listDeregisterItems();
+            log.debug("{} RegCacheItems found to delete", deregister.size());
+
+            List<SCCVirtualizationHostJson> virtHosts = SCCCachingFactory.listVirtualizationHosts();
+            log.debug("{} VirtHosts found to send", virtHosts.size());
+
+            sccRegManager.deregister(deregister, false);
+            sccRegManager.register(forwardRegistration, sccPrimaryCredentials);
+            sccRegManager.virtualInfo(virtHosts, sccPrimaryCredentials);
+
+            if (updateLastSeenRun) {
+                List<SCCUpdateSystemItem> updateLastSeenItems =
+                        SCCCachingFactory.listUpdateLastSeenItems(sccPrimaryCredentials);
+                sccRegManager.updateLastSeen(updateLastSeenItems, sccPrimaryCredentials);
+            }
+        });
+
+        return updateLastSeenRun;
+    }
+
+    /**
+     * Execute tasks acting as proxy for peripherals
+     */
+    protected void executeSCCTasksAsProxy() {
+        getSCCCredentials().ifPresent(sccPrimaryCredentials -> {
+            SCCSystemRegistrationManager sccRegManager = getSCCSystemRegistrationManager();
+
+            List<SCCProxyRecord> proxyForwardRegistration = sccProxyFactory.findSystemsToForwardRegistration();
+            log.debug("{} ProxyRecords found to forward", proxyForwardRegistration.size());
+
+            List<SCCProxyRecord> proxyDeregister = sccProxyFactory.listDeregisterItems();
+            log.debug("{} ProxyRecords found to delete", proxyDeregister.size());
+
+            List<SCCProxyRecord> proxyVirtHosts = sccProxyFactory.findVirtualizationHosts();
+            log.debug("{} VirtHosts ProxyRecords found to send", proxyVirtHosts.size());
+
+            sccRegManager.proxyDeregister(proxyDeregister, sccPrimaryCredentials, false);
+            sccRegManager.proxyRegister(proxyForwardRegistration, sccPrimaryCredentials);
+            sccRegManager.proxyVirtualInfo(proxyVirtHosts, sccPrimaryCredentials);
+
+            //the updates are sent by the peripherals, we don't want to hold the information here
+            List<SCCProxyRecord> proxyUpdateLastSeen = sccProxyFactory.listUpdateLastSeenItems();
+            log.debug("{} Proxy systems to update last seen", proxyUpdateLastSeen.size());
+            sccRegManager.proxyUpdateLastSeen(proxyUpdateLastSeen, sccPrimaryCredentials);
+        });
+    }
+
+    /**
+     * cleans up stuff when a peripheral is deregistered
+     *
+     * @param peripheralFqdn the fqdn of the peripheral that is giong to be deregistered
+     */
+    public void cleanupSccProxyWhenDeregisteringPeripheral(String peripheralFqdn) {
+        //set scc proxy entries of this peripheral as if they applied to be deregistered
+        sccProxyFactory.deregisterProxyEntriesForPeripheral(peripheralFqdn);
+
+        //update proxy entries deregistering
+        if (isSCCProxy()) {
+            executeSCCTasksAsProxy();
+        }
+    }
+
+    /**
+     * deregister all proxy records
+     * @param credentialsAboutToDelete the credentials about to be deleted
+     */
+    public void cleanupSccWhenDeletingPrimaryCredentials(Credentials credentialsAboutToDelete) {
+        // Check for systems registered under this credentials and start delete requests
+        List<SCCRegCacheItem> itemList = SCCCachingFactory.listRegItemsByCredentials(credentialsAboutToDelete);
+        SCCSystemRegistrationManager sccRegManager = getSCCSystemRegistrationManager(getUrlStandardCase());
+        sccRegManager.deregister(itemList, true);
+    }
+
+    /**
+     * deregister all proxy records
+     */
+    public void cleanupSccProxyWhenDeletingPrimaryCredentials() {
+        List<SCCProxyRecord> proxyDeregister = sccProxyFactory.lookupByStatusAndRetry(SccProxyStatus.SCC_CREATED);
+        log.debug("{} ProxyRecords found to force deregister", proxyDeregister.size());
+
+        getSCCCredentials().ifPresent(sccPrimaryCredentials -> {
+            SCCSystemRegistrationManager sccRegManager = getSCCSystemRegistrationManager();
+            sccRegManager.proxyForceDeregister(proxyDeregister, sccPrimaryCredentials);
+        });
+
+        sccProxyFactory.setReregisterProxyEntries();
+    }
+}

--- a/java/code/src/com/suse/scc/client/SCCClient.java
+++ b/java/code/src/com/suse/scc/client/SCCClient.java
@@ -19,10 +19,10 @@ import com.redhat.rhn.manager.content.ProductTreeEntry;
 import com.suse.scc.model.SCCOrderJson;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 
 import java.util.List;
@@ -87,10 +87,10 @@ public interface SCCClient {
      * @param username the username for http basic auth
      * @param password the password for http basic auth
      * @throws SCCClientException SCCRegisterSystemItemJson
-     * @return SCCRegisterSystemJson a collection of systems created/updated
+     * @return SCCRegisterSystemItem a collection of systems created/updated
      */
     SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-            List<SCCRegisterSystemJson> systems, String username, String password
+            List<SCCRegisterSystemItem> systems, String username, String password
     ) throws SCCClientException;
 
     /**
@@ -100,7 +100,7 @@ public interface SCCClient {
      * @param password the password
      * @throws SCCClientException
      */
-    void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
+    void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password)
             throws SCCClientException;
 
     /**

--- a/java/code/src/com/suse/scc/client/SCCFileClient.java
+++ b/java/code/src/com/suse/scc/client/SCCFileClient.java
@@ -20,10 +20,10 @@ import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.scc.model.SCCOrderJson;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 
 import com.google.gson.Gson;
@@ -102,13 +102,13 @@ public class SCCFileClient implements SCCClient {
 
     @Override
     public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-            List<SCCRegisterSystemJson> systems, String username, String password
+            List<SCCRegisterSystemItem> systems, String username, String password
     ) {
         return null;
     }
 
     @Override
-    public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+    public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
         // Not handled
     }
 

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -122,8 +122,17 @@ public class SCCWebClient implements SCCClient {
      * @param configIn the configuration object
      */
     public SCCWebClient(SCCConfig configIn) {
+        this(configIn, new HttpClientAdapter(configIn.getAdditionalCerts(), false));
+    }
+
+    /**
+     * Constructor for testing purposes
+     * @param configIn the configuration object
+     * @param httpClientIn the HttpClientAdapter object
+     */
+    public SCCWebClient(SCCConfig configIn, HttpClientAdapter httpClientIn) {
         config = configIn;
-        httpClient = new HttpClientAdapter(configIn.getAdditionalCerts(), false);
+        httpClient = httpClientIn;
     }
 
     private <T> T writeCache(T value, String name) {

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -22,10 +22,10 @@ import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.scc.model.SCCOrderJson;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 
 import com.google.gson.Gson;
@@ -122,7 +122,8 @@ public class SCCWebClient implements SCCClient {
      * @param configIn the configuration object
      */
     public SCCWebClient(SCCConfig configIn) {
-        this(configIn, new HttpClientAdapter(configIn.getAdditionalCerts(), false));
+        this(configIn, new HttpClientAdapter(
+                Optional.ofNullable(configIn).map(SCCConfig::getAdditionalCerts).orElse(List.of()), false));
     }
 
     /**
@@ -313,19 +314,17 @@ public class SCCWebClient implements SCCClient {
         }
     }
 
-    @Override
-    public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
+    private String coreCreateUpdateSystems(String requestBody, String username, String password)
             throws SCCClientException {
 
         HttpPut request = new HttpPut(config.getUrl() + "/connect/organizations/systems");
         // Additional request headers
         addHeaders(request);
-        Map<String, List<SCCUpdateSystemJson>> payload = Map.of("systems", systems);
-        request.setEntity(new StringEntity(gson.toJson(payload), ContentType.APPLICATION_JSON));
+        request.setEntity(new StringEntity(requestBody, ContentType.APPLICATION_JSON));
 
         LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/systems");
         if (LOG.isDebugEnabled()) {
-            LOG.debug(gson.toJson(payload));
+            LOG.debug("Request body: {}", requestBody);
         }
 
         try {
@@ -333,7 +332,15 @@ public class SCCWebClient implements SCCClient {
             HttpResponse response = httpClient.executeRequest(request, username, password);
 
             int responseCode = response.getStatusLine().getStatusCode();
-            if (responseCode != HttpStatus.SC_CREATED) {
+            String responseBody = EntityUtils.toString(response.getEntity());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Response code: {}", responseCode);
+                LOG.debug("Response body: {}", responseBody);
+            }
+            if (responseCode == HttpStatus.SC_CREATED) {
+                return responseBody;
+            }
+            else {
                 // Request was not successful
                 throw new SCCClientException(responseCode, request.getURI().toString(),
                         "Got response code " + responseCode + " connecting to " + request.getURI());
@@ -353,50 +360,21 @@ public class SCCWebClient implements SCCClient {
     }
 
     @Override
+    public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password)
+            throws SCCClientException {
+        Map<String, List<SCCUpdateSystemItem>> payload = Map.of("systems", systems);
+        String requestBody = gson.toJson(payload);
+        coreCreateUpdateSystems(requestBody, username, password);
+    }
+
+    @Override
     public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-            List<SCCRegisterSystemJson> systems, String username, String password
-    ) throws SCCClientException {
-        HttpPut request = new HttpPut(config.getUrl() + "/connect/organizations/systems");
-        // Additional request headers
-        addHeaders(request);
-        Map<String, Collection<SCCRegisterSystemJson>> payload = Map.of("systems", systems);
-        request.setEntity(new StringEntity(gson.toJson(payload), ContentType.APPLICATION_JSON));
+            List<SCCRegisterSystemItem> systems, String username, String password) throws SCCClientException {
+        Map<String, Collection<SCCRegisterSystemItem>> payload = Map.of("systems", systems);
+        String requestBody = gson.toJson(payload);
+        String responseBody = coreCreateUpdateSystems(requestBody, username, password);
 
-        LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/systems");
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Request body: {}", gson.toJson(payload));
-        }
-
-        try {
-            // Connect and parse the response on success
-            HttpResponse response = httpClient.executeRequest(request, username, password);
-
-            int responseCode = response.getStatusLine().getStatusCode();
-            String responseBody = EntityUtils.toString(response.getEntity());
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Response code: {}", responseCode);
-                LOG.debug("Response body: {}", responseBody);
-            }
-            if (responseCode == HttpStatus.SC_CREATED) {
-                return gson.fromJson(responseBody, SCCOrganizationSystemsUpdateResponse.class);
-            }
-            else {
-                // Request was not successful
-                throw new SCCClientException(responseCode, request.getURI().toString(),
-                        "Got response code " + responseCode + " connecting to " + request.getURI());
-            }
-        }
-        catch (NoRouteToHostException e) {
-            String proxy = ConfigDefaults.get().getProxyHost();
-            throw new SCCClientException("No route to SCC" +
-                    (proxy != null ? " or the Proxy: " + proxy : ""));
-        }
-        catch (IOException e) {
-            throw new SCCClientException(e);
-        }
-        finally {
-            request.releaseConnection();
-        }
+        return gson.fromJson(responseBody, SCCOrganizationSystemsUpdateResponse.class);
     }
 
     @Override

--- a/java/code/src/com/suse/scc/model/SCCRegisterSystemItem.java
+++ b/java/code/src/com/suse/scc/model/SCCRegisterSystemItem.java
@@ -23,7 +23,7 @@ import java.util.List;
 /**
  * This is a System Item send to SCC for registration.
  */
-public class SCCRegisterSystemJson {
+public class SCCRegisterSystemItem {
 
     private String login;
     private String password;
@@ -43,8 +43,8 @@ public class SCCRegisterSystemJson {
      * @param productsIn the products
      * @param lastSeenIn the last seen date
      */
-    public SCCRegisterSystemJson(String loginIn, String passwdIn, String hostnameIn,
-            SCCHwInfoJson hwinfoIn, List<SCCMinProductJson> productsIn, Date lastSeenIn) {
+    public SCCRegisterSystemItem(String loginIn, String passwdIn, String hostnameIn,
+                                 SCCHwInfoJson hwinfoIn, List<SCCMinProductJson> productsIn, Date lastSeenIn) {
         login = loginIn;
         password = passwdIn;
         hostname = hostnameIn;
@@ -99,5 +99,13 @@ public class SCCRegisterSystemJson {
      */
     public Date getLastSeenAt() {
         return lastSeenAt;
+    }
+
+    /**
+     * @return Returns true if it contains only the last seen info
+     */
+    public boolean isOnlyLastSeenAt() {
+        return (null != login) && (null != password) && (null != lastSeenAt) &&
+                (null == hostname) && (null == hwinfo) && (null == products) && (null == regcodes);
     }
 }

--- a/java/code/src/com/suse/scc/model/SCCSystemCredentialsJson.java
+++ b/java/code/src/com/suse/scc/model/SCCSystemCredentialsJson.java
@@ -14,25 +14,52 @@
  */
 package com.suse.scc.model;
 
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Date;
+
 /**
- * SCCSystemCredentialsJson
+ * SCCSystemCredentialsJson: response to SCC put to /organizations/systems
  */
 public class SCCSystemCredentialsJson {
 
+    private Long id;
     private String login;
     private String password;
-    private Long id;
+    @SerializedName("system_token")
+    private String systemToken;
+    @SerializedName("last_seen_at")
+    private Date lastSeenAt;
 
     /**
      * Constructor
-     * @param loginIn the login
+     *
+     * @param loginIn    the login
      * @param passwordIn the password
-     * @param idIn the scc ID
+     * @param idIn       the scc ID
      */
     public SCCSystemCredentialsJson(String loginIn, String passwordIn, Long idIn) {
-       this.login = loginIn;
-       this.password = passwordIn;
-       this.id = idIn;
+        this.login = loginIn;
+        this.password = passwordIn;
+        this.id = idIn;
+        this.systemToken = null;
+        this.lastSeenAt = null;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param loginIn      the login
+     * @param passwordIn   the password
+     * @param idIn         the scc ID
+     * @param lastSeenAtIn the last seen date
+     */
+    public SCCSystemCredentialsJson(String loginIn, String passwordIn, Long idIn, Date lastSeenAtIn) {
+        this.login = loginIn;
+        this.password = passwordIn;
+        this.id = idIn;
+        this.systemToken = null;
+        this.lastSeenAt = lastSeenAtIn;
     }
 
     /**

--- a/java/code/src/com/suse/scc/model/SCCUpdateSystemItem.java
+++ b/java/code/src/com/suse/scc/model/SCCUpdateSystemItem.java
@@ -21,7 +21,7 @@ import java.util.Date;
 /**
  * This is a System Item send to SCC for minimal update registration.
  */
-public class SCCUpdateSystemJson {
+public class SCCUpdateSystemItem {
 
     private String login;
     private String password;
@@ -34,7 +34,7 @@ public class SCCUpdateSystemJson {
      * @param passwdIn the password
      * @param lastSeenIn last seen date
      */
-    public SCCUpdateSystemJson(String loginIn, String passwdIn, Date lastSeenIn) {
+    public SCCUpdateSystemItem(String loginIn, String passwdIn, Date lastSeenIn) {
         login = loginIn;
         password = passwdIn;
         lastSeenAt = lastSeenIn;

--- a/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
@@ -64,6 +64,22 @@ public class SCCProxyFactory extends HibernateFactory {
     }
 
     /**
+     * Lookup {@link SCCProxyRecord} object by sccLogin and the status
+     *
+     * @param sccLoginIn the scc login
+     * @param statusIn the status
+     * @return return {@link SCCProxyRecord} or empty
+     */
+    public Optional<SCCProxyRecord> lookupBySccLoginAndStatus(String sccLoginIn, SccProxyStatus statusIn) {
+        return getSession()
+                .createQuery("FROM SCCProxyRecord WHERE sccLogin = :sccLogin AND status = :status",
+                        SCCProxyRecord.class)
+                .setParameter("sccLogin", sccLoginIn)
+                .setParameter("status", statusIn)
+                .uniqueResultOptional();
+    }
+
+    /**
      * Lookup {@link SCCProxyRecord} list of objects with given status
      *
      * @param statusIn the status
@@ -115,5 +131,14 @@ public class SCCProxyFactory extends HibernateFactory {
      */
     public List<SCCProxyRecord> listDeregisterItems() {
         return lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING);
+    }
+
+    /**
+     * Returns virtualization host items which should be forwarded to SCC
+     *
+     * @return list of {@link SCCProxyRecord}
+     */
+    public List<SCCProxyRecord> findVirtualizationHosts() {
+        return lookupByStatusAndRetry(SccProxyStatus.SCC_VIRTHOST_PENDING);
     }
 }

--- a/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
@@ -172,4 +172,46 @@ public class SCCProxyFactory extends HibernateFactory {
                 .setParameter("status", SccProxyStatus.SCC_CREATED)
                 .list();
     }
+
+    /**
+     * set all proxy entries of a given peripheral to be deregistered
+     *
+     * @param peripheralFqdn the given peripheral fqn
+     */
+    public void deregisterProxyEntriesForPeripheral(String peripheralFqdn) {
+        getSession().createQuery("""
+                        UPDATE SCCProxyRecord p
+                        SET p.status = :removalPending
+                        WHERE p.peripheralFqdn = :fqdn
+                        """)
+                .setParameter("removalPending", SccProxyStatus.SCC_REMOVAL_PENDING)
+                .setParameter("fqdn", peripheralFqdn)
+                .executeUpdate();
+    }
+
+    /**
+     * set all proxy entries as if they have to be registered again
+     */
+    public void setReregisterProxyEntries() {
+        getSession().createQuery("""
+                        UPDATE SCCProxyRecord p
+                        SET p.sccId = NULL, p.status = :creationPending
+                        WHERE p.status = :created
+                        """)
+                .setParameter("creationPending", SccProxyStatus.SCC_CREATION_PENDING)
+                .setParameter("created", SccProxyStatus.SCC_CREATED)
+                .executeUpdate();
+    }
+
+    /**
+     * remove all proxy entries with status "removal pending"
+     */
+    public void removeRemovalPendingProxyEntries() {
+        getSession().createQuery("""
+                        DELETE SCCProxyRecord p
+                        WHERE p.status = :removalPending
+                        """)
+                .setParameter("removalPending", SccProxyStatus.SCC_REMOVAL_PENDING)
+                .executeUpdate();
+    }
 }

--- a/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.scc.proxy;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+public class SCCProxyFactory extends HibernateFactory {
+
+    private static final Logger LOG = LogManager.getLogger(SCCProxyFactory.class);
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    /**
+     * Save a {@link SCCProxyRecord} object
+     *
+     * @param sccProxyRecord object to save
+     */
+    public void save(SCCProxyRecord sccProxyRecord) {
+        sccProxyRecord.setModified(new Date());
+        saveObject(sccProxyRecord);
+    }
+
+    /**
+     * Remove a {@link SCCProxyRecord} object
+     *
+     * @param sccProxyRecord object to remove
+     */
+    public void remove(SCCProxyRecord sccProxyRecord) {
+        removeObject(sccProxyRecord);
+    }
+
+    /**
+     * Lookup {@link SCCProxyRecord} object by its proxy generated id
+     *
+     * @param proxyId the proxy generated id
+     * @return return {@link SCCProxyRecord} with the given proxy generated id or empty
+     */
+    public Optional<SCCProxyRecord> lookupByProxyId(long proxyId) {
+        return getSession()
+                .createQuery("FROM SCCProxyRecord WHERE proxyId = :proxyId", SCCProxyRecord.class)
+                .setParameter("proxyId", proxyId)
+                .uniqueResultOptional();
+    }
+
+    /**
+     * Lookup {@link SCCProxyRecord} list of objects with given status
+     *
+     * @param statusIn the status
+     * @return return list of {@link SCCProxyRecord} with the given status
+     */
+    public List<SCCProxyRecord> lookupByStatus(SccProxyStatus statusIn) {
+        return getSession()
+                .createQuery("FROM SCCProxyRecord WHERE status = :status", SCCProxyRecord.class)
+                .setParameter("status", statusIn)
+                .list();
+    }
+
+    /**
+     * Lookup {@link SCCProxyRecord} list of objects with given status and with retry time not expired
+     *
+     * @param statusIn the status
+     * @return return list of {@link SCCProxyRecord} with the given status
+     */
+    public List<SCCProxyRecord> lookupByStatusAndRetry(SccProxyStatus statusIn) {
+        int regErrorExpireTime = Config.get().getInt(ConfigDefaults.REG_ERROR_EXPIRE_TIME, 168);
+        Calendar retryTime = Calendar.getInstance();
+        retryTime.add(Calendar.HOUR, -1 * regErrorExpireTime);
+
+        return getSession()
+                .createQuery("""
+                            FROM SCCProxyRecord
+                            WHERE status = :status
+                            AND (sccRegistrationErrorTime IS NULL
+                                 OR sccRegistrationErrorTime < :retryTime)
+                        """, SCCProxyRecord.class)
+                .setParameter("status", statusIn)
+                .setParameter("retryTime", new Date(retryTime.getTimeInMillis()))
+                .list();
+    }
+
+    /**
+     * Returns registration items of systems which should be forwarded to SCC
+     *
+     * @return list of {@link SCCProxyRecord}
+     */
+    public List<SCCProxyRecord> findSystemsToForwardRegistration() {
+        return lookupByStatusAndRetry(SccProxyStatus.SCC_CREATION_PENDING);
+    }
+
+    /**
+     * Returns registration items of systems which should be de-registered from SCC
+     *
+     * @return list of {@link SCCProxyRecord}
+     */
+    public List<SCCProxyRecord> listDeregisterItems() {
+        return lookupByStatusAndRetry(SccProxyStatus.SCC_REMOVAL_PENDING);
+    }
+}

--- a/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
@@ -80,6 +80,22 @@ public class SCCProxyFactory extends HibernateFactory {
     }
 
     /**
+     * Lookup {@link SCCProxyRecord} object by sccLogin and sccPasswd
+     *
+     * @param sccLoginIn the scc login
+     * @param sccPasswdIn the scc password
+     * @return return {@link SCCProxyRecord} or empty
+     */
+    public Optional<SCCProxyRecord> lookupBySccLoginAndPassword(String sccLoginIn, String sccPasswdIn) {
+        return getSession()
+                .createQuery("FROM SCCProxyRecord WHERE sccLogin = :sccLogin AND sccPasswd = :sccPasswd",
+                        SCCProxyRecord.class)
+                .setParameter("sccLogin", sccLoginIn)
+                .setParameter("sccPasswd", sccPasswdIn)
+                .uniqueResultOptional();
+    }
+
+    /**
      * Lookup {@link SCCProxyRecord} list of objects with given status
      *
      * @param statusIn the status
@@ -140,5 +156,20 @@ public class SCCProxyFactory extends HibernateFactory {
      */
     public List<SCCProxyRecord> findVirtualizationHosts() {
         return lookupByStatusAndRetry(SccProxyStatus.SCC_VIRTHOST_PENDING);
+    }
+
+    /**
+     * Return list of data for last seen SCC update call
+     *
+     * @return list of {@link SCCProxyRecord}
+     */
+    public List<SCCProxyRecord> listUpdateLastSeenItems() {
+        return getSession()
+                .createQuery("""
+                            FROM SCCProxyRecord
+                            WHERE sccRegistrationErrorTime IS NULL AND status = :status AND lastSeenAt IS NOT NULL
+                            """, SCCProxyRecord.class)
+                .setParameter("status", SccProxyStatus.SCC_CREATED)
+                .list();
     }
 }

--- a/java/code/src/com/suse/scc/proxy/SCCProxyManager.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyManager.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.scc.proxy;
+
+import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.utils.Json;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Business logic to manage SCC proxy in hub
+ */
+public class SCCProxyManager {
+
+    private final SCCProxyFactory sccProxyFactory;
+
+    /**
+     * Default constructor
+     */
+    public SCCProxyManager() {
+        this(new SCCProxyFactory());
+    }
+
+    /**
+     * Builds an instance with the given dependencies
+     *
+     * @param sccProxyFactoryIn the sccProxyFactory factory
+     */
+    public SCCProxyManager(SCCProxyFactory sccProxyFactoryIn) {
+        this.sccProxyFactory = sccProxyFactoryIn;
+    }
+
+    /**
+     * Creates systems from the lists and stores data to be later registered to SCC
+     *
+     * @param systemsList a list of {@Link SCCRegisterSystemJson} to be created
+     * @param peripheralFqdnIn the fqdn of the peripheral
+     * @return list of corresponding generated records
+     */
+    public List<SCCProxyRecord> createSystems(List<SCCRegisterSystemJson> systemsList, String peripheralFqdnIn) {
+
+        List<SCCProxyRecord> systemsRecords = new ArrayList<>();
+
+        for (SCCRegisterSystemJson system : systemsList) {
+            String sccLogin = system.getLogin();
+            String sccPasswd = system.getPassword();
+            String sccCreationJson = Json.GSON.toJson(system);
+
+            SCCProxyRecord sccProxyRecord = new SCCProxyRecord(peripheralFqdnIn, sccLogin, sccPasswd, sccCreationJson);
+            sccProxyFactory.save(sccProxyRecord);
+            systemsRecords.add(sccProxyRecord);
+        }
+
+        return systemsRecords;
+    }
+
+    /**
+     * Marks a system for deletion
+     *
+     * @param systemProxyId the proxy id of the system
+     * @return false if the id was not found
+     */
+    public boolean deleteSystem(long systemProxyId) {
+        Optional<SCCProxyRecord> proxyRecord = sccProxyFactory.lookupByProxyId(systemProxyId);
+
+        if (proxyRecord.isPresent()) {
+            SCCProxyRecord sccProxyRecord = proxyRecord.get();
+            sccProxyRecord.setStatus(SccProxyStatus.SCC_REMOVAL_PENDING);
+            sccProxyFactory.save(sccProxyRecord);
+            return true;
+        }
+
+        return false; //not found
+    }
+}

--- a/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.scc.proxy;
+
+import static java.util.Optional.ofNullable;
+
+import com.redhat.rhn.domain.BaseDomainHelper;
+
+import org.hibernate.annotations.Type;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+@Entity
+@Table(name = "suseSccProxy")
+public class SCCProxyRecord extends BaseDomainHelper {
+
+    private Long proxyId;
+    private String peripheralFqdn;
+    private String sccLogin;
+    private String sccPasswd;
+    private String sccCreationJson;
+    private Long sccId;
+    private Date sccRegistrationErrorTime;
+    private SccProxyStatus status;
+
+    /**
+     * Default constructor
+     */
+    public SCCProxyRecord() {
+        this(null, null, null, null);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param peripheralFqdnIn peripheral from which the request comes from
+     * @param sccLoginIn login of the system to register in SCC
+     * @param sccPasswdIn password of the system to register in SCC
+     * @param sccCreationJsonIn original creation json of the system to register in SCC
+     */
+    public SCCProxyRecord(String peripheralFqdnIn, String sccLoginIn, String sccPasswdIn, String sccCreationJsonIn) {
+        peripheralFqdn = peripheralFqdnIn;
+        sccLogin = sccLoginIn;
+        sccPasswd = sccPasswdIn;
+        sccCreationJson = sccCreationJsonIn;
+        status = SccProxyStatus.SCC_CREATION_PENDING;
+    }
+
+    @Id
+    @Column(name = "proxy_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long getProxyId() {
+        return proxyId;
+    }
+
+    public void setProxyId(Long proxyIdIn) {
+        proxyId = proxyIdIn;
+    }
+
+    @Column(name = "peripheral_fqdn")
+    public String getPeripheralFqdn() {
+        return peripheralFqdn;
+    }
+
+    public void setPeripheralFqdn(String peripheralFqdnIn) {
+        peripheralFqdn = peripheralFqdnIn;
+    }
+
+    @Column(name = "scc_login")
+    public String getSccLogin() {
+        return sccLogin;
+    }
+
+    public void setSccLogin(String sccLoginIn) {
+        sccLogin = sccLoginIn;
+    }
+
+    @Column(name = "scc_passwd")
+    public String getSccPasswd() {
+        return sccPasswd;
+    }
+
+    public void setSccPasswd(String sccPasswdIn) {
+        sccPasswd = sccPasswdIn;
+    }
+
+    @Column(name = "scc_creation_json")
+    public String getSccCreationJson() {
+        return sccCreationJson;
+    }
+
+    public void setSccCreationJson(String sccCreationJsonIn) {
+        sccCreationJson = sccCreationJsonIn;
+    }
+
+    @Column(name = "scc_id")
+    public Long getSccId() {
+        return sccId;
+    }
+
+    public void setSccId(Long sccIdIn) {
+        sccId = sccIdIn;
+    }
+
+    /**
+     * @return Returns the SCC ID when this system was registered already
+     */
+    @Transient
+    public Optional<Long> getOptSccId() {
+        return ofNullable(sccId);
+    }
+
+    @Column(name = "scc_regerror_timestamp")
+    public Date getSccRegistrationErrorTime() {
+        return sccRegistrationErrorTime;
+    }
+
+    public void setSccRegistrationErrorTime(Date sccRegistrationErrorTimeIn) {
+        sccRegistrationErrorTime = sccRegistrationErrorTimeIn;
+    }
+
+    /**
+     * @return the time when the last registration failed
+     */
+    @Transient
+    public Optional<Date> getOptSccRegistrationErrorTime() {
+        return ofNullable(sccRegistrationErrorTime);
+    }
+
+    @Type(type = "com.suse.scc.proxy.SccProxyStatusEnumType")
+    public SccProxyStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SccProxyStatus statusIn) {
+        status = statusIn;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (!(oIn instanceof SCCProxyRecord that)) {
+            return false;
+        }
+        return Objects.equals(getProxyId(), that.getProxyId()) &&
+                Objects.equals(getPeripheralFqdn(), that.getPeripheralFqdn()) &&
+                Objects.equals(getSccLogin(), that.getSccLogin()) &&
+                Objects.equals(getSccPasswd(), that.getSccPasswd()) &&
+                Objects.equals(getSccId(), that.getSccId()) &&
+                Objects.equals(getStatus(), that.getStatus());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getProxyId(),
+                getPeripheralFqdn(),
+                getSccLogin(),
+                getSccPasswd(),
+                getSccId(),
+                getStatus());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("SCCProxyRecord{");
+        sb.append("proxyId=").append(proxyId);
+        sb.append(", peripheralFqdn='").append(peripheralFqdn).append('\'');
+        sb.append(", sccLogin='").append(sccLogin).append('\'');
+        sb.append(", sccPasswd='").append(sccPasswd).append('\'');
+        sb.append(", sccCreationJson='").append(sccCreationJson).append('\'');
+        sb.append(", sccId=").append(sccId);
+        sb.append(", sccRegistrationErrorTime=").append(sccRegistrationErrorTime);
+        sb.append(", status=").append(status);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
@@ -39,6 +39,7 @@ public class SCCProxyRecord extends BaseDomainHelper {
     private String sccCreationJson;
     private Long sccId;
     private Date sccRegistrationErrorTime;
+    private Date lastSeenAt;
     private SccProxyStatus status;
 
     /**
@@ -46,6 +47,17 @@ public class SCCProxyRecord extends BaseDomainHelper {
      */
     public SCCProxyRecord() {
         this(null, null, null, null);
+    }
+
+    /**
+     * Constructor with status SCC_CREATION_PENDING
+     *
+     * @param peripheralFqdnIn peripheral from which the request comes from
+     * @param sccLoginIn login of the system to register in SCC
+     * @param sccPasswdIn password of the system to register in SCC
+     */
+    public SCCProxyRecord(String peripheralFqdnIn, String sccLoginIn, String sccPasswdIn) {
+        this(peripheralFqdnIn, sccLoginIn, sccPasswdIn, null, SccProxyStatus.SCC_CREATION_PENDING);
     }
 
     /**
@@ -142,6 +154,9 @@ public class SCCProxyRecord extends BaseDomainHelper {
         return ofNullable(sccId);
     }
 
+    /**
+     * @return the time when the last registration failed
+     */
     @Column(name = "scc_regerror_timestamp")
     public Date getSccRegistrationErrorTime() {
         return sccRegistrationErrorTime;
@@ -151,13 +166,28 @@ public class SCCProxyRecord extends BaseDomainHelper {
         sccRegistrationErrorTime = sccRegistrationErrorTimeIn;
     }
 
-    /**
-     * @return the time when the last registration failed
-     */
     @Transient
     public Optional<Date> getOptSccRegistrationErrorTime() {
         return ofNullable(sccRegistrationErrorTime);
     }
+
+    /**
+     * @return the time when the system has been seen
+     */
+    @Column(name = "last_seen_at")
+    public Date getLastSeenAt() {
+        return lastSeenAt;
+    }
+
+    public void setLastSeenAt(Date lastSeenAtIn) {
+        lastSeenAt = lastSeenAtIn;
+    }
+
+    @Transient
+    public Optional<Date> getOptLastSeenAt() {
+        return ofNullable(lastSeenAt);
+    }
+
 
     @Type(type = "com.suse.scc.proxy.SccProxyStatusEnumType")
     public SccProxyStatus getStatus() {
@@ -201,6 +231,7 @@ public class SCCProxyRecord extends BaseDomainHelper {
         sb.append(", sccCreationJson='").append(sccCreationJson).append('\'');
         sb.append(", sccId=").append(sccId);
         sb.append(", sccRegistrationErrorTime=").append(sccRegistrationErrorTime);
+        sb.append(", lastSeenAt=").append(lastSeenAt);
         sb.append(", status=").append(status);
         sb.append('}');
         return sb.toString();

--- a/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
@@ -49,7 +49,7 @@ public class SCCProxyRecord extends BaseDomainHelper {
     }
 
     /**
-     * Constructor
+     * Constructor with status SCC_CREATION_PENDING
      *
      * @param peripheralFqdnIn peripheral from which the request comes from
      * @param sccLoginIn login of the system to register in SCC
@@ -57,11 +57,25 @@ public class SCCProxyRecord extends BaseDomainHelper {
      * @param sccCreationJsonIn original creation json of the system to register in SCC
      */
     public SCCProxyRecord(String peripheralFqdnIn, String sccLoginIn, String sccPasswdIn, String sccCreationJsonIn) {
+        this(peripheralFqdnIn, sccLoginIn, sccPasswdIn, sccCreationJsonIn, SccProxyStatus.SCC_CREATION_PENDING);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param peripheralFqdnIn peripheral from which the request comes from
+     * @param sccLoginIn login of the system to register in SCC
+     * @param sccPasswdIn password of the system to register in SCC
+     * @param sccCreationJsonIn original creation json of the system to register in SCC
+     * @param statusIn the status of this entry
+     */
+    public SCCProxyRecord(String peripheralFqdnIn, String sccLoginIn, String sccPasswdIn, String sccCreationJsonIn,
+                          SccProxyStatus statusIn) {
         peripheralFqdn = peripheralFqdnIn;
         sccLogin = sccLoginIn;
         sccPasswd = sccPasswdIn;
         sccCreationJson = sccCreationJsonIn;
-        status = SccProxyStatus.SCC_CREATION_PENDING;
+        status = statusIn;
     }
 
     @Id

--- a/java/code/src/com/suse/scc/proxy/SccProxyStatus.java
+++ b/java/code/src/com/suse/scc/proxy/SccProxyStatus.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.scc.proxy;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.Labeled;
+
+public enum SccProxyStatus implements Labeled {
+    SCC_CREATION_PENDING,
+    SCC_CREATED,
+    SCC_REMOVAL_PENDING;
+
+    @Override
+    public String getLabel() {
+        return this.name().toLowerCase();
+    }
+
+    public String getDescription() {
+        return LocalizationService.getInstance().getMessage("proxy.status." + this.name().toLowerCase());
+    }
+}

--- a/java/code/src/com/suse/scc/proxy/SccProxyStatus.java
+++ b/java/code/src/com/suse/scc/proxy/SccProxyStatus.java
@@ -17,7 +17,8 @@ import com.redhat.rhn.domain.Labeled;
 public enum SccProxyStatus implements Labeled {
     SCC_CREATION_PENDING,
     SCC_CREATED,
-    SCC_REMOVAL_PENDING;
+    SCC_REMOVAL_PENDING,
+    SCC_VIRTHOST_PENDING;
 
     @Override
     public String getLabel() {

--- a/java/code/src/com/suse/scc/proxy/SccProxyStatusEnumType.java
+++ b/java/code/src/com/suse/scc/proxy/SccProxyStatusEnumType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.scc.proxy;
+
+import com.redhat.rhn.domain.DatabaseEnumType;
+
+/**
+ * Maps the {@link SccProxyStatus} enum to its label
+ */
+public class SccProxyStatusEnumType extends DatabaseEnumType<SccProxyStatus> {
+
+    /**
+     * Default Constructor
+     */
+    public SccProxyStatusEnumType() {
+        super(SccProxyStatus.class);
+    }
+}
+

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistration.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistration.java
@@ -29,7 +29,7 @@ import java.util.List;
  */
 public class SCCSystemRegistration {
 
-    private final List<SCCSystemRegistrationContextHandler> contextHandlerChain = new ArrayList<>();
+    protected final List<SCCSystemRegistrationContextHandler> contextHandlerChain = new ArrayList<>();
 
     /**
      * Constructor

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationContext.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationContext.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.domain.credentials.SCCCredentials;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 
 import com.suse.scc.client.SCCClient;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ public class SCCSystemRegistrationContext {
     private final SCCCredentials primaryCredential;
 
     private final Map<String, SCCRegCacheItem> itemsByLogin;
-    private final Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin;
+    private final Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin;
 
     private final List<SCCRegCacheItem> paygSystems;
 
@@ -77,7 +77,7 @@ public class SCCSystemRegistrationContext {
         return itemsByLogin;
     }
 
-    public Map<String, SCCRegisterSystemJson> getPendingRegistrationSystemsByLogin() {
+    public Map<String, SCCRegisterSystemItem> getPendingRegistrationSystemsByLogin() {
         return pendingRegistrationSystemsByLogin;
     }
 

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationCreateUpdateSystems.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationCreateUpdateSystems.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 
 import com.suse.scc.client.SCCClientException;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,13 +41,13 @@ public class SCCSystemRegistrationCreateUpdateSystems implements SCCSystemRegist
     @Override
     public void handle(SCCSystemRegistrationContext context) {
         final int batchSize = Config.get().getInt(ConfigDefaults.REG_BATCH_SIZE, 50);
-        final List<SCCRegisterSystemJson> pendingRegistrationSystems =
+        final List<SCCRegisterSystemItem> pendingRegistrationSystems =
                 new ArrayList<>(context.getPendingRegistrationSystemsByLogin().values());
 
         // split items into batches
-        List<List<SCCRegisterSystemJson>> systemsBatches = splitListIntoBatches(pendingRegistrationSystems, batchSize);
+        List<List<SCCRegisterSystemItem>> systemsBatches = splitListIntoBatches(pendingRegistrationSystems, batchSize);
 
-        for (List<SCCRegisterSystemJson> batch : systemsBatches) {
+        for (List<SCCRegisterSystemItem> batch : systemsBatches) {
             try {
                 SCCOrganizationSystemsUpdateResponse response = context.getSccClient().createUpdateSystems(
                         batch,
@@ -65,7 +65,7 @@ public class SCCSystemRegistrationCreateUpdateSystems implements SCCSystemRegist
         }
     }
 
-    private List<List<SCCRegisterSystemJson>> splitListIntoBatches(List<SCCRegisterSystemJson> list, int batchSize) {
+    private List<List<SCCRegisterSystemItem>> splitListIntoBatches(List<SCCRegisterSystemItem> list, int batchSize) {
         return IntStream.range(0, (list.size() + batchSize - 1) / batchSize)
                 .mapToObj(i -> list.subList(i * batchSize, Math.min((i + 1) * batchSize, list.size())))
                 .collect(Collectors.toList());

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
@@ -29,7 +29,7 @@ import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.suse.scc.model.SAPJson;
 import com.suse.scc.model.SCCHwInfoJson;
 import com.suse.scc.model.SCCMinProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -78,7 +78,7 @@ public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegis
                 cacheItem.getOptServer().filter(Server::isPayg).isEmpty();
     }
 
-    private Optional<SCCRegisterSystemJson> getPayload(SCCRegCacheItem rci) {
+    private Optional<SCCRegisterSystemItem> getPayload(SCCRegCacheItem rci) {
         return rci.getOptServer().map(srv -> {
             List<SCCMinProductJson> products = srv.getInstalledProductSet().stream()
                     .flatMap(product -> {
@@ -146,7 +146,7 @@ public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegis
                 return pw;
             });
 
-            return new SCCRegisterSystemJson(login, passwd, srv.getHostname(), hwInfo, products,
+            return new SCCRegisterSystemItem(login, passwd, srv.getHostname(), hwInfo, products,
                     srv.getServerInfo().getCheckin());
         });
     }

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
@@ -46,7 +46,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
         context.getItems().forEach(cacheItem -> cacheItem.getOptServer().ifPresent(ServerFactory::save));
     }
 
-    private void updateSuccessfullyRegisteredItems(SCCSystemRegistrationContext context) {
+    protected void updateSuccessfullyRegisteredItems(SCCSystemRegistrationContext context) {
         for (SCCSystemCredentialsJson systemCredentials : context.getRegisteredSystems()) {
 
             SCCRegCacheItem cacheItem = context.getItemsByLogin().get(systemCredentials.getLogin());
@@ -63,7 +63,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
         }
     }
 
-    private void updateFailedRegisteredItems(SCCSystemRegistrationContext context) {
+    protected void updateFailedRegisteredItems(SCCSystemRegistrationContext context) {
         for (Map.Entry<String, SCCRegisterSystemJson> entry :
                 context.getPendingRegistrationSystemsByLogin().entrySet()) {
             SCCRegCacheItem cacheItem = context.getItemsByLogin().get(entry.getKey());
@@ -74,7 +74,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
         }
     }
 
-    private void updatePaygSystems(SCCSystemRegistrationContext context) {
+    protected void updatePaygSystems(SCCSystemRegistrationContext context) {
         context.getPaygSystems().forEach(cacheItem -> context.setItemAsNonRegistrationRequiredItem(cacheItem));
     }
 

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
@@ -20,7 +20,7 @@ import static com.suse.utils.Predicates.isAbsent;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 import com.redhat.rhn.domain.server.ServerFactory;
 
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 
 import org.apache.logging.log4j.LogManager;
@@ -64,7 +64,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
     }
 
     protected void updateFailedRegisteredItems(SCCSystemRegistrationContext context) {
-        for (Map.Entry<String, SCCRegisterSystemJson> entry :
+        for (Map.Entry<String, SCCRegisterSystemItem> entry :
                 context.getPendingRegistrationSystemsByLogin().entrySet()) {
             SCCRegCacheItem cacheItem = context.getItemsByLogin().get(entry.getKey());
             if (LOG.isErrorEnabled()) {

--- a/java/code/src/com/suse/scc/test/SCCRegisterUpdateSystemItemTest.java
+++ b/java/code/src/com/suse/scc/test/SCCRegisterUpdateSystemItemTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.scc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.suse.scc.model.SCCRegisterSystemItem;
+import com.suse.scc.model.SCCUpdateSystemItem;
+import com.suse.utils.Json;
+
+import com.google.gson.reflect.TypeToken;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link SCCRegisterSystemItem} and {@link SCCUpdateSystemItem}.
+ */
+public class SCCRegisterUpdateSystemItemTest {
+
+    private static final String LAST_SEEN_REQUEST_STRING = """
+            {
+               "systems":[
+                  {
+                     "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010265",
+                     "password":"wuTmFh2RKUTQAAA013OCbzeluSteRXXclTUKFTN0lMjQ5ZANSMEtgynM2RAoxk3l",
+                     "last_seen_at":"2025-01-21T01:00:00.000+01"
+                  },
+                  {
+                     "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010266",
+                     "password":"vMAZGApR4Xx6UD3uAVR5DuuOoK7fuzYR1TCCAeNTH6X7WWtQwddT8iUFGgXpsh2d",
+                     "last_seen_at":"2025-01-22T01:00:00.000+01"
+                  },
+                  {
+                     "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010267",
+                     "password":"cwvK5YuRgQaUbipMRz5xEYq0KLpHtcmvxjIq4WX3EmR4oKao2w6FzZl46omCAAgL",
+                     "last_seen_at":"2025-01-23T01:00:00.000+01"
+                  }
+               ]
+            }
+            """;
+
+    private static final String CREATE_REQUEST_STRING = """
+            {
+                "systems":[
+                   {
+                      "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010002",
+                      "password":"0deFZmn14ZzX6N4jYQ5ZQ6nMGAgYsMGafU8vceShmb32uWVWDKGErALICO2ui2rV",
+                      "hwinfo":{
+                         "cpus":0,
+                         "sockets":0,
+                         "mem_total":1024,
+                         "arch":"i386",
+                         "sap":[]
+                      },
+                      "products":[],
+                      "regcodes":[],
+                      "last_seen_at":"2025-03-01T01:00:00.000+01"
+                   },
+                   {
+                      "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010013",
+                      "password":"rNCp2TvRELSIZFmPJH9595x8ehFBjtb4wnq8jiPjzvNysRwbJEFfcfZCVqGhRDCc",
+                      "hwinfo":{
+                         "cpus":0,
+                         "sockets":0,
+                         "mem_total":1024,
+                         "arch":"i386",
+                         "sap":[]
+                      },
+                      "products":[],
+                      "regcodes":[],
+                      "last_seen_at":"2025-03-01T01:00:00.000+01"
+                   },
+                   {
+                      "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010003",
+                      "password":"trHD0ytf5eVCoDxUYVhKs05EpjKWPtjjUkWu6P6eJXf6EhX6O8wIPn8vMQvGOWSF",
+                      "hwinfo":{
+                         "cpus":0,
+                         "sockets":0,
+                         "mem_total":1024,
+                         "arch":"i386",
+                         "sap":[]
+                      },
+                      "products":[],
+                      "regcodes":[],
+                      "last_seen_at":"2025-03-01T01:00:00.000+01"
+                   }
+                ]
+             }
+            """;
+
+    private final TypeToken<Map<String, List<SCCRegisterSystemItem>>> registerSystemTypeToken = new TypeToken<>() { };
+    private final TypeToken<Map<String, List<SCCUpdateSystemItem>>> updateSystemTypeToken = new TypeToken<>() { };
+    private static final String SYSTEMS_KEY = "systems";
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+
+    @Test
+    public void ensureRegularCreateRequestParsingWorks() {
+        Map<String, List<SCCRegisterSystemItem>> createRequestToRegisterSystem =
+                Json.GSON.fromJson(CREATE_REQUEST_STRING, registerSystemTypeToken.getType());
+
+        assertTrue(createRequestToRegisterSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, createRequestToRegisterSystem.get(SYSTEMS_KEY).size());
+        for (SCCRegisterSystemItem jsonItem : createRequestToRegisterSystem.get(SYSTEMS_KEY)) {
+            assertFalse(jsonItem.isOnlyLastSeenAt());
+            assertEquals("2025-03-01", dateFormat.format(jsonItem.getLastSeenAt()));
+        }
+    }
+
+    @Test
+    public void ensureRegularLastSeenRequestParsingWorks() {
+        Map<String, List<SCCUpdateSystemItem>> lastSeenRequestToUpdateSystem =
+                Json.GSON.fromJson(LAST_SEEN_REQUEST_STRING, updateSystemTypeToken.getType());
+
+        assertTrue(lastSeenRequestToUpdateSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, lastSeenRequestToUpdateSystem.get(SYSTEMS_KEY).size());
+    }
+
+    @Test
+    public void acknowledgeInvertedCreateRequestParsingIsNotFailing() {
+        Map<String, List<SCCUpdateSystemItem>> createRequestToUpdateSystem =
+                Json.GSON.fromJson(CREATE_REQUEST_STRING, updateSystemTypeToken.getType());
+
+        assertTrue(createRequestToUpdateSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, createRequestToUpdateSystem.get(SYSTEMS_KEY).size());
+    }
+
+    @Test
+    public void acknowledgeInvertedLastSeenRequestParsingIsNotFailing() {
+        Map<String, List<SCCRegisterSystemItem>> lastSeenRequestRegisterSystem =
+                Json.GSON.fromJson(LAST_SEEN_REQUEST_STRING, registerSystemTypeToken.getType());
+
+        assertTrue(lastSeenRequestRegisterSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, lastSeenRequestRegisterSystem.get(SYSTEMS_KEY).size());
+        for (SCCRegisterSystemItem jsonItem : lastSeenRequestRegisterSystem.get(SYSTEMS_KEY)) {
+            assertTrue(jsonItem.isOnlyLastSeenAt());
+            assertNotEquals("2025-03-01", dateFormat.format(jsonItem.getLastSeenAt()));
+        }
+    }
+}

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
@@ -51,6 +51,7 @@ import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.model.SCCUpdateSystemJson;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 import com.suse.scc.model.SCCVirtualizationHostPropertiesJson;
+import com.suse.scc.proxy.SCCProxyFactory;
 
 import org.junit.jupiter.api.Test;
 
@@ -66,6 +67,7 @@ import java.util.stream.Collectors;
  * Tests for {@link SCCClient} methods.
  */
 public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
+    private SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
 
     @Test
     public void testSCCSystemRegistrationLifecycle() throws Exception {
@@ -110,7 +112,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
         };
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCRegCacheItem> testSystems = allUnregistered.stream()
@@ -172,7 +175,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
                 .createSCCConfig();
         SCCWebClient sccWebClient = new SCCWebClient(sccConfig);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
 
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
@@ -238,7 +242,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
         };
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCRegCacheItem> testSystems = allUnregistered.stream()
@@ -312,7 +317,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
         };
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCRegCacheItem> testSystems = allUnregistered.stream()
@@ -403,7 +409,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         credentials.setUrl("https://scc.suse.com");
         CredentialsFactory.storeCredentials(credentials);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCVirtualizationHostJson> virtHostsJson = SCCCachingFactory.listVirtualizationHosts();
@@ -489,7 +496,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         credentials.setUrl("https://scc.suse.com");
         CredentialsFactory.storeCredentials(credentials);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCVirtualizationHostJson> virtHostsJson = SCCCachingFactory.listVirtualizationHosts();
@@ -590,7 +598,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         credentials.setUrl("https://scc.suse.com");
         CredentialsFactory.storeCredentials(credentials);
 
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         SCCCachingFactory.initNewSystemsToForward();
         List<SCCRegCacheItem> allUnregistered = SCCCachingFactory.findSystemsToForwardRegistration();
         List<SCCVirtualizationHostJson> virtHostsJson = SCCCachingFactory.listVirtualizationHosts();

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
@@ -46,9 +46,9 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 import com.suse.scc.model.SCCVirtualizationHostPropertiesJson;
 import com.suse.scc.proxy.SCCProxyFactory;
@@ -89,7 +89,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         SCCWebClient sccWebClient = new SCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 assertNotEmpty(systems);
@@ -212,7 +212,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         SCCWebClient sccWebClient = new SCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 assertNotEmpty(systems);
@@ -235,7 +235,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 assertEquals(new Date(0), systems.get(0).getLastSeenAt());
@@ -254,7 +254,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         CredentialsFactory.storeCredentials(credentials);
         sccSystemRegistrationManager.register(testSystems, credentials);
 
-        sccSystemRegistrationManager.updateLastSeen(credentials);
+        sccSystemRegistrationManager.updateLastSeen(SCCCachingFactory.listUpdateLastSeenItems(credentials),
+                credentials);
     }
 
     @Test
@@ -294,7 +295,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         TestSCCWebClient sccWebClient = new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 return new SCCOrganizationSystemsUpdateResponse(
                         systems.stream()
                                 .map(system ->
@@ -305,7 +306,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 callCnt += 1;
                 assertTrue(callCnt <= 4, "more requests then expected");
                 if (callCnt < 4) {
@@ -329,7 +330,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         CredentialsFactory.storeCredentials(credentials);
         sccSystemRegistrationManager.register(testSystems, credentials);
 
-        sccSystemRegistrationManager.updateLastSeen(credentials);
+        sccSystemRegistrationManager.updateLastSeen(SCCCachingFactory.listUpdateLastSeenItems(credentials),
+                credentials);
     }
 
     @Test
@@ -361,7 +363,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
 
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
 
@@ -383,7 +385,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
             }
@@ -449,7 +451,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
 
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 return new SCCOrganizationSystemsUpdateResponse(
@@ -470,7 +472,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
             }
@@ -551,7 +553,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
 
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 return new SCCOrganizationSystemsUpdateResponse(
@@ -572,7 +574,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
             }

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
@@ -34,7 +34,7 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.proxy.SCCProxyFactory;
 
@@ -185,7 +185,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         TestSCCWebClient sccWebClient = new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) throws SCCClientException {
                 callCnt += 1;
                 throw new SCCClientException(400, "Bad Request");
@@ -237,7 +237,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         TestSCCWebClient sccWebClient = new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) throws SCCClientException {
                 callCnt += 1;
                 // allow first call to fail
@@ -362,7 +362,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         return new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) {
                 callCnt += 1;
                 return new SCCOrganizationSystemsUpdateResponse(

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
@@ -36,6 +36,7 @@ import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCRegisterSystemJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
+import com.suse.scc.proxy.SCCProxyFactory;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,6 +65,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
     private Integer systemSize;
     private Integer batchSize;
 
+    private SCCProxyFactory sccProxyFactory = new SCCProxyFactory();
 
     @Override
     @BeforeEach
@@ -115,7 +117,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -136,7 +139,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -156,7 +160,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -191,7 +196,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions
@@ -253,7 +259,8 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         assertPreConditions();
 
         // execution
-        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient);
+        SCCSystemRegistrationManager sccSystemRegistrationManager = new SCCSystemRegistrationManager(sccWebClient,
+                sccProxyFactory);
         sccSystemRegistrationManager.register(testSystems, getCredentials());
 
         // assertions

--- a/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationCreateUpdateSystemsTest.java
+++ b/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationCreateUpdateSystemsTest.java
@@ -21,7 +21,7 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.registration.SCCSystemRegistrationContext;
 import com.suse.scc.registration.SCCSystemRegistrationCreateUpdateSystems;
@@ -96,7 +96,7 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         TestSCCWebClient sccWebClient = new TestSCCWebClient(null) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems,
+                    List<SCCRegisterSystemItem> systems,
                     String username,
                     String password
             ) throws SCCClientException {
@@ -131,7 +131,7 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         TestSCCWebClient sccWebClient = new TestSCCWebClient(null) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems,
+                    List<SCCRegisterSystemItem> systems,
                     String username,
                     String password
             ) {
@@ -173,8 +173,8 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         for (int i = 0; i < systemSize; i++) {
             context.getPendingRegistrationSystemsByLogin().put(
                     "SCCSystemId.login" + i,
-                    new SCCRegisterSystemJson(
-                            "SCCRegisterSystemJson.login" + i, "SCCRegisterSystemJson.pwd" + i,
+                    new SCCRegisterSystemItem(
+                            "SCCRegisterSystemItem.login" + i, "SCCRegisterSystemItem.pwd" + i,
                             null, null, null, null)
             );
         }
@@ -215,7 +215,7 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         return new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) {
                 callCnt += 1;
                 return new SCCOrganizationSystemsUpdateResponse(

--- a/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationSystemDataAcquisitorTest.java
+++ b/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationSystemDataAcquisitorTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.product.SUSEProductSet;
 import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 import com.redhat.rhn.domain.server.CPU;
+import com.redhat.rhn.domain.server.SAPWorkload;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerArch;
 import com.redhat.rhn.domain.server.ServerInfo;
@@ -35,7 +36,7 @@ import com.redhat.rhn.domain.server.VirtualInstanceType;
 
 import com.suse.scc.model.SCCHwInfoJson;
 import com.suse.scc.model.SCCMinProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.registration.SCCSystemRegistrationContext;
 import com.suse.scc.registration.SCCSystemRegistrationSystemDataAcquisitor;
 
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -169,22 +171,22 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin =
+        Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin();
         assertEquals(1, pendingRegistrationSystemsByLogin.size());
-        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystemsByLogin.values().iterator().next();
-        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
-        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
-        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
-        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemJson.getProducts().size());
-        assertTrue(sccRegisterSystemJson.getProducts().stream()
+        SCCRegisterSystemItem sccRegisterSystemItem = pendingRegistrationSystemsByLogin.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemItem.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemItem.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemItem.getHostname());
+        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemItem.getProducts().size());
+        assertTrue(sccRegisterSystemItem.getProducts().stream()
                 .map(SCCMinProductJson::getIdentifier)
                 .toList()
                 .containsAll(expectedProductIdentifiers));
-        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+        assertTrue(!sccRegisterSystemItem.getLastSeenAt().before(testBeginTimestamp));
 
-        assertNotNull(sccRegisterSystemJson.getHwinfo());
-        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertNotNull(sccRegisterSystemItem.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemItem.getHwinfo();
         assertEquals(expectedCpus, hwInfo.getCpus());
         assertEquals(expectedSockets, hwInfo.getSockets());
         assertEquals("server0", hwInfo.getArch());
@@ -225,18 +227,18 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin =
+        Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin();
         assertEquals(1, pendingRegistrationSystemsByLogin.size());
-        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystemsByLogin.values().iterator().next();
-        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
-        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
-        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
-        assertEquals(0, sccRegisterSystemJson.getProducts().size());
-        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+        SCCRegisterSystemItem sccRegisterSystemItem = pendingRegistrationSystemsByLogin.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemItem.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemItem.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemItem.getHostname());
+        assertEquals(0, sccRegisterSystemItem.getProducts().size());
+        assertTrue(!sccRegisterSystemItem.getLastSeenAt().before(testBeginTimestamp));
 
-        assertNotNull(sccRegisterSystemJson.getHwinfo());
-        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertNotNull(sccRegisterSystemItem.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemItem.getHwinfo();
         assertEquals(expectedCpus, hwInfo.getCpus());
         assertEquals(expectedSockets, hwInfo.getSockets());
         assertEquals("server1", hwInfo.getArch());
@@ -278,18 +280,18 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin =
+        Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin();
         assertEquals(1, pendingRegistrationSystemsByLogin.size());
-        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystemsByLogin.values().iterator().next();
-        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
-        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
-        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
-        assertEquals(0, sccRegisterSystemJson.getProducts().size());
-        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+        SCCRegisterSystemItem sccRegisterSystemItem = pendingRegistrationSystemsByLogin.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemItem.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemItem.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemItem.getHostname());
+        assertEquals(0, sccRegisterSystemItem.getProducts().size());
+        assertTrue(!sccRegisterSystemItem.getLastSeenAt().before(testBeginTimestamp));
 
-        assertNotNull(sccRegisterSystemJson.getHwinfo());
-        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertNotNull(sccRegisterSystemItem.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemItem.getHwinfo();
         assertEquals(0L, hwInfo.getCpus());
         assertEquals(0L, hwInfo.getSockets());
         assertEquals("server2", hwInfo.getArch());
@@ -317,9 +319,9 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         // Assertions
         assertNull(suseProductSet.getBaseProduct());
         assertTrue(suseProductSet.getAddonProducts().isEmpty());
-        SCCRegisterSystemJson sccRegisterSystemJson =
+        SCCRegisterSystemItem sccRegisterSystemItem =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin().values().iterator().next();
-        assertTrue(sccRegisterSystemJson.getProducts().isEmpty());
+        assertTrue(sccRegisterSystemItem.getProducts().isEmpty());
     }
 
     /**
@@ -340,9 +342,9 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         // Assertions
         assertNull(suseProductSet.getBaseProduct());
         assertNull(suseProductSet.getAddonProducts());
-        SCCRegisterSystemJson sccRegisterSystemJson =
+        SCCRegisterSystemItem sccRegisterSystemItem =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin().values().iterator().next();
-        assertTrue(sccRegisterSystemJson.getProducts().isEmpty());
+        assertTrue(sccRegisterSystemItem.getProducts().isEmpty());
     }
 
 
@@ -376,10 +378,10 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        SCCRegisterSystemJson sccRegisterSystemJson =
+        SCCRegisterSystemItem sccRegisterSystemItem =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin().values().iterator().next();
-        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemJson.getProducts().size());
-        assertTrue(sccRegisterSystemJson.getProducts().stream()
+        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemItem.getProducts().size());
+        assertTrue(sccRegisterSystemItem.getProducts().stream()
                 .map(SCCMinProductJson::getIdentifier)
                 .toList()
                 .containsAll(expectedProductIdentifiers));
@@ -469,7 +471,7 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         public static final String SCC_PWD = "sccPasswd";
 
         // Maps we need to spy on
-        private final Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin = new HashMap<>();
+        private final Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin = new HashMap<>();
 
         private final SCCSystemRegistrationContext contextMock;
 
@@ -530,16 +532,18 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
                 allowing(cacheItemMock).getOptSccLogin(); will(returnValue(Optional.of(SCC_LOGIN)));
                 allowing(cacheItemMock).getOptSccPasswd(); will(returnValue(Optional.of(SCC_PWD)));
 
-                // Additional data required for SCCRegisterSystemJson
+                // Additional data required for SCCRegisterSystemItem
                 allowing(serverMock).getHostname(); will(returnValue(builder.hostname));
                 allowing(serverMock).getServerInfo(); will(returnValue(serverInfoMock));
                 allowing(serverInfoMock).getCheckin(); will(returnValue(new Date()));
 
+                allowing(serverMock).getSapWorkloads(); will(returnValue(new HashSet<SAPWorkload>()));
+                allowing(serverMock).asMinionServer(); will(returnValue(Optional.empty()));
             }});
 
         }
 
-        public Map<String, SCCRegisterSystemJson> getPendingRegistrationSystemsByLogin() {
+        public Map<String, SCCRegisterSystemItem> getPendingRegistrationSystemsByLogin() {
             return pendingRegistrationSystemsByLogin;
         }
 

--- a/java/spacewalk-java.changes.carlo.issv3-scc-proxy-register
+++ b/java/spacewalk-java.changes.carlo.issv3-scc-proxy-register
@@ -1,0 +1,2 @@
+- Implement hub registration data forwarding
+  from the peripherals towards the scc

--- a/java/spacewalk-java.changes.carlo.issv3-update-last-seen
+++ b/java/spacewalk-java.changes.carlo.issv3-update-last-seen
@@ -1,0 +1,2 @@
+- Implements and tests the update last seen mechanism
+  when a hub is acting as an SCC proxy

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -92,6 +92,16 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/hub/scc/suma/product_tree.json', 'GET', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/hub/scc/connect/organizations/systems', 'PUT', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/hub/scc/connect/organizations/systems/:id', 'DELETE', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/hub/scc/connect/organizations/virtualization_hosts', 'PUT', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+
 
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/admin/hub/hub-details', 'GET', 'W', True)

--- a/schema/spacewalk/common/tables/suseSccProxy.sql
+++ b/schema/spacewalk/common/tables/suseSccProxy.sql
@@ -1,0 +1,35 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+
+CREATE TABLE suseSccProxy
+(
+    proxy_id            BIGINT CONSTRAINT suse_sccproxy_proxy_id_pk PRIMARY KEY
+                                                  GENERATED ALWAYS AS IDENTITY,
+    peripheral_fqdn     VARCHAR(128),
+    scc_login           VARCHAR(64),
+    scc_passwd          VARCHAR(64),
+    scc_creation_json   TEXT,
+    scc_id              NUMERIC,
+    status              scc_proxy_status_t NOT NULL,
+    scc_regerror_timestamp TIMESTAMPTZ,
+    last_seen_at TIMESTAMPTZ,
+
+    created        TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL
+);
+

--- a/schema/spacewalk/common/tables/tables.deps
+++ b/schema/spacewalk/common/tables/tables.deps
@@ -261,6 +261,7 @@ susePackageState                   :: rhnPackageName rhnPackageEVR rhnPackageArc
 suseProducts                       :: rhnPackageArch rhnChannelFamily
 suseProductChannel                 :: suseProducts rhnChannel
 suseProductExtension               :: suseProducts
+suseSccProxy                       :: scc_proxy_status_t
 suseChannelTemplate                :: suseProducts suseSCCRepository
 suseSaltPillar                     :: rhnServer rhnServerGroup web_customer
 suseSCCOrderItem                   :: suseCredentials

--- a/schema/spacewalk/postgres/class/scc_proxy_status_t.sql
+++ b/schema/spacewalk/postgres/class/scc_proxy_status_t.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+CREATE TYPE scc_proxy_status_t AS ENUM (
+    'scc_creation_pending',
+    'scc_created',
+    'scc_removal_pending',
+    'scc_virthost_pending'
+);

--- a/schema/spacewalk/susemanager-schema.changes.carlo.issv3-scc-rbac-endpoints
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.issv3-scc-rbac-endpoints
@@ -1,0 +1,1 @@
+- Added issv3 scc missing RBAC entries

--- a/schema/spacewalk/susemanager-schema.changes.carlo.issv3-update-last-seen
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.issv3-update-last-seen
@@ -1,0 +1,1 @@
+- Add column last_seen_at to suseSCCProxy table

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.8-to-susemanager-schema-5.1.9/100-create_suseSccProxy.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.8-to-susemanager-schema-5.1.9/100-create_suseSccProxy.sql
@@ -1,0 +1,47 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'scc_proxy_status_t') THEN
+        CREATE TYPE scc_proxy_status_t AS ENUM (
+            'scc_creation_pending',
+            'scc_created',
+            'scc_removal_pending',
+            'scc_virthost_pending'
+        );
+    ELSE
+        RAISE NOTICE 'type "scc_proxy_status_t" already exists, skipping';
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS suseSccProxy
+(
+    proxy_id            BIGINT CONSTRAINT suse_sccproxy_proxy_id_pk PRIMARY KEY
+                                                  GENERATED ALWAYS AS IDENTITY,
+    peripheral_fqdn     VARCHAR(128),
+    scc_login           VARCHAR(64),
+    scc_passwd          VARCHAR(64),
+    scc_creation_json   TEXT,
+    scc_id              NUMERIC,
+    status              scc_proxy_status_t NOT NULL,
+    scc_regerror_timestamp TIMESTAMPTZ,
+
+    created        TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL
+);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.8-to-susemanager-schema-5.1.9/101-add-updatelastseen-susesccproxy.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.8-to-susemanager-schema-5.1.9/101-add-updatelastseen-susesccproxy.sql
@@ -1,0 +1,14 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+ALTER TABLE suseSccProxy ADD COLUMN IF NOT EXISTS
+last_seen_at TIMESTAMPTZ;
+

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.8-to-susemanager-schema-5.1.9/102-rbac-endpoints-for-scc.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.8-to-susemanager-schema-5.1.9/102-rbac-endpoints-for-scc.sql
@@ -1,0 +1,13 @@
+-- scc endpoints
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/hub/scc/connect/organizations/systems', 'PUT', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/hub/scc/connect/organizations/systems' AND http_method = 'PUT');
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/hub/scc/connect/organizations/systems/:id', 'DELETE', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/hub/scc/connect/organizations/systems/:id' AND http_method = 'DELETE');
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/hub/scc/connect/organizations/virtualization_hosts', 'PUT', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/hub/scc/connect/organizations/virtualization_hosts' AND http_method = 'PUT');
+
+


### PR DESCRIPTION
## What does this PR change?

Clients registered on a Peripheral Server should be forwarded to the Hub and the Hub should send it to SCC. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- TBD?

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25350

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
