### PR TITLE
Fix character encoding issue on organization credentials page (bsc#1246436)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/io/CachingOutputStream.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/io/CachingOutputStream.java
@@ -18,6 +18,7 @@ package com.redhat.rhn.frontend.action.renderers.io;
 import com.redhat.rhn.frontend.servlets.LegacyServletOutputStream;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Caches all content written to it to be retrieved
@@ -40,6 +41,6 @@ public class CachingOutputStream extends LegacyServletOutputStream {
      * @return returns the cached content
      */
     public String getCachedContent() {
-        return buffer.toString();
+        return buffer.toString(StandardCharsets.UTF_8);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/io/CachingResponseWrapper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/io/CachingResponseWrapper.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.frontend.action.renderers.io;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
@@ -30,7 +31,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
 public class CachingResponseWrapper extends HttpServletResponseWrapper {
 
     private CachingOutputStream stream = new CachingOutputStream();
-    private PrintWriter writer = new PrintWriter(stream);
+    private PrintWriter writer = new PrintWriter(stream, false, StandardCharsets.UTF_8);
 
     /**
      * constructor

--- a/java/code/src/com/redhat/rhn/frontend/servlets/SetCharacterEncodingFilter.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/SetCharacterEncodingFilter.java
@@ -15,6 +15,9 @@
 
 package com.redhat.rhn.frontend.servlets;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.IOException;
 
 import javax.servlet.Filter;
@@ -23,6 +26,7 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * <p>Example filter that sets the character encoding to be used in parsing the
@@ -46,6 +50,8 @@ import javax.servlet.ServletResponse;
  */
 
 public class SetCharacterEncodingFilter implements Filter {
+
+    private static final Logger LOG = LogManager.getLogger(SetCharacterEncodingFilter.class);
 
     /**
      * The default character encoding to set for requests that pass through
@@ -87,10 +93,14 @@ public class SetCharacterEncodingFilter implements Filter {
         // Conditionally select and set the character encoding to be used
         if ((request.getCharacterEncoding() == null)) {
             String encodingIn = selectEncoding(request);
-            if (encoding != null) {
+            if (encodingIn != null) {
                 request.setCharacterEncoding(encodingIn);
                 response.setContentType("text/html; charset=" + encodingIn);
                 response.setCharacterEncoding(encodingIn);
+            }
+            else {
+                HttpServletRequest httpRequest = (HttpServletRequest) request;
+                LOG.error("No character encoding defined for request: {}", httpRequest.getRequestURI());
             }
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/ajax/AjaxHandlerServlet.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/ajax/AjaxHandlerServlet.java
@@ -178,10 +178,11 @@ public class AjaxHandlerServlet extends HttpServlet {
             boolean isJsonResponse = JSON_RESULT_URLS.contains(url);
 
             String response = isJsonResponse ? gson.toJson(result) : result.toString();
-            String contentType = isJsonResponse ? "application/json" : "text/html";
+            String contentType = isJsonResponse ? "application/json; charset=UTF-8" : "text/html; charset=UTF-8";
             resp.setContentType(contentType);
-            resp.getOutputStream().print(response);
-            resp.getOutputStream().close();
+            resp.setCharacterEncoding("UTF-8");
+            resp.getWriter().print(response);
+            resp.getWriter().close();
         }
         catch (ServletException | IOException e) {
             logger.error("Error processing ajax request.", e);

--- a/java/spacewalk-java.changes.eth.encoding-m
+++ b/java/spacewalk-java.changes.eth.encoding-m
@@ -1,0 +1,2 @@
+- Fix character encoding issue on organization credentials page
+  (bsc#1246436)


### PR DESCRIPTION
## What does this PR change?

The organization credentials page breaks if you use e.g. Korean characters:

```
java.io.CharConversionException: Not an ISO 8859-1 character: [비]
```

This change fixes the issue.

## GUI diff

Org credentials page works again.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1246436

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
