### PR TITLE
Set user-data-dir when in a Cloud environment

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -97,6 +97,8 @@ def capybara_register_driver
     )
     chrome_options.args << 'headless=new' unless $debug_mode
     chrome_options.args << "remote-debugging-port=#{$chromium_dev_port}" if $chromium_dev_tools
+    chrome_options.args << '--user-data-dir=/root' if $is_cloud_provider
+
     chrome_options.add_preference('prompt_for_download', false)
     chrome_options.add_preference('download.default_directory', '/tmp/downloads')
     chrome_options.add_preference('unhandledPromptBehavior', 'accept')


### PR DESCRIPTION
## What does this PR change?

Explicitly sets the argument so that the spawned webdriver Chromium instances can correctly retrieve stored certs from the NSS database, when running in a Cloud environment.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests' setup was modified.

- [x] **DONE**

## Links

Issue(s):  https://github.com/SUSE/spacewalk/issues/26989
Port(s): 

- 5.0 (?): https://github.com/SUSE/spacewalk/pull/27342

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
