### PR TITLE
reposync: allow commas a part of HTTP Proxy passwd (bsc#1243460)

### DIFF
--- a/python/spacewalk/common/suseLib.py
+++ b/python/spacewalk/common/suseLib.py
@@ -661,7 +661,18 @@ def _get_proxy_from_rhn_conf():
         # CFG.http_proxy format is <hostname>[:<port>] in 1.7
         # pylint: disable-next=consider-using-f-string
         url = "http://%s" % CFG.http_proxy
-        result = (url, CFG.http_proxy_username, CFG.http_proxy_password)
+        # CFG.http_proxy_password can be a list in case of legitimate
+        # commas "," are part of the password. If so, we need to
+        # rebuilt the original password.
+        result = (
+            url,
+            CFG.http_proxy_username,
+            (
+                CFG.http_proxy_password
+                if not isinstance(CFG.http_proxy_password, list)
+                else ",".join(CFG.http_proxy_password)
+            ),
+        )
     initCFG(comp)
     log_debug(2, "Could not read proxy URL from rhn config.")
     return result

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-bsc1243460
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-bsc1243460
@@ -1,0 +1,2 @@
+- Make reposync to allow commas as part of HTTP Proxy password
+  (bsc#1243460)

--- a/python/test/unit/spacewalk/common/test_suseLib.py
+++ b/python/test/unit/spacewalk/common/test_suseLib.py
@@ -121,6 +121,16 @@ class SuseLibTest(unittest.TestCase):
 
         self.assertEqual((HTTP_PROXY, "user", None), suseLib.get_proxy())
 
+    @mock.patch("spacewalk.common.suseLib.CFG")
+    def test_get_proxy_rhn_conf_password_with_commas(self, mocked_CFG):
+        mocked_CFG.http_proxy = PROXY_ADDR
+        mocked_CFG.http_proxy_username = PROXY_USER
+        mocked_CFG.http_proxy_password = ["password", "with", "commas"]
+
+        self.assertEqual(
+            (HTTP_PROXY, PROXY_USER, "password,with,commas"), suseLib.get_proxy()
+        )
+
     def test_URL_getURL_with_stipPw(self):
         self.assertEqual(
             suseLib.URL("https://example.org/path/to/repo").getURL(stripPw=True),


### PR DESCRIPTION
## What does this PR change?

This PR prevents an issue in `spacewalk-repo-sync` when a HTTP Proxy is configured and the password for it contains a comma (`,`) as part of it:

```console
uyuni-server:/ # spacewalk-repo-sync -c mytestchannel
17:11:03 ======================================
17:11:03 | Channel: mytestchannel
17:11:03 ======================================
17:11:03 Sync of channel started.
17:11:05 Unexpected error: <class 'TypeError'>
17:11:05 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 754, in sync
    repo_checksum_type = plugin.get_md_checksum_type()
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 1141, in get_md_checksum_type
    if self._md_exists("repomd"):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 1078, in _md_exists
    self.setup_repo(self.repo)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 887, in setup_repo
    zypp_repo_url = self._prep_zypp_repo_url(self.url, uln_repo)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/yum_src.py", line 1003, in _prep_zypp_repo_url
    query_params["proxypass"] = quote(self.proxy_pass)
  File "/usr/lib64/python3.6/urllib/parse.py", line 882, in quote
    return quote_from_bytes(string, safe)
  File "/usr/lib64/python3.6/urllib/parse.py", line 907, in quote_from_bytes
    raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes
```

This issue is caused as `CFG` considers the commas in a config value as list separator between items, as some config values are expected to be comma separated lists, therefore leading to `CFG.http_proxy_password` being a `list` in case the password contains commas.

This PR makes the parsing function of proxy configuration settings to recontructs the password in case a `list` is found. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27308
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
