### PR TITLE
Use the env variables MGR_SERVER_HOSTNAME for the hostname

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -107,7 +107,10 @@ REACTIVATION_KEY=${{REACTIVATION_KEY:-}}
 
 # can be edited, but probably correct:
 CLIENT_OVERRIDES={overrides}
-HOSTNAME={hostname}
+
+#If the environment variable MGR_SERVER_HOSTNAME is set, its value will be used.
+#Otherwise, or they will default to the templated value.
+HOSTNAME=${{MGR_SERVER_HOSTNAME:-{hostname}}}
 
 ORG_CA_CERT={orgCACert}
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.abid.use-env-varibale-for-hostname
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.abid.use-env-varibale-for-hostname
@@ -1,0 +1,1 @@
+- Add the possibility to use env variable for HOSTNAME


### PR DESCRIPTION
## What does this PR change?

This add the possibility to use the env variable for hostname, this will significantly improve the situation where users needs to have a bootstrap script for each proxy and some users have number of proxies in 4 digits

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: I will create a PR for the visibility

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests:  Not covered


- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
