### PR TITLE
Add new password policy test

### DIFF
--- a/testsuite/features/secondary/srv_password_restriction.feature
+++ b/testsuite/features/secondary/srv_password_restriction.feature
@@ -1,0 +1,81 @@
+# Copyright (c) 2025 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@skip_if_github_validation
+Feature: Password Policy Management
+  As an organization administrator,
+  I want to configure and enforce password complexity requirements,
+  So that user accounts comply with security policies
+
+  Scenario: Log in as org admin user
+    Given I am authorized as "admin" with password "admin"
+
+  Scenario: Navigate to Password Policy settings page
+    When I follow the left menu "Admin > Manager Configuration > Password Policy"
+    Then I should see a "Server Configuration - Password Policy" text
+
+  Scenario: Configure password complexity restrictions
+    When I set the minimum password length to "5"
+    And I set the maximum password length to "12"
+    And I enable the following restrictions:
+      | Require Digits                  |
+      | Require Lowercase Characters    |
+      | Require Uppercase Characters    |
+      | Require Special Characters      |
+      | Restrict Characters Occurrences |
+      | Restrict Consecutive Characters |
+    And I click on "Save"
+    And I should see a "Password Policy Changed" text
+
+  Scenario: Verify password complexity restrictions are saved correctly
+    When I refresh the page
+    Then the following restrictions should be enabled:
+      | Require Digits                  |
+      | Require Lowercase Characters    |
+      | Require Uppercase Characters    |
+      | Require Special Characters      |
+      | Restrict Characters Occurrences |
+      | Restrict Consecutive Characters |
+
+  # WORKAROUND: Page must be refreshed before editing special characters fields (bsc1244430)
+  Scenario: Update special characters list and maximum character occurrence
+    When I set the special characters list to "$@?"
+    And I set the maximum allowed occurrence of any character to "3"
+    And I click on "Save"
+    And I should see a "Password Policy Changed" text
+
+  Scenario Outline: Reject invalid passwords based on policy enforcement
+    When I attempt to create a user with username "password_policy_user" and password "<password>"
+    Then the user creation should fail with error containing "<error_message>"
+
+    Examples:
+      | password      | error_message                                                                              |
+      | aB$1          | Passwords must be at least 5 characters                                                    |
+      | ab$123        | Passwords must contain at least one upper case character                                   |
+      | AB$123        | Passwords must contain at least one lower case character                                   |
+      | aB$cde        | Passwords must contain at least one digit                                                  |
+      | aBc123        | Passwords must contain at least one special character                                      |
+      | aB:123        | Passwords must contain at least one special character, allowed special characters are: $@? |
+      | aaB$123       | consecutive_characters_presents                                                            |
+      | aB$a12aa3     | Password characters occurrences exceeded maximum allowed 3                                 |
+      | aBcdef$123456 | Passwords cannot be more than 12 characters                                                |
+
+  Scenario: Accept valid password complying with policy
+    When I attempt to create a user with username "password_policy_user" and password "aB$123"
+    Then the user creation should succeed
+
+  Scenario: Reset password policy to default settings
+    When I follow the left menu "Admin > Manager Configuration > Password Policy"
+    And I click on "Reset"
+    And I should see a "Password Policy Reset to Default" text
+    And I refresh the page
+    Then the following restrictions should be disabled:
+      | Require Digits                  |
+      | Require Lowercase Characters    |
+      | Require Uppercase Characters    |
+      | Require Special Characters      |
+      | Restrict Characters Occurrences |
+      | Restrict Consecutive Characters |
+
+  Scenario: Cleanup: Delete test user
+    When I delete user "password_policy_user"

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -148,8 +148,25 @@ Given(/^I create a user with name "([^"]*)" and password "([^"]*)"/) do |user, p
     $api_test.user.add_role(user, role)
   end
   add_context('user', user)
-  add_context('password', 'linux')
+  add_context('password', password)
   log "New user #{user} created"
+end
+
+Given(/^I attempt to create a user with username "([^"]*)" and password "([^"]*)"/) do |user, password|
+  raise "User #{user} already exists. Cannot create duplicate." if $api_test.user.list_users.to_s.include?(user)
+
+  begin
+    $api_test.user.create(user, password, user, user, 'galaxy-noise@localhost')
+    roles = %w[config_admin system_group_admin activation_key_admin image_admin]
+    roles.each { |role| $api_test.user.add_role(user, role) }
+
+    add_context('user_creation_status', 'success')
+    log "New user #{user} created"
+  rescue StandardError => e
+    add_context('user_creation_status', 'error')
+    add_context('user_creation_error', e.message)
+    log "Failed to create user #{user}: #{e.message}"
+  end
 end
 
 # channel namespace

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -539,3 +539,16 @@ When(/^I schedule a task to update ReportDB$/) do
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
   '
 end
+
+Then(/^the user creation should fail with error containing "([^"]*)"$/) do |expected_text|
+  status = get_context('user_creation_status')
+  error_message = get_context('user_creation_error')
+
+  raise "Expected user creation to fail, but status was '#{status}'" unless status == 'error'
+  raise "Expected error message to include '#{expected_text}', but got '#{error_message}'" unless error_message.include?(expected_text)
+end
+
+Then(/^the user creation should succeed$/) do
+  status = get_context('user_creation_status')
+  raise "Expected user creation to succeed, but status was '#{status}'" unless status == 'success'
+end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1288,3 +1288,66 @@ When(/^I visit the grafana dashboards of this "([^"]*)"$/) do |host|
   node = get_target(host)
   visit("http://#{node.public_ip}:3000/dashboards")
 end
+
+###################################
+## Password Policy navigation steps
+###################################
+
+And(/^I set the minimum password length to "([^"]*)"$/) do |min_length|
+  fill_in 'minLength', with: min_length
+end
+
+And(/^I set the maximum password length to "([^"]*)"$/) do |max_length|
+  fill_in 'maxLength', with: max_length
+end
+
+And(/^I set the special characters list to "([^"]*)"$/) do |characters_list|
+  fill_in 'specialChars', with: characters_list
+end
+
+And(/^I set the maximum allowed occurrence of any character to "([^"]*)"$/) do |max_occurence|
+  fill_in 'maxCharacterOccurrence', with: max_occurence
+end
+
+And(/^I (enable|disable) the following restrictions:$/) do |action, table|
+  restriction_map = {
+    'Require Digits' => 'digitFlag',
+    'Require Lowercase Characters' => 'lowerCharFlag',
+    'Require Uppercase Characters' => 'upperCharFlag',
+    'Require Special Characters' => 'specialCharFlag',
+    'Restrict Characters Occurrences' => 'restrictedOccurrenceFlag',
+    'Restrict Consecutive Characters' => 'consecutiveCharsFlag'
+  }
+
+  toggle = action == 'enable' ? 'check' : 'uncheck'
+
+  table.raw.flatten.each do |restriction|
+    checkbox_id = restriction_map[restriction]
+    raise "Unknown restriction: #{restriction}" unless checkbox_id
+
+    toggle_checkbox(toggle, checkbox_id)
+  end
+end
+
+Then(/^the following restrictions should be (enabled|disabled):$/) do |expected_state, table|
+  restriction_map = {
+    'Require Digits' => 'digitFlag',
+    'Require Lowercase Characters' => 'lowerCharFlag',
+    'Require Uppercase Characters' => 'upperCharFlag',
+    'Require Special Characters' => 'specialCharFlag',
+    'Restrict Characters Occurrences' => 'restrictedOccurrenceFlag',
+    'Restrict Consecutive Characters' => 'consecutiveCharsFlag'
+  }
+
+  expected_checkbox_state = expected_state == 'enabled' ? 'checked' : 'unchecked'
+
+  table.raw.flatten.each do |restriction|
+    checkbox_id = restriction_map[restriction]
+    raise "Unknown restriction: #{restriction}" unless checkbox_id
+
+    actual = checkbox_state(checkbox_id)
+    unless actual == expected_checkbox_state
+      raise "Expected '#{restriction}' to be #{expected_checkbox_state}, but was #{actual}"
+    end
+  end
+end

--- a/testsuite/features/support/navigation_step_helper.rb
+++ b/testsuite/features/support/navigation_step_helper.rb
@@ -44,3 +44,31 @@ def filter_by_package_name(package_name)
 
   find("input[placeholder='Filter by Package Name: ']").set(package_name)
 end
+
+# Toggles a checkbox based on the desired action.
+#
+# @param action [String] Either 'check' or 'uncheck'
+# @param id [String] The HTML id of the checkbox input element
+#
+# This function ensures the checkbox ends in the desired state by comparing
+# the current checked status with the intended one. It performs a click only
+# if necessary (e.g., when current and desired states differ).
+#
+# Example:
+#   toggle_checkbox('check', 'digitFlag')   # Ensures checkbox is checked
+#   toggle_checkbox('uncheck', 'digitFlag') # Ensures checkbox is unchecked
+def toggle_checkbox(action, id)
+  checkbox = find("##{id}", visible: :all)
+  desired_state = (action == 'check')
+
+  checkbox.click if checkbox.checked? != desired_state
+end
+
+# Returns the textual state of a checkbox (toggle) based on its HTML ID.
+#
+# @param id [String] The ID of the checkbox element.
+# @return [String] "checked" if the box is selected, "unchecked" otherwise.
+def checkbox_state(id)
+  checkbox = find("##{id}", visible: :all)
+  checkbox.checked? ? 'checked' : 'unchecked'
+end

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -23,6 +23,7 @@
 - features/secondary/srv_handle_software_channels_with_ISS_v2.feature
 - features/secondary/srv_handle_config_channels_with_ISS_v2.feature
 - features/secondary/srv_salt_git_pillar.feature
+- features/secondary/srv_password_restriction.feature
 - features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature
 - features/secondary/min_cve_audit.feature


### PR DESCRIPTION
## What does this PR change?

Add new feature to test password policies

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s):  Need port after validation

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
