### PR TITLE
Revert --disable-gpu flag addition

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -93,7 +93,7 @@ def capybara_register_driver
     # WORKAROUND failure at Scenario: Test IPMI functions: increase from 60 s to 180 s
     client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 30, read_timeout: 240)
     chrome_options = Selenium::WebDriver::Chrome::Options.new(
-      args: %w[disable-dev-shm-usage ignore-certificate-errors window-size=2048,2048 js-flags=--max_old_space_size=2048 no-sandbox disable-notifications disable-gpu]
+      args: %w[disable-dev-shm-usage ignore-certificate-errors window-size=2048,2048 js-flags=--max_old_space_size=2048 no-sandbox disable-notifications]
     )
     chrome_options.args << 'headless=new' unless $debug_mode
     chrome_options.args << "remote-debugging-port=#{$chromium_dev_port}" if $chromium_dev_tools


### PR DESCRIPTION
## What does this PR change?

Revert commit cd768da530d00ef772d68fa630bf87d89593eb62

It did not help with `crashed tab` issue, and it even seemed to slow down the chrome renderer.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/27850
 * 5.0: https://github.com/SUSE/spacewalk/pull/27851

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
