### PR TITLE
Maximum Javascript heap size option uses dashes

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -93,10 +93,17 @@ def capybara_register_driver
     # WORKAROUND failure at Scenario: Test IPMI functions: increase from 60 s to 180 s
     client = Selenium::WebDriver::Remote::Http::Default.new(open_timeout: 30, read_timeout: 240)
     chrome_options = Selenium::WebDriver::Chrome::Options.new(
-      args: %w[disable-dev-shm-usage ignore-certificate-errors window-size=2048,2048 js-flags=--max_old_space_size=2048 no-sandbox disable-notifications]
+      args: %w[
+        --disable-dev-shm-usage
+        --ignore-certificate-errors
+        --window-size=2048,2048
+        --js-flags=--max-old-space-size=2048
+        --no-sandbox
+        --disable-notifications
+      ]
     )
-    chrome_options.args << 'headless=new' unless $debug_mode
-    chrome_options.args << "remote-debugging-port=#{$chromium_dev_port}" if $chromium_dev_tools
+    chrome_options.args << '--headless=new' unless $debug_mode
+    chrome_options.args << "--remote-debugging-port=#{$chromium_dev_port}" if $chromium_dev_tools
     chrome_options.args << '--user-data-dir=/root' if $is_cloud_provider
 
     chrome_options.add_preference('prompt_for_download', false)


### PR DESCRIPTION
## What does this PR change?

This PR fixes the maxumum Javascript heap size option:
 * wrong: `--js-flags=--max_old_space_size=2048`
 * correct:  `--js-flags=--max-old-space-size=2048`

Note: this bug had no practical effect, the default is 4096, and in practice the Javascript heap size never grew beyong 320 MiB.

This PR also does cosmetical changes for readability:
 * add double dashes everywhere
 * vertical array of options


## GUI diff

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/27879
 * 5.0: https://github.com/SUSE/spacewalk/pull/27878

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
