### PR TITLE
Prevent NPE when parsing hosts from playbook

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ansible/PlaybookActionFormatter.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ansible/PlaybookActionFormatter.java
@@ -112,8 +112,10 @@ public class PlaybookActionFormatter extends ActionFormatter {
             Map<String, Object> result = entry.get().getValue();
             List<Map<String, List<Map<String, Map<String, Object>>>>> plays = getNestedValue(
                     result, "changes", "ret", "plays");
-            List<Map<String, Map<String, Object>>> tasks = plays.get(0).get("tasks");
-            tasks.forEach(t -> hosts.addAll(t.get("hosts").keySet()));
+            if (plays != null) {
+                List<Map<String, Map<String, Object>>> tasks = plays.get(0).get("tasks");
+                tasks.forEach(t -> hosts.addAll(t.get("hosts").keySet()));
+            }
         }
         return hosts;
     }

--- a/java/spacewalk-java.changes.parlt.fix-npe-hosts-parsing
+++ b/java/spacewalk-java.changes.parlt.fix-npe-hosts-parsing
@@ -1,0 +1,2 @@
+- Fix possible NPE when parsing hosts from playbook return
+  (bsc#1244186)


### PR DESCRIPTION
## What does this PR change?

Prevents possible NPE from happening when parsing hosts from playbook output.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage
- No tests: **Bugfix**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27439

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
