### PR TITLE
SonarCloud fix: java:S108 Nested blocks of code should not be left empty

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -395,6 +395,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             fail();
         }
         catch (ServerNotInGroupException e) {
+            //should be here
         }
 
         assertFalse(serverGroup.getServers().contains(testServer1));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
@@ -818,6 +818,7 @@ public class ActivationKeyHandlerTest extends BaseHandlerTestCase {
             fail("Expected NoSuchSystemException");
         }
         catch (NoSuchSystemException e) {
+            //should be here
         }
         catch (Throwable t) {
             fail("Expected NoSuchSystemException but got " + t);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/test/AdminMonitoringHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/admin/monitoring/test/AdminMonitoringHandlerTest.java
@@ -107,6 +107,7 @@ public class AdminMonitoringHandlerTest extends BaseHandlerTestCase {
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
 
         try {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/test/ConfigChannelHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/test/ConfigChannelHandlerTest.java
@@ -459,7 +459,7 @@ public class ConfigChannelHandlerTest extends BaseHandlerTestCase {
 
         }
         catch (InvalidOperationException e) {
-
+            //should be here
         }
         //Symlinks are not allowed for state channel
         try {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/test/ImageProfileHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/test/ImageProfileHandlerTest.java
@@ -207,6 +207,7 @@ public class ImageProfileHandlerTest extends BaseHandlerTestCase {
             fail("Invalid store provided.");
         }
         catch (NoSuchImageStoreException ignore) {
+            //should be here
         }
 
         try {

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -213,6 +213,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
             fail("Must throw LookupException.");
         }
         catch (LookupException ignored) {
+            //should be here
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -143,7 +143,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
             fail("Exception expected but didn't throw");
         }
         catch (InvalidFormulaException ex) {
-
+            //should be here
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
@@ -364,6 +364,7 @@ public class VirtualInstanceManager extends BaseManager {
             }
         }
         catch (IllegalArgumentException ignored) {
+            //ignored
         }
         return uuid;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -143,6 +143,7 @@ public class SchedulerKernel {
                     this.shutdownLock.wait();
                 }
                 catch (InterruptedException ignored) {
+                    //ignored
                 }
             }
         }

--- a/java/code/src/com/suse/manager/xmlrpc/admin/test/AdminPaygHandlerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/admin/test/AdminPaygHandlerTest.java
@@ -88,12 +88,14 @@ public class AdminPaygHandlerTest extends BaseHandlerTestCase {
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
         try {
             handler.list(admin);
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
     }
 
@@ -107,12 +109,14 @@ public class AdminPaygHandlerTest extends BaseHandlerTestCase {
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
         try {
             handler.create(regular, null, null, null, null, null, null, null);
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
     }
 
@@ -126,12 +130,14 @@ public class AdminPaygHandlerTest extends BaseHandlerTestCase {
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
         try {
             handler.setDetails(regular, null, null);
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
     }
 
@@ -142,12 +148,14 @@ public class AdminPaygHandlerTest extends BaseHandlerTestCase {
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
         try {
             handler.delete(regular, null);
             fail("PermissionCheckFailureException should be thrown");
         }
         catch (PermissionCheckFailureException e) {
+            //should be here
         }
     }
 


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rule java:S108 Nested blocks of code should not be left empty

An empty code block is confusing. It will require some effort from maintainers to determine if it is intentional or indicates the implementation is incomplete.
Removing or filling the empty code blocks takes away ambiguity and generally results in a more straightforward and less surprising code.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): not backported
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"


