### PR TITLE
Fix installation of python lib files on Ubuntu 24.04 (bsc#1246586)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -992,4 +992,3 @@ Wed Sep 15 08:32:37 CEST 2010 - mantel@suse.de
 
 - Initial release of spacecmd
 
--------------------------------------------------------------------

--- a/spacecmd/spacecmd.changes.mcalmer.fix-build-spacecmd-on-ubuntu
+++ b/spacecmd/spacecmd.changes.mcalmer.fix-build-spacecmd-on-ubuntu
@@ -1,0 +1,2 @@
+- Fix installation of python lib files on Ubuntu 24.04
+  (bsc#1246586)

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -21,6 +21,7 @@
 %if ! (0%{?fedora} || 0%{?rhel})
 %if "%{_vendor}" == "debbuild"
 %global __python /usr/bin/python3
+%global python_sitelib %(%{__python} -c "import sysconfig as s; print(s.get_paths('deb_system').get('purelib'))")
 %endif
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}


### PR DESCRIPTION
## What does this PR change?

On Ubuntu 24.04 python_sitelib was evaluating to "" (nothing) and spacecmd files were installed in /.
This cause import errors when calling spacecmd command.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
