### PR TITLE
ISSv3 - Show a message when there are no slaves to migrate (bsc#1242773)

### DIFF
--- a/web/html/src/components/hub/MigrateSlavesForm.tsx
+++ b/web/html/src/components/hub/MigrateSlavesForm.tsx
@@ -83,40 +83,10 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
         {/* Modal dialog to show the problems happened during migration */}
         {this.state.migrationResult && this.renderMigrationResultDialog()}
 
-        <Table data={this.state.tableModel} identifier={(row: MigrationEntry) => row.id}>
-          <Column
-            columnKey="selected"
-            header={t("Migrate?")}
-            cell={(row: MigrationEntry) => this.renderSelection(row)}
-          />
-          <Column columnKey="fqdn" header={t("Server FQDN")} cell={(row: MigrationEntry) => row.fqdn} />
-          <Column
-            columnKey="accessToken"
-            header={t("Access Token")}
-            cell={(row: MigrationEntry) => this.renderToken(row)}
-          />
-          <Column
-            columnKey="rootCA"
-            header={t("Root Certificate Authority")}
-            cell={(row: MigrationEntry) => this.renderRootCA(row)}
-          />
-        </Table>
-        <div className="btn-group pull-right">
-          <AsyncButton
-            id="submit-btn"
-            className="btn-primary"
-            text={t("Submit")}
-            disabled={this.state.loading || !this.state.tableModelValid}
-            action={() => this.onSubmit()}
-          />
-          <Button
-            id="cancel-btn"
-            className="btn-default"
-            text={t("Cancel")}
-            disabled={this.state.loading}
-            handler={() => window.pageRenderers?.spaengine?.navigate?.(`/rhn/manager/admin/hub/peripherals`)}
-          />
-        </div>
+        {/* When we are migrating from ISSv1 it is possible that we don't have any server to migrate. In this case
+         * show an error message instead of the server table. This cannot happen for ISSv2 because the user must always
+         * insert the server information manually. */}
+        {this.noServerToMigrate() ? this.renderNothingToMigrateMessage() : this.renderServerTable()}
       </TopPanel>
     );
   }
@@ -212,6 +182,79 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
           </div>
         }
       />
+    );
+  }
+
+  private noServerToMigrate(): boolean {
+    if (this.props.migrateFrom === MigrationVersion.v2) {
+      return false;
+    }
+
+    return this.state.tableModel.length === 0;
+  }
+
+  private renderNothingToMigrateMessage(): React.ReactNode {
+    return (
+      <>
+        <Messages
+          items={[
+            {
+              severity: "info",
+              text: <p>{t("There are no ISSv1 slaves to migrate.")}</p>,
+            },
+          ]}
+        />
+        <div className="btn-group pull-right">
+          <Button
+            id="cancel-btn"
+            className="btn-default"
+            text={t("Back")}
+            disabled={this.state.loading}
+            handler={() => window.pageRenderers?.spaengine?.navigate?.(`/rhn/manager/admin/hub/peripherals`)}
+          />
+        </div>
+      </>
+    );
+  }
+
+  private renderServerTable(): React.ReactNode {
+    return (
+      <>
+        <Table data={this.state.tableModel} identifier={(row: MigrationEntry) => row.id}>
+          <Column
+            columnKey="selected"
+            header={t("Migrate?")}
+            cell={(row: MigrationEntry) => this.renderSelection(row)}
+          />
+          <Column columnKey="fqdn" header={t("Server FQDN")} cell={(row: MigrationEntry) => row.fqdn} />
+          <Column
+            columnKey="accessToken"
+            header={t("Access Token")}
+            cell={(row: MigrationEntry) => this.renderToken(row)}
+          />
+          <Column
+            columnKey="rootCA"
+            header={t("Root Certificate Authority")}
+            cell={(row: MigrationEntry) => this.renderRootCA(row)}
+          />
+        </Table>
+        <div className="btn-group pull-right">
+          <AsyncButton
+            id="submit-btn"
+            className="btn-primary"
+            text={t("Submit")}
+            disabled={this.state.loading || !this.state.tableModelValid}
+            action={() => this.onSubmit()}
+          />
+          <Button
+            id="cancel-btn"
+            className="btn-default"
+            text={t("Cancel")}
+            disabled={this.state.loading}
+            handler={() => window.pageRenderers?.spaengine?.navigate?.(`/rhn/manager/admin/hub/peripherals`)}
+          />
+        </div>
+      </>
     );
   }
 

--- a/web/spacewalk-web.changes.mackdk.issv3-no-issv1-slaves
+++ b/web/spacewalk-web.changes.mackdk.issv3-no-issv1-slaves
@@ -1,0 +1,2 @@
+- Show an error message when there are no ISSv1 slaves to migrate
+  (bsc#1242773)


### PR DESCRIPTION
## What does this PR change?

This changes the ISSv1 Migration page to show a message when there are no ISSv1 to migrate instead of showing an empty table.

## GUI diff

No difference.

Before:
![image](https://github.com/user-attachments/assets/6d25ed84-4b29-4d9d-becc-f1dabc980948)

After:
![image](https://github.com/user-attachments/assets/4a8f62ec-f5af-456b-964d-d7341167a8e3)

- [X] **DONE**

## Documentation
- No documentation needed: already documented

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27173

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
