### PR TITLE
Avoid excessive journal logging from RPM when syncing GPG keys

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -229,6 +229,7 @@ class ZyppoSync:
                     # We delete this key from the RPM database to allow importing the newer version.
                     args = [
                         "rpm",
+                        "-q",
                         "--dbpath",
                         REPOSYNC_ZYPPER_RPMDB_PATH,
                         "-e",

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.master-avoid-logging-garbage-importing-gpg-keys
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.master-avoid-logging-garbage-importing-gpg-keys
@@ -1,0 +1,2 @@
+- Avoid excessive logging from RPM when syncing
+  GPG keys during reposync execution


### PR DESCRIPTION
## What does this PR change?

This PR prevents excessive and annoying journal logging coming from some `rpm` calls that happens on every `spacewalk-repo-sync` execution at the time of internally syncing the gpg keys provided by `uyuni-build-keys` package with the reposync rpm database:

```
...
jun 03 16:10:38 suma-43-srv [RPM][5055]: Transaction ID 683f025e started
jun 03 16:10:38 suma-43-srv [RPM][5055]: erase gpg-pubkey-aec0a8f0-63cbd05d: success
jun 03 16:10:38 suma-43-srv [RPM][5055]: erase gpg-pubkey-aec0a8f0-63cbd05d: success
jun 03 16:10:38 suma-43-srv [RPM][5055]: Transaction ID 683f025e finished: 0
jun 03 16:10:38 suma-43-srv [RPM][5056]: Transaction ID 683f025e started
jun 03 16:10:38 suma-43-srv [RPM][5056]: erase gpg-pubkey-2b90d010-546fa819: success
jun 03 16:10:38 suma-43-srv [RPM][5056]: erase gpg-pubkey-2b90d010-546fa819: success
jun 03 16:10:38 suma-43-srv [RPM][5056]: Transaction ID 683f025e finished: 0
jun 03 16:10:38 suma-43-srv [RPM][5057]: Transaction ID 683f025e started
jun 03 16:10:38 suma-43-srv [RPM][5057]: erase gpg-pubkey-4aad5c5d-60041cb0: success
jun 03 16:10:38 suma-43-srv [RPM][5057]: erase gpg-pubkey-4aad5c5d-60041cb0: success
jun 03 16:10:38 suma-43-srv [RPM][5057]: Transaction ID 683f025e finished: 0
...
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **no tests around reposync logging**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
