### PR TITLE
QE: Subscribing suse like minions to python channels to test the installation of an ansible control node

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -64,6 +64,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "Development Tools Module 15 SP4 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
     And I should see the "Development Tools Module 15 SP4 x86_64" selected
+    When I select "Python 3 Module 15 SP4 x86_64" as a product
+    Then I should see the "Python 3 Module 15 SP4 x86_64" selected
     When I select "Containers Module 15 SP4 x86_64" as a product
     Then I should see the "Containers Module 15 SP4 x86_64" selected
     When I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SLE 15 x86_64 (BETA)" beta client tools

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -2,13 +2,27 @@
 # Licensed under the terms of the MIT license.
 
 @scope_ansible
+@sle_minion
 Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Log in as org admin user
-    Given I am authorized
+    Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     When I deploy testing playbooks and inventory files to "sle_minion"
+
+  @susemanager
+  Scenario: Pre-requisite: Subscribe SUSE minions to SLE-Module-Python3-15-SP4-Pool for x86_64
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I check "SLE-Module-Python3-15-SP4-Pool for x86_64" by label
+    And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" by label
+    And I click on "Next"
+    And I click on "Confirm"
+    And I wait until I see "Changing the channels has been scheduled." text
+    And I follow "scheduled"
+    And I wait until I see "1 system successfully completed this action" text, refreshing the page
 
 # TODO: Check why tools_update_repo is not available on the openSUSE minion
 @skip_if_github_validation
@@ -84,6 +98,19 @@ Feature: Operate an Ansible control node in a normal minion
     Then I should see a "System properties changed" text
     And I remove package "orion-dummy" from this "sle_minion" without error control
     And I remove "/tmp/file.txt" from "sle_minion"
+
+  @susemanager
+  Scenario: Cleanup: Unsubscribe SUSE minions from SLE-Module-Python3-15-SP4-Pool for x86_64
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I uncheck "SLE-Module-Python3-15-SP4-Pool for x86_64" by label
+    And I uncheck "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" by label
+    And I click on "Next"
+    And I click on "Confirm"
+    And I wait until I see "Changing the channels has been scheduled." text
+    And I follow "scheduled"
+    And I wait until I see "1 system successfully completed this action" text, refreshing the page
 
 @skip_if_github_validation
 @uyuni

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -7,10 +7,23 @@
 Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Log in as org admin user
-    Given I am authorized
+    Given I am authorized for the "Admin" section
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     When I deploy testing playbooks and inventory files to "ssh_minion"
+
+  @susemanager
+  Scenario: Pre-requisite: Subscribe SUSE minions to SLE-Module-Python3-15-SP4-Pool for x86_64
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I check "SLE-Module-Python3-15-SP4-Pool for x86_64" by label
+    And I check "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" by label
+    And I click on "Next"
+    And I click on "Confirm"
+    And I wait until I see "Changing the channels has been scheduled." text
+    And I follow "scheduled"
+    And I wait until I see "1 system successfully completed this action" text, refreshing the page
 
 # TODO: Check why tools_update_repo is not available on the openSUSE minion
 @skip_if_github_validation
@@ -86,6 +99,19 @@ Feature: Operate an Ansible control node in SSH minion
     Then I should see a "System properties changed" text
     And I remove package "orion-dummy" from this "ssh_minion" without error control
     And I remove "/tmp/file.txt" from "ssh_minion"
+
+  @susemanager
+  Scenario: Cleanup: Unsubscribe SUSE minions from SLE-Module-Python3-15-SP4-Pool for x86_64
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I uncheck "SLE-Module-Python3-15-SP4-Pool for x86_64" by label
+    And I uncheck "SLE-Product-SLES15-SP4-LTSS-Updates for x86_64" by label
+    And I click on "Next"
+    And I click on "Confirm"
+    And I wait until I see "Changing the channels has been scheduled." text
+    And I follow "scheduled"
+    And I wait until I see "1 system successfully completed this action" text, refreshing the page
 
 @skip_if_github_validation
 @uyuni


### PR DESCRIPTION
## What does this PR change?

The ansible control node needs the pytho3 channel to be installed. In this PR this step is added

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): None
Port(s):
- Manager 5.0:

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
