### PR TITLE
Fix ISE when using SSM in advanced search (bsc#1244298)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchHelper.java
@@ -690,13 +690,14 @@ public class SystemSearchHelper {
     protected static void filterOutIdsNotInSSM(
             User user, Map<Long, Map<String, Object>> ids) {
         RhnSet systems = RhnSetDecl.SYSTEMS.get(user);
-        for (Long id : ids.keySet()) {
-            if (!systems.contains(id)) {
+        ids.keySet().removeIf(id -> {
+            boolean shouldRemove = !systems.contains(id);
+            if (shouldRemove) {
                 log.debug("SystemSearchHelper.filterOutIdsNotInSSM() removing system id {}, because it is not" +
                         " in the SystemSetManager list of ids", id);
-                ids.remove(id);
             }
-        }
+            return shouldRemove;
+        });
     }
 
     protected static Map<Long, Map<String, Object>> invertResults(User user, Map<Long, Map<String, Object>> ids) {

--- a/java/spacewalk-java.changes.welder.bsc1244298
+++ b/java/spacewalk-java.changes.welder.bsc1244298
@@ -1,0 +1,1 @@
+- Fix ISE when using SSM in advanced search (bsc#1244298)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an Internal Server Error (500) caused by a `ConcurrentModificationException` when removing items from a collection during iteration.

Replaced the manual for-each loop with a removeIf lambda expression, ensuring safe removal during iteration.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27461

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
