### PR TITLE
Install products automatically on SL-Micro (bsc#1243486)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -168,7 +168,7 @@ install_gnupg_debian:
 {%- endif %}
 
 {%- if not salt['pillar.get']('susemanager:distupgrade:dryrun', False) %}
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and "opensuse" not in grains['oscodename']|lower %}
+{%- if grains['os_family'] == 'Suse' and "opensuse" not in grains['oscodename']|lower %}
 mgrchannels_install_products:
   product.all_installed:
     - require:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-micro-product-install-in-highstate
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-micro-product-install-in-highstate
@@ -1,0 +1,2 @@
+- Install products automatically on SLE Micro 5 and SL Micro 6
+  (bsc#1243486)


### PR DESCRIPTION
## What does this PR change?

Micro has product versions lover than 11.
The SLES11 guard in the channel.sls file prevent to install the products automatically on Micro 5 and 6.
As SLES11 is not supported on 5.1 and later, we can remove this check.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): Only 5.1+ - I am unsure if customers run SLE11 successful on 5.0

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
