### PR TITLE
Use a fallback method to select first row if last package fail

### DIFF
--- a/testsuite/features/support/navigation_step_helper.rb
+++ b/testsuite/features/support/navigation_step_helper.rb
@@ -7,17 +7,18 @@
 # @param text [String] The text to match in the row
 # @param last_version [Boolean] Whether to select the row with the latest package version
 def toggle_checkbox_in_package_list(action, text, last_version: false)
-  if last_version
+  return toggle_checkbox_in_list(action, text) unless last_version
+
+  begin
     link_elements = all(:xpath, "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a")
-    packages_list = link_elements.map(&:text)
-    latest = latest_package(packages_list)
-    top_level_xpath_query = "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a[text()='#{latest}']/../../td/input[@type='checkbox']"
+    packages      = link_elements.map(&:text)
+    latest        = latest_package(packages)
 
-    row = find(:xpath, top_level_xpath_query, match: :first)
-    raise "xpath: #{top_level_xpath_query} not found" if row.nil?
-
+    xpath = "//div[@class='table-responsive']/table/tbody/tr/td[@class=' sortedCol']/a[text()='#{latest}']/../../td/input[@type='checkbox']"
+    row   = find(:xpath, xpath, match: :first)
     row.set(action == 'check')
-  else
+  rescue StandardError => e
+    warn "[toggle_checkbox] fallback to text match: #{e.message}"
     toggle_checkbox_in_list(action, text)
   end
 end


### PR DESCRIPTION

## What does this PR change?

Use a fallback method to select first row if last package regex is failing

## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered


- [x] **DONE**

## Links

Issue(s): #
Port(s): 5.0: https://github.com/SUSE/spacewalk/pull/27812
4.3: https://github.com/SUSE/spacewalk/pull/27811

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
