### PR TITLE
testsuite: extend timeout for supportconfig generation

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1063,7 +1063,7 @@ end
 
 When(/I generate a supportconfig for the server$/) do
   node = get_target('server')
-  node.run('mgradm support config', runs_in_container: false)
+  node.run('mgradm support config', timeout: 600, runs_in_container: false)
   node.run('mv /root/scc_*.tar.gz /root/server-supportconfig.tar.gz', runs_in_container: false)
 end
 

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -78,6 +78,5 @@
 - features/secondary/srv_cobbler_distro.feature
 - features/secondary/srv_cobbler_buildiso.feature
 - features/secondary/srv_cobbler_profile.feature
-- features/secondary/srv_health_check_supportconfig.feature
 
 ## Secondary features END ##

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -38,6 +38,7 @@
 - features/secondary/srv_dist_channel_mapping.feature
 - features/secondary/srv_task_status_engine.feature
 - features/secondary/srv_errata_api.feature
+- features/secondary/srv_health_check_supportconfig.feature
 
 - features/secondary/allcli_overview_systems_details.feature
 - features/secondary/allcli_system_group.feature


### PR DESCRIPTION
## What does this PR change?

This PR extends the timeout in the teststuite for running the `supportconfig` command during health check tool scenarios.

The default value for timeout is set to 250, which is not enough to cover the full generation of the supportconfig.

Additionally, this PR moves the health check testsuite feature back to parallelizable.
 
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
