### PR TITLE
Fix ISSv3: Inconsistent behavior of the URLs linking to peripherals (bsc#1244220)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/admin/AdminViewsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/AdminViewsController.java
@@ -32,6 +32,7 @@ import com.suse.manager.admin.PaygAdminManager;
 import com.suse.manager.hub.HubManager;
 import com.suse.manager.model.hub.HubFactory;
 import com.suse.manager.model.hub.IssAccessToken;
+import com.suse.manager.model.hub.IssPeripheral;
 import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.webui.controllers.ECMAScriptDateAdapter;
 import com.suse.manager.webui.controllers.admin.beans.ChannelSyncModel;
@@ -204,6 +205,12 @@ public class AdminViewsController {
      */
     private static ModelAndView showChannelSync(Request request, Response response, User user) {
         long peripheralId = Long.parseLong(request.params("id"));
+        IssPeripheral issPeripheral = HUB_FACTORY.findPeripheralById(peripheralId);
+        if (issPeripheral == null) {
+            LOG.error("Peripheral not found");
+            throw Spark.halt(HttpStatus.SC_NOT_FOUND, "Peripheral not found");
+        }
+
         String peripheralFqdn;
         ChannelSyncModel channelSyncModel;
 

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-1244220-links-peripherals
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-1244220-links-peripherals
@@ -1,0 +1,2 @@
+- Fix ISSv3: Inconsistent behavior of the URLs linking
+  to peripherals (bsc#1244220)


### PR DESCRIPTION
## What does this PR change?
Fixes behaviour of the URLs linking to the peripherals

Both URLs:
https://<SERVER>/rhn/manager/admin/hub/peripherals/<ANY_UNDEFINED-NUMBER>/ 
https://<SERVER>/rhn/manager/admin/hub/peripherals/<ANY_UNDEFINED-NUMBER>/sync-channels
now return "Peripheral not found" rather than "500 Internal Server Error"

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s):  https://github.com/SUSE/spacewalk/issues/27496
Port(s): not backported to 4.3 nor to 5.0 (ISSv3 hub online sync)
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)

