### PR TITLE
Show full list of kernel versions in live-patching filter template form (bsc#1239907)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -784,7 +784,7 @@ public class SUSEProductFactory extends HibernateFactory {
         return HibernateFactory.getSession().createQuery(
                 "SELECT DISTINCT pkg.packageEvr " +
                 "FROM SUSEProductExtension x " +
-                "JOIN SUSEProduct ext ON x.extensionProduct = ext " +
+                "JOIN SUSEProduct ext ON x.baseProduct = ext " +
                 "JOIN SUSEProductChannel pc ON pc.product = ext " +
                 "JOIN pc.channel.packages pkg " +
                 "WHERE pkg.packageName.name = 'kernel-default' " +

--- a/java/spacewalk-java.changes.cbbayburt.bsc1239907
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1239907
@@ -1,0 +1,2 @@
+- In CLM live-patching template form, show kernel versions from
+  base product as well (bsc#1239907)


### PR DESCRIPTION
In SLES for SAP, kernel packages are served across different products. This PR updates the DB query to show kernel versions from the base product too.

Port of: https://github.com/SUSE/spacewalk/pull/26956

## Documentation
- No documentation needed: bugfix

## Links

Fixes https://github.com/SUSE/spacewalk/issues/26777
https://bugzilla.suse.com/show_bug.cgi?id=1239907

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
