### PR TITLE
Find running salt jobs async

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -394,9 +394,11 @@ public interface SaltApi extends Serializable {
      * Returns the currently running jobs on the target
      *
      * @param target the target
-     * @return list of running jobs
+     * @param cancel the cancel condition
+     * @return map of running jobs
      */
-    Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target);
+    Map<String, CompletionStage<Result<List<SaltUtil.RunningInfo>>>> running(MinionList target,
+                                                                             CompletableFuture<GenericError> cancel);
 
     /**
      * Return the result for a jobId

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -696,9 +696,11 @@ public class SaltService implements SystemQuery, SaltApi {
      * {@inheritDoc}
      */
     @Override
-    public Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target) {
+    public Map<String, CompletionStage<Result<List<SaltUtil.RunningInfo>>>> running(MinionList target,
+            CompletableFuture<GenericError> cancel) {
         try {
-            return callSync(SaltUtil.running(), target);
+            return completableAsyncCall(SaltUtil.running(), target, getEventStream(), cancel)
+                    .orElseGet(Collections::emptyMap);
         }
         catch (SaltException e) {
             throw new RhnRuntimeException(e);

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -253,7 +253,8 @@ public class TestSaltApi implements SaltApi {
     }
 
     @Override
-    public Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target) {
+    public Map<String, CompletionStage<Result<List<SaltUtil.RunningInfo>>>> running(MinionList target,
+            CompletableFuture<GenericError> cancel) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -28,12 +28,13 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.context.Context;
 
 import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.services.FutureUtils;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.salt.netapi.calls.modules.SaltUtil;
 import com.suse.salt.netapi.calls.runner.Jobs.Info;
 import com.suse.salt.netapi.datatypes.target.MinionList;
-import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.errors.GenericError;
 import com.suse.utils.Json;
 
 import com.google.gson.JsonElement;
@@ -54,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -155,21 +157,23 @@ public class MinionActionUtils {
                 }
             ).toList();
 
-        List<String> minionIds = serverActions.stream().flatMap(sa ->
-                sa.getServer().asMinionServer()
-                        .map(MinionServer::getMinionId)
-                        .map(Stream::of)
-                        .orElseGet(Stream::empty)
-        ).collect(Collectors.toList());
+        List<String> minionIds = serverActions.stream()
+                .flatMap(sa -> sa.getServer().asMinionServer().map(MinionServer::getMinionId).stream())
+                .distinct()
+                .collect(Collectors.toList());
 
-        Map<String, Result<List<SaltUtil.RunningInfo>>> running =
-                saltApi.running(new MinionList(minionIds));
+        CompletableFuture<GenericError> failAfter = FutureUtils.failAfter(600);
+        var running = saltApi.running(new MinionList(minionIds), failAfter).entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().toCompletableFuture().join()));
 
         serverActions.forEach(serverAction ->
             serverAction.getServer().asMinionServer().map(minion -> running.get(minion.getMinionId()))
               .ifPresent(r -> {
-                  r.consume(error -> LOG.error(error.toString()),
-                  runningInfos -> ActionFactory.save(updateMinionActionStatus(serverAction, runningInfos)));
+                  r.consume(
+                          error -> LOG.error(error.toString()),
+                          runningInfos -> ActionFactory.save(updateMinionActionStatus(serverAction, runningInfos)));
               })
         );
     }

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -169,12 +169,14 @@ public class MinionActionUtils {
                         e -> e.getValue().toCompletableFuture().join()));
 
         serverActions.forEach(serverAction ->
-            serverAction.getServer().asMinionServer().map(minion -> running.get(minion.getMinionId()))
-              .ifPresent(r -> {
-                  r.consume(
-                          error -> LOG.error(error.toString()),
-                          runningInfos -> ActionFactory.save(updateMinionActionStatus(serverAction, runningInfos)));
-              })
+                serverAction.getServer().asMinionServer()
+                        .map(minion -> running.get(minion.getMinionId()))
+                        .ifPresentOrElse(
+                                r -> r.consume(
+                                        error -> LOG.error(error.toString()),
+                                        runningInfos -> ActionFactory.save(
+                                                updateMinionActionStatus(serverAction, runningInfos))),
+                                () -> ActionFactory.save(updateMinionActionStatus(serverAction, List.of())))
         );
     }
 

--- a/java/spacewalk-java.changes.mcalmer.Manager-4.3-find-running-salt-jobs-async
+++ b/java/spacewalk-java.changes.mcalmer.Manager-4.3-find-running-salt-jobs-async
@@ -1,0 +1,1 @@
+- Query running salt jobs async (bsc#1236904)


### PR DESCRIPTION
## What does this PR change?

Change querying running salt jobs to async call to lower memory consumption and prevent stuck calls to
create trouble.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/27828

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
