### PR TITLE
Include implied RBAC groups for ORG_ADMIN and SAT_ADMIN users (bsc#1243145)

### DIFF
--- a/java/spacewalk-java.changes.welder.bsc1243145
+++ b/java/spacewalk-java.changes.welder.bsc1243145
@@ -1,0 +1,2 @@
+- Include implied RBAC groups for ORG_ADMIN
+  and SAT_ADMIN users (bsc#1243145)


### PR DESCRIPTION
## What does this PR change?

It updates the `isMemberOf` method to account for role-based access implications:

- Users with the `SAT_ADMIN` role are now considered members of all access groups.

- Users with the `ORG_ADMIN` role are:

  - Considered members of all access groups within their organization.
  - Automatically granted access to default (non-org-specific) RBAC groups if those groups are part of the IMPLIEDROLES set.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27223

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
