### PR TITLE
Fix to don't let Taskomatic tasks interfere with our BV tests

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_disable_scheduled_reposync.feature
+++ b/testsuite/features/build_validation/reposync/srv_disable_scheduled_reposync.feature
@@ -1,14 +1,21 @@
-# Copyright (c) 2019-2023 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Delete the scheduled task for mgr-sync-refresh
+Feature: Do not let Taskomatic tasks interfere with our BV tests
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Delete scheduled reposyncs
+  Scenario: Disable scheduled reposyncs
     When I follow the left menu "Admin > Task Schedules"
     And I follow "mgr-sync-refresh-default"
     And I choose "disabled"
     And I click on "Update Schedule"
-    And I click on "Delete Schedule"
+    And I click on "Disable Schedule"
+
+  Scenario: Disable scheduled Cobbler syncs
+    When I follow the left menu "Admin > Task Schedules"
+    And I follow "cobbler-sync-default"
+    And I choose "disabled"
+    And I click on "Update Schedule"
+    And I click on "Disable Schedule"

--- a/testsuite/features/reposync/srv_disable_scheduled_reposync.feature
+++ b/testsuite/features/reposync/srv_disable_scheduled_reposync.feature
@@ -1,7 +1,7 @@
-# Copyright (c) 2019-2024 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Do not let Taskomatic tasks interfer with our tests
+Feature: Do not let Taskomatic tasks interfere with our CI tests
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section


### PR DESCRIPTION
## What does this PR change?

Fix to don't let Taskomatic tasks interfere with our BV tests.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/27786
- Manager-5.0 https://github.com/SUSE/spacewalk/pull/27785

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
