### PR TITLE
salt-broker: enable passing config and log paths via environment vars

### DIFF
--- a/proxy/proxy/salt-broker/salt-broker
+++ b/proxy/proxy/salt-broker/salt-broker
@@ -13,7 +13,7 @@
     :depends:   python-PyYAML
     :depends:   python-pyzmq
 
-    Copyright (c) 2016 SUSE LINUX Products GmbH, Nuernberg, Germany.
+    Copyright (c) 2016--2025 SUSE LLC
 
     All modifications and additions to the file contributed by third parties
     remain the property of their copyright owners, unless otherwise agreed
@@ -41,10 +41,14 @@ import time
 import traceback
 import yaml
 
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
 try:
     # Import RHN libs
     from spacewalk.common.rhnConfig import RHNOptions
 except ImportError:
+    log.info("RHNOptions is not available, running standalone")
     RHNOptions = None
 
 # Import pyzmq lib
@@ -52,14 +56,9 @@ import zmq
 
 from zmq.utils.monitor import recv_monitor_message
 
-
-RHN_CONF_FILE = "/etc/rhn/rhn.conf"
-SALT_BROKER_CONF_FILE = "/etc/salt/broker"
-SALT_BROKER_LOGFILE = "/var/log/salt/broker"
+SALT_BROKER_CONF_FILE = os.environ.get("SALT_BROKER_CONF_FILE", "/etc/salt/broker")
+SALT_BROKER_LOGFILE = os.environ.get("SALT_BROKER_LOGFILE", "/var/log/salt/broker")
 SUPERVISOR_TIMEOUT = 5
-
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def ip_bracket(addr, strip=False):

--- a/proxy/proxy/spacewalk-proxy.changes.meaksh.master-standalone-salt-broker
+++ b/proxy/proxy/spacewalk-proxy.changes.meaksh.master-standalone-salt-broker
@@ -1,0 +1,2 @@
+- Enable passing config and log paths via environment
+  variables to salt-broker


### PR DESCRIPTION
## What does this PR change?

This PR just tries to make `salt-broker` execution a bit more standalone an not dependand on other Uyuni components to be able to run. This makes the salt-broker easier to consume outside of the Uyuni context.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
