### PR TITLE
Remove nested steps to check fields presence

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -51,7 +51,18 @@ Feature: Smoke tests for <client>
     And the IPv6 address for "<client>" should be correct
     And the system ID for "<client>" should be correct
     And the system name for "<client>" should be correct
-    And I should see several text fields
+
+  Scenario: Client <client> fields are displayed correctly on the details page
+    And I should see a "Virtualization" text
+    And I should see a "Installed Products" text
+    And I should see a "Checked In" text
+    And I should see a "Registered" text
+    And I should see a "Contact Method" text
+    And I should see a "Auto Patch Update" text
+    And I should see a "Maintenance Schedule" text
+    And I should see a "Description" text
+    And I should see a "Location" text
+    And I should see a "UUID" text
 
 @skip_for_debianlike
 @skip_for_rocky9

--- a/testsuite/features/secondary/allcli_overview_systems_details.feature
+++ b/testsuite/features/secondary/allcli_overview_systems_details.feature
@@ -27,7 +27,16 @@ Feature: The system details of each minion and client provides an overview of th
     And the system ID for "sle_minion" should be correct
     And the system name for "sle_minion" should be correct
     And the uptime for "sle_minion" should be correct
-    And I should see several text fields
+    And I should see a "UUID" text
+    And I should see a "Virtualization" text
+    And I should see a "Installed Products" text
+    And I should see a "Checked In" text
+    And I should see a "Registered" text
+    And I should see a "Contact Method" text
+    And I should see a "Auto Patch Update" text
+    And I should see a "Maintenance Schedule" text
+    And I should see a "Description" text
+    And I should see a "Location" text
 
 @rhlike_minion
   Scenario: Red Hat-like minion hardware refresh
@@ -49,7 +58,16 @@ Feature: The system details of each minion and client provides an overview of th
     And the system ID for "rhlike_minion" should be correct
     And the system name for "rhlike_minion" should be correct
     And the uptime for "rhlike_minion" should be correct
-    And I should see several text fields
+    And I should see a "UUID" text
+    And I should see a "Virtualization" text
+    And I should see a "Installed Products" text
+    And I should see a "Checked In" text
+    And I should see a "Registered" text
+    And I should see a "Contact Method" text
+    And I should see a "Auto Patch Update" text
+    And I should see a "Maintenance Schedule" text
+    And I should see a "Description" text
+    And I should see a "Location" text
 
 @deblike_minion
   Scenario: Debian-like minion hardware refresh
@@ -71,7 +89,16 @@ Feature: The system details of each minion and client provides an overview of th
     And the system ID for "deblike_minion" should be correct
     And the system name for "deblike_minion" should be correct
     And the uptime for "deblike_minion" should be correct
-    And I should see several text fields
+    And I should see a "UUID" text
+    And I should see a "Virtualization" text
+    And I should see a "Installed Products" text
+    And I should see a "Checked In" text
+    And I should see a "Registered" text
+    And I should see a "Contact Method" text
+    And I should see a "Auto Patch Update" text
+    And I should see a "Maintenance Schedule" text
+    And I should see a "Description" text
+    And I should see a "Location" text
 
 @ssh_minion
   Scenario: SSH-managed minion hardware refresh
@@ -92,4 +119,13 @@ Feature: The system details of each minion and client provides an overview of th
     And the system ID for "ssh_minion" should be correct
     And the system name for "ssh_minion" should be correct
     And the uptime for "ssh_minion" should be correct
-    And I should see several text fields
+    And I should see a "UUID" text
+    And I should see a "Virtualization" text
+    And I should see a "Installed Products" text
+    And I should see a "Checked In" text
+    And I should see a "Registered" text
+    And I should see a "Contact Method" text
+    And I should see a "Auto Patch Update" text
+    And I should see a "Maintenance Schedule" text
+    And I should see a "Description" text
+    And I should see a "Location" text

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -145,20 +145,6 @@ Then(/^the uptime for "([^"]*)" should be correct$/) do |host|
   raise ScriptError, "Expected uptime message to be one of #{valid_uptime_messages} - found '#{ui_uptime_text}'" unless check
 end
 
-Then(/^I should see several text fields$/) do
-  steps 'Then I should see a "UUID" text
-    And I should see a "Virtualization" text
-    And I should see a "Installed Products" text
-    And I should see a "Checked In" text
-    And I should see a "Registered" text
-    And I should see a "Contact Method" text
-    And I should see a "Auto Patch Update" text
-    And I should see a "Maintenance Schedule" text
-    And I should see a "Description" text
-    And I should see a "Location" text
-  '
-end
-
 # events
 
 When(/^I wait until event "([^"]*)" is completed$/) do |event|


### PR DESCRIPTION
## What does this PR change?

Remove nested steps to check fields presence.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were improved

- [x] **DONE**

## Links

Ports:
- Manager-4.3 https://github.com/SUSE/spacewalk/pull/27829
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
