### PR TITLE
Change salt queue allocation

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEvent.hbm.xml
@@ -41,11 +41,4 @@
         <return-scalar column="id" type="long"/>
     </sql-query>
 
-    <sql-query name="SaltEvent.fixQueueNumbers">
-        <![CDATA[
-            UPDATE suseSaltEvent
-                SET queue = mod(cast(cast('x'||substr(md5(minion_id),1,8) as bit(32)) as bigint), :queues) + 1
-                WHERE minion_id <> '';
-        ]]>
-    </sql-query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEventFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEventFactory.java
@@ -84,14 +84,14 @@ public class SaltEventFactory extends HibernateFactory {
 
     /**
      * Update event queue numbers after config change.
-     * @param queues number of queues
+     * Has an effect only when reducing the number of available queues.
+     * All events which are in queues higher than max queues will be moved to the last queue
+     * @param maxQueueNum maximal available queue number
      * @return the number of updated events
      */
-    public static int fixQueueNumbers(int queues) {
-        return getSession()
-                .getNamedQuery("SaltEvent.fixQueueNumbers")
-                .setParameter("queues", queues)
+    public static int fixQueueNumbers(int maxQueueNum) {
+        return getSession().createNativeQuery("UPDATE suseSaltEvent SET queue = :q WHERE queue > :q")
+                .setParameter("q", maxQueueNum)
                 .executeUpdate();
     }
-
 }

--- a/java/code/src/com/redhat/rhn/domain/reactor/SaltEventFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/reactor/SaltEventFactory.java
@@ -32,12 +32,12 @@ import java.util.stream.Stream;
  */
 public class SaltEventFactory extends HibernateFactory {
 
-    private static Logger log = LogManager.getLogger(SaltEventFactory.class);
-    private static SaltEventFactory singleton = new SaltEventFactory();
+    private static final Logger LOG = LogManager.getLogger(SaltEventFactory.class);
+    private static final SaltEventFactory SINGLETON = new SaltEventFactory();
 
     @Override
     protected Logger getLogger() {
-        return log;
+        return LOG;
     }
 
     private SaltEventFactory() {
@@ -50,7 +50,7 @@ public class SaltEventFactory extends HibernateFactory {
      *  without any minion ID. This queue is referred to as queue 0.
      */
     public static List<Long> countSaltEvents(int queuesCount) {
-        List<Object[]> countObjects = singleton.listObjectsByNamedQuery("SaltEvent.countSaltEvents", Map.of());
+        List<Object[]> countObjects = SINGLETON.listObjectsByNamedQuery("SaltEvent.countSaltEvents", Map.of());
 
         return IntStream.range(0, queuesCount).mapToLong(i -> countObjects.stream()
                 .filter(c -> c[0].equals(i))
@@ -66,7 +66,7 @@ public class SaltEventFactory extends HibernateFactory {
      * @return events
      */
     public static Stream<SaltEvent> popSaltEvents(int limit, int queue) {
-        List<Object[]> eventObjects = singleton.listObjectsByNamedQuery("SaltEvent.popSaltEvents",
+        List<Object[]> eventObjects = SINGLETON.listObjectsByNamedQuery("SaltEvent.popSaltEvents",
                 Map.of("limit", limit, "queue", queue));
 
         return eventObjects.stream()
@@ -79,7 +79,7 @@ public class SaltEventFactory extends HibernateFactory {
      * @return event ids actually deleted
      */
     public static List<Long> deleteSaltEvents(Collection<Long> ids) {
-        return singleton.listObjectsByNamedQuery("SaltEvent.deleteSaltEvents", Map.of("ids", ids));
+        return SINGLETON.listObjectsByNamedQuery("SaltEvent.deleteSaltEvents", Map.of("ids", ids));
     }
 
     /**

--- a/java/spacewalk-java.changes.mcalmer.change-salt-queue-allocation
+++ b/java/spacewalk-java.changes.mcalmer.change-salt-queue-allocation
@@ -1,0 +1,3 @@
+- Assign a salt event not anymore to a fix queue but choose the
+  least used one by keeping all events from the same minion in
+  the same queue

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -66,7 +66,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 import time
 import fnmatch
-import hashlib
 
 try:
     import psycopg2
@@ -148,16 +147,9 @@ class Responder:
             and not self._is_salt_mine_event(tag, data)
             and not self._is_presence_ping(tag, data)
         ):
-            queue = 0
-            if "id" in data:
-                hash_sum = hashlib.sha256(
-                    data.get("id").encode(self.connection.encoding)
-                ).hexdigest()[0:8]
-                queue = (
-                    int(hash_sum, 16) % self.config["events"]["thread_pool_size"] + 1
-                )
-            log.debug("%s: Adding event to queue %d -> %s", __name__, queue, tag)
             try:
+                queue = self._get_queue(data.get("id"))
+                log.debug("%s: Adding event to queue %d -> %s", __name__, queue, tag)
                 self.cursor.execute(
                     "INSERT INTO suseSaltEvent (minion_id, data, queue) VALUES (%s, %s, %s);",
                     (data.get("id"), json.dumps({"tag": tag, "data": data}), queue),
@@ -177,6 +169,29 @@ class Responder:
                 log.debug("%s: %s", __name__, self.cursor.query)
         else:
             log.debug("%s: Discarding event -> %s", __name__, tag)
+
+    def _get_queue(self, minion_id):
+        if minion_id:
+            self.cursor.execute(
+                """
+                  SELECT COALESCE (
+                      (SELECT MAX(queue)
+                       FROM   suseSaltEvent
+                       WHERE  minion_id = %s),
+                      (SELECT X.queue
+                       FROM   (SELECT   Q.queue,
+                                        (SELECT COUNT(*) FROM suseSaltEvent sa where Q.queue = sa.queue) as count
+                               FROM     (SELECT generate_series(1, %s) queue) Q
+                               ORDER BY count, Q.queue
+                               LIMIT 1) X
+                      )
+                  ) queue;""",
+                (minion_id, int(self.config["events"]["thread_pool_size"])),
+            )
+            row = self.cursor.fetchone()
+            if row is not None:
+                return int(row[0])
+        return 0
 
     def trace_log(self):
         log.trace("%s: queues sizes -> %s", __name__, self.counters)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.change-salt-queue-allocation
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.change-salt-queue-allocation
@@ -1,0 +1,3 @@
+- Assign a salt event not anymore to a fix queue but choose the
+  least used one by keeping all events from the same minion in
+  the same queue


### PR DESCRIPTION
## What does this PR change?

With the current allocation algorithm we cannot say if we equally allocate the events over all queues.
It might happen that a few queues are fully loaded and events must wait, while others are empty.

The idea of a better allocation algorithm is, that we use for new minion ids the queue with the fewest entries.
If a minion id has already an event waiting to be handled in a queue, we add new events to the same queue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manual tested

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27713
Port(s): To be discussed

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
