### PR TITLE
Simplify action handling (step 3 - ActionStatus)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action.java
+++ b/java/code/src/com/redhat/rhn/domain/action/Action.java
@@ -330,8 +330,8 @@ public class Action extends BaseDomainHelper implements Serializable, WebSocketA
         if (getServerActions() == null) {
             return true;
         }
-        return getServerActions().stream().allMatch(sa -> ActionFactory.STATUS_COMPLETED.equals(sa.getStatus()) ||
-                ActionFactory.STATUS_FAILED.equals(sa.getStatus()));
+        return getServerActions().stream().allMatch(sa -> sa.isStatusCompleted() ||
+                sa.isStatusFailed());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/ActionChain.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChain.java
@@ -146,7 +146,7 @@ public class ActionChain extends BaseDomainHelper {
         return !getEntries().isEmpty() &&
                 getEntries().stream().noneMatch(ace -> ace.getAction().getServerActions().isEmpty()) &&
                 getEntries().stream().flatMap(ace -> ace.getAction().getServerActions().stream())
-                .allMatch(sa -> sa.getStatus().isDone());
+                .allMatch(sa -> sa.isDone());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -260,7 +260,7 @@ public class ActionFactory extends HibernateFactory {
         ServerAction sa = new ServerAction();
         sa.setCreated(new Date());
         sa.setModified(new Date());
-        sa.setStatus(STATUS_QUEUED);
+        sa.setStatusQueued();
         sa.setServerWithCheck(server);
         sa.setParentActionWithCheck(parent);
         sa.setRemainingTries(5L); //arbitrary number from perl
@@ -495,6 +495,9 @@ public class ActionFactory extends HibernateFactory {
         }
         else if (typeIn.equals(TYPE_APPSTREAM_CONFIGURE)) {
             retval = new AppStreamAction();
+        }
+        else if (typeIn.equals(TYPE_INVENTORY)) {
+            retval = new InventoryAction();
         }
         else if (typeIn.equals(TYPE_INVENTORY)) {
             retval = new InventoryAction();
@@ -1059,6 +1062,17 @@ public class ActionFactory extends HibernateFactory {
      */
     public static final List<ActionStatus> ALL_STATUSES = List.of(STATUS_QUEUED, STATUS_PICKED_UP, STATUS_COMPLETED,
         STATUS_FAILED);
+
+    /**
+     * All the possible action statuses, but completed
+     */
+    public static final List<ActionStatus> ALL_STATUSES_BUT_COMPLETED = List.of(STATUS_QUEUED, STATUS_PICKED_UP,
+            STATUS_FAILED);
+
+    /**
+     * All the pending action statuses
+     */
+    public static final List<ActionStatus> ALL_PENDING_STATUSES = List.of(STATUS_QUEUED, STATUS_PICKED_UP);
 
     /**
      * The constant representing Package Refresh List action.  [ID:1]

--- a/java/code/src/com/redhat/rhn/domain/action/ActionStatus.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionStatus.java
@@ -59,7 +59,23 @@ public class ActionStatus {
      * (either completed or failed)
      */
     public boolean isDone() {
-        return this.equals(ActionFactory.STATUS_COMPLETED) || this.equals(ActionFactory.STATUS_FAILED);
+        return isCompleted() || isFailed();
+    }
+
+    public boolean isQueued() {
+        return this.equals(ActionFactory.STATUS_QUEUED);
+    }
+
+    public boolean isPickedUp() {
+        return this.equals(ActionFactory.STATUS_PICKED_UP);
+    }
+
+    public boolean isCompleted() {
+        return this.equals(ActionFactory.STATUS_COMPLETED);
+    }
+
+    public boolean isFailed() {
+        return this.equals(ActionFactory.STATUS_FAILED);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/CoCoAttestationAction.java
@@ -93,14 +93,14 @@ public class CoCoAttestationAction extends Action {
         Optional<ServerCoCoAttestationReport> optReport =
                 mgr.lookupReportByServerAndAction(serverAction.getServer(), this);
         if (optReport.isEmpty()) {
-            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setStatusFailed();
             serverAction.setResultMsg("Failed to find a report entry");
             return;
         }
         ServerCoCoAttestationReport report = optReport.get();
 
         if (jsonResult == null) {
-            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setStatusFailed();
             if (StringUtils.isBlank(serverAction.getResultMsg())) {
                 serverAction.setResultMsg("Error while request attestation data from target system:\n" +
                         "Got no result from system");
@@ -119,11 +119,11 @@ public class CoCoAttestationAction extends Action {
                     .map(JsonElement::toString)
                     .orElse("Got no result");
             LOG.error(msg);
-            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setStatusFailed();
             serverAction.setResultMsg(msg);
             return;
         }
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+        if (serverAction.isStatusFailed()) {
             String msg = "Error while request attestation data from target system:\n";
             msg += SaltUtils.getJsonResultWithPrettyPrint(jsonResult);
             serverAction.setResultMsg(msg);

--- a/java/code/src/com/redhat/rhn/domain/action/HardwareRefreshAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/HardwareRefreshAction.java
@@ -87,7 +87,7 @@ public class HardwareRefreshAction extends Action {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+        if (serverAction.isStatusFailed()) {
             serverAction.setResultMsg("Failure");
         }
         else {
@@ -155,7 +155,7 @@ public class HardwareRefreshAction extends Action {
 
         // Let the action fail in case there is error messages
         if (!hwMapper.getErrors().isEmpty()) {
-            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setStatusFailed();
             serverAction.setResultMsg("Hardware list could not be refreshed completely:\n" +
                     hwMapper.getErrors().stream().collect(Collectors.joining("\n")));
             serverAction.setResultCode(-1L);

--- a/java/code/src/com/redhat/rhn/domain/action/ansible/InventoryAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ansible/InventoryAction.java
@@ -20,7 +20,6 @@ import static java.util.Optional.of;
 
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.AnsibleFactory;
 import com.redhat.rhn.domain.server.MinionSummary;
@@ -116,13 +115,13 @@ public class InventoryAction extends Action {
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
         if (jsonResult == null) {
-            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setStatusFailed();
             serverAction.setResultMsg(
                     "Error while requesting inventory data from target system: Got no result from system");
             return;
         }
         String inventoryPath = details.getInventoryPath();
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
+        if (serverAction.isStatusCompleted()) {
             try {
                 Set<String> inventorySystems = AnsibleManager.parseInventoryAndGetHostnames(
                         Json.GSON.fromJson(jsonResult, Map.class));
@@ -142,12 +141,12 @@ public class InventoryAction extends Action {
             }
             catch (JsonSyntaxException e) {
                 LOG.error("Unable to parse Ansible hostnames from json: {}", e.getMessage());
-                serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                serverAction.setStatusFailed();
                 serverAction.setResultMsg("Unable to parse hostnames from inventory: " + inventoryPath);
             }
             catch (LookupException e) {
                 LOG.error(e.getMessage());
-                serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                serverAction.setStatusFailed();
                 serverAction.setResultMsg(e.getMessage());
             }
         }

--- a/java/code/src/com/redhat/rhn/domain/action/appstream/AppStreamAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/appstream/AppStreamAction.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.domain.action.appstream;
 import static java.util.Collections.singletonList;
 
 import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionSummary;
@@ -120,7 +119,7 @@ public class AppStreamAction extends Action {
             return;
         }
 
-        if (ActionFactory.STATUS_FAILED.equals(serverAction.getStatus())) {
+        if (serverAction.isStatusFailed()) {
             // Filter out the subsequent errors to find the root cause
             var originalErrorMsg = SaltUtils.jsonEventToStateApplyResults(jsonResult)
                     .map(AppStreamAction::getOriginalStateApplyError)

--- a/java/code/src/com/redhat/rhn/domain/action/channel/SubscribeChannelsAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/channel/SubscribeChannelsAction.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.domain.action.channel;
 
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
@@ -102,7 +101,7 @@ public class SubscribeChannelsAction extends Action {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
+        if (serverAction.isStatusCompleted()) {
             serverAction.setResultMsg("Successfully applied state: " + ApplyStatesEventMessage.CHANNELS);
         }
         else {

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigDeployAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigDeployAction.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.domain.action.config;
 
 import com.redhat.rhn.common.localization.LocalizationService;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.server.MinionSummary;
@@ -80,7 +79,7 @@ public class ConfigDeployAction extends ConfigAction {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
+        if (serverAction.isStatusCompleted()) {
             serverAction.setResultMsg(LocalizationService.getInstance().getMessage("configfiles.deployed"));
         }
         else {

--- a/java/code/src/com/redhat/rhn/domain/action/config/ConfigDiffAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/config/ConfigDiffAction.java
@@ -11,7 +11,6 @@
 package com.redhat.rhn.domain.action.config;
 
 import com.redhat.rhn.common.localization.LocalizationService;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.server.MinionSummary;
@@ -116,7 +115,7 @@ public class ConfigDiffAction extends ConfigAction {
          * 'result' attribute(actionFailed method check this attribute) when File(File, Dir, Symlink)
          * already exist on the system and action is considered as Failed even though there was no error.
          */
-        serverAction.setStatus(ActionFactory.STATUS_COMPLETED);
+        serverAction.setStatusCompleted();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageLockAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageLockAction.java
@@ -18,7 +18,6 @@ package com.redhat.rhn.domain.action.rhnpackage;
 import static java.util.Collections.singletonMap;
 
 import com.redhat.rhn.common.db.datasource.DataResult;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.server.MinionSummary;
@@ -92,7 +91,7 @@ public class PackageLockAction extends PackageAction {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+        if (serverAction.isStatusFailed()) {
             String msg = "Error while changing the lock status";
             SaltUtils.jsonEventToStateApplyResults(jsonResult).ifPresentOrElse(
                     r -> {

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRefreshListAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRefreshListAction.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.domain.action.rhnpackage;
 
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
@@ -89,7 +88,7 @@ public class PackageRefreshListAction extends PackageAction {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+        if (serverAction.isStatusFailed()) {
             serverAction.setResultMsg("Failure");
         }
         else {

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/test/PackageActionTest.java
@@ -155,7 +155,7 @@ public class PackageActionTest extends RhnBaseTestCase {
         Server srvr = ServerFactoryTest.createTestServer(user);
 
         ServerAction sa = new ServerAction();
-        sa.setStatus(ActionFactory.STATUS_QUEUED);
+        sa.setStatusQueued();
         sa.setRemainingTries(10L);
         sa.setServerWithCheck(srvr);
         log.debug("Creating PackageRemoveAction.");

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesAction.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.domain.action.salt;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionFormatter;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.notification.NotificationMessage;
@@ -127,7 +126,7 @@ public class ApplyStatesAction extends Action {
 
         // Revisit the action status if test=true
         if (details.isTest() && auxArgs.getSuccess() && auxArgs.getRetcode() == 0) {
-            serverAction.setStatus(ActionFactory.STATUS_COMPLETED);
+            serverAction.setStatusCompleted();
         }
 
         ApplyStatesActionResult statesResult = Optional.ofNullable(
@@ -150,7 +149,7 @@ public class ApplyStatesAction extends Action {
         String states = details.getMods().isEmpty() ?
                 "highstate" : details.getMods().toString();
         String message = "Successfully applied state(s): " + states;
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+        if (serverAction.isStatusFailed()) {
             message = "Failed to apply state(s): " + states;
 
             NotificationMessage nm = UserNotificationFactory.createNotificationMessage(

--- a/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/build/ImageBuildAction.java
@@ -21,7 +21,6 @@ import static java.util.stream.Collectors.toMap;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionFormatter;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.channel.Channel;
@@ -256,7 +255,7 @@ public class ImageBuildAction extends Action {
 
         handleImageBuildLog(info, auxArgs.getSaltApi());
 
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
+        if (serverAction.isStatusCompleted()) {
             if (details == null) {
                 LOG.error("Details not found while performing: {} in handleImageBuildData", getName());
                 return;
@@ -316,7 +315,7 @@ public class ImageBuildAction extends Action {
                                 .orElseThrow(() -> new RuntimeException("Failed to download image."));
 
                         if (collectResult.getReturnCode() != 0) {
-                            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                            serverAction.setStatusFailed();
                             serverAction.setResultMsg(StringUtils
                                     .left(SaltUtils.printStdMessages(collectResult.getStderr(),
                                                     collectResult.getStdout()),
@@ -341,7 +340,7 @@ public class ImageBuildAction extends Action {
                 }
             }
         }
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
+        if (serverAction.isStatusCompleted()) {
             // both building and uploading results succeeded
             info.setBuilt(true);
 

--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
@@ -20,7 +20,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.Server;
@@ -178,7 +177,7 @@ public class ScapAction extends Action {
         }
         catch (JsonSyntaxException e) {
             serverAction.setResultMsg("Error parsing minion response: " + jsonResult);
-            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setStatusFailed();
             return;
         }
         if (openscapResult.isSuccess()) {
@@ -204,7 +203,7 @@ public class ScapAction extends Action {
                                     }
                                     catch (Exception e) {
                                         LOG.error("Error processing SCAP results file {}", resultsFile, e);
-                                        serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                                        serverAction.setStatusFailed();
                                         serverAction.setResultMsg(
                                                 "Error processing SCAP results file " +
                                                         resultsFile + ": " +
@@ -212,7 +211,7 @@ public class ScapAction extends Action {
                                     }
                                 }
                                 else {
-                                    serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                                    serverAction.setStatusFailed();
                                     serverAction.setResultMsg(
                                             "Could not store SCAP files on server: " +
                                                     moved.getValue());
@@ -220,7 +219,7 @@ public class ScapAction extends Action {
                             });
                         }
                         catch (Exception e) {
-                            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                            serverAction.setStatusFailed();
                             serverAction.setResultMsg(
                                     "Error saving SCAP result: " + e.getMessage());
                         }
@@ -228,7 +227,7 @@ public class ScapAction extends Action {
         }
         else {
             serverAction.setResultMsg(openscapResult.getError());
-            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+            serverAction.setStatusFailed();
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -207,7 +207,7 @@ public class ScriptRunAction extends ScriptAction {
      */
     @Override
     public void handleUpdateServerAction(ServerAction serverAction, JsonElement jsonResult, UpdateAuxArgs auxArgs) {
-        if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+        if (serverAction.isStatusFailed()) {
             serverAction.setResultMsg("Failed to execute script. [jid=" + auxArgs.getJid() + "]");
         }
         else {

--- a/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/ServerAction.java
@@ -53,11 +53,10 @@ public class ServerAction extends ActionChild implements Serializable {
 
     private static MaintenanceManager maintenanceManager = new MaintenanceManager();
 
-
     /**
      * Getter for status
      * @return ActionStatus to get
-    */
+     */
     public ActionStatus getStatus() {
         return this.status;
     }
@@ -65,7 +64,7 @@ public class ServerAction extends ActionChild implements Serializable {
     /**
      * Setter for status
      * @param statusIn to set
-    */
+     */
     public void setStatus(ActionStatus statusIn) {
         if (Objects.equals(statusIn, ActionFactory.STATUS_FAILED) && !Objects.equals(status, statusIn)) {
             Optional.ofNullable(getParentAction()).ifPresent(pa -> {
@@ -78,6 +77,58 @@ public class ServerAction extends ActionChild implements Serializable {
             });
         }
         this.status = statusIn;
+    }
+
+    public boolean isStatusQueued() {
+        return status.isQueued();
+    }
+
+    /**
+     * set ServerAction status to Queued
+     */
+    public void setStatusQueued() {
+        setStatus(ActionFactory.STATUS_QUEUED);
+    }
+
+    public boolean isStatusPickedUp() {
+        return status.isPickedUp();
+    }
+
+    /**
+     * set ServerAction status to PickedUp
+     */
+    public void setStatusPickedUp() {
+        setStatus(ActionFactory.STATUS_PICKED_UP);
+    }
+
+    public boolean isStatusCompleted() {
+        return status.isCompleted();
+    }
+
+    /**
+     * set ServerAction status to Completed
+     */
+    public void setStatusCompleted() {
+        setStatus(ActionFactory.STATUS_COMPLETED);
+    }
+
+    public boolean isStatusFailed() {
+        return status.isFailed();
+    }
+
+    /**
+     * set ServerAction status to Failed
+     */
+    public void setStatusFailed() {
+        setStatus(ActionFactory.STATUS_FAILED);
+    }
+
+    /**
+     * @return if the status represents an action that is in its final state and considered done.
+     * (either completed or failed)
+     */
+    public boolean isDone() {
+        return isStatusCompleted() || isStatusFailed();
     }
 
     /**
@@ -296,7 +347,7 @@ public class ServerAction extends ActionChild implements Serializable {
     public void fail(long resultCodeIn, String message, Date completionTimeIn) {
         this.setCompletionTime(completionTimeIn);
         this.setResultCode(resultCodeIn);
-        this.setStatus(ActionFactory.STATUS_FAILED);
+        this.setStatusFailed();
         this.setResultMsg(message);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -17,10 +17,10 @@ package com.redhat.rhn.domain.action.server.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
 import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
@@ -36,6 +36,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
+import java.util.function.Consumer;
 
 /**
  * ServerActionTest
@@ -48,19 +49,19 @@ public class ServerActionTest extends RhnBaseTestCase {
         sa1.fail(-1L, "Fail_message", new Date());
         assertEquals(sa1.getResultMsg(), "Fail_message");
         assertEquals(sa1.getResultCode(), Long.valueOf(-1));
-        assertEquals(sa1.getStatus(), ActionFactory.STATUS_FAILED);
+        assertTrue(sa1.isStatusFailed());
 
         ServerAction sa2 = new ServerAction();
         sa2.fail(-1L, "Fail_message");
         assertEquals(sa2.getResultMsg(), "Fail_message");
         assertEquals(sa2.getResultCode(), Long.valueOf(-1));
-        assertEquals(sa2.getStatus(), ActionFactory.STATUS_FAILED);
+        assertTrue(sa2.isStatusFailed());
 
         ServerAction sa3 = new ServerAction();
         sa3.fail("Fail_message");
         assertEquals(sa3.getResultMsg(), "Fail_message");
         assertEquals(sa3.getResultCode(), Long.valueOf(-1));
-        assertEquals(sa3.getStatus(), ActionFactory.STATUS_FAILED);
+        assertTrue(sa3.isStatusFailed());
     }
 
     @Test
@@ -143,20 +144,20 @@ public class ServerActionTest extends RhnBaseTestCase {
      * @return ServerAction created
      */
     public static ServerAction createServerAction(Server newS, Action newA) {
-        return createServerAction(newS, newA, ActionFactory.STATUS_QUEUED);
+        return createServerAction(newS, newA, ServerAction::setStatusQueued);
     }
 
     /**
      * Create a new ServerAction
      * @param newS new server
      * @param newA new action
-     * @param status action status
+     * @param statusSetter method that set status to a ServerAction
      * @return ServerAction created
      */
-    public static ServerAction createServerAction(Server newS, Action newA, ActionStatus status) {
+    public static ServerAction createServerAction(Server newS, Action newA, Consumer<ServerAction> statusSetter) {
         ServerAction sa = new ServerAction();
-        sa.setStatus(status);
-        sa.setRemainingTries(ActionFactory.STATUS_FAILED.equals(status) ? 0L : 10L);
+        statusSetter.accept(sa);
+        sa.setRemainingTries(sa.isStatusFailed() ? 0L : 10L);
         sa.setServerWithCheck(newS);
         sa.setParentActionWithCheck(newA);
         newA.addServerAction(sa);

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFormatterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFormatterTest.java
@@ -75,15 +75,15 @@ public class ActionFormatterTest extends RhnBaseTestCase {
                 ActionFactory.TYPE_REBOOT);
         ActionFormatter af = areboot.getFormatter();
         ServerAction sa = (ServerAction) areboot.getServerActions().toArray()[0];
-        sa.setStatus(ActionFactory.STATUS_FAILED);
+        sa.setStatusFailed();
         sa = (ServerAction) TestUtils.saveAndReload(sa);
         assertTrue(af.getNotes().startsWith(
                 "<a href=\"/rhn/schedule/FailedSystems.do?aid="));
         assertTrue(af.getNotes().endsWith(
                 ">1 system</a></strong> failed to complete this action.<br/><br/>"));
 
-        sa.setStatus(ActionFactory.STATUS_COMPLETED);
-        TestUtils.saveAndReload(sa);
+        sa.setStatusCompleted();
+        sa = (ServerAction) TestUtils.saveAndReload(sa);
         assertTrue(af.getNotes().startsWith(
                 "<a href=\"/rhn/schedule/CompletedSystems.do?aid="));
         assertTrue(af.getNotes().endsWith(

--- a/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
@@ -118,9 +118,10 @@ public class MinionServerFactoryTest extends BaseTestCaseWithUser {
                 .collect(Collectors.toSet());
 
 
-        ServerAction failed = ActionFactoryTest.createServerAction(minion1, action, ActionFactory.STATUS_FAILED);
-        ServerAction completed = ActionFactoryTest.createServerAction(minion2, action, ActionFactory.STATUS_COMPLETED);
-        ServerAction queued = ActionFactoryTest.createServerAction(minion3, action, ActionFactory.STATUS_QUEUED);
+        ServerAction failed = ActionFactoryTest.createServerAction(minion1, action, ServerAction::setStatusFailed);
+        ServerAction completed = ActionFactoryTest.createServerAction(minion2, action,
+                ServerAction::setStatusCompleted);
+        ServerAction queued = ActionFactoryTest.createServerAction(minion3, action, ServerAction::setStatusQueued);
 
         action.setServerActions(new HashSet<>(Set.of(failed, completed, queued)));
 

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/OverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/sdc/OverviewAction.java
@@ -254,7 +254,7 @@ public class OverviewAction extends RhnAction {
                     server.getId();
             String messageKey;
 
-            if (sa == null || ActionFactory.STATUS_FAILED.equals(sa.getStatus())) {
+            if (sa == null || sa.isStatusFailed()) {
                 messageKey = "sdc.config.deploy.failure";
             }
             else {

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/CompletedActionsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/CompletedActionsSetupActionTest.java
@@ -67,7 +67,7 @@ public class CompletedActionsSetupActionTest extends RhnPostMockStrutsTestCase {
 
         Action act = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         ServerAction sAction = ActionFactoryTest.createServerAction(server, act);
-        sAction.setStatus(ActionFactory.STATUS_COMPLETED);
+        sAction.setStatusCompleted();
         TestUtils.saveAndFlush(sAction);
 
 

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/FailedActionsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/FailedActionsSetupActionTest.java
@@ -67,7 +67,7 @@ public class FailedActionsSetupActionTest extends RhnPostMockStrutsTestCase {
 
         Action act = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         ServerAction sAction = ActionFactoryTest.createServerAction(server, act);
-        sAction.setStatus(ActionFactory.STATUS_FAILED);
+        sAction.setStatusFailed();
         TestUtils.saveAndFlush(sAction);
 
 

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/PendingActionsDeleteConfirmActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/PendingActionsDeleteConfirmActionTest.java
@@ -36,11 +36,11 @@ public class PendingActionsDeleteConfirmActionTest extends RhnMockStrutsTestCase
         Action a = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         Server server = ServerFactoryTest.createTestServer(user, true);
         ServerAction saction = ServerActionTest.createServerAction(server, a);
-        saction.setStatus(ActionFactory.STATUS_QUEUED);
+        saction.setStatusQueued();
 
         Action b = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         ServerAction saction2 = ServerActionTest.createServerAction(server, b);
-        saction2.setStatus(ActionFactory.STATUS_QUEUED);
+        saction2.setStatusQueued();
 
         ActionFactory.save(a);
         ActionFactory.save(b);

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/PendingActionsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/PendingActionsSetupActionTest.java
@@ -68,7 +68,7 @@ public class PendingActionsSetupActionTest extends RhnPostMockStrutsTestCase {
 
         Action act = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
         ServerAction sAction = ActionFactoryTest.createServerAction(server, act);
-        sAction.setStatus(ActionFactory.STATUS_QUEUED);
+        sAction.setStatusQueued();
         TestUtils.saveAndFlush(sAction);
 
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
@@ -100,11 +100,11 @@ public class SystemHistoryEventAction extends RhnAction {
         request.setAttribute("actionnotes", af.getDetails(server,
                 requestContext.getCurrentUser()));
         request.setAttribute("failed",
-                serverAction.getStatus().equals(ActionFactory.STATUS_FAILED));
+                serverAction.isStatusFailed());
         request.setAttribute("pickedup",
-                serverAction.getStatus().equals(ActionFactory.STATUS_PICKED_UP));
+                serverAction.isStatusPickedUp());
         request.setAttribute("completed",
-                serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED));
+                serverAction.isStatusCompleted());
         boolean typeDistUpgradeDryRun = action.getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE) &&
                         ((DistUpgradeAction) action).getDetails().isDryRun();
         request.setAttribute("typeDistUpgradeDryRun", typeDistUpgradeDryRun);
@@ -115,14 +115,14 @@ public class SystemHistoryEventAction extends RhnAction {
                     serverAction, requestContext.getCurrentUser());
             request.setAttribute("inventory", inventory);
         }
-        if (!serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED) &&
-                !serverAction.getStatus().equals(ActionFactory.STATUS_FAILED)) {
+        if (!serverAction.isStatusCompleted() &&
+                !serverAction.isStatusFailed()) {
             request.setAttribute("referrerLink", "Pending.do");
             request.setAttribute("linkLabel", "system.event.pendingReturn");
             request.setAttribute("headerLabel", "system.event.pendingHeader");
         }
         if (isSubmitted((DynaActionForm)formIn)) {
-            if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED) && typeDistUpgradeDryRun) {
+            if (serverAction.isStatusCompleted() && typeDistUpgradeDryRun) {
                 return mapping.findForward("spmigration");
             }
             createMessage(request, "system.event.rescheduled", action.getName(),

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
@@ -19,7 +19,6 @@ import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.ActionedSystem;
@@ -66,7 +65,7 @@ public class ScheduleHandler extends BaseHandler {
             }
 
             for (ServerAction sa : action.getServerActions()) {
-                if (ActionFactory.STATUS_PICKED_UP.equals(sa.getStatus())) {
+                if (sa.isStatusPickedUp()) {
                     throw new UnsupportedOperationException(locService.getMessage("api.schedule.cannotcancelpickedup"));
                 }
             }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
@@ -64,17 +64,17 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action a1 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction1 = ServerActionTest.createServerAction(server, a1);
-        saction1.setStatus(ActionFactory.STATUS_COMPLETED);
+        saction1.setStatusCompleted();
 
         Action a2 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction2 = ServerActionTest.createServerAction(server, a2);
-        saction2.setStatus(ActionFactory.STATUS_QUEUED);
+        saction2.setStatusQueued();
 
         Action a3 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction3 = ServerActionTest.createServerAction(server, a3);
-        saction3.setStatus(ActionFactory.STATUS_FAILED);
+        saction3.setStatusFailed();
 
         apiActions = handler.listAllActions(admin);
         assertEquals(numActions + 3, apiActions.length);
@@ -111,17 +111,17 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action a1 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction1 = ServerActionTest.createServerAction(server, a1);
-        saction1.setStatus(ActionFactory.STATUS_COMPLETED);
+        saction1.setStatusCompleted();
 
         Action a2 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction2 = ServerActionTest.createServerAction(server, a2);
-        saction2.setStatus(ActionFactory.STATUS_QUEUED);
+        saction2.setStatusQueued();
 
         Action a3 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction3 = ServerActionTest.createServerAction(server, a3);
-        saction3.setStatus(ActionFactory.STATUS_FAILED);
+        saction3.setStatusFailed();
 
         // execute
         apiActions = handler.listAllActions(admin);
@@ -148,7 +148,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action a = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction = ServerActionTest.createServerAction(server, a);
-        saction.setStatus(ActionFactory.STATUS_COMPLETED);
+        saction.setStatusCompleted();
 
         apiActions = handler.listCompletedActions(admin);
 
@@ -172,7 +172,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action a = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction = ServerActionTest.createServerAction(server, a);
-        saction.setStatus(ActionFactory.STATUS_QUEUED);
+        saction.setStatusQueued();
 
         apiActions = handler.listInProgressActions(admin);
 
@@ -196,7 +196,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action a = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction = ServerActionTest.createServerAction(server, a);
-        saction.setStatus(ActionFactory.STATUS_FAILED);
+        saction.setStatusFailed();
 
         apiActions = handler.listFailedActions(admin);
 
@@ -221,7 +221,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         a.setArchived(1L);
         ServerAction saction = ServerActionTest.createServerAction(server, a);
-        saction.setStatus(ActionFactory.STATUS_QUEUED);
+        saction.setStatusQueued();
 
         apiActions = handler.listArchivedActions(admin);
 
@@ -245,13 +245,13 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         a.setArchived(1L);
         ServerAction saction = ServerActionTest.createServerAction(server, a);
-        saction.setStatus(ActionFactory.STATUS_QUEUED);
+        saction.setStatusQueued();
 
         Action a2 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         a2.setArchived(1L);
         ServerAction saction2 = ServerActionTest.createServerAction(server, a2);
-        saction2.setStatus(ActionFactory.STATUS_QUEUED);
+        saction2.setStatusQueued();
 
         apiActions = handler.listAllArchivedActions(admin);
         assertTrue(apiActions.length > numActions);
@@ -281,12 +281,12 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action a = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction = ServerActionTest.createServerAction(server, a);
-        saction.setStatus(ActionFactory.STATUS_COMPLETED);
+        saction.setStatusCompleted();
 
         Action a2 = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction2 = ServerActionTest.createServerAction(server, a2);
-        saction2.setStatus(ActionFactory.STATUS_COMPLETED);
+        saction2.setStatusCompleted();
 
         apiActions = handler.listAllCompletedActions(admin);
         assertTrue(apiActions.length > numActions);
@@ -307,7 +307,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action action = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction = ServerActionTest.createServerAction(server, action);
-        saction.setStatus(ActionFactory.STATUS_COMPLETED);
+        saction.setStatusCompleted();
 
         //obtain number of systems from action manager
         DataResult<ActionedSystem> systems = ActionManager.completedSystems(admin, action, null);
@@ -328,7 +328,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action action = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction = ServerActionTest.createServerAction(server, action);
-        saction.setStatus(ActionFactory.STATUS_QUEUED);
+        saction.setStatusQueued();
 
         //obtain number of systems from action manager
         DataResult<ActionedSystem> systems = ActionManager.inProgressSystems(admin, action, null);
@@ -349,7 +349,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         Action action = ActionFactoryTest.createAction(admin,
                 ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction saction = ServerActionTest.createServerAction(server, action);
-        saction.setStatus(ActionFactory.STATUS_FAILED);
+        saction.setStatusFailed();
 
         //obtain number of systems from action manager
         DataResult<ActionedSystem> systems = ActionManager.failedSystems(admin, action, null);
@@ -388,7 +388,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
 
         Action action = ActionFactoryTest.createEmptyAction(admin, ActionFactory.TYPE_PACKAGES_UPDATE);
         ServerAction serverAction = ServerActionTest.createServerAction(server, action);
-        serverAction.setStatus(ActionFactory.STATUS_PICKED_UP);
+        serverAction.setStatusPickedUp();
 
         ActionFactory.save(action);
         ActionFactory.save(serverAction);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1688,7 +1688,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 Arrays.asList("channels", "packages"), new Date());
 
         final ServerAction serverAction = ServerActionTest.createServerAction(server, action);
-        serverAction.setStatus(ActionFactory.STATUS_PICKED_UP);
+        serverAction.setStatusPickedUp();
 
         ActionFactory.save(action);
         clearSession();

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -43,7 +43,6 @@ import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.common.validator.ValidatorWarning;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.ActionType;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.server.test.ServerActionTest;
@@ -179,6 +178,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 
@@ -1902,7 +1902,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         final Server server = ServerTestUtils.createTestSystem(user);
 
         Long historyEventId = createHistoryEntry(server, "Event 1");
-        Long actionEventId = createTestAction(server, ActionFactory.TYPE_APPLY_STATES, ActionFactory.STATUS_PICKED_UP);
+        Long actionEventId = createTestAction(server, ActionFactory.TYPE_APPLY_STATES, ServerAction::setStatusPickedUp);
 
         final Long sid = server.getId();
         final Long oid = user.getOrg().getId();
@@ -2129,15 +2129,16 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         return historyEvent.getId();
     }
 
-    private Long createTestAction(Server server, ActionType actionType) throws Exception {
-        return createTestAction(server, actionType, ActionFactory.STATUS_COMPLETED);
+    private void createTestAction(Server server, ActionType actionType) throws Exception {
+        createTestAction(server, actionType, ServerAction::setStatusCompleted);
     }
 
-    private Long createTestAction(Server server, ActionType actionType, ActionStatus actionStatus) throws Exception {
+    private Long createTestAction(Server server, ActionType actionType, Consumer<ServerAction> statusSetter)
+            throws Exception {
         final Action action = ActionFactoryTest.createAction(user, actionType);
         final ServerAction serverAction = ServerActionTest.createServerAction(server, action);
 
-        serverAction.setStatus(actionStatus);
+        statusSetter.accept(serverAction);
 
         ActionFactory.save(action);
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -195,7 +195,7 @@ public class MinionActionChainExecutor extends RhnJavaJob {
                           .map(ActionChainEntry::getAction)
                           .filter(action -> action != null && CollectionUtils.isNotEmpty(action.getServerActions()))
                           .flatMap(action -> action.getServerActions().stream())
-                          .filter(serverAction -> ActionFactory.STATUS_QUEUED.equals(serverAction.getStatus()))
+                          .filter(serverAction -> serverAction.isStatusQueued())
                           .count();
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -193,7 +193,7 @@ public class MinionActionExecutor extends RhnJavaJob {
 
         return action.getServerActions()
                      .stream()
-                     .filter(serverAction -> ActionFactory.STATUS_QUEUED.equals(serverAction.getStatus()))
+                     .filter(serverAction -> serverAction.isStatusQueued())
                      .count();
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
@@ -109,7 +109,7 @@ public class RebootActionCleanup extends RhnJavaJob {
         Server s = ServerFactory.lookupById(serverId);
         Action a = ActionFactory.lookupById(actionId);
         ServerAction sa = ActionFactory.getServerActionForServerAndAction(s, a);
-        if (!"Failed".equals(sa.getStatus().getName())) {
+        if (!sa.isStatusFailed()) {
             sa.fail(-100L, "Prerequisite failed", sa.getPickupTime());
 
             s.asMinionServer()

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
@@ -104,7 +104,7 @@ public class SSHMinionActionExecutor extends RhnJavaJob {
         action.getServerActions().stream()
                 .filter(sa -> sshMinionOpt.get().getId().equals(sa.getServerId())).findFirst()
                 .ifPresent(sa -> {
-                    sa.setStatus(ActionFactory.STATUS_PICKED_UP);
+                    sa.setStatusPickedUp();
                     sa.setPickupTime(new Date());
                     HibernateFactory.commitTransaction();
                 });

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceWorker.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshservice/SSHServiceWorker.java
@@ -255,7 +255,7 @@ public class SSHServiceWorker implements QueueWorker {
                 .map(ActionFactory::lookupById)
                 .flatMap(action -> action.getServerActions().stream()
                         .filter(sa -> sa.getServer().equals(minion)).findFirst())
-                .filter(sa -> ActionFactory.STATUS_FAILED.equals(sa.getStatus()))
+                .filter(sa -> sa.isStatusFailed())
                 .isPresent();
         if (nextActionIsFailed) {
             // Next action is failed due to some previous error in the action chain.

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionChainExecutorTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionChainExecutorTest.java
@@ -18,6 +18,7 @@ package com.redhat.rhn.taskomatic.task.test;
 import static org.jmock.AbstractExpectations.any;
 import static org.jmock.AbstractExpectations.returnValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
@@ -88,13 +89,13 @@ public class MinionActionChainExecutorTest extends JMockBaseTestCaseWithUser {
 
         Action a1 = ActionFactoryTest.createEmptyAction(user, ActionFactory.TYPE_REBOOT);
         a1.setEarliestAction(Date.from(Instant.now().minus(7, ChronoUnit.DAYS)));
-        ServerAction sa1 = ActionFactoryTest.addServerAction(user, a1, ActionFactory.STATUS_QUEUED);
+        ServerAction sa1 = ActionFactoryTest.addServerAction(user, a1, ServerAction::setStatusQueued);
         TestUtils.saveAndReload(a1);
         ActionChainFactory.queueActionChainEntry(a1, actionChain, sa1.getServer());
 
         Action a2 = ActionFactoryTest.createEmptyAction(user, ActionFactory.TYPE_PACKAGES_UPDATE);
         a2.setEarliestAction(Date.from(Instant.now().minus(7, ChronoUnit.DAYS)));
-        ServerAction sa2 = ActionFactoryTest.addServerAction(user, a2, ActionFactory.STATUS_QUEUED);
+        ServerAction sa2 = ActionFactoryTest.addServerAction(user, a2, ServerAction::setStatusQueued);
         TestUtils.saveAndReload(a2);
         ActionChainFactory.queueActionChainEntry(a2, actionChain, sa2.getServer());
 
@@ -137,11 +138,11 @@ public class MinionActionChainExecutorTest extends JMockBaseTestCaseWithUser {
         sa1 = HibernateFactory.reload(sa1);
         sa2 = HibernateFactory.reload(sa2);
 
-        assertEquals(ActionFactory.STATUS_FAILED, sa1.getStatus());
+        assertTrue(sa1.isStatusFailed());
         assertEquals(expectedMessage, sa1.getResultMsg());
         assertEquals(-1, sa1.getResultCode());
 
-        assertEquals(ActionFactory.STATUS_FAILED, sa2.getStatus());
+        assertTrue(sa2.isStatusFailed());
         assertEquals(expectedMessage, sa2.getResultMsg());
         assertEquals(-1, sa2.getResultCode());
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionExecutorTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionActionExecutorTest.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.taskomatic.task.test;
 
 import static org.jmock.AbstractExpectations.returnValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
@@ -85,8 +86,8 @@ public class MinionActionExecutorTest extends JMockBaseTestCaseWithUser {
         // Set the earliest action date to one week ago
         a1.setEarliestAction(Date.from(Instant.now().minus(7, ChronoUnit.DAYS)));
 
-        ServerAction sa1 = ActionFactoryTest.addServerAction(user, a1, ActionFactory.STATUS_COMPLETED);
-        ServerAction sa2 = ActionFactoryTest.addServerAction(user, a1, ActionFactory.STATUS_QUEUED);
+        ServerAction sa1 = ActionFactoryTest.addServerAction(user, a1, ServerAction::setStatusCompleted);
+        ServerAction sa2 = ActionFactoryTest.addServerAction(user, a1, ServerAction::setStatusQueued);
 
         TestUtils.saveAndReload(a1);
 
@@ -134,9 +135,9 @@ public class MinionActionExecutorTest extends JMockBaseTestCaseWithUser {
         String expectedMessage = LOCALIZATION.getMessage("task.action.rejection.reason",
             MinionActionExecutor.MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS);
 
-        assertEquals(ActionFactory.STATUS_COMPLETED, sa1.getStatus());
+        assertTrue(sa1.isStatusCompleted());
 
-        assertEquals(ActionFactory.STATUS_FAILED, sa2.getStatus());
+        assertTrue(sa2.isStatusFailed());
         assertEquals(expectedMessage, sa2.getResultMsg());
         assertEquals(-1, sa2.getResultCode());
     }

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -28,7 +28,6 @@ import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.util.download.DownloadException;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -724,12 +723,8 @@ public class MaintenanceManager {
 
         Optional<Calendar> calendarOpt = schedule.getCalendarOpt().flatMap(c -> icalUtils.parseCalendar(c));
 
-        List<ActionStatus> pending = new LinkedList<>();
-        pending.add(ActionFactory.STATUS_PICKED_UP);
-        pending.add(ActionFactory.STATUS_QUEUED);
-
         Map<Action, List<Server>> actionsForServerToReschedule = servers.stream()
-            .flatMap(s -> ActionFactory.listServerActionsForServer(s, pending).stream())
+            .flatMap(s -> ActionFactory.listServerActionsForServer(s, ActionFactory.ALL_PENDING_STATUSES).stream())
             .filter(sa -> {
                 Action a = sa.getParentAction();
                 if (a.getPrerequisite() != null) {

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -378,7 +378,7 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         action.setEarliestAction(Date.from(start.toInstant()));
 
         ServerAction serverAction = ServerActionTest.createServerAction(server, action);
-        serverAction.setStatus(ActionFactory.STATUS_QUEUED);
+        serverAction.setStatusQueued();
 
         action.addServerAction(serverAction);
         ActionManager.storeAction(action);

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceTestUtils.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceTestUtils.java
@@ -49,7 +49,7 @@ public class MaintenanceTestUtils {
         action.setEarliestAction(Date.from(start.toInstant()));
 
         ServerAction serverAction = ServerActionTest.createServerAction(server, action);
-        serverAction.setStatus(ActionFactory.STATUS_QUEUED);
+        serverAction.setStatusQueued();
 
         action.addServerAction(serverAction);
         ActionManager.storeAction(action);

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -172,7 +172,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                                             .filter(m -> m.getMinionId().equals(jobReturnEvent.getMinionId()))
                                             .isPresent()
                                     )
-                                    .filter(sa -> !sa.getStatus().isDone())
+                                    .filter(sa -> !sa.isDone())
                                     .forEach(sa -> sa.fail(jobReturnEvent.getData().getResult().toString()));
                             if (ac.isDone()) {
                                 ActionChainFactory.delete(ac);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -235,9 +235,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals("Suse", minion.getOsFamily());
 
         // Verify the action status
-        assertEquals(action.getServerActions().stream()
+        assertTrue(action.getServerActions().stream()
                 .filter(serverAction -> serverAction.getServer().equals(minion))
-                .findAny().get().getStatus(), ActionFactory.STATUS_COMPLETED);
+                .findAny().get().isStatusCompleted());
     }
 
     @Test
@@ -587,9 +587,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals("RedHat", minion.getOsFamily());
 
         // Verify the action status
-        assertEquals(action.getServerActions().stream()
+        assertTrue(action.getServerActions().stream()
                 .filter(serverAction -> serverAction.getServer().equals(minion))
-                .findAny().get().getStatus(), ActionFactory.STATUS_COMPLETED);
+                .findAny().get().isStatusCompleted());
     }
 
     /**
@@ -646,9 +646,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals("Debian", minion.getOsFamily());
 
         // Verify the action status
-        assertEquals(action.getServerActions().stream()
+        assertTrue(action.getServerActions().stream()
                 .filter(serverAction -> serverAction.getServer().equals(minion))
-                .findAny().get().getStatus(), ActionFactory.STATUS_COMPLETED);
+                .findAny().get().isStatusCompleted());
     }
 
     /**
@@ -706,9 +706,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals("Debian", minion.getOsFamily());
 
         // Verify the action status
-        assertEquals(action.getServerActions().stream()
+        assertTrue(action.getServerActions().stream()
                 .filter(serverAction -> serverAction.getServer().equals(minion))
-                .findAny().get().getStatus(), ActionFactory.STATUS_COMPLETED);
+                .findAny().get().isStatusCompleted());
     }
 
     @Test
@@ -1359,7 +1359,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             ).collect(java.util.stream.Collectors.toList()));
 
         // Verify the action status
-        assertEquals(ActionFactory.STATUS_FAILED, sa.getStatus());
+        assertTrue(sa.isStatusFailed());
         context().assertIsSatisfied();
     }
 
@@ -1420,7 +1420,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ScapAction.setXccdfResumeXsl(resumeXsl);
         messageAction.execute(message);
 
-        assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
+        assertTrue(sa.isStatusCompleted());
     }
 
     /**
@@ -2089,7 +2089,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
-        assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
+        assertTrue(sa.isStatusCompleted());
         assertEquals(0L, (long)sa.getResultCode());
         assertEquals(baseChannel.get().getId(), minion.getBaseChannel().getId());
         assertEquals(2, minion.getChildChannels().size());
@@ -2176,7 +2176,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        applyStateAction.getServerActions().stream().findFirst().get().setStatus(ActionFactory.STATUS_FAILED);
+        applyStateAction.getServerActions().stream().findFirst().get().setStatusFailed();
 
         saltServerActionService.failDependentServerActions(applyStateAction.getId(),
                 minion.getMinionId(), Optional.empty());
@@ -2192,9 +2192,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         ServerAction runScriptSeverAction = runScriptAction.getServerActions().stream()
                 .filter(sa -> sa.getServerId().equals(minion.getId())).findFirst().get();
 
-        assertEquals(ActionFactory.STATUS_FAILED, applyStateServerAction.getStatus());
-        assertEquals(ActionFactory.STATUS_FAILED, rebootSeverAction.getStatus());
-        assertEquals(ActionFactory.STATUS_FAILED, runScriptSeverAction.getStatus());
+        assertTrue(applyStateServerAction.isStatusFailed());
+        assertTrue(rebootSeverAction.isStatusFailed());
+        assertTrue(runScriptSeverAction.isStatusFailed());
 
         //Check the output of dependent actions
         assertEquals("Prerequisite failed", rebootSeverAction.getResultMsg());
@@ -2248,7 +2248,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         applyHighstate = (ApplyStatesAction)ActionFactory.lookupById(applyHighstate.getId());
         saHighstate = applyHighstate.getServerActions().stream().findFirst().get();
 
-        assertEquals(ActionFactory.STATUS_COMPLETED, saHighstate.getStatus());
+        assertTrue(saHighstate.isStatusCompleted());
         assertEquals(0L, (long)saHighstate.getResultCode());
         assertEquals(minion.getId(), saHighstate.getServer().getId());
         assertEquals("Successfully applied state(s): highstate", saHighstate.getResultMsg());
@@ -2256,7 +2256,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         runScript = (ScriptRunAction)ActionFactory.lookupById(runScript.getId());
         ServerAction saScript = runScript.getServerActions().stream().findFirst().get();
 
-        assertEquals(ActionFactory.STATUS_COMPLETED, saScript.getStatus());
+        assertTrue(saScript.isStatusCompleted());
         assertEquals(0L, (long)saScript.getResultCode());
         assertEquals(minion.getId(), saScript.getServer().getId());
         ScriptResult scriptResult = runScript.getScriptActionDetails().getResults()

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -14,10 +14,6 @@
  */
 package com.suse.manager.webui.services.test;
 
-import static com.redhat.rhn.domain.action.ActionFactory.STATUS_COMPLETED;
-import static com.redhat.rhn.domain.action.ActionFactory.STATUS_FAILED;
-import static com.redhat.rhn.domain.action.ActionFactory.STATUS_PICKED_UP;
-import static com.redhat.rhn.domain.action.ActionFactory.STATUS_QUEUED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +25,6 @@ import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainEntry;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.domain.action.ActionStatus;
 import com.redhat.rhn.domain.action.ansible.PlaybookAction;
 import com.redhat.rhn.domain.action.ansible.PlaybookActionDetails;
 import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
@@ -109,6 +104,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 
@@ -288,7 +284,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         List<MinionSummary> summaries = result.values().iterator().next();
         assertTrue(summaries.isEmpty());
         ServerAction serverAction = HibernateFactory.reload(action.getServerActions().iterator().next());
-        assertEquals(STATUS_FAILED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusFailed());
     }
 
     @Test
@@ -685,17 +681,17 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         // prerequisite is still queued
         Action prereq = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction prereqServerAction = createChildServerAction(prereq, STATUS_QUEUED, 5L);
+        ServerAction prereqServerAction = createChildServerAction(prereq, ServerAction::setStatusQueued, 5L);
 
         // action is queued as well
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         action.setPrerequisite(prereq);
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusQueued, 5L);
 
         testService.executeSSHAction(action, minion);
 
         // both status and remaining tries should remain unchanged
-        assertEquals(STATUS_QUEUED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusQueued());
         assertEquals(Long.valueOf(5L), serverAction.getRemainingTries());
 
         AtomicInteger counter2 = new AtomicInteger();
@@ -709,11 +705,11 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         testService = createSaltServerActionService(new TestSystemQuery(), saltApi);
 
         testService.executeSSHAction(prereq, minion);
-        assertEquals(STATUS_COMPLETED, prereqServerAction.getStatus());
+        assertTrue(prereqServerAction.isStatusCompleted());
 
         // 2nd try
         testService.executeSSHAction(action, minion);
-        assertEquals(STATUS_COMPLETED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusCompleted());
 
         assertEquals(0, counter.get());
         assertEquals(2, counter2.get());
@@ -730,25 +726,25 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         AtomicInteger counter = new AtomicInteger();
         SaltServerActionService testService = countSaltActionCalls(counter);
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction serverAction = createChildServerAction(action, STATUS_COMPLETED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusCompleted, 5L);
 
         testService.executeSSHAction(action, minion);
 
-        assertEquals(STATUS_COMPLETED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusCompleted());
         assertEquals(Long.valueOf(5L), serverAction.getRemainingTries());
         assertEquals(0, counter.get());
     }
 
-    private ServerAction createChildServerAction(Action action, ActionStatus status,
+    private ServerAction createChildServerAction(Action action, Consumer<ServerAction> statusSetter,
                                                  long remainingTries) {
-        return createChildServerAction(action, status, minion, remainingTries);
+        return createChildServerAction(action, statusSetter, minion, remainingTries);
     }
 
-    private ServerAction createChildServerAction(Action action, ActionStatus status,
+    private ServerAction createChildServerAction(Action action, Consumer<ServerAction> statusSetter,
                                                  MinionServer minionIn,
                                                  long remainingTries) {
         ServerAction serverAction = ActionFactoryTest.createServerAction(minionIn, action);
-        serverAction.setStatus(status);
+        statusSetter.accept(serverAction);
         serverAction.setRemainingTries(remainingTries);
         if (action.getServerActions() == null) {
             Set<ServerAction> set = new HashSet<>();
@@ -772,11 +768,11 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         AtomicInteger counter = new AtomicInteger();
         SaltServerActionService testService = countSaltActionCalls(counter);
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction serverAction = createChildServerAction(action, STATUS_FAILED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusFailed, 5L);
 
         testService.executeSSHAction(action, minion);
 
-        assertEquals(STATUS_FAILED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusFailed());
         assertEquals(Long.valueOf(5L), serverAction.getRemainingTries());
         assertEquals(0, counter.get());
     }
@@ -794,15 +790,15 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         // prerequisite failed
         Action prereq = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        createChildServerAction(prereq, STATUS_FAILED, 0L);
+        createChildServerAction(prereq, ServerAction::setStatusFailed, 0L);
 
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         action.setPrerequisite(prereq);
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusQueued, 5L);
 
         testService.executeSSHAction(action, minion);
 
-        assertEquals(STATUS_FAILED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusFailed());
         assertEquals("Prerequisite failed.", serverAction.getResultMsg());
         // this comes from the xmlrpc/queue.py
         assertEquals(Long.valueOf(-100L), serverAction.getResultCode());
@@ -823,12 +819,12 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         // create action without servers
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusQueued, 5L);
 
         saltServerActionService.executeSSHAction(action, minion);
 
         assertEquals(Long.valueOf(4L), serverAction.getRemainingTries());
-        assertEquals(STATUS_COMPLETED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusCompleted());
     }
 
     /**
@@ -850,11 +846,11 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         SaltServerActionService testService = createSaltServerActionService(new TestSystemQuery(), saltApi);
 
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusQueued, 5L);
 
         testService.executeSSHAction(action, minion);
 
-        assertEquals(STATUS_FAILED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusFailed());
         assertEquals("Minion is down or could not be contacted.", serverAction.getResultMsg());
     }
 
@@ -876,7 +872,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         };
         SaltServerActionService testService = createSaltServerActionService(new TestSystemQuery(), saltApi);
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusQueued, 5L);
         try {
             testService.executeSSHAction(action, minion);
         }
@@ -884,7 +880,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
             fail("Runtime exception should not have been thrown.");
         }
 
-        assertEquals(STATUS_FAILED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusFailed());
         assertTrue(serverAction.getResultMsg().startsWith("Error calling Salt: "));
     }
 
@@ -907,11 +903,11 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         SaltServerActionService testService = createSaltServerActionService(new TestSystemQuery(), saltApi);
 
         Action action = createRebootAction(new Date(1L));
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusQueued, 5L);
 
         testService.executeSSHAction(action, minion);
 
-        assertEquals(STATUS_PICKED_UP, serverAction.getStatus());
+        assertTrue(serverAction.isStatusPickedUp());
         assertEquals(Long.valueOf(4L), serverAction.getRemainingTries());
     }
 
@@ -936,18 +932,18 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         // prerequisite is still queued
         Action prereq = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
-        ServerAction prereqServerAction = createChildServerAction(prereq, STATUS_QUEUED, 5L);
+        ServerAction prereqServerAction = createChildServerAction(prereq, ServerAction::setStatusQueued, 5L);
         prereq.setServerActions(Collections.singleton(prereqServerAction));
 
         // action is queued as well
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         action.setPrerequisite(prereq);
-        ServerAction serverAction = createChildServerAction(action, STATUS_QUEUED, 5L);
+        ServerAction serverAction = createChildServerAction(action, ServerAction::setStatusQueued, 5L);
 
         testService.executeSSHAction(action, minion);
 
         // both status and remaining tries should remain unchanged
-        assertEquals(STATUS_QUEUED, serverAction.getStatus());
+        assertTrue(serverAction.isStatusQueued());
         assertEquals(Long.valueOf(5L), serverAction.getRemainingTries());
         assertEquals(0, counter.get());
     }
@@ -963,8 +959,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         action.getServerActions().forEach(sa -> sa.fail("not needed"));
         action.setServerActions(null);
 
-        createChildServerAction(action, STATUS_QUEUED, sshMinion, 5L);
-        createChildServerAction(action, STATUS_QUEUED, testMinionServer, 5L);
+        createChildServerAction(action, ServerAction::setStatusQueued, sshMinion, 5L);
+        createChildServerAction(action, ServerAction::setStatusQueued, testMinionServer, 5L);
         HibernateFactory.getSession().flush();
 
         SaltService saltServiceMock = mock(SaltService.class);
@@ -997,8 +993,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         // set the auto generated server action to failed
         action.getServerActions().forEach(sa -> sa.fail("not needed"));
         action.setServerActions(null);
-        createChildServerAction(action, STATUS_COMPLETED, firstMinion, 5L);
-        createChildServerAction(action, STATUS_QUEUED, secondMinion, 5L);
+        createChildServerAction(action, ServerAction::setStatusCompleted, firstMinion, 5L);
+        createChildServerAction(action, ServerAction::setStatusQueued, secondMinion, 5L);
 
         HibernateFactory.getSession().flush();
 
@@ -1039,7 +1035,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
             public void updateServerAction(ServerAction serverAction, long retcode, boolean success, String jid,
                                            JsonElement jsonResult, Optional<Xor<String[], String>> function,
                                            Date endTime) {
-                serverAction.setStatus(STATUS_COMPLETED);
+                serverAction.setStatusCompleted();
             }
         };
         saltUtils.setScriptsDir(Files.createTempDirectory("actionscripts"));

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -131,7 +131,7 @@ public class MinionActionUtils {
              .isPresent()
         );
 
-        if (!actionIsRunning && !serverAction.getStatus().equals(ActionFactory.STATUS_QUEUED)) {
+        if (!actionIsRunning && !serverAction.isStatusQueued()) {
             String message = "No job return event was received.";
             serverAction.fail(message);
         }

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -87,10 +87,10 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
 
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         ServerAction sa = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
-        sa.setStatus(ActionFactory.STATUS_COMPLETED);
+        sa.setStatusCompleted();
         action.addServerAction(sa);
         ServerAction sa2 = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
-        sa2.setStatus(ActionFactory.STATUS_FAILED);
+        sa2.setStatusFailed();
         action.addServerAction(sa2);
         Path scriptFile = Files.createFile(saltUtils.getScriptPath(action.getId()));
 
@@ -122,10 +122,10 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         ServerAction sa = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
-        sa.setStatus(ActionFactory.STATUS_PICKED_UP);
+        sa.setStatusPickedUp();
         action.addServerAction(sa);
         ServerAction sa2 = ActionFactoryTest.createServerAction(ServerFactoryTest.createTestServer(user), action);
-        sa2.setStatus(ActionFactory.STATUS_COMPLETED);
+        sa2.setStatusCompleted();
         action.addServerAction(sa2);
         Path scriptFile = Files.createFile(saltUtils.getScriptPath(action.getId()));
 


### PR DESCRIPTION
## What does this PR change?
This PR is one step towards the simplification of Action handling.
The specific aim of this PR is to simplify the use of the class `ActionStatus`.
This substantially is an enum of four action statuses: `Queued, Picked Up, Completed, Failed`.
As for legacy code, they were represented in the table `rhnActionStatus`, and are a member of `ServerAction` class (`rhnServerAction` table).
The class `ActionFactory` looks up for the objects in the table in 4 static variables (e.g. `public static final ActionStatus STATUS_QUEUED`), and these static variables are used everywhere for setting and comparing statuses.

This PR aims at a first step, reducing the presence of the `ActionFactory` static status variables everywhere, and introducing "`setState`" and "`isState`" predicates, so that the status can actually be modified/adjusted in the future in a single place.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/13569
Port(s): # **add downstream PR(s), if any**
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

