### PR TITLE
Fix missing scc_proxy_status_t type creation in table creation

### DIFF
--- a/schema/spacewalk/common/tables/suseSccProxy.sql
+++ b/schema/spacewalk/common/tables/suseSccProxy.sql
@@ -13,6 +13,12 @@
 -- in this software or its documentation.
 --
 
+CREATE TYPE scc_proxy_status_t AS ENUM (
+    'scc_creation_pending',
+    'scc_created',
+    'scc_removal_pending',
+    'scc_virthost_pending'
+);
 
 CREATE TABLE suseSccProxy
 (


### PR DESCRIPTION
## What does this PR change?
the script creating a brand new suseSccProxy table (in schema7spacewalk/common/tables/) is missing the creation  of the scc_proxy_status_t enumeration

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): #
Port(s): # 
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
