### PR TITLE
Remove SCAP File Upload Size Limit from database table

### DIFF
--- a/schema/spacewalk/common/tables/rhnOrgConfiguration.sql
+++ b/schema/spacewalk/common/tables/rhnOrgConfiguration.sql
@@ -35,10 +35,6 @@ create table rhnOrgConfiguration
                                    default ('Y') not null
                                    constraint rhn_org_conf_clm_sync_patches
                                    check (clm_sync_patches in ('Y', 'N')),
-    scap_file_sizelimit        NUMERIC
-                                   default(2097152) not null
-                                   constraint rhn_org_conf_scap_szlmt_chk
-                                   check (scap_file_sizelimit >= 0),
     scap_retention_period_days NUMERIC
                                    default(90)
                                    constraint rhn_org_conf_scap_reten_chk

--- a/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-remove-scap-filesize-limit-from-db
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-remove-scap-filesize-limit-from-db
@@ -1,0 +1,1 @@
+- Remove SCAP File Upload Size Limit from database table

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/300-remove-scap-filesize-limit-from-db.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/300-remove-scap-filesize-limit-from-db.sql
@@ -1,0 +1,18 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+
+alter table rhnOrgConfiguration drop column if exists scap_file_sizelimit;
+


### PR DESCRIPTION
## What does this PR change?
As referred from issue [https://github.com/SUSE/spacewalk/issues/26829](https://github.com/SUSE/spacewalk/issues/26829)  the database field `scap_file_sizelimit` from the table `rhnOrgConfiguration` should be removed since that is a "dead" field (not referenced, read, updated by anyone)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/26829
Port(s):   **only in master 5.2, not backported**
- [x] **DONE**

## Changelogs
- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql" 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
