### PR TITLE
Fix L3: Unable to remove certain system profiles (bsc#1237536)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/ProxyClientsAction.java
@@ -61,7 +61,8 @@ public class ProxyClientsAction extends BaseSystemsAction {
             Optional<InstalledProduct> proxyProduct = server.getInstalledProducts().stream()
                     .filter(p -> p.getName().toLowerCase().contains("proxy"))
                     .findFirst();
-            if (proxyProduct.isPresent() || server.getProxyInfo().getVersion() != null) {
+            if (proxyProduct.isPresent() ||
+                    ((server.getProxyInfo() != null) && (server.getProxyInfo().getVersion() != null))) {
                 request.setAttribute("version", proxyProduct.isPresent() ?
                         proxyProduct.get().getVersion() :
                         server.getProxyInfo().getVersion().getVersion());

--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 SUSE LLC
+ * Copyright (c) 2024--2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.manager.webui.controllers;
@@ -457,7 +453,8 @@ public class SystemsController {
                     Long.toString(sid));
         }
         catch (RuntimeException e) {
-            if (e.getMessage().contains("cobbler")) {
+            LOG.error("Deleting the server {} failed.", sid, e);
+            if (e.getMessage() != null && e.getMessage().contains("cobbler")) {
                 createErrorMessage(request.raw(), "message.servernotdeleted_cobbler",
                         Long.toString(sid));
             }

--- a/java/spacewalk-java.changes.carlo.uyuni-fix-1237536-remove-with-empty-proxy
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-1237536-remove-with-empty-proxy
@@ -1,0 +1,2 @@
+- Ensure null safety when converting from proxy paths to host
+  names (bsc#1237536)


### PR DESCRIPTION
## What does this PR change?
After a thorough and long investigation, it seems that for some strange reason in the customer setup the proxy info vahished, in fact the query "select * from rhnproxyinfo;" shows no records.
In this configuration, removing a minion with no cleanup results in a series of exceptions due to the fact that the method Server::getProxyInfo returns null.

This PR ensures null safety in this case

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s):  https://github.com/SUSE/spacewalk/issues/26528
Port(s): # **add upstream PR, if any**
- [ ] **DONE**

## Changelogs
If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
