### PR TITLE
Proxy helm: fix the traefik api version (bsc#1244919)

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.5.0-proxy-helm
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.5.0-proxy-helm
@@ -1,0 +1,1 @@
+- Use traefik.io API group (bsc#1244919)

--- a/containers/proxy-helm/templates/k3s-ingress-routes.yaml
+++ b/containers/proxy-helm/templates/k3s-ingress-routes.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.ingress "traefik" }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: ssl-router
@@ -15,7 +15,7 @@ spec:
   tls:
     passthrough: true
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: ssh-router
@@ -29,7 +29,7 @@ spec:
       - name: uyuni-proxy-tcp
         port: 8022
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: salt-publish-router
@@ -43,7 +43,7 @@ spec:
       - name: uyuni-proxy-tcp
         port: 4505
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: salt-request-router
@@ -57,7 +57,7 @@ spec:
       - name: uyuni-proxy-tcp
         port: 4506
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteUDP
 metadata:
   name: tftp-router


### PR DESCRIPTION
## What does this PR change?

Traefik v3 moved the API group from traefik.containo.us to traefik.io, the helm chart needs to be updated with this. The new API group valid since traefik 2.10 (shipped with k3s 1.25.15 / 1.26.10 / 1.27.7 / 1.28.3 / 1.29+)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: no test of the proxy on kubernetes yet

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27573
Port(s): https://github.com/SUSE/spacewalk/pull/27725

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
