### PR TITLE
Add missing proxies entitlements on upgrade (bsc#1243829)

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.rjpmestre.bsc1243829
+++ b/schema/spacewalk/susemanager-schema.changes.rjpmestre.bsc1243829
@@ -1,0 +1,1 @@
+- Add missing proxies entitlements on upgrade (bsc#1243829)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.6-to-susemanager-schema-5.1.7/200-proxy-server-group-members.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.6-to-susemanager-schema-5.1.7/200-proxy-server-group-members.sql
@@ -1,0 +1,20 @@
+--------------------------------------------------------------------------------
+-- Ensure existing proxies get the proxy_entitled and update the group count ---
+--------------------------------------------------------------------------------
+INSERT INTO rhnservergroupmembers (server_id, server_group_id)
+    SELECT rpi.server_id, (SELECT id FROM rhnservergroup WHERE name = 'Proxy')
+    FROM rhnproxyinfo rpi
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM rhnservergroupmembers sg
+        WHERE sg.server_id = rpi.server_id
+          AND sg.server_group_id = (SELECT id FROM rhnservergroup WHERE name = 'Proxy')
+    );
+
+UPDATE rhnservergroup
+    SET current_members = (
+        SELECT COUNT(*)
+        FROM rhnservergroupmembers
+        WHERE server_group_id = (SELECT id FROM rhnservergroup WHERE name = 'Proxy')
+    )
+    WHERE id = (SELECT id FROM rhnservergroup WHERE name = 'Proxy');


### PR DESCRIPTION
## What does this PR change?

With the Simplified Proxy onboarding, we introduced a proxy entitlement that's automatically added for new proxies.
However, existing proxies (e.g., after an upgrade) were missing this entitlement. This PR fixes that, by ensuring all proxies are added to the proxy server group and also updates the group's member count.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27362
Port(s): 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
