### PR TITLE
Rename 'Roles' to 'Administrative Roles' in user UI

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -1917,6 +1917,12 @@ button below, and &lt;b&gt;will be unable to log back in&lt;/b&gt;.</source>
           <context context-type="sourcefile">/rhn/users/UserDetails</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="userdetails.jsp.adminroles" xml:space="preserve">
+        <source>Administrative Roles</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/users/UserDetails</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="userdetails.jsp.adminRoles" xml:space="preserve">
         <source>Administrative Roles</source>
         <context-group name="ctx">

--- a/java/code/webapp/WEB-INF/pages/admin/users/activelist.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/users/activelist.jsp
@@ -51,7 +51,7 @@
         <rl:column attr="roleNames"
                    bound="true"
                    sortable="true"
-                   headerkey="userdetails.jsp.roles"
+                   headerkey="userdetails.jsp.adminroles"
                     />
 
         <!-- Last logged in column -->

--- a/java/code/webapp/WEB-INF/pages/common/fragments/user/userlist_columns.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/user/userlist_columns.jspf
@@ -8,7 +8,7 @@
 </rl:column>
 
 <rl:column bound="true"
-        headerkey="userdetails.jsp.roles"
+        headerkey="userdetails.jsp.adminroles"
         sortable="true"
         attr="roleNames"/>
 

--- a/java/spacewalk-java.changes.parlt.rename-roles-user-ui
+++ b/java/spacewalk-java.changes.parlt.rename-roles-user-ui
@@ -1,0 +1,2 @@
+- Rename 'Roles' to 'Administrative Roles'
+  in users UI (bsc#1243394)


### PR DESCRIPTION
## What does this PR change?

I moved this from the RBAC UI PR to its own so it can be merged.

Rename 'Roles' to 'Administrative Roles' in the user UI

## GUI diff

Renamed colmn header 'Roles' to 'Administrative Roles

- [x] **DONE**

## Documentation
- No documentation needed: **BUGFIX**
- [x] **DONE**

## Test coverage
- No tests: **BUGFIX**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27284

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
