### PR TITLE
Remove java 11 from `uyuni-java-parent`

### DIFF
--- a/microservices/coco-attestation/attestation-core/pom.xml
+++ b/microservices/coco-attestation/attestation-core/pom.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/CoCoAttestation.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/CoCoAttestation.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AbstractProcessorThread.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AbstractProcessorThread.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.attestation;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AttestationQueueProcessor.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AttestationQueueProcessor.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.attestation;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AttestationResultService.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/AttestationResultService.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.attestation;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ListeningThread.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ListeningThread.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.attestation;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ProcessingThread.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/attestation/ProcessingThread.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.attestation;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/Configuration.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/Configuration.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.configuration;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/DefaultConfiguration.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/DefaultConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SUSE LLC
+ * Copyright (c) 2024--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
  */
 public class DefaultConfiguration implements Configuration {
 
+    // These are the only properties that do not have a default value in configuration-defaults.properties
     private static final Stream<String> MANDATORY_PROPERTIES = Stream.of(
         "database_user",
         "database_password",
@@ -55,44 +56,37 @@ public class DefaultConfiguration implements Configuration {
 
     @Override
     public String getDatabaseUser() {
-        return configurationSource.getString("database_user")
-            .orElseThrow(() -> new MissingConfigurationException("No value set for database_user"));
+        return configurationSource.requireString("database_user");
     }
 
     @Override
     public String getDatabasePassword() {
-        return configurationSource.getString("database_password")
-            .orElseThrow(() -> new MissingConfigurationException("No value set for database_password"));
+        return configurationSource.requireString("database_password");
     }
 
     @Override
     public String getDatabaseConnectionString() {
-        return configurationSource.getString("database_connection")
-            .orElseThrow(() -> new MissingConfigurationException("No value set for database_connection"));
+        return configurationSource.requireString("database_connection");
     }
 
     @Override
     public int getCorePoolSize() {
-        return configurationSource.getInteger("processor_corePoolSize")
-            .orElseThrow(() -> new MissingConfigurationException("No value set for database_connection"));
+        return configurationSource.requireInteger("processor_corePoolSize");
     }
 
     @Override
     public int getMaximumPoolSize() {
-        return configurationSource.getInteger("processor_maxPoolSize")
-            .orElseThrow(() -> new MissingConfigurationException("No value set for database_connection"));
+        return configurationSource.requireInteger("processor_maxPoolSize");
     }
 
     @Override
     public long getThreadKeepAliveInSeconds() {
-        return configurationSource.getInteger("processor_threadKeepAlive")
-            .orElseThrow(() -> new MissingConfigurationException("No value set for database_connection"));
+        return configurationSource.requireInteger("processor_threadKeepAlive");
     }
 
     @Override
     public int getBatchSize() {
-        return configurationSource.getInteger("processor_batchSize")
-            .orElseThrow(() -> new MissingConfigurationException("No value set for database_connection"));
+        return configurationSource.requireInteger("processor_batchSize");
     }
 
     @Override

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/DefaultConfiguration.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/DefaultConfiguration.java
@@ -22,7 +22,6 @@ import com.suse.common.configuration.ResourceConfigurationSource;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -51,7 +50,7 @@ public class DefaultConfiguration implements Configuration {
 
         List<String> missingProperty = MANDATORY_PROPERTIES
             .filter(property -> configurationSource.getString(property).isEmpty())
-            .collect(Collectors.toList());
+            .toList();
 
         if (!missingProperty.isEmpty()) {
             throw new IllegalArgumentException("Mandatory configuration properties are missing: " + missingProperty);

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/DefaultConfiguration.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/DefaultConfiguration.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.configuration;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/MissingConfigurationException.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/configuration/MissingConfigurationException.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.configuration;

--- a/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/module/AttestationModuleLoader.java
+++ b/microservices/coco-attestation/attestation-core/src/main/java/com/suse/coco/module/AttestationModuleLoader.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module;

--- a/microservices/coco-attestation/attestation-core/src/main/resources/mappers/attestation-result.xml
+++ b/microservices/coco-attestation/attestation-core/src/main/resources/mappers/attestation-result.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">

--- a/microservices/coco-attestation/attestation-core/src/main/resources/mybatis-config.xml
+++ b/microservices/coco-attestation/attestation-core/src/main/resources/mybatis-config.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 <!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD SQL Map Config 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-config.dtd">

--- a/microservices/coco-attestation/attestation-core/src/package/log4j2.xml
+++ b/microservices/coco-attestation/attestation-core/src/package/log4j2.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 
 <!-- Confidential Computing Attestation Log4j2 configuration -->

--- a/microservices/coco-attestation/attestation-core/src/test/java/com/suse/coco/attestation/AttestationQueueProcessorTest.java
+++ b/microservices/coco-attestation/attestation-core/src/test/java/com/suse/coco/attestation/AttestationQueueProcessorTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.attestation;

--- a/microservices/coco-attestation/attestation-core/src/test/java/com/suse/coco/attestation/AttestationResultServiceTest.java
+++ b/microservices/coco-attestation/attestation-core/src/test/java/com/suse/coco/attestation/AttestationResultServiceTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.attestation;

--- a/microservices/coco-attestation/attestation-module-secureboot/src/main/java/com/suse/coco/module/secureboot/SecureBootModule.java
+++ b/microservices/coco-attestation/attestation-module-secureboot/src/main/java/com/suse/coco/module/secureboot/SecureBootModule.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.coco.module.secureboot;
 

--- a/microservices/coco-attestation/attestation-module-secureboot/src/main/java/com/suse/coco/module/secureboot/SecureBootWorker.java
+++ b/microservices/coco-attestation/attestation-module-secureboot/src/main/java/com/suse/coco/module/secureboot/SecureBootWorker.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.coco.module.secureboot;
 

--- a/microservices/coco-attestation/attestation-module-secureboot/src/main/resources/mappers/secureboot.xml
+++ b/microservices/coco-attestation/attestation-module-secureboot/src/main/resources/mappers/secureboot.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">

--- a/microservices/coco-attestation/attestation-module-secureboot/src/test/java/com/suse/coco/module/secureboot/SecureBootWorkerTest.java
+++ b/microservices/coco-attestation/attestation-module-secureboot/src/test/java/com/suse/coco/module/secureboot/SecureBootWorkerTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 package com.suse.coco.module.secureboot;
 

--- a/microservices/coco-attestation/attestation-module-snpguest/pom.xml
+++ b/microservices/coco-attestation/attestation-module-snpguest/pom.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestModule.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestModule.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/SNPGuestWorker.java
@@ -209,27 +209,17 @@ public class SNPGuestWorker implements AttestationWorker {
 
         StringBuilder processBuilder = new StringBuilder();
         if (processOutput.getExitCode() != 0) {
-            processBuilder.append(" ".repeat(INDENT_SIZE)).append("- Exit code: ")
-                .append(processOutput.getExitCode())
-                .append(System.lineSeparator());
+            processBuilder.append("- Exit code: %d".formatted(processOutput.getExitCode()).indent(INDENT_SIZE));
         }
 
         if (processOutput.hasStandardOutput()) {
-            processBuilder.append(" ".repeat(INDENT_SIZE)).append("- Standard output: >")
-                .append(System.lineSeparator());
-            processOutput.getStandardOutput().lines()
-                .forEach(line ->
-                    processBuilder.append(" ".repeat(INDENT_SIZE * 2)).append(line).append(System.lineSeparator())
-                );
+            processBuilder.append("- Standard output: >".indent(INDENT_SIZE));
+            processBuilder.append(processOutput.getStandardOutput().indent(INDENT_SIZE * 2));
         }
 
         if (processOutput.hasStandardError()) {
-            processBuilder.append(" ".repeat(INDENT_SIZE)).append("- Standard error: >")
-                .append(System.lineSeparator());
-            processOutput.getStandardError().lines()
-                .forEach(line ->
-                    processBuilder.append(" ".repeat(INDENT_SIZE * 2)).append(line).append(System.lineSeparator())
-                );
+            processBuilder.append("- Standard error: >".indent(INDENT_SIZE));
+            processBuilder.append(processOutput.getStandardError().indent(INDENT_SIZE * 2));
         }
 
         return processBuilder.toString();

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/ProcessOutput.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/ProcessOutput.java
@@ -82,10 +82,9 @@ public class ProcessOutput {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof ProcessOutput)) {
+        if (!(o instanceof ProcessOutput that)) {
             return false;
         }
-        ProcessOutput that = (ProcessOutput) o;
         return exitCode == that.exitCode && Objects.equals(standardOutput,
             that.standardOutput) && Objects.equals(standardError, that.standardError);
     }

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/ProcessOutput.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/ProcessOutput.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.execution;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/SNPGuestWrapper.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/execution/SNPGuestWrapper.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.execution;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/io/VerificationDirectory.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/io/VerificationDirectory.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.io;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/io/VerificationDirectoryProvider.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/io/VerificationDirectoryProvider.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.io;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/model/AttestationReport.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/model/AttestationReport.java
@@ -69,10 +69,9 @@ public class AttestationReport {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof AttestationReport)) {
+        if (!(o instanceof AttestationReport attestationReport)) {
             return false;
         }
-        AttestationReport attestationReport = (AttestationReport) o;
         return id == attestationReport.id &&
             cpuGeneration == attestationReport.cpuGeneration &&
             Arrays.equals(randomNonce, attestationReport.randomNonce);

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/model/AttestationReport.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/model/AttestationReport.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.model;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/model/EpycGeneration.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/java/com/suse/coco/module/snpguest/model/EpycGeneration.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.model;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/main/resources/mappers/snpguest.xml
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/main/resources/mappers/snpguest.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">

--- a/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/SNPGuestWorkerTest.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/SNPGuestWorkerTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/SNPGuestWorkerTest.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/SNPGuestWorkerTest.java
@@ -99,11 +99,9 @@ class SNPGuestWorkerTest {
             .thenThrow(PersistenceException.class);
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- Unable to process attestation result: org.apache.ibatis.exceptions.PersistenceException",
-                ""
-            ),
+        assertEquals("""
+                - Unable to process attestation result: org.apache.ibatis.exceptions.PersistenceException
+                """,
             result.getProcessOutput()
         );
 
@@ -123,11 +121,9 @@ class SNPGuestWorkerTest {
             .thenReturn(null);
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- Unable to retrieve attestation report for result",
-                ""
-            ),
+        assertEquals("""
+                - Unable to retrieve attestation report for result
+                """,
             result.getProcessOutput()
         );
 
@@ -146,11 +142,9 @@ class SNPGuestWorkerTest {
         report.setCpuGeneration(EpycGeneration.UNKNOWN);
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- Unable to identify Epyc processor generation for attestation report",
-                ""
-            ),
+        assertEquals("""
+                - Unable to identify Epyc processor generation for attestation report
+                """,
             result.getProcessOutput()
         );
 
@@ -165,16 +159,13 @@ class SNPGuestWorkerTest {
     @Test
     @DisplayName("Rejects report if nonce is null")
     void rejectsWithNullNonce() {
-        // Set the model as UNKNOWN
         report.setRandomNonce(null);
         report.setReport("REPORT".getBytes(StandardCharsets.UTF_8));
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- Unable to verify: randomized nonce not found",
-                ""
-            ),
+        assertEquals("""
+                - Unable to verify: randomized nonce not found
+                """,
             result.getProcessOutput()
         );
 
@@ -189,16 +180,13 @@ class SNPGuestWorkerTest {
     @Test
     @DisplayName("Rejects report if nonce is empty")
     void rejectsWithEmptyNonce() {
-        // Set the model as UNKNOWN
         report.setRandomNonce(new byte[0]);
         report.setReport("REPORT".getBytes(StandardCharsets.UTF_8));
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- Unable to verify: randomized nonce not found",
-                ""
-            ),
+        assertEquals("""
+                - Unable to verify: randomized nonce not found
+                """,
             result.getProcessOutput()
         );
 
@@ -213,16 +201,13 @@ class SNPGuestWorkerTest {
     @Test
     @DisplayName("Rejects report if data is null")
     void rejectsWithNullReport() {
-        // Set the model as UNKNOWN
         report.setReport(null);
         report.setRandomNonce("NONCE".getBytes(StandardCharsets.UTF_8));
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- Unable to verify: attestation report not found",
-                ""
-            ),
+        assertEquals("""
+                - Unable to verify: attestation report not found
+                """,
             result.getProcessOutput()
         );
 
@@ -237,16 +222,13 @@ class SNPGuestWorkerTest {
     @Test
     @DisplayName("Rejects report if data is empty")
     void rejectsWithEmptyReport() {
-        // Set the model as UNKNOWN
         report.setReport(new byte[0]);
         report.setRandomNonce("NONCE".getBytes(StandardCharsets.UTF_8));
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- Unable to verify: attestation report not found",
-                ""
-            ),
+        assertEquals("""
+                - Unable to verify: attestation report not found
+                """,
             result.getProcessOutput()
         );
 
@@ -261,7 +243,6 @@ class SNPGuestWorkerTest {
     @Test
     @DisplayName("Rejects report if nonce is not found in sequence")
     void rejectsWithoutTheNonceInTheReport() throws IOException {
-        // Set the model as UNKNOWN
         report.setCpuGeneration(EpycGeneration.MILAN);
         report.setRandomNonce("NONCE".getBytes(StandardCharsets.UTF_8));
         report.setReport("REPORT THAT DOES NOT CONTAIN THE RANDOM SEQUENCE".getBytes(StandardCharsets.UTF_8));
@@ -272,11 +253,9 @@ class SNPGuestWorkerTest {
         when(sequenceFinder.search(report.getReport())).thenReturn(-1);
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- The report does not contain the expected random nonce",
-                ""
-            ),
+        assertEquals("""
+                - The report does not contain the expected random nonce
+                """,
             result.getProcessOutput()
         );
 
@@ -313,15 +292,13 @@ class SNPGuestWorkerTest {
             .thenReturn(new ProcessOutput(-1, "", "Fetch FAILED"));
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- The report contains the expected random nonce",
-                "- Unable to retrieve VCEK file:",
-                "    - Exit code: -1",
-                "    - Standard error: >",
-                "        Fetch FAILED",
-                ""
-            ),
+        assertEquals("""
+                - The report contains the expected random nonce
+                - Unable to retrieve VCEK file:
+                    - Exit code: -1
+                    - Standard error: >
+                        Fetch FAILED
+                """,
             result.getProcessOutput()
         );
 
@@ -362,14 +339,12 @@ class SNPGuestWorkerTest {
         when(directory.isVCEKAvailable()).thenReturn(false);
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- The report contains the expected random nonce",
-                "- Unable to retrieve VCEK file:",
-                "    - Standard output: >",
-                "        Fetch ok",
-                ""
-            ),
+        assertEquals("""
+                - The report contains the expected random nonce
+                - Unable to retrieve VCEK file:
+                    - Standard output: >
+                        Fetch ok
+                """,
             result.getProcessOutput()
         );
 
@@ -414,18 +389,16 @@ class SNPGuestWorkerTest {
             .thenReturn(new ProcessOutput(-1, "", "Certificate verify FAILED"));
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- The report contains the expected random nonce",
-                "- VCEK fetched successfully:",
-                "    - Standard output: >",
-                "        Fetch ok",
-                "- Unable to verify the validity of the certificates:",
-                "    - Exit code: -1",
-                "    - Standard error: >",
-                "        Certificate verify FAILED",
-                ""
-            ),
+        assertEquals("""
+                - The report contains the expected random nonce
+                - VCEK fetched successfully:
+                    - Standard output: >
+                        Fetch ok
+                - Unable to verify the validity of the certificates:
+                    - Exit code: -1
+                    - Standard error: >
+                        Certificate verify FAILED
+                """,
             result.getProcessOutput()
         );
 
@@ -477,21 +450,19 @@ class SNPGuestWorkerTest {
             .thenReturn(new ProcessOutput(-1, "", "Attestation verify FAILED"));
 
         assertFalse(worker.process(session, result));
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- The report contains the expected random nonce",
-                "- VCEK fetched successfully:",
-                "    - Standard output: >",
-                "        Fetch ok",
-                "- Certification chain validated successfully:",
-                "    - Standard output: >",
-                "        Certificate verify ok",
-                "- Unable to verify the attestation report:",
-                "    - Exit code: -1",
-                "    - Standard error: >",
-                "        Attestation verify FAILED",
-                ""
-            ),
+        assertEquals("""
+                - The report contains the expected random nonce
+                - VCEK fetched successfully:
+                    - Standard output: >
+                        Fetch ok
+                - Certification chain validated successfully:
+                    - Standard output: >
+                        Certificate verify ok
+                - Unable to verify the attestation report:
+                    - Exit code: -1
+                    - Standard error: >
+                        Attestation verify FAILED
+                """,
             result.getProcessOutput()
         );
 
@@ -532,36 +503,46 @@ class SNPGuestWorkerTest {
 
         // Pass fetching of the VECK
         when(snpWrapper.fetchVCEK(EpycGeneration.MILAN, MOCK_CERTS_DIR, MOCK_REPORT_FILE))
-            .thenReturn(new ProcessOutput(0, "Fetch ok", ""));
+            .thenReturn(new ProcessOutput(0, """
+                Attempting to fetch VCEK...
+                Fetch ok
+                """, ""));
         when(directory.isVCEKAvailable()).thenReturn(true);
 
         // Pass the certificate verification
         when(snpWrapper.verifyCertificates(MOCK_CERTS_DIR))
-            .thenReturn(new ProcessOutput(0, "Certificate verify ok", ""));
+            .thenReturn(new ProcessOutput(0, """
+                Verifying certificate chain validity...
+                Certificates ok
+                """, ""));
 
         // Pass the attestation verification
         when(snpWrapper.verifyAttestation(MOCK_CERTS_DIR, MOCK_REPORT_FILE))
-            .thenReturn(new ProcessOutput(0, "Attestation verify ok", ""));
+            .thenReturn(new ProcessOutput(0, """
+                Verifying attestation status...
+                Attestation ok
+                """, ""));
 
         // Retrieve the report
         when(snpWrapper.displayReport(MOCK_REPORT_FILE)).thenReturn(new ProcessOutput(0, "dummy-report", ""));
 
         assertTrue(worker.process(session, result));
         assertEquals("dummy-report", result.getDetails());
-        assertEquals(
-            String.join(System.lineSeparator(),
-                "- The report contains the expected random nonce",
-                "- VCEK fetched successfully:",
-                "    - Standard output: >",
-                "        Fetch ok",
-                "- Certification chain validated successfully:",
-                "    - Standard output: >",
-                "        Certificate verify ok",
-                "- Attestation report correctly verified:",
-                "    - Standard output: >",
-                "        Attestation verify ok",
-                ""
-            ),
+        assertEquals("""
+                - The report contains the expected random nonce
+                - VCEK fetched successfully:
+                    - Standard output: >
+                        Attempting to fetch VCEK...
+                        Fetch ok
+                - Certification chain validated successfully:
+                    - Standard output: >
+                        Verifying certificate chain validity...
+                        Certificates ok
+                - Attestation report correctly verified:
+                    - Standard output: >
+                        Verifying attestation status...
+                        Attestation ok
+                """,
             result.getProcessOutput()
         );
 

--- a/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/execution/SNPGuestWrapperTest.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/execution/SNPGuestWrapperTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.execution;

--- a/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/io/VerificationDirectoryProviderTest.java
+++ b/microservices/coco-attestation/attestation-module-snpguest/src/test/java/com/suse/coco/module/snpguest/io/VerificationDirectoryProviderTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module.snpguest.io;

--- a/microservices/coco-attestation/attestation-module/pom.xml
+++ b/microservices/coco-attestation/attestation-module/pom.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationResult.java
+++ b/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationResult.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.model;

--- a/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationResult.java
+++ b/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationResult.java
@@ -101,10 +101,9 @@ public class AttestationResult {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof AttestationResult)) {
+        if (!(o instanceof AttestationResult that)) {
             return false;
         }
-        AttestationResult that = (AttestationResult) o;
         return Objects.equals(reportId, that.reportId) && Objects.equals(resultType, that.resultType);
     }
 

--- a/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationStatus.java
+++ b/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/model/AttestationStatus.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.model;

--- a/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/module/AttestationModule.java
+++ b/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/module/AttestationModule.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module;

--- a/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/module/AttestationWorker.java
+++ b/microservices/coco-attestation/attestation-module/src/main/java/com/suse/coco/module/AttestationWorker.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.coco.module;

--- a/microservices/coco-attestation/pom.xml
+++ b/microservices/coco-attestation/pom.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/microservices/uyuni-java-common/pom.xml
+++ b/microservices/uyuni-java-common/pom.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/concurrent/UnboundedGrowingThreadPoolExecutor.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/concurrent/UnboundedGrowingThreadPoolExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SUSE LLC
+ * Copyright (c) 2024--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.concurrent;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/BaseConfigurationSource.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/BaseConfigurationSource.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/ConfigurationSource.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/ConfigurationSource.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/ConfigurationSource.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/ConfigurationSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SUSE LLC
+ * Copyright (c) 2024--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -26,11 +26,33 @@ public interface ConfigurationSource {
     Optional<Boolean> getBoolean(String property);
 
     /**
+     * Retrieve the boolean value of a required property.
+     * @param property the property name
+     * @return the boolean value
+     * @throws MissingConfigurationException if the property is not available in this source
+     */
+    default Boolean requireBoolean(String property) {
+        return getBoolean(property)
+            .orElseThrow(() -> new MissingConfigurationException("No value set for " + property));
+    }
+
+    /**
      * Retrieve the string value of a property.
      * @param property the property name
      * @return the string wrapped into an {@link Optional}
      */
     Optional<String> getString(String property);
+
+    /**
+     * Retrieve the string value of a required property.
+     * @param property the property name
+     * @return the string value
+     * @throws MissingConfigurationException if the property is not available in this source
+     */
+    default String requireString(String property) {
+        return getString(property)
+            .orElseThrow(() -> new MissingConfigurationException("No value set for " + property));
+    }
 
     /**
      * Retrieve the integer value of a property.
@@ -40,11 +62,33 @@ public interface ConfigurationSource {
     Optional<Integer> getInteger(String property);
 
     /**
+     * Retrieve the integer value of a required property.
+     * @param property the property name
+     * @return the integer value
+     * @throws MissingConfigurationException if the property is not available in this source
+     */
+    default Integer requireInteger(String property) {
+        return getInteger(property)
+            .orElseThrow(() -> new MissingConfigurationException("No value set for " + property));
+    }
+
+    /**
      * Retrieve the long value of a property.
      * @param property the property name
      * @return the long wrapped into an {@link Optional}
      */
     Optional<Long> getLong(String property);
+
+    /**
+     * Retrieve the long value of a required property.
+     * @param property the property name
+     * @return the long value
+     * @throws MissingConfigurationException if the property is not available in this source
+     */
+    default Long requireLong(String property) {
+        return getLong(property)
+            .orElseThrow(() -> new MissingConfigurationException("No value set for " + property));
+    }
 
     /**
      * Retrieve the float value of a property.
@@ -54,11 +98,33 @@ public interface ConfigurationSource {
     Optional<Float> getFloat(String property);
 
     /**
+     * Retrieve the float value of a required property.
+     * @param property the property name
+     * @return the float value
+     * @throws MissingConfigurationException if the property is not available in this source
+     */
+    default Float requireFloat(String property) {
+        return getFloat(property)
+            .orElseThrow(() -> new MissingConfigurationException("No value set for " + property));
+    }
+
+    /**
      * Retrieve the double value of a property.
      * @param property the property name
      * @return the double wrapped into an {@link Optional}
      */
     Optional<Double> getDouble(String property);
+
+    /**
+     * Retrieve the double value of a required property.
+     * @param property the property name
+     * @return the double value
+     * @throws MissingConfigurationException if the property is not available in this source
+     */
+    default Double requireDouble(String property) {
+        return getDouble(property)
+            .orElseThrow(() -> new MissingConfigurationException("No value set for " + property));
+    }
 
     /**
      * Retrieve the list value of a property.
@@ -68,6 +134,19 @@ public interface ConfigurationSource {
      * @param <T> the type of item of the list
      */
     <T> Optional<List<T>> getList(String property, Class<T> itemClass);
+
+    /**
+     * Retrieve the list value of a required property.
+     * @param property the property name
+     * @param itemClass the type of item of the list.
+     * @return the list value
+     * @param <T> the type of item of the list
+     * @throws MissingConfigurationException if the property is not available in this source
+     */
+    default <T> List<T> requireList(String property, Class<T> itemClass) {
+        return getList(property, itemClass)
+            .orElseThrow(() -> new MissingConfigurationException("No value set for " + property));
+    }
 
     /**
      * Retrieves the names of all the available properties.

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/EnvironmentConfigurationSource.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/EnvironmentConfigurationSource.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/FileConfigurationSource.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/FileConfigurationSource.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/MissingConfigurationException.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/MissingConfigurationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SUSE LLC
+ * Copyright (c) 2024--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -9,7 +9,7 @@
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
  */
 
-package com.suse.coco.configuration;
+package com.suse.common.configuration;
 
 import java.util.NoSuchElementException;
 

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/MultipleConfigurationSource.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/MultipleConfigurationSource.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/ResourceConfigurationSource.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/configuration/ResourceConfigurationSource.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/database/C3P0DataSourceFactory.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/database/C3P0DataSourceFactory.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.database;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/database/DatabaseSessionFactory.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/database/DatabaseSessionFactory.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.database;

--- a/microservices/uyuni-java-common/src/main/java/com/suse/common/io/ByteSequenceFinder.java
+++ b/microservices/uyuni-java-common/src/main/java/com/suse/common/io/ByteSequenceFinder.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.io;

--- a/microservices/uyuni-java-common/src/test/java/com/suse/common/concurrent/UnboundedGrowingThreadPoolExecutorTest.java
+++ b/microservices/uyuni-java-common/src/test/java/com/suse/common/concurrent/UnboundedGrowingThreadPoolExecutorTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.concurrent;

--- a/microservices/uyuni-java-common/src/test/java/com/suse/common/configuration/AbstractConfigurationSourceTest.java
+++ b/microservices/uyuni-java-common/src/test/java/com/suse/common/configuration/AbstractConfigurationSourceTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/test/java/com/suse/common/configuration/BaseConfigurationSourceTest.java
+++ b/microservices/uyuni-java-common/src/test/java/com/suse/common/configuration/BaseConfigurationSourceTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/test/java/com/suse/common/configuration/FileConfigurationSourceTest.java
+++ b/microservices/uyuni-java-common/src/test/java/com/suse/common/configuration/FileConfigurationSourceTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.configuration;

--- a/microservices/uyuni-java-common/src/test/java/com/suse/common/io/ByteSequenceFinderTest.java
+++ b/microservices/uyuni-java-common/src/test/java/com/suse/common/io/ByteSequenceFinderTest.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.common.io;

--- a/microservices/uyuni-java-parent/pom.xml
+++ b/microservices/uyuni-java-parent/pom.xml
@@ -33,30 +33,6 @@
         <module>../coco-attestation</module>
     </modules>
 
-    <!-- Profiles based on the jdk Maven is running on.
-       ~ to ensure the compilation happens with the proper release target
-      -->
-    <profiles>
-        <profile>
-            <id>java-11</id>
-            <activation>
-                <jdk>[11,17)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>11</maven.compiler.release>
-            </properties>
-        </profile>
-        <profile>
-            <id>java-17</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.release>17</maven.compiler.release>
-            </properties>
-        </profile>
-    </profiles>
-
     <!-- Global dependencies based on the package version in OBS -->
     <dependencyManagement>
         <dependencies>
@@ -122,6 +98,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.11.0</version>
+                    <configuration>
+                        <release>17</release>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/microservices/uyuni-java-parent/pom.xml
+++ b/microservices/uyuni-java-parent/pom.xml
@@ -8,10 +8,6 @@
   ~ FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
   ~ along with this software; if not, see
   ~ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-  ~
-  ~ Red Hat trademarks are not licensed under GPLv2. No permission is
-  ~ granted to use or replicate Red Hat trademarks that are incorporated
-  ~ in this software or its documentation.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"


### PR DESCRIPTION
## What does this PR change?

This PR introduces the following changes:

- Remove support for compilation on java 11 in `uyuni-java-parent`. 
- Update coco attestation code to take advantage of java 17 features, where applicable
- Remove the Red Hat trademarks section from the header, since it's not applicable to the source code.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
