### PR TITLE
Added missing bootstrap definition for OES24.4 (bsc#1241013)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -428,6 +428,11 @@ DATA = {
         "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/4/bootstrap/",
     },
+    "OES24.4": {
+        "PDID": -45,
+        "PKGLIST": PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/sle/15/4/bootstrap/",
+    },
     "SLE-15-aarch64": {
         "PDID": [1589, 3052],
         "BETAPDID": [3056],

--- a/susemanager/susemanager.changes.mackdk.add-OES24.4-bootstrap-definition
+++ b/susemanager/susemanager.changes.mackdk.add-OES24.4-bootstrap-definition
@@ -1,0 +1,2 @@
+- Added missing bootrap repository definition for OES 24.4
+  (bsc#1241013)


### PR DESCRIPTION
## What does this PR change?

This PR adds the bootstrap repository definition for OES 24.4, which is currently available as a product to synchronize but it is not listed when trying to create its bootstrap  repository.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix on a documented feature

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27005
Port(s): [4.3](https://github.com/SUSE/spacewalk/pull/27680) [5.0](https://github.com/SUSE/spacewalk/pull/27681)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
