### PR TITLE
Fix selection of recommended addons in Product Migration (bsc#1243766)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -380,7 +380,8 @@ public class DistUpgradeManager extends BaseManager {
             result.add(new SUSEProductSet(base, Collections.emptyList()));
         }
         else {
-            List<SUSEProduct> addonProducts = combination.subList(1, combination.size());
+            List<SUSEProduct> addonProducts = ensureRecommendedAddons(base,
+                    combination.subList(1, combination.size()));
             addLibertyLinuxAddonIfMissing(base, addonProducts);
             // No Product Channels means, no subscription to access the channels
             if (addonProducts.stream().anyMatch(ap -> !mgr.isProductAvailable(ap, base))) {

--- a/java/spacewalk-java.changes.mcalmer.fix-sles-2-sles4sap-migration
+++ b/java/spacewalk-java.changes.mcalmer.fix-sles-2-sles4sap-migration
@@ -1,0 +1,2 @@
+- Fix selection of recommended addons in Product Migration
+  (bsc#1243766)


### PR DESCRIPTION
## What does this PR change?

During product migration we should select all recommended addons automatically.
Otherwise the migration might fail

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27363
Port(s): Not needed - new feature

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
