### PR TITLE
Fix setup wizard organization credentials list subscriptions not showing correctly the first time (bsc#1243765)

### DIFF
--- a/web/html/javascript/susemanager-setup-wizard-mirror-credentials.js
+++ b/web/html/javascript/susemanager-setup-wizard-mirror-credentials.js
@@ -26,6 +26,8 @@ function initDelete(id, user) {
 function initSubscriptions(id) {
   console.log("initSubscriptions(): " + id);
   subscriptionsId = id;
+  showSpinner("modal-list-subscriptions-body");
+  ajax("list-mirror-subscriptions", { subscriptionsId }, makeRendererHandler("modal-list-subscriptions-body", false).callback)
 }
 
 // Hide any modal dialogs
@@ -120,11 +122,5 @@ jQuery(document).ready(function() {
   // Clear input fields whenever the edit modal is hidden
   jQuery('#modal-edit-credentials').on('hidden.bs.modal', function() {
     initEdit("", "");
-  });
-
-  // Load subscriptions when modal is shown
-  jQuery('#modal-list-subscriptions').on('show.bs.modal', function() {
-    showSpinner("modal-list-subscriptions-body");
-    ajax("list-mirror-subscriptions", { subscriptionsId }, makeRendererHandler("modal-list-subscriptions-body", false).callback)
   });
 });

--- a/web/spacewalk-web.changes.carlo.uyuni-bsc1243765-list-subscriptions
+++ b/web/spacewalk-web.changes.carlo.uyuni-bsc1243765-list-subscriptions
@@ -1,0 +1,2 @@
+- Fixes setup wizard organization credentials list subscriptions
+  not showing correctly the first time (bsc#1243765)


### PR DESCRIPTION
## What does this PR change?
This PR fixes bug 1243765.
When entering correct credentials, and then clicking on `list subscriptions` for the entered credentials,  the first time the UI is misbehaving, not showing any information and giving a log error.
The UI is behaving correctly from the second time it's clicked

The error is in the code of the "list subscription button"

`<a href="javascript:void(0);" onCLick="initSubscriptions('<DB_ID>')" data-bs-toggle="modal" data-bs-target="#modal-list-subscriptions">
`

clicking on that button fires two function calls: the "onClick" one 

```
function initSubscriptions(id) {
  subscriptionsId = id;
}
```

and the one fired when the modal is shown
```
  jQuery('#modal-list-subscriptions').on('show.bs.modal', function() {
    showSpinner("modal-list-subscriptions-body");
    ajax("list-mirror-subscriptions", { subscriptionsId }, makeRendererHandler("modal-list-subscriptions-body", false).callback)
  });
```

since the second function happens to be called before the `onClick`, the variable `subscriptionsId` is not set correctly the first time the button is clicked. After that, the variable is set and everything works smoothly

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27369
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
