### PR TITLE
Dedupe top level `" AND "` in license lists

### DIFF
--- a/web/html/src/build/check-package.js
+++ b/web/html/src/build/check-package.js
@@ -8,7 +8,7 @@ const fs = require("fs");
 const path = require("path");
 const semver = require("semver");
 
-module.exports = async () => {
+module.exports = async (opts) => {
   let hasFailed = false;
 
   const dirname = path.dirname(__filename);
@@ -42,6 +42,12 @@ module.exports = async () => {
     }
   }
   if (hasFailed) {
-    throw new RangeError("Have you installed the latest dependencies? Try running: yarn install");
+    const errorMessage = "Have you installed the latest dependencies? Try running: yarn install";
+    if (opts.force) {
+      console.error(errorMessage);
+      console.warn("WARN: Ignoring package check errors because build was called with --force");
+    } else {
+      throw new RangeError(errorMessage);
+    }
   }
 };

--- a/web/html/src/build/licenses/index.js
+++ b/web/html/src/build/licenses/index.js
@@ -13,7 +13,7 @@ const licenseTextFile = path.resolve(vendors, "npm.licenses.txt");
 const licenseListFile = path.resolve(vendors, "npm.licenses.structured.js");
 const hashFile = path.resolve(vendors, "npm.licenses.hash.txt");
 
-async function aggregateLicenses() {
+async function aggregateLicenses(opts) {
   const licenseTextExists = await fileExists(licenseTextFile);
   const licenseListExists = await fileExists(licenseListFile);
   let previousHash;
@@ -24,7 +24,7 @@ async function aggregateLicenses() {
   }
 
   const currentHash = await getFileHash(path.resolve(webHtmlSrc, "yarn.lock"));
-  if (previousHash && previousHash === currentHash && licenseTextExists && licenseListExists) {
+  if (opts.force !== true && previousHash && previousHash === currentHash && licenseTextExists && licenseListExists) {
     console.info("Skipping license check, hashes match");
     return;
   }
@@ -50,7 +50,8 @@ async function aggregateLicenses() {
       ...new Set(
         Array.from(dependencies.values())
           .flat()
-          .map((item) => item.license)
+          // If the license is "X AND Y", append "X" and "Y" into the individual license types separately to dedupe them
+          .flatMap((item) => item?.license?.split(" AND "))
           .filter(Boolean)
           .sort((a, b) => a.localeCompare(b))
       ),

--- a/web/html/src/build/licenses/override.js
+++ b/web/html/src/build/licenses/override.js
@@ -1,9 +1,9 @@
 const applyOverrides = (name, version, license) => {
   /**
-   * If the license is "X OR Y" or "X AND B", but doesn't include parentheses, wrap it so it's correct in the aggregate list
+   * If the license is "X OR Y" but doesn't include parentheses, wrap it so it's correct in the aggregate list
    */
   const hasParens = /^\(.*\)$/.test(license);
-  if ((license.includes(" OR ") || license.includes(" AND ")) && !hasParens) {
+  if (license.includes(" OR ") && !hasParens) {
     license = `(${license})`;
   }
 

--- a/web/html/src/build/webpack.config.js
+++ b/web/html/src/build/webpack.config.js
@@ -91,7 +91,7 @@ module.exports = (env, opts) => {
     console.log("webpack mode: " + opts.mode);
   }
 
-  return {
+  const config = {
     mode: opts.mode,
     entry: {
       "javascript/manager/main": path.resolve(__dirname, "../manager/index.ts"),
@@ -282,4 +282,10 @@ module.exports = (env, opts) => {
       },
     },
   };
+
+  if (opts.force) {
+    config.cache = false;
+  }
+
+  return config;
 };

--- a/web/html/src/vendors/npm.licenses.structured.js
+++ b/web/html/src/vendors/npm.licenses.structured.js
@@ -1,1 +1,1 @@
-module.exports = ["(GPL-3.0 OR MIT)","(MPL-2.0 OR Apache-2.0)","(OFL-1.1 AND MIT)","0BSD","Apache-2.0","BSD-2-Clause","BSD-3-Clause","CC-BY-4.0","ISC","LGPL-3.0-or-later","MIT","MPL-2.0","Python-2.0"];
+module.exports = ["(GPL-3.0 OR MIT)","(MPL-2.0 OR Apache-2.0)","0BSD","Apache-2.0","BSD-2-Clause","BSD-3-Clause","CC-BY-4.0","ISC","LGPL-3.0-or-later","MIT","MPL-2.0","OFL-1.1","Python-2.0"];

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n spacewalk-html
 Summary:        HTML document files for Spacewalk
-License:        (GPL-3.0 OR MIT) AND (MPL-2.0 OR Apache-2.0) AND (OFL-1.1 AND MIT) AND 0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-4.0 AND GPL-2.0-only AND ISC AND LGPL-3.0-or-later AND MIT AND MPL-2.0 AND Python-2.0
+License:        (GPL-3.0 OR MIT) AND (MPL-2.0 OR Apache-2.0) AND 0BSD AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC-BY-4.0 AND GPL-2.0-only AND ISC AND LGPL-3.0-or-later AND MIT AND MPL-2.0 AND OFL-1.1 AND Python-2.0
 # FIXME: use correct group or remove it, see "https://en.opensuse.org/openSUSE:Package_group_guidelines"
 Group:          Applications/Internet
 Requires:       httpd


### PR DESCRIPTION
## What does this PR change?

First part of license information normalization, see https://suse.slack.com/archives/C02D130RBA6/p1751369981259119 for context.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: build tooling

- [x] **DONE**

## Links

https://suse.slack.com/archives/C02D130RBA6/p1751369981259119

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
