### PR TITLE
Ensure bootstrap.sh can write to overlay fs

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -948,6 +948,10 @@ if [ $VENV_ENABLED -eq 1 ]; then
     MINION_SERVICE="venv-salt-minion"
 fi
 
+if [ -n "$SNAPSHOT_ID" ]; then
+    test -d "$MINION_CONFIG_DIR" || mkdir -p "$MINION_CONFIG_DIR"
+fi
+
 if [ $REGISTER_THIS_BOX -eq 1 ]; then
     echo "* registering"
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.agraul.ensure-boostrap-sh-micro-overlay-exists
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.agraul.ensure-boostrap-sh-micro-overlay-exists
@@ -1,0 +1,1 @@
+- Ensure bootstrap.sh can write minion config on SLE Micro


### PR DESCRIPTION
## What does this PR change?
We can't assume that the overlay dir corresponding to the transaction we open contains the minion config directory. For example, when venv-salt-minion was previously installed and bootstrap.sh is executed again, the new overlay dir might not have etc/venv-salt-minion.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
