### PR TITLE
QE: Removing expect command from testsuite

### DIFF
--- a/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
@@ -26,7 +26,9 @@ Feature: PXE boot a terminal with Cobbler and containerized proxy
   # The build host has same version as the terminal
   Scenario: Prepare the autoinstallation files on the server
     When I install packages "tftpboot-installation-SLE-15-SP4-x86_64 expect" on this "build_host"
-    And I copy the tftpboot installation files from the build host to the server
+    And I perform a key exchange to allow machine:"build_host" authenticate to machine:"server"
+    And I transfer file:"/usr/share/tftpboot-installation" from:"build_host" to:"server" via scp
+    And I delete the keys previously exchanged
     And I copy the distribution inside the container on the server
 
   Scenario: Create auto installation distribution

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -315,6 +315,12 @@ class RemoteNode
     $stdout.puts "Node #{hostname} is online."
   end
 
+  # Get the node's hostname
+  def get_hostname
+    hostname, _code = run_local('hostname')
+    hostname.delete("\n")
+  end
+
   private
 
   # Obtain the Public IP for a node

--- a/testsuite/features/upload_files/copy-tftpboot-files.exp
+++ b/testsuite/features/upload_files/copy-tftpboot-files.exp
@@ -1,7 +1,0 @@
-set address [lindex $argv 0]
-
-spawn /usr/bin/scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r /usr/share/tftpboot-installation root@$address:/tmp
-expect {
-	"*?assword:*" { send "linux\r"; interact }
-	eof { exit }
-}


### PR DESCRIPTION
## What does this PR change?

Removing the expect command from the client tools

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27138
Port(s): None, just in head and uyuni

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
