### PR TITLE
Fix parameter binding in product repositories query (bsc#1244724)

### DIFF
--- a/python/spacewalk/server/importlib/backend.py
+++ b/python/spacewalk/server/importlib/backend.py
@@ -2094,15 +2094,14 @@ class Backend:
             )
         if toinsert[0]:
             insert_pr.executemany(
-                id=toinsert[0],
-                product_id=toinsert[1],
-                root_id=toinsert[2],
-                repo_id=toinsert[3],
-                channel_label=toinsert[4],
-                parent_channel_label=toinsert[5],
-                channel_name=toinsert[6],
-                mandatory=toinsert[7],
-                update_tag=toinsert[8],
+                product_id=toinsert[0],
+                root_id=toinsert[1],
+                repo_id=toinsert[2],
+                channel_label=toinsert[3],
+                parent_channel_label=toinsert[4],
+                channel_name=toinsert[5],
+                mandatory=toinsert[6],
+                update_tag=toinsert[7],
             )
         if toupdate[0]:
             update_pr.executemany(

--- a/python/spacewalk/spacewalk-backend.changes.mackdk.fix-parameter-binding
+++ b/python/spacewalk/spacewalk-backend.changes.mackdk.fix-parameter-binding
@@ -1,0 +1,2 @@
+- Fix parameter error when syncing product repositories in ISS v1
+  (bsc#1244724)


### PR DESCRIPTION
## What does this PR change?

This PR fixes the parameter binding that happens when executing the query to insert new rows into `susechanneltemplate`. In fact, since the table has been renamed, the number and the order of the parameters is wrong, breaking the ISSv1 synchronization.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27563
Port(s): 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
