### PR TITLE
Enhances org info gathered from the peripheral with the list of channels of each org

### DIFF
--- a/java/code/src/com/suse/manager/hub/HubController.java
+++ b/java/code/src/com/suse/manager/hub/HubController.java
@@ -29,6 +29,7 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.ConnectionManager;
 import com.redhat.rhn.common.hibernate.ConnectionManagerFactory;
 import com.redhat.rhn.common.hibernate.ReportDbHibernateFactory;
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.HubRegistrationChanged;
 import com.redhat.rhn.domain.role.RoleFactory;
@@ -313,7 +314,10 @@ public class HubController {
     private String listAllPeripheralOrgs(Request request, Response response, IssAccessToken token) {
         List<OrgInfoJson> allOrgsInfo = hubManager.collectAllOrgs(token)
                 .stream()
-                .map(org -> new OrgInfoJson(org.getId(), org.getName()))
+                .map(org -> new OrgInfoJson(
+                        org.getId(),
+                        org.getName(),
+                        org.getOwnedChannels().stream().map(Channel::getLabel).toList()))
                 .toList();
 
         return success(response, allOrgsInfo);

--- a/java/code/src/com/suse/manager/model/hub/OrgInfoJson.java
+++ b/java/code/src/com/suse/manager/model/hub/OrgInfoJson.java
@@ -11,6 +11,7 @@
 
 package com.suse.manager.model.hub;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -20,6 +21,8 @@ public class OrgInfoJson {
 
     private final String orgName;
 
+    private final List<String> orgChannelLabels;
+
     /**
      * Constructor
      *
@@ -27,8 +30,20 @@ public class OrgInfoJson {
      * @param orgNameIn the org name
      */
     public OrgInfoJson(long orgIdIn, String orgNameIn) {
+        this(orgIdIn, orgNameIn, List.of());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param orgIdIn   the org id
+     * @param orgNameIn the org name
+     * @param orgChannelLabelsIn the list of channel labels belonging to the org
+     */
+    public OrgInfoJson(long orgIdIn, String orgNameIn, List<String> orgChannelLabelsIn) {
         orgId = orgIdIn;
         orgName = orgNameIn;
+        orgChannelLabels = orgChannelLabelsIn;
     }
 
     /**
@@ -43,6 +58,13 @@ public class OrgInfoJson {
      */
     public String getOrgName() {
         return orgName;
+    }
+
+    /**
+     * @return return the list of channel labels belonging to the org
+     */
+    public List<String> getOrgChannelLabels() {
+        return orgChannelLabels;
     }
 
     @Override
@@ -67,6 +89,7 @@ public class OrgInfoJson {
         return new StringJoiner(", ", OrgInfoJson.class.getSimpleName() + "[", "]")
                 .add("orgId='" + getOrgId() + "'")
                 .add("orgName='" + getOrgName() + "'")
+                .add("orgChannelLabels='" + getOrgChannelLabels() + "'")
                 .toString();
     }
 }

--- a/java/spacewalk-java.changes.carlo.uyuni-get-peripheral-extended-org-info
+++ b/java/spacewalk-java.changes.carlo.uyuni-get-peripheral-extended-org-info
@@ -1,0 +1,2 @@
+- Enhances org info gathered from the peripheral with the list
+  of channels of each org


### PR DESCRIPTION
## What does this PR change?
When showing the UI to sync channels on a peripheral, the hub requests to the peripheral a list of organizations (name and id) to be used if the hub wants to synchronize a channel with any of the peripheral orgs.
This PR adds to this information also the list of peripheral channels already belonging to each peripheral org.
This way, the UI can find if a channel is already belonging to an org, hence not giving the chance to select any peripheral org to assign to the channel


## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): #
Port(s): # 
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

