### PR TITLE
Remove tmate from Github actions

### DIFF
--- a/.github/workflows/javascript-build.yml
+++ b/.github/workflows/javascript-build.yml
@@ -11,13 +11,6 @@ on:
     paths:
       - 'web/html/src/**'
       - '.github/workflows/javascript-build.yml'
-  workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
 
 jobs:
   javascript_build:
@@ -52,10 +45,3 @@ jobs:
 
     - name: Build application
       run: yarn build
-
-    # See https://github.com/mxschmitt/action-tmate?tab=readme-ov-file#only-on-failure
-    - name: Setup tmate session
-      if: ${{ failure() && github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
-      uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 #v3.19
-      with:
-        limit-access-to-actor: true


### PR DESCRIPTION
## What does this PR change?

In the past we used to use tmate to debug NPM cache mismatch issues and other similar problems which you couldn't replicate in local. Since we haven't had a need for this in a long while, I'm removing it to simplify the workflow.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: GH actions

- [x] **DONE**

## Links

Related: https://github.com/uyuni-project/uyuni/pull/10280

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
