### PR TITLE
RBAC endpoint validation on startup

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/access/AccessGroup.java
+++ b/java/code/src/com/redhat/rhn/domain/access/AccessGroup.java
@@ -45,7 +45,8 @@ public class AccessGroup {
     private Org org;
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
-            name = "access.accessGroupNamespace",
+            name = "accessGroupNamespace",
+            schema = "access",
             joinColumns = @JoinColumn(name = "group_id"),
             inverseJoinColumns = @JoinColumn(name = "namespace_id")
     )

--- a/java/code/src/com/redhat/rhn/domain/access/Namespace.java
+++ b/java/code/src/com/redhat/rhn/domain/access/Namespace.java
@@ -15,7 +15,9 @@
 
 package com.redhat.rhn.domain.access;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -24,6 +26,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
 @Entity
@@ -33,9 +36,13 @@ public class Namespace {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String namespace;
+    @ManyToMany(mappedBy = "namespaces")
+    private Set<WebEndpoint> endpoints = new HashSet<>();
     @Enumerated(EnumType.STRING)
     @Column(name = "access_mode")
     private AccessMode accessMode;
+    @ManyToMany(mappedBy = "namespaces")
+    private Set<AccessGroup> accessGroups = new HashSet<>();
     private String description;
 
     public enum AccessMode {
@@ -89,12 +96,20 @@ public class Namespace {
         namespace = namespaceIn;
     }
 
+    public Set<WebEndpoint> getEndpoints() {
+        return endpoints;
+    }
+
     public AccessMode getAccessMode() {
         return accessMode;
     }
 
     public void setAccessMode(AccessMode accessModeIn) {
         accessMode = accessModeIn;
+    }
+
+    public Set<AccessGroup> getAccessGroups() {
+        return accessGroups;
     }
 
     public String getDescription() {

--- a/java/code/src/com/redhat/rhn/domain/access/WebEndpoint.java
+++ b/java/code/src/com/redhat/rhn/domain/access/WebEndpoint.java
@@ -17,7 +17,9 @@ package com.redhat.rhn.domain.access;
 
 import com.redhat.rhn.domain.BaseDomainHelper;
 
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -26,6 +28,9 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import javax.persistence.NamedNativeQuery;
 import javax.persistence.Table;
 
@@ -61,9 +66,19 @@ public class WebEndpoint extends BaseDomainHelper {
     @Column(name = "class_method")
     private String className;
     private String endpoint;
+    @Column(name = "http_method")
     private String httpMethod;
+    @ManyToMany
+    @JoinTable(
+            name = "endpointNamespace",
+            schema = "access",
+            joinColumns = @JoinColumn(name = "endpoint_id"),
+            inverseJoinColumns = @JoinColumn(name = "namespace_id")
+    )
+    private Set<Namespace> namespaces = new HashSet<>();
     @Enumerated(EnumType.STRING)
     private Scope scope;
+    @Column(name = "auth_required")
     private Boolean authRequired;
 
     public enum Scope {
@@ -144,6 +159,10 @@ public class WebEndpoint extends BaseDomainHelper {
 
     public void setHttpMethod(String httpMethodIn) {
         httpMethod = httpMethodIn;
+    }
+
+    public Set<Namespace> getNamespaces() {
+        return namespaces;
     }
 
     public Boolean isAuthRequired() {

--- a/java/code/src/com/redhat/rhn/domain/access/WebEndpointFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/access/WebEndpointFactory.java
@@ -24,6 +24,7 @@ import org.hibernate.query.NativeQuery;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class WebEndpointFactory extends HibernateFactory {
 
@@ -104,5 +105,13 @@ public class WebEndpointFactory extends HibernateFactory {
         // TODO: Cache
         NativeQuery<String> query = getSession().getNamedNativeQuery("WebEndpoint_get_unauthorized_api");
         return query.getResultStream().collect(Collectors.toUnmodifiableSet());
+    }
+
+    /**
+     * Get a {@code Stream} of all RBAC endpoints
+     * @return the {@code Stream} of all endpoints
+     */
+    public static Stream<WebEndpoint> getAllEndpoints() {
+        return WebEndpointFactory.getSession().createQuery("from WebEndpoint", WebEndpoint.class).stream();
     }
 }

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -85,6 +85,7 @@ import com.suse.manager.webui.controllers.maintenance.MaintenanceCalendarControl
 import com.suse.manager.webui.controllers.maintenance.MaintenanceController;
 import com.suse.manager.webui.controllers.maintenance.MaintenanceScheduleController;
 import com.suse.manager.webui.errors.NotFoundException;
+import com.suse.manager.webui.services.RbacRouteValidator;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.scc.SCCEndpoints;
@@ -272,6 +273,9 @@ public class Router implements SparkApplication {
 
         // ISSv3 Sync
         initISSv3Routes();
+
+        // Validate RBAC endpoints
+        RbacRouteValidator.validateEndpoints();
 
         // if the calls above opened Hibernate session, close it now
         HibernateFactory.closeSession();

--- a/java/code/src/com/suse/manager/webui/services/RbacRouteValidator.java
+++ b/java/code/src/com/suse/manager/webui/services/RbacRouteValidator.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.webui.services;
+
+import com.redhat.rhn.domain.access.Namespace;
+import com.redhat.rhn.domain.access.NamespaceFactory;
+import com.redhat.rhn.domain.access.WebEndpoint;
+import com.redhat.rhn.domain.access.WebEndpointFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import spark.route.HttpMethod;
+import spark.route.ServletRoutes;
+import spark.routematch.RouteMatch;
+
+/**
+ * Utility class to verify that all Spark routes are properly mapped to corresponding RBAC endpoints.
+ */
+public class RbacRouteValidator {
+
+    /**
+     * Represents URI and HTTP method information for any route.
+     */
+    public static class RouteInfo {
+        private final String uri;
+        private final String httpMethod;
+
+        /**
+         * Constructs a {@code RouteInfo} object from a Spark {@link RouteMatch}.
+         *
+         * @param routeMatch The Spark route match containing the URI and HTTP method.
+         */
+        public RouteInfo(RouteMatch routeMatch) {
+            this.uri = routeMatch.getMatchUri();
+            this.httpMethod = routeMatch.getHttpMethod().toString().toUpperCase();
+        }
+
+        /**
+         * Constructs a {@code RouteInfo} object from a {@link WebEndpoint} retrieved from the DB.
+         *
+         * @param endpoint The RBAC entry containing the URI (endpoint) and HTTP method.
+         */
+        public RouteInfo(WebEndpoint endpoint) {
+            this.uri = endpoint.getEndpoint();
+            this.httpMethod = endpoint.getHttpMethod().toUpperCase();
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public String getHttpMethod() {
+            return httpMethod;
+        }
+
+        @Override
+        public boolean equals(Object oIn) {
+            if (!(oIn instanceof RouteInfo routeInfo)) {
+                return false;
+            }
+            return Objects.equals(uri, routeInfo.uri) && Objects.equals(httpMethod, routeInfo.httpMethod);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(uri, httpMethod);
+        }
+    }
+
+    private RbacRouteValidator() { }
+
+    private static final Logger LOG = LogManager.getLogger(RbacRouteValidator.class);
+
+    /**
+     * Validates the defined Spark endpoints against the RBAC configuration in the database.
+     * It checks for the following inconsistencies:
+     * <ul>
+     * <li>
+     *     Routes defined in the Spark framework that do not have a corresponding {@link WebEndpoint} in the database.
+     * </li>
+     * <li>
+     *     {@link WebEndpoint}s in the database that require authentication but are not associated with any
+     *     {@link Namespace}.
+     * </li>
+     * <li>
+     *     {@link Namespace}s in the database that are not accessible by any {@code AccessGroup} (excluding Sat Admin).
+     * </li>
+     * </ul>
+     */
+    public static void validateEndpoints() {
+        LOG.debug("Validating RBAC data");
+
+        // Collect endpoints defined in DB
+        Map<RouteInfo, WebEndpoint> endpointMap = WebEndpointFactory.getAllEndpoints()
+                .collect(Collectors.toMap(RouteInfo::new, e -> e));
+
+        LOG.debug("Retrieved {} endpoints from DB", endpointMap.size());
+
+        List<RouteInfo> missingRoutes = new ArrayList<>();
+        List<WebEndpoint> noNamespaceEndpts = new ArrayList<>();
+
+        // Collect endpoints registered to Spark
+        ServletRoutes.get().findAll().stream()
+                .filter(rm ->
+                        // Filter out Spark meta-routes
+                        !HttpMethod.before.equals(rm.getHttpMethod()) &&
+                                !HttpMethod.after.equals(rm.getHttpMethod()) &&
+                                !HttpMethod.afterafter.equals(rm.getHttpMethod()))
+                .map(RouteInfo::new)
+                .forEach(route -> {
+                    // Validate each route against RBAC entries
+                    WebEndpoint endpoint = endpointMap.get(route);
+
+                    if (endpoint == null) {
+                        // Route is not defined for RBAC
+                        missingRoutes.add(route);
+                    }
+                    else if (endpoint.isAuthRequired() && endpoint.getNamespaces().isEmpty()) {
+                        // Endpoint is not part of any namespace (inaccessible)
+                        noNamespaceEndpts.add(endpoint);
+                    }
+                });
+
+        // Collect namespaces that no group has access to (except for Sat Admin)
+        List<Namespace> noAccessNamespaces = NamespaceFactory.list().stream()
+                .filter(ns -> ns.getAccessGroups().isEmpty())
+                .toList();
+
+        if (missingRoutes.isEmpty() && noNamespaceEndpts.isEmpty()) {
+            LOG.info("RBAC data validation successful.");
+            return;
+        }
+        else {
+            LOG.error("RBAC data validation failed.");
+        }
+
+        // Report invalid items
+        if (!missingRoutes.isEmpty()) {
+            StringBuilder sb = new StringBuilder("Found " + missingRoutes.size() +
+                    " endpoints missing RBAC mappings:");
+            for (RouteInfo route : missingRoutes) {
+                sb.append("\n\t").append(route.getUri())
+                        .append(" [").append(route.getHttpMethod()).append("]");
+            }
+            LOG.error(sb.toString());
+        }
+
+        if (!noNamespaceEndpts.isEmpty()) {
+            StringBuilder sb = new StringBuilder("Found " + noNamespaceEndpts.size() +
+                    " endpoints missing namespace definitions:");
+            for (WebEndpoint endpoint : noNamespaceEndpts) {
+                sb.append("\n\t").append(endpoint.getEndpoint())
+                        .append(" [").append(endpoint.getHttpMethod()).append("]");
+            }
+            LOG.error(sb.toString());
+        }
+
+        if (!noAccessNamespaces.isEmpty()) {
+            StringBuilder sb = new StringBuilder("The following " + noAccessNamespaces.size() +
+                    " namespaces cannot be accessed by any role:");
+            for (Namespace ns : noAccessNamespaces) {
+                sb.append("\n\t").append(ns.getNamespace())
+                        .append(" [").append(ns.getAccessMode().getLabel()).append("]");
+            }
+            LOG.warn(sb.toString());
+        }
+
+        LOG.warn("Please note an invalid configuration will terminate execution in later releases.");
+        // TODO: Halt execution on invalid config
+    }
+}

--- a/java/spacewalk-java.changes.cbbayburt.rbac-endpoint-validation
+++ b/java/spacewalk-java.changes.cbbayburt.rbac-endpoint-validation
@@ -1,0 +1,1 @@
+- Run RBAC endpoint validation on startup


### PR DESCRIPTION
Adds validation logic for RBAC endpoints that does the following checks on webapp startup:

- Routes defined in the Spark framework that do not have a corresponding endpoint in the database.
- Endpoints in the database that require authentication but are not associated with any namespace.
- Namespaces in the database that are not accessible by any access group (excluding Sat Admin).

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
