### PR TITLE
Issv3 SCC: Implement and test the update last seen mechanism when a hub is acting as an SCC proxy

### DIFF
--- a/java/code/src/com/suse/scc/SCCEndpoints.java
+++ b/java/code/src/com/suse/scc/SCCEndpoints.java
@@ -39,7 +39,7 @@ import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCFileClient;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.model.SCCVirtualizationHostJson;
@@ -160,7 +160,7 @@ public class SCCEndpoints {
         get("/hub/scc/connect/organizations/subscriptions", asJson(withSCCAuth(this::subscriptions)));
         get("/hub/scc/connect/organizations/orders", asJson(withSCCAuth(this::orders)));
         get("/hub/scc/suma/product_tree.json", asJson(this::productTree));
-        put("/hub/scc/connect/organizations/systems", asJson(withSCCAuth(this::createSystems)));
+        put("/hub/scc/connect/organizations/systems", asJson(withSCCAuth(this::createOrUpdateSystems)));
         delete("/hub/scc/connect/organizations/systems/:id", asJson(withSCCAuth(this::deleteSystem)));
         put("/hub/scc/connect/organizations/virtualization_hosts", asJson(withSCCAuth(this::setVirtualizationHosts)));
     }
@@ -349,17 +349,17 @@ public class SCCEndpoints {
      * @param credentials
      * @return a {@Link SCCOrganizationSystemsUpdateResponse} json object
      */
-    public String createSystems(Request request, Response response, HubSCCCredentials credentials) {
+    public String createOrUpdateSystems(Request request, Response response, HubSCCCredentials credentials) {
         try {
-            TypeToken<Map<String, List<SCCRegisterSystemJson>>> typeToken = new TypeToken<>() { };
-            Map<String, List<SCCRegisterSystemJson>> payload = gson.fromJson(request.body(), typeToken.getType());
+            TypeToken<Map<String, List<SCCRegisterSystemItem>>> typeToken = new TypeToken<>() { };
+            Map<String, List<SCCRegisterSystemItem>> payload = gson.fromJson(request.body(), typeToken.getType());
             if (!payload.containsKey("systems")) {
                 return badRequest(response, "wrong json input: missing systems key");
             }
 
-            List<SCCRegisterSystemJson> systemsList = payload.get("systems");
+            List<SCCRegisterSystemItem> systemsList = payload.get("systems");
 
-            List<SCCSystemCredentialsJson> systemsResponse = sccProxyManager.createSystems(systemsList,
+            List<SCCSystemCredentialsJson> systemsResponse = sccProxyManager.createOrUpdateSystems(systemsList,
                             credentials.getPeripheralUrl())
                     .stream()
                     .map(r -> new SCCSystemCredentialsJson(

--- a/java/code/src/com/suse/scc/client/SCCClient.java
+++ b/java/code/src/com/suse/scc/client/SCCClient.java
@@ -19,10 +19,10 @@ import com.redhat.rhn.manager.content.ProductTreeEntry;
 import com.suse.scc.model.SCCOrderJson;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 
 import java.util.List;
@@ -87,10 +87,10 @@ public interface SCCClient {
      * @param username the username for http basic auth
      * @param password the password for http basic auth
      * @throws SCCClientException SCCRegisterSystemItemJson
-     * @return SCCRegisterSystemJson a collection of systems created/updated
+     * @return SCCRegisterSystemItem a collection of systems created/updated
      */
     SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-            List<SCCRegisterSystemJson> systems, String username, String password
+            List<SCCRegisterSystemItem> systems, String username, String password
     ) throws SCCClientException;
 
     /**
@@ -100,7 +100,7 @@ public interface SCCClient {
      * @param password the password
      * @throws SCCClientException
      */
-    void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
+    void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password)
             throws SCCClientException;
 
     /**

--- a/java/code/src/com/suse/scc/client/SCCFileClient.java
+++ b/java/code/src/com/suse/scc/client/SCCFileClient.java
@@ -20,10 +20,10 @@ import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.scc.model.SCCOrderJson;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 
 import com.google.gson.Gson;
@@ -102,13 +102,13 @@ public class SCCFileClient implements SCCClient {
 
     @Override
     public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-            List<SCCRegisterSystemJson> systems, String username, String password
+            List<SCCRegisterSystemItem> systems, String username, String password
     ) {
         return null;
     }
 
     @Override
-    public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+    public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
         // Not handled
     }
 

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -22,10 +22,10 @@ import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.scc.model.SCCOrderJson;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
 import com.suse.scc.model.SCCProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 
 import com.google.gson.Gson;
@@ -122,7 +122,8 @@ public class SCCWebClient implements SCCClient {
      * @param configIn the configuration object
      */
     public SCCWebClient(SCCConfig configIn) {
-        this(configIn, new HttpClientAdapter(configIn.getAdditionalCerts(), false));
+        this(configIn, new HttpClientAdapter(
+                Optional.ofNullable(configIn).map(SCCConfig::getAdditionalCerts).orElse(List.of()), false));
     }
 
     /**
@@ -313,19 +314,17 @@ public class SCCWebClient implements SCCClient {
         }
     }
 
-    @Override
-    public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password)
+    private String coreCreateUpdateSystems(String requestBody, String username, String password)
             throws SCCClientException {
 
         HttpPut request = new HttpPut(config.getUrl() + "/connect/organizations/systems");
         // Additional request headers
         addHeaders(request);
-        Map<String, List<SCCUpdateSystemJson>> payload = Map.of("systems", systems);
-        request.setEntity(new StringEntity(gson.toJson(payload), ContentType.APPLICATION_JSON));
+        request.setEntity(new StringEntity(requestBody, ContentType.APPLICATION_JSON));
 
         LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/systems");
         if (LOG.isDebugEnabled()) {
-            LOG.debug(gson.toJson(payload));
+            LOG.debug("Request body: {}", requestBody);
         }
 
         try {
@@ -333,7 +332,15 @@ public class SCCWebClient implements SCCClient {
             HttpResponse response = httpClient.executeRequest(request, username, password);
 
             int responseCode = response.getStatusLine().getStatusCode();
-            if (responseCode != HttpStatus.SC_CREATED) {
+            String responseBody = EntityUtils.toString(response.getEntity());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Response code: {}", responseCode);
+                LOG.debug("Response body: {}", responseBody);
+            }
+            if (responseCode == HttpStatus.SC_CREATED) {
+                return responseBody;
+            }
+            else {
                 // Request was not successful
                 throw new SCCClientException(responseCode, request.getURI().toString(),
                         "Got response code " + responseCode + " connecting to " + request.getURI());
@@ -353,50 +360,21 @@ public class SCCWebClient implements SCCClient {
     }
 
     @Override
+    public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password)
+            throws SCCClientException {
+        Map<String, List<SCCUpdateSystemItem>> payload = Map.of("systems", systems);
+        String requestBody = gson.toJson(payload);
+        coreCreateUpdateSystems(requestBody, username, password);
+    }
+
+    @Override
     public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-            List<SCCRegisterSystemJson> systems, String username, String password
-    ) throws SCCClientException {
-        HttpPut request = new HttpPut(config.getUrl() + "/connect/organizations/systems");
-        // Additional request headers
-        addHeaders(request);
-        Map<String, Collection<SCCRegisterSystemJson>> payload = Map.of("systems", systems);
-        request.setEntity(new StringEntity(gson.toJson(payload), ContentType.APPLICATION_JSON));
+            List<SCCRegisterSystemItem> systems, String username, String password) throws SCCClientException {
+        Map<String, Collection<SCCRegisterSystemItem>> payload = Map.of("systems", systems);
+        String requestBody = gson.toJson(payload);
+        String responseBody = coreCreateUpdateSystems(requestBody, username, password);
 
-        LOG.info("Send PUT to {}{}", config.getUrl(), "/connect/organizations/systems");
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Request body: {}", gson.toJson(payload));
-        }
-
-        try {
-            // Connect and parse the response on success
-            HttpResponse response = httpClient.executeRequest(request, username, password);
-
-            int responseCode = response.getStatusLine().getStatusCode();
-            String responseBody = EntityUtils.toString(response.getEntity());
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Response code: {}", responseCode);
-                LOG.debug("Response body: {}", responseBody);
-            }
-            if (responseCode == HttpStatus.SC_CREATED) {
-                return gson.fromJson(responseBody, SCCOrganizationSystemsUpdateResponse.class);
-            }
-            else {
-                // Request was not successful
-                throw new SCCClientException(responseCode, request.getURI().toString(),
-                        "Got response code " + responseCode + " connecting to " + request.getURI());
-            }
-        }
-        catch (NoRouteToHostException e) {
-            String proxy = ConfigDefaults.get().getProxyHost();
-            throw new SCCClientException("No route to SCC" +
-                    (proxy != null ? " or the Proxy: " + proxy : ""));
-        }
-        catch (IOException e) {
-            throw new SCCClientException(e);
-        }
-        finally {
-            request.releaseConnection();
-        }
+        return gson.fromJson(responseBody, SCCOrganizationSystemsUpdateResponse.class);
     }
 
     @Override

--- a/java/code/src/com/suse/scc/model/SCCRegisterSystemItem.java
+++ b/java/code/src/com/suse/scc/model/SCCRegisterSystemItem.java
@@ -23,7 +23,7 @@ import java.util.List;
 /**
  * This is a System Item send to SCC for registration.
  */
-public class SCCRegisterSystemJson {
+public class SCCRegisterSystemItem {
 
     private String login;
     private String password;
@@ -43,8 +43,8 @@ public class SCCRegisterSystemJson {
      * @param productsIn the products
      * @param lastSeenIn the last seen date
      */
-    public SCCRegisterSystemJson(String loginIn, String passwdIn, String hostnameIn,
-            SCCHwInfoJson hwinfoIn, List<SCCMinProductJson> productsIn, Date lastSeenIn) {
+    public SCCRegisterSystemItem(String loginIn, String passwdIn, String hostnameIn,
+                                 SCCHwInfoJson hwinfoIn, List<SCCMinProductJson> productsIn, Date lastSeenIn) {
         login = loginIn;
         password = passwdIn;
         hostname = hostnameIn;
@@ -99,5 +99,13 @@ public class SCCRegisterSystemJson {
      */
     public Date getLastSeenAt() {
         return lastSeenAt;
+    }
+
+    /**
+     * @return Returns true if it contains only the last seen info
+     */
+    public boolean isOnlyLastSeenAt() {
+        return (null != login) && (null != password) && (null != lastSeenAt) &&
+                (null == hostname) && (null == hwinfo) && (null == products) && (null == regcodes);
     }
 }

--- a/java/code/src/com/suse/scc/model/SCCUpdateSystemItem.java
+++ b/java/code/src/com/suse/scc/model/SCCUpdateSystemItem.java
@@ -21,7 +21,7 @@ import java.util.Date;
 /**
  * This is a System Item send to SCC for minimal update registration.
  */
-public class SCCUpdateSystemJson {
+public class SCCUpdateSystemItem {
 
     private String login;
     private String password;
@@ -34,7 +34,7 @@ public class SCCUpdateSystemJson {
      * @param passwdIn the password
      * @param lastSeenIn last seen date
      */
-    public SCCUpdateSystemJson(String loginIn, String passwdIn, Date lastSeenIn) {
+    public SCCUpdateSystemItem(String loginIn, String passwdIn, Date lastSeenIn) {
         login = loginIn;
         password = passwdIn;
         lastSeenAt = lastSeenIn;

--- a/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyFactory.java
@@ -80,6 +80,22 @@ public class SCCProxyFactory extends HibernateFactory {
     }
 
     /**
+     * Lookup {@link SCCProxyRecord} object by sccLogin and sccPasswd
+     *
+     * @param sccLoginIn the scc login
+     * @param sccPasswdIn the scc password
+     * @return return {@link SCCProxyRecord} or empty
+     */
+    public Optional<SCCProxyRecord> lookupBySccLoginAndPassword(String sccLoginIn, String sccPasswdIn) {
+        return getSession()
+                .createQuery("FROM SCCProxyRecord WHERE sccLogin = :sccLogin AND sccPasswd = :sccPasswd",
+                        SCCProxyRecord.class)
+                .setParameter("sccLogin", sccLoginIn)
+                .setParameter("sccPasswd", sccPasswdIn)
+                .uniqueResultOptional();
+    }
+
+    /**
      * Lookup {@link SCCProxyRecord} list of objects with given status
      *
      * @param statusIn the status
@@ -140,5 +156,20 @@ public class SCCProxyFactory extends HibernateFactory {
      */
     public List<SCCProxyRecord> findVirtualizationHosts() {
         return lookupByStatusAndRetry(SccProxyStatus.SCC_VIRTHOST_PENDING);
+    }
+
+    /**
+     * Return list of data for last seen SCC update call
+     *
+     * @return list of {@link SCCProxyRecord}
+     */
+    public List<SCCProxyRecord> listUpdateLastSeenItems() {
+        return getSession()
+                .createQuery("""
+                            FROM SCCProxyRecord
+                            WHERE sccRegistrationErrorTime IS NULL AND status = :status AND lastSeenAt IS NOT NULL
+                            """, SCCProxyRecord.class)
+                .setParameter("status", SccProxyStatus.SCC_CREATED)
+                .list();
     }
 }

--- a/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
+++ b/java/code/src/com/suse/scc/proxy/SCCProxyRecord.java
@@ -39,6 +39,7 @@ public class SCCProxyRecord extends BaseDomainHelper {
     private String sccCreationJson;
     private Long sccId;
     private Date sccRegistrationErrorTime;
+    private Date lastSeenAt;
     private SccProxyStatus status;
 
     /**
@@ -46,6 +47,17 @@ public class SCCProxyRecord extends BaseDomainHelper {
      */
     public SCCProxyRecord() {
         this(null, null, null, null);
+    }
+
+    /**
+     * Constructor with status SCC_CREATION_PENDING
+     *
+     * @param peripheralFqdnIn peripheral from which the request comes from
+     * @param sccLoginIn login of the system to register in SCC
+     * @param sccPasswdIn password of the system to register in SCC
+     */
+    public SCCProxyRecord(String peripheralFqdnIn, String sccLoginIn, String sccPasswdIn) {
+        this(peripheralFqdnIn, sccLoginIn, sccPasswdIn, null, SccProxyStatus.SCC_CREATION_PENDING);
     }
 
     /**
@@ -142,6 +154,9 @@ public class SCCProxyRecord extends BaseDomainHelper {
         return ofNullable(sccId);
     }
 
+    /**
+     * @return the time when the last registration failed
+     */
     @Column(name = "scc_regerror_timestamp")
     public Date getSccRegistrationErrorTime() {
         return sccRegistrationErrorTime;
@@ -151,13 +166,28 @@ public class SCCProxyRecord extends BaseDomainHelper {
         sccRegistrationErrorTime = sccRegistrationErrorTimeIn;
     }
 
-    /**
-     * @return the time when the last registration failed
-     */
     @Transient
     public Optional<Date> getOptSccRegistrationErrorTime() {
         return ofNullable(sccRegistrationErrorTime);
     }
+
+    /**
+     * @return the time when the system has been seen
+     */
+    @Column(name = "last_seen_at")
+    public Date getLastSeenAt() {
+        return lastSeenAt;
+    }
+
+    public void setLastSeenAt(Date lastSeenAtIn) {
+        lastSeenAt = lastSeenAtIn;
+    }
+
+    @Transient
+    public Optional<Date> getOptLastSeenAt() {
+        return ofNullable(lastSeenAt);
+    }
+
 
     @Type(type = "com.suse.scc.proxy.SccProxyStatusEnumType")
     public SccProxyStatus getStatus() {
@@ -201,6 +231,7 @@ public class SCCProxyRecord extends BaseDomainHelper {
         sb.append(", sccCreationJson='").append(sccCreationJson).append('\'');
         sb.append(", sccId=").append(sccId);
         sb.append(", sccRegistrationErrorTime=").append(sccRegistrationErrorTime);
+        sb.append(", lastSeenAt=").append(lastSeenAt);
         sb.append(", status=").append(status);
         sb.append('}');
         return sb.toString();

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationContext.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationContext.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.domain.credentials.SCCCredentials;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 
 import com.suse.scc.client.SCCClient;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ public class SCCSystemRegistrationContext {
     private final SCCCredentials primaryCredential;
 
     private final Map<String, SCCRegCacheItem> itemsByLogin;
-    private final Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin;
+    private final Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin;
 
     private final List<SCCRegCacheItem> paygSystems;
 
@@ -77,7 +77,7 @@ public class SCCSystemRegistrationContext {
         return itemsByLogin;
     }
 
-    public Map<String, SCCRegisterSystemJson> getPendingRegistrationSystemsByLogin() {
+    public Map<String, SCCRegisterSystemItem> getPendingRegistrationSystemsByLogin() {
         return pendingRegistrationSystemsByLogin;
     }
 

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationCreateUpdateSystems.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationCreateUpdateSystems.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 
 import com.suse.scc.client.SCCClientException;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,13 +41,13 @@ public class SCCSystemRegistrationCreateUpdateSystems implements SCCSystemRegist
     @Override
     public void handle(SCCSystemRegistrationContext context) {
         final int batchSize = Config.get().getInt(ConfigDefaults.REG_BATCH_SIZE, 50);
-        final List<SCCRegisterSystemJson> pendingRegistrationSystems =
+        final List<SCCRegisterSystemItem> pendingRegistrationSystems =
                 new ArrayList<>(context.getPendingRegistrationSystemsByLogin().values());
 
         // split items into batches
-        List<List<SCCRegisterSystemJson>> systemsBatches = splitListIntoBatches(pendingRegistrationSystems, batchSize);
+        List<List<SCCRegisterSystemItem>> systemsBatches = splitListIntoBatches(pendingRegistrationSystems, batchSize);
 
-        for (List<SCCRegisterSystemJson> batch : systemsBatches) {
+        for (List<SCCRegisterSystemItem> batch : systemsBatches) {
             try {
                 SCCOrganizationSystemsUpdateResponse response = context.getSccClient().createUpdateSystems(
                         batch,
@@ -65,7 +65,7 @@ public class SCCSystemRegistrationCreateUpdateSystems implements SCCSystemRegist
         }
     }
 
-    private List<List<SCCRegisterSystemJson>> splitListIntoBatches(List<SCCRegisterSystemJson> list, int batchSize) {
+    private List<List<SCCRegisterSystemItem>> splitListIntoBatches(List<SCCRegisterSystemItem> list, int batchSize) {
         return IntStream.range(0, (list.size() + batchSize - 1) / batchSize)
                 .mapToObj(i -> list.subList(i * batchSize, Math.min((i + 1) * batchSize, list.size())))
                 .collect(Collectors.toList());

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationSystemDataAcquisitor.java
@@ -29,7 +29,7 @@ import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.suse.scc.model.SAPJson;
 import com.suse.scc.model.SCCHwInfoJson;
 import com.suse.scc.model.SCCMinProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -78,7 +78,7 @@ public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegis
                 cacheItem.getOptServer().filter(Server::isPayg).isEmpty();
     }
 
-    private Optional<SCCRegisterSystemJson> getPayload(SCCRegCacheItem rci) {
+    private Optional<SCCRegisterSystemItem> getPayload(SCCRegCacheItem rci) {
         return rci.getOptServer().map(srv -> {
             List<SCCMinProductJson> products = srv.getInstalledProductSet().stream()
                     .flatMap(product -> {
@@ -146,7 +146,7 @@ public class SCCSystemRegistrationSystemDataAcquisitor implements SCCSystemRegis
                 return pw;
             });
 
-            return new SCCRegisterSystemJson(login, passwd, srv.getHostname(), hwInfo, products,
+            return new SCCRegisterSystemItem(login, passwd, srv.getHostname(), hwInfo, products,
                     srv.getServerInfo().getCheckin());
         });
     }

--- a/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
+++ b/java/code/src/com/suse/scc/registration/SCCSystemRegistrationUpdateCachedItems.java
@@ -20,7 +20,7 @@ import static com.suse.utils.Predicates.isAbsent;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 import com.redhat.rhn.domain.server.ServerFactory;
 
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 
 import org.apache.logging.log4j.LogManager;
@@ -64,7 +64,7 @@ public class SCCSystemRegistrationUpdateCachedItems implements SCCSystemRegistra
     }
 
     protected void updateFailedRegisteredItems(SCCSystemRegistrationContext context) {
-        for (Map.Entry<String, SCCRegisterSystemJson> entry :
+        for (Map.Entry<String, SCCRegisterSystemItem> entry :
                 context.getPendingRegistrationSystemsByLogin().entrySet()) {
             SCCRegCacheItem cacheItem = context.getItemsByLogin().get(entry.getKey());
             if (LOG.isErrorEnabled()) {

--- a/java/code/src/com/suse/scc/test/SCCRegisterUpdateSystemItemTest.java
+++ b/java/code/src/com/suse/scc/test/SCCRegisterUpdateSystemItemTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.scc.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.suse.scc.model.SCCRegisterSystemItem;
+import com.suse.scc.model.SCCUpdateSystemItem;
+import com.suse.utils.Json;
+
+import com.google.gson.reflect.TypeToken;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link SCCRegisterSystemItem} and {@link SCCUpdateSystemItem}.
+ */
+public class SCCRegisterUpdateSystemItemTest {
+
+    private static final String LAST_SEEN_REQUEST_STRING = """
+            {
+               "systems":[
+                  {
+                     "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010265",
+                     "password":"wuTmFh2RKUTQAAA013OCbzeluSteRXXclTUKFTN0lMjQ5ZANSMEtgynM2RAoxk3l",
+                     "last_seen_at":"2025-01-21T01:00:00.000+01"
+                  },
+                  {
+                     "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010266",
+                     "password":"vMAZGApR4Xx6UD3uAVR5DuuOoK7fuzYR1TCCAeNTH6X7WWtQwddT8iUFGgXpsh2d",
+                     "last_seen_at":"2025-01-22T01:00:00.000+01"
+                  },
+                  {
+                     "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010267",
+                     "password":"cwvK5YuRgQaUbipMRz5xEYq0KLpHtcmvxjIq4WX3EmR4oKao2w6FzZl46omCAAgL",
+                     "last_seen_at":"2025-01-23T01:00:00.000+01"
+                  }
+               ]
+            }
+            """;
+
+    private static final String CREATE_REQUEST_STRING = """
+            {
+                "systems":[
+                   {
+                      "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010002",
+                      "password":"0deFZmn14ZzX6N4jYQ5ZQ6nMGAgYsMGafU8vceShmb32uWVWDKGErALICO2ui2rV",
+                      "hwinfo":{
+                         "cpus":0,
+                         "sockets":0,
+                         "mem_total":1024,
+                         "arch":"i386",
+                         "sap":[]
+                      },
+                      "products":[],
+                      "regcodes":[],
+                      "last_seen_at":"2025-03-01T01:00:00.000+01"
+                   },
+                   {
+                      "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010013",
+                      "password":"rNCp2TvRELSIZFmPJH9595x8ehFBjtb4wnq8jiPjzvNysRwbJEFfcfZCVqGhRDCc",
+                      "hwinfo":{
+                         "cpus":0,
+                         "sockets":0,
+                         "mem_total":1024,
+                         "arch":"i386",
+                         "sap":[]
+                      },
+                      "products":[],
+                      "regcodes":[],
+                      "last_seen_at":"2025-03-01T01:00:00.000+01"
+                   },
+                   {
+                      "login":"52156f60-8aa2-4165-8645-367efdc2a510-1000010003",
+                      "password":"trHD0ytf5eVCoDxUYVhKs05EpjKWPtjjUkWu6P6eJXf6EhX6O8wIPn8vMQvGOWSF",
+                      "hwinfo":{
+                         "cpus":0,
+                         "sockets":0,
+                         "mem_total":1024,
+                         "arch":"i386",
+                         "sap":[]
+                      },
+                      "products":[],
+                      "regcodes":[],
+                      "last_seen_at":"2025-03-01T01:00:00.000+01"
+                   }
+                ]
+             }
+            """;
+
+    private final TypeToken<Map<String, List<SCCRegisterSystemItem>>> registerSystemTypeToken = new TypeToken<>() { };
+    private final TypeToken<Map<String, List<SCCUpdateSystemItem>>> updateSystemTypeToken = new TypeToken<>() { };
+    private static final String SYSTEMS_KEY = "systems";
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+
+    @Test
+    public void ensureRegularCreateRequestParsingWorks() {
+        Map<String, List<SCCRegisterSystemItem>> createRequestToRegisterSystem =
+                Json.GSON.fromJson(CREATE_REQUEST_STRING, registerSystemTypeToken.getType());
+
+        assertTrue(createRequestToRegisterSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, createRequestToRegisterSystem.get(SYSTEMS_KEY).size());
+        for (SCCRegisterSystemItem jsonItem : createRequestToRegisterSystem.get(SYSTEMS_KEY)) {
+            assertFalse(jsonItem.isOnlyLastSeenAt());
+            assertEquals("2025-03-01", dateFormat.format(jsonItem.getLastSeenAt()));
+        }
+    }
+
+    @Test
+    public void ensureRegularLastSeenRequestParsingWorks() {
+        Map<String, List<SCCUpdateSystemItem>> lastSeenRequestToUpdateSystem =
+                Json.GSON.fromJson(LAST_SEEN_REQUEST_STRING, updateSystemTypeToken.getType());
+
+        assertTrue(lastSeenRequestToUpdateSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, lastSeenRequestToUpdateSystem.get(SYSTEMS_KEY).size());
+    }
+
+    @Test
+    public void acknowledgeInvertedCreateRequestParsingIsNotFailing() {
+        Map<String, List<SCCUpdateSystemItem>> createRequestToUpdateSystem =
+                Json.GSON.fromJson(CREATE_REQUEST_STRING, updateSystemTypeToken.getType());
+
+        assertTrue(createRequestToUpdateSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, createRequestToUpdateSystem.get(SYSTEMS_KEY).size());
+    }
+
+    @Test
+    public void acknowledgeInvertedLastSeenRequestParsingIsNotFailing() {
+        Map<String, List<SCCRegisterSystemItem>> lastSeenRequestRegisterSystem =
+                Json.GSON.fromJson(LAST_SEEN_REQUEST_STRING, registerSystemTypeToken.getType());
+
+        assertTrue(lastSeenRequestRegisterSystem.containsKey(SYSTEMS_KEY));
+        assertEquals(3, lastSeenRequestRegisterSystem.get(SYSTEMS_KEY).size());
+        for (SCCRegisterSystemItem jsonItem : lastSeenRequestRegisterSystem.get(SYSTEMS_KEY)) {
+            assertTrue(jsonItem.isOnlyLastSeenAt());
+            assertNotEquals("2025-03-01", dateFormat.format(jsonItem.getLastSeenAt()));
+        }
+    }
+}

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationManagerTest.java
@@ -46,9 +46,9 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
-import com.suse.scc.model.SCCUpdateSystemJson;
+import com.suse.scc.model.SCCUpdateSystemItem;
 import com.suse.scc.model.SCCVirtualizationHostJson;
 import com.suse.scc.model.SCCVirtualizationHostPropertiesJson;
 import com.suse.scc.proxy.SCCProxyFactory;
@@ -89,7 +89,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         SCCWebClient sccWebClient = new SCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 assertNotEmpty(systems);
@@ -212,7 +212,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         SCCWebClient sccWebClient = new SCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 assertNotEmpty(systems);
@@ -235,7 +235,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 assertEquals(new Date(0), systems.get(0).getLastSeenAt());
@@ -254,7 +254,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         CredentialsFactory.storeCredentials(credentials);
         sccSystemRegistrationManager.register(testSystems, credentials);
 
-        sccSystemRegistrationManager.updateLastSeen(credentials);
+        sccSystemRegistrationManager.updateLastSeen(SCCCachingFactory.listUpdateLastSeenItems(credentials),
+                credentials);
     }
 
     @Test
@@ -294,7 +295,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         TestSCCWebClient sccWebClient = new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 return new SCCOrganizationSystemsUpdateResponse(
                         systems.stream()
                                 .map(system ->
@@ -305,7 +306,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 callCnt += 1;
                 assertTrue(callCnt <= 4, "more requests then expected");
                 if (callCnt < 4) {
@@ -329,7 +330,8 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
         CredentialsFactory.storeCredentials(credentials);
         sccSystemRegistrationManager.register(testSystems, credentials);
 
-        sccSystemRegistrationManager.updateLastSeen(credentials);
+        sccSystemRegistrationManager.updateLastSeen(SCCCachingFactory.listUpdateLastSeenItems(credentials),
+                credentials);
     }
 
     @Test
@@ -361,7 +363,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
 
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
 
@@ -383,7 +385,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
             }
@@ -449,7 +451,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
 
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 return new SCCOrganizationSystemsUpdateResponse(
@@ -470,7 +472,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
             }
@@ -551,7 +553,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
 
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password) {
+                    List<SCCRegisterSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
                 return new SCCOrganizationSystemsUpdateResponse(
@@ -572,7 +574,7 @@ public class SCCSystemRegistrationManagerTest extends BaseTestCaseWithUser {
             }
 
             @Override
-            public void updateBulkLastSeen(List<SCCUpdateSystemJson> systems, String username, String password) {
+            public void updateBulkLastSeen(List<SCCUpdateSystemItem> systems, String username, String password) {
                 assertEquals("username", username);
                 assertEquals("password", password);
             }

--- a/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
+++ b/java/code/src/com/suse/scc/test/SCCSystemRegistrationTest.java
@@ -34,7 +34,7 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.proxy.SCCProxyFactory;
 
@@ -185,7 +185,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         TestSCCWebClient sccWebClient = new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) throws SCCClientException {
                 callCnt += 1;
                 throw new SCCClientException(400, "Bad Request");
@@ -237,7 +237,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         TestSCCWebClient sccWebClient = new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) throws SCCClientException {
                 callCnt += 1;
                 // allow first call to fail
@@ -362,7 +362,7 @@ public class SCCSystemRegistrationTest extends BaseTestCaseWithUser {
         return new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) {
                 callCnt += 1;
                 return new SCCOrganizationSystemsUpdateResponse(

--- a/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationCreateUpdateSystemsTest.java
+++ b/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationCreateUpdateSystemsTest.java
@@ -21,7 +21,7 @@ import com.suse.scc.client.SCCConfig;
 import com.suse.scc.client.SCCConfigBuilder;
 import com.suse.scc.client.SCCWebClient;
 import com.suse.scc.model.SCCOrganizationSystemsUpdateResponse;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.model.SCCSystemCredentialsJson;
 import com.suse.scc.registration.SCCSystemRegistrationContext;
 import com.suse.scc.registration.SCCSystemRegistrationCreateUpdateSystems;
@@ -96,7 +96,7 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         TestSCCWebClient sccWebClient = new TestSCCWebClient(null) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems,
+                    List<SCCRegisterSystemItem> systems,
                     String username,
                     String password
             ) throws SCCClientException {
@@ -131,7 +131,7 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         TestSCCWebClient sccWebClient = new TestSCCWebClient(null) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems,
+                    List<SCCRegisterSystemItem> systems,
                     String username,
                     String password
             ) {
@@ -173,8 +173,8 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         for (int i = 0; i < systemSize; i++) {
             context.getPendingRegistrationSystemsByLogin().put(
                     "SCCSystemId.login" + i,
-                    new SCCRegisterSystemJson(
-                            "SCCRegisterSystemJson.login" + i, "SCCRegisterSystemJson.pwd" + i,
+                    new SCCRegisterSystemItem(
+                            "SCCRegisterSystemItem.login" + i, "SCCRegisterSystemItem.pwd" + i,
                             null, null, null, null)
             );
         }
@@ -215,7 +215,7 @@ public class SCCSystemRegistrationCreateUpdateSystemsTest extends AbstractSCCSys
         return new TestSCCWebClient(sccConfig) {
             @Override
             public SCCOrganizationSystemsUpdateResponse createUpdateSystems(
-                    List<SCCRegisterSystemJson> systems, String username, String password
+                    List<SCCRegisterSystemItem> systems, String username, String password
             ) {
                 callCnt += 1;
                 return new SCCOrganizationSystemsUpdateResponse(

--- a/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationSystemDataAcquisitorTest.java
+++ b/java/code/src/com/suse/scc/test/registration/SCCSystemRegistrationSystemDataAcquisitorTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.product.SUSEProductSet;
 import com.redhat.rhn.domain.product.test.SUSEProductTestUtils;
 import com.redhat.rhn.domain.scc.SCCRegCacheItem;
 import com.redhat.rhn.domain.server.CPU;
+import com.redhat.rhn.domain.server.SAPWorkload;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerArch;
 import com.redhat.rhn.domain.server.ServerInfo;
@@ -35,7 +36,7 @@ import com.redhat.rhn.domain.server.VirtualInstanceType;
 
 import com.suse.scc.model.SCCHwInfoJson;
 import com.suse.scc.model.SCCMinProductJson;
-import com.suse.scc.model.SCCRegisterSystemJson;
+import com.suse.scc.model.SCCRegisterSystemItem;
 import com.suse.scc.registration.SCCSystemRegistrationContext;
 import com.suse.scc.registration.SCCSystemRegistrationSystemDataAcquisitor;
 
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -169,22 +171,22 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin =
+        Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin();
         assertEquals(1, pendingRegistrationSystemsByLogin.size());
-        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystemsByLogin.values().iterator().next();
-        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
-        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
-        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
-        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemJson.getProducts().size());
-        assertTrue(sccRegisterSystemJson.getProducts().stream()
+        SCCRegisterSystemItem sccRegisterSystemItem = pendingRegistrationSystemsByLogin.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemItem.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemItem.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemItem.getHostname());
+        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemItem.getProducts().size());
+        assertTrue(sccRegisterSystemItem.getProducts().stream()
                 .map(SCCMinProductJson::getIdentifier)
                 .toList()
                 .containsAll(expectedProductIdentifiers));
-        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+        assertTrue(!sccRegisterSystemItem.getLastSeenAt().before(testBeginTimestamp));
 
-        assertNotNull(sccRegisterSystemJson.getHwinfo());
-        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertNotNull(sccRegisterSystemItem.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemItem.getHwinfo();
         assertEquals(expectedCpus, hwInfo.getCpus());
         assertEquals(expectedSockets, hwInfo.getSockets());
         assertEquals("server0", hwInfo.getArch());
@@ -225,18 +227,18 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin =
+        Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin();
         assertEquals(1, pendingRegistrationSystemsByLogin.size());
-        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystemsByLogin.values().iterator().next();
-        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
-        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
-        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
-        assertEquals(0, sccRegisterSystemJson.getProducts().size());
-        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+        SCCRegisterSystemItem sccRegisterSystemItem = pendingRegistrationSystemsByLogin.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemItem.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemItem.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemItem.getHostname());
+        assertEquals(0, sccRegisterSystemItem.getProducts().size());
+        assertTrue(!sccRegisterSystemItem.getLastSeenAt().before(testBeginTimestamp));
 
-        assertNotNull(sccRegisterSystemJson.getHwinfo());
-        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertNotNull(sccRegisterSystemItem.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemItem.getHwinfo();
         assertEquals(expectedCpus, hwInfo.getCpus());
         assertEquals(expectedSockets, hwInfo.getSockets());
         assertEquals("server1", hwInfo.getArch());
@@ -278,18 +280,18 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin =
+        Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin();
         assertEquals(1, pendingRegistrationSystemsByLogin.size());
-        SCCRegisterSystemJson sccRegisterSystemJson = pendingRegistrationSystemsByLogin.values().iterator().next();
-        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemJson.getLogin());
-        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemJson.getPassword());
-        assertEquals(expectedHostname, sccRegisterSystemJson.getHostname());
-        assertEquals(0, sccRegisterSystemJson.getProducts().size());
-        assertTrue(!sccRegisterSystemJson.getLastSeenAt().before(testBeginTimestamp));
+        SCCRegisterSystemItem sccRegisterSystemItem = pendingRegistrationSystemsByLogin.values().iterator().next();
+        assertEquals(SCCRegCacheItemMock.SCC_LOGIN, sccRegisterSystemItem.getLogin());
+        assertEquals(SCCRegCacheItemMock.SCC_PWD, sccRegisterSystemItem.getPassword());
+        assertEquals(expectedHostname, sccRegisterSystemItem.getHostname());
+        assertEquals(0, sccRegisterSystemItem.getProducts().size());
+        assertTrue(!sccRegisterSystemItem.getLastSeenAt().before(testBeginTimestamp));
 
-        assertNotNull(sccRegisterSystemJson.getHwinfo());
-        SCCHwInfoJson hwInfo = sccRegisterSystemJson.getHwinfo();
+        assertNotNull(sccRegisterSystemItem.getHwinfo());
+        SCCHwInfoJson hwInfo = sccRegisterSystemItem.getHwinfo();
         assertEquals(0L, hwInfo.getCpus());
         assertEquals(0L, hwInfo.getSockets());
         assertEquals("server2", hwInfo.getArch());
@@ -317,9 +319,9 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         // Assertions
         assertNull(suseProductSet.getBaseProduct());
         assertTrue(suseProductSet.getAddonProducts().isEmpty());
-        SCCRegisterSystemJson sccRegisterSystemJson =
+        SCCRegisterSystemItem sccRegisterSystemItem =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin().values().iterator().next();
-        assertTrue(sccRegisterSystemJson.getProducts().isEmpty());
+        assertTrue(sccRegisterSystemItem.getProducts().isEmpty());
     }
 
     /**
@@ -340,9 +342,9 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         // Assertions
         assertNull(suseProductSet.getBaseProduct());
         assertNull(suseProductSet.getAddonProducts());
-        SCCRegisterSystemJson sccRegisterSystemJson =
+        SCCRegisterSystemItem sccRegisterSystemItem =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin().values().iterator().next();
-        assertTrue(sccRegisterSystemJson.getProducts().isEmpty());
+        assertTrue(sccRegisterSystemItem.getProducts().isEmpty());
     }
 
 
@@ -376,10 +378,10 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         new SCCSystemRegistrationSystemDataAcquisitor().handle(sccRegCacheItemMock.getContextMock());
 
         // Assertions
-        SCCRegisterSystemJson sccRegisterSystemJson =
+        SCCRegisterSystemItem sccRegisterSystemItem =
                 sccRegCacheItemMock.getPendingRegistrationSystemsByLogin().values().iterator().next();
-        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemJson.getProducts().size());
-        assertTrue(sccRegisterSystemJson.getProducts().stream()
+        assertEquals(expectedProductIdentifiers.size(), sccRegisterSystemItem.getProducts().size());
+        assertTrue(sccRegisterSystemItem.getProducts().stream()
                 .map(SCCMinProductJson::getIdentifier)
                 .toList()
                 .containsAll(expectedProductIdentifiers));
@@ -469,7 +471,7 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
         public static final String SCC_PWD = "sccPasswd";
 
         // Maps we need to spy on
-        private final Map<String, SCCRegisterSystemJson> pendingRegistrationSystemsByLogin = new HashMap<>();
+        private final Map<String, SCCRegisterSystemItem> pendingRegistrationSystemsByLogin = new HashMap<>();
 
         private final SCCSystemRegistrationContext contextMock;
 
@@ -530,16 +532,18 @@ public class SCCSystemRegistrationSystemDataAcquisitorTest extends AbstractSCCSy
                 allowing(cacheItemMock).getOptSccLogin(); will(returnValue(Optional.of(SCC_LOGIN)));
                 allowing(cacheItemMock).getOptSccPasswd(); will(returnValue(Optional.of(SCC_PWD)));
 
-                // Additional data required for SCCRegisterSystemJson
+                // Additional data required for SCCRegisterSystemItem
                 allowing(serverMock).getHostname(); will(returnValue(builder.hostname));
                 allowing(serverMock).getServerInfo(); will(returnValue(serverInfoMock));
                 allowing(serverInfoMock).getCheckin(); will(returnValue(new Date()));
 
+                allowing(serverMock).getSapWorkloads(); will(returnValue(new HashSet<SAPWorkload>()));
+                allowing(serverMock).asMinionServer(); will(returnValue(Optional.empty()));
             }});
 
         }
 
-        public Map<String, SCCRegisterSystemJson> getPendingRegistrationSystemsByLogin() {
+        public Map<String, SCCRegisterSystemItem> getPendingRegistrationSystemsByLogin() {
             return pendingRegistrationSystemsByLogin;
         }
 

--- a/java/spacewalk-java.changes.carlo.issv3-update-last-seen
+++ b/java/spacewalk-java.changes.carlo.issv3-update-last-seen
@@ -1,0 +1,2 @@
+- Implements and tests the update last seen mechanism
+  when a hub is acting as an SCC proxy

--- a/schema/spacewalk/common/tables/suseSccProxy.sql
+++ b/schema/spacewalk/common/tables/suseSccProxy.sql
@@ -25,6 +25,7 @@ CREATE TABLE suseSccProxy
     scc_id              NUMERIC,
     status              scc_proxy_status_t NOT NULL,
     scc_regerror_timestamp TIMESTAMPTZ,
+    last_seen_at TIMESTAMPTZ,
 
     created        TIMESTAMPTZ
                        DEFAULT (current_timestamp) NOT NULL,

--- a/schema/spacewalk/susemanager-schema.changes.carlo.issv3-update-last-seen
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.issv3-update-last-seen
@@ -1,0 +1,1 @@
+- Add column last_seen_at to suseSCCProxy table

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.7-to-susemanager-schema-5.1.8/100-add-updatelastseen-susesccproxy.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.7-to-susemanager-schema-5.1.8/100-add-updatelastseen-susesccproxy.sql
@@ -1,0 +1,14 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+ALTER TABLE suseSccProxy ADD COLUMN IF NOT EXISTS
+last_seen_at TIMESTAMPTZ;
+


### PR DESCRIPTION
## What does this PR change?
Implements and tests the update last seen mechanism when a hub is acting as an SCC proxy

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27058
Port(s): not backported
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"


