### PR TITLE
Supportdata fix transactional

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
@@ -15,6 +15,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="states" column="states" type="string" />
         <property name="pillars" column="pillars" type="string" />
         <property name="test" column="test" type="yes_no" />
+        <property name="direct" column="direct" type="yes_no" />
         <property name="created" type="timestamp" insert="false" update="false" />
         <property name="modified" type="timestamp" insert="false" update="false" />
         <many-to-one name="parentAction" column="action_id"

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.java
@@ -39,6 +39,7 @@ public class ApplyStatesActionDetails extends ActionChild {
     private String pillars;
     private Set<ApplyStatesActionResult> results;
     private boolean test = false;
+    private boolean direct = false;
 
     /**
      * @return the id
@@ -208,5 +209,19 @@ public class ApplyStatesActionDetails extends ActionChild {
      */
     public void setTest(boolean testIn) {
         test = testIn;
+    }
+
+    /**
+     * @return is a direct Call or not
+     */
+    public boolean isDirect() {
+        return direct;
+    }
+
+    /**
+     * @param directIn set to direct call or not
+     */
+    public void setDirect(boolean directIn) {
+        direct = directIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -2344,6 +2344,26 @@ public class ActionManager extends BaseManager {
      */
     public static ApplyStatesAction scheduleApplyStates(User scheduler, List<Long> sids, List<String> mods,
             Optional<Map<String, Object>> pillar, Date earliest, Optional<Boolean> test, boolean recurring) {
+        return scheduleApplyStates(scheduler, sids, mods, pillar, earliest, test, recurring, false);
+    }
+
+    /**
+     * Schedule state application given a list of state modules. Salt will apply the
+     * highstate if an empty list of state modules is given.
+     *
+     * @param scheduler the user who is scheduling
+     * @param sids list of server ids
+     * @param mods list of state modules to be applied
+     * @param pillar optional pillar map
+     * @param earliest action will not be executed before this date
+     * @param test run states in test-only mode
+     * @param recurring whether the state is being applied recurring
+     * @param direct  whenther the state should be executed as direct call
+     * @return the action object
+     */
+    public static ApplyStatesAction scheduleApplyStates(User scheduler, List<Long> sids, List<String> mods,
+                                                        Optional<Map<String, Object>> pillar, Date earliest,
+                                                        Optional<Boolean> test, boolean recurring, boolean direct) {
         ApplyStatesAction action = (ApplyStatesAction) ActionFactory
                 .createAction(ActionFactory.TYPE_APPLY_STATES, earliest);
         action.setName(defineStatesActionName(mods, recurring));
@@ -2355,6 +2375,7 @@ public class ActionManager extends BaseManager {
         actionDetails.setMods(mods);
         actionDetails.setPillarsMap(pillar);
         test.ifPresent(actionDetails::setTest);
+        actionDetails.setDirect(direct);
         action.setDetails(actionDetails);
         ActionFactory.save(action);
 

--- a/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
@@ -51,6 +51,7 @@ public class ApplyStatesEventMessage implements EventDatabaseMessage {
     private final boolean forcePackageListRefresh;
     private final Transaction txn;
     private final Optional<Map<String, Object>> pillar;
+    private final boolean directCall;
 
     /**
      * Constructor for creating a {@link ApplyStatesEventMessage} for a given server.
@@ -130,12 +131,29 @@ public class ApplyStatesEventMessage implements EventDatabaseMessage {
     public ApplyStatesEventMessage(long serverIdIn, Long userIdIn,
             boolean forcePackageListRefreshIn, Map<String, Object> pillarIn,
             String... stateNamesIn) {
+        this(serverIdIn, userIdIn, forcePackageListRefreshIn, pillarIn, false, stateNamesIn);
+    }
+
+    /**
+     * Constructor for creating a {@link ApplyStatesEventMessage} for a given server.
+     *
+     * @param serverIdIn the server id
+     * @param userIdIn the user id
+     * @param forcePackageListRefreshIn set true to request a package list refresh
+     * @param pillarIn state specific pillar data
+     * @param stateNamesIn state module names to be applied to the server
+     * @param directCallIn set true when the state.apply should be executed as direct call
+     */
+    public ApplyStatesEventMessage(long serverIdIn, Long userIdIn, boolean forcePackageListRefreshIn,
+                                   Map<String, Object> pillarIn, boolean directCallIn,
+                                   String... stateNamesIn) {
         serverId = serverIdIn;
         userId = userIdIn;
         stateNames = Arrays.asList(stateNamesIn);
         forcePackageListRefresh = forcePackageListRefreshIn;
         txn = HibernateFactory.getSession().getTransaction();
         pillar = Optional.ofNullable(pillarIn);
+        directCall = directCallIn;
     }
 
     /**
@@ -172,6 +190,14 @@ public class ApplyStatesEventMessage implements EventDatabaseMessage {
      */
     public boolean isForcePackageListRefresh() {
         return forcePackageListRefresh;
+    }
+
+    /**
+     * Return true when this should be requested as salt direct call
+     * @return true on direct call
+     */
+    public boolean isDirectCall() {
+        return directCall;
     }
 
     @Override

--- a/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessageAction.java
@@ -67,7 +67,8 @@ public class ApplyStatesEventMessageAction implements MessageAction {
                         Arrays.asList(server.getId()),
                         applyStatesEvent.getStateNames(),
                         applyStatesEvent.getPillar(),
-                        new Date(), Optional.of(false));
+                        new Date(), Optional.of(false),
+                        false, applyStatesEvent.isDirectCall());
                 TASKOMATIC_API.scheduleActionExecution(action,
                         applyStatesEvent.isForcePackageListRefresh());
             }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -120,6 +120,7 @@ import com.suse.manager.webui.utils.MinionActionUtils;
 import com.suse.manager.webui.utils.SaltModuleRun;
 import com.suse.manager.webui.utils.SaltState;
 import com.suse.manager.webui.utils.SaltSystemReboot;
+import com.suse.manager.webui.utils.salt.LocalCallWithExecutors;
 import com.suse.manager.webui.utils.salt.custom.MgrActionChains;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.manager.webui.utils.token.DownloadTokenBuilder;
@@ -321,7 +322,8 @@ public class SaltServerActionService {
         else if (ActionFactory.TYPE_APPLY_STATES.equals(actionType)) {
             ApplyStatesActionDetails actionDetails = ((ApplyStatesAction) actionIn).getDetails();
             return applyStatesAction(minions, actionDetails.getMods(),
-                                     actionDetails.getPillarsMap(), actionDetails.isTest());
+                                     actionDetails.getPillarsMap(), actionDetails.isTest(),
+                                     actionDetails.isDirect());
         }
         else if (ActionFactory.TYPE_IMAGE_INSPECT.equals(actionType)) {
             ImageInspectAction iia = (ImageInspectAction) actionIn;
@@ -1355,10 +1357,17 @@ public class SaltServerActionService {
 
     private Map<LocalCall<?>, List<MinionSummary>> applyStatesAction(
             List<MinionSummary> minionSummaries, List<String> mods,
-            Optional<Map<String, Object>> pillar, boolean test) {
+            Optional<Map<String, Object>> pillar, boolean test, boolean direct) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        ret.put(com.suse.salt.netapi.calls.modules.State.apply(mods, pillar, Optional.of(true),
-                test ? Optional.of(test) : Optional.empty()), minionSummaries);
+        LocalCall<Map<String, ApplyResult>> apply = State.apply(mods, pillar, Optional.of(true),
+                test ? Optional.of(test) : Optional.empty());
+        if (direct) {
+            ret.put(new LocalCallWithExecutors<>(apply, List.of("direct_call"), Collections.emptyMap()),
+                    minionSummaries);
+        }
+        else {
+            ret.put(apply, minionSummaries);
+        }
         return ret;
     }
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -397,7 +397,9 @@ public class SaltServerActionService {
         var full = partitioned.get(false);
         var onlyUpload = partitioned.get(true);
         if (!full.isEmpty()) {
-            ret.put(State.apply(List.of("supportdata"), pillar), full);
+            // supportdata should be taken always in direct mode - also on transactional systems
+            var apply = State.apply(List.of("supportdata"), pillar);
+            ret.put(new LocalCallWithExecutors<>(apply, List.of("direct_call"), Collections.emptyMap()), full);
         }
         if (!onlyUpload.isEmpty()) {
             ret.put(Test.echo("supportdata"), onlyUpload);

--- a/java/code/src/com/suse/manager/webui/utils/salt/LocalCallWithExecutors.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/LocalCallWithExecutors.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.webui.utils.salt;
+
+import com.suse.salt.netapi.calls.LocalCall;
+
+import com.google.gson.reflect.TypeToken;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * LocalCall with configuration of executor modules
+ * @param <T> type
+ */
+public class LocalCallWithExecutors<T> extends LocalCall<T> {
+
+    private List<String> executors;
+    private Map<String, ?> executorOpts;
+
+    /**
+     * Constructor
+     * @param call a LocalCall
+     * @param executorsIn list of executors
+     * @param executorOptsIn executor options
+     */
+    public LocalCallWithExecutors(LocalCall<T> call, List<String> executorsIn, Map<String, ?> executorOptsIn) {
+        super((String) call.getPayload().get("fun"),
+                Optional.ofNullable((List<?>) call.getPayload().get("arg")),
+                Optional.ofNullable((Map<String, ?>) call.getPayload().get("kwarg")),
+                call.getReturnType());
+        this.executors = executorsIn;
+        this.executorOpts = executorOptsIn;
+    }
+
+    /**
+     * Constructor
+     * @param functionName
+     * @param arg
+     * @param kwarg
+     * @param returnType
+     * @param metadata
+     * @param executorsIn
+     * @param executorOptsIn
+     */
+    public LocalCallWithExecutors(String functionName, Optional<List<?>> arg,
+                                  Optional<Map<String, ?>> kwarg, TypeToken<T> returnType, Optional<?> metadata,
+                                  List<String> executorsIn, Map<String, ?> executorOptsIn) {
+        super(functionName, arg, kwarg, returnType, metadata, Optional.empty(), Optional.empty());
+        executors = executorsIn;
+        executorOpts = executorOptsIn;
+    }
+
+
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payPaload = super.getPayload();
+        if (executors != null && !executors.isEmpty()) {
+            payPaload.put("module_executors", executors);
+        }
+        if (executorOpts != null && !executorOpts.isEmpty()) {
+            payPaload.put("executor_opts", executorOpts);
+        }
+        return payPaload;
+    }
+
+    @Override
+    public LocalCallWithExecutors<T> withMetadata(Object metadata) {
+        return new LocalCallWithExecutors<>(
+                (String) getPayload().get("fun"),
+                Optional.ofNullable((List<?>)getPayload().get("arg")),
+                Optional.ofNullable((Map<String, ?>) getPayload().get("kwarg")),
+                this.getReturnType(),
+                Optional.of(metadata),
+                this.executors, this.executorOpts);
+    }
+}

--- a/susemanager-utils/susemanager-sls/salt/supportdata/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/supportdata/init.sls
@@ -1,3 +1,4 @@
+{% if not grains.get('transactional', False) %}
 install-supportdata-command:
   pkg.latest:
 {%- if grains['os_family'] == 'Suse' %}
@@ -5,11 +6,10 @@ install-supportdata-command:
 {%- else %}
     - name: sos
 {%- endif %}
+{% endif %}
 
 
 gather-supportdata:
   mgrcompat.module_run:
     - name: supportdata.get
     - cmd_args: "{{ pillar.get('arguments', '') }}"
-    - require:
-      - install-supportdata-command

--- a/susemanager-utils/susemanager-sls/src/modules/supportdata.py
+++ b/susemanager-utils/susemanager-sls/src/modules/supportdata.py
@@ -104,7 +104,7 @@ def get(cmd_args: str = "", **kwargs) -> Dict[str, Any]:
         os.makedirs(output_dir, exist_ok=True)
         cmd.extend(extra_args)
         log.debug("executing: %s", cmd)
-        ret = __salt__["cmd.run_all"](cmd, python_shell=False)
+        ret = __salt__["cmd.run_all"](cmd, runas="root")
 
         log.debug("return: %s", ret)
         returncode = ret["retcode"]

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_supportdata.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_supportdata.py
@@ -47,7 +47,7 @@ def test_supportdata_suse():
 
         supportdata.__salt__["cmd.run_all"].assert_called_once_with(
             ["/sbin/supportconfig", "-R", "/var/log/supportdata"],
-            python_shell=False,
+            runas="root",
         )
 
 
@@ -76,7 +76,7 @@ def test_supportdata_suse_extra_args():
                 "-l",
                 "10000",
             ],
-            python_shell=False,
+            runas="root",
         )
 
 
@@ -103,7 +103,7 @@ def test_supportdata_mlm_proxy():
                 "--output",
                 "/var/log/supportdata",
             ],
-            python_shell=False,
+            runas="root",
         )
 
 
@@ -130,7 +130,7 @@ def test_supportdata_mlm_server():
                 "--output",
                 "/var/log/supportdata",
             ],
-            python_shell=False,
+            runas="root",
         )
 
 
@@ -156,7 +156,7 @@ def test_supportdata_redhat():
                 "--tmp-dir",
                 "/var/log/supportdata",
             ],
-            python_shell=False,
+            runas="root",
         )
 
 
@@ -183,7 +183,7 @@ def test_supportdata_debian():
                 "--tmp-dir",
                 "/var/log/supportdata",
             ],
-            python_shell=False,
+            runas="root",
         )
 
 


### PR DESCRIPTION
## What does this PR change?

On transactional systems we need to run supportdata state in direct mode.
Bring back the direct mode implementation from 5.0 (db schema still exists)
and call supportdata state always in direct mode.

Exclude installation and update of the supportdata tool when we are running on a transactional system.
SL-Micro has supportutils as requires in its base pattern. So it should be available by default.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- part of bigger test case

- [x] **DONE**

## Links

Port(s): no port needed

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"    
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
