### PR TITLE
Wait for page to download before pressing "Create" again

### DIFF
--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -57,6 +57,10 @@ Feature: Maintenance windows
     And I select "multicalendar" from "calendarSelect"
     And I click on "Create Schedule"
     Then I should see a "Schedule successfully created" text
+
+  Scenario: Create another multi schedule
+    When I follow the left menu "Schedule > Maintenance Windows > Schedules"
+    Then I should see a "Items 1 - 2 of 2" text
     When I click on "Create"
     And I enter "Core Server Window" as "name"
     And I choose "MULTI"


### PR DESCRIPTION
## What does this PR change?

Again, the current page has not finished downloading and we press "Create" too early


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s):
 * 4.3:
 * 5.0:

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
