### PR TITLE
return json also when exception is not a FaultException (bsc#1246452)

### DIFF
--- a/java/spacewalk-java.changes.mcalmer.fix-exceptions-for-restapi
+++ b/java/spacewalk-java.changes.mcalmer.fix-exceptions-for-restapi
@@ -1,0 +1,3 @@
+- Fix exception handling for rest like API to not strictly
+  require Fault Exceptions to return a json error object
+  (bsc#1246452)


### PR DESCRIPTION
## What does this PR change?

Partly port of https://github.com/uyuni-project/uyuni/pull/10589

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27854
Port(s): https://github.com/SUSE/spacewalk/pull/27920

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
