### PR TITLE
Temporary: need more infor for tab crashed in head

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -150,6 +150,7 @@ After do |scenario|
   log "This scenario took: #{current_epoch - @scenario_start_time} seconds"
   if scenario.failed?
     begin
+      $stdout.puts scenario.exception
       if scenario.exception.is_a?(Selenium::WebDriver::Error::WebDriverError)
         log "Caught web driver error: #{scenario.exception.message}"
         Capybara.current_session.driver.quit


### PR DESCRIPTION
## What does this PR change?

Temporary: add more debug information for tab crashed


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Ports: none, head only, the fix works fine in 4.3 and 5.0

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
