### PR TITLE
Change the search server defaults to postgresql

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.changes.cbosdo.oracle-driver-search
+++ b/search-server/spacewalk-search/spacewalk-search.changes.cbosdo.oracle-driver-search
@@ -1,0 +1,1 @@
+- Set the default JDBC driver to use postgresql (bsc#1244934)

--- a/search-server/spacewalk-search/src/config/search/rhn_search.conf
+++ b/search-server/spacewalk-search/src/config/search/rhn_search.conf
@@ -1,6 +1,6 @@
 search.index_work_dir=/var/lib/rhn/search/indexes
 search.rpc_handlers=index:com.redhat.satellite.search.rpc.handlers.IndexHandler,db:com.redhat.satellite.search.rpc.handlers.DatabaseHandler,admin:com.redhat.satellite.search.rpc.handlers.AdminHandler
-search.connection.driver_class=oracle.jdbc.driver.OracleDriver
+search.connection.driver_class=org.postgresql.Driver
 # https://www.mchange.com/projects/c3p0/#maxIdleTime
 search.connection.max_idle_time=0
 # https://www.mchange.com/projects/c3p0/#maxIdleTimeExcessConnections


### PR DESCRIPTION
## What does this PR change?

For some reason the config defaults of the search server were still Oracle. It didn't break anything until probably a cleanup forced those properties to be used.

Setting it to postgresql for good (bsc#1244934)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: search server is not tested

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27568

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
