### PR TITLE
Remove product_name overwrite from rhn.conf (bsc#1244021)

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes.mcalmer.branding-fix-product-name
+++ b/spacewalk/admin/spacewalk-admin.changes.mcalmer.branding-fix-product-name
@@ -1,0 +1,1 @@
+- Remove product_name overwrite from rhn.conf (bsc#1244021)

--- a/spacewalk/admin/uyuni-update-config
+++ b/spacewalk/admin/uyuni-update-config
@@ -11,6 +11,7 @@
 #
 #  pylint: disable=missing-module-docstring,invalid-name
 
+import re
 import sys
 import os.path
 import uuid
@@ -186,6 +187,17 @@ def change_billing_data_service():
         sys.stdout.write("billing-data-service sysconfig: changed LISTEN address\n")
 
 
+def remove_product_name_overwrite():
+    pattern = re.compile(r"^product_name\s*=.*$")
+    with open("/etc/rhn/rhn.conf", "r+", encoding="utf8") as f:
+        new_f = f.readlines()
+        f.seek(0)
+        for line in new_f:
+            if not pattern.match(line.strip()):
+                f.write(line)
+        f.truncate()
+
+
 def main():
     run_uyuni_configfiles_sync()
     init_scc_login()
@@ -193,6 +205,7 @@ def main():
     copy_ca()
     move_config_to_db()
     change_billing_data_service()
+    remove_product_name_overwrite()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR change?

product_name should not be overwritten in rhn.conf.
This prevent product rename and and new brandings

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27429
Port(s): Not needed

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
