### PR TITLE
Remove perl from cleanup as it is not installed anymore by default

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.mcalmer.adapt-container-cleanup
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.mcalmer.adapt-container-cleanup
@@ -1,0 +1,2 @@
+- Remove perl from cleanup as it is not installed anymore
+  by default

--- a/containers/proxy-httpd-image/remove_unused.sh
+++ b/containers/proxy-httpd-image/remove_unused.sh
@@ -3,9 +3,6 @@
 
 set -xe
 
-# remove perl and its dependencies
-rpm -e --nodeps perl
-
 # remove locale data
 rm -rf /usr/share/locale
 


### PR DESCRIPTION
## What does this PR change?

Seems that perl is not installed anymore.
Now `rpm -e perl` report and error and let the container build fail.
We need to remove this.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): Not needed

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
