### PR TITLE
Simplify action handling (step 1 - SaltServerActionService)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action.java
+++ b/java/code/src/com/redhat/rhn/domain/action/Action.java
@@ -18,25 +18,33 @@ import com.redhat.rhn.common.util.StringUtil;
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
 import com.suse.manager.webui.websocket.WebSocketActionIdProvider;
+import com.suse.salt.netapi.calls.LocalCall;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * Action - Class representation of the table rhnAction.
  */
 public class Action extends BaseDomainHelper implements Serializable, WebSocketActionIdProvider {
+    private static final Logger LOG = LogManager.getLogger(Action.class);
 
     public static final Integer NAME_LENGTH_LIMIT = 128;
 
@@ -398,4 +406,17 @@ public class Action extends BaseDomainHelper implements Serializable, WebSocketA
     public String getWebSocketActionId() {
         return null;
     }
+
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Action type {} is not supported with Salt", actionType != null ? actionType.getName() : "");
+        }
+        return Collections.emptyMap();
+    }
 }
+

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -30,10 +30,13 @@ import com.redhat.rhn.domain.action.ansible.PlaybookAction;
 import com.redhat.rhn.domain.action.appstream.AppStreamAction;
 import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
 import com.redhat.rhn.domain.action.config.ConfigAction;
+import com.redhat.rhn.domain.action.config.ConfigDeployAction;
+import com.redhat.rhn.domain.action.config.ConfigDiffAction;
 import com.redhat.rhn.domain.action.config.ConfigRevisionAction;
 import com.redhat.rhn.domain.action.config.ConfigRevisionActionResult;
 import com.redhat.rhn.domain.action.config.ConfigUploadAction;
 import com.redhat.rhn.domain.action.config.ConfigUploadMtimeAction;
+import com.redhat.rhn.domain.action.config.ConfigVerifyAction;
 import com.redhat.rhn.domain.action.config.DaemonConfigAction;
 import com.redhat.rhn.domain.action.dup.DistUpgradeAction;
 import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
@@ -46,6 +49,14 @@ import com.redhat.rhn.domain.action.kickstart.KickstartInitiateGuestAction;
 import com.redhat.rhn.domain.action.kickstart.KickstartScheduleSyncAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageActionDetails;
+import com.redhat.rhn.domain.action.rhnpackage.PackageAutoUpdateAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageDeltaAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageLockAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageRefreshListAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageRemoveAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageRunTransactionAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageUpdateAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageVerifyAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesActionDetails;
 import com.redhat.rhn.domain.action.salt.build.ImageBuildAction;
@@ -362,47 +373,86 @@ public class ActionFactory extends HibernateFactory {
      */
     public static Action createAction(ActionType typeIn, Date earliest) {
         Action retval;
-        if (typeIn.equals(TYPE_ERRATA)) {
+
+        if (typeIn.equals(TYPE_PACKAGES_REFRESH_LIST)) {
+            retval = new PackageRefreshListAction();
+        }
+        else if (typeIn.equals(TYPE_HARDWARE_REFRESH_LIST)) {
+            retval = new HardwareRefreshAction();
+        }
+        else if (typeIn.equals(TYPE_PACKAGES_UPDATE)) {
+            retval = new PackageUpdateAction();
+        }
+        else if (typeIn.equals(TYPE_PACKAGES_REMOVE)) {
+            retval = new PackageRemoveAction();
+        }
+        else if (typeIn.equals(TYPE_ERRATA)) {
             ErrataAction ea = new ErrataAction();
             ea.setDetails(new ActionPackageDetails(ea, false));
             retval = ea;
         }
-        else if (typeIn.equals(TYPE_SCRIPT_RUN)) {
-            retval = new ScriptRunAction();
+        else if (typeIn.equals(TYPE_UP2DATE_CONFIG_GET)) {
+            retval = new Up2DateConfigGetAction();
         }
-        else if (typeIn.equals(TYPE_CONFIGFILES_DIFF) ||
-                typeIn.equals(TYPE_CONFIGFILES_DEPLOY) ||
-                typeIn.equals(TYPE_CONFIGFILES_VERIFY)) {
-            retval = new ConfigAction();
+        else if (typeIn.equals(TYPE_UP2DATE_CONFIG_UPDATE)) {
+            retval = new Up2DateConfigUpdateAction();
+        }
+        else if (typeIn.equals(TYPE_PACKAGES_DELTA)) {
+            retval = new PackageDeltaAction();
+        }
+        else if (typeIn.equals(TYPE_REBOOT)) {
+            retval = new RebootAction();
+        }
+        else if (typeIn.equals(TYPE_ROLLBACK_CONFIG)) {
+            retval = new RollbackConfigAction();
+        }
+        else if (typeIn.equals(TYPE_ROLLBACK_LISTTRANSACTIONS)) {
+            retval = new RollbackListTransactionsAction();
+        }
+        else if (typeIn.equals(TYPE_ROLLBACK_ROLLBACK)) {
+            retval = new RollbackAction();
+        }
+        else if (typeIn.equals(TYPE_PACKAGES_AUTOUPDATE)) {
+            retval = new PackageAutoUpdateAction();
+        }
+        else if (typeIn.equals(TYPE_PACKAGES_RUNTRANSACTION)) {
+            retval = new PackageRunTransactionAction();
         }
         else if (typeIn.equals(TYPE_CONFIGFILES_UPLOAD)) {
             retval = new ConfigUploadAction();
         }
-        else if (typeIn.equals(TYPE_PACKAGES_AUTOUPDATE) ||
-                typeIn.equals(TYPE_PACKAGES_DELTA) ||
-                typeIn.equals(TYPE_PACKAGES_REFRESH_LIST) ||
-                typeIn.equals(TYPE_PACKAGES_REMOVE) ||
-                typeIn.equals(TYPE_PACKAGES_RUNTRANSACTION) ||
-                typeIn.equals(TYPE_PACKAGES_UPDATE) ||
-                typeIn.equals(TYPE_PACKAGES_VERIFY) ||
-                typeIn.equals(TYPE_PACKAGES_LOCK)) {
-            retval = new PackageAction();
+        else if (typeIn.equals(TYPE_CONFIGFILES_DEPLOY)) {
+            retval = new ConfigDeployAction();
         }
-        else if (typeIn.equals(TYPE_CONFIGFILES_MTIME_UPLOAD)) {
-            retval = new ConfigUploadMtimeAction();
+        else if (typeIn.equals(TYPE_CONFIGFILES_VERIFY)) {
+            retval = new ConfigVerifyAction();
         }
-        //Kickstart Actions
-        else if (typeIn.equals(TYPE_KICKSTART_SCHEDULE_SYNC)) {
-            retval = new KickstartScheduleSyncAction();
+        else if (typeIn.equals(TYPE_CONFIGFILES_DIFF)) {
+            retval = new ConfigDiffAction();
         }
         else if (typeIn.equals(TYPE_KICKSTART_INITIATE)) {
             retval = new KickstartInitiateAction();
         }
-        else if (typeIn.equals(TYPE_KICKSTART_INITIATE_GUEST)) {
-            retval = new KickstartInitiateGuestAction();
+        else if (typeIn.equals(TYPE_KICKSTART_SCHEDULE_SYNC)) {
+            retval = new KickstartScheduleSyncAction();
+        }
+        else if (typeIn.equals(TYPE_CONFIGFILES_MTIME_UPLOAD)) {
+            retval = new ConfigUploadMtimeAction();
+        }
+        else if (typeIn.equals(TYPE_SCRIPT_RUN)) {
+            retval = new ScriptRunAction();
         }
         else if (typeIn.equals(TYPE_DAEMON_CONFIG)) {
             retval = new DaemonConfigAction();
+        }
+        else if (typeIn.equals(TYPE_PACKAGES_VERIFY)) {
+            retval = new PackageVerifyAction();
+        }
+        else if (typeIn.equals(TYPE_RHN_APPLET_USE_SATELLITE)) {
+            retval = new AppletUseSatelliteAction();
+        }
+        else if (typeIn.equals(TYPE_KICKSTART_INITIATE_GUEST)) {
+            retval = new KickstartInitiateGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTIZATION_HOST_SUBSCRIBE_TO_TOOLS_CHANNEL)) {
             retval = new KickstartHostToolsChannelSubscriptionAction();
@@ -413,11 +463,17 @@ public class ActionFactory extends HibernateFactory {
         else if (typeIn.equals(TYPE_SCAP_XCCDF_EVAL)) {
             retval = new ScapAction();
         }
+        else if (typeIn.equals(TYPE_CLIENTCERT_UPDATE_CLIENT_CERT)) {
+            retval = new CertificateUpdateAction();
+        }
         else if (typeIn.equals(TYPE_DEPLOY_IMAGE)) {
             retval = new DeployImageAction();
         }
         else if (typeIn.equals(TYPE_DIST_UPGRADE)) {
             retval = new DistUpgradeAction();
+        }
+        else if (typeIn.equals(TYPE_PACKAGES_LOCK)) {
+            retval = new PackageLockAction();
         }
         else if (typeIn.equals(TYPE_APPLY_STATES)) {
             retval = new ApplyStatesAction();
@@ -434,14 +490,14 @@ public class ActionFactory extends HibernateFactory {
         else if (typeIn.equals(TYPE_PLAYBOOK)) {
             retval = new PlaybookAction();
         }
-        else if (typeIn.equals(TYPE_INVENTORY)) {
-            retval = new InventoryAction();
-        }
         else if (typeIn.equals(TYPE_COCO_ATTESTATION)) {
             retval = new CoCoAttestationAction();
         }
         else if (typeIn.equals(TYPE_APPSTREAM_CONFIGURE)) {
             retval = new AppStreamAction();
+        }
+        else if (typeIn.equals(TYPE_INVENTORY)) {
+            retval = new InventoryAction();
         }
         else if (typeIn.equals(TYPE_SUPPORTDATA_GET)) {
             retval = new SupportDataAction();

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -166,7 +166,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 </subclass>
                 <!-- ConfigAction subclass: 16, 17, 18, 22 -->
                 <subclass name="com.redhat.rhn.domain.action.config.ConfigAction"
-                        discriminator-value="16" lazy="true">
+                        discriminator-value="-16" lazy="true">
                         <set lazy="true" cascade="all" inverse="true" name="configRevisionActions" >
                                 <key column="action_id" />
                                 <one-to-many
@@ -175,10 +175,14 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                         </set>
                         <subclass
                                 name="com.redhat.rhn.domain.action.config.ConfigDeployAction"
-                                discriminator-value="17" lazy="true">
+                                discriminator-value="16" lazy="true">
                         </subclass>
                         <subclass
                                 name="com.redhat.rhn.domain.action.config.ConfigVerifyAction"
+                                discriminator-value="17" lazy="true">
+                        </subclass>
+                        <subclass
+                                name="com.redhat.rhn.domain.action.config.ConfigDiffAction"
                                 discriminator-value="18" lazy="true">
                         </subclass>
                         <!-- TODO: These last two subclasses probably don't belong here.

--- a/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -17,15 +17,22 @@ package com.redhat.rhn.domain.action;
 
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.server.MinionSummary;
 
 import com.suse.manager.attestation.AttestationManager;
 import com.suse.manager.model.attestation.CoCoAttestationStatus;
 import com.suse.manager.model.attestation.ServerCoCoAttestationReport;
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -56,5 +63,17 @@ public class CoCoAttestationAction extends Action {
         catch (Exception e) {
             LOG.log(Level.ERROR, e);
         }
+    }
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        return Map.of(
+                State.apply(Collections.singletonList(SaltParameters.COCOATTEST_REQUESTDATA), Optional.empty()),
+                minionSummaries
+        );
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/HardwareRefreshAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/HardwareRefreshAction.java
@@ -15,9 +15,54 @@
 package com.redhat.rhn.domain.action;
 
 
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
  * HardwareRefreshAction
  */
 public class HardwareRefreshAction extends Action {
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+
+        // salt-ssh minions in the 'true' partition
+        // regular minions in the 'false' partition
+        Map<Boolean, List<MinionSummary>> partitionBySSHPush = minionSummaries.stream()
+                .collect(Collectors.partitioningBy(MinionSummary::isSshPush));
+
+        // Separate SSH push minions from regular minions to apply different states
+        List<MinionSummary> sshPushMinions = partitionBySSHPush.get(true);
+        List<MinionSummary> regularMinions = partitionBySSHPush.get(false);
+
+        if (!sshPushMinions.isEmpty()) {
+            ret.put(State.apply(List.of(
+                            ApplyStatesEventMessage.HARDWARE_PROFILE_UPDATE),
+                    Optional.empty()), sshPushMinions);
+        }
+        if (!regularMinions.isEmpty()) {
+            ret.put(State.apply(Arrays.asList(
+                            ApplyStatesEventMessage.SYNC_ALL,
+                            ApplyStatesEventMessage.HARDWARE_PROFILE_UPDATE),
+                    Optional.empty()), regularMinions);
+        }
+
+        return ret;
+    }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/RebootAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/RebootAction.java
@@ -15,9 +15,34 @@
 package com.redhat.rhn.domain.action;
 
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.TransactionalUpdate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
  * RebootAction - Class representing TYPE_REBOOT
  */
 public class RebootAction extends Action {
 
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        int rebootDelay = ConfigDefaults.get().getRebootDelay();
+        return minionSummaries.stream().collect(
+                Collectors.groupingBy(
+                        m -> m.isTransactionalUpdate() ? TransactionalUpdate.reboot() :
+                                com.suse.salt.netapi.calls.modules.System.reboot(Optional.of(rebootDelay))
+                )
+        );
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/ansible/InventoryAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ansible/InventoryAction.java
@@ -14,16 +14,28 @@
  */
 package com.redhat.rhn.domain.action.ansible;
 
+import static java.util.Collections.singletonMap;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
 import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * InventoryAction - Action class representing the execution of an Ansible inventory refresh
  */
 public class InventoryAction extends Action {
-
     private InventoryActionDetails details;
 
     /**
@@ -62,5 +74,21 @@ public class InventoryAction extends Action {
                 .appendSuper(super.hashCode())
                 .append(details)
                 .toHashCode();
+    }
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        return singletonMap(executeInventoryActionCall(), minionSummaries);
+    }
+
+    private LocalCall<?> executeInventoryActionCall() {
+        String inventoryPath = details.getInventoryPath();
+
+        return new LocalCall<>(SaltParameters.ANSIBLE_INVENTORIES, empty(), of(Map.of("inventory", inventoryPath)),
+                new TypeToken<>() { });
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/ansible/PlaybookAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ansible/PlaybookAction.java
@@ -14,15 +14,31 @@
  */
 package com.redhat.rhn.domain.action.ansible;
 
-import com.redhat.rhn.domain.action.Action;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * PlaybookAction - Action class representing the execution of an Ansible playbook
  */
 public class PlaybookAction extends Action {
+    private static final String INVENTORY_PATH = "/etc/ansible/hosts";
 
     private PlaybookActionDetails details;
 
@@ -63,4 +79,34 @@ public class PlaybookAction extends Action {
                 .append(details)
                 .toHashCode();
     }
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        return singletonMap(executePlaybookActionCall(), minionSummaries);
+    }
+
+    private LocalCall<?> executePlaybookActionCall() {
+        String playbookPath = details.getPlaybookPath();
+        String rundir = new File(playbookPath).getAbsoluteFile().getParent();
+        String inventoryPath = details.getInventoryPath();
+
+        if (StringUtils.isEmpty(inventoryPath)) {
+            inventoryPath = INVENTORY_PATH;
+        }
+
+        Map<String, Object> pillarData = new HashMap<>();
+        pillarData.put("playbook_path", playbookPath);
+        pillarData.put("inventory_path", inventoryPath);
+        pillarData.put("rundir", rundir);
+        pillarData.put("flush_cache", details.isFlushCache());
+        pillarData.put("extra_vars", details.getExtraVarsContents());
+        return State.apply(singletonList(SaltParameters.ANSIBLE_RUNPLAYBOOK),
+                Optional.of(pillarData), Optional.of(true),
+                Optional.of(details.isTestMode()));
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigAction.java
@@ -17,22 +17,30 @@ package com.redhat.rhn.domain.action.config;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
+import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.html.HtmlTag;
+
+import com.suse.salt.netapi.calls.LocalCall;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
- * ConfigAction - Class representation of the table rhnAction.
+ * ConfigAction
  */
 public class ConfigAction extends Action {
-
     private Set<ConfigRevisionAction> configRevisionActions;
+
+    protected ConfigAction() {
+        //ConfigAction should never be instantiated
+        //instead, one of ConfigDiffAction, ConfigDeployAction,ConfigVerifyAction classes should
+    }
 
     /**
      * @return Returns the configRevisionActions.
@@ -115,5 +123,10 @@ public class ConfigAction extends Action {
             return p1.compareTo(p2);
         });
         return Collections.unmodifiableList(revisionActions);
+    }
+
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        throw new RuntimeException("SHOULDN'T BE HERE!");
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigDeployAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigDeployAction.java
@@ -14,9 +14,62 @@
  */
 package com.redhat.rhn.domain.action.config;
 
+import com.redhat.rhn.domain.config.ConfigRevision;
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.webui.services.ConfigChannelSaltManager;
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 /**
  * ConfigDeployAction - Class representing TYPE_CONFIGFILES_DEPLOY
  */
 public class ConfigDeployAction extends ConfigAction {
+
+
+    /**
+     * Deploy files(files, directory, symlink) through state.apply
+     *
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+
+        Map<Long, MinionSummary> targetMap = minionSummaries.stream().
+                collect(Collectors.toMap(MinionSummary::getServerId, minionId-> minionId));
+
+        Map<MinionSummary, Set<ConfigRevision>> serverConfigMap = getConfigRevisionActions()
+                .stream()
+                .filter(cra -> targetMap.containsKey(cra.getServer().getId()))
+                .collect(Collectors.groupingBy(
+                        cra -> targetMap.get(cra.getServer().getId()),
+                        Collectors.mapping(ConfigRevisionAction::getConfigRevision, Collectors.toSet())));
+        Map<Set<ConfigRevision>, Set<MinionSummary>> revsServersMap = serverConfigMap.entrySet()
+                .stream()
+                .collect(Collectors.groupingBy(Map.Entry::getValue,
+                        Collectors.mapping(Map.Entry::getKey, Collectors.toSet())));
+        revsServersMap.forEach((configRevisions, selectedServers) -> {
+            List<Map<String, Object>> fileStates = configRevisions
+                    .stream()
+                    .map(revision -> ConfigChannelSaltManager.getInstance().getStateParameters(revision))
+                    .toList();
+            ret.put(State.apply(List.of(SaltParameters.CONFIG_DEPLOY_FILES),
+                            Optional.of(Collections.singletonMap(SaltParameters.PARAM_FILES, fileStates))),
+                    new ArrayList<>(selectedServers));
+        });
+        return ret;
+    }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigDiffAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigDiffAction.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.domain.action.config;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.server.MinionSummary;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.html.HtmlTag;
+
+import com.suse.manager.webui.services.ConfigChannelSaltManager;
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ConfigDiffAction - Class representing TYPE_CONFIGFILES_DIFF
+ */
+public class ConfigDiffAction extends ConfigAction {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getHistoryDetails(Server server, User currentUser) {
+        LocalizationService ls = LocalizationService.getInstance();
+        StringBuilder retval = new StringBuilder();
+        retval.append("</br>");
+        retval.append(ls.getMessage("system.event.configFiles"));
+        retval.append("</br>");
+        for (ConfigRevisionAction rev : this.getConfigRevisionActionsSorted()) {
+            if (rev.getServer().equals(server)) {
+                HtmlTag a = new HtmlTag("a");
+                a.setAttribute("href", "/rhn/configuration/file/FileDetails.do?sid=" +
+                        server.getId() + "&crid=" + rev.getConfigRevision().getId());
+                a.addBody(rev.getConfigRevision().getConfigFile().getConfigFileName()
+                        .getPath());
+                retval.append(a.render());
+                retval.append(" (rev. " + rev.getConfigRevision().getRevision() + ")");
+                if (rev.getConfigRevisionActionResult() != null) {
+                    a.setAttribute("href",
+                            "/rhn/systems/details/configuration/ViewDiffResult.do?sid=" +
+                                    server.getId() + "&acrid=" +
+                                    rev.getConfigRevisionActionResult().getConfigRevisionAction()
+                                            .getId());
+                    a.setBody(ls.getMessage("system.event.configFiesDiffExist"));
+                    retval.append(" ");
+                    retval.append(a.render());
+                }
+                if (rev.getFailureId() != null) {
+                    retval.append(" ");
+                    retval.append(ls.getMessage("system.event.configFiesMissing"));
+                }
+                retval.append("</br>");
+            }
+        }
+        return retval.toString();
+    }
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        List<Map<String, Object>> fileStates = getConfigRevisionActions().stream()
+                .map(ConfigRevisionAction::getConfigRevision)
+                .filter(revision -> revision.isFile() ||
+                        revision.isDirectory() ||
+                        revision.isSymlink())
+                .map(revision -> ConfigChannelSaltManager.getInstance().getStateParameters(revision))
+                .toList();
+        ret.put(com.suse.salt.netapi.calls.modules.State.apply(
+                List.of(SaltParameters.CONFIG_DIFF_FILES),
+                Optional.of(Collections.singletonMap(SaltParameters.PARAM_FILES, fileStates)),
+                Optional.of(true), Optional.of(true)), minionSummaries);
+        return ret;
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigActionTest.java
@@ -21,6 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.config.ConfigAction;
+import com.redhat.rhn.domain.action.config.ConfigDeployAction;
+import com.redhat.rhn.domain.action.config.ConfigDiffAction;
+import com.redhat.rhn.domain.action.config.ConfigVerifyAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.RhnBaseTestCase;
@@ -56,6 +59,45 @@ public class ConfigActionTest extends RhnBaseTestCase {
         assertNotNull(sameAction.getConfigRevisionActions().toArray()[1]);
         assertEquals(sameAction.getName(), testAction.getName());
         assertEquals(sameAction.getId(), testAction.getId());
+    }
+
+    @Test
+    public void testCreateConfigDeployAction() throws Exception {
+        User user = UserTestUtils.createUser("testUser", UserTestUtils
+                .createOrg("testOrg" + this.getClass().getSimpleName()));
+        Action a = ActionFactoryTest.createAction(user,
+                ActionFactory.TYPE_CONFIGFILES_DEPLOY);
+
+        assertNotNull(a);
+        assertInstanceOf(ConfigAction.class, a);
+        assertInstanceOf(ConfigDeployAction.class, a);
+        assertNotNull(a.getActionType());
+    }
+
+    @Test
+    public void testCreateConfigVerifyAction() throws Exception {
+        User user = UserTestUtils.createUser("testUser", UserTestUtils
+                .createOrg("testOrg" + this.getClass().getSimpleName()));
+        Action a = ActionFactoryTest.createAction(user,
+                ActionFactory.TYPE_CONFIGFILES_VERIFY);
+
+        assertNotNull(a);
+        assertInstanceOf(ConfigAction.class, a);
+        assertInstanceOf(ConfigVerifyAction.class, a);
+        assertNotNull(a.getActionType());
+    }
+
+    @Test
+    public void testCreateConfigDiffAction() throws Exception {
+        User user = UserTestUtils.createUser("testUser", UserTestUtils
+                .createOrg("testOrg" + this.getClass().getSimpleName()));
+        Action a = ActionFactoryTest.createAction(user,
+                ActionFactory.TYPE_CONFIGFILES_DIFF);
+
+        assertNotNull(a);
+        assertInstanceOf(ConfigAction.class, a);
+        assertInstanceOf(ConfigDiffAction.class, a);
+        assertNotNull(a.getActionType());
     }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigRevisionActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/test/ConfigRevisionActionTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.config.ConfigAction;
+import com.redhat.rhn.domain.action.config.ConfigDiffAction;
 import com.redhat.rhn.domain.action.config.ConfigRevisionAction;
 import com.redhat.rhn.domain.action.config.ConfigRevisionActionResult;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
@@ -48,7 +49,7 @@ public class ConfigRevisionActionTest extends RhnBaseTestCase {
         ConfigRevisionAction cra = new ConfigRevisionAction();
         Date now = new Date();
         Long three = 3L;
-        ConfigAction parent = new ConfigAction();
+        ConfigAction parent = new ConfigDiffAction();
         Server server = ServerFactory.createServer();
         ConfigRevision revision = ConfigurationFactory.newConfigRevision();
         ConfigRevisionActionResult result = new ConfigRevisionActionResult();

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeAction.java
@@ -15,13 +15,35 @@
 
 package com.redhat.rhn.domain.action.dup;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.product.SUSEProduct;
+import com.redhat.rhn.domain.product.SUSEProductUpgrade;
+import com.redhat.rhn.domain.server.MinionSummary;
+import com.redhat.rhn.domain.server.ServerFactory;
+
+import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+import com.suse.utils.Opt;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * DistUpgradeAction - Class representation of distribution upgrade action.
  */
 public class DistUpgradeAction extends Action {
-
     private static final long serialVersionUID = 1585401756449185047L;
     private DistUpgradeActionDetails details;
 
@@ -40,5 +62,69 @@ public class DistUpgradeAction extends Action {
     public void setDetails(DistUpgradeActionDetails detailsIn) {
         detailsIn.setParentAction(this);
         this.details = detailsIn;
+    }
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<Boolean, List<Channel>> collect = getDetails().getChannelTasks()
+                .stream().collect(Collectors.partitioningBy(
+                        ct -> ct.getTask() == DistUpgradeChannelTask.SUBSCRIBE,
+                        Collectors.mapping(DistUpgradeChannelTask::getChannel,
+                                Collectors.toList())
+                ));
+
+        List<Channel> subbed = collect.get(true);
+        List<Channel> unsubbed = collect.get(false);
+
+        getServerActions()
+                .stream()
+                .flatMap(s -> Opt.stream(s.getServer().asMinionServer()))
+                .forEach(minion -> {
+                    Set<Channel> currentChannels = minion.getChannels();
+                    unsubbed.forEach(currentChannels::remove);
+                    currentChannels.addAll(subbed);
+                    MinionPillarManager.INSTANCE.generatePillar(minion);
+                    ServerFactory.save(minion);
+                });
+
+        Map<String, Object> pillar = new HashMap<>();
+        Map<String, Object> susemanager = new HashMap<>();
+        pillar.put("susemanager", susemanager);
+        Map<String, Object> distupgrade = new HashMap<>();
+        susemanager.put("distupgrade", distupgrade);
+        distupgrade.put("dryrun", getDetails().isDryRun());
+        distupgrade.put(SaltParameters.ALLOW_VENDOR_CHANGE, getDetails().isAllowVendorChange());
+        distupgrade.put("channels", subbed.stream()
+                .sorted()
+                .map(c -> "susemanager:" + c.getLabel())
+                .collect(Collectors.toList()));
+        if (Objects.nonNull(getDetails().getMissingSuccessors())) {
+            pillar.put("missing_successors", Arrays.asList(getDetails().getMissingSuccessors().split(",")));
+        }
+        getDetails().getProductUpgrades().stream()
+                .map(SUSEProductUpgrade::getToProduct)
+                .filter(SUSEProduct::isBase)
+                .forEach(tgt -> {
+                    Map<String, String> baseproduct = new HashMap<>();
+                    baseproduct.put("name", tgt.getName());
+                    baseproduct.put("version", tgt.getVersion());
+                    baseproduct.put("arch", tgt.getArch().getLabel());
+                    distupgrade.put("targetbaseproduct", baseproduct);
+                });
+
+        HibernateFactory.commitTransaction();
+
+        LocalCall<Map<String, State.ApplyResult>> distUpgrade = State.apply(
+                Collections.singletonList(ApplyStatesEventMessage.DISTUPGRADE),
+                Optional.of(pillar)
+        );
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        ret.put(distUpgrade, minionSummaries);
+
+        return ret;
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
@@ -14,21 +14,39 @@
  */
 package com.redhat.rhn.domain.action.errata;
 
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
 import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.product.Tuple2;
+import com.redhat.rhn.domain.server.ErrataInfo;
+import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * ErrataAction - Class representation of the table rhnAction.
  */
 public class ErrataAction extends Action {
-
     private Set<Errata> errata;
     private ActionPackageDetails details;
 
@@ -107,4 +125,101 @@ public class ErrataAction extends Action {
         return retval.toString();
     }
 
+
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Set<Long> errataIds = getErrata().stream()
+                .map(Errata::getId).collect(Collectors.toSet());
+        boolean allowVendorChange = getDetails().getAllowVendorChange();
+
+        Map<Boolean, List<MinionSummary>> byUbuntu = minionSummaries.stream()
+                .collect(partitioningBy(m -> m.getOs().equals("Ubuntu")));
+
+        Map<LocalCall<Map<String, State.ApplyResult>>, List<MinionSummary>> ubuntuErrataInstallCalls =
+                errataToPackageInstallCalls(byUbuntu.get(true), errataIds);
+
+        Set<Long> minionServerIds = byUbuntu.get(false).stream()
+                .map(MinionSummary::getServerId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Map<Long, Set<ErrataInfo>>> errataInfos = ServerFactory
+                .listErrataNamesForServers(minionServerIds, errataIds);
+
+        // Group targeted minions by errata names
+        Map<Set<ErrataInfo>, List<MinionSummary>> collect = byUbuntu.get(false).stream()
+                .collect(Collectors.groupingBy(minionId -> errataInfos.get(minionId.getServerId())
+                        .values().stream()
+                        .flatMap(Set::stream)
+                        .collect(Collectors.toSet())
+                ));
+
+        // Convert errata names to LocalCall objects of type State.apply
+        Map<LocalCall<?>, List<MinionSummary>> patchableCalls = collect.entrySet().stream()
+                .collect(Collectors.toMap(entry -> {
+                            Map<String, Object> params = new HashMap<>();
+                            params.put(SaltParameters.PARAM_REGULAR_PATCHES,
+                                    entry.getKey().stream()
+                                            .filter(e -> !e.isUpdateStack())
+                                            .map(ErrataInfo::getName)
+                                            .sorted()
+                                            .collect(toList())
+                            );
+                            params.put(SaltParameters.ALLOW_VENDOR_CHANGE, allowVendorChange);
+                            params.put(SaltParameters.PARAM_UPDATE_STACK_PATCHES,
+                                    entry.getKey().stream()
+                                            .filter(ErrataInfo::isUpdateStack)
+                                            .map(ErrataInfo::getName)
+                                            .sorted()
+                                            .collect(toList())
+                            );
+                            if (entry.getKey().stream().anyMatch(ErrataInfo::includeSalt)) {
+                                params.put("include_salt_upgrade", true);
+                            }
+                            return State.apply(
+                                    List.of(SaltParameters.PACKAGES_PATCHINSTALL),
+                                    Optional.of(params)
+                            );
+                        },
+                        Map.Entry::getValue));
+        patchableCalls.putAll(ubuntuErrataInstallCalls);
+        return patchableCalls;
+    }
+
+    private Map<LocalCall<Map<String, State.ApplyResult>>, List<MinionSummary>> errataToPackageInstallCalls(
+            List<MinionSummary> minions,
+            Set<Long> errataIds) {
+        Set<Long> minionIds = minions.stream()
+                .map(MinionSummary::getServerId).collect(Collectors.toSet());
+        Map<Long, Map<String, Tuple2<String, String>>> longMapMap =
+                ServerFactory.listNewestPkgsForServerErrata(minionIds, errataIds);
+
+        // group minions by packages that need to be updated
+        Map<Map<String, Tuple2<String, String>>, List<MinionSummary>> nameArchVersionToMinions =
+                minions.stream().collect(
+                        Collectors.groupingBy(minion -> longMapMap.get(minion.getServerId()))
+                );
+
+        return nameArchVersionToMinions.entrySet().stream().collect(toMap(
+                entry -> State.apply(
+                        singletonList(SaltParameters.PACKAGES_PKGINSTALL),
+                        Optional.of(singletonMap(SaltParameters.PARAM_PKGS,
+                                entry.getKey().entrySet()
+                                        .stream()
+                                        .map(e -> List.of(
+                                                e.getKey(),
+                                                e.getValue().getA().replaceAll("-deb$", ""),
+                                                e.getValue().getB().endsWith("-X") ?
+                                                        e.getValue().getB()
+                                                                .substring(0, e.getValue().getB().length() - 2) :
+                                                        e.getValue().getB()))
+                                        .collect(Collectors.toList())))
+                ),
+                Map.Entry::getValue
+        ));
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartInitiateAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/kickstart/KickstartInitiateAction.java
@@ -15,9 +15,160 @@
 package com.redhat.rhn.domain.action.kickstart;
 
 
+import com.redhat.rhn.domain.kickstart.KickstartFactory;
+import com.redhat.rhn.domain.kickstart.KickstartableTree;
+import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.server.MinionSummary;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
+
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.cobbler.CobblerConnection;
+import org.cobbler.Distro;
+import org.cobbler.Profile;
+import org.cobbler.SystemRecord;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * KickstartInitiateAction
  */
 public class KickstartInitiateAction extends KickstartAction {
+    private static final Logger LOG = LogManager.getLogger(KickstartInitiateAction.class);
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        KickstartActionDetails ksActionDetails = getKickstartActionDetails();
+        String cobblerSystem = ksActionDetails.getCobblerSystemName();
+        String host = ksActionDetails.getKickstartHost();
+        Map<String, String> bootParams = prepareCobblerBoot(host, cobblerSystem, true);
+        Map<String, Object> pillar = new HashMap<>(bootParams);
+        pillar.put("uyuni-reinstall-name", "reinstall-system");
+        String kOpts = bootParams.get("kopts");
+
+        if (kOpts.contains("autoupgrade=1") || kOpts.contains("uyuni_keep_saltkey=1")) {
+            ksActionDetails.setUpgrade(true);
+        }
+        ret.put(State.apply(List.of(SaltParameters.KICKSTART_INITIATE), Optional.of(pillar)), minionSummaries);
+
+        return ret;
+    }
+
+    private Map<String, String> prepareCobblerBoot(String kickstartHost,
+                                                   String cobblerSystem,
+                                                   boolean autoinstall) {
+        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
+        SystemRecord system = SystemRecord.lookupByName(con, cobblerSystem);
+        Profile profile = system.getProfile();
+        Distro dist = profile.getDistro();
+        String kernel = dist.getKernel();
+        String initrd = dist.getInitrd();
+
+        List<String> nameParts = Arrays.asList(dist.getName().split(":"));
+        String saltFSKernel = Paths.get(nameParts.get(1), nameParts.get(0), new File(kernel).getName()).toString();
+        String saltFSInitrd = Paths.get(nameParts.get(1), nameParts.get(0), new File(initrd).getName()).toString();
+        KickstartableTree tree = KickstartFactory.lookupKickstartTreeByLabel(nameParts.get(0),
+                OrgFactory.lookupById(Long.valueOf(nameParts.get(1))));
+        tree.createOrUpdateSaltFS();
+        String kOpts = buildKernelOptions(system, kickstartHost, autoinstall);
+
+
+        Map<String, String> pillar = new HashMap<>();
+        pillar.put("kernel", saltFSKernel);
+        pillar.put("initrd", saltFSInitrd);
+        pillar.put("kopts", kOpts);
+
+        return pillar;
+    }
+
+
+
+    private static String buildKernelOptions(SystemRecord sys, String host, boolean autoinstall) {
+        String breed = sys.getProfile().getDistro().getBreed();
+        Map<String, Object> kopts = sys.getResolvedKernelOptions();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Resolved kernel options for {}: {}", sys.getName(), convertOptionsMap(kopts));
+        }
+        if (breed.equals("suse")) {
+            //SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
+            if (kopts.containsKey("textmode")) {
+                kopts.remove("text");
+            }
+            else if (kopts.containsKey("text")) {
+                kopts.remove("text");
+                kopts.put("textmode", "1");
+            }
+        }
+        // no additional initrd parameter allowed
+        kopts.remove("initrd");
+        String kernelOptions = convertOptionsMap(kopts);
+        String autoinst = "http://" + host + "/cblr/svc/op/autoinstall/system/" + sys.getName();
+
+        if (StringUtils.isBlank(breed) || breed.equals("redhat")) {
+            if (sys.getProfile().getDistro().getOsVersion().equals("rhel6")) {
+                kernelOptions += " kssendmac ks=" + autoinst;
+            }
+            else {
+                kernelOptions += " inst.ks.sendmac ks=" + autoinst;
+            }
+        }
+        else if (breed.equals("suse")) {
+            kernelOptions += "autoyast=" + autoinst;
+        }
+        else if (breed.equals("debian") || breed.equals("ubuntu")) {
+            kernelOptions += "auto-install/enable=true priority=critical netcfg/choose_interface=auto url=" + autoinst;
+        }
+
+        if (autoinstall) {
+            String infoUrl = "http://" + host + "/cblr/svc/op/nopxe/system/" + sys.getName();
+            kernelOptions += " info=" + infoUrl;
+        }
+        return kernelOptions;
+    }
+
+
+
+    private static String convertOptionsMap(Map<String, Object> map) {
+        StringBuilder string = new StringBuilder();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            List<String> keyList;
+            try {
+                keyList = (List<String>)entry.getValue();
+            }
+            catch (ClassCastException e) {
+                keyList = new ArrayList<>();
+                keyList.add((String) entry.getValue());
+            }
+            string.append(key);
+            if (keyList.isEmpty()) {
+                string.append(" ");
+            }
+            else {
+                for (String value : keyList) {
+                    string.append("=").append(value).append(" ");
+                }
+            }
+        }
+        return string.toString();
+    }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
@@ -31,9 +31,12 @@ import java.util.Set;
  * PackageAction
  */
 public class PackageAction extends Action {
-
     private static final long serialVersionUID = -6964115307447205711L;
     private Set<PackageActionDetails> details = new HashSet<>();
+
+    protected PackageAction() {
+        //should instantiate one of the child classes
+    }
 
     /**
      * Add a PackageActionDetails to the set of details

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRefreshListAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRefreshListAction.java
@@ -15,9 +15,31 @@
 package com.redhat.rhn.domain.action.rhnpackage;
 
 
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * PackageRefreshListAction
  */
 public class PackageRefreshListAction extends PackageAction {
 
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        ret.put(State.apply(List.of(ApplyStatesEventMessage.PACKAGES_PROFILE_UPDATE),
+                Optional.empty()), minionSummaries);
+        return ret;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRemoveAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRemoveAction.java
@@ -15,9 +15,55 @@
 package com.redhat.rhn.domain.action.rhnpackage;
 
 
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
  * PackageRemoveAction
  */
 public class PackageRemoveAction extends PackageAction {
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        List<List<String>> pkgsAll =
+                getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
+                        d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
+                .toList();
+
+        List<List<String>> uniquePkgs = new ArrayList<>();
+        pkgsAll.forEach(d -> {
+            if (!uniquePkgs.stream().map(p -> p.get(0))
+                    .toList()
+                    .contains(d.get(0))) {
+                uniquePkgs.add(d);
+            }
+        });
+        List<List<String>> duplicatedPkgs = pkgsAll.stream()
+                .filter(p -> !uniquePkgs.contains(p)).collect(Collectors.toList());
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(SaltParameters.PARAM_PKGS, uniquePkgs);
+        params.put("param_pkgs_duplicates", duplicatedPkgs);
+
+        ret.put(State.apply(List.of(SaltParameters.PACKAGES_PKGREMOVE),
+                Optional.of(params)), minionSummaries);
+        return ret;
+    }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageUpdateAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageUpdateAction.java
@@ -14,9 +14,79 @@
  */
 package com.redhat.rhn.domain.action.rhnpackage;
 
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+import com.redhat.rhn.domain.errata.ErrataFactory;
+import com.redhat.rhn.domain.product.Tuple2;
+import com.redhat.rhn.domain.rhnpackage.PackageArch;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.domain.rhnpackage.PackageName;
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * PackageUpdateAction
  */
 public class PackageUpdateAction extends PackageAction {
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+
+        List<Long> sids = minionSummaries.stream().map(MinionSummary::getServerId).collect(toList());
+
+        List<String> nevraStrings = getDetails().stream().map(details -> {
+            PackageName name = details.getPackageName();
+            PackageEvr evr = details.getEvr();
+            PackageArch arch = details.getArch();
+            return name.getName() + "-" + evr.toUniversalEvrString() + "." + arch.getLabel();
+        }).collect(toList());
+
+        List<Tuple2<Long, Long>> retractedPidSidPairs = ErrataFactory.retractedPackagesByNevra(nevraStrings, sids);
+        Map<Long, List<Long>> retractedPidsBySid = retractedPidSidPairs.stream()
+                .collect(groupingBy(Tuple2::getB, mapping(Tuple2::getA, toList())));
+        getServerActions().forEach(sa -> {
+            List<Long> packageIds = retractedPidsBySid.get(sa.getServerId());
+            if (packageIds != null) {
+                sa.fail("contains retracted packages: " +
+                        packageIds.stream().map(Object::toString).collect(joining(",")));
+            }
+        });
+        List<MinionSummary> filteredMinions = minionSummaries.stream()
+                .filter(ms -> retractedPidsBySid.get(ms.getServerId()) == null ||
+                        retractedPidsBySid.get(ms.getServerId()).isEmpty())
+                .collect(toList());
+
+        List<List<String>> pkgs =
+                getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
+                        d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
+                .toList();
+        if (pkgs.isEmpty()) {
+            // Full system package update using update state
+            ret.put(State.apply(List.of(SaltParameters.PACKAGES_PKGUPDATE), Optional.empty()), filteredMinions);
+        }
+        else {
+            ret.put(State.apply(List.of(SaltParameters.PACKAGES_PKGINSTALL),
+                    Optional.of(singletonMap(SaltParameters.PARAM_PKGS, pkgs))), filteredMinions);
+        }
+        return ret;
+    }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionDetailsTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionDetailsTest.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.rhnpackage.PackageAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageActionDetails;
 import com.redhat.rhn.domain.action.rhnpackage.PackageActionResult;
+import com.redhat.rhn.domain.action.rhnpackage.PackageRefreshListAction;
 import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageName;
@@ -61,7 +62,7 @@ public class PackageActionDetailsTest extends RhnBaseTestCase {
 
         PackageEvr evr = PackageEvrFactoryTest.createTestPackageEvr();
         PackageName pn = PackageNameTest.createTestPackageName();
-        PackageAction action = new PackageAction();
+        PackageAction action = new PackageRefreshListAction();
 
         pad.setCreated(now);
         assertEquals(now, pad.getCreated());

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
@@ -17,10 +17,15 @@ package com.redhat.rhn.domain.action.salt;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
+import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 
+import com.suse.salt.netapi.calls.LocalCall;
+
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -87,4 +92,19 @@ public class ApplyStatesAction extends Action {
         }
         return ActionFormatter.formatSaltResultMessage(resultList.get());
     }
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        ret.put(com.suse.salt.netapi.calls.modules.State.apply(details.getMods(), details.getPillarsMap(),
+                Optional.of(true),
+                details.isTest() ? Optional.of(details.isTest()) : Optional.empty()), minionSummaries);
+        return ret;
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildAction.java
@@ -14,13 +14,53 @@
  */
 package com.redhat.rhn.domain.action.salt.build;
 
+import static java.util.stream.Collectors.toMap;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.image.DockerfileProfile;
+import com.redhat.rhn.domain.image.ImageProfile;
+import com.redhat.rhn.domain.image.ImageProfileFactory;
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.image.KiwiProfile;
+import com.redhat.rhn.domain.image.ProfileCustomDataValue;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactory;
+import com.redhat.rhn.domain.server.MinionSummary;
+import com.redhat.rhn.domain.token.ActivationKey;
+import com.redhat.rhn.domain.token.ActivationKeyFactory;
+
+import com.suse.manager.webui.utils.token.DownloadTokenBuilder;
+import com.suse.manager.webui.utils.token.TokenBuildingException;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * ApplyStatesAction - Action class representing the application of Salt states.
  */
 public class ImageBuildAction extends Action {
+    private static final Logger LOG = LogManager.getLogger(ImageBuildAction.class);
 
     private ImageBuildActionDetails details;
 
@@ -51,4 +91,130 @@ public class ImageBuildAction extends Action {
         return formatter;
     }
 
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+
+        if (details == null) {
+            return Collections.emptyMap();
+        }
+        return ImageProfileFactory.lookupById(details.getImageProfileId()).map(
+                ip -> imageBuildAction(minionSummaries, Optional.ofNullable(details.getVersion()), ip,
+                        getId())
+        ).orElseGet(Collections::emptyMap);
+    }
+
+    protected Map<LocalCall<?>, List<MinionSummary>> imageBuildAction(
+            List<MinionSummary> minionSummaries, Optional<String> version,
+            ImageProfile profile, Long actionId) {
+        List<ImageStore> imageStores = new LinkedList<>();
+        imageStores.add(profile.getTargetStore());
+
+        List<MinionServer> minions = MinionServerFactory.findMinionsByServerIds(
+                minionSummaries.stream().map(MinionSummary::getServerId).collect(Collectors.toList()));
+
+        //TODO: optimal scheduling would be to group by host and orgid
+        return minions.stream().collect(
+                Collectors.toMap(minion -> {
+                            Map<String, Object> pillar = new HashMap<>();
+
+                            profile.asDockerfileProfile().ifPresent(dockerfileProfile -> {
+                                Map<String, Object> dockerRegistries = ImageStore.dockerRegPillar(imageStores);
+                                pillar.put("docker-registries", dockerRegistries);
+
+                                String repoPath = Path.of(profile.getTargetStore().getUri(),
+                                        profile.getLabel()).toString();
+                                String tag = version.orElse("");
+                                String certificate = "";
+                                // salt 2016.11 dockerng require imagename while salt 2018.3 docker requires it separate
+                                pillar.put("imagerepopath", repoPath);
+                                pillar.put("imagetag", tag);
+                                pillar.put("imagename", repoPath + ":" + tag);
+                                pillar.put("builddir", dockerfileProfile.getPath());
+                                pillar.put("build_id", "build" + actionId);
+                                try {
+                                    //TODO: maybe from the database
+                                    certificate = String.join("\n\n", Files.readAllLines(
+                                            Paths.get("/srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT"),
+                                            Charset.defaultCharset()
+                                    ));
+                                }
+                                catch (IOException e) {
+                                    LOG.error("Could not read certificate", e);
+                                }
+                                pillar.put("cert", certificate);
+                                String repocontent = "";
+                                if (profile.getToken() != null) {
+                                    repocontent = profile.getToken().getChannels().stream()
+                                            .map(s -> "[susemanager:" + s.getLabel() + "]\n\n" +
+                                                    "name=" + s.getName() + "\n\n" +
+                                                    "enabled=1\n\n" +
+                                                    "autorefresh=1\n\n" +
+                                                    "baseurl=" + getChannelUrl(minion, s.getLabel()) + "\n\n" +
+                                                    "type=rpm-md\n\n" +
+                                                    "gpgcheck=0\n\n" // we use trusted content and SSL.
+                                            ).collect(Collectors.joining("\n\n"));
+                                }
+                                pillar.put("repo", repocontent);
+
+                                // Add custom info values
+                                pillar.put("customvalues", profile.getCustomDataValues().stream()
+                                        .collect(toMap(v -> v.getKey().getLabel(), ProfileCustomDataValue::getValue)));
+                            });
+
+                            profile.asKiwiProfile().ifPresent(kiwiProfile -> {
+                                pillar.put("source", kiwiProfile.getPath());
+                                pillar.put("build_id", "build" + actionId);
+                                pillar.put("kiwi_options", kiwiProfile.getKiwiOptions());
+                                List<String> repos = new ArrayList<>();
+                                final ActivationKey activationKey =
+                                        ActivationKeyFactory.lookupByToken(profile.getToken());
+                                Set<Channel> channels = activationKey.getChannels();
+                                for (Channel channel : channels) {
+                                    repos.add(getChannelUrl(minion, channel.getLabel()));
+                                }
+                                pillar.put("kiwi_repositories", repos);
+                                pillar.put("activation_key", activationKey.getKey());
+                            });
+
+                            String saltCall = "";
+                            if (profile instanceof DockerfileProfile) {
+                                saltCall = "images.docker";
+                            }
+                            else if (profile instanceof KiwiProfile) {
+                                saltCall = "images.kiwi-image-build";
+                            }
+
+                            return State.apply(
+                                    Collections.singletonList(saltCall),
+                                    Optional.of(pillar)
+                            );
+                        },
+                        m -> Collections.singletonList(new MinionSummary(m))
+                ));
+    }
+
+    private String getChannelUrl(MinionServer minion, String channelLabel) {
+        String token;
+
+        try {
+            token = new DownloadTokenBuilder(minion.getOrg().getId())
+                    .usingServerSecret()
+                    .expiringAfterMinutes(Config.get().getInt(ConfigDefaults.TEMP_TOKEN_LIFETIME))
+                    .allowingOnlyChannels(Set.of(channelLabel))
+                    .build()
+                    .getSerializedForm();
+        }
+        catch (TokenBuildingException e) {
+            LOG.error("Could not generate token for {}", channelLabel, e);
+            token = "";
+        }
+
+        String host = minion.getChannelHost();
+
+        return "https://" + host + "/rhn/manager/download/" + channelLabel + "?" + token;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/inspect/ImageInspectAction.java
@@ -16,6 +16,19 @@ package com.redhat.rhn.domain.action.salt.inspect;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFormatter;
+import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.image.ImageStoreFactory;
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * ImageInspectAction
@@ -49,6 +62,47 @@ public class ImageInspectAction extends Action {
             formatter = new ImageInspectActionFormatter(this);
         }
         return formatter;
+    }
+
+    /**
+     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        if (details == null) {
+            return Collections.emptyMap();
+        }
+        return ImageStoreFactory.lookupById(details.getImageStoreId())
+                .map(store -> imageInspectAction(minionSummaries, store))
+                .orElseGet(Collections::emptyMap);
+    }
+
+    private Map<LocalCall<?>, List<MinionSummary>> imageInspectAction(List<MinionSummary> minions,
+                                                                      ImageStore store) {
+        Map<String, Object> pillar = new HashMap<>();
+        Map<LocalCall<?>, List<MinionSummary>> result = new HashMap<>();
+        if (ImageStoreFactory.TYPE_OS_IMAGE.equals(store.getStoreType())) {
+            pillar.put("build_id", "build" + details.getBuildActionId());
+            LocalCall<Map<String, State.ApplyResult>> apply = State.apply(
+                    Collections.singletonList("images.kiwi-image-inspect"),
+                    Optional.of(pillar));
+            result.put(apply, minions);
+            return result;
+        }
+        else {
+            List<ImageStore> imageStores = new LinkedList<>();
+            imageStores.add(store);
+            Map<String, Object> dockerRegistries = ImageStore.dockerRegPillar(imageStores);
+            pillar.put("docker-registries", dockerRegistries);
+            pillar.put("imagename", store.getUri() + "/" + details.getName() + ":" + details.getVersion());
+            pillar.put("build_id", "build" + details.getBuildActionId());
+            LocalCall<Map<String, State.ApplyResult>> apply = State.apply(
+                    Collections.singletonList("images.profileupdate"),
+                    Optional.of(pillar));
+            result.put(apply, minions);
+            return result;
+        }
     }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -14,22 +14,60 @@
  */
 package com.redhat.rhn.domain.action.script;
 
+import static com.suse.manager.webui.services.SaltConstants.SALT_FS_PREFIX;
+import static com.suse.manager.webui.services.SaltConstants.SCRIPTS_DIR;
+
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.FileUtils;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.download.DownloadManager;
 
 import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.services.SaltParameters;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
 
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.file.attribute.UserPrincipal;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 
 /**
  * ScriptRunAction
  */
 public class ScriptRunAction extends ScriptAction {
+    /* Logger for this class */
+    private static final Logger LOG = LogManager.getLogger(ScriptRunAction.class);
+
+    private static boolean skipCommandScriptPerms = false;
+    /**
+     * Only used in unit tests.
+     * @param skipCommandScriptPermsIn to set
+     */
+    public static void setSkipCommandScriptPerms(boolean skipCommandScriptPermsIn) {
+        skipCommandScriptPerms = skipCommandScriptPermsIn;
+    }
 
     private static final SaltUtils SALT_UTILS = GlobalInstanceHolder.SALT_UTILS;
 
@@ -86,5 +124,74 @@ public class ScriptRunAction extends ScriptAction {
         if (allServersFinished()) {
             FileUtils.deleteFile(SALT_UTILS.getScriptPath(getId()));
         }
+    }
+
+
+    /**
+     * @param minions a list of minion summaries of the minions involved in the given Action
+     * @return minion summaries grouped by local call
+     */
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minions) {
+        String script = getScriptActionDetails().getScriptContents();
+
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+        // write script to /srv/susemanager/salt/scripts/script_<action_id>.sh
+        Path scriptFile = SALT_UTILS.getScriptPath(getId());
+        try {
+            // make sure parent dir exists
+            if (!Files.exists(scriptFile) && !Files.exists(scriptFile.getParent())) {
+                FileAttribute<Set<PosixFilePermission>> dirAttributes =
+                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x"));
+
+                Files.createDirectory(scriptFile.getParent(), dirAttributes);
+                // make sure correct user is set
+            }
+
+            if (!skipCommandScriptPerms) {
+                setFileOwner(scriptFile.getParent());
+            }
+
+            // In case of action retry, the files script files will be already created.
+            if (!Files.exists(scriptFile)) {
+                FileAttribute<Set<PosixFilePermission>> fileAttributes =
+                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
+                Files.createFile(scriptFile, fileAttributes);
+                org.apache.commons.io.FileUtils.writeStringToFile(scriptFile.toFile(),
+                        script.replace("\r\n", "\n"), StandardCharsets.UTF_8);
+            }
+
+            if (!skipCommandScriptPerms) {
+                setFileOwner(scriptFile);
+            }
+
+            // state.apply remotecommands
+            Map<String, Object> pillar = new HashMap<>();
+            pillar.put("mgr_remote_cmd_script", SALT_FS_PREFIX + SCRIPTS_DIR + "/" + scriptFile.getFileName());
+            pillar.put("mgr_remote_cmd_runas", getScriptActionDetails().getUsername());
+            pillar.put("mgr_remote_cmd_timeout", getScriptActionDetails().getTimeout());
+            ret.put(State.apply(List.of(SaltParameters.REMOTE_COMMANDS), Optional.of(pillar)), minions);
+        }
+        catch (IOException e) {
+            String errorMsg = "Could not write script to file " + scriptFile + " - " + e;
+            LOG.error(errorMsg, e);
+            getServerActions().stream()
+                    .filter(entry -> entry.getServer().asMinionServer()
+                            .map(minionServer -> minions.contains(new MinionSummary(minionServer)))
+                            .orElse(false))
+                    .forEach(sa -> {
+                        sa.fail("Error scheduling the action: " + errorMsg);
+                        ActionFactory.save(sa);
+                    });
+        }
+        return ret;
+    }
+
+    private void setFileOwner(Path path) throws IOException {
+        FileSystem fileSystem = FileSystems.getDefault();
+        UserPrincipalLookupService service = fileSystem.getUserPrincipalLookupService();
+        UserPrincipal tomcatUser = service.lookupPrincipalByName("tomcat");
+
+        Files.setOwner(path, tomcatUser);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/supportdata/SupportDataAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/supportdata/SupportDataAction.java
@@ -12,9 +12,24 @@
 package com.redhat.rhn.domain.action.supportdata;
 
 import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.server.MinionSummary;
+
+import com.suse.manager.webui.utils.MinionActionUtils;
+import com.suse.manager.webui.utils.salt.LocalCallWithExecutors;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.State;
+import com.suse.salt.netapi.calls.modules.Test;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * SupportDataAction - Class representing TYPE_SUPPORTDATA_GET
@@ -53,5 +68,31 @@ public class SupportDataAction extends Action {
                 .appendSuper(super.hashCode())
                 .append(details)
                 .toHashCode();
+    }
+
+    @Override
+    public Map<LocalCall<?>, List<MinionSummary>> getSaltCalls(List<MinionSummary> minionSummaries) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+
+        var partitioned = minionSummaries.stream().collect(Collectors.partitioningBy(minionSummary -> {
+            var actionPath = MinionActionUtils.getFullActionPath(getOrg().getId(), minionSummary.getServerId(),
+                    getId());
+            var bundle = actionPath.resolve("bundle.tar");
+            return Files.exists(bundle);
+        }));
+
+        var pillar = Optional.ofNullable(getDetails().getParameter())
+                .map(p -> Map.of("arguments", (Object)p));
+        var full = partitioned.get(false);
+        var onlyUpload = partitioned.get(true);
+        if (!full.isEmpty()) {
+            // supportdata should be taken always in direct mode - also on transactional systems
+            var apply = State.apply(List.of("supportdata"), pillar);
+            ret.put(new LocalCallWithExecutors<>(apply, List.of("direct_call"), Collections.emptyMap()), full);
+        }
+        if (!onlyUpload.isEmpty()) {
+            ret.put(Test.echo("supportdata"), onlyUpload);
+        }
+        return ret;
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/image/ImageStore.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageStore.java
@@ -21,6 +21,12 @@ import com.redhat.rhn.domain.org.Org;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.beans.Transient;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -170,4 +176,23 @@ public class ImageStore extends BaseDomainHelper {
                                     .append(org)
                                     .toHashCode();
     }
+
+    /**
+     * @param stores list of stores
+     * @return map
+     */
+    @Transient
+    public static Map<String, Object> dockerRegPillar(List<ImageStore> stores) {
+        Map<String, Object> dockerRegistries = new HashMap<>();
+        stores.forEach(store -> Optional.ofNullable(store.getCreds())
+                .ifPresent(credentials -> {
+                    Map<String, Object> reg = new HashMap<>();
+                    reg.put("email", "tux@example.com");
+                    reg.put("password", credentials.getPassword());
+                    reg.put("username", credentials.getUsername());
+                    dockerRegistries.put(store.getUri(), reg);
+                }));
+        return dockerRegistries;
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -26,6 +26,8 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.access.AccessGroupFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
+import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.action.server.test.ServerActionTest;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.channel.Channel;
@@ -107,6 +109,7 @@ import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.services.SaltParameters;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
@@ -1143,8 +1146,12 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         List<MinionServer> minions = Arrays.asList(zypperSystem, nonZypperSystem);
         List<MinionSummary> minionSummaries = minions.stream().map(MinionSummary::new).collect(Collectors.toList());
 
-        Map<LocalCall<?>, List<MinionSummary>> localCallListMap =
-                SALT_SERVER_ACTION_SERVICE.errataAction(minionSummaries, Collections.singleton(e1.getId()), false);
+        ErrataAction ea = new ErrataAction();
+        ea.addErrata(e1);
+        ActionPackageDetails apd = new ActionPackageDetails(ea, false);
+        ea.setDetails(apd);
+
+        Map<LocalCall<?>, List<MinionSummary>> localCallListMap = ea.getSaltCalls(minionSummaries);
 
         assertEquals(1, localCallListMap.size());
         localCallListMap.forEach((call, value) -> {
@@ -1154,12 +1161,12 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             assertEquals(Collections.singletonList("packages.patchinstall"), kwarg.get("mods"));
             Map<String, Object> pillar = (Map<String, Object>) kwarg.get("pillar");
             Collection<String> regularPatches = (Collection<String>) pillar
-                    .get(SaltServerActionService.PARAM_REGULAR_PATCHES);
+                    .get(SaltParameters.PARAM_REGULAR_PATCHES);
             assertEquals(1, regularPatches.size());
             assertTrue(regularPatches.contains("SUSE-" + updateTag + "-2016-1234"));
 
             Collection<String> updateStackPatches = (Collection<String>) pillar
-                    .get(SaltServerActionService.PARAM_UPDATE_STACK_PATCHES);
+                    .get(SaltParameters.PARAM_UPDATE_STACK_PATCHES);
             assertEquals(0, updateStackPatches.size());
         });
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -404,6 +404,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
@@ -423,6 +426,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
@@ -526,6 +532,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
@@ -545,6 +554,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
@@ -638,6 +650,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
@@ -656,6 +671,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
 
         HibernateFactory.getSession().flush();
@@ -721,6 +739,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 
@@ -739,6 +760,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 .filter(a -> a.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS))
                 .findFirst();
         assertTrue(first.isPresent(), "No Subscribe Channels Action created");
+        if (first.isPresent()) {
+            ((SubscribeChannelsAction) first.get()).setSaltApi(saltApi);
+        }
         sa.execute(first.get(), false, false, Optional.empty());
         finishedActions.add(first.get().getId());
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -53,7 +53,7 @@ import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.controllers.channels.ChannelsUtils;
-import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.SaltParameters;
 import com.suse.manager.webui.services.iface.RedhatProductInfo;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
@@ -182,12 +182,12 @@ public class RegistrationUtils {
         if (activationKey.isPresent() && activationKey.get().getChannels().stream().anyMatch(Channel::isModular)) {
             var appStreamsToEnable = activationKey.get().getAppStreams();
             if (!appStreamsToEnable.isEmpty()) {
-                statesToApply.add(SaltServerActionService.APPSTREAMS_CONFIGURE);
+                statesToApply.add(SaltParameters.APPSTREAMS_CONFIGURE);
                 var appStreamsParams = appStreamsToEnable
                     .stream()
                     .map(it -> List.of(it.getName(), it.getStream()))
                     .collect(toList());
-                statesToApplyPillar.put(SaltServerActionService.PARAM_APPSTREAMS_ENABLE, appStreamsParams);
+                statesToApplyPillar.put(SaltParameters.PARAM_APPSTREAMS_ENABLE, appStreamsParams);
             }
         }
     }

--- a/java/code/src/com/suse/manager/reactor/test/RebootInfoBeaconTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RebootInfoBeaconTest.java
@@ -17,6 +17,7 @@ package com.suse.manager.reactor.test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
@@ -132,7 +133,7 @@ public class RebootInfoBeaconTest extends RhnJmockBaseTestCase {
     private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery, SaltApi saltApi) {
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi);
         SaltServerActionService service = new SaltServerActionService(saltApi, saltUtils, new SaltKeyUtils(saltApi));
-        service.setSkipCommandScriptPerms(true);
+        ScriptRunAction.setSkipCommandScriptPerms(true);
         return service;
     }
 }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -30,8 +30,8 @@ import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.ActionType;
 import com.redhat.rhn.domain.action.ansible.InventoryAction;
+import com.redhat.rhn.domain.action.config.ConfigAction;
 import com.redhat.rhn.domain.action.config.ConfigRevisionActionResult;
-import com.redhat.rhn.domain.action.config.ConfigVerifyAction;
 import com.redhat.rhn.domain.action.dup.DistUpgradeAction;
 import com.redhat.rhn.domain.action.dup.DistUpgradeActionDetails;
 import com.redhat.rhn.domain.action.dup.DistUpgradeChannelTask;
@@ -1169,7 +1169,11 @@ public class SaltUtils {
                                 .orElse(null),
                         fdr));
 
-        ConfigVerifyAction configAction = (ConfigVerifyAction) action;
+        ConfigAction configAction = (ConfigAction) action;
+        if (null == configAction.getConfigRevisionActions()) {
+            return;
+        }
+
         configAction.getConfigRevisionActions().forEach(cra -> {
             ConfigRevision cr = cra.getConfigRevision();
             String fileName = cr.getConfigFile().getConfigFileName().getPath();

--- a/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
@@ -16,10 +16,6 @@ package com.suse.manager.webui.services;
 
 import static com.suse.manager.webui.services.SaltConstants.SALT_FS_PREFIX;
 import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
-import static com.suse.manager.webui.services.SaltServerActionService.PACKAGES_PATCHINSTALL;
-import static com.suse.manager.webui.services.SaltServerActionService.PACKAGES_PKGINSTALL;
-import static com.suse.manager.webui.services.SaltServerActionService.PARAM_REGULAR_PATCHES;
-import static com.suse.manager.webui.services.SaltServerActionService.PARAM_UPDATE_STACK_PATCHES;
 import static com.suse.manager.webui.services.impl.SaltSSHService.ACTION_STATES_LIST;
 import static com.suse.manager.webui.services.impl.SaltSSHService.DEFAULT_TOPS;
 
@@ -267,7 +263,7 @@ public class SaltActionChainGeneratorService {
         Optional<String> mods = getModsString(moduleRun);
         SaltState retState = null;
 
-        if (mods.isPresent() && mods.get().contains(PACKAGES_PKGINSTALL)) {
+        if (mods.isPresent() && mods.get().contains(SaltParameters.PACKAGES_PKGINSTALL)) {
             Map<String, List<List<String>>> paramPillar =
                     (Map<String, List<List<String>>>) moduleRun.getKwargs().get("pillar");
             SaltPkgInstalled pkgInstalled = new SaltPkgInstalled();
@@ -279,14 +275,14 @@ public class SaltActionChainGeneratorService {
                     });
             retState = pkgInstalled;
         }
-        else if (mods.isPresent() && mods.get().contains(PACKAGES_PATCHINSTALL)) {
+        else if (mods.isPresent() && mods.get().contains(SaltParameters.PACKAGES_PATCHINSTALL)) {
             Map<String, List<String>> paramPillar =
                     (Map<String, List<String>>) moduleRun.getKwargs().get("pillar");
             SaltPatchInstalled patchInstalled = new SaltPatchInstalled();
-            for (String patch : paramPillar.get(PARAM_UPDATE_STACK_PATCHES)) {
+            for (String patch : paramPillar.get(SaltParameters.PARAM_UPDATE_STACK_PATCHES)) {
                 patchInstalled.addPatch(patch);
             }
-            for (String patch : paramPillar.get(PARAM_REGULAR_PATCHES)) {
+            for (String patch : paramPillar.get(SaltParameters.PARAM_REGULAR_PATCHES)) {
                 patchInstalled.addPatch(patch);
             }
             retState = patchInstalled;
@@ -324,7 +320,7 @@ public class SaltActionChainGeneratorService {
         if (state instanceof SaltModuleRun moduleRun) {
             Optional<String> mods = getModsString(moduleRun);
 
-            if (mods.isPresent() && mods.get().contains(PACKAGES_PKGINSTALL)) {
+            if (mods.isPresent() && mods.get().contains(SaltParameters.PACKAGES_PKGINSTALL)) {
                 if (moduleRun.getKwargs() != null) {
                     Map<String, List<List<String>>> paramPillar =
                             (Map<String, List<List<String>>>) moduleRun.getKwargs().get("pillar");
@@ -335,7 +331,7 @@ public class SaltActionChainGeneratorService {
                     }
                 }
             }
-            else if (mods.isPresent() && mods.get().contains(PACKAGES_PATCHINSTALL)) {
+            else if (mods.isPresent() && mods.get().contains(SaltParameters.PACKAGES_PATCHINSTALL)) {
                 if (moduleRun.getKwargs() != null) {
                     Map<String, List<String>> paramPillar =
                             (Map<String, List<String>>) moduleRun.getKwargs().get("pillar");
@@ -365,13 +361,13 @@ public class SaltActionChainGeneratorService {
         if (state instanceof SaltModuleRun moduleRun) {
             Optional<String> mods = getModsString(moduleRun);
 
-            if (mods.isPresent() && mods.get().contains(PACKAGES_PKGINSTALL) &&
+            if (mods.isPresent() && mods.get().contains(SaltParameters.PACKAGES_PKGINSTALL) &&
                     isSaltUpgrade(state) && !minion.isSshPush()) {
                 // split only for regular minions, salt-ssh minions don't have a
                 // salt-minion process
                 return true;
             }
-            else if (mods.isPresent() && mods.get().contains(PACKAGES_PATCHINSTALL) &&
+            else if (mods.isPresent() && mods.get().contains(SaltParameters.PACKAGES_PATCHINSTALL) &&
                     isSaltUpgrade(state)) {
                 return true;
             }

--- a/java/code/src/com/suse/manager/webui/services/SaltParameters.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltParameters.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.services;
+
+public class SaltParameters {
+    private SaltParameters() { }
+
+    public static final String PACKAGES_PKGINSTALL = "packages.pkginstall";
+    public static final String PACKAGES_PKGUPDATE = "packages.pkgupdate";
+    public static final String PACKAGES_PKGDOWNLOAD = "packages.pkgdownload";
+    public static final String PACKAGES_PATCHINSTALL = "packages.patchinstall";
+    public static final String PACKAGES_PATCHDOWNLOAD = "packages.patchdownload";
+    public static final String PACKAGES_PKGREMOVE = "packages.pkgremove";
+    public static final String PACKAGES_PKGLOCK = "packages.pkglock";
+    public static final String CONFIG_DEPLOY_FILES = "configuration.deploy_files";
+    public static final String CONFIG_DIFF_FILES = "configuration.diff_files";
+    public static final String PARAM_PKGS = "param_pkgs";
+    public static final String PARAM_PATCHES = "param_patches";
+    public static final String PARAM_FILES = "param_files";
+    public static final String REMOTE_COMMANDS = "remotecommands";
+    public static final String SYSTEM_REBOOT = "system.reboot";
+    public static final String KICKSTART_INITIATE = "bootloader.autoinstall";
+    public static final String ANSIBLE_RUNPLAYBOOK = "ansible.runplaybook";
+    public static final String ANSIBLE_INVENTORIES = "ansible.targets";
+    public static final String COCOATTEST_REQUESTDATA = "cocoattest.requestdata";
+    public static final String APPSTREAMS_CONFIGURE = "appstreams.configure";
+    public static final String PARAM_APPSTREAMS_ENABLE = "param_appstreams_enable";
+    public static final String PARAM_APPSTREAMS_DISABLE = "param_appstreams_disable";
+
+    /** SLS pillar parameter name for the list of update stack patch names. */
+    public static final String PARAM_UPDATE_STACK_PATCHES = "param_update_stack_patches";
+
+    /** SLS pillar parameter name for the list of regular patch names. */
+    public static final String PARAM_REGULAR_PATCHES = "param_regular_patches";
+    public static final String ALLOW_VENDOR_CHANGE = "allow_vendor_change";
+    public static final String INVENTORY_PATH = "/etc/ansible/hosts";
+}

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -10,30 +10,17 @@
  */
 package com.suse.manager.webui.services;
 
-import static com.redhat.rhn.common.hibernate.HibernateFactory.unproxy;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_COMPLETED;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_FAILED;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_QUEUED;
-import static com.suse.manager.webui.services.SaltConstants.SALT_FS_PREFIX;
-import static com.suse.manager.webui.services.SaltConstants.SCRIPTS_DIR;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.RhnRuntimeException;
-import com.redhat.rhn.common.conf.Config;
-import com.redhat.rhn.common.conf.ConfigDefaults;
-import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
@@ -41,96 +28,36 @@ import com.redhat.rhn.domain.action.ActionChainEntry;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
-import com.redhat.rhn.domain.action.ActionType;
-import com.redhat.rhn.domain.action.ansible.InventoryAction;
-import com.redhat.rhn.domain.action.ansible.InventoryActionDetails;
-import com.redhat.rhn.domain.action.ansible.PlaybookAction;
-import com.redhat.rhn.domain.action.ansible.PlaybookActionDetails;
-import com.redhat.rhn.domain.action.appstream.AppStreamAction;
-import com.redhat.rhn.domain.action.appstream.AppStreamActionDetails;
-import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
-import com.redhat.rhn.domain.action.channel.SubscribeChannelsActionDetails;
-import com.redhat.rhn.domain.action.config.ConfigAction;
-import com.redhat.rhn.domain.action.config.ConfigRevisionAction;
-import com.redhat.rhn.domain.action.dup.DistUpgradeAction;
-import com.redhat.rhn.domain.action.dup.DistUpgradeChannelTask;
 import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.action.kickstart.KickstartAction;
-import com.redhat.rhn.domain.action.kickstart.KickstartActionDetails;
-import com.redhat.rhn.domain.action.kickstart.KickstartInitiateAction;
-import com.redhat.rhn.domain.action.rhnpackage.PackageLockAction;
-import com.redhat.rhn.domain.action.rhnpackage.PackageRemoveAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageUpdateAction;
-import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
-import com.redhat.rhn.domain.action.salt.ApplyStatesActionDetails;
-import com.redhat.rhn.domain.action.salt.build.ImageBuildAction;
-import com.redhat.rhn.domain.action.salt.build.ImageBuildActionDetails;
-import com.redhat.rhn.domain.action.salt.inspect.ImageInspectAction;
-import com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionDetails;
-import com.redhat.rhn.domain.action.scap.ScapAction;
-import com.redhat.rhn.domain.action.scap.ScapActionDetails;
-import com.redhat.rhn.domain.action.script.ScriptAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
-import com.redhat.rhn.domain.action.supportdata.SupportDataAction;
-import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.errata.Errata;
-import com.redhat.rhn.domain.errata.ErrataFactory;
-import com.redhat.rhn.domain.image.DockerfileProfile;
-import com.redhat.rhn.domain.image.ImageProfile;
-import com.redhat.rhn.domain.image.ImageProfileFactory;
-import com.redhat.rhn.domain.image.ImageStore;
-import com.redhat.rhn.domain.image.ImageStoreFactory;
-import com.redhat.rhn.domain.image.KiwiProfile;
-import com.redhat.rhn.domain.image.ProfileCustomDataValue;
-import com.redhat.rhn.domain.kickstart.KickstartFactory;
-import com.redhat.rhn.domain.kickstart.KickstartableTree;
-import com.redhat.rhn.domain.org.OrgFactory;
-import com.redhat.rhn.domain.product.SUSEProduct;
-import com.redhat.rhn.domain.product.SUSEProductUpgrade;
-import com.redhat.rhn.domain.product.Tuple2;
-import com.redhat.rhn.domain.rhnpackage.PackageArch;
-import com.redhat.rhn.domain.rhnpackage.PackageEvr;
-import com.redhat.rhn.domain.rhnpackage.PackageName;
 import com.redhat.rhn.domain.server.ErrataInfo;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
-import com.redhat.rhn.domain.server.ServerGroupFactory;
-import com.redhat.rhn.domain.token.ActivationKey;
-import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.dto.PackageListItem;
 import com.redhat.rhn.manager.action.ActionManager;
-import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
-import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
-import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.pillar.MinionPillarManager;
-import com.suse.manager.webui.utils.MinionActionUtils;
 import com.suse.manager.webui.utils.SaltModuleRun;
 import com.suse.manager.webui.utils.SaltState;
 import com.suse.manager.webui.utils.SaltSystemReboot;
-import com.suse.manager.webui.utils.salt.LocalCallWithExecutors;
 import com.suse.manager.webui.utils.salt.custom.MgrActionChains;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
-import com.suse.manager.webui.utils.token.DownloadTokenBuilder;
-import com.suse.manager.webui.utils.token.TokenBuildingException;
 import com.suse.salt.netapi.calls.LocalAsyncResult;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.State.ApplyResult;
-import com.suse.salt.netapi.calls.modules.Test;
-import com.suse.salt.netapi.calls.modules.TransactionalUpdate;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.exception.SaltException;
@@ -148,31 +75,11 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.cobbler.CobblerConnection;
-import org.cobbler.Distro;
-import org.cobbler.Profile;
-import org.cobbler.SystemRecord;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.nio.file.attribute.UserPrincipal;
-import java.nio.file.attribute.UserPrincipalLookupService;
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Instant;
@@ -193,12 +100,9 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -210,36 +114,6 @@ public class SaltServerActionService {
 
     /* Logger for this class */
     private static final Logger LOG = LogManager.getLogger(SaltServerActionService.class);
-    public static final String PACKAGES_PKGINSTALL = "packages.pkginstall";
-    public static final String PACKAGES_PKGUPDATE = "packages.pkgupdate";
-    private static final String PACKAGES_PKGDOWNLOAD = "packages.pkgdownload";
-    public static final String PACKAGES_PATCHINSTALL = "packages.patchinstall";
-    private static final String PACKAGES_PATCHDOWNLOAD = "packages.patchdownload";
-    private static final String PACKAGES_PKGREMOVE = "packages.pkgremove";
-    private static final String PACKAGES_PKGLOCK = "packages.pkglock";
-    private static final String CONFIG_DEPLOY_FILES = "configuration.deploy_files";
-    private static final String CONFIG_DIFF_FILES = "configuration.diff_files";
-    private static final String PARAM_PKGS = "param_pkgs";
-    private static final String PARAM_PATCHES = "param_patches";
-    private static final String PARAM_FILES = "param_files";
-    private static final String REMOTE_COMMANDS = "remotecommands";
-    private static final String SYSTEM_REBOOT = "system.reboot";
-    private static final String KICKSTART_INITIATE = "bootloader.autoinstall";
-    private static final String ANSIBLE_RUNPLAYBOOK = "ansible.runplaybook";
-    private static final String ANSIBLE_INVENTORIES = "ansible.targets";
-    private static final String COCOATTEST_REQUESTDATA = "cocoattest.requestdata";
-    public static final String APPSTREAMS_CONFIGURE = "appstreams.configure";
-    public static final String PARAM_APPSTREAMS_ENABLE = "param_appstreams_enable";
-    public static final String PARAM_APPSTREAMS_DISABLE = "param_appstreams_disable";
-
-    /** SLS pillar parameter name for the list of update stack patch names. */
-    public static final String PARAM_UPDATE_STACK_PATCHES = "param_update_stack_patches";
-
-    /** SLS pillar parameter name for the list of regular patch names. */
-    public static final String PARAM_REGULAR_PATCHES = "param_regular_patches";
-    public static final String ALLOW_VENDOR_CHANGE = "allow_vendor_change";
-    private static final String INVENTORY_PATH = "/etc/ansible/hosts";
-
 
     private boolean commitTransaction = true;
 
@@ -250,7 +124,6 @@ public class SaltServerActionService {
     private final SaltSSHService saltSSHService = GlobalInstanceHolder.SALT_API.getSaltSSHService();
     private SaltUtils saltUtils;
     private final SaltKeyUtils saltKeyUtils;
-    private boolean skipCommandScriptPerms;
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
 
     /**
@@ -287,133 +160,7 @@ public class SaltServerActionService {
             return Collections.emptyMap();
         }
 
-        ActionType actionType = actionIn.getActionType();
-        actionIn = unproxy(actionIn);
-        if (ActionFactory.TYPE_ERRATA.equals(actionType)) {
-            ErrataAction errataAction = (ErrataAction) actionIn;
-            Set<Long> errataIds = errataAction.getErrata().stream()
-                    .map(Errata::getId).collect(Collectors.toSet());
-            return errataAction(minions, errataIds, errataAction.getDetails().getAllowVendorChange());
-        }
-        else if (ActionFactory.TYPE_PACKAGES_LOCK.equals(actionType)) {
-            return packagesLockAction(minions, (PackageLockAction) actionIn);
-        }
-        else if (ActionFactory.TYPE_SUPPORTDATA_GET.equals(actionType)) {
-            return supportDataAction(minions, (SupportDataAction) actionIn);
-        }
-        else if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(actionType)) {
-            return packagesUpdateAction(minions, (PackageUpdateAction) actionIn);
-        }
-        else if (ActionFactory.TYPE_PACKAGES_REMOVE.equals(actionType)) {
-            return packagesRemoveAction(minions, (PackageRemoveAction) actionIn);
-        }
-        else if (ActionFactory.TYPE_PACKAGES_REFRESH_LIST.equals(actionType)) {
-            return packagesRefreshListAction(minions);
-        }
-        else if (ActionFactory.TYPE_HARDWARE_REFRESH_LIST.equals(actionType)) {
-            return hardwareRefreshListAction(minions);
-        }
-        else if (ActionFactory.TYPE_VIRT_PROFILE_REFRESH.equals(actionType)) {
-            return virtualInstanceRefreshListAction(minions);
-        }
-        else if (ActionFactory.TYPE_REBOOT.equals(actionType)) {
-            return rebootAction(minions);
-        }
-        else if (ActionFactory.TYPE_CONFIGFILES_DEPLOY.equals(actionType)) {
-            return deployFiles(minions, (ConfigAction) actionIn);
-        }
-        else if (ActionFactory.TYPE_CONFIGFILES_DIFF.equals(actionType)) {
-            return diffFiles(minions, (ConfigAction) actionIn);
-        }
-        else if (ActionFactory.TYPE_SCRIPT_RUN.equals(actionType)) {
-            return remoteCommandAction(minions, (ScriptAction) actionIn);
-        }
-        else if (ActionFactory.TYPE_APPLY_STATES.equals(actionType)) {
-            ApplyStatesActionDetails actionDetails = ((ApplyStatesAction) actionIn).getDetails();
-            return applyStatesAction(minions, actionDetails.getMods(),
-                                     actionDetails.getPillarsMap(), actionDetails.isTest(),
-                                     actionDetails.isDirect());
-        }
-        else if (ActionFactory.TYPE_IMAGE_INSPECT.equals(actionType)) {
-            ImageInspectAction iia = (ImageInspectAction) actionIn;
-            ImageInspectActionDetails details = iia.getDetails();
-            if (details == null) {
-                return Collections.emptyMap();
-            }
-            return ImageStoreFactory.lookupById(details.getImageStoreId())
-                    .map(store -> imageInspectAction(minions, details, store))
-                    .orElseGet(Collections::emptyMap);
-        }
-        else if (ActionFactory.TYPE_IMAGE_BUILD.equals(actionType)) {
-            ImageBuildAction imageBuildAction = (ImageBuildAction) actionIn;
-           ImageBuildActionDetails details = imageBuildAction.getDetails();
-            if (details == null) {
-                return Collections.emptyMap();
-            }
-            return ImageProfileFactory.lookupById(details.getImageProfileId()).map(
-                    ip -> imageBuildAction(minions, Optional.ofNullable(details.getVersion()), ip,
-                            imageBuildAction.getId())
-            ).orElseGet(Collections::emptyMap);
-        }
-        else if (ActionFactory.TYPE_DIST_UPGRADE.equals(actionType)) {
-            return distUpgradeAction((DistUpgradeAction) actionIn, minions);
-        }
-        else if (ActionFactory.TYPE_SCAP_XCCDF_EVAL.equals(actionType)) {
-            ScapAction scapAction = (ScapAction)actionIn;
-            return scapXccdfEvalAction(minions, scapAction.getScapActionDetails());
-        }
-        else if (ActionFactory.TYPE_SUBSCRIBE_CHANNELS.equals(actionType)) {
-            SubscribeChannelsAction subscribeAction = (SubscribeChannelsAction)actionIn;
-            return subscribeChanelsAction(minions, subscribeAction.getDetails());
-        }
-        else if (ActionFactory.TYPE_KICKSTART_INITIATE.equals(actionType)) {
-            KickstartInitiateAction autoInitAction = (KickstartInitiateAction)actionIn;
-            return autoinstallInitAction(minions, autoInitAction);
-        }
-        else if (ActionFactory.TYPE_PLAYBOOK.equals(actionType)) {
-            return singletonMap(executePlaybookActionCall((PlaybookAction) actionIn), minions);
-        }
-        else if (ActionFactory.TYPE_INVENTORY.equals(actionType)) {
-            return singletonMap(executeInventoryActionCall((InventoryAction) actionIn), minions);
-        }
-        else if (ActionFactory.TYPE_COCO_ATTESTATION.equals(actionType)) {
-            return cocoAttestationAction(minions);
-        }
-        else if (ActionFactory.TYPE_APPSTREAM_CONFIGURE.equals(actionType)) {
-            return appStreamAction(minions, (AppStreamAction) actionIn);
-        }
-        else {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Action type {} is not supported with Salt", actionType != null ? actionType.getName() : "");
-            }
-            return Collections.emptyMap();
-        }
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> supportDataAction(List<MinionSummary> minions,
-                                                                     SupportDataAction action) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-
-        var partitioned = minions.stream().collect(Collectors.partitioningBy(minionSummary -> {
-            var actionPath = MinionActionUtils.getFullActionPath(action.getOrg().getId(), minionSummary.getServerId(),
-                    action.getId());
-            var bundle = actionPath.resolve("bundle.tar");
-            return Files.exists(bundle);
-        }));
-
-        var pillar = Optional.ofNullable(action.getDetails().getParameter())
-                .map(p -> Map.of("arguments", (Object)p));
-        var full = partitioned.get(false);
-        var onlyUpload = partitioned.get(true);
-        if (!full.isEmpty()) {
-            // supportdata should be taken always in direct mode - also on transactional systems
-            var apply = State.apply(List.of("supportdata"), pillar);
-            ret.put(new LocalCallWithExecutors<>(apply, List.of("direct_call"), Collections.emptyMap()), full);
-        }
-        if (!onlyUpload.isEmpty()) {
-            ret.put(Test.echo("supportdata"), onlyUpload);
-        }
-        return ret;
+        return actionIn.getSaltCalls(minions);
     }
 
     /**
@@ -693,7 +440,7 @@ public class SaltServerActionService {
                         // skip reboot, needs special handling
                         stateResult ->
                                 stateResult.getName().map(x -> x.fold(Arrays::asList, List::of)
-                                        .contains(SYSTEM_REBOOT)).orElse(false));
+                                        .contains(SaltParameters.SYSTEM_REBOOT)).orElse(false));
 
                 boolean refreshPkg = false;
                 Optional<User> scheduler = Optional.empty();
@@ -710,7 +457,7 @@ public class SaltServerActionService {
 
                         Action action = ActionFactory.lookupById(stateId.getActionId());
                         if (stateResult.getName().map(x -> x.fold(Arrays::asList, List::of)
-                                .contains(SYSTEM_REBOOT)).orElse(false) && stateResult.isResult() &&
+                                .contains(SaltParameters.SYSTEM_REBOOT)).orElse(false) && stateResult.isResult() &&
                                 action.getActionType().equals(ActionFactory.TYPE_REBOOT)) {
 
                             Optional<ServerAction> rebootServerAction =
@@ -725,7 +472,7 @@ public class SaltServerActionService {
                                         }
                                     },
                                     () -> LOG.error("Action of type {} found in action chain result but not " +
-                                            "in actions for minion {}", SYSTEM_REBOOT, minionId));
+                                            "in actions for minion {}", SaltParameters.SYSTEM_REBOOT, minionId));
                         }
 
                         if (stateResult.isResult() &&
@@ -986,7 +733,7 @@ public class SaltServerActionService {
                             !mods.isEmpty() ?
                                     singletonMap("mods", mods) : emptyMap(),
                             createStateApplyKwargs(kwargs));
-                case SYSTEM_REBOOT:
+                case SaltParameters.SYSTEM_REBOOT:
                     Integer time = (Integer)kwargs.get("at_time");
                     return new SaltSystemReboot(stateId,
                             serverAction.getParentAction().getId(), time);
@@ -1009,862 +756,6 @@ public class SaltServerActionService {
         return applyKwargs;
     }
 
-
-    /**
-     * This function will return a map with list of minions grouped by the
-     * salt netapi local call that executes what needs to be executed on
-     * those minions for the given errata ids and minions.
-     *
-     * @param minionSummaries list of minion summaries to target
-     * @param errataIds list of errata ids
-     * @param allowVendorChange true if vendor change allowed
-     * @return minion summaries grouped by local call
-     */
-    public Map<LocalCall<?>, List<MinionSummary>> errataAction(List<MinionSummary> minionSummaries,
-            Set<Long> errataIds, boolean allowVendorChange) {
-        Map<Boolean, List<MinionSummary>> byUbuntu = minionSummaries.stream()
-                .collect(partitioningBy(m -> m.getOs().equals("Ubuntu")));
-
-        Map<LocalCall<Map<String, ApplyResult>>, List<MinionSummary>> ubuntuErrataInstallCalls =
-                errataToPackageInstallCalls(byUbuntu.get(true), errataIds);
-
-        Set<Long> minionServerIds = byUbuntu.get(false).stream()
-                .map(MinionSummary::getServerId)
-                .collect(Collectors.toSet());
-
-        Map<Long, Map<Long, Set<ErrataInfo>>> errataInfos = ServerFactory
-                .listErrataNamesForServers(minionServerIds, errataIds);
-
-        // Group targeted minions by errata names
-        Map<Set<ErrataInfo>, List<MinionSummary>> collect = byUbuntu.get(false).stream()
-                .collect(Collectors.groupingBy(minionId -> errataInfos.get(minionId.getServerId())
-                        .values().stream()
-                        .flatMap(Set::stream)
-                        .collect(Collectors.toSet())
-        ));
-
-        // Convert errata names to LocalCall objects of type State.apply
-        Map<LocalCall<?>, List<MinionSummary>> patchableCalls = collect.entrySet().stream()
-            .collect(Collectors.toMap(entry -> {
-                Map<String, Object> params = new HashMap<>();
-                params.put(PARAM_REGULAR_PATCHES,
-                    entry.getKey().stream()
-                        .filter(e -> !e.isUpdateStack())
-                        .map(ErrataInfo::getName)
-                        .sorted()
-                        .collect(toList())
-                );
-                params.put(ALLOW_VENDOR_CHANGE, allowVendorChange);
-                params.put(PARAM_UPDATE_STACK_PATCHES,
-                    entry.getKey().stream()
-                        .filter(ErrataInfo::isUpdateStack)
-                        .map(ErrataInfo::getName)
-                        .sorted()
-                        .collect(toList())
-                );
-                if (entry.getKey().stream().anyMatch(ErrataInfo::includeSalt)) {
-                    params.put("include_salt_upgrade", true);
-                }
-                return State.apply(
-                        List.of(PACKAGES_PATCHINSTALL),
-                        Optional.of(params)
-                );
-            },
-            Map.Entry::getValue));
-        patchableCalls.putAll(ubuntuErrataInstallCalls);
-        return patchableCalls;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> packagesLockAction(
-            List<MinionSummary> minionSummaries, PackageLockAction action) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-
-        for (MinionSummary m : minionSummaries) {
-            DataResult<PackageListItem> setLockPkg = PackageManager.systemSetLockedPackages(
-                    m.getServerId(), action.getId(), null);
-            List<List<String>> pkgs = setLockPkg.stream().map(d -> Arrays.asList(d.getName(), d.getArch(),
-                    new PackageEvr(d.getEpoch(), d.getVersion(), d.getRelease(), d.getPackageType())
-                    .toUniversalEvrString())).toList();
-            LocalCall<Map<String, ApplyResult>> localCall =
-                    State.apply(List.of(PACKAGES_PKGLOCK), Optional.of(singletonMap(PARAM_PKGS, pkgs)));
-            List<MinionSummary> mSums = ret.getOrDefault(localCall, new ArrayList<>());
-            mSums.add(m);
-            ret.put(localCall, mSums);
-        }
-        return ret;
-    }
-
-    private Map<LocalCall<Map<String, ApplyResult>>, List<MinionSummary>> errataToPackageInstallCalls(
-            List<MinionSummary> minions,
-            Set<Long> errataIds) {
-        Set<Long> minionIds = minions.stream()
-                .map(MinionSummary::getServerId).collect(Collectors.toSet());
-        Map<Long, Map<String, Tuple2<String, String>>> longMapMap =
-                ServerFactory.listNewestPkgsForServerErrata(minionIds, errataIds);
-
-        // group minions by packages that need to be updated
-        Map<Map<String, Tuple2<String, String>>, List<MinionSummary>> nameArchVersionToMinions =
-                minions.stream().collect(
-                        Collectors.groupingBy(minion -> longMapMap.get(minion.getServerId()))
-                );
-
-        return nameArchVersionToMinions.entrySet().stream().collect(toMap(
-                entry -> State.apply(
-                        singletonList(PACKAGES_PKGINSTALL),
-                        Optional.of(singletonMap(PARAM_PKGS,
-                                entry.getKey().entrySet()
-                                        .stream()
-                                        .map(e -> List.of(
-                                                e.getKey(),
-                                                e.getValue().getA().replaceAll("-deb$", ""),
-                                                e.getValue().getB().endsWith("-X") ?
-                                                    e.getValue().getB().substring(0, e.getValue().getB().length() - 2) :
-                                                    e.getValue().getB()))
-                                        .collect(Collectors.toList())))
-                ),
-                Map.Entry::getValue
-        ));
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> packagesUpdateAction(
-            List<MinionSummary> minionSummaries, PackageUpdateAction action) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-
-        List<Long> sids = minionSummaries.stream().map(MinionSummary::getServerId).collect(toList());
-
-        List<String> nevraStrings = action.getDetails().stream().map(details -> {
-            PackageName name = details.getPackageName();
-            PackageEvr evr = details.getEvr();
-            PackageArch arch = details.getArch();
-            return name.getName() + "-" + evr.toUniversalEvrString() + "." + arch.getLabel();
-        }).collect(toList());
-
-        List<Tuple2<Long, Long>> retractedPidSidPairs = ErrataFactory.retractedPackagesByNevra(nevraStrings, sids);
-        Map<Long, List<Long>> retractedPidsBySid = retractedPidSidPairs.stream()
-                .collect(groupingBy(Tuple2::getB, mapping(Tuple2::getA, toList())));
-        action.getServerActions().forEach(sa -> {
-            List<Long> packageIds = retractedPidsBySid.get(sa.getServerId());
-            if (packageIds != null) {
-                sa.fail("contains retracted packages: " +
-                        packageIds.stream().map(Object::toString).collect(joining(",")));
-            }
-        });
-        List<MinionSummary> filteredMinions = minionSummaries.stream()
-                .filter(ms -> retractedPidsBySid.get(ms.getServerId()) == null ||
-                        retractedPidsBySid.get(ms.getServerId()).isEmpty())
-                .collect(toList());
-
-        List<List<String>> pkgs = action
-                .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
-                        d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
-                .toList();
-        if (pkgs.isEmpty()) {
-            // Full system package update using update state
-            ret.put(State.apply(List.of(PACKAGES_PKGUPDATE), Optional.empty()), filteredMinions);
-        }
-        else {
-            ret.put(State.apply(List.of(PACKAGES_PKGINSTALL),
-                    Optional.of(singletonMap(PARAM_PKGS, pkgs))), filteredMinions);
-        }
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> packagesRemoveAction(
-            List<MinionSummary> minionSummaries, PackageRemoveAction action) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        List<List<String>> pkgsAll = action
-                .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
-                        d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
-                .toList();
-
-        List<List<String>> uniquePkgs = new ArrayList<>();
-        pkgsAll.forEach(d -> {
-                if (!uniquePkgs.stream().map(p -> p.get(0))
-                        .toList()
-                        .contains(d.get(0))) {
-                                uniquePkgs.add(d);
-                }
-        });
-        List<List<String>> duplicatedPkgs = pkgsAll.stream()
-                .filter(p -> !uniquePkgs.contains(p)).collect(Collectors.toList());
-
-        Map<String, Object> params = new HashMap<>();
-        params.put(PARAM_PKGS, uniquePkgs);
-        params.put("param_pkgs_duplicates", duplicatedPkgs);
-
-        ret.put(State.apply(List.of(PACKAGES_PKGREMOVE),
-                Optional.of(params)), minionSummaries);
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> packagesRefreshListAction(
-            List<MinionSummary> minionSummaries) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        ret.put(State.apply(List.of(ApplyStatesEventMessage.PACKAGES_PROFILE_UPDATE),
-                Optional.empty()), minionSummaries);
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> hardwareRefreshListAction(
-            List<MinionSummary> minionSummaries) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-
-        // salt-ssh minions in the 'true' partition
-        // regular minions in the 'false' partition
-        Map<Boolean, List<MinionSummary>> partitionBySSHPush = minionSummaries.stream()
-                .collect(Collectors.partitioningBy(MinionSummary::isSshPush));
-
-        // Separate SSH push minions from regular minions to apply different states
-        List<MinionSummary> sshPushMinions = partitionBySSHPush.get(true);
-        List<MinionSummary> regularMinions = partitionBySSHPush.get(false);
-
-        if (!sshPushMinions.isEmpty()) {
-            ret.put(State.apply(List.of(
-                            ApplyStatesEventMessage.HARDWARE_PROFILE_UPDATE),
-                    Optional.empty()), minionSummaries);
-        }
-        if (!regularMinions.isEmpty()) {
-            ret.put(State.apply(Arrays.asList(
-                    ApplyStatesEventMessage.SYNC_ALL,
-                    ApplyStatesEventMessage.HARDWARE_PROFILE_UPDATE),
-                    Optional.empty()), minionSummaries);
-        }
-
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> virtualInstanceRefreshListAction(
-            List<MinionSummary> minionSummaries) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-
-        // salt-ssh minions in the 'true' partition
-        // regular minions in the 'false' partition
-        Map<Boolean, List<MinionSummary>> partitionBySSHPush = minionSummaries.stream()
-                .collect(Collectors.partitioningBy(MinionSummary::isSshPush));
-
-        // Separate SSH push minions from regular minions to apply different states
-        List<MinionSummary> sshPushMinions = partitionBySSHPush.get(true);
-        List<MinionSummary> regularMinions = partitionBySSHPush.get(false);
-
-        if (!sshPushMinions.isEmpty()) {
-            ret.put(State.apply(List.of(
-                            ApplyStatesEventMessage.VIRTUAL_PROFILE_UPDATE),
-                    Optional.empty()), minionSummaries);
-        }
-        if (!regularMinions.isEmpty()) {
-            ret.put(State.apply(Arrays.asList(
-                            ApplyStatesEventMessage.SYNC_ALL,
-                            ApplyStatesEventMessage.VIRTUAL_PROFILE_UPDATE),
-                    Optional.empty()), minionSummaries);
-        }
-
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> rebootAction(List<MinionSummary> minionSummaries) {
-        int rebootDelay = ConfigDefaults.get().getRebootDelay();
-        return minionSummaries.stream().collect(
-            Collectors.groupingBy(
-                m -> m.isTransactionalUpdate() ? TransactionalUpdate.reboot() :
-                        com.suse.salt.netapi.calls.modules.System.reboot(Optional.of(rebootDelay))
-            )
-        );
-    }
-
-    /**
-     * Deploy files(files, directory, symlink) through state.apply
-     *
-     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
-     * @param action action which has all the revisions
-     * @return minion summaries grouped by local call
-     */
-    private Map<LocalCall<?>, List<MinionSummary>> deployFiles(List<MinionSummary> minionSummaries,
-            ConfigAction action) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-
-        Map<Long, MinionSummary> targetMap = minionSummaries.stream().
-                collect(Collectors.toMap(MinionSummary::getServerId, minionId-> minionId));
-
-        Map<MinionSummary, Set<ConfigRevision>> serverConfigMap = action.getConfigRevisionActions()
-                .stream()
-                .filter(cra -> targetMap.containsKey(cra.getServer().getId()))
-                .collect(Collectors.groupingBy(
-                        cra -> targetMap.get(cra.getServer().getId()),
-                        Collectors.mapping(ConfigRevisionAction::getConfigRevision, Collectors.toSet())));
-        Map<Set<ConfigRevision>, Set<MinionSummary>> revsServersMap = serverConfigMap.entrySet()
-                .stream()
-                .collect(Collectors.groupingBy(Map.Entry::getValue,
-                        Collectors.mapping(Map.Entry::getKey, Collectors.toSet())));
-        revsServersMap.forEach((configRevisions, selectedServers) -> {
-            List<Map<String, Object>> fileStates = configRevisions
-                    .stream()
-                    .map(revision -> ConfigChannelSaltManager.getInstance().getStateParameters(revision))
-                    .toList();
-            ret.put(State.apply(List.of(CONFIG_DEPLOY_FILES),
-                    Optional.of(Collections.singletonMap(PARAM_FILES, fileStates))),
-                    new ArrayList<>(selectedServers));
-        });
-        return ret;
-    }
-
-    /**
-     * Deploy files(files, directory, symlink) through state.apply
-     *
-     * @param minionSummaries a list of minion summaries of the minions involved in the given Action
-     * @param action action which has all the revisions
-     * @return minion summaries grouped by local call
-     */
-    private Map<LocalCall<?>, List<MinionSummary>> diffFiles(List<MinionSummary> minionSummaries, ConfigAction action) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        List<Map<String, Object>> fileStates = action.getConfigRevisionActions().stream()
-                .map(ConfigRevisionAction::getConfigRevision)
-                .filter(revision -> revision.isFile() ||
-                        revision.isDirectory() ||
-                        revision.isSymlink())
-                .map(revision -> ConfigChannelSaltManager.getInstance().getStateParameters(revision))
-                .toList();
-        ret.put(com.suse.salt.netapi.calls.modules.State.apply(
-                List.of(CONFIG_DIFF_FILES),
-                Optional.of(Collections.singletonMap(PARAM_FILES, fileStates)),
-                Optional.of(true), Optional.of(true)), minionSummaries);
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> remoteCommandAction(
-            List<MinionSummary> minions, ScriptAction scriptAction) {
-        String script = scriptAction.getScriptActionDetails().getScriptContents();
-
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        // write script to /srv/susemanager/salt/scripts/script_<action_id>.sh
-        Path scriptFile = saltUtils.getScriptPath(scriptAction.getId());
-        try {
-            // make sure parent dir exists
-            if (!Files.exists(scriptFile) && !Files.exists(scriptFile.getParent())) {
-                FileAttribute<Set<PosixFilePermission>> dirAttributes =
-                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x"));
-
-                Files.createDirectory(scriptFile.getParent(), dirAttributes);
-                // make sure correct user is set
-            }
-
-            if (!skipCommandScriptPerms) {
-                setFileOwner(scriptFile.getParent());
-            }
-
-            // In case of action retry, the files script files will be already created.
-            if (!Files.exists(scriptFile)) {
-                FileAttribute<Set<PosixFilePermission>> fileAttributes =
-                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
-                Files.createFile(scriptFile, fileAttributes);
-                FileUtils.writeStringToFile(scriptFile.toFile(),
-                        script.replace("\r\n", "\n"), StandardCharsets.UTF_8);
-            }
-
-            if (!skipCommandScriptPerms) {
-                setFileOwner(scriptFile);
-            }
-
-            // state.apply remotecommands
-            Map<String, Object> pillar = new HashMap<>();
-            pillar.put("mgr_remote_cmd_script", SALT_FS_PREFIX + SCRIPTS_DIR + "/" + scriptFile.getFileName());
-            pillar.put("mgr_remote_cmd_runas", scriptAction.getScriptActionDetails().getUsername());
-            pillar.put("mgr_remote_cmd_timeout", scriptAction.getScriptActionDetails().getTimeout());
-            ret.put(State.apply(List.of(REMOTE_COMMANDS), Optional.of(pillar)), minions);
-        }
-        catch (IOException e) {
-            String errorMsg = "Could not write script to file " + scriptFile + " - " + e;
-            LOG.error(errorMsg, e);
-            scriptAction.getServerActions().stream()
-                    .filter(entry -> entry.getServer().asMinionServer()
-                            .map(minionServer -> minions.contains(new MinionSummary(minionServer)))
-                            .orElse(false))
-                    .forEach(sa -> {
-                        sa.fail("Error scheduling the action: " + errorMsg);
-                        ActionFactory.save(sa);
-            });
-        }
-        return ret;
-    }
-
-    private void setFileOwner(Path path) throws IOException {
-        FileSystem fileSystem = FileSystems.getDefault();
-        UserPrincipalLookupService service = fileSystem.getUserPrincipalLookupService();
-        UserPrincipal tomcatUser = service.lookupPrincipalByName("tomcat");
-
-        Files.setOwner(path, tomcatUser);
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> applyStatesAction(
-            List<MinionSummary> minionSummaries, List<String> mods,
-            Optional<Map<String, Object>> pillar, boolean test, boolean direct) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        LocalCall<Map<String, ApplyResult>> apply = State.apply(mods, pillar, Optional.of(true),
-                test ? Optional.of(test) : Optional.empty());
-        if (direct) {
-            ret.put(new LocalCallWithExecutors<>(apply, List.of("direct_call"), Collections.emptyMap()),
-                    minionSummaries);
-        }
-        else {
-            ret.put(apply, minionSummaries);
-        }
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> subscribeChanelsAction(
-            List<MinionSummary> minionSummaries, SubscribeChannelsActionDetails actionDetails) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        SystemManager sysMgr = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON, saltApi);
-
-        List<MinionServer> minions = MinionServerFactory.lookupByMinionIds(
-                minionSummaries.stream().map(MinionSummary::getMinionId).collect(Collectors.toSet()));
-
-        minions.forEach(minion ->
-            // change channels in DB and execult the ChannelsChangedEventMessageAction
-            // which regenerate pillar and refresh Tokens but does not execute a "state.apply channels"
-            sysMgr.updateServerChannels(
-                    actionDetails.getParentAction().getSchedulerUser(),
-                    minion,
-                    Optional.ofNullable(actionDetails.getBaseChannel()),
-                    actionDetails.getChannels())
-        );
-        ret.put(State.apply(List.of(ApplyStatesEventMessage.CHANNELS), Optional.empty()),
-                minionSummaries);
-
-        return ret;
-    }
-
-    private static Map<String, Object> dockerRegPillar(List<ImageStore> stores) {
-        Map<String, Object> dockerRegistries = new HashMap<>();
-        stores.forEach(store -> Optional.ofNullable(store.getCreds())
-                .ifPresent(credentials -> {
-                    Map<String, Object> reg = new HashMap<>();
-                    reg.put("email", "tux@example.com");
-                    reg.put("password", credentials.getPassword());
-                    reg.put("username", credentials.getUsername());
-                    dockerRegistries.put(store.getUri(), reg);
-                }));
-        return dockerRegistries;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> imageInspectAction(
-            List<MinionSummary> minions, ImageInspectActionDetails details, ImageStore store) {
-        Map<String, Object> pillar = new HashMap<>();
-        Map<LocalCall<?>, List<MinionSummary>> result = new HashMap<>();
-        if (ImageStoreFactory.TYPE_OS_IMAGE.equals(store.getStoreType())) {
-            pillar.put("build_id", "build" + details.getBuildActionId());
-            LocalCall<Map<String, ApplyResult>> apply = State.apply(
-                    Collections.singletonList("images.kiwi-image-inspect"),
-                    Optional.of(pillar));
-            result.put(apply, minions);
-            return result;
-        }
-        else {
-            List<ImageStore> imageStores = new LinkedList<>();
-            imageStores.add(store);
-            Map<String, Object> dockerRegistries = dockerRegPillar(imageStores);
-            pillar.put("docker-registries", dockerRegistries);
-            pillar.put("imagename", store.getUri() + "/" + details.getName() + ":" + details.getVersion());
-            pillar.put("build_id", "build" + details.getBuildActionId());
-            LocalCall<Map<String, ApplyResult>> apply = State.apply(
-                    Collections.singletonList("images.profileupdate"),
-                    Optional.of(pillar));
-            result.put(apply, minions);
-            return result;
-        }
-    }
-
-    private String getChannelUrl(MinionServer minion, String channelLabel) {
-        String token;
-
-        try {
-            token = new DownloadTokenBuilder(minion.getOrg().getId())
-                .usingServerSecret()
-                .expiringAfterMinutes(Config.get().getInt(ConfigDefaults.TEMP_TOKEN_LIFETIME))
-                .allowingOnlyChannels(Set.of(channelLabel))
-                .build()
-                .getSerializedForm();
-        }
-        catch (TokenBuildingException e) {
-            LOG.error("Could not generate token for {}", channelLabel, e);
-            token = "";
-        }
-
-        String host = minion.getChannelHost();
-
-        return "https://" + host + "/rhn/manager/download/" + channelLabel + "?" + token;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> imageBuildAction(
-            List<MinionSummary> minionSummaries, Optional<String> version,
-            ImageProfile profile, Long actionId) {
-        List<ImageStore> imageStores = new LinkedList<>();
-        imageStores.add(profile.getTargetStore());
-
-        List<MinionServer> minions = MinionServerFactory.findMinionsByServerIds(
-                minionSummaries.stream().map(MinionSummary::getServerId).collect(Collectors.toList()));
-
-        //TODO: optimal scheduling would be to group by host and orgid
-        return minions.stream().collect(
-                Collectors.toMap(minion -> {
-                    Map<String, Object> pillar = new HashMap<>();
-
-                    profile.asDockerfileProfile().ifPresent(dockerfileProfile -> {
-                        Map<String, Object> dockerRegistries = dockerRegPillar(imageStores);
-                        pillar.put("docker-registries", dockerRegistries);
-
-                        String repoPath = Path.of(profile.getTargetStore().getUri(), profile.getLabel()).toString();
-                        String tag = version.orElse("");
-                        String certificate = "";
-                        // salt 2016.11 dockerng require imagename while salt 2018.3 docker requires it separate
-                        pillar.put("imagerepopath", repoPath);
-                        pillar.put("imagetag", tag);
-                        pillar.put("imagename", repoPath + ":" + tag);
-                        pillar.put("builddir", dockerfileProfile.getPath());
-                        pillar.put("build_id", "build" + actionId);
-                        try {
-                            //TODO: maybe from the database
-                            certificate = String.join("\n\n", Files.readAllLines(
-                                    Paths.get("/srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT"),
-                                    Charset.defaultCharset()
-                            ));
-                        }
-                        catch (IOException e) {
-                            LOG.error("Could not read certificate", e);
-                        }
-                        pillar.put("cert", certificate);
-                        String repocontent = "";
-                        if (profile.getToken() != null) {
-                            repocontent = profile.getToken().getChannels().stream()
-                                .map(s -> "[susemanager:" + s.getLabel() + "]\n\n" +
-                                    "name=" + s.getName() + "\n\n" +
-                                    "enabled=1\n\n" +
-                                    "autorefresh=1\n\n" +
-                                    "baseurl=" + getChannelUrl(minion, s.getLabel()) + "\n\n" +
-                                    "type=rpm-md\n\n" +
-                                    "gpgcheck=0\n\n" // we use trusted content and SSL.
-                                ).collect(Collectors.joining("\n\n"));
-                        }
-                        pillar.put("repo", repocontent);
-
-                        // Add custom info values
-                        pillar.put("customvalues", profile.getCustomDataValues().stream()
-                                .collect(toMap(v -> v.getKey().getLabel(), ProfileCustomDataValue::getValue)));
-                    });
-
-                    profile.asKiwiProfile().ifPresent(kiwiProfile -> {
-                        pillar.put("source", kiwiProfile.getPath());
-                        pillar.put("build_id", "build" + actionId);
-                        pillar.put("kiwi_options", kiwiProfile.getKiwiOptions());
-                        List<String> repos = new ArrayList<>();
-                        final ActivationKey activationKey = ActivationKeyFactory.lookupByToken(profile.getToken());
-                        Set<Channel> channels = activationKey.getChannels();
-                        for (Channel channel: channels) {
-                            repos.add(getChannelUrl(minion, channel.getLabel()));
-                        }
-                        pillar.put("kiwi_repositories", repos);
-                        pillar.put("activation_key", activationKey.getKey());
-                    });
-
-                    String saltCall = "";
-                    if (profile instanceof DockerfileProfile) {
-                        saltCall = "images.docker";
-                    }
-                    else if (profile instanceof KiwiProfile) {
-                        saltCall = "images.kiwi-image-build";
-                    }
-
-                    return State.apply(
-                            Collections.singletonList(saltCall),
-                            Optional.of(pillar)
-                    );
-                },
-                m -> Collections.singletonList(new MinionSummary(m))
-        ));
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> distUpgradeAction(
-            DistUpgradeAction action,
-            List<MinionSummary> minionSummaries) {
-        Map<Boolean, List<Channel>> collect = action.getDetails().getChannelTasks()
-                .stream().collect(Collectors.partitioningBy(
-                        ct -> ct.getTask() == DistUpgradeChannelTask.SUBSCRIBE,
-                        Collectors.mapping(DistUpgradeChannelTask::getChannel,
-                                Collectors.toList())
-                        ));
-
-        List<Channel> subbed = collect.get(true);
-        List<Channel> unsubbed = collect.get(false);
-
-        action.getServerActions()
-        .stream()
-        .flatMap(s -> Opt.stream(s.getServer().asMinionServer()))
-        .forEach(minion -> {
-            Set<Channel> currentChannels = minion.getChannels();
-            unsubbed.forEach(currentChannels::remove);
-            currentChannels.addAll(subbed);
-            MinionPillarManager.INSTANCE.generatePillar(minion);
-            ServerFactory.save(minion);
-        });
-
-        Map<String, Object> pillar = new HashMap<>();
-        Map<String, Object> susemanager = new HashMap<>();
-        pillar.put("susemanager", susemanager);
-        Map<String, Object> distupgrade = new HashMap<>();
-        susemanager.put("distupgrade", distupgrade);
-        distupgrade.put("dryrun", action.getDetails().isDryRun());
-        distupgrade.put(ALLOW_VENDOR_CHANGE, action.getDetails().isAllowVendorChange());
-        distupgrade.put("channels", subbed.stream()
-                .sorted()
-                .map(c -> "susemanager:" + c.getLabel())
-                .collect(Collectors.toList()));
-        if (Objects.nonNull(action.getDetails().getMissingSuccessors())) {
-            pillar.put("missing_successors", Arrays.asList(action.getDetails().getMissingSuccessors().split(",")));
-        }
-        action.getDetails().getProductUpgrades().stream()
-                .map(SUSEProductUpgrade::getToProduct)
-                .filter(SUSEProduct::isBase)
-                .forEach(tgt -> {
-                    Map<String, String> baseproduct = new HashMap<>();
-                    baseproduct.put("name", tgt.getName());
-                    baseproduct.put("version", tgt.getVersion());
-                    baseproduct.put("arch", tgt.getArch().getLabel());
-                    distupgrade.put("targetbaseproduct", baseproduct);
-                });
-
-        if (commitTransaction) {
-            HibernateFactory.commitTransaction();
-        }
-
-        LocalCall<Map<String, ApplyResult>> distUpgrade = State.apply(
-                Collections.singletonList(ApplyStatesEventMessage.DISTUPGRADE),
-                Optional.of(pillar)
-                );
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        ret.put(distUpgrade, minionSummaries);
-
-        return ret;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> scapXccdfEvalAction(
-            List<MinionSummary> minionSummaries, ScapActionDetails scapActionDetails) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        Map<String, Object> pillar = new HashMap<>();
-        Matcher profileMatcher = Pattern.compile("--profile (([\\w.-])+)")
-                .matcher(scapActionDetails.getParametersContents());
-        Matcher ruleMatcher = Pattern.compile("--rule (([\\w.-])+)")
-                .matcher(scapActionDetails.getParametersContents());
-        Matcher tailoringFileMatcher = Pattern.compile("--tailoring-file (([\\w./-])+)")
-                .matcher(scapActionDetails.getParametersContents());
-        Matcher tailoringIdMatcher = Pattern.compile("--tailoring-id (([\\w.-])+)")
-                .matcher(scapActionDetails.getParametersContents());
-
-        String oldParameters = "eval " +
-                scapActionDetails.getParametersContents() + " " + scapActionDetails.getPath();
-        pillar.put("old_parameters", oldParameters);
-
-        pillar.put("xccdffile", scapActionDetails.getPath());
-        if (scapActionDetails.getOvalfiles() != null) {
-            pillar.put("ovalfiles", Arrays.stream(scapActionDetails.getOvalfiles().split(","))
-                    .map(String::trim).collect(toList()));
-        }
-        if (profileMatcher.find()) {
-            pillar.put("profile", profileMatcher.group(1));
-        }
-        if (ruleMatcher.find()) {
-            pillar.put("rule", ruleMatcher.group(1));
-        }
-        if (tailoringFileMatcher.find()) {
-            pillar.put("tailoring_file", tailoringFileMatcher.group(1));
-        }
-        if (tailoringIdMatcher.find()) {
-            pillar.put("tailoring_id", tailoringIdMatcher.group(1));
-        }
-        if (scapActionDetails.getParametersContents().contains("--fetch-remote-resources")) {
-            pillar.put("fetch_remote_resources", true);
-        }
-        if (scapActionDetails.getParametersContents().contains("--remediate")) {
-            pillar.put("remediate", true);
-        }
-
-        ret.put(State.apply(singletonList("scap"),
-                Optional.of(singletonMap("mgr_scap_params", (Object)pillar))),
-                minionSummaries);
-        return ret;
-    }
-
-    private Map<String, String> prepareCobblerBoot(String kickstartHost,
-                                                   String cobblerSystem,
-                                                   boolean autoinstall) {
-        CobblerConnection con = CobblerXMLRPCHelper.getAutomatedConnection();
-        SystemRecord system = SystemRecord.lookupByName(con, cobblerSystem);
-        Profile profile = system.getProfile();
-        Distro dist = profile.getDistro();
-        String kernel = dist.getKernel();
-        String initrd = dist.getInitrd();
-
-        List<String> nameParts = Arrays.asList(dist.getName().split(":"));
-        String saltFSKernel = Paths.get(nameParts.get(1), nameParts.get(0), new File(kernel).getName()).toString();
-        String saltFSInitrd = Paths.get(nameParts.get(1), nameParts.get(0), new File(initrd).getName()).toString();
-        KickstartableTree tree = KickstartFactory.lookupKickstartTreeByLabel(nameParts.get(0),
-                OrgFactory.lookupById(Long.valueOf(nameParts.get(1))));
-        tree.createOrUpdateSaltFS();
-        String kOpts = buildKernelOptions(system, kickstartHost, autoinstall);
-
-
-        Map<String, String> pillar = new HashMap<>();
-        pillar.put("kernel", saltFSKernel);
-        pillar.put("initrd", saltFSInitrd);
-        pillar.put("kopts", kOpts);
-
-        return pillar;
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> autoinstallInitAction(List<MinionSummary> minions,
-            KickstartInitiateAction autoInitAction) {
-
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        KickstartActionDetails ksActionDetails = autoInitAction.getKickstartActionDetails();
-        String cobblerSystem = ksActionDetails.getCobblerSystemName();
-        String host = ksActionDetails.getKickstartHost();
-        Map<String, String> bootParams = prepareCobblerBoot(host, cobblerSystem, true);
-        Map<String, Object> pillar = new HashMap<>(bootParams);
-        pillar.put("uyuni-reinstall-name", "reinstall-system");
-        String kOpts = bootParams.get("kopts");
-
-        if (kOpts.contains("autoupgrade=1") || kOpts.contains("uyuni_keep_saltkey=1")) {
-            ksActionDetails.setUpgrade(true);
-        }
-        ret.put(State.apply(List.of(KICKSTART_INITIATE), Optional.of(pillar)), minions);
-
-        return ret;
-    }
-
-    private String buildKernelOptions(SystemRecord sys, String host, boolean autoinstall) {
-        String breed = sys.getProfile().getDistro().getBreed();
-        Map<String, Object> kopts = sys.getResolvedKernelOptions();
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Resolved kernel options for {}: {}", sys.getName(), convertOptionsMap(kopts));
-        }
-        if (breed.equals("suse")) {
-            //SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-            if (kopts.containsKey("textmode")) {
-                kopts.remove("text");
-            }
-            else if (kopts.containsKey("text")) {
-                kopts.remove("text");
-                kopts.put("textmode", "1");
-            }
-        }
-        // no additional initrd parameter allowed
-        kopts.remove("initrd");
-        String kernelOptions = convertOptionsMap(kopts);
-        String autoinst = "http://" + host + "/cblr/svc/op/autoinstall/system/" + sys.getName();
-
-        if (StringUtils.isBlank(breed) || breed.equals("redhat")) {
-            if (sys.getProfile().getDistro().getOsVersion().equals("rhel6")) {
-                kernelOptions += " kssendmac ks=" + autoinst;
-            }
-            else {
-                kernelOptions += " inst.ks.sendmac ks=" + autoinst;
-            }
-        }
-        else if (breed.equals("suse")) {
-            kernelOptions += "autoyast=" + autoinst;
-        }
-        else if (breed.equals("debian") || breed.equals("ubuntu")) {
-            kernelOptions += "auto-install/enable=true priority=critical netcfg/choose_interface=auto url=" + autoinst;
-        }
-
-        if (autoinstall) {
-            String infoUrl = "http://" + host + "/cblr/svc/op/nopxe/system/" + sys.getName();
-            kernelOptions += " info=" + infoUrl;
-        }
-        return kernelOptions;
-    }
-
-    private String convertOptionsMap(Map<String, Object> map) {
-        StringBuilder string = new StringBuilder();
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            String key = entry.getKey();
-            List<String> keyList;
-            try {
-                 keyList = (List<String>)entry.getValue();
-            }
-            catch (ClassCastException e) {
-                keyList = new ArrayList<>();
-                keyList.add((String) entry.getValue());
-            }
-            string.append(key);
-            if (keyList.isEmpty()) {
-                string.append(" ");
-            }
-            else {
-                for (String value : keyList) {
-                    string.append("=").append(value).append(" ");
-                }
-            }
-        }
-        return string.toString();
-    }
-
-    private LocalCall<?> executePlaybookActionCall(PlaybookAction action) {
-        PlaybookActionDetails details = action.getDetails();
-
-        String playbookPath = details.getPlaybookPath();
-        String rundir = new File(playbookPath).getAbsoluteFile().getParent();
-        String inventoryPath = details.getInventoryPath();
-
-        if (StringUtils.isEmpty(inventoryPath)) {
-            inventoryPath = INVENTORY_PATH;
-        }
-
-        Map<String, Object> pillarData = new HashMap<>();
-        pillarData.put("playbook_path", playbookPath);
-        pillarData.put("inventory_path", inventoryPath);
-        pillarData.put("rundir", rundir);
-        pillarData.put("flush_cache", details.isFlushCache());
-        pillarData.put("extra_vars", details.getExtraVarsContents());
-        return State.apply(singletonList(ANSIBLE_RUNPLAYBOOK), Optional.of(pillarData), Optional.of(true),
-                Optional.of(details.isTestMode()));
-    }
-
-    private LocalCall<?> executeInventoryActionCall(InventoryAction action) {
-        InventoryActionDetails details = action.getDetails();
-        String inventoryPath = details.getInventoryPath();
-
-        return new LocalCall<>(ANSIBLE_INVENTORIES, empty(), of(Map.of("inventory", inventoryPath)),
-                new TypeToken<>() { });
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> cocoAttestationAction(List<MinionSummary> minionSummaries) {
-        return Map.of(
-                State.apply(Collections.singletonList(COCOATTEST_REQUESTDATA), Optional.empty()),
-                minionSummaries
-        );
-    }
-
-    private Map<LocalCall<?>, List<MinionSummary>> appStreamAction(
-            List<MinionSummary> minionSummaries, AppStreamAction action) {
-        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-
-        Map<Boolean, Set<AppStreamActionDetails>> details = action.getDetails().stream()
-            .collect(Collectors.partitioningBy(AppStreamActionDetails::isEnable, Collectors.toSet()));
-
-        var enableParams = details.get(true).stream()
-            .map(d -> d.getStream() == null ?
-                singletonList(d.getModuleName()) :
-                Arrays.asList(d.getModuleName(), d.getStream()))
-            .toList();
-        var disableParams = details.get(false).stream().map(AppStreamActionDetails::getModuleName).toList();
-
-        Optional<Map<String, Object>> params = Optional.of(Map.of(
-            PARAM_APPSTREAMS_ENABLE, enableParams,
-            PARAM_APPSTREAMS_DISABLE, disableParams
-        ));
-        ret.put(State.apply(List.of(APPSTREAMS_CONFIGURE), params), minionSummaries);
-        return ret;
-    }
-
     /**
      * Prepare to execute staging job via Salt
      * @param actionIn the action
@@ -1878,8 +769,8 @@ public class SaltServerActionService {
                     .getDetails().stream().map(d -> Arrays.asList(d.getPackageName().getName(),
                             d.getArch().toUniversalArchString(), d.getEvr().toUniversalEvrString()))
                     .toList();
-            call = State.apply(List.of(PACKAGES_PKGDOWNLOAD),
-                    Optional.of(Collections.singletonMap(PARAM_PKGS, args)));
+            call = State.apply(List.of(SaltParameters.PACKAGES_PKGDOWNLOAD),
+                    Optional.of(Collections.singletonMap(SaltParameters.PARAM_PKGS, args)));
             LOG.info("Executing staging of packages");
         }
         if (actionIn.getActionType().equals(ActionFactory.TYPE_ERRATA)) {
@@ -1896,8 +787,8 @@ public class SaltServerActionService {
                 )
                 .toList();
 
-            call = State.apply(List.of(PACKAGES_PATCHDOWNLOAD),
-                    Optional.of(Collections.singletonMap(PARAM_PATCHES, errataArgs)));
+            call = State.apply(List.of(SaltParameters.PACKAGES_PATCHDOWNLOAD),
+                    Optional.of(Collections.singletonMap(SaltParameters.PARAM_PATCHES, errataArgs)));
             LOG.info("Executing staging of patches");
         }
         return call;
@@ -2485,14 +1376,6 @@ public class SaltServerActionService {
      */
     public void setSaltApi(SaltApi saltApiIn) {
         this.saltApi = saltApiIn;
-    }
-
-    /**
-     * Only used in unit tests.
-     * @param skipCommandScriptPermsIn to set
-     */
-    public void setSkipCommandScriptPerms(boolean skipCommandScriptPermsIn) {
-        this.skipCommandScriptPerms = skipCommandScriptPermsIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -36,6 +36,7 @@ import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
 import com.redhat.rhn.domain.action.channel.SubscribeChannelsActionDetails;
 import com.redhat.rhn.domain.action.config.ConfigAction;
 import com.redhat.rhn.domain.action.script.ScriptActionDetails;
+import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.channel.Channel;
@@ -116,6 +117,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private MinionServer minion;
     private SaltServerActionService saltServerActionService;
     private TaskomaticApi taskomaticMock;
+    private SaltService saltService;
 
     @Override
     @BeforeEach
@@ -123,7 +125,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         super.setUp();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
-        SaltService saltService = new SaltService() {
+        saltService = new SaltService() {
             @Override
             public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
                 return Optional.of(Result.success(new JsonObject()));
@@ -143,7 +145,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery, SaltApi saltApi) {
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi);
         SaltServerActionService service = new SaltServerActionService(saltApi, saltUtils, new SaltKeyUtils(saltApi));
-        service.setSkipCommandScriptPerms(true);
+        ScriptRunAction.setSkipCommandScriptPerms(true);
         return service;
     }
 
@@ -613,6 +615,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
         SubscribeChannelsAction action = (SubscribeChannelsAction) ActionManager.createAction(
                 user, ActionFactory.TYPE_SUBSCRIBE_CHANNELS, "Subscribe to channels", Date.from(now.toInstant()));
+        action.setSaltApi(saltService);
 
         SubscribeChannelsActionDetails details = new SubscribeChannelsActionDetails();
         details.setBaseChannel(base);


### PR DESCRIPTION
## What does this PR change?
This PR is one step towards the simplification of Action handling.
The specific aim of this PR is to simplify the method `SaltServerActionService::callsForAction.`
This method has a list of "if" clauses that, for any given action type, return the salt calls that need to be executed for the targeted minions. Making a list of "ifs" on a type is a code smell of a misuse of object-oriented inheritance.
   
The final goal is to have a single method call `actionIn.getSaltCalls(minions)` where each action is implementing their own logic of handling, getting rid of the "if" on type, making a correct use of the Action object hierarchy.

The steps followed were:

1) moving each chunk of code executed in the "if" body part to a public static method of the relevant action class, maintaining the same name as the handler method in `SaltServerActionService` (if any). This part allows to move the relevant handling code (as well as constants and other helper methods) to the appropriate Action classes.

2) moving `SaltServerActionService` constants in a new class `SaltParameters`, to be shared among classes

3) act on `ActionFactory::createAction(ActionType typeIn) `to make sure that all action types create a different action class (it was not true for `ConfigAction` and `PackageAction` child classes). This step touched also the database discriminator-value of `ConfigAction` subclasses

4) renaming the newly created public static methods of Action derived classes with the same name (`getSaltCalls`) and unifying calling parameters

5) creating an Action base class method `getSaltCalls` and making the public static methods of Action derived classes as `@Override` methods of the base class

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**
## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/13569
Port(s): # **add downstream PR(s), if any**
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

