### PR TITLE
Save proxy info when converting a system to proxy

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
+++ b/java/code/src/com/redhat/rhn/manager/system/proxycontainerconfig/ProxyContainerConfigCreateAcquisitor.java
@@ -100,6 +100,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
                 context.getSystemEntitlementManager(),
                 context.getUser(), context.getProxyFqdn(), fqdns, context.getProxyPort(), proxySshKey.getPublicKey()
         );
+        SystemManager.updateSystemOverview(proxySystem);
         try {
             context.setClientCertificate(SystemManager.createClientCertificate(proxySystem));
         }
@@ -160,6 +161,7 @@ public class ProxyContainerConfigCreateAcquisitor implements ProxyContainerConfi
 
             systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
 
+            ServerFactory.save(server);
             return server;
         }
         Server server = ServerFactory.createServer();

--- a/java/spacewalk-java.changes.cbosdo.5.0-proxy-fix
+++ b/java/spacewalk-java.changes.cbosdo.5.0-proxy-fix
@@ -1,0 +1,2 @@
+- Update the systems cache table after converting a system to
+  proxy (bsc#1239158)


### PR DESCRIPTION
## What does this PR change?

When creating the proxy configuration for an existing system we need to save the changes in the Server object to have them in the DB.

We also need to trigger an update of the systems list cache table for the changed server.

bsc#1239158

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26643
Port(s): https://github.com/SUSE/spacewalk/pull/26950

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
