### PR TITLE
pedantic fix of typo in spacewalk-common-channels.ini

### DIFF
--- a/utils/spacewalk-utils.changes.os-sengel.patch-1
+++ b/utils/spacewalk-utils.changes.os-sengel.patch-1
@@ -1,0 +1,2 @@
+- Fix base channel for openSUSE Micro 6.1 Uyuni Client Devel in spacewalk-common-channels
+- Fix base channel for Oracle Linux 6 mysql57 in spacewalk-common-channels

--- a/utils/utils/spacewalk-utils.changes.os-sengel.patch-1
+++ b/utils/utils/spacewalk-utils.changes.os-sengel.patch-1
@@ -1,2 +1,0 @@
-- Fix base channel openSUSE Micro 6.1 Uyuni Client Devel in spacewalk-common-channels
-- Fix base channel Oracle Linux6  mysql57 in spacewalk-common-channels


### PR DESCRIPTION
## What does this PR change?

In the config file for `spacewalk-common-channels` there was a typo which resulted in creation of a child channel within the wrong basechannel.

Though the correction addresses an oracle linux 6 channel, which is EOL.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: this change doesn't change any features, only data changed.

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

No previous issue exists

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
