### PR TITLE
Add the possibility to specify the installation of the last package v…

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -78,7 +78,7 @@ Feature: Smoke tests for <client>
     And I wait until I see "Installable Packages" text
     And I enter the package for "<client>" as the filtered package name
     And I click on the filter button
-    And I check the package for "<client>" in the list
+    And I check the package last version for "<client>" in the list
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
@@ -167,7 +167,7 @@ Feature: Smoke tests for <client>
     And I wait until I see "Installable Packages" text
     And I enter "spacecmd" as the filtered package name
     And I click on the filter button
-    And I check "spacecmd" in the list
+    And I check "spacecmd" last version in the list
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2024 SUSE LLC.
+# Copyright (c) 2020-2025 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @<client>

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -900,9 +900,7 @@ When(/^I enter the hostname of "([^"]*)" as the filtered system name$/) do |host
 end
 
 When(/^I enter "([^"]*)" as the filtered package name$/) do |input|
-  raise ArgumentError, 'Package name is not set' if input.empty?
-
-  find('input[placeholder=\'Filter by Package Name: \']').set(input)
+  filter_by_package_name(input)
 end
 
 When(/^I enter "([^"]*)" as the filtered latest package$/) do |input|
@@ -936,11 +934,11 @@ When(/^I enter "([^"]*)" as the filtered formula name$/) do |input|
 end
 
 When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |host|
-  step %(I enter "#{PACKAGE_BY_CLIENT[host]}" as the filtered package name)
+  filter_by_package_name(PACKAGE_BY_CLIENT[host])
 end
 
-When(/^I check the package for "([^"]*)" in the list$/) do |host|
-  step %(I check "#{PACKAGE_BY_CLIENT[host]}" in the list)
+When(/^I check the package(| last version) for "([^"]*)" in the list$/) do |version_flag,host|
+  toggle_checkbox_in_package_list('check',PACKAGE_BY_CLIENT[host], !version_flag.empty?)
 end
 
 When(/^I check row with "([^"]*)" and arch of "([^"]*)"$/) do |text, client|
@@ -983,12 +981,8 @@ When(/^I check the first row in the list$/) do
   end
 end
 
-When(/^I (check|uncheck) "([^"]*)" in the list$/) do |check_option, text|
-  top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]//input[@type='checkbox']"
-  row = find(:xpath, top_level_xpath_query, match: :first)
-  raise "xpath: #{top_level_xpath_query} not found" if row.nil?
-
-  row.set(check_option == 'check')
+When(/^I (check|uncheck) "([^"]*)"(| last version) in the list$/) do |check_option, text, version_flag|
+  toggle_checkbox_in_package_list(check_option,text, !version_flag.empty?)
 end
 
 When(/^I (check|uncheck) the "([^"]*)" CLM filter$/) do |check_option, text|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2024 SUSE LLC.
+# Copyright (c) 2010-2025 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning navigation through the Web UI
@@ -937,8 +937,8 @@ When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |hos
   filter_by_package_name(PACKAGE_BY_CLIENT[host])
 end
 
-When(/^I check the package(| last version) for "([^"]*)" in the list$/) do |version_flag,host|
-  toggle_checkbox_in_package_list('check',PACKAGE_BY_CLIENT[host], !version_flag.empty?)
+When(/^I check the package(| last version) for "([^"]*)" in the list$/) do |version_flag, host|
+  toggle_checkbox_in_package_list('check', PACKAGE_BY_CLIENT[host], !version_flag.empty?)
 end
 
 When(/^I check row with "([^"]*)" and arch of "([^"]*)"$/) do |text, client|
@@ -982,7 +982,7 @@ When(/^I check the first row in the list$/) do
 end
 
 When(/^I (check|uncheck) "([^"]*)"(| last version) in the list$/) do |check_option, text, version_flag|
-  toggle_checkbox_in_package_list(check_option,text, !version_flag.empty?)
+  toggle_checkbox_in_package_list(check_option, text, !version_flag.empty?)
 end
 
 When(/^I (check|uncheck) the "([^"]*)" CLM filter$/) do |check_option, text|

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -503,7 +503,7 @@ end
 
 When(/^I check the "([^"]*)" client$/) do |host|
   system_name = get_system_name(host)
-  toggle_checkbox_in_package_list('check', system_name)
+  toggle_checkbox_in_list('check', system_name)
 end
 
 Then(/^table row for "([^"]*)" should contain "([^"]*)"$/) do |arg1, arg2|
@@ -620,11 +620,11 @@ Then(/^I should see an update in the list$/) do
 end
 
 When(/^I check test channel$/) do
-  toggle_checkbox_in_package_list('check', 'Fake-Base-Channel-SUSE-like')
+  toggle_checkbox_in_list('check', 'Fake-Base-Channel-SUSE-like')
 end
 
 When(/^I check "([^"]*)" patch$/) do |arg1|
-  toggle_checkbox_in_package_list('check', arg1)
+  toggle_checkbox_in_list('check', arg1)
 end
 
 Then(/^I should see "([^"]*)" systems selected for SSM$/) do |arg|
@@ -842,15 +842,15 @@ Then(/^I should only see success signs in the product list$/) do
 end
 
 Then(/^I select the "([^"]*)" repo$/) do |repo|
-  toggle_checkbox_in_package_list('check', repo)
+  toggle_checkbox_in_list('check', repo)
 end
 
 Then(/^I check the row with the "([^"]*)" link$/) do |text|
-  toggle_checkbox_in_package_list('check', text)
+  toggle_checkbox_in_list('check', text)
 end
 
 Then(/^I check the row with the "([^"]*)" text$/) do |text|
-  toggle_checkbox_in_package_list('check', text)
+  toggle_checkbox_in_list('check', text)
 end
 
 When(/^I check the first patch in the list, that does not require a reboot$/) do

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -503,7 +503,7 @@ end
 
 When(/^I check the "([^"]*)" client$/) do |host|
   system_name = get_system_name(host)
-  step %(I check "#{system_name}" in the list)
+  toggle_checkbox_in_package_list('check', system_name)
 end
 
 Then(/^table row for "([^"]*)" should contain "([^"]*)"$/) do |arg1, arg2|
@@ -620,11 +620,11 @@ Then(/^I should see an update in the list$/) do
 end
 
 When(/^I check test channel$/) do
-  step 'I check "Fake-Base-Channel-SUSE-like" in the list'
+  toggle_checkbox_in_package_list('check', 'Fake-Base-Channel-SUSE-like')
 end
 
 When(/^I check "([^"]*)" patch$/) do |arg1|
-  step %(I check "#{arg1}" in the list)
+  toggle_checkbox_in_package_list('check', arg1)
 end
 
 Then(/^I should see "([^"]*)" systems selected for SSM$/) do |arg|
@@ -842,15 +842,15 @@ Then(/^I should only see success signs in the product list$/) do
 end
 
 Then(/^I select the "([^"]*)" repo$/) do |repo|
-  step %(I check "#{repo}" in the list)
+  toggle_checkbox_in_package_list('check', repo)
 end
 
 Then(/^I check the row with the "([^"]*)" link$/) do |text|
-  step %(I check "#{text}" in the list)
+  toggle_checkbox_in_package_list('check', text)
 end
 
 Then(/^I check the row with the "([^"]*)" text$/) do |text|
-  step %(I check "#{text}" in the list)
+  toggle_checkbox_in_package_list('check', text)
 end
 
 When(/^I check the first patch in the list, that does not require a reboot$/) do
@@ -938,7 +938,7 @@ When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |hos
 end
 
 When(/^I check the package(| last version) for "([^"]*)" in the list$/) do |version_flag, host|
-  toggle_checkbox_in_package_list('check', PACKAGE_BY_CLIENT[host], !version_flag.empty?)
+  toggle_checkbox_in_package_list('check', PACKAGE_BY_CLIENT[host], last_version: !version_flag.empty?)
 end
 
 When(/^I check row with "([^"]*)" and arch of "([^"]*)"$/) do |text, client|
@@ -982,7 +982,7 @@ When(/^I check the first row in the list$/) do
 end
 
 When(/^I (check|uncheck) "([^"]*)"(| last version) in the list$/) do |check_option, text, version_flag|
-  toggle_checkbox_in_package_list(check_option, text, !version_flag.empty?)
+  toggle_checkbox_in_package_list(check_option, text, last_version: !version_flag.empty?)
 end
 
 When(/^I (check|uncheck) the "([^"]*)" CLM filter$/) do |check_option, text|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -1,10 +1,11 @@
-# Copyright (c) 2013-2024 SUSE LLC.
+# Copyright (c) 2013-2025 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'tempfile'
 require 'yaml'
 require 'nokogiri'
 require 'timeout'
+require 'rubygems'
 require_relative 'constants'
 require_relative 'api_test'
 
@@ -817,4 +818,19 @@ end
 # @param package String The package name where it will trigger an upgrade
 def trigger_upgrade(hostname, package)
   get_target('server').run("spacecmd -u admin -p admin system_upgradepackage #{hostname} #{package} -y", check_errors: true)
+end
+
+# Function to select the latest package from a list based on version and release
+#
+# @param packages [Array<String>] A list of package strings in the format 'name-version-release'
+# @return [String] The package string with the highest version and release
+def latest_package(packages)
+  packages.max_by do |package|
+    if package =~ /^(.+)-(\d+\.\d+\.\d+)-(.+)$/
+      _name, version, release = $1, $2, $3
+      [Gem::Version.new(version), Gem::Version.new(release.gsub(/[^\d.]/, '.'))]
+    else
+      [Gem::Version.new('0.0.0'), Gem::Version.new('0')]
+    end
+  end
 end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -827,7 +827,8 @@ end
 def latest_package(packages)
   packages.max_by do |package|
     if package =~ /^(.+)-(\d+\.\d+\.\d+)-(.+)$/
-      _name, version, release = $1, $2, $3
+      version = Regexp.last_match(2)
+      release = Regexp.last_match(3)
       [Gem::Version.new(version), Gem::Version.new(release.gsub(/[^\d.]/, '.'))]
     else
       [Gem::Version.new('0.0.0'), Gem::Version.new('0')]

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -20,6 +20,7 @@ require_relative 'code_coverage'
 require_relative 'quality_intelligence'
 require_relative 'remote_nodes_env'
 require_relative 'commonlib'
+require_relative 'navigation_step_helper'
 
 $stdout.puts("Using Ruby version: #{RUBY_VERSION}")
 

--- a/testsuite/features/support/navigation_step_helper.rb
+++ b/testsuite/features/support/navigation_step_helper.rb
@@ -1,20 +1,33 @@
 # Copyright (c) 2025 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-# Function to check or uncheck a checkbox in a table row matching the provided text
+# Function to check or uncheck a checkbox in a the package list with the possibility to select the last package version
 #
 # @param action [String] Either 'check' or 'uncheck'
 # @param text [String] The text to match in the row
-# @param last_version [Boolean] Whether to select the row with the latest version
+# @param last_version [Boolean] Whether to select the row with the latest package version
 def toggle_checkbox_in_package_list(action, text, last_version: false)
   if last_version
     link_elements = all(:xpath, "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a")
     packages_list = link_elements.map(&:text)
     latest = latest_package(packages_list)
     top_level_xpath_query = "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a[text()='#{latest}']/../../td/input[@type='checkbox']"
+
+    row = find(:xpath, top_level_xpath_query, match: :first)
+    raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+
+    row.set(action == 'check')
   else
-    top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]//input[@type='checkbox']"
+    toggle_checkbox_in_list(action, text)
   end
+end
+
+# Function to check or uncheck a checkbox in a table first row matching the provided text
+#
+# @param action [String] Either 'check' or 'uncheck'
+# @param text [String] The text to match in the row
+def toggle_checkbox_in_list(action, text)
+  top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]//input[@type='checkbox']"
 
   row = find(:xpath, top_level_xpath_query, match: :first)
   raise "xpath: #{top_level_xpath_query} not found" if row.nil?

--- a/testsuite/features/support/navigation_step_helper.rb
+++ b/testsuite/features/support/navigation_step_helper.rb
@@ -1,0 +1,33 @@
+# Copyright (c) 2025 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+# Function to check or uncheck a checkbox in a table row matching the provided text
+#
+# @param action [String] Either 'check' or 'uncheck'
+# @param text [String] The text to match in the row
+# @param last_version [Boolean] Whether to select the row with the latest version
+def toggle_checkbox_in_package_list(action, text, last_version = false)
+  if last_version
+    link_elements = all(:xpath, "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a")
+    packages_list = link_elements.map(&:text)
+    latest = latest_package(packages_list)
+    top_level_xpath_query = "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a[text()='#{latest}']/../../td/input[@type='checkbox']"
+  else
+    top_level_xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//td[contains(.,'#{text}')]]//input[@type='checkbox']"
+  end
+
+  row = find(:xpath, top_level_xpath_query, match: :first)
+  raise "xpath: #{top_level_xpath_query} not found" if row.nil?
+
+  row.set(action == 'check')
+end
+
+# Function to enter a package name into the "Filter by Package Name" input field
+#
+# @param package_name [String] The package name to enter
+# @raise [ArgumentError] If the package name is empty
+def filter_by_package_name(package_name)
+  raise ArgumentError, 'Package name is not set' if package_name.empty?
+
+  find("input[placeholder='Filter by Package Name: ']").set(package_name)
+end

--- a/testsuite/features/support/navigation_step_helper.rb
+++ b/testsuite/features/support/navigation_step_helper.rb
@@ -6,7 +6,7 @@
 # @param action [String] Either 'check' or 'uncheck'
 # @param text [String] The text to match in the row
 # @param last_version [Boolean] Whether to select the row with the latest version
-def toggle_checkbox_in_package_list(action, text, last_version = false)
+def toggle_checkbox_in_package_list(action, text, last_version: false)
   if last_version
     link_elements = all(:xpath, "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a")
     packages_list = link_elements.map(&:text)


### PR DESCRIPTION
## Context

When installing a package via the UI, searching for a package displays all available versions.
Currently, the first package in the list is selected by default, which often does not correspond to the latest version.
This behavior can lead to outdated versions being installed unintentionally.

This PR improves the package selection logic to ensure that the latest version is selected when needed.

## What does this PR change?
**Update**
I found the toggle action was use not only in package list but in all other similar list.
I split the toggle function in two. One specific to the package list and one generic to match the first row for all the other lists.

**New**

Add a last version option that, when filtering a package, retrieves the list of available versions and automatically selects the latest version.
Update the BV smoke test to use last version option when installing a package.

*Note: I was not sure to keep the old method (first match) and decided to keep it because we also use this toggle for removing package. In this case, we don't care about the version.*

</details>

</details>

**Refactor**

The filtering and package selection steps currently rely on substeps.
Refactor these substeps into standalone functions that can be reused.

To achieve this:
 - Create a new helper file named navigation_step_helper.rb
 - Move the relevant logic into functions within this file
 - Update the step definitions to call these new helper functions directly


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27417
Port(s): Need port if accepted

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
