### PR TITLE
Build validation variable is not set when calling remote_nodes_env. M…

### DIFF
--- a/testsuite/features/support/remote_nodes_env.rb
+++ b/testsuite/features/support/remote_nodes_env.rb
@@ -4,11 +4,14 @@
 require 'require_all'
 require_relative 'remote_node'
 
+# QAM and Build Validation pipelines will provide a json file including all custom (MI) repositories
+custom_repos_path = "#{File.dirname(__FILE__)}/../upload_files/custom_repositories.json"
+
 # Raise a warning if any of these environment variables is missing
 raise ArgumentError, 'Server IP address or domain name variable empty' if ENV['SERVER'].nil?
 
 warn 'Proxy IP address or domain name variable empty' if ENV['PROXY'].nil?
-unless $build_validation
+unless File.exist?(custom_repos_path)
   warn 'Minion IP address or domain name variable empty' if ENV['MINION'].nil?
   warn 'Buildhost IP address or domain name variable empty' if ENV['BUILD_HOST'].nil?
   warn 'Red Hat-like minion IP address or domain name variable empty' if ENV['RHLIKE_MINION'].nil?


### PR DESCRIPTION
## Context

In remote_nodes_env.rb, we conditionally raise or warn about missing environment variables based on the value of the global variable $build_validation.

However, in env.rb, the $build_validation flag is only set after requiring remote_nodes_env.rb, like this:
```ruby
require_relative 'remote_nodes_env'

# Later in the file:
if File.exist?(custom_repos_path)
  $build_validation = true
end
```

This means that when remote_nodes_env.rb runs, $build_validation is not yet set, so it defaults to nil, and all warnings for missing env vars are triggered — even in valid build validation runs.

## What does this PR change?

This PR fixes a logic ordering issue in env.rb where the build_validation flag was being set after remote_nodes_env.rb was loaded. This caused false warnings about missing environment variables in build validation scenarios.
Moving the require was causing other issue so I move the file check into the remote_nodes

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
