### PR TITLE
Fix /pub proxypass which was missing /pub in the internal loop

### DIFF
--- a/proxy/proxy/httpd-conf/smlm-proxy-forwards.conf
+++ b/proxy/proxy/httpd-conf/smlm-proxy-forwards.conf
@@ -21,10 +21,17 @@ ProxyPassReverse /rhn/manager/api https://{{ SERVER }}/rhn/manager/api
 # Use our squid cache for any proxypass to localhost
 ProxyRemote http://localhost http://localhost:8080
 # Anything received on proxyInternalLoop gets forwarded to upstream server
-ProxyPassMatch /proxyInternalLoop/(.*)$ https://{{ SERVER }}/$1
+ProxyPass /proxyInternalLoop https://{{ SERVER }}
+ProxyPassReverse /proxyInternalLoop https://{{ SERVER }}
 
 # Proxy pass following to ourselves via proxyInternalLoop path. With above it will go through our squid to the server
 ProxyPass /os-images http://localhost/proxyInternalLoop/os-images
 ProxyPass /tftp http://localhost/proxyInternalLoop/tftp
 ProxyPass /saltboot http://localhost/proxyInternalLoop/saltboot
-ProxyPassMatch /pub/(.*)$ http://localhost/proxyInternalLoop/$1
+ProxyPass /pub http://localhost/proxyInternalLoop/pub
+
+# Reverses, needed for correct 301 responses to point to the proxy
+ProxyPassReverse /os-images http://localhost/proxyInternalLoop/os-images
+ProxyPassReverse /tftp http://localhost/proxyInternalLoop/tftp
+ProxyPassReverse /saltboot http://localhost/proxyInternalLoop/saltboot
+ProxyPassReverse /pub http://localhost/proxyInternalLoop/pub


### PR DESCRIPTION
## What does this PR change?

- Add ProxyPassReverse for correct redirect responses
- ProxyPassMatch is not really needed, replaced by efficient ProxyPass
- fix /pub proxypass which was missing /pub in the internal loop

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
