### PR TITLE
Precautionally secure redirection of SSO getACS endpoint

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/SSOController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SSOController.java
@@ -119,8 +119,18 @@ public final class SSOController {
                                     request.raw(), response.raw(), user.getId());
                             if (relayState != null && !relayState.isEmpty() &&
                                     !relayState.equals(ServletUtils.getSelfRoutedURLNoQuery(request.raw()))) {
-                                response.redirect(request.raw().getParameter("RelayState"));
-                                return response;
+                                // If the execution is at this point of the code, it means that the request successfully
+                                // passed Auth.processResponse(), meaning that it containes a "SAMLResponse" parameter
+                                // as an encoded64 XML file. This XML file has been in turn validated (signature)
+                                // and it has a correct timestamp, so has not been forged by an attacker.
+                                // The other parameter sent with the http request is named "RelayState", which usually
+                                // has always a value of "/rhn/YourRhn.do" (sent by SSO, pointing to the main web page).
+                                // As a precautionary measure, we can allow redirection only if RelayState parameter
+                                // points to "/rhn/" pages, hence validating against redirection to external urls
+                                if (relayState.startsWith("/rhn/")) {
+                                    response.redirect(relayState);
+                                    return response;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## What does this PR change?
In the SSO getACS endpoint, as a precautionary measure,  it validates redirection only to internal urls

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manual debugging and testing
- [x] **DONE**

## Links
Issue(s):  https://github.com/SUSE/spacewalk/issues/26929
Port(s): not backported
- [x] **DONE**

## Changelogs
- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

