### PR TITLE
Enable changelog tests for the staging branch

### DIFF
--- a/.github/workflows/changelogs.yml
+++ b/.github/workflows/changelogs.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened, closed]
     # Only execute on the main branches (feature branches are excluded)
     branches:
+      - master-staging # Temporary branch for staging until 5.1 GM
       - master
       # Uyuni patches
       - 'Uyuni-[0-9]+.[0-9]+'


### PR DESCRIPTION
Enable changelog tests to be triggered for PRs to `master-staging`.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
