### PR TITLE
Add Issv3 SCC missing rbac endpoint entries

### DIFF
--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -92,6 +92,16 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/hub/scc/suma/product_tree.json', 'GET', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/hub/scc/connect/organizations/systems', 'PUT', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/hub/scc/connect/organizations/systems/:id', 'DELETE', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/hub/scc/connect/organizations/virtualization_hosts', 'PUT', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+
 
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/admin/hub/hub-details', 'GET', 'W', True)

--- a/schema/spacewalk/susemanager-schema.changes.carlo.issv3-scc-rbac-endpoints
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.issv3-scc-rbac-endpoints
@@ -1,0 +1,1 @@
+- Added issv3 scc missing RBAC entries

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.7-to-susemanager-schema-5.1.8/200-rbac-endpoints-for-scc.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.7-to-susemanager-schema-5.1.8/200-rbac-endpoints-for-scc.sql
@@ -1,0 +1,13 @@
+-- scc endpoints
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/hub/scc/connect/organizations/systems', 'PUT', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/hub/scc/connect/organizations/systems' AND http_method = 'PUT');
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/hub/scc/connect/organizations/systems/:id', 'DELETE', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/hub/scc/connect/organizations/systems/:id' AND http_method = 'DELETE');
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/hub/scc/connect/organizations/virtualization_hosts', 'PUT', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/hub/scc/connect/organizations/virtualization_hosts' AND http_method = 'PUT');
+
+


### PR DESCRIPTION
## What does this PR change?
This PR adds missing RBAC entries for ISSv3 SCC endpoints
See https://github.com/uyuni-project/uyuni/pull/10325#discussion_r2120336776

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/25350
Port(s): not backported
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"  
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

