### PR TITLE
Fix AWK script to edit Debian/Ubuntu repos

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -878,7 +878,7 @@ When(/^I (enable|disable) Debian-like "([^"]*)" repository on "([^"]*)"$/) do |a
 
   # edit ubuntu.sources with downloaded utility
   sources = '/etc/apt/sources.list.d/ubuntu.sources'
-  tmp = '/tmp//ubuntu.sources'
+  tmp = '/tmp/ubuntu.sources'
   node.run("awk -f #{dest} -v action=#{action} -v distro=$(lsb_release -sc) -v repo=#{repo} #{sources} > #{tmp} && mv #{tmp} #{sources}")
 end
 

--- a/testsuite/features/upload_files/edit-deb822.awk
+++ b/testsuite/features/upload_files/edit-deb822.awk
@@ -5,28 +5,61 @@
 #              -v repo=universe \
 #              ubuntu.sources
 
-BEGIN             { suites = ""
-                    components = ""
-                  }
+BEGIN            {
+in_relevant_block = 0
+enabled_processed = 0
+}
 
-/^Suites: */      { suites = $0
-                    sub(/^Suites: */, "", suites)
-                  }
+/^Suites: */     {
+    # Match the distro as substring in a suite
+    in_relevant_block = (index($0, distro) != 0)
+    print $0
+    next
+}
 
-/^Components: */  { components = $0
-                    sub(/^Components: */, "", components)
-                    if (match(suites " ", distro " ") != 0)
-                    { if (action == "enable")
-                      { if (match(components " ", repo " ") == 0)
-                          components = components " " repo
-                      }
-                      if (action == "disable")
-                      { sub(repo, "", components)
-                        sub(/  */, " ", components)
-                      }
-                    }
-                    print "Components: " components
-                  }
+/^Components: */ {
+    if (in_relevant_block) {
+        if (action == "enable") {
+            if (index($0, repo) == 0) {
+                $0 = $0 " " repo
+            }
+        }
+        if (action == "disable") {
+            gsub(repo, "", $0)
+            gsub("  ", " ", $0)
+        }
+    }
+    print $0
+    # Add the Enabled line after the components line if it's not present
+    if (in_relevant_block && action == "enable" && index($0, "Enabled:") == 0) {
+        print "Enabled: yes"
+        enabled_processed = 1
+    }
+    next
+}
 
-!/^Components: */ { print $0
-                  }
+/^Enabled: */ {
+    if (enabled_processed) {
+        next
+    }
+    if (in_relevant_block) {
+        if (action == "enable") {
+            print "Enabled: yes"
+        } else {
+            print "Enabled: no"
+        }
+    } else {
+        print $0
+    }
+    next
+}
+
+# Remove Architectures section if it's empty
+/^Architectures: *$/ {
+    next
+}
+
+# Print any other line
+{
+    print
+}


### PR DESCRIPTION
## What does this PR change?

The previous version of edit-deb822.awk didn't enable/disable the suite, but just add a new component on the sources.
This script in addition to add the component, it will:
- Enable/Disable the correct suite
- Fix "Architectures" block, when it's empty

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
