### PR TITLE
add-apt-repository cannot be used on Ubuntu 24.04

### DIFF
--- a/testsuite/features/upload_files/edit-deb822.awk
+++ b/testsuite/features/upload_files/edit-deb822.awk
@@ -1,0 +1,32 @@
+# Edit deb822 file such as ubuntu.sources
+# Example: awk -f edit-ubuntu-sources.awk \
+#              -v action=disable \
+#              -v distro=noble \
+#              -v repo=universe \
+#              ubuntu.sources
+
+BEGIN             { suites = ""
+                    components = ""
+                  }
+
+/^Suites: */      { suites = $0
+                    sub(/^Suites: */, "", suites)
+                  }
+
+/^Components: */  { components = $0
+                    sub(/^Components: */, "", components)
+                    if (match(suites " ", distro " ") != 0)
+                    { if (action == "enable")
+                      { if (match(components " ", repo " ") == 0)
+                          components = components " " repo
+                      }
+                      if (action == "disable")
+                      { sub(repo, "", components)
+                        sub(/  */, " ", components)
+                      }
+                    }
+                    print "Components: " components
+                  }
+
+!/^Components: */ { print $0
+                  }


### PR DESCRIPTION
## What does this PR change?

In cucumber steps, replace `add-apt-repository` by ad hoc script.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

Cucumber tests were modified

- [x] **DONE**

## Links

Port(s):
 * 5.0:

4.3 branch still uses Ubuntu 22.04.

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
