### PR TITLE
For GPG keys using file URL, check if the file exists

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -91,8 +91,9 @@ mgr_deploy_{{ keyname }}:
 {%- if args['gpgkeyurl'] is defined %}
 {%- set keys = args['gpgkeyurl'].split(' ') %}
 {%- for gpgkey in keys %}
+{%- set keyexists = gpgkey.startswith('file://') and salt['file.file_exists'](gpgkey[7:]) or gpgkey.startswith('http') %}
 {%- set gpgkey = gpgkey|replace(pillar.get('mgr_origin_server', 'no-replace-origin-not-found'), pillar.get('mgr_server', '')) %}
-{%- if gpgkey not in gpg_urls %}
+{%- if keyexists and gpgkey not in gpg_urls %}
 {{ gpg_urls.append(gpgkey) | default("", True) }}
 {%- endif %}
 {%- endfor %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.check-gpgkey-file-exists
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.check-gpgkey-file-exists
@@ -1,0 +1,2 @@
+- For GPG keys using file URL, check if the file exists before
+  importing it


### PR DESCRIPTION
## What does this PR change?

When importing GPG keys which are defined with a file URL, check if the file exists.
If not, skip the key.
This is useful when the key file was renamed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): TBD

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
