### PR TITLE
Uyuni fix store proxy passwd  (bsc#1242148)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/satellite/ProxySettingsConfigureSatelliteCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/ProxySettingsConfigureSatelliteCommand.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.satellite;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.domain.user.User;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+
+public class ProxySettingsConfigureSatelliteCommand extends ConfigureSatelliteCommand {
+
+    private static Logger logger = LogManager.getLogger(ProxySettingsConfigureSatelliteCommand.class);
+
+    private static final String RHN_CONFIG_SATELLITE_ENV_PREFIX = "UYUNICFG_";
+    private static final String PWD_PLACEHOLDER = "PWD_PLACEHOLDER";
+    protected String[] environmentVars;
+
+    /**
+     * Create a new ProxySettingsConfigureSatelliteCommand class with the
+     * user requesting the config.
+     *
+     * @param userIn who wants to config the sat.
+     */
+    public ProxySettingsConfigureSatelliteCommand(User userIn) {
+        super(userIn);
+        environmentVars = null;
+    }
+
+    /**
+     * Get the formatted String array of command line arguments to execute
+     * when we call out to the system utility to store the config.
+     *
+     * @param configFilePath path to config file to update
+     * @param optionMap      Map of key/value pairs to update local config with.
+     * @param removals       List of keys that will be removed
+     *                       Note that they have preference over the updated keys
+     * @return String[] array of arguments.
+     */
+    @Override
+    public String[] getCommandArguments(String configFilePath,
+                                        Map<String, String> optionMap, List<String> removals) {
+
+        if (optionMap.containsKey(ConfigDefaults.HTTP_PROXY_PASSWORD)) {
+            String passwordEnvVariable = RHN_CONFIG_SATELLITE_ENV_PREFIX + PWD_PLACEHOLDER;
+            String passwordValue = optionMap.get(ConfigDefaults.HTTP_PROXY_PASSWORD);
+
+            optionMap.put(ConfigDefaults.HTTP_PROXY_PASSWORD, PWD_PLACEHOLDER);
+
+            environmentVars = new String[1];
+            environmentVars[0] = "%s=%s".formatted(passwordEnvVariable, passwordValue);
+            environmentVars = new String[]{"%s=%s".formatted(passwordEnvVariable, passwordValue)};
+
+            return getCommandArguments(true, configFilePath, optionMap, removals);
+        }
+        else {
+            return getCommandArguments(false, configFilePath, optionMap, removals);
+        }
+    }
+
+    @Override
+    protected ValidatorError[] executeStore() {
+        String[] commandArguments = getCommandArguments();
+        if (commandArguments != null) {
+            SystemCommandExecutor e = new SystemCommandExecutor();
+            int exitcode = e.execute(commandArguments, environmentVars);
+            if (exitcode != 0) {
+                ValidatorError[] retval = new ValidatorError[1];
+                retval[0] = new ValidatorError("config.storeconfig.error",
+                        Integer.toString(exitcode));
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("storeConfiguration() - end - return value={}", (Object) retval);
+                }
+                return retval;
+            }
+        }
+        return null;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/satellite/SystemCommandExecutor.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/SystemCommandExecutor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 SUSE LLC
  * Copyright (c) 2009--2014 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -61,6 +62,17 @@ public class SystemCommandExecutor implements Executor {
      */
     @Override
     public int execute(String[] args) {
+        return execute(args, null);
+    }
+
+    /**
+     * Execute any command with the passed in arguments.
+     *
+     * @param args array of command you wish to execute.
+     * @param envp array of environment variable settings in the format name=value
+     * @return exit code of command executed.
+     */
+    public int execute(String[] args, String[] envp) {
         if (logger.isDebugEnabled()) {
             logger.debug("execute(String[] args={}) - start", Arrays.asList(args));
         }
@@ -70,7 +82,7 @@ public class SystemCommandExecutor implements Executor {
             if (logger.isDebugEnabled()) {
                 logger.debug("execute() - Calling r.exec ..");
             }
-            Process p = r.exec(args);
+            Process p = r.exec(args, envp);
 
             lastCommandOutput = inputStreamToString(p.getInputStream());
             if (logger.isDebugEnabled()) {

--- a/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsDto.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsDto.java
@@ -118,4 +118,14 @@ public class ProxySettingsDto {
         }
         return true;
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ProxySettingsDto{");
+        sb.append("hostname='").append(hostname).append('\'');
+        sb.append(", username='").append(username).append('\'');
+        sb.append(", password='").append("****").append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
 }

--- a/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsManager.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 SUSE LLC
+ * Copyright (c) 2014--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,9 +15,10 @@
 package com.redhat.rhn.manager.setup;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.satellite.ConfigureSatelliteCommand;
+import com.redhat.rhn.manager.satellite.ProxySettingsConfigureSatelliteCommand;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -25,13 +26,6 @@ import javax.servlet.http.HttpServletRequest;
  * Domain logic for the Setup Wizard proxy settings page.
  */
 public final class ProxySettingsManager {
-
-    /** Configuration key for proxy hostname */
-    public static final String KEY_PROXY_HOSTNAME = "server.satellite.http_proxy";
-    /** Configuration key for proxy username */
-    public static final String KEY_PROXY_USERNAME = "server.satellite.http_proxy_username";
-    /** Configuration key for proxy password */
-    public static final String KEY_PROXY_PASSWORD = "server.satellite.http_proxy_password";
 
     private ProxySettingsManager() { }
 
@@ -41,8 +35,8 @@ public final class ProxySettingsManager {
      */
     public static ProxySettingsDto getProxySettings() {
         ProxySettingsDto settings = new ProxySettingsDto();
-        settings.setHostname(Config.get().getString(KEY_PROXY_HOSTNAME));
-        settings.setUsername(Config.get().getString(KEY_PROXY_USERNAME));
+        settings.setHostname(Config.get().getString(ConfigDefaults.HTTP_PROXY));
+        settings.setUsername(Config.get().getString(ConfigDefaults.HTTP_PROXY_USERNAME));
         return settings;
     }
 
@@ -55,10 +49,10 @@ public final class ProxySettingsManager {
      */
     public static ValidatorError[] storeProxySettings(ProxySettingsDto settings,
             User userIn, HttpServletRequest request) {
-        ConfigureSatelliteCommand configCommand = new ConfigureSatelliteCommand(userIn);
-        configCommand.updateString(KEY_PROXY_HOSTNAME, settings.getHostname());
-        configCommand.updateString(KEY_PROXY_USERNAME, settings.getUsername());
-        configCommand.updateString(KEY_PROXY_PASSWORD, settings.getPassword());
+        ProxySettingsConfigureSatelliteCommand configCommand = new ProxySettingsConfigureSatelliteCommand(userIn);
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY, settings.getHostname());
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_USERNAME, settings.getUsername());
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_PASSWORD, settings.getPassword());
         ValidatorError[] ret = configCommand.storeConfiguration();
         if (ret == null) {
             // Settings have changed, remove the cached subscriptions as proxy settings

--- a/java/code/src/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 SUSE LLC
+ * Copyright (c) 2014--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -16,18 +16,69 @@ package com.redhat.rhn.manager.setup.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.manager.satellite.ConfigureSatelliteCommand;
+import com.redhat.rhn.manager.satellite.ProxySettingsConfigureSatelliteCommand;
 import com.redhat.rhn.manager.setup.ProxySettingsDto;
 import com.redhat.rhn.manager.setup.ProxySettingsManager;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.RhnMockHttpServletRequest;
+import com.redhat.rhn.testing.TestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Tests for {@link ProxySettingsManager}.
  */
 public class ProxySettingsManagerTest extends RhnBaseTestCase {
+
+    private static final String TEST_HOSTNAME = "proxy.foobar.com";
+    private static final String TEST_USERNAME = "foobaruser";
+    private static final String TEST_PASSWD = "foobarpasswd";
+
+    private ProxySettingsDto proxySettingsDto;
+    private User satAdmin;
+
+    @BeforeEach
+    public void setupTest() {
+        Long satOrg = UserTestUtils.createOrg("satOrg");
+        satAdmin = UserTestUtils.createUser("satUser", satOrg);
+        satAdmin.addPermanentRole(RoleFactory.SAT_ADMIN);
+        UserFactory.save(satAdmin);
+
+        proxySettingsDto = new ProxySettingsDto();
+        proxySettingsDto.setHostname(TEST_HOSTNAME);
+        proxySettingsDto.setUsername(TEST_USERNAME);
+        proxySettingsDto.setPassword(TEST_PASSWD);
+
+        Config.get().remove(ConfigDefaults.HTTP_PROXY);
+        Config.get().remove(ConfigDefaults.HTTP_PROXY_USERNAME);
+        Config.get().remove(ConfigDefaults.HTTP_PROXY_PASSWORD);
+
+    }
+
+    static class MockProxySettingsConfigureCommand extends ProxySettingsConfigureSatelliteCommand {
+        MockProxySettingsConfigureCommand(User userIn) {
+            super(userIn);
+        }
+        public String getFirstEnvironmentVar() {
+            if ((null == environmentVars) || (0 == environmentVars.length)) {
+                return "";
+            }
+            return environmentVars[0];
+        }
+    }
 
     /**
      * Tests getProxySettings().
@@ -35,14 +86,10 @@ public class ProxySettingsManagerTest extends RhnBaseTestCase {
      */
     @Test
     public void testGetProxySettings() {
-        ProxySettingsDto proxy = new ProxySettingsDto();
-        proxy.setHostname("proxy.foobar.com");
-        proxy.setUsername("foobaruser");
-        proxy.setPassword("foobarpassword");
-        setProxySettings(proxy);
+        setProxySettings(proxySettingsDto);
         ProxySettingsDto proxySettingsResult = ProxySettingsManager.getProxySettings();
-        assertEquals(proxy.getHostname(), proxySettingsResult.getHostname());
-        assertEquals(proxy.getUsername(), proxySettingsResult.getUsername());
+        assertEquals(proxySettingsDto.getHostname(), proxySettingsResult.getHostname());
+        assertEquals(proxySettingsDto.getUsername(), proxySettingsResult.getUsername());
         assertNull(proxySettingsResult.getPassword());
     }
 
@@ -52,8 +99,104 @@ public class ProxySettingsManagerTest extends RhnBaseTestCase {
      * @param proxy the new proxy settings
      */
     public static void setProxySettings(ProxySettingsDto proxy) {
-        Config.get().setString(ProxySettingsManager.KEY_PROXY_HOSTNAME, proxy.getHostname());
-        Config.get().setString(ProxySettingsManager.KEY_PROXY_USERNAME, proxy.getUsername());
-        Config.get().setString(ProxySettingsManager.KEY_PROXY_PASSWORD, proxy.getPassword());
+        Config.get().setString(ConfigDefaults.HTTP_PROXY, proxy.getHostname());
+        Config.get().setString(ConfigDefaults.HTTP_PROXY_USERNAME, proxy.getUsername());
+        Config.get().setString(ConfigDefaults.HTTP_PROXY_PASSWORD, proxy.getPassword());
+    }
+
+
+    @Test
+    public void testConfigureSatelliteCommandArguments() {
+        ConfigureSatelliteCommand configCommand = new ConfigureSatelliteCommand(satAdmin);
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY, proxySettingsDto.getHostname());
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_USERNAME, proxySettingsDto.getUsername());
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_PASSWORD, proxySettingsDto.getPassword());
+
+        String[] cmdArgs = configCommand.getCommandArguments();
+        assertEquals(9, cmdArgs.length);
+        assertEquals("/usr/bin/sudo", cmdArgs[0]);
+        assertEquals("/usr/bin/rhn-config-satellite.pl", cmdArgs[1]);
+        assertTrue(cmdArgs[2].startsWith("--target="));
+        assertEquals("--option=server.satellite.http_proxy=%s".formatted(TEST_HOSTNAME), cmdArgs[3]);
+        assertEquals("--option=server.satellite.http_proxy_username=%s".formatted(TEST_USERNAME), cmdArgs[4]);
+        assertEquals("--option=server.satellite.http_proxy_password=%s".formatted(TEST_PASSWD), cmdArgs[5]);
+        assertEquals("2>&1", cmdArgs[6]);
+        assertEquals(">", cmdArgs[7]);
+        assertEquals("/dev/null", cmdArgs[8]);
+    }
+
+    @Test
+    public void testProxySettingsManagerStoreProxySettings() {
+        HttpServletRequest request = new RhnMockHttpServletRequest();
+        ProxySettingsDto proxySettingsDtoToStore = new ProxySettingsDto();
+        proxySettingsDtoToStore.setHostname(TEST_HOSTNAME + TestUtils.randomString());
+        proxySettingsDtoToStore.setUsername(TEST_USERNAME + TestUtils.randomString());
+        proxySettingsDtoToStore.setPassword(TEST_PASSWD + TestUtils.randomString());
+
+        ValidatorError[] errors = ProxySettingsManager.storeProxySettings(proxySettingsDtoToStore, satAdmin, request);
+        assertEquals(1, errors.length);
+        assertEquals("config.storeconfig.error", errors[0].getKey());
+        // error: sudo: a terminal is required to read the password; either use the -S option to read
+        // from standard input or configure an askpass helper
+    }
+
+    @Test
+    public void testProxySettingsConfigureSatelliteCommandArguments() {
+        MockProxySettingsConfigureCommand configCommand = new MockProxySettingsConfigureCommand(satAdmin);
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY, proxySettingsDto.getHostname());
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_USERNAME, proxySettingsDto.getUsername());
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_PASSWORD, proxySettingsDto.getPassword());
+
+        String[] cmdArgs = configCommand.getCommandArguments();
+        assertEquals(10, cmdArgs.length);
+        assertEquals("/usr/bin/sudo", cmdArgs[0]);
+        assertEquals("-E", cmdArgs[1]);
+        assertEquals("/usr/bin/rhn-config-satellite.pl", cmdArgs[2]);
+        assertTrue(cmdArgs[3].startsWith("--target="));
+        assertEquals("--option=server.satellite.http_proxy=%s".formatted(TEST_HOSTNAME), cmdArgs[4]);
+        assertEquals("--option=server.satellite.http_proxy_username=%s".formatted(TEST_USERNAME), cmdArgs[5]);
+        assertEquals("--option=server.satellite.http_proxy_password=PWD_PLACEHOLDER", cmdArgs[6]);
+        assertEquals("2>&1", cmdArgs[7]);
+        assertEquals(">", cmdArgs[8]);
+        assertEquals("/dev/null", cmdArgs[9]);
+
+        assertEquals("UYUNICFG_PWD_PLACEHOLDER=%s".formatted(TEST_PASSWD), configCommand.getFirstEnvironmentVar());
+    }
+
+    @Test
+    public void testProxySettingsConfigureSatelliteCommandArgumentsPartialArguments() {
+        MockProxySettingsConfigureCommand configCommand = new MockProxySettingsConfigureCommand(satAdmin);
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY, "");
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_USERNAME, proxySettingsDto.getUsername());
+
+        String[] cmdArgs = configCommand.getCommandArguments();
+        assertEquals(8, cmdArgs.length);
+        assertEquals("/usr/bin/sudo", cmdArgs[0]);
+        assertEquals("/usr/bin/rhn-config-satellite.pl", cmdArgs[1]);
+        assertTrue(cmdArgs[2].startsWith("--target="));
+        assertEquals("--option=server.satellite.http_proxy=", cmdArgs[3]);
+        assertEquals("--option=server.satellite.http_proxy_username=%s".formatted(TEST_USERNAME), cmdArgs[4]);
+        assertEquals("2>&1", cmdArgs[5]);
+        assertEquals(">", cmdArgs[6]);
+        assertEquals("/dev/null", cmdArgs[7]);
+    }
+
+    @Test
+    public void testProxySettingsConfigureSatelliteCommandArgumentsOnlyPasswd() {
+        MockProxySettingsConfigureCommand configCommand = new MockProxySettingsConfigureCommand(satAdmin);
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_PASSWORD, proxySettingsDto.getPassword());
+
+        String[] cmdArgs = configCommand.getCommandArguments();
+        assertEquals(8, cmdArgs.length);
+        assertEquals("/usr/bin/sudo", cmdArgs[0]);
+        assertEquals("-E", cmdArgs[1]);
+        assertEquals("/usr/bin/rhn-config-satellite.pl", cmdArgs[2]);
+        assertTrue(cmdArgs[3].startsWith("--target="));
+        assertEquals("--option=server.satellite.http_proxy_password=PWD_PLACEHOLDER", cmdArgs[4]);
+        assertEquals("2>&1", cmdArgs[5]);
+        assertEquals(">", cmdArgs[6]);
+        assertEquals("/dev/null", cmdArgs[7]);
+
+        assertEquals("UYUNICFG_PWD_PLACEHOLDER=%s".formatted(TEST_PASSWD), configCommand.getFirstEnvironmentVar());
     }
 }

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-store-proxy-passwd
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-store-proxy-passwd
@@ -1,0 +1,2 @@
+- Fix http_proxy_password stored as clear text in
+  /var/log/messages (bsc#1242148)

--- a/spacewalk/admin/rhn-config-satellite.pl
+++ b/spacewalk/admin/rhn-config-satellite.pl
@@ -69,6 +69,16 @@ if ($tmpfile =~ m!^/etc/rhn/!) {
   chown 0, $apache_group, $tmpfile;
 }
 
+foreach my $opt_name (keys %options) {
+  my $val = $options{$opt_name};
+  if ($val =~ /^[A-Z0-9_]+$/) {
+    my $envkey = "UYUNICFG_" . $val;
+    if (exists $ENV{$envkey} && defined $ENV{$envkey} && $ENV{$envkey} ne '') {
+      $options{$opt_name} = $ENV{$envkey};
+    }
+  }
+}
+
 while (my $line = <TARGET>) {
   my $removed = 0;
   if ($line =~ /\[prompt\]/ or $line =~ /^#/) {

--- a/spacewalk/admin/spacewalk-admin.changes.carlo.uyuni-fix-store-proxy-passwd
+++ b/spacewalk/admin/spacewalk-admin.changes.carlo.uyuni-fix-store-proxy-passwd
@@ -1,0 +1,2 @@
+- Support environment variables in rhn-config-satellite
+  (bsc#1242148)

--- a/spacewalk/config/etc/sudoers.d/spacewalk
+++ b/spacewalk/config/etc/sudoers.d/spacewalk
@@ -10,7 +10,7 @@ Cmnd_Alias CONFIG_RHN = /usr/sbin/rhn-sat-restart-silent,\
 # The CONFIG_RHN commands are required for reconfiguration of a
 # running Red Hat Satellite.  They should be enabled for proper operation
 # of the Red Hat Satellite.
-tomcat  ALL=(root)      NOPASSWD: CONFIG_RHN
+tomcat  ALL=(root)      NOPASSWD:SETENV: CONFIG_RHN
 
 # These two directives allow tomcat and apache to invoke CONFIG_RHN
 # commands via sudo even without a real tty

--- a/spacewalk/config/spacewalk-config.changes.carlo.uyuni-fix-store-proxy-passwd
+++ b/spacewalk/config/spacewalk-config.changes.carlo.uyuni-fix-store-proxy-passwd
@@ -1,0 +1,2 @@
+- Allow passing env variables to rhn-config-satellite
+  (bsc#1242148)


### PR DESCRIPTION
## What does this PR change?
The page SUSE Multi-Linux Manager>Admin>Setup Wizard>HTTP Proxy lets set the proxy hostname, username, and password. The result ends up into tomcat running a command like:

/usr/bin/sudo /usr/bin/rhn-config-satellite.pl --target=/etc/rhn/rhn.conf --option=server.satellite.http_proxy=DUMMYPROXYHOSTNAME:1 --option=server.satellite.http_proxy_username=DUMMYPROXYUSERNAME --option=server.satellite.http_proxy_password=DUMMYPROXYPASSWORD 2>&1 > /dev/null

unfortunately, since this is a sudo invocation , there appears a log entry into /var/log/messages like:

2025-06-04T16:07:21.003177+02:00 uyuni-server sudo:   tomcat : PWD=/usr/share/tomcat ; USER=root ; COMMAND=/usr/bin/rhn-config-satellite.pl --target=/etc/rhn/rhn.conf --option=server.satellite.http_proxy=DUMMYPROXYHOSTNAME:1 --option=server.satellite.http_proxy_username=DUMMYPROXYUSERNAME --option=server.satellite.http_proxy_password=DUMMYPROXYPASSWORD 2>&1 > /dev/null

hence saving the password in clear text. 

Then by running `mgradm support config` everything from inside the container gets collected, packaged and is accessible on the host running the container. 

In order to fix this, we had to pass the password variable in an environment variable, so that it doesn't get logged
To be able to pass env vars to sudo command, the SETENV directive had to be added to the `/etc/sudoers.d/spacewalk` configuration file
`tomcat  ALL=(root)      NOPASSWD:`**SETENV**: `CONFIG_RHN`

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/27139
Port(s): https://github.com/SUSE/spacewalk/pull/27471, https://github.com/SUSE/spacewalk/pull/27473
- [x ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
