### PR TITLE
SonarCloud fix: javasecurity:S5145 Logging should not be vulnerable to injection attacks

### DIFF
--- a/java/code/src/org/cobbler/CobblerConnection.java
+++ b/java/code/src/org/cobbler/CobblerConnection.java
@@ -15,6 +15,8 @@
 
 package org.cobbler;
 
+import com.redhat.rhn.common.util.StringUtil;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -150,7 +152,8 @@ public class CobblerConnection {
                     dbgArgs.add("<token>");
                 }
             }
-            log.debug("procedure: {} args: {}", procedureName, dbgArgs);
+            log.debug("procedure: {} args: {}",
+                    StringUtil.sanitizeLogInput(procedureName), StringUtil.sanitizeLogInput(dbgArgs.toString()));
         }
         Object retval;
         try {


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rule javasecurity:S5145 Logging should not be vulnerable to injection attacks

Log injection occurs when an application fails to sanitize untrusted data used for logging.
An attacker can forge log content to prevent an organization from being able to trace back malicious activities.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

