### PR TITLE
Wait for VHM page to finish downloading before pressing "Delete"

### DIFF
--- a/testsuite/features/secondary/srv_virtual_host_manager.feature
+++ b/testsuite/features/secondary/srv_virtual_host_manager.feature
@@ -55,7 +55,8 @@ Feature: Virtual host manager web UI
   Scenario: Delete Virtual Host Manager
     When I follow the left menu "Systems > Virtual Host Managers"
     And I follow "file-vmware"
-    And I click on "Delete" in element "virtual-host-managers"
+    Then I should see a "file:///var/tmp/vCenter.json" text
+    When I click on "Delete" in element "virtual-host-managers"
     And I click on "Delete" in "Delete Virtual Host Manager" modal
     And I wait until I see "Virtual Host Manager has been deleted." text
     Then I should see a "No Virtual Host Managers." text


### PR DESCRIPTION
## What does this PR change?

Wait for VHM page to finish downloading before pressing "Detete"

Tested on Head, 100% working after the change


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified.

- [x] **DONE**


## Links

Issue(s): #27196
Port(s):
* 4.3: https://github.com/SUSE/spacewalk/pull/27805
* 5.0: https://github.com/SUSE/spacewalk/pull/27806

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
