### PR TITLE
Skip password verification for PAM users (bsc#1245398)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009--2014 Red Hat, Inc.
+ * Copyright (c) 2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -46,7 +47,7 @@ public class CreateUserAction extends RhnAction {
     public static final String FAILURE = "failure";
     public static final String SUCCESS_INTO_ORG = "existorgsuccess";
 
-    private ActionErrors populateCommand(DynaActionForm form, CreateUserCommand command, boolean validatePassword) {
+    private ActionErrors populateCommand(DynaActionForm form, CreateUserCommand command) {
         ActionErrors errors = new ActionErrors();
 
         command.setEmail(form.getString("email"));
@@ -67,7 +68,7 @@ public class CreateUserAction extends RhnAction {
         String passwd = (String)form.get(UserActionHelper.DESIRED_PASS);
         String passwdConfirm = (String)form.get(UserActionHelper.DESIRED_PASS_CONFIRM);
         if (passwd.equals(passwdConfirm)) {
-            command.setPassword(passwd, validatePassword);
+            command.setPassword(passwd);
         }
         else {
             errors.add(ActionMessages.GLOBAL_MESSAGE,
@@ -122,7 +123,6 @@ public class CreateUserAction extends RhnAction {
          * in the db (even though it won't be used), we'll just validate it like a regular
          * password and allow it.
          */
-        boolean validatePassword = true;
         if (form.get("usepam") != null && (Boolean) form.get("usepam")) {
             String fakePassword = CryptHelper.getRandomPasswordForPamAuth();
             if (form.get(UserActionHelper.DESIRED_PASS) == null ||
@@ -144,7 +144,7 @@ public class CreateUserAction extends RhnAction {
 
         // Create the user and do some more validation
         CreateUserCommand command = getCommand();
-        ActionErrors errors = populateCommand(form, command, validatePassword);
+        ActionErrors errors = populateCommand(form, command);
         if (!errors.isEmpty()) {
             return returnError(mapping, request, errors);
         }

--- a/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009--2015 Red Hat, Inc.
+ * Copyright (c) 2025 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -85,7 +86,7 @@ public class CreateUserCommand {
     public ValidatorError[] validate() {
         errors = new ArrayList<>(); //clear validation errors
 
-        if (passwordErrors != null && !user.getUsePamAuthentication()) {
+        if (passwordErrors != null) {
             errors.addAll(passwordErrors); //add any password validation errors
         }
         validateEmail();
@@ -305,11 +306,13 @@ public class CreateUserCommand {
     }
 
     /**
+     * Set password to the user if passed validation.
+     *
+     * PAM enabled users will skip verification of the password
      * @param passwordIn The password to set
-     * @param validate if password requirements should be validated
      */
-    public void setPassword(String passwordIn, boolean validate) {
-        if (!validate) {
+    public void setPassword(String passwordIn) {
+        if (user.getUsePamAuthentication()) {
             user.setPassword(passwordIn);
         }
         else {
@@ -320,13 +323,6 @@ public class CreateUserCommand {
                 user.setPassword(passwordIn);
             }
         }
-    }
-
-    /**
-     * @param passwordIn The password to set
-     */
-    public void setPassword(String passwordIn) {
-        setPassword(passwordIn, true);
     }
 
     /**
@@ -365,6 +361,8 @@ public class CreateUserCommand {
     }
 
     /**
+     * PAM enabled user
+     * Setting this to true will skip password policy verification
      * @param val Should this user use pam authentication?
      */
     public void setUsePamAuthentication(boolean val) {

--- a/java/spacewalk-java.changes.oholecek.no-password-validation-on-pam
+++ b/java/spacewalk-java.changes.oholecek.no-password-validation-on-pam
@@ -1,0 +1,2 @@
+- Do not validate random password when using PAM
+  (bsc#1245398)


### PR DESCRIPTION
## What does this PR change?

This commit changes how PAM users password verification works. Instead of relying on additional variable, which was not correctly set, always rely on user PAM settings.
Also use PAM settings only in the actual password set routine in order not to hide some potential future errors.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27630
Port(s): https://github.com/SUSE/spacewalk/pull/27639

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
