### PR TITLE
Uyuni fix hub sync ch before parent (bsc#1244222)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -32,6 +32,7 @@ import com.redhat.rhn.domain.scc.SCCRepository;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.appstreams.AppStreamsManager;
+import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.content.MgrSyncUtils;
 import com.redhat.rhn.manager.ssm.SsmChannelDto;
@@ -1877,8 +1878,9 @@ public class ChannelFactory extends HibernateFactory {
                         modifyChannelInfo.getPeripheralOrgId() +
                         "] for channel [" + modifyChannelInfo.getLabel() + "]");
             }
+            String channelOrgName = (null == channel.getOrg()) ? "vendor" : channel.getOrg().getName();
             if (!org.equals(channel.getOrg())) {
-                throw new IllegalArgumentException("Unable to modify org from [" + channel.getOrg().getName() +
+                throw new IllegalArgumentException("Unable to modify org from [" + channelOrgName +
                         "] to [" + org.getName() +
                         "] for channel [" + modifyChannelInfo.getLabel() + "]");
             }
@@ -1894,12 +1896,7 @@ public class ChannelFactory extends HibernateFactory {
                         "] for channel [" + modifyChannelInfo.getLabel() + "]");
             }
 
-            if (channel.asCloned().isEmpty()) {
-                throw new IllegalArgumentException("Cannot set original channel " +
-                        "for not cloned channel [" + modifyChannelInfo.getLabel() + "]");
-            }
-
-            channel.asCloned().get().setOriginal(originalChannel);
+            ChannelManager.forceBecomingCloneOf(channel, originalChannel);
         }
 
         setValueIfNotNull(channel, modifyChannelInfo.getBaseDir(), Channel::setBaseDir);

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -1280,6 +1280,21 @@ public class ChannelManager extends BaseManager {
     }
 
     /**
+     * Forces the original-clone relation. If the channel is regular (not cloned), it is transformed to a cloned one.
+     *
+     * @param maybeClonedChannel the channel id
+     * @param originalChannel    the original channel id
+     */
+    public static void forceBecomingCloneOf(Channel maybeClonedChannel, Channel originalChannel) {
+        maybeClonedChannel.asCloned().ifPresentOrElse(
+                asClonedCh -> asClonedCh.setOriginal(originalChannel),
+                () -> {
+                    log.info("Channel is not a clone: {}. Adding clone info.", maybeClonedChannel);
+                    ChannelManager.addCloneInfo(originalChannel.getId(), maybeClonedChannel.getId());
+                });
+    }
+
+    /**
      * Finds the id of a child channel with the given parent channel id that contains
      * a package with the given name.  Returns all child channel unless expectOne is True
      * @param org Organization of the current user.

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -1108,6 +1108,37 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
         assertEquals(result.get(0).getId(), testPackage.getId());
     }
 
+    @Test
+    public void ensureForceBecomingCloneOfWorksOnClonedChannels() throws Exception {
+        user.addToGroup(AccessGroupFactory.CHANNEL_ADMIN);
+        Channel origCh = ChannelFactoryTest.createTestChannel(user);
+        Channel clonedCh = ChannelFactoryTest.createTestClonedChannel(origCh, user);
+
+        assertTrue(clonedCh.asCloned().isPresent());
+        assertEquals(origCh, clonedCh.asCloned().orElseThrow().getOriginal());
+
+        Channel substituteOrigCh = ChannelFactoryTest.createTestChannel(user);
+        ChannelManager.forceBecomingCloneOf(clonedCh, substituteOrigCh);
+
+        assertTrue(clonedCh.asCloned().isPresent());
+        assertEquals(substituteOrigCh, clonedCh.asCloned().orElseThrow().getOriginal());
+    }
+
+    @Test
+    public void ensureForceBecomingCloneOfWorksOnRegularChannels() throws Exception {
+        user.addToGroup(AccessGroupFactory.CHANNEL_ADMIN);
+        Channel regularCh = ChannelFactoryTest.createTestChannel(user);
+
+        assertFalse(regularCh.asCloned().isPresent());
+
+        Channel origCh = ChannelFactoryTest.createTestChannel(user);
+        ChannelManager.forceBecomingCloneOf(regularCh, origCh);
+        regularCh = HibernateFactory.reload(regularCh);
+
+        assertTrue(regularCh.asCloned().isPresent());
+        assertEquals(origCh, regularCh.asCloned().orElseThrow().getOriginal());
+    }
+
     /**
      * Clears the list of servers in the SSM.
      */

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -846,12 +846,7 @@ public class ContentManager {
         tgt.setParentChannel(newParent);
 
         // fix the original-clone relation
-        tgt.asCloned().ifPresentOrElse(
-                t -> t.setOriginal(newSource),
-                () -> {
-                    LOG.info("Channel is not a clone: {}. Adding clone info.", tgt);
-                    ChannelManager.addCloneInfo(newSource.getId(), tgt.getId());
-                });
+        ChannelManager.forceBecomingCloneOf(tgt, newSource);
 
         // handle the module data: if there are modules filters present, we strip them, even if the source is modular;
         // otherwise we set them according to the source channel modules

--- a/java/code/src/com/suse/manager/hub/HubManager.java
+++ b/java/code/src/com/suse/manager/hub/HubManager.java
@@ -1249,7 +1249,8 @@ public class HubManager {
                         (peripheralChannel != null &&
                                 Objects.equals(peripheralChannel.getPeripheralOrgId(), po.getOrgId())) ||
                         // or channel exists on the peripheral side
-                        po.getOrgChannelLabels().contains(channel.getLabel()))
+                                ((null != po.getOrgChannelLabels()) &&
+                                        (po.getOrgChannelLabels().contains(channel.getLabel()))))
                     .map(po -> new ChannelOrg(po.getOrgId(), po.getOrgName()))
                     .findFirst()
                     .orElse(null);

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-1244222-hub-sync-ch-before-parent
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-1244222-hub-sync-ch-before-parent
@@ -1,0 +1,2 @@
+- Allows correct sync of an original channel after the
+  relative cloned channel has been synced (bsc#1244222)


### PR DESCRIPTION
## What does this PR change?
This PR allows correct sync of an original channel after the relative cloned channel has been synced, fixing bsc#1244222

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27457
Port(s): not backported to 4.3 nor to 5.0 (ISSv3 hub online sync)
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [x] Re-run test "spacecmd_unittests"

