### PR TITLE
Fix fetching the mirrorlist with a RHUI ca bundle (bsc#1243241)

### DIFF
--- a/python/spacewalk/common/suseLib.py
+++ b/python/spacewalk/common/suseLib.py
@@ -22,6 +22,8 @@ except ImportError:
     except ImportError:
         from StringIO import StringIO
 
+import io
+import os
 import re
 import pycurl
 
@@ -733,3 +735,118 @@ def _useProxyFor(url):
         ):
             return False
     return True
+
+
+def get_content_type(
+    url: str,
+    certfile: str = None,
+    keyfile: str = None,
+    cafile: str = None,
+    proxies: dict = None,
+    headers: dict = None,
+):
+    """
+    Makes an HTTPS GET request to the given URL and return the Content-Type header.
+
+    Args:
+        url (str): The URL to make the request to.
+        certfile (str, optional): Path to the client certificate file (e.g., 'client.pem').
+        keyfile (str, optional): Path to the client's private key file (e.g., 'client_key.pem').
+        cafile (str, optional): Path to a file containing concatenated CA certificates in PEM format.
+                                If provided, pycurl will use these CAs to verify the server's certificate.
+                                If not provided, default system CAs will be used.
+        proxies (dict, optional): A dictionary of proxies. Keys are protocol names (e.g., 'http', 'https')
+                                  and values are the proxy URLs (e.g., 'http://your.proxy.com:8080').
+                                  PycURL typically uses a single proxy setting, so if both http and https
+                                  proxies are given, the 'https' proxy will be prioritized for HTTPS requests.
+        headers (dict, optional): A dictionary of custom HTTP headers to send with the request.
+    """
+    c = pycurl.Curl()
+    buffer = (
+        io.BytesIO()
+    )  # Buffer to store the response body (not used, but required by pycurl)
+
+    try:
+        c.setopt(pycurl.URL, url)
+        c.setopt(
+            pycurl.WRITEFUNCTION, buffer.write
+        )  # Dummy write function, content not used but needed
+
+        # Set custom headers
+        if headers:
+            header_list = [f"{key}: {value}" for key, value in headers.items()]
+            c.setopt(pycurl.HTTPHEADER, header_list)
+
+        # Client certificate authentication
+        if certfile and keyfile:
+            if not os.path.exists(certfile):
+                log_error(f"Error: Client certificate file not found at '{certfile}'")
+                return ""
+            if not os.path.exists(keyfile):
+                log_error(f"Error: Client private key file not found at '{keyfile}'")
+                return ""
+            try:
+                c.setopt(pycurl.SSLCERT, certfile)
+                c.setopt(pycurl.SSLKEY, keyfile)
+            except pycurl.error as pycurl_err:
+                log_error(
+                    f"PycURL SSL Error loading client certificate or key: {pycurl_err}"
+                )
+                log_error(
+                    "Please ensure your certfile and keyfile are valid and in PEM format."
+                )
+                return ""
+
+        # CA bundle for server certificate validation
+        if cafile:
+            if not os.path.exists(cafile):
+                log_error(f"Error: CA bundle file not found at '{cafile}'")
+                return ""
+            c.setopt(pycurl.CAINFO, cafile)
+        else:
+            # For pycurl, it's often good practice to explicitly verify peer even if no custom CAINFO
+            c.setopt(pycurl.SSL_VERIFYPEER, 1)
+            c.setopt(pycurl.SSL_VERIFYHOST, 2)
+
+        # Proxy configuration
+        if proxies:
+            # PycURL typically takes a single proxy.
+            # We'll try to use the 'https' proxy if available for https URLs, otherwise 'http'.
+            proxy_url = None
+            if url.startswith("https://") and "https" in proxies:
+                proxy_url = proxies["https"]
+            elif "http" in proxies:
+                proxy_url = proxies["http"]
+
+            if proxy_url:
+                c.setopt(pycurl.PROXY, proxy_url)
+            else:
+                log_error(
+                    "Warning: No suitable proxy found in the 'proxies' dictionary."
+                )
+
+        # Perform the request
+        c.perform()
+
+        # Get Content-Type from info
+        content_type = c.getinfo(pycurl.CONTENT_TYPE)
+
+        if content_type:
+            # PycURL content_type might be bytes, decode it
+            if isinstance(content_type, bytes):
+                content_type = content_type.decode("utf-8")
+            return content_type
+
+    except pycurl.error as e:
+        # pycurl.error contains the error code and string message
+        error_code, error_string = e.args
+        log_error(f"PycURL Error occurred for {url}: ({error_code}) {error_string}")
+        if (
+            error_code == pycurl.E_SSL_CACERT
+            or error_code == pycurl.E_SSL_CERTPROBLEM
+            or error_code == pycurl.E_PEER_FAILED_VERIFICATION
+        ):
+            log_error("This might be an SSL/TLS certificate validation error.")
+    finally:
+        c.close()  # Always close the curl handle
+    return ""

--- a/python/spacewalk/common/suseLib.py
+++ b/python/spacewalk/common/suseLib.py
@@ -829,7 +829,10 @@ def get_content_type(
         c.perform()
 
         # Get Content-Type from info
-        content_type = c.getinfo(pycurl.CONTENT_TYPE)
+        try:
+            content_type = c.getinfo(pycurl.CONTENT_TYPE)
+        except TypeError:
+            content_type = None
 
         if content_type:
             # PycURL content_type might be bytes, decode it

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.Manager-5.0-fix-RHUI-mirrorlist-fetching
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.Manager-5.0-fix-RHUI-mirrorlist-fetching
@@ -1,0 +1,3 @@
+- Fix fetching the mirrorlist with a ca bundle which include only
+  the intermediate CAs. This is the case for RHUI CA bundles
+  (bsc#1243241).

--- a/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
@@ -432,14 +432,12 @@ class YumSrcTest(unittest.TestCase):
         self.repo.root = self.tmpdir
         cs.channel_arch = "arch1"
         grabber_mock = Mock()
-        mirror_request_mock = Mock()
-        mirror_request_mock.return_value.headers = {"Content-Type": "text/plain"}
-        nonmirror_request_mock = Mock()
-        nonmirror_request_mock.return_value.headers = {"Content-Type": "text/html"}
+        mirror_request_mock = Mock(return_value="text/plain")
+        nonmirror_request_mock = Mock(return_value="text/html")
 
         # If webpage is plaintext format, check list of mirrors is returned
         with patch(
-            "spacewalk.satellite_tools.repo_plugins.yum_src.requests.get",
+            "spacewalk.satellite_tools.repo_plugins.yum_src.get_content_type",
             mirror_request_mock,
         ):
             with patch(
@@ -468,7 +466,7 @@ class YumSrcTest(unittest.TestCase):
 
         # If webpage is html format, and so not mirrorlist, check list of 'mirrors' is blank
         with patch(
-            "spacewalk.satellite_tools.repo_plugins.yum_src.requests.get",
+            "spacewalk.satellite_tools.repo_plugins.yum_src.get_content_type",
             nonmirror_request_mock,
         ):
             with patch(
@@ -490,7 +488,7 @@ class YumSrcTest(unittest.TestCase):
 
         # If mirrorlist contains invalid repos, check they are discarded
         with patch(
-            "spacewalk.satellite_tools.repo_plugins.yum_src.requests.get",
+            "spacewalk.satellite_tools.repo_plugins.yum_src.get_content_type",
             mirror_request_mock,
         ):
             with patch(
@@ -570,11 +568,10 @@ class YumSrcTest(unittest.TestCase):
                 )
             )
         grabber_mock = Mock()
-        mirror_request_mock = Mock()
-        mirror_request_mock.return_value.headers = {"Content-Type": "text/plain"}
+        mirror_request_mock = Mock(return_value="text/plain")
 
         with patch(
-            "spacewalk.satellite_tools.repo_plugins.yum_src.requests.get",
+            "spacewalk.satellite_tools.repo_plugins.yum_src.get_content_type",
             mirror_request_mock,
         ):
             with patch(


### PR DESCRIPTION
## What does this PR change?

RHUI specify a CA bundle which does not include the Root CA, but only the intermediate CAs.
This seems to be valid as yum, zypp and curl successfully work with such a bundle.

But we use python requests to fetch the mirrorlist and look for the content type and this module fail to download the content without the Root CA in the bundle.

This is a re-write to change python requests into pycurl.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/27431

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
