### PR TITLE
QE: Removing expect command from testsuite

### DIFF
--- a/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
@@ -26,7 +26,7 @@ Feature: PXE boot a terminal with Cobbler and containerized proxy
   # The build host has same version as the terminal
   Scenario: Prepare the autoinstallation files on the server
     When I install packages "tftpboot-installation-SLE-15-SP4-x86_64 expect" on this "build_host"
-    And I copy the tftpboot installation files from the build host to the server
+    And I copy "/usr/share/tftpboot-installation" from "build_host" to "server" via scp in the path "/tmp"
     And I copy the distribution inside the container on the server
 
   Scenario: Create auto installation distribution

--- a/testsuite/features/upload_files/copy-tftpboot-files.exp
+++ b/testsuite/features/upload_files/copy-tftpboot-files.exp
@@ -1,7 +1,0 @@
-set address [lindex $argv 0]
-
-spawn /usr/bin/scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -r /usr/share/tftpboot-installation root@$address:/tmp
-expect {
-	"*?assword:*" { send "linux\r"; interact }
-	eof { exit }
-}


### PR DESCRIPTION
## What does this PR change?

There is an occurrence of the expect command for establish the communication between two machines for testing purposes. Therefore for removing the expect command from our testsuite a key exchange should be performed by sumaform to allow the communication between `build_host` and `server`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27138
Port(s): None. It is just going to be applied in HEAD.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
