### PR TITLE
Remove workaround from testsuite

### DIFF
--- a/testsuite/features/reposync/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/reposync/srv_create_bootstrap_repositories.feature
@@ -13,8 +13,6 @@ Feature: Create bootstrap repositories
   Scenario: Create the bootstrap repository for SUSE Minion
     When I create the bootstrap repository for "sle_minion" on the server
 
-# WORKAROUND: Skipping because SL Micro 6 MLM tools are not ready and this fails
-@skip
 @proxy
   Scenario: Create the bootstrap repository for Proxy
     When I create the bootstrap repository for "proxy" on the server


### PR DESCRIPTION
## What does this PR change?

Removes the workaround that disables bootstrap repo creation on proxy, now the products are enabled in SCC and we can run this.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s):  no issue, directly from testsuite review and partly https://github.com/SUSE/spacewalk/issues/25943#issuecomment-2930136463
Port(s): was only needed on head since that's where we have 5.1 only

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
