### PR TITLE
Change the default value to new rebranded name

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -9,7 +9,7 @@ EXIT_ERROR=2
 EXIT_ALREADY_CONFIGURED=3
 
 
-# get product name, default: SUSE Manager
+# get product name, default: SUSE Multi-Linux Manager
 IFS=" = "
 DEFAULT_RHN_CONF="/usr/share/rhn/config-defaults/rhn.conf"
 
@@ -22,7 +22,7 @@ if [ -f "$DEFAULT_RHN_CONF" ]; then
     done < $DEFAULT_RHN_CONF
 fi
 if [ ! -n "$PRODUCT_NAME" ]; then
-    PRODUCT_NAME="SUSE Manager"
+    PRODUCT_NAME="SUSE Multi-Linux Manager"
 fi
 
 if [ ! $UID -eq 0 ]; then


### PR DESCRIPTION
## What does this PR change?

This fixes the fallback name of the product.

We have a problem where after upgrade from 5.0 to 5.1, we still see old name in UI where it shouldn't be. Apparently, the old value is coming from web.product_name from the rhn.conf. I don't know if this change fixes that issue but this is more of a hunch.

## GUI diff

This should affect multiple places if that's really the issue

- [ ] **DONE**

## Documentation
- No documentation needed: User facing change


- [x] **DONE**

## Test coverage

- No tests: N/A


- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
