### PR TITLE
fix issue: XMLRPC API endpoint channel.software.updateRepoSsl resets hasSignedMetadata property

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ContentSource.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ContentSource.java
@@ -55,6 +55,7 @@ public class ContentSource extends BaseDomainHelper implements Identifiable {
         type = cs.getType();
         sourceUrl = cs.getSourceUrl();
         label = cs.getLabel();
+        metadataSigned = cs.getMetadataSigned();
         channels = new HashSet<>(cs.getChannels());
         sslSets = new HashSet<>(cs.getSslSets());
         repositoryAuth = cs.getRepositoryAuth();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2399,6 +2399,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
         }
 
         EditRepoCommand repoEditor = new EditRepoCommand(loggedInUser, repo.getId());
+        repoEditor.setMetadataSigned(repo.getMetadataSigned());
 
         // set new SSL Certificates for the repository
         if (!StringUtils.isEmpty(sslCaCert)) {

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-update-repo-ssl-property
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-update-repo-ssl-property
@@ -1,0 +1,2 @@
+- Fix bug: XMLRPC API endpoint updateRepoSsl resets
+  hasSignedMetadata repository property


### PR DESCRIPTION
## What does this PR change?

The Endpoint [channel.software.updateRepoSsl](https://www.uyuni-project.org/uyuni-docs-api/uyuni/api/channel.software.html#apidoc-channel_software-updateRepoSsl-loggedInUser-id-sslCaCert-sslCliCert-sslCliKey) resets the repository property hasSignedMetadata. This is likely unintended behavior, and somewhat undermines checks regarding the authenticity of the respective upstream repository - if channels, repos, etc are managed via the API.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/10331, https://github.com/SUSE/spacewalk/issues/27359
Port(s): https://github.com/SUSE/spacewalk/pull/27592, https://github.com/SUSE/spacewalk/pull/27593
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

