### PR TITLE
Fix Vendor Advisory URL in SUSE Manager directing to error 404 not found (bsc#1243808)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -398,6 +398,12 @@ public class ConfigDefaults {
      */
     public static final String RHUI_DEFAULT_ORG_ID = "java.rhui_default_org_id";
 
+    /**
+     * url to download advisory-map.csv, the map of errata patch id, announcement id and advisory URL
+     */
+    private static final String ERRATA_ADVISORY_MAP_CSV_DOWNLOAD_URL = "java.errata_advisory_map_csv_download_url";
+
+
     private ConfigDefaults() {
     }
 
@@ -1235,5 +1241,15 @@ public class ConfigDefaults {
      * */
     public boolean isOvalEnabledForCveAudit() {
         return Config.get().getBoolean(CVE_AUDIT_ENABLE_OVAL_METADATA, false);
+    }
+
+    /**
+     * Return the url to download advisory-map.csv, the map of errata patch id, announcement id and advisory URL
+     *
+     * @return the url to download advisory-map.csv, the map of errata patch id, announcement id and advisory URL
+     */
+    public String getErrataAdvisoryMapCsvDownloadUrl() {
+        return Config.get().getString(ERRATA_ADVISORY_MAP_CSV_DOWNLOAD_URL,
+                "https://ftp.suse.com/pub/projects/security/advisory-map.csv");
     }
 }

--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -165,6 +165,7 @@ import com.redhat.rhn.taskomatic.domain.TaskoTemplate;
 
 import com.suse.cloud.domain.PaygDimensionComputation;
 import com.suse.cloud.domain.PaygDimensionResult;
+import com.suse.manager.errata.model.errata.ErrataAdvisoryMap;
 import com.suse.manager.model.attestation.CoCoAttestationResult;
 import com.suse.manager.model.attestation.CoCoEnvironmentTypeConverter;
 import com.suse.manager.model.attestation.CoCoResultTypeConverter;
@@ -232,6 +233,7 @@ public class AnnotationRegistry {
             DockerfileProfile.class,
             EntitlementServerGroup.class,
             EnvironmentTarget.class,
+            ErrataAdvisoryMap.class,
             ErrataFilter.class,
             GroupRecurringAction.class,
             HubSCCCredentials.class,

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8872,6 +8872,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="task.status.oval-data-sync" xml:space="preserve">
         <source>Sync OVAL Data</source>
       </trans-unit>
+      <trans-unit id="task.status.errata-advisory-map-sync" xml:space="preserve">
+        <source>Update SUSE errata advisory map</source>
+      </trans-unit>
       <trans-unit id="task.status.mgr-sync-refresh" xml:space="preserve">
         <source>Refresh mgr-sync data</source>
       </trans-unit>
@@ -8916,6 +8919,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       </trans-unit>
       <trans-unit id="bunch.jsp.description.oval-data-sync-bunch" xml:space="preserve">
         <source>Generate OVAL data required to increase the accuracy of CVE audit queries</source>
+      </trans-unit>
+      <trans-unit id="bunch.jsp.description.errata-advisory-map-sync-bunch" xml:space="preserve">
+        <source>Update SUSE errata advisory map to retrieve announcement ids and advisor URLs</source>
       </trans-unit>
       <trans-unit id="bunch.jsp.description.mgr-sync-refresh-bunch" xml:space="preserve">
         <source>Refreshes data about channels, products and subscriptions</source>

--- a/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/ChannelManager.java
@@ -2865,4 +2865,25 @@ public class ChannelManager extends BaseManager {
         var m = ModeFactory.getCallableMode(CHANNEL_QUERIES, "analyze_channel_packages");
         m.execute(new HashMap<>(), new HashMap<>());
     }
+
+    /**
+     * Find the update tag for a given channel looking also at original channels
+     * in case the given channel is a clone.
+     * @param channel channel
+     * @return update tag or null
+     */
+    public static String findUpdateTag(Channel channel) {
+        String updateTag = channel.getUpdateTag();
+        if (StringUtils.isEmpty(updateTag)) {
+            Channel current = channel;
+            while (current.isCloned()) {
+                current = current.asCloned().map(ClonedChannel::getOriginal).orElseThrow();
+                updateTag = current.getUpdateTag();
+                if (updateTag != null && !updateTag.isEmpty()) {
+                    break;
+                }
+            }
+        }
+        return updateTag;
+    }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataAdvisoryMapSync.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataAdvisoryMapSync.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task;
+
+import com.suse.manager.errata.advisorymap.ErrataAdvisoryMapManager;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.io.IOException;
+
+/**
+ * Update SUSE errata advisory map to retrieve announcement ids and advisor URLs
+ * */
+public class ErrataAdvisoryMapSync extends RhnJavaJob {
+
+    /**
+     * default constructor
+     */
+    public ErrataAdvisoryMapSync() {
+        this(new ErrataAdvisoryMapManager());
+    }
+
+    /**
+     * constructor
+     *
+     * @param advisoryMapManagerIn an instance of ErrataAdvisoryMapManager.
+     */
+    public ErrataAdvisoryMapSync(ErrataAdvisoryMapManager advisoryMapManagerIn) {
+        this.advisoryMapManager = advisoryMapManagerIn;
+    }
+
+    private final ErrataAdvisoryMapManager advisoryMapManager;
+
+
+    @Override
+    public String getConfigNamespace() {
+        return "errata_advisory_map_sync";
+    }
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        log.info("Updates SUSE errata advisory map");
+
+        try {
+            advisoryMapManager.syncErrataAdvisoryMap();
+        }
+        catch (IOException eIn) {
+            log.info("Error while updating SUSE errata advisory map", eIn);
+        }
+
+        log.info("Done Updates SUSE errata advisory map");
+    }
+}

--- a/java/code/src/com/suse/manager/errata/ErrataParserFactory.java
+++ b/java/code/src/com/suse/manager/errata/ErrataParserFactory.java
@@ -37,7 +37,7 @@ public final class ErrataParserFactory {
         REDHAT("release-engineering@redhat.com", RedhatErrataParser::new),
         ROCKYLINUX("releng@rockylinux.org", RockyLinuxErrataParser::new),
         SUSE_RES("res-maintenance@suse.de", SUSERESErrataParser::new),
-        SUSE("maint-coord@suse.de", SUSEErrataParser::new);
+        SUSE("maint-coord@suse.de", SUSEAdvisoryMapErrataParser::new);
 
         /** Email used in the errata */
         private final String vendorEmail;

--- a/java/code/src/com/suse/manager/errata/SUSEAdvisoryMapErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/SUSEAdvisoryMapErrataParser.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ */
+package com.suse.manager.errata;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.manager.errata.ErrataManager;
+
+
+import com.suse.manager.errata.model.errata.ErrataAdvisoryMap;
+import com.suse.manager.errata.model.errata.ErrataAdvisoryMapFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class SUSEAdvisoryMapErrataParser implements VendorSpecificErrataParser {
+
+    /**
+     * default constructor
+     */
+    public SUSEAdvisoryMapErrataParser() {
+        this(new ErrataAdvisoryMapFactory());
+    }
+
+    /**
+     * constructor
+     *
+     * @param advisoryMapFactoryIn an instance of ErrataAdvisoryMapFactory.
+     */
+    public SUSEAdvisoryMapErrataParser(ErrataAdvisoryMapFactory advisoryMapFactoryIn) {
+        this.advisoryMapFactory = advisoryMapFactoryIn;
+    }
+
+    private final ErrataAdvisoryMapFactory advisoryMapFactory;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URI getAdvisoryUri(Errata errata) throws ErrataParsingException {
+        try {
+            String uri = errata.getChannels().stream()
+                .map(ch -> ErrataManager.getPatchId(errata, ch))
+                .flatMap(s -> advisoryMapFactory.lookupByPatchId(s).stream())
+                .map(ErrataAdvisoryMap::getAdvisoryUri)
+                .findFirst()
+                .orElseThrow(() -> new ErrataParsingException(
+                        "Unable generate announcement vendor link for errata: " + errata.getAdvisory()));
+            return new URI(uri);
+        }
+        catch (URISyntaxException ex) {
+            throw new ErrataParsingException("Unable to generate vendor link for errata " + errata.getAdvisory(), ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAnnouncementId(Errata errata) throws ErrataParsingException {
+        return errata.getChannels().stream()
+                .map(ch -> ErrataManager.getPatchId(errata, ch))
+                .flatMap(s -> advisoryMapFactory.lookupByPatchId(s).stream())
+                .map(ErrataAdvisoryMap::getAnnouncementId)
+                .findFirst()
+                .orElseThrow(() -> new ErrataParsingException(
+                        "Unable to generate announcement id for errata: " + errata.getAdvisory()));
+    }
+}

--- a/java/code/src/com/suse/manager/errata/advisorymap/ErrataAdvisoryMapManager.java
+++ b/java/code/src/com/suse/manager/errata/advisorymap/ErrataAdvisoryMapManager.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.errata.advisorymap;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.util.http.HttpClientAdapter;
+
+import com.suse.manager.errata.model.errata.ErrataAdvisoryMap;
+import com.suse.manager.errata.model.errata.ErrataAdvisoryMapFactory;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.NoRouteToHostException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ErrataAdvisoryMapManager {
+
+    private final ErrataAdvisoryMapFactory advisoryMapFactory;
+
+    private static final Logger LOG = LogManager.getLogger(ErrataAdvisoryMapManager.class);
+
+    private static final String ADVISORY_MAP_CSV_DELIMITER = ",";
+
+    /**
+     * Default constructor
+     */
+    public ErrataAdvisoryMapManager() {
+        this(new ErrataAdvisoryMapFactory());
+    }
+
+    /**
+     * Builds an instance with the given dependencies
+     *
+     * @param advisoryMapFactoryIn the errata advisory map factory
+     */
+    public ErrataAdvisoryMapManager(ErrataAdvisoryMapFactory advisoryMapFactoryIn) {
+        this.advisoryMapFactory = advisoryMapFactoryIn;
+    }
+
+    /**
+     * Returns the advisory map size
+     *
+     * @return the advisory map size
+     */
+    public long getAdvisoryMapSize() {
+        return advisoryMapFactory.count();
+    }
+
+    /**
+     * parses an advisory map csv file, saving the entries in the database
+     * <p>
+     * the advisory map csv file has the following structure:
+     * a) first row has headers
+     * b) each row represents an entry
+     * c) each entry row contains fields, coma (",") separated
+     * d) first field is the advisory (e.g. "SUSE-SLE-Module-Basesystem-15-SP6-2025-1733")
+     * e) second field is the announcementId (e.g. "SUSE-RU-2025:01733-1")
+     * f) third field (optional) is the advisoryUri
+     * (e.g. "https://www.suse.com/support/update/announcement/2025/suse-ru-202501733-1")
+     *
+     * @param inputStreamIn the errata advisory map input stream
+     */
+    public void readAdvisoryMapPopulateDatabase(InputStream inputStreamIn) throws IOException {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(inputStreamIn))) {
+            String line;
+            boolean firstLine = true;
+            while ((line = br.readLine()) != null) {
+                if (firstLine) {
+                    //skip first line (headers) and clear database
+                    advisoryMapFactory.clearErrataAdvisoryMap();
+                }
+                else {
+                    String[] advisoryItem = line.split(ADVISORY_MAP_CSV_DELIMITER);
+
+                    String advisory = (advisoryItem.length > 0 ? advisoryItem[0] : "");
+                    String announcementId = (advisoryItem.length > 1 ? advisoryItem[1] : "");
+                    String advisoryUri = (advisoryItem.length > 2 ? advisoryItem[2] : "");
+
+                    ErrataAdvisoryMap advisoryMapEntry = new ErrataAdvisoryMap(advisory, announcementId, advisoryUri);
+                    advisoryMapFactory.save(advisoryMapEntry);
+                }
+                firstLine = false;
+            }
+        }
+    }
+
+    /**
+     * Synchronizes the advisory map
+     * Downloads the advisory map, parses the csv file and saves the entries in the database
+     */
+    public void syncErrataAdvisoryMap() throws IOException {
+        String downloadUrl = ConfigDefaults.get().getErrataAdvisoryMapCsvDownloadUrl();
+
+        URI advisoryMapURI = null;
+        try {
+            advisoryMapURI = new URI(downloadUrl);
+        }
+        catch (URISyntaxException ex) {
+            LOG.error("Unable to create advisory map url: {} {}.", downloadUrl, ex.getMessage());
+        }
+
+        HttpClientAdapter httpClient = new HttpClientAdapter(null, false);
+
+        HttpRequestBase request = null;
+        try {
+            request = new HttpGet(advisoryMapURI);
+
+            // Connect and parse the response on success
+            HttpResponse response = httpClient.executeRequest(request);
+            int responseCode = response.getStatusLine().getStatusCode();
+
+            if (responseCode == HttpStatus.SC_OK) {
+                try (InputStream inputStream = response.getEntity().getContent()) {
+                    readAdvisoryMapPopulateDatabase(inputStream);
+                }
+            }
+            else {
+                // Request was not successful
+                String errorString = "Unable to get content for advisory map request: response code " + responseCode +
+                        " connecting to " + request.getURI();
+                LOG.error(errorString);
+                throw new IOException(errorString);
+            }
+        }
+        catch (NoRouteToHostException ex) {
+            String proxy = ConfigDefaults.get().getProxyHost();
+            String errorString = "No route to download advisory map" + (proxy != null ? " or the Proxy: " + proxy : "");
+            LOG.error(errorString, ex);
+            throw new IOException(errorString);
+        }
+        catch (IOException ioEx) {
+            LOG.error("Unable to get content for advisory map request: {} {}", downloadUrl, ioEx);
+            throw ioEx;
+        }
+        finally {
+            request.releaseConnection();
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/advisorymap/test/ErrataAdvisoryMapManagerTest.java
+++ b/java/code/src/com/suse/manager/errata/advisorymap/test/ErrataAdvisoryMapManagerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.errata.advisorymap.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import com.suse.manager.errata.advisorymap.ErrataAdvisoryMapManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ErrataAdvisoryMapManagerTest extends RhnBaseTestCase {
+    private static final String TEST_ADVISORY_MAP_CSV_FILE_NAME =
+            "/com/suse/manager/errata/advisorymap/test/advisory-map.csv";
+    private static final long TEST_ADVISORY_MAP_RECORDS_NUM = 140938L;
+
+    private static final boolean PRINT_STD_OUTPUT = false;
+    private static final boolean PERFORM_LONG_TESTS = false;
+    private long startTimeMs;
+
+    private final ErrataAdvisoryMapManager advisoryMapManager = new ErrataAdvisoryMapManager();
+
+    @SuppressWarnings("java:S106")
+    private static void testPrintOut(String arg) {
+        if (!PRINT_STD_OUTPUT) {
+            return;
+        }
+        System.out.println(arg);
+    }
+
+    private void startTimeMeasure(String message) {
+        testPrintOut(message);
+        startTimeMs = System.currentTimeMillis();
+    }
+
+    private void stopTimeMeasure(String message) {
+        long estimatedTimeMs = System.currentTimeMillis() - startTimeMs;
+        testPrintOut(message + String.format("%d seconds (%d ms)", estimatedTimeMs / 1000L, estimatedTimeMs));
+    }
+
+    @Test
+    public void storeNewAdvisoryMapLongTest() throws IOException {
+        if (PERFORM_LONG_TESTS) {
+            //test time: about 20 seconds for 140K records
+            assertEquals(0, advisoryMapManager.getAdvisoryMapSize());
+
+            InputStream inputStream = this.getClass().getResourceAsStream(TEST_ADVISORY_MAP_CSV_FILE_NAME);
+
+            startTimeMeasure(String.format("Populating EMPTY ErrataAdvisoryMap with %d records",
+                    TEST_ADVISORY_MAP_RECORDS_NUM));
+            advisoryMapManager.readAdvisoryMapPopulateDatabase(inputStream);
+            stopTimeMeasure("Elapsed time: ");
+
+            assertEquals(TEST_ADVISORY_MAP_RECORDS_NUM, advisoryMapManager.getAdvisoryMapSize());
+        }
+    }
+
+    @Test
+    public void syncErrataAdvisoryMapTest() throws IOException {
+        if (PERFORM_LONG_TESTS) {
+            //download time: about 5 seconds for about 140K records
+            //populate records time: about 20 seconds for 140K records
+            assertEquals(0, advisoryMapManager.getAdvisoryMapSize());
+
+            startTimeMeasure("Synchronize ErrataAdvisoryMap and populate database");
+            advisoryMapManager.syncErrataAdvisoryMap();
+            stopTimeMeasure("Elapsed time: ");
+
+            testPrintOut(String.format("Num records: %d", advisoryMapManager.getAdvisoryMapSize()));
+            assertTrue(advisoryMapManager.getAdvisoryMapSize() > 140000);
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/model/errata/ErrataAdvisoryMap.java
+++ b/java/code/src/com/suse/manager/errata/model/errata/ErrataAdvisoryMap.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.errata.model.errata;
+
+import com.redhat.rhn.domain.BaseDomainHelper;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "suseErrataAdvisoryMap")
+public class ErrataAdvisoryMap extends BaseDomainHelper {
+
+    private long id;
+    private String patchId;
+    private String announcementId;
+    private String advisoryUri;
+
+    /**
+     * Default constructor
+     */
+    public ErrataAdvisoryMap() {
+        this(null, null, null);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param patchIdIn
+     * @param announcementIdIn
+     * @param advisoryUriIn
+     */
+    public ErrataAdvisoryMap(String patchIdIn, String announcementIdIn, String advisoryUriIn) {
+        patchId = patchIdIn;
+        announcementId = announcementIdIn;
+        advisoryUri = advisoryUriIn;
+    }
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long idIn) {
+        id = idIn;
+    }
+
+    @Column(name = "patch_id")
+    public String getPatchId() {
+        return patchId;
+    }
+
+    public void setPatchId(String patchIdIn) {
+        patchId = patchIdIn;
+    }
+
+    @Column(name = "announcement_id")
+    public String getAnnouncementId() {
+        return announcementId;
+    }
+
+    public void setAnnouncementId(String announcementIdIn) {
+        announcementId = announcementIdIn;
+    }
+
+    @Column(name = "advisory_uri")
+    public String getAdvisoryUri() {
+        return advisoryUri;
+    }
+
+    public void setAdvisoryUri(String advisoryUriIn) {
+        advisoryUri = advisoryUriIn;
+    }
+
+    @Override
+    public boolean equals(Object oIn) {
+        if (!(oIn instanceof ErrataAdvisoryMap that)) {
+            return false;
+        }
+        return Objects.equals(getPatchId(), that.getPatchId()) &&
+                Objects.equals(getAnnouncementId(), that.getAnnouncementId()) &&
+                Objects.equals(getAdvisoryUri(), that.getAdvisoryUri());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPatchId(),
+                getAnnouncementId(),
+                getAdvisoryUri());
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ErrataAdvisoryMap{");
+        sb.append("id=").append(id);
+        sb.append(", patchId='").append(patchId).append('\'');
+        sb.append(", announcementId='").append(announcementId).append('\'');
+        sb.append(", advisoryUri='").append(advisoryUri).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/java/code/src/com/suse/manager/errata/model/errata/ErrataAdvisoryMapFactory.java
+++ b/java/code/src/com/suse/manager/errata/model/errata/ErrataAdvisoryMapFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.manager.errata.model.errata;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+
+public class ErrataAdvisoryMapFactory extends HibernateFactory {
+
+    private static final Logger LOG = LogManager.getLogger(ErrataAdvisoryMapFactory.class);
+
+    @Override
+    protected Logger getLogger() {
+        return LOG;
+    }
+
+    /**
+     * Save a {@link ErrataAdvisoryMap} object
+     *
+     * @param advisoryMapEntryIn object to save
+     */
+    public void save(ErrataAdvisoryMap advisoryMapEntryIn) {
+        saveObject(advisoryMapEntryIn);
+    }
+
+    /**
+     * Remove a {@link ErrataAdvisoryMap} object
+     *
+     * @param advisoryMapEntryIn the object to remove
+     */
+    public void remove(ErrataAdvisoryMap advisoryMapEntryIn) {
+        removeObject(advisoryMapEntryIn);
+    }
+
+
+    /**
+     * Retrieves the ErrataAdvisoryMap item with the given advisory
+     *
+     * @param patchId the patch id to look for
+     * @return the ErrataAdvisoryMap item instance, if present
+     */
+    public Optional<ErrataAdvisoryMap> lookupByPatchId(String patchId) {
+        return getSession()
+                .createQuery("FROM ErrataAdvisoryMap k WHERE k.patchId = :patchId", ErrataAdvisoryMap.class)
+                .setParameter("patchId", patchId)
+                .uniqueResultOptional();
+    }
+
+    /**
+     * Count the existing table entries
+     *
+     * @return the current number of table entries
+     */
+    public long count() {
+        return getSession()
+                .createQuery("SELECT COUNT(*) FROM ErrataAdvisoryMap k", Long.class)
+                .uniqueResult();
+    }
+
+    /**
+     * Clear all repositories from the database.
+     */
+    public void clearErrataAdvisoryMap() {
+        getSession().createQuery("DELETE FROM ErrataAdvisoryMap").executeUpdate();
+    }
+}
+
+

--- a/java/code/src/com/suse/manager/errata/test/BaseErrataTestCase.java
+++ b/java/code/src/com/suse/manager/errata/test/BaseErrataTestCase.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.errata.test;
 
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 
@@ -29,11 +30,11 @@ abstract class BaseErrataTestCase extends RhnBaseTestCase {
     /**
      * Builds a test errata object
      */
-    protected Errata createErrata(String advisory, String type, LocalDate issedDate, Long release) {
+    protected Errata createErrata(String advisory, String type, LocalDate issuedDate, Long release) {
         final Errata errata = new Errata();
 
-        if (issedDate != null) {
-            errata.setIssueDate(Date.from(issedDate.atStartOfDay(ZoneOffset.systemDefault()).toInstant()));
+        if (issuedDate != null) {
+            errata.setIssueDate(Date.from(issuedDate.atStartOfDay(ZoneOffset.systemDefault()).toInstant()));
         }
 
         errata.setAdvisory(advisory);
@@ -42,5 +43,18 @@ abstract class BaseErrataTestCase extends RhnBaseTestCase {
         return errata;
     }
 
+    /**
+     * Builds a test errata object with one channel owning an update tag
+     */
+    protected Errata createErrataWithUpdateTag(String updateTag,
+                                               String advisory, String type, LocalDate issuedDate, Long release) {
+        final Errata errata = createErrata(advisory, type, issuedDate, release);
 
+        Channel ch = new Channel();
+        ch.addErrata(errata);
+        ch.setUpdateTag(updateTag);
+        errata.addChannel(ch);
+
+        return errata;
+    }
 }

--- a/java/code/src/com/suse/manager/errata/test/SUSEAdvisoryMapErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/SUSEAdvisoryMapErrataParserTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.errata.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.ErrataParsingException;
+import com.suse.manager.errata.SUSEAdvisoryMapErrataParser;
+import com.suse.manager.errata.advisorymap.ErrataAdvisoryMapManager;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.Month;
+
+public class SUSEAdvisoryMapErrataParserTest extends BaseErrataTestCase {
+
+    public static void createTestAdvisoryMapDatabase() throws IOException {
+
+        String testAdvisoryMapCsv =
+            """
+            # patchid, notice id, url
+            SUSE-SLE-Live-Patching-12-SP5-2025-1901,SUSE-SU-2025:01901-1,\
+            https://www.suse.com/support/update/announcement/2025/suse-su-202501901-1/
+            SUSE-SLE-Module-Basesystem-15-SP7-2025-1638,SUSE-SU-2025:01638-2,\
+            https://www.suse.com/support/update/announcement/2025/suse-su-202501638-2/
+            SUSE-Manager-Tools-For-SL-Micro-6-5,SUSE-RU-2025:20291-1,\
+            https://www.suse.com/support/update/announcement/2025/suse-ru-202520291-1/
+            SUSE-SLE-Module-Live-Patching-15-SP3-2025-1112,SUSE-SU-2025:1119-1,\
+            https://www.suse.com/support/update/announcement/2025/suse-su-20251119-1/
+            SUSE-SLE-Module-Basesystem-15-SP6-2025-1562,SUSE-OU-2025:1562-1,\
+            https://www.suse.com/support/update/announcement/2025/suse-ou-20251562-1/
+            SUSE-SLE-Module-Packagehub-Subpackages-15-SP6-2025-37,SUSE-FU-2025:0037-1,\
+            https://www.suse.com/support/update/announcement/2025/suse-fu-20250037-1/
+            SUSE-SLE-Manager-Tools-For-Micro-5-2025-1319,SUSE-RU-2025:1319-1,\
+            https://www.suse.com/support/update/announcement/2025/suse-ru-20251319-1/
+            SUSE-SLE-Module-Development-Tools-15-SP6-2025-990,SUSE-RU-2025:0990-1,\
+            https://www.suse.com/support/update/announcement/2025/suse-ru-20250990-1/
+            """;
+
+        InputStream inputStream = new ByteArrayInputStream(testAdvisoryMapCsv.getBytes(StandardCharsets.UTF_8));
+        ErrataAdvisoryMapManager amm = new ErrataAdvisoryMapManager();
+        amm.readAdvisoryMapPopulateDatabase(inputStream);
+    }
+
+    private Errata createTestErrata(String updateTag, String advisory) {
+        return createErrataWithUpdateTag(updateTag, advisory, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2025, Month.FEBRUARY, 8), 1L);
+    }
+
+     /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    @Test
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException, IOException {
+        createTestAdvisoryMapDatabase();
+        final SUSEAdvisoryMapErrataParser parser = new SUSEAdvisoryMapErrataParser();
+
+
+        Errata errata = createTestErrata("SLE-Live-Patching", "SUSE-12-SP5-2025-1901");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-SU-2025:01901-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-su-202501901-1/"));
+
+        errata = createTestErrata("SLE-Module-Basesystem", "SUSE-15-SP7-2025-1638");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-SU-2025:01638-2"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-su-202501638-2/"));
+
+
+        errata = createTestErrata("Manager-Tools-For", "SUSE-SL-Micro-6-5");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-RU-2025:20291-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-ru-202520291-1/"));
+
+        errata = createTestErrata("", "SUSE-Manager-Tools-For-SL-Micro-6-5");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-RU-2025:20291-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-ru-202520291-1/"));
+
+
+        errata = createTestErrata("SLE-Module-Live-Patching", "SUSE-15-SP3-2025-1112");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-SU-2025:1119-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-su-20251119-1/"));
+
+
+        errata = createTestErrata("SLE-Module-Basesystem", "SUSE-15-SP6-2025-1562");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-OU-2025:1562-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-ou-20251562-1/"));
+
+        errata = createTestErrata("SLE-Module-Packagehub-Subpackages", "SUSE-15-SP6-2025-37");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-FU-2025:0037-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-fu-20250037-1/"));
+
+
+        errata = createTestErrata("SLE-Manager-Tools-For-Micro", "SUSE-5-2025-1319");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-RU-2025:1319-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-ru-20251319-1/"));
+
+        errata = createTestErrata("SLE-Module-Development-Tools", "SUSE-15-SP6-2025-990");
+        assertTrue(parser.getAnnouncementId(errata).equals("SUSE-RU-2025:0990-1"));
+        assertTrue(parser.getAdvisoryUri(errata).toString()
+                .equals("https://www.suse.com/support/update/announcement/2025/suse-ru-20250990-1/"));
+
+    }
+}

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -270,3 +270,7 @@ java.cve_audit.enable_oval_metadata = true
 
 # Disable the supportdata upload UI and API
 java.disable_supportdata_upload = false
+
+#url to download advisory-map.csv, the map of errata patch id, announcement id and advisory URL
+java.errata_advisory_map_csv_download_url = https://ftp.suse.com/pub/projects/security/advisory-map.csv
+

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-1243808-suse-advisory-url
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-1243808-suse-advisory-url
@@ -1,0 +1,2 @@
+- Display correct advisory link by using an errata advisory map
+  (bsc#1243808)

--- a/schema/spacewalk/common/data/rhnTaskoBunch.sql
+++ b/schema/spacewalk/common/data/rhnTaskoBunch.sql
@@ -147,4 +147,7 @@ VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'root-ca-cert-update-bunch',
 INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
 VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'custom-gpg-key-import-bunch', 'Import a customer GPG key into the keyring', null);
 
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'errata-advisory-map-sync-bunch', 'Update SUSE errata advisory map to retrieve announcement ids and advisor URLs.', null);
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoSchedule.sql
+++ b/schema/spacewalk/common/data/rhnTaskoSchedule.sql
@@ -194,4 +194,10 @@ VALUES (sequence_nextval('rhn_tasko_schedule_id_seq'),
         (SELECT id FROM rhnTaskoBunch WHERE name = 'oval-data-sync-bunch'),
         current_timestamp, '0 0 23 ? * *');
 
+INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
+VALUES (sequence_nextval('rhn_tasko_schedule_id_seq'),
+        'errata-advisory-map-sync-default',
+        (SELECT id FROM rhnTaskoBunch WHERE name = 'errata-advisory-map-sync-bunch'),
+        current_timestamp, '0 0 23 ? * *');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -155,4 +155,7 @@ VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'root-ca-cert-update', 'com.r
 INSERT INTO rhnTaskoTask (id, name, class)
 VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'custom-gpg-key-import', 'com.redhat.rhn.taskomatic.task.GpgImportTask');
 
+INSERT INTO rhnTaskoTask (id, name, class)
+VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'errata-advisory-map-sync', 'com.redhat.rhn.taskomatic.task.ErrataAdvisoryMapSync');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -343,4 +343,11 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
                     0,
                     null);
 
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+            VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
+                    (SELECT id FROM rhnTaskoBunch WHERE name = 'errata-advisory-map-sync-bunch'),
+                    (SELECT id FROM rhnTaskoTask WHERE name = 'errata-advisory-map-sync'),
+                    0,
+                    null);
+
 commit;

--- a/schema/spacewalk/common/tables/suseErrataAdvisoryMap.sql
+++ b/schema/spacewalk/common/tables/suseErrataAdvisoryMap.sql
@@ -1,0 +1,29 @@
+
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+--
+
+CREATE TABLE suseErrataAdvisoryMap
+(
+    id            BIGINT CONSTRAINT suse_errata_advisory_map_id_pk PRIMARY KEY
+                                                  GENERATED ALWAYS AS IDENTITY,
+    patch_id     VARCHAR(128),
+    announcement_id           VARCHAR(64),
+    advisory_uri   TEXT,
+
+    created        TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL
+);
+
+CREATE UNIQUE INDEX suse_errata_advisory_map_patch_id_idx
+    ON suseErrataAdvisoryMap (patch_id);

--- a/schema/spacewalk/postgres/data/reschedule.sql
+++ b/schema/spacewalk/postgres/data/reschedule.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2014 SUSE LLC.
+-- Copyright (c) 2014--2025 SUSE LLC.
 --
 -- This software is licensed to you under the GNU General Public License,
 -- version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -10,3 +10,4 @@
 --
 
 select randomize_bunch_schedule('mgr-sync-refresh-default');
+select randomize_bunch_schedule('errata-advisory-map-sync-default');

--- a/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-fix-1243808-suse-advisory-url
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-fix-1243808-suse-advisory-url
@@ -1,0 +1,3 @@
+- Creation of table suseErrataAdvisoryMap and
+  added errata-advisory-map-sync taskomatic job
+  fixing bug (bsc#1243808)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/100-create-suseErrataAdvisoryMap.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/100-create-suseErrataAdvisoryMap.sql
@@ -1,0 +1,29 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+--
+
+CREATE TABLE IF NOT EXISTS suseErrataAdvisoryMap
+(
+    id            BIGINT CONSTRAINT suse_errata_advisory_map_id_pk PRIMARY KEY
+                                                  GENERATED ALWAYS AS IDENTITY,
+    patch_id     VARCHAR(128),
+    announcement_id           VARCHAR(64),
+    advisory_uri   TEXT,
+
+    created        TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                       DEFAULT (current_timestamp) NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS suse_errata_advisory_map_patch_id_idx
+    ON suseErrataAdvisoryMap (patch_id);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/101-errata-advisory-map-taskomatic.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/101-errata-advisory-map-taskomatic.sql
@@ -1,0 +1,52 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+
+-- Insert task and map to the Java class
+INSERT INTO rhnTaskoTask (id, name, class)
+SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'errata-advisory-map-sync', 'com.redhat.rhn.taskomatic.task.ErrataAdvisoryMapSync'
+WHERE NOT EXISTS (SELECT 1
+                  FROM rhnTaskoTask
+                  WHERE name = 'errata-advisory-map-sync');
+
+-- Insert bunch
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+SELECT sequence_nextval('rhn_tasko_bunch_id_seq'),
+       'errata-advisory-map-sync-bunch',
+       'Update SUSE errata advisory map to retrieve announcement ids and advisor URLs.',
+       null
+WHERE NOT EXISTS (SELECT 1
+                  FROM rhnTaskoBunch
+                  WHERE name = 'errata-advisory-map-sync-bunch');
+
+-- Insert template
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+SELECT sequence_nextval('rhn_tasko_template_id_seq'),
+       (SELECT id FROM rhnTaskoBunch WHERE name = 'errata-advisory-map-sync-bunch'),
+       (SELECT id FROM rhnTaskoTask WHERE name = 'errata-advisory-map-sync'),
+       0,
+       null
+WHERE NOT EXISTS (SELECT 1
+                  FROM rhnTaskoTemplate
+                  WHERE bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name = 'errata-advisory-map-sync-bunch')
+                    AND task_id = (SELECT id FROM rhnTaskoTask WHERE name = 'errata-advisory-map-sync')
+                    AND ordering = 0);
+
+-- Insert schedule for task (once a day at 11:00 PM)
+INSERT INTO rhnTaskoSchedule (id, job_label, bunch_id, active_from, cron_expr)
+SELECT sequence_nextval('rhn_tasko_schedule_id_seq'),
+       'errata-advisory-map-sync-default',
+       (SELECT id FROM rhnTaskoBunch WHERE name = 'errata-advisory-map-sync-bunch'),
+       current_timestamp,
+       '0 0 23 ? * *'
+WHERE NOT EXISTS (SELECT 1
+                  FROM rhnTaskoSchedule
+                  WHERE job_label = 'errata-advisory-map-sync-default');

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/102-errata-advisory-map-taskomatic-reschedule.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.10-to-susemanager-schema-5.1.11/102-errata-advisory-map-taskomatic-reschedule.sql
@@ -1,0 +1,12 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+select randomize_bunch_schedule('errata-advisory-map-sync-default');

--- a/susemanager-utils/testing/docker/scripts/pre_idempotency_test_query.sql
+++ b/susemanager-utils/testing/docker/scripts/pre_idempotency_test_query.sql
@@ -1,0 +1,15 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+-- resets randomized cron_expr of errata-advisory-map-sync-default, to pass idempotency test
+-- in order toreset the effects of "select randomize_bunch_schedule('errata-advisory-map-sync-default');"
+
+update rhnTaskoschedule set cron_expr = '0 0 23 ? * *' where job_label = 'errata-advisory-map-sync-default'

--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -359,6 +359,20 @@ def argparser():
     return args
 
 
+def pre_idempotency_test():
+    """run sql command prior to idempotency test"""
+    # pylint: disable-next=consider-using-f-string
+    command = "psql -U postgres -d susemanager -f %s" % (
+        sys.path[0] + "/pre_idempotency_test_query.sql",
+    )
+    if run_command(command):
+        # pylint: disable-next=consider-using-f-string
+        print("Pre idempotency test script correctly executed")
+    else:
+        # pylint: disable-next=consider-using-f-string
+        raise RuntimeError("Error in pre idempotency test script!")
+
+
 def main():
     """Main function"""
     print("============================================================")
@@ -371,9 +385,11 @@ def main():
         args.schema_path, new_version, args.pr_file, args.version
     )
     manage_postgresql("start")
+    pre_idempotency_test()
     initial_dump = "/tmp/initial_dump.sql"
     dump_database(initial_dump, args.excluded_tables)
     run_upgrade(args.upgrade_script, new_version)
+    pre_idempotency_test()
     migrated_dump = "/tmp/migrated_dump.sql"
     dump_database(migrated_dump, args.excluded_tables)
     manage_postgresql("stop")


### PR DESCRIPTION
## What does this PR change?
Given a SUSE errata advisory (e.g. "SUSE-15-SP6-2025-1733"), both the announcementID (e.g. "SUSE-RU-2025:1733-1") and the advisory url (e.g. "https://www.suse.com/support/update/announcement/2025/suse-ru-202501733-1/") were computed from the errata data, through the class SUSEErrataParser.

The numbering is not anymore following a rule, so the only option to get these data is to download once per day a file from https://ftp.suse.com/pub/projects/security/advisory-map.csv, collect this association data in a table and get the data from there

## GUI diff
After:

![1](https://github.com/user-attachments/assets/6bdefaf1-3c4d-43bf-ad5a-6fafbe1a0b80)
![2](https://github.com/user-attachments/assets/7b97985a-225f-426b-99e7-8906e4407e65)
![3](https://github.com/user-attachments/assets/3449171c-91d5-4eeb-9e5d-a7a6ff76cf74)

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/pull/4080
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/27375
Port(s): https://github.com/SUSE/spacewalk/pull/27625, https://github.com/SUSE/spacewalk/pull/27622
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql" 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

