### PR TITLE
Fix systems page numeric filter

### DIFF
--- a/web/html/src/components/table/NumericSearchField.tsx
+++ b/web/html/src/components/table/NumericSearchField.tsx
@@ -20,12 +20,27 @@ const resultingCriteria = (matcher: string, value: string) => {
   return matcher && value && value.trim() !== "" ? matcher + value : null;
 };
 
+const decodeHTMLEntities = (str) => {
+  const txt = document.createElement("textarea");
+  txt.innerHTML = str;
+  return txt.value;
+};
+
 export const NumericSearchField = ({ name, criteria, onSearch }) => {
   let criteriaMatcher = "";
   let criteriaValue = "";
   if (criteria) {
-    criteriaMatcher = matchers.find((it) => criteria.startsWith(it.value))?.value ?? "=";
-    criteriaValue = criteria.includes(criteriaMatcher) ? criteria.split(criteriaMatcher)[1] : criteria;
+    const criteriaDecoded = decodeHTMLEntities(criteria);
+    const bestMatcher = matchers.reduce((bestFound, currentMatcher) => {
+      // Find the longest matcher that is a prefix of the criteria string.
+      // It prevents to take "<" matcher when it should be "<="
+      if (criteriaDecoded.startsWith(currentMatcher.value) && currentMatcher.value.length > bestFound.length) {
+        return currentMatcher.value;
+      }
+      return bestFound;
+    }, "");
+    criteriaMatcher = bestMatcher || "=";
+    criteriaValue = criteriaDecoded.substring(criteriaMatcher.length);
   }
 
   const [matcher, setMatcher] = useState<string>(criteriaMatcher);

--- a/web/spacewalk-web.changes.welder.bsc1243183
+++ b/web/spacewalk-web.changes.welder.bsc1243183
@@ -1,0 +1,1 @@
+- Fix recently registered systems filter (bsc#1243183)


### PR DESCRIPTION
## What does this PR change?

It fixes the numeric filter by decoding HTML entities and improving the matcher selection logic. Previously, the component could incorrectly match shorter operators (like <) when longer ones (like <=) were intended.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bug fix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

Issue(s): 

https://github.com/SUSE/spacewalk/issues/27222

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
