### PR TITLE
Leftover 'Bootstrap using Salt' checkbox in bootstrap script web page (bsc#1244329)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/BootstrapConfigAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/BootstrapConfigAction.java
@@ -43,7 +43,6 @@ public class BootstrapConfigAction extends BaseConfigAction {
 
     public static final String HOSTNAME = "hostname";
     public static final String SSL_CERT = "ssl-cert";
-    public static final String SALT = "salt";
 
     public static final String ENABLE_GPG = "gpg";
     public static final String HTTP_PROXY = "http-proxy";
@@ -78,7 +77,6 @@ public class BootstrapConfigAction extends BaseConfigAction {
                 getCommand(requestContext.getCurrentUser());
                 cmd.setHostname(IDN.toASCII(form.getString(HOSTNAME)));
                 cmd.setSslPath(form.getString(SSL_CERT));
-                cmd.setSaltEnabled((Boolean) form.get(SALT));
                 cmd.setEnableGpg((Boolean) form.get(ENABLE_GPG));
                 cmd.setHttpProxy(form.getString(HTTP_PROXY));
                 cmd.setHttpProxyUsername(form.getString(HTTP_PROXY_USERNAME));
@@ -99,7 +97,6 @@ public class BootstrapConfigAction extends BaseConfigAction {
             String caCertPath = CACertPathUtil.processCACertPath();
             form.set(HOSTNAME, IDN.toUnicode(ConfigDefaults.get().getHostname()));
             form.set(SSL_CERT, caCertPath);
-            form.set(SALT, Boolean.TRUE);
             form.set(ENABLE_GPG, Boolean.TRUE);
         }
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);

--- a/java/code/src/com/redhat/rhn/frontend/action/satellite/test/BootstrapConfigActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/satellite/test/BootstrapConfigActionTest.java
@@ -61,8 +61,6 @@ public class BootstrapConfigActionTest extends RhnPostMockStrutsTestCase {
                 CACertPathUtil.processCACertPath());
         assertEquals(Boolean.TRUE,
                 form.get(BootstrapConfigAction.ENABLE_GPG));
-        assertEquals(Boolean.TRUE,
-                form.get(BootstrapConfigAction.SALT));
         assertEquals("", form.getString(BootstrapConfigAction.HTTP_PROXY));
         assertEquals("", form.getString(BootstrapConfigAction.HTTP_PROXY_USERNAME));
         assertEquals("", form.getString(BootstrapConfigAction.HTTP_PROXY_PASSWORD));

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -8672,12 +8672,6 @@ Please note that some manual configuration of these scripts may still be require
           <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="bootstrap.jsp.salt" xml:space="preserve">
-        <source>Bootstrap using Salt</source>
-        <context-group name="ctx">
-          <context context-type="sourcefile">/rhn/admin/config/BootstrapConfig.do</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="bootstrap.jsp.gpg" xml:space="preserve">
         <source>Enable Client GPG checking</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/manager/satellite/ConfigureBootstrapCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/ConfigureBootstrapCommand.java
@@ -33,7 +33,6 @@ public class ConfigureBootstrapCommand extends BaseConfigureCommand
         implements SatelliteConfigurator {
 
     private String hostname;
-    private Boolean saltEnabled;
     private String sslPath;
     private Boolean enableGpg;
     private String httpProxy;
@@ -69,9 +68,6 @@ public class ConfigureBootstrapCommand extends BaseConfigureCommand
             args.add("--hostname=" + this.hostname);
         }
 
-        if (!BooleanUtils.toBooleanDefaultIfNull(this.saltEnabled, false)) {
-            args.add("--traditional");
-        }
         if (!StringUtils.isEmpty(this.sslPath)) {
             args.add("--ssl-cert=" + this.sslPath);
         }
@@ -190,20 +186,5 @@ public class ConfigureBootstrapCommand extends BaseConfigureCommand
      */
     public void setSslPath(String sslPathIn) {
         this.sslPath = sslPathIn;
-    }
-
-    /**
-     * @return Returns the saltEnabled.
-     */
-    public Boolean getSaltEnabled() {
-        return saltEnabled;
-    }
-
-
-    /**
-     * @param saltEnabledIn The saltEnabled to set.
-     */
-    public void setSaltEnabled(Boolean saltEnabledIn) {
-        this.saltEnabled = saltEnabledIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/satellite/test/ConfigureBootstrapCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/test/ConfigureBootstrapCommandTest.java
@@ -58,7 +58,7 @@ public class ConfigureBootstrapCommandTest extends BaseTestCaseWithUser {
 
         @Override
         public int execute(String[] args) {
-            if (args.length != 9) {
+            if (args.length != 8) {
                 return -1;
             }
             if (!args[0].equals("/usr/bin/sudo")) {
@@ -73,20 +73,17 @@ public class ConfigureBootstrapCommandTest extends BaseTestCaseWithUser {
             else if (!args[3].startsWith("--hostname=localhost")) {
                 return -5;
             }
-            else if (!args[4].startsWith("--traditional")) {
+            else if (!args[4].startsWith("--ssl-cert=/tmp/somepath.cert")) {
                 return -6;
             }
-            else if (!args[5].startsWith("--ssl-cert=/tmp/somepath.cert")) {
+            else if (!args[5].startsWith("--http-proxy=proxy-host.redhat.com")) {
                 return -7;
             }
-            else if (!args[6].startsWith("--http-proxy=proxy-host.redhat.com")) {
+            else if (!args[6].startsWith("--http-proxy-username=username")) {
                 return -8;
             }
-            else if (!args[7].startsWith("--http-proxy-username=username")) {
+            else if (!args[7].startsWith("--http-proxy-password=password")) {
                 return -9;
-            }
-            else if (!args[8].startsWith("--http-proxy-password=password")) {
-                return -10;
             }
             else {
                 return 0;

--- a/java/code/webapp/WEB-INF/pages/admin/config/bootstrap.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/config/bootstrap.jsp
@@ -37,16 +37,6 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-lg-3 control-label" for="salt">
-                            <bean:message key="bootstrap.jsp.salt"/>
-                        </label>
-                        <div class="col-lg-6">
-                            <div class="checkbox">
-                                <html:checkbox property="salt" styleId="salt" />
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-group">
                         <label class="col-lg-3 control-label" for="gpg">
                             <bean:message key="bootstrap.jsp.gpg"/>
                         </label>
@@ -70,14 +60,6 @@
                         </label>
                         <div class="col-lg-6">
                             <html:text size="32" property="http-proxy-username" styleClass="form-control" styleId="http-proxy-username" />
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="col-lg-3 control-label" for="http-proxy-password">
-                            <bean:message key="bootstrap.jsp.http-proxy-password"/>
-                        </label>
-                        <div class="col-lg-6">
-                            <html:text size="32" property="http-proxy-password" styleId="http-proxy-password" styleClass="form-control" />
                         </div>
                     </div>
                     <div class="form-group">

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-1244329-leftover-salt-checkbox
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-1244329-leftover-salt-checkbox
@@ -1,0 +1,2 @@
+- Removes leftover 'Bootstrap using Salt' checkbox in
+  bootstrap script web page (bsc#1244329)


### PR DESCRIPTION
## What does this PR change?
Removes "Bootstrap using Salt" checkbox in Admin>Manager Configuration>Bootstrap Script web page.
The only possible way to bootstrap a system in 5.1 is via Salt.

## GUI diff
Before:
![Pre](https://github.com/user-attachments/assets/e40a5c43-13bb-4a77-ac3e-c12e90d8253e)


After:
![Post](https://github.com/user-attachments/assets/dd7a5dfb-0a04-42e9-b327-8ea45f75f667)


- [x ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27506
Port(s): https://github.com/SUSE/spacewalk/pull/27520, not backported to 4.3 (traditional)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
