### PR TITLE
Remove unused python dependencies

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.mcalmer.cleanup-spacewalk-client-tools-deps
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.mcalmer.cleanup-spacewalk-client-tools-deps
@@ -1,0 +1,2 @@
+- Remove unused python dependencies to dbus, dmidecode, ethtool,
+  hwdata, udev, pygobject2 and hal

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -172,34 +172,7 @@ Requires:       rhnlib >= 4.2.2
 %if "%{_vendor}" != "debbuild"
 Requires:       python2-uyuni-common-libs
 Requires:       rpm-python
-%ifnarch s390 s390x
-Requires:       python-dmidecode
-%endif
-Requires:       python-ethtool >= 0.4
 BuildRequires:  python-devel
-%if 0%{?fedora}
-Requires:       libgudev
-Requires:       pygobject2
-Requires:       python-hwdata
-%else
-%if 0%{?suse_version} >= 1140
-Requires:       python-hwdata
-Requires:       python-pyudev
-%else
-%if 0%{?rhel} > 5
-Requires:       python-gudev
-Requires:       python-hwdata
-%else
-Requires:       hal >= 0.5.8.1-52
-%endif # 0{?rhel} > 5
-%endif # 0{?suse_version} >= 1140
-%endif # 0{?fedora}
-
-%if 0%{?suse_version}
-Requires:       dbus-1-python
-%else
-Requires:       dbus-python
-%endif # 0{?suse_version}
 Requires:       logrotate
 
 %if %{with test} && 0%{?rhel} != 6
@@ -213,14 +186,8 @@ BuildRequires:  rpm-python
 BuildRequires:  python-coverage
 BuildRequires:  python-dev
 BuildRequires:  python-rpm
-Requires:       gir1.2-gudev-1.0
-Requires:       python-dbus
-Requires:       python-dmidecode
-Requires:       python-ethtool >= 0.4
 Requires:       python-gi
-Requires:       python-pyudev
 Requires:       python-rpm
-Requires:       python2-hwdata
 Requires(post): python-minimal
 Requires(preun): python-minimal
 %endif
@@ -242,38 +209,17 @@ Provides:       python3-rhn-client-tools = %{version}-%{release}
 Obsoletes:      python3-rhn-client-tools < %{version}-%{release}
 Requires:       %{name} = %{version}-%{release}
 %if "%{_vendor}" != "debbuild"
-%if 0%{?suse_version}
-%if 0%{?suse_version} >= 1500
-Requires:       python3-dbus-python
-%else
-Requires:       dbus-1-python3
-%endif
-Requires:       libgudev-1_0-0
-Requires:       python3-pyudev
-%else
-Requires:       libgudev
-Requires:       python3-dbus
-Requires:       python3-gobject-base
-%endif
 BuildRequires:  python3-devel
 BuildRequires:  python3-rpm-macros
 %endif
 
-%ifnarch s390 s390x
-Requires:       python3-dmidecode
-%endif
-Requires:       python3-hwdata
-Requires:       python3-netifaces
 Requires:       python3-rhnlib >= 4.2.2
 Requires:       python3-rpm
 Requires:       python3-uyuni-common-libs
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires:  python3-dev
-Requires:       gir1.2-gudev-1.0
-Requires:       python3-dbus
 Requires:       python3-gi
-Requires:       python3-pyudev
 Requires(post): python3-minimal
 Requires(preun): python3-minimal
 %endif

--- a/client/tools/mgr-push/mgr-push.changes.mcalmer.cleanup-spacewalk-client-tools-deps
+++ b/client/tools/mgr-push/mgr-push.changes.mcalmer.cleanup-spacewalk-client-tools-deps
@@ -1,0 +1,1 @@
+- Require the current name of spacewalk-client-tools

--- a/client/tools/mgr-push/mgr-push.spec
+++ b/client/tools/mgr-push/mgr-push.spec
@@ -63,10 +63,10 @@ per channel.
 Summary:        Package uploader for the Spacewalk or Red Hat Satellite Server
 # FIXME: use correct group or remove it, see "https://en.opensuse.org/openSUSE:Package_group_guidelines"
 Group:          Applications/System
-BuildRequires:  python2-rhn-client-tools
+BuildRequires:  python2-spacewalk-client-tools
 BuildRequires:  python2-uyuni-common-libs
 Requires:       %{name} = %{version}-%{release}
-Requires:       python2-rhn-client-tools
+Requires:       python2-spacewalk-client-tools
 Requires:       python2-uyuni-common-libs
 Requires:       rhnlib >= 2.8.3
 Provides:       python2-%{oldname} = %{oldversion}
@@ -89,11 +89,11 @@ Summary:        Package uploader for the Spacewalk or Red Hat Satellite Server
 # FIXME: use correct group or remove it, see "https://en.opensuse.org/openSUSE:Package_group_guidelines"
 Group:          Applications/System
 BuildRequires:  python3-devel
-BuildRequires:  python3-rhn-client-tools
+BuildRequires:  python3-spacewalk-client-tools
 BuildRequires:  python3-rpm-macros
 BuildRequires:  python3-uyuni-common-libs
 Requires:       %{name} = %{version}-%{release}
-Requires:       python3-rhn-client-tools
+Requires:       python3-spacewalk-client-tools
 Requires:       python3-rhnlib >= 2.8.3
 Requires:       python3-uyuni-common-libs
 Provides:       python3-%{oldname} = %{oldversion}

--- a/python/spacewalk/spacewalk-backend.changes.mcalmer.cleanup-spacewalk-client-tools-deps
+++ b/python/spacewalk/spacewalk-backend.changes.mcalmer.cleanup-spacewalk-client-tools-deps
@@ -1,0 +1,1 @@
+- Require the current name of spacewalk-client-tools

--- a/python/spacewalk/spacewalk-backend.spec
+++ b/python/spacewalk/spacewalk-backend.spec
@@ -81,7 +81,7 @@ BuildRequires:  fdupes
 BuildRequires:  make
 BuildRequires:  python3
 BuildRequires:  python3-debian
-BuildRequires:  python3-rhn-client-tools
+BuildRequires:  python3-spacewalk-client-tools
 BuildRequires:  python3-rhnlib >= 2.5.74
 BuildRequires:  python3-rpm
 BuildRequires:  python3-rpm-macros
@@ -178,7 +178,7 @@ BuildRequires:  systemd-rpm-macros
 %{?systemd_requires}
 %endif
 
-Requires:       python3-rhn-client-tools
+Requires:       python3-spacewalk-client-tools
 Requires:       python3-solv
 Requires:       python3-urlgrabber >= 4
 Requires:       python3-looseversion


### PR DESCRIPTION
## What does this PR change?

We dropped a lot of code from spacewalk-client-tools but never cleaned up the python dependencies in the RPM spec file.
As we dropped the registration part which did also provide hardware data, we can remove a lot of these dependencies:

- dbus
- dmidecode
- ethtool
- hwdata
- udev
- pygobject2
- hal

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): No ports - only 5.1 and later

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
