### PR TITLE
Full cleanup of any kind of salt package. Refactor use_salt_bundle.

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -236,7 +236,7 @@ end
 
 When(/^I query latest Salt changes on "(.*?)"$/) do |host|
   node = get_target(host)
-  salt = use_salt_bundle ? 'venv-salt-minion' : 'salt'
+  salt = $use_salt_bundle ? 'venv-salt-minion' : 'salt'
   if host == 'server'
     salt = 'salt'
   end
@@ -250,12 +250,12 @@ end
 When(/^I query latest Salt changes on Debian-like system "(.*?)"$/) do |host|
   node = get_target(host)
   salt =
-    if use_salt_bundle
+    if $use_salt_bundle
       'venv-salt-minion'
     else
       'salt'
     end
-  changelog_file = use_salt_bundle ? 'changelog.gz' : 'changelog.Debian.gz'
+  changelog_file = $use_salt_bundle ? 'changelog.gz' : 'changelog.Debian.gz'
   result, _return_code = node.run("zcat /usr/share/doc/#{salt}/#{changelog_file}")
   result.split("\n")[0, 15].each do |line|
     line.force_encoding('UTF-8')
@@ -856,7 +856,7 @@ end
 # Repositories and packages management
 When(/^I migrate the non-SUMA repositories on "([^"]*)"$/) do |host|
   node = get_target(host)
-  salt_call = use_salt_bundle ? 'venv-salt-call' : 'salt-call'
+  salt_call = $use_salt_bundle ? 'venv-salt-call' : 'salt-call'
   # use sumaform states to migrate to latest SP the system repositories:
   node.run("#{salt_call} --local --file-root /root/salt/ state.apply repos")
   # disable again the non-SUMA repositories:
@@ -1366,7 +1366,7 @@ end
 
 When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   node = get_target(host)
-  salt_call = use_salt_bundle ? 'venv-salt-call' : 'salt-call'
+  salt_call = $use_salt_bundle ? 'venv-salt-call' : 'salt-call'
   if host == 'server'
     salt_call = 'salt-call'
   end

--- a/testsuite/features/step_definitions/file_management_steps.rb
+++ b/testsuite/features/step_definitions/file_management_steps.rb
@@ -56,7 +56,7 @@ When(/^I bootstrap "([^"]*)" using bootstrap script with activation key "([^"]*)
   end
 
   # Prepare bootstrap script for different types of clients
-  force_bundle = use_salt_bundle ? '--force-bundle' : ''
+  force_bundle = $use_salt_bundle ? '--force-bundle' : ''
 
   node = get_target(host)
   gpg_keys = get_gpg_keys(node, target)

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -208,7 +208,7 @@ end
 When(/^I create the bootstrap script for "([^"]+)" hostname and "([^"]*)" activation key on "([^"]*)"$/) do |hostname, key, host|
   node = get_target(host)
   # WORKAROUND: Revert once pxeboot autoinstallation contains venv-salt-minion
-  # force_bundle = use_salt_bundle ? '--force-bundle' : ''
+  # force_bundle = $use_salt_bundle ? '--force-bundle' : ''
   # get_target(host).run("mgr-bootstrap #{force_bundle}")
   node.run("mgr-bootstrap --hostname=#{hostname} --activation-keys=#{key}")
 

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -71,17 +71,6 @@ def product_version_full
   out.strip if code.zero? && !out.nil?
 end
 
-# TODO: All our current supported versions are using Salt Bundle, consider to remove this method
-#       Refactoring all the code call it.
-# Determines whether to use the Salt bundle based on the product and product version.
-#
-# @return [Boolean] true if the product is 'Uyuni' or the product version is 'head', '5.0', '4.3', or '4.2'
-# - false otherwise
-def use_salt_bundle
-  # Use venv-salt-minion in Uyuni, or SUMA Head, 5.1, 5.0, 4.2 and 4.3
-  product == 'Uyuni' || %w[develHead 5.1 5.0 4.3 4.2].include?(product_version)
-end
-
 # WARN: It's working for /24 mask, but couldn't not work properly with others
 # Returns the reverse DNS lookup address for a given network address.
 #

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -59,6 +59,7 @@ $current_user = 'admin'
 $current_password = 'admin'
 $chromium_dev_tools = ENV.fetch('REMOTE_DEBUG', false)
 $chromium_dev_port = 9222 + ENV['TEST_ENV_NUMBER'].to_i
+$use_salt_bundle = ENV.fetch('USE_SALT_BUNDLE', true)
 
 # maximal wait before giving up
 # the tests return much before that delay in case of success
@@ -647,12 +648,12 @@ end
 
 # do some tests only if we are using salt bundle
 Before('@salt_bundle') do
-  skip_this_scenario unless use_salt_bundle
+  skip_this_scenario unless $use_salt_bundle
 end
 
 # do some tests only if we are using salt bundle
 Before('@skip_if_salt_bundle') do
-  skip_this_scenario if use_salt_bundle
+  skip_this_scenario if $use_salt_bundle
 end
 
 # do test only if HTTP proxy for Uyuni is defined


### PR DESCRIPTION
## What does this PR change?

1. Full cleanup of any kind of salt package: Instead of only removing files and packages depending the use_salt_bundle value, we make a clean up of any kind of salt content.
2. Refactor use_salt_bundle: As all our supported products use by default Salt Bundle, we don't need anymore a method to evaluate the boolean. Instead I converted to a env. variable, in case we want to force it to don't use salt-bundle, in such case, it will use salt-classic.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
