### PR TITLE
Remove real url health connectivity test

### DIFF
--- a/java/code/src/com/suse/oval/config/test/OVALConfigTest.java
+++ b/java/code/src/com/suse/oval/config/test/OVALConfigTest.java
@@ -15,7 +15,6 @@
 
 package com.suse.oval.config.test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.redhat.rhn.testing.TestUtils;
@@ -33,8 +32,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +55,7 @@ public class OVALConfigTest {
     }
 
     @Test
-    public void testAllSources() throws IOException {
+    public void testAllSources() {
         Map<OsFamily, OVALDistributionSourceInfo> sources = config.getSources();
 
         List<String> allSources = sources.keySet().stream().flatMap(osFamily -> {
@@ -87,16 +84,6 @@ public class OVALConfigTest {
         }).toList();
 
         assertFalse(allSources.isEmpty());
-
-        for (String sourceURL : allSources) {
-            HttpURLConnection huc = (HttpURLConnection) new URL(sourceURL).openConnection();
-
-            huc.setRequestMethod("HEAD");
-
-            int responseCode = huc.getResponseCode();
-
-            assertEquals(HttpURLConnection.HTTP_OK, responseCode, () -> "Can't connect to URL: " + sourceURL);
-        }
     }
 
     public void testOsFamilies() {


### PR DESCRIPTION
## What does this PR change?

During recent downtime of ftp.suse.com, a java_pgsql_tests task began failing due to live url health check against that host. We confirmed these checks do not drive any production logic or are reused. So for now we can remove them and stabilize the test suite.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: adjusted tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
