### PR TITLE
Refactor commonlib to match edge cases

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -828,10 +828,23 @@ end
 # @return [String] The package string with the highest version and release
 def latest_package(packages)
   packages.max_by do |package|
-    if package =~ /^(.+)-(\d+\.\d+\.\d+)-(.+)$/
-      version = Regexp.last_match(2)
-      release = Regexp.last_match(3)
-      [Gem::Version.new(version), Gem::Version.new(release.gsub(/[^\d.]/, '.'))]
+    # Match something like 'bison-3.8.2-3.oe2403sp1'
+    if package =~ /^(.+)-(\d+(?:\.\d+)*?)-(.+)$/
+      version = Regexp.last_match(2)          # => "3.8.2"
+      release = Regexp.last_match(3)          # => "3.oe2403sp1"
+
+      begin
+        # extract numeric components like ["3", "2403", "1"]
+        numeric_parts = release.scan(/\d+/)
+        cleaned_release = numeric_parts.join('.')
+        [
+          Gem::Version.new(version),
+          Gem::Version.new(cleaned_release)
+        ]
+      rescue ArgumentError => e
+        puts "WARNING: Failed to parse version in package '#{package}': #{e.message}"
+        [Gem::Version.new('0.0.0'), Gem::Version.new('0')]
+      end
     else
       [Gem::Version.new('0.0.0'), Gem::Version.new('0')]
     end


### PR DESCRIPTION
## What does this PR change?

split from https://github.com/uyuni-project/uyuni/pull/10531, specifically it's this commit https://github.com/uyuni-project/uyuni/pull/10531/commits/c87e27a8468f5f61bc6c7909a7158b772b08aeee to make it separate from openeuler because it seems it might not be needed in the BV. But this commonlib refactor is needed

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): no issue directly from testsuite review
Port(s): 

5.0: https://github.com/SUSE/spacewalk/pull/27910
4.3: https://github.com/SUSE/spacewalk/pull/27911

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
