### PR TITLE
Add amazon to RH families

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -320,7 +320,7 @@ end
 # @return [Boolean] true if the host name belongs to a Red Hat-like distribution, false otherwise
 def rh_host?(name)
   os_family = get_target(name).os_family
-  %w[rocky centos redhat alma oracle liberty almalinux ol rhel].include? os_family
+  %w[alma almalinux amzn centos liberty ol oracle rocky redhat rhel].include? os_family
 end
 
 # Determines if the given host name is a Debian-based host.


### PR DESCRIPTION
## What does this PR change?

Add amazon (`amzn`) to the list of RedHat-like families.


## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
Cucumber tests were modified

 - [x] **DONE**

## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/27371
 * 5.0: https://github.com/SUSE/spacewalk/pull/27370

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
