### PR TITLE
Fix arch_specs grain unit test

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_cpuinfo.py
@@ -152,9 +152,17 @@ def test_cpusockets_cpu_data(arch):
 
 
 def test_arch_specs_unknown():
-    cpuinfo._get_architecture = MagicMock(return_value="ppc64")
-    specs = cpuinfo.arch_specs()
-    assert specs == { "cpu_arch_specs": {} }
+    with patch('src.grains.cpuinfo._get_architecture', return_value="unknown"), \
+         patch('src.grains.cpuinfo._add_ppc64_extras') as mock_ppc64, \
+         patch('src.grains.cpuinfo._add_arm64_extras') as mock_arm64, \
+         patch('src.grains.cpuinfo._add_z_systems_extras') as mock_z:
+
+        specs = cpuinfo.arch_specs()
+
+        assert mock_ppc64.call_count == 0
+        assert mock_arm64.call_count == 0
+        assert mock_z.call_count == 0
+        assert specs == {"cpu_arch_specs": {}}
 
 def test_arch_specs_ppc64():
     cpuinfo._get_architecture = MagicMock(return_value="ppc64")


### PR DESCRIPTION
## What does this PR change?

If fixes the `test_arch_specs_unknown` unit test to properly simulate an unknown architecture. The test was previously passing by accident, depending on the environment where it was executed, because it mocked the architecture as "ppc64" instead of an unknown value.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were fixed

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
