### PR TITLE
Simplify action handling (step 4 - unifying os family constants) 

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRefreshListAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageRefreshListAction.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.ServerAppStream;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.system.SystemManager;
@@ -68,9 +69,6 @@ import java.util.stream.Stream;
  */
 public class PackageRefreshListAction extends PackageAction {
     private static final Logger LOG = LogManager.getLogger(PackageRefreshListAction.class);
-
-    // SUSE OS family as defined in Salt grains
-    private static final String OS_FAMILY_SUSE = "Suse";
 
     /**
      * {@inheritDoc}
@@ -242,7 +240,7 @@ public class PackageRefreshListAction extends PackageAction {
              Also, the getOsRelease method requires remote command execution and was therefore avoided for now.
              If we decide to support RedHat distro/SP upgrades in the future, this code has to be reviewed.
              */
-            if (server.getOsFamily().equals(OS_FAMILY_SUSE)) {
+            if (server.getOsFamily().equals(ServerConstants.OS_FAMILY_SUSE)) {
                 server.setRelease(grains.getValueAsString("osrelease"));
             }
         }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.domain.entitlement.ContainerBuildHostEntitlement;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -77,7 +78,7 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
     public void testIsAllowedOnServerWithGrains() throws Exception {
         Server minion = MinionServerFactoryTest.createTestMinionServer(user);
         Map<String, Object> grains = new HashMap<>();
-        grains.put("os_family", "Suse");
+        grains.put("os_family", ServerConstants.OS_FAMILY_SUSE);
         grains.put("osmajorrelease", "12");
 
         assertTrue(ent.isAllowedOnServer(minion, new ValueMap(grains)));

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2607,12 +2607,27 @@ public class Server extends BaseDomainHelper implements Identifiable {
     }
 
     /**
+     * Predicate to check for Suse os family
+     * @return true is Suse os family
+     */
+    public boolean isOsFamilySuse() {
+        return this.osFamily.equals(ServerConstants.OS_FAMILY_SUSE);
+    }
+
+    /**
      * Setter for os family
      *
      * @param osFamilyIn to set
      */
     public void setOsFamily(String osFamilyIn) {
         this.osFamily = osFamilyIn;
+    }
+
+    /**
+     * Setter for Suse os family
+     */
+    public void setOsFamilySuse() {
+        this.osFamily = ServerConstants.OS_FAMILY_SUSE;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
@@ -41,6 +41,12 @@ public class ServerConstants {
     public static final String SLED = "SLED";
     public static final String RHEL = "Red Hat Enterprise Linux";
 
+    // SUSE OS family as defined in Salt grains
+    public static final String OS_FAMILY_SUSE = "Suse";
+
+    public static final String OS_FAMILY_DEBIAN = "Debian";
+    public static final String OS_FAMILY_REDHAT = "RedHat";
+
     private ServerConstants() {
 
     }

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -735,7 +735,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             // a Mgr Server is also a Minion
             MinionServer minionServer = (MinionServer) s;
             minionServer.setMinionId(s.getName());
-            minionServer.setOsFamily("Suse");
+            minionServer.setOsFamily(ServerConstants.OS_FAMILY_SUSE);
             minionServer.setMachineId(TestUtils.randomString());
 
             ReportDBCredentials reportCredentials = CredentialsFactory.createReportCredentials("pythia", "secret");
@@ -754,7 +754,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
             // a Proxy Server is also a Minion
             MinionServer minionServer = (MinionServer) s;
             minionServer.setMinionId(s.getName());
-            minionServer.setOsFamily("Suse");
+            minionServer.setOsFamily(ServerConstants.OS_FAMILY_SUSE);
             minionServer.setMachineId(TestUtils.randomString());
 
             ProxyInfo info = new ProxyInfo();
@@ -765,7 +765,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         else if (type == TYPE_SERVER_MINION) {
             MinionServer minionServer = (MinionServer) s;
             minionServer.setMinionId(s.getName());
-            minionServer.setOsFamily("Suse");
+            minionServer.setOsFamily(ServerConstants.OS_FAMILY_SUSE);
             minionServer.setMachineId(TestUtils.randomString());
         }
     }

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -252,7 +252,7 @@ public class ServerTest extends BaseTestCaseWithUser {
         MinionServer s = (MinionServer) ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
                 ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOsFamily("RedHat");
+        s.setOsFamily(ServerConstants.OS_FAMILY_REDHAT);
         s.setRelease("6");
         assertTrue(s.doesOsSupportsMonitoring());
     }
@@ -265,7 +265,7 @@ public class ServerTest extends BaseTestCaseWithUser {
         MinionServer s = (MinionServer) ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
                 ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOsFamily("RedHat");
+        s.setOsFamily(ServerConstants.OS_FAMILY_REDHAT);
         s.setRelease("7");
         assertTrue(s.doesOsSupportsMonitoring());
     }
@@ -278,7 +278,7 @@ public class ServerTest extends BaseTestCaseWithUser {
         MinionServer s = (MinionServer) ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
                 ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOsFamily("RedHat");
+        s.setOsFamily(ServerConstants.OS_FAMILY_REDHAT);
         s.setRelease("8");
         assertTrue(s.doesOsSupportsMonitoring());
     }
@@ -291,7 +291,7 @@ public class ServerTest extends BaseTestCaseWithUser {
         MinionServer s = (MinionServer) ServerFactoryTest.createTestServer(user, true,
                 ServerConstants.getServerGroupTypeSaltEntitled(),
                 ServerFactoryTest.TYPE_SERVER_MINION);
-        s.setOsFamily("RedHat");
+        s.setOsFamily(ServerConstants.OS_FAMILY_REDHAT);
         s.setRelease("9");
         assertTrue(s.doesOsSupportsMonitoring());
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -71,7 +71,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
         boolean isMinion = minion.isPresent();
         LOG.debug("{}is a minion system? {}", server.getId(), isMinion);
         // Check if this is a SUSE system (for minions only)
-        boolean isSUSEMinion = isMinion && minion.get().getOsFamily().equals("Suse");
+        boolean isSUSEMinion = isMinion && minion.get().isOsFamilySuse();
         LOG.debug("{}is a SUSE system? {}", server.getId(), isSUSEMinion);
 
         if (isSUSEMinion || !isMinion) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
@@ -89,7 +89,7 @@ public class ErrataSetupAction extends RhnAction implements Listable<ErrataOverv
 
         Optional<MinionServer> minion = MinionServerFactory.lookupById(sid);
         // Check if this is a SUSE system
-        boolean isSUSEMinion = minion.map(m -> m.getOsFamily().equals("Suse")).orElse(false);
+        boolean isSUSEMinion = minion.map(m -> m.isOsFamilySuse()).orElse(false);
         boolean zyppPluginInstalled = false;
         if (!isSUSEMinion) {
             Server server = ServerFactory.lookupById(sid);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -147,7 +147,7 @@ public class SPMigrationAction extends RhnAction {
         request.setAttribute(IS_MINION, isMinion);
 
         // Check if this is a SUSE system (for minions only)
-        boolean isSUSEMinion = isMinion && minion.get().getOsFamily().equals("Suse");
+        boolean isSUSEMinion = isMinion && minion.get().isOsFamilySuse();
         logger.debug("is a SUSE minion? {}", isSUSEMinion);
         request.setAttribute(IS_SUSE_MINION, isSUSEMinion);
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScapSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScapSetupAction.java
@@ -53,11 +53,11 @@ public abstract class ScapSetupAction extends RhnAction {
         if (server.asMinionServer().isPresent()) {
             MinionServer minion = server.asMinionServer().get();
             switch (minion.getOsFamily()) {
-                case "Suse":
+                case ServerConstants.OS_FAMILY_SUSE:
                     requiredPackage = OPENSCAP_SUSE_PKG;
                     break;
 
-                case "Debian":
+                case ServerConstants.OS_FAMILY_DEBIAN:
                     requiredPackage = getPackageForDebianFamily(minion.getOs(), minion.getRelease());
                     break;
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/test/ScapSetupActionTest.java
@@ -57,7 +57,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void canSearchForCorrectPackageForSUSE() {
-        server.setOsFamily("Suse");
+        server.setOsFamilySuse();
         server.setOs(ServerConstants.SLES);
         server.setRelease("15.6");
 
@@ -70,7 +70,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void canSearchForCorrectPackageForRHEL() {
-        server.setOsFamily("RedHat");
+        server.setOsFamily(ServerConstants.OS_FAMILY_REDHAT);
         server.setOs(ServerConstants.ROCKY);
         server.setRelease("8");
 
@@ -83,7 +83,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void canSearchForCorrectPackageForDebianLegacy() {
-        server.setOsFamily("Debian");
+        server.setOsFamily(ServerConstants.OS_FAMILY_DEBIAN);
         server.setOs(ServerConstants.DEBIAN);
         server.setRelease("10");
 
@@ -96,7 +96,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void canSearchForCorrectPackageForDebian() {
-        server.setOsFamily("Debian");
+        server.setOsFamily(ServerConstants.OS_FAMILY_DEBIAN);
         server.setOs(ServerConstants.DEBIAN);
         server.setRelease("12");
 
@@ -112,7 +112,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void canSearchForCorrectPackageForUbuntuLegacy() {
-        server.setOsFamily("Debian");
+        server.setOsFamily(ServerConstants.OS_FAMILY_DEBIAN);
         server.setOs(ServerConstants.UBUNTU);
         server.setRelease("22.04");
 
@@ -125,7 +125,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void canSearchForCorrectPackageForUbuntu() {
-        server.setOsFamily("Debian");
+        server.setOsFamily(ServerConstants.OS_FAMILY_DEBIAN);
         server.setOs(ServerConstants.UBUNTU);
         server.setRelease("24.04");
 
@@ -141,7 +141,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void scapIsEnabledWhenCorrectPackageIsInstalled() {
-        server.setOsFamily("Suse");
+        server.setOsFamilySuse();
         server.setOs(ServerConstants.SLES);
         server.setRelease("15.6");
 
@@ -157,7 +157,7 @@ public class ScapSetupActionTest extends RhnMockStrutsTestCase {
 
     @Test
     public void scapIsEnabledWhenAllRequiredPackagesAreInstalled() {
-        server.setOsFamily("Debian");
+        server.setOsFamily(ServerConstants.OS_FAMILY_DEBIAN);
         server.setOs(ServerConstants.DEBIAN);
         server.setRelease("12");
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -3014,7 +3014,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         });
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
         server.setServerArch(ServerFactory.lookupServerArchByName("x86_64"));
-        server.setOsFamily("Suse"); // SP Migration will only work for Minions with OS family `SUSE
+        server.setOsFamilySuse(); // SP Migration will only work for Minions with OS family `SUSE
 
         // Setup source products
         ChannelFamily family = createTestChannelFamily();
@@ -3119,7 +3119,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     public void testListMigrationTargetWithAndWithoutSuccessor() throws Exception {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
         server.setServerArch(ServerFactory.lookupServerArchByName("x86_64"));
-        server.setOsFamily("Suse"); // SP Migration will only work for Minions with OS family `SUSE
+        server.setOsFamilySuse(); // SP Migration will only work for Minions with OS family `SUSE
 
         // Setup source products
         ChannelFamily family = createTestChannelFamily();

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -605,7 +605,7 @@ public class DistUpgradeManager extends BaseManager {
         }
         else {
             Optional<MinionServer> minion = MinionServerFactory.lookupById(server.getId());
-            if (minion.isEmpty() || !minion.get().getOsFamily().equals("Suse")) {
+            if (minion.isEmpty() || !minion.get().isOsFamilySuse()) {
                 throw new DistUpgradeException("Dist upgrade only supported for SUSE systems");
             }
         }

--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.server.Dmi;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.NetworkInterface;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerNetAddress4;
@@ -678,7 +679,7 @@ public class HardwareMapper {
             List<VirtualInstance> virtualInstances = VirtualInstanceFactory.getInstance()
                     .lookupVirtualInstanceByUuid(virtUuid);
 
-            if (grains.getValueAsString("os_family").contentEquals("Suse") &&
+            if (grains.getValueAsString("os_family").contentEquals(ServerConstants.OS_FAMILY_SUSE) &&
                     grains.getValueAsString("osrelease").startsWith("11") &&
                         StringUtils.isEmpty(instanceId)) {
                 virtUuid = fixAndReturnSle11Uuid(virtUuid);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -232,7 +232,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals(1, minion.getInstalledProducts().size());
 
         // Verify OS family
-        assertEquals("Suse", minion.getOsFamily());
+        assertTrue(minion.isOsFamilySuse());
 
         // Verify the action status
         assertTrue(action.getServerActions().stream()

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -614,7 +614,7 @@ public class StatesAPI {
         SaltPkgLatest pkgLatest = new SaltPkgLatest();
 
         MinionServerFactory.lookupById(server.getId()).ifPresent(minion -> {
-            if (minion.getOsFamily().equals("Suse")) {
+            if (minion.isOsFamilySuse()) {
                 pkgInstalled.addRequire("file", ZYPPER_SUMA_CHANNEL_REPO_FILE);
                 pkgRemoved.addRequire("file", ZYPPER_SUMA_CHANNEL_REPO_FILE);
                 pkgLatest.addRequire("file", ZYPPER_SUMA_CHANNEL_REPO_FILE);


### PR DESCRIPTION
## What does this PR change?
As per https://github.com/uyuni-project/uyuni/pull/10564#discussion_r2200519431, the string representing SUSE os family has been made public and re-used also on other places where we check for os_family = Suse

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/13569
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
