### PR TITLE
Clean up stale sessions on websocket open (bsc#1246119)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/servlets/LocalizedEnvironmentFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/LocalizedEnvironmentFilter.java
@@ -88,6 +88,9 @@ public class LocalizedEnvironmentFilter implements Filter {
         if (webSession != null) {
             CURRENT_SESSION_ID.set(webSession.getId());
         }
+        else {
+            CURRENT_SESSION_ID.remove();
+        }
     }
 
     private void setTimeZone(Context ctx, User user, HttpServletRequest request) {

--- a/java/spacewalk-java.changes.cbbayburt.bsc1244641
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1244641
@@ -1,0 +1,2 @@
+- CVE-2025-46811: Clean up stale sessions on websocket open
+  (bsc#1246119)


### PR DESCRIPTION
Remove the stale thread-local session ID to prevent cross-session leaks in remote command websocket handling.

Port of: https://github.com/SUSE/spacewalk/pull/27770

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1246119

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
