### PR TITLE
Do not expose sensitive data when breaking URL format (bsc#1245005)

### DIFF
--- a/python/spacewalk/satellite_tools/download.py
+++ b/python/spacewalk/satellite_tools/download.py
@@ -126,7 +126,7 @@ def get_proxies(proxy, user, password):
     if user:
         auth = quote(user)
         if password:
-            auth += ":" + quote(password)
+            auth += ":" + quote(password, safe="")
         proto, rest = re.match(r"(\w+://)(.+)", proxy_string).groups()
         # pylint: disable-next=consider-using-f-string
         proxy_string = "%s%s@%s" % (proto, auth, rest)

--- a/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/deb_src.py
@@ -37,12 +37,12 @@ import looseversion
 
 try:
     #  python 2
-    from urllib import unquote
+    from urllib import unquote, quote
     import urlparse
 except ImportError:
     #  python3
     import urllib.parse as urlparse  # pylint: disable=F0401,E0611
-    from urllib.parse import unquote
+    from urllib.parse import unquote, quote
 
 RETRIES = 10
 RETRY_DELAY = 1
@@ -237,13 +237,13 @@ class DebRepo:
                     "http": "http://"
                     + self.proxy_username
                     + ":"
-                    + self.proxy_password
+                    + quote(self.proxy_password, safe="")
                     + "@"
                     + netloc,
                     "https": "http://"
                     + self.proxy_username
                     + ":"
-                    + self.proxy_password
+                    + quote(self.proxy_password, safe="")
                     + "@"
                     + netloc,
                 }

--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -993,7 +993,7 @@ type=rpm-md
         if self.proxy_user:
             query_params["proxyuser"] = quote(self.proxy_user)
         if self.proxy_pass:
-            query_params["proxypass"] = quote(self.proxy_pass)
+            query_params["proxypass"] = quote(self.proxy_pass, safe="")
         if self.sslcacert:
             # Since Zypper only accepts CAPATH, we need to split the certificates bundle
             # and run "c_rehash" on our custom CAPATH

--- a/python/spacewalk/spacewalk-backend.changes.meaksh.Manager-5.0-bsc1245005
+++ b/python/spacewalk/spacewalk-backend.changes.meaksh.Manager-5.0-bsc1245005
@@ -1,0 +1,2 @@
+- CVE-2025-46809: Do not expose HTTP Proxy password
+  when breaking URL format (bsc#1245005)

--- a/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
@@ -605,7 +605,7 @@ class YumSrcTest(unittest.TestCase):
         ]
         proxy_url = "http://proxy.example.com:8080"
         proxy_user = "user"
-        proxy_pass = "pass"
+        proxy_pass = "password with spaces and /, % and $"
         cs.proxy_hostname = proxy_url
         cs.proxy_user = proxy_user
         cs.proxy_pass = proxy_pass
@@ -645,7 +645,7 @@ class YumSrcTest(unittest.TestCase):
                 separator,
                 quote(proxy_url),
                 proxy_user,
-                proxy_pass,
+                quote(proxy_pass, safe=""),
                 extra_query,
             )
             with patch("builtins.open", mock_open()), patch(

--- a/testsuite/features/build_validation/core/srv_first_settings.feature
+++ b/testsuite/features/build_validation/core/srv_first_settings.feature
@@ -63,8 +63,8 @@ Feature: Very first settings
     And I should see a "HTTP Proxy Username" text
     And I should see a "HTTP Proxy Password" text
     When I enter the address of the HTTP proxy as "HTTP Proxy Hostname"
-    And I enter "suma2" as "HTTP Proxy Username"
-    And I enter "P4$$wordWith%and&" as "HTTP Proxy Password"
+    And I enter "suma3" as "HTTP Proxy Username"
+    And I enter "P4$$w/ord With%and&" as "HTTP Proxy Password"
     And I click on "Save and Verify"
     Then HTTP proxy verification should have succeeded
 

--- a/testsuite/features/core/srv_first_settings.feature
+++ b/testsuite/features/core/srv_first_settings.feature
@@ -76,8 +76,8 @@ Feature: Very first settings
     And I should see a "HTTP Proxy Username" text
     And I should see a "HTTP Proxy Password" text
     When I enter the address of the HTTP proxy as "HTTP Proxy Hostname"
-    And I enter "suma2" as "HTTP Proxy Username"
-    And I enter "P4$$wordWith%and&" as "HTTP Proxy Password"
+    And I enter "suma3" as "HTTP Proxy Username"
+    And I enter "P4$$w/ord With%and&" as "HTTP Proxy Password"
     And I click on "Save and Verify"
     Then HTTP proxy verification should have succeeded
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -58,7 +58,9 @@ end
 
 Then(/^it should be possible to use the HTTP proxy$/) do
   url = 'https://www.suse.com'
-  proxy = "suma2:P4$$wordWith%and&@#{$server_http_proxy}"
+  # Proxy Password: P4$$w/ord With%and&
+  # we must escape it before passing it to curl
+  proxy = "suma3:P4$$w%2Ford%20With%and&@#{$server_http_proxy}"
   get_target('server').run("curl --insecure --proxy '#{proxy}' --proxy-anyauth --location '#{url}' --output /dev/null")
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in `spacewalk-repo-sync` when a `/` is passed as part of an HTTP proxy password. This leads to an exception that logs sensitive data.

By default, the `quote` function has `safe = '/'`, which prevents the slash to be quoted, leading to breaking the URL format if `/` is used.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27588

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
