### PR TITLE
Fix action chain scheduled within SSM creates no link for the new action chain (bsc#1243825)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/ProvisioningRemoteCommand.java
@@ -248,7 +248,7 @@ public class ProvisioningRemoteCommand extends RhnAction implements
                 else {
                     infoMessages.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
                         "ssm.operations.provisioning.remotecommand.form.queue.succeed",
-                        label, actionChain.getLabel()));
+                        label, actionChain.getId(), actionChain.getLabel()));
                 }
             }
             else {

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -18409,7 +18409,7 @@ any of these revisions.  Are you sure you want to do this?</source>
         </context-group>
         </trans-unit>
         <trans-unit id="ssm.operations.provisioning.remotecommand.form.queue.succeed">
-          <source>Task "{0}" has been successfully added to Action Chain {1}.</source>
+          <source>Task "{0}" has been successfully added to Action Chain &lt;a href="/rhn/schedule/ActionChain.do?id={1}"&gt;{2}&lt;/a&gt;.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/kickstart/KickstartableSystems.do</context>
         </context-group>

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-1243825-ssm-no-link-action-chain
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-1243825-ssm-no-link-action-chain
@@ -1,0 +1,2 @@
+- Fix action chain scheduled within SSM creates no link
+  for the new action chain (bsc#1243825)


### PR DESCRIPTION
## What does this PR change?
When a remote command is scheduled for an action chain in the System Set Manager, the message in the "blue box" creates a link with the name of action chain the user can click on.

## GUI diff
Before:
![Pre](https://github.com/user-attachments/assets/5335e710-3add-44a0-98f5-a44414dfaa0a)

After:
![Post](https://github.com/user-attachments/assets/415de888-5169-434c-9f27-20639316a7da)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27376
Port(s): https://github.com/SUSE/spacewalk/pull/27474, https://github.com/SUSE/spacewalk/pull/27475
- [x] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

