### PR TITLE
SonarCloud error reduction fix, miscellaneous 11 rules

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/manifestfactory/test/PrimitiveBuilder.java
+++ b/java/code/src/com/redhat/rhn/common/util/manifestfactory/test/PrimitiveBuilder.java
@@ -48,7 +48,7 @@ public class PrimitiveBuilder implements ManifestFactoryBuilder {
             String lenStr = (String)params.get("length");
             String containedType = (String)params.get("contained-type");
 
-            int len = Integer.valueOf(lenStr);
+            int len = Integer.parseInt(lenStr);
             List ret = new ArrayList<>();
             for (int i = 0; i < len; i++) {
                 try {

--- a/java/code/src/com/redhat/rhn/common/validator/LongConstraint.java
+++ b/java/code/src/com/redhat/rhn/common/validator/LongConstraint.java
@@ -60,7 +60,7 @@ public class LongConstraint extends RequiredIfConstraint {
 
         // Validate against range specifications
         try {
-            long longValue = Long.valueOf(value.toString());
+            long longValue = Long.parseLong(value.toString());
             // Now we know its a valid number
             if (longValue < getMinInclusive()) {
                 log.debug("Number too small ...");

--- a/java/code/src/com/redhat/rhn/domain/recurringactions/state/RecurringStateConfig.java
+++ b/java/code/src/com/redhat/rhn/domain/recurringactions/state/RecurringStateConfig.java
@@ -50,7 +50,7 @@ public abstract class RecurringStateConfig {
     /**
      * Standard constructor
      */
-    public RecurringStateConfig() {
+    protected RecurringStateConfig() {
     }
 
     /**
@@ -58,7 +58,7 @@ public abstract class RecurringStateConfig {
      *
      * @param positionIn the position
      */
-    public RecurringStateConfig(Long positionIn) {
+    protected RecurringStateConfig(Long positionIn) {
         this.position = positionIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/NetworkInterfaceTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/NetworkInterfaceTest.java
@@ -91,7 +91,7 @@ public class NetworkInterfaceTest extends RhnBaseTestCase {
      * @return Returns a new NetworkInterface object all filled out for testing purposes.
      * @throws Exception something bad happened
      */
-    public static NetworkInterface createTestNetworkInterface() throws Exception {
+    public static NetworkInterface createTestNetworkInterface() {
         User user = UserTestUtils.findNewUser("testuser", "testorg");
         Server s = ServerFactoryTest.createTestServer(user);
         return createTestNetworkInterface(s);
@@ -103,8 +103,7 @@ public class NetworkInterfaceTest extends RhnBaseTestCase {
      * @return Returns a new NetworkInterface object all filled out for testing purposes.
      * @throws Exception something bad happened
      */
-    public static NetworkInterface createTestNetworkInterface(Server server)
-    throws Exception {
+    public static NetworkInterface createTestNetworkInterface(Server server) {
         return createTestNetworkInterface(server, TestUtils.randomString(),
                 "127.0.0.1", TEST_MAC);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/help/ForgotCredentialsAction.java
@@ -141,7 +141,7 @@ public class ForgotCredentialsAction extends RhnAction {
     }
 
     private boolean validateNewPasswordFields(String login, String email, ActionErrors errors) {
-        return validateLogin(login, errors) & validateEmail(email, errors);
+        return validateLogin(login, errors) && validateEmail(email, errors);
     }
 
     private boolean validateLogin(String login, ActionErrors errors) {

--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/YourRhnClipsRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/YourRhnClipsRenderer.java
@@ -72,9 +72,6 @@ public class YourRhnClipsRenderer extends RhnAction {
         else if (key.equals(Pane.SYSTEM_GROUPS)) {
             renderer = new SystemGroupsRenderer();
         }
-        else if (key.equals(Pane.TASKS)) {
-            renderer = new TasksRenderer();
-        }
 
         if (renderer != null) {
             request.setAttribute("pageUrl", renderer.getPageUrl());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotTagsDeleteAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SnapshotTagsDeleteAction.java
@@ -67,7 +67,7 @@ public class SnapshotTagsDeleteAction extends RhnAction {
                         ServerFactory.lookupSnapshotTagbyName(sTag.getName()));
             }
             createSuccessMessage(request, "system.history.snapshot.tagDeleteSuccess",
-                    Integer.valueOf(set.size()).toString());
+                    Integer.toString(set.size()));
             set.clear();
             RhnSetManager.store(set);
             Map<String, Object> params = makeParamMap(request);

--- a/java/code/src/com/redhat/rhn/frontend/dto/SetupWizardProductDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SetupWizardProductDto.java
@@ -104,7 +104,7 @@ public class SetupWizardProductDto implements Selectable,
          * @param stageIn the stage to compare to
          * @return whether the stages are equal
          */
-        boolean equals(SyncStage stageIn) {
+        boolean isEqualTo(SyncStage stageIn) {
             return getStage().equals(stageIn);
         }
 
@@ -168,7 +168,7 @@ public class SetupWizardProductDto implements Selectable,
          * @return true if the stage is not mirrored
          */
         public boolean isNotMirrored() {
-            return equals(SyncStage.NOT_MIRRORED);
+            return isEqualTo(SyncStage.NOT_MIRRORED);
         }
 
         /**
@@ -176,7 +176,7 @@ public class SetupWizardProductDto implements Selectable,
          * @return true if the stage is in progress
          */
         public boolean isInProgress() {
-            return equals(SyncStage.IN_PROGRESS);
+            return isEqualTo(SyncStage.IN_PROGRESS);
         }
 
         /**
@@ -184,7 +184,7 @@ public class SetupWizardProductDto implements Selectable,
          * @return true if the stage is failed
          */
         public boolean isFailed() {
-            return equals(SyncStage.FAILED);
+            return isEqualTo(SyncStage.FAILED);
         }
 
         /**
@@ -192,7 +192,7 @@ public class SetupWizardProductDto implements Selectable,
          * @return true if the stage is finished
          */
         public boolean isFinished() {
-            return equals(SyncStatus.SyncStage.FINISHED);
+            return isEqualTo(SyncStatus.SyncStage.FINISHED);
         }
     }
 
@@ -541,7 +541,7 @@ public class SetupWizardProductDto implements Selectable,
      * @see com.redhat.rhn.frontend.dto.SetupWizardProductDto.SyncStatus.SyncStage
      */
     public boolean isStatusNotMirrored() {
-        return getSyncStatus().equals(SyncStatus.SyncStage.NOT_MIRRORED);
+        return getSyncStatus().isEqualTo(SyncStatus.SyncStage.NOT_MIRRORED);
     }
 
     /**
@@ -558,7 +558,7 @@ public class SetupWizardProductDto implements Selectable,
      * @see com.redhat.rhn.frontend.dto.SetupWizardProductDto.SyncStatus.SyncStage
      */
     public boolean isStatusInProgress() {
-        return getSyncStatus().equals(SyncStatus.SyncStage.IN_PROGRESS);
+        return getSyncStatus().isEqualTo(SyncStatus.SyncStage.IN_PROGRESS);
     }
 
     /**
@@ -575,7 +575,7 @@ public class SetupWizardProductDto implements Selectable,
      * @see com.redhat.rhn.frontend.dto.SetupWizardProductDto.SyncStatus.SyncStage
      */
     public boolean isStatusFinished() {
-        return getSyncStatus().equals(SyncStatus.SyncStage.FINISHED);
+        return getSyncStatus().isEqualTo(SyncStatus.SyncStage.FINISHED);
     }
 
     /**
@@ -592,7 +592,7 @@ public class SetupWizardProductDto implements Selectable,
      * @see com.redhat.rhn.frontend.dto.SetupWizardProductDto.SyncStatus.SyncStage
      */
     public boolean isStatusFailed() {
-        return getSyncStatus().equals(SyncStatus.SyncStage.FAILED);
+        return getSyncStatus().isEqualTo(SyncStatus.SyncStage.FAILED);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/TransactionHelper.java
@@ -37,6 +37,10 @@ public abstract class TransactionHelper {
 
     private static Logger log = LogManager.getLogger(TransactionHelper.class);
 
+    private TransactionHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
     /**
      * Runs the runnable and handles the closing of the transaction and Hibernate session upon completion,
      * rolling back in case of unexpected Exceptions.

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -1246,11 +1246,9 @@ public class ErrataHandler extends BaseHandler {
             catch (ClassCastException e) {
                 // just catch, do not do anything
             }
-            finally {
-                if (cc == null || !cc.isCloned()) {
-                    throw new InvalidChannelException("Cloned channel " +
-                            "expected: " + c.getLabel());
-                }
+            if (cc == null || !cc.isCloned()) {
+                throw new InvalidChannelException("Cloned channel " +
+                        "expected: " + c.getLabel());
             }
             Channel original = ChannelFactory.lookupOriginalChannel(c);
             if (original == null) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/systemgroup/ServerGroupHandler.java
@@ -124,8 +124,7 @@ public class ServerGroupHandler extends BaseHandler {
         String admins = null;
         for (String login : loginNames) {
             User user = UserFactory.lookupByLogin(login);
-            if ((user != null) && ((user.hasRole(RoleFactory.SAT_ADMIN) ||
-                (user.hasRole(RoleFactory.ORG_ADMIN))))) {
+            if ((user != null) && (user.hasRole(RoleFactory.SAT_ADMIN) || user.hasRole(RoleFactory.ORG_ADMIN))) {
                 if (admins == null) {
                     admins = login;
                 }

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoQuartzHelper.java
@@ -37,7 +37,7 @@ import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
-import org.quartz.impl.jdbcjobstore.StdJDBCConstants;
+import org.quartz.impl.jdbcjobstore.Constants;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -51,7 +51,7 @@ import java.util.Date;
 public class TaskoQuartzHelper {
 
     private static final String QRTZ_PREFIX = Config.get()
-            .getString("org.quartz.jobStore.tablePrefix", StdJDBCConstants.DEFAULT_TABLE_PREFIX);
+            .getString("org.quartz.jobStore.tablePrefix", Constants.DEFAULT_TABLE_PREFIX);
     private static final String QRTZ_TRIGGERS = QRTZ_PREFIX.concat("TRIGGERS");
     private static final String QRTZ_SIMPLE_TRIGGERS = QRTZ_PREFIX.concat("SIMPLE_TRIGGERS");
     private static final String QRTZ_CRON_TRIGGERS = QRTZ_PREFIX.concat("CRON_TRIGGERS");

--- a/java/code/src/com/redhat/rhn/taskomatic/core/TaskEnvironmentListener.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/TaskEnvironmentListener.java
@@ -33,7 +33,7 @@ public class TaskEnvironmentListener implements TriggerListener {
 
     public static final String LISTENER_NAME = "TaskEnvironmentListener";
 
-    private static Logger logger = LogManager.getLogger(SchedulerKernel.class);
+    private static Logger logger = LogManager.getLogger(TaskEnvironmentListener.class);
 
     private Map<Integer, Boolean> vetoedJobs = new HashMap<>();
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/test/SSHServiceWorkerTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/test/SSHServiceWorkerTest.java
@@ -287,7 +287,7 @@ public class SSHServiceWorkerTest extends JMockBaseTestCaseWithUser {
     }
 
     private ServerAction createChildServerAction(Action action, ActionStatus status,
-            long remainingTries) throws Exception {
+            long remainingTries) {
         return createChildServerAction(minion, action, status, remainingTries);
     }
 

--- a/java/code/src/com/suse/manager/maintenance/rescheduling/FailRescheduleStrategy.java
+++ b/java/code/src/com/suse/manager/maintenance/rescheduling/FailRescheduleStrategy.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * FailRescheduleStrategy - fallback which always fail to reschedule the action.
  */
 public class FailRescheduleStrategy implements RescheduleStrategy {
-    private static final Logger LOG = LogManager.getLogger(CancelRescheduleStrategy.class);
+    private static final Logger LOG = LogManager.getLogger(FailRescheduleStrategy.class);
 
     @Override
     public RescheduleResult reschedule(User user, Map<Action, List<Server>> actionsServers,


### PR DESCRIPTION
## What does this PR change?
SonarCloud error reduction fix, rules:

[ java:S1118 Utility classes should not have public constructors](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1118&rule_key=java%3AS1118)
[java:S2178 Short-circuit logic should be used in boolean contexts](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS2178&rule_key=java%3AS2178)
[java:S1862 Related if/else if statements should not have the same condition](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1862&rule_key=java%3AS1862)
[java:S1110 Redundant pairs of parentheses should be removed](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1110&rule_key=java%3AS1110)
[java:S1158 Primitive wrappers should not be instantiated only for toString or compareTo calls](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1158&rule_key=java%3AS1158)
[java:S1163 Exceptions should not be thrown in finally blocks](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1163&rule_key=java%3AS1163)
[java:S3252 static base class members should not be accessed via derived types](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS3252&rule_key=java%3AS3252)
[java:S1201 equals method overrides should accept Object parameters](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1201&rule_key=java%3AS1201)
[java:S2130 Parsing should be used to convert Strings to primitives](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS2130&rule_key=java%3AS2130)
[java:S3416 Loggers should be named for their enclosing classes](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS3416&rule_key=java%3AS3416)
[java:S1130 Exceptions in throws clauses should not be superfluous](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1130&rule_key=java%3AS1130)
[java:S5993 Constructors of an abstract class should not be declared public](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS5993&rule_key=java%3AS5993)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s):
- [x] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
