### PR TITLE
Use defusedxml as more secured xml parser (bsc#1227577)

### DIFF
--- a/python/rhn/rhnlib.changes.meaksh.master-use-defusedxml
+++ b/python/rhn/rhnlib.changes.meaksh.master-use-defusedxml
@@ -1,0 +1,1 @@
+- Use more secure defusedxml parser (bsc#1227577)

--- a/python/rhn/rhnlib.spec
+++ b/python/rhn/rhnlib.spec
@@ -71,8 +71,10 @@ Group:          Development/Libraries
 %if 0%{?fedora} >= 28 || 0%{?rhel} >= 8
 BuildRequires:  python2-devel
 Requires:       python2-pyOpenSSL
+Requires:       python2-defusedxml
 %else
 BuildRequires:  python-devel
+Requires:       python-defusedxml
 %if 0%{?suse_version}
 %if 0%{?suse_version} > 1200
 Requires:       python-pyOpenSSL
@@ -92,6 +94,7 @@ BuildRequires:  rpm
 Requires(preun):python-minimal
 Requires(post): python-minimal
 Requires:       python-openssl
+Requires:       python-defusedxml
 Obsoletes:      python-rhn
 Conflicts:      python-rhn
 %endif
@@ -124,6 +127,7 @@ BuildRequires:  python-rpm-macros
 %endif
 %endif
 Requires:       python3-pyOpenSSL
+Requires:       python3-defusedxml
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires:  python3-dev

--- a/python/rhn/transports.py
+++ b/python/rhn/transports.py
@@ -14,6 +14,8 @@
 import os
 import sys
 import time
+from defusedxml import xmlrpc as defused_xmlrpc
+
 from rhn import connections
 from rhn.stringutils import sstr, bstr
 from rhn.SmartIO import SmartIO
@@ -256,6 +258,21 @@ class Transport(xmlrpclib.Transport):
     # Give back the new URL if redirected
     def redirected(self):
         return self._redirected
+
+    def getparser(self):
+        """
+        Overrides xmlrpclib.getparser to ensure we use defusedxml
+        to protect against vulnerabilities
+        """
+        unmarshaller = xmlrpclib.Unmarshaller()
+
+        if self._use_builtin_types:
+            unmarshaller.use_builtin_types = 1
+        if self._use_datetime:
+            unmarshaller.use_datetime = 1
+
+        parser = defused_xmlrpc.DefusedExpatParser(target=unmarshaller)
+        return parser, unmarshaller
 
     # Rewrite parse_response to provide refresh callbacks
     def parse_response(self, f):

--- a/python/spacewalk/server/apacheRequest.py
+++ b/python/spacewalk/server/apacheRequest.py
@@ -28,6 +28,7 @@ except ImportError:
     #  python3
     import xmlrpc.client as xmlrpclib
 from rhn.rpclib import transports
+from defusedxml import xmlrpc as defused_xmlrpc
 
 # common modules
 from uyuni.common.usix import raise_with_tb
@@ -83,8 +84,11 @@ class apacheRequest:
         self.req = req
         # grab an Input object
         self.input = transports.Input(req.headers_in)
-        # make sure we have a parser and a decoder available
-        self.parser, self.decoder = xmlrpclib.getparser()
+
+        # Use defusedxml parser to protect against vulnerabilities
+        self.decoder = xmlrpclib.Unmarshaller()
+        self.parser = defused_xmlrpc.DefusedExpatParser(target=self.decoder)
+
         # Make sure the decoder doesn't assume UTF-8 data, that would break if
         # non-UTF-8 chars are sent (bug 139370)
         self.decoder._encoding = None

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-use-defusedxml
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-use-defusedxml
@@ -1,0 +1,1 @@
+- Use more secure defusedxml parser (bsc#1227577)

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -120,6 +120,7 @@ Requires:       %{name}-sql = %{version}-%{release}
 Requires:       spacewalk-config
 Requires:       (apache2-mod_wsgi or python3-mod_wsgi)
 Requires:       (python3-pam or python3-python-pam)
+Requires:       python3-defusedxml
 
 # cobbler-web is known to break our configuration
 Conflicts:      cobbler-web


### PR DESCRIPTION
## What does this PR change?

This PR makes use of `defusedxml` in `rhnlib` and `spacewalk-backend-server` to ensure more secure xml parsing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24784

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
