### PR TITLE
Remove BETA from product names

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -75,7 +75,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see the "Development Tools Module 15 SP4 x86_64" selected
     When I select "Containers Module 15 SP4 x86_64" as a product
     Then I should see the "Containers Module 15 SP4 x86_64" selected
-    When I select or deselect "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64 (BETA)" beta client tools
+    # When I select or deselect "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64 (BETA)" beta client tools
     And I select "SUSE Linux Enterprise Server LTSS 15 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 15 SP4 x86_64" selected
     When I click the Add Product button
@@ -367,7 +367,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see the "SUSE Linux Enterprise Micro 5.5 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Micro 5.5 x86_64"
     And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE Micro 5 x86_64" if present
-    And I select or deselect "SUSE Multi-Linux Manager Client Tools Beta for SLE Micro 5 x86_64 (BETA)" beta client tools
+    # And I select or deselect "SUSE Multi-Linux Manager Client Tools Beta for SLE Micro 5 x86_64 (BETA)" beta client tools
     And I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Micro 5.5 x86_64" product has been added
@@ -562,7 +562,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Liberty Linux LTSS 7 x86_64" as a product
     Then I should see the "SUSE Liberty Linux LTSS 7 x86_64" selected
     When I open the sub-list of the product "SUSE Liberty Linux LTSS 7 x86_64"
-    And I should see the "SUSE Multi-Linux Manager Client Tools for SUSE Liberty Linux 7, RHEL and clones 7 x86_64 (BETA)" selected
+    And I should see the "SUSE Multi-Linux Manager Client Tools for SUSE Liberty Linux 7, RHEL and clones 7 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Liberty Linux LTSS 7 x86_64" product has been added
     And I wait until all synchronized channels for "sll-7-ltss" have finished
@@ -811,11 +811,11 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Multi-Linux Manager Proxy Extension 5.1" as the filtered product description
     Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" product has been added
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
     And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51" have finished
 
 @uyuni
@@ -855,8 +855,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1" as the filtered product description
     Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -37,8 +37,8 @@ Feature: List available channels and enable them
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 15 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.3 x86_64"
-    And I should get "  [ ] (R) SUSE Multi-Linux Manager Client Tools for SUSE Liberty Linux 7, RHEL and clones 7 x86_64 (BETA)"
-    And I should get "  [ ] (R) SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64 (BETA)"
+    And I should get "  [ ] (R) SUSE Multi-Linux Manager Client Tools for SUSE Liberty Linux 7, RHEL and clones 7 x86_64"
+    And I should get "  [ ] (R) SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64"
 
   Scenario: List products with filter
     When I execute mgr-sync "list products --expand --filter x86_64"

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -51,15 +51,15 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP4 x86_64"
     And I open the sub-list of the product "Basesystem Module 15 SP4 x86_64"
     And I open the sub-list of the product "Desktop Applications Module 15 SP4 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64 (BETA)" if present
+    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64" if present
     Then I should see that the "Basesystem Module 15 SP4 x86_64" product is "recommended"
     And I should see that the "Server Applications Module 15 SP4 x86_64" product is "recommended"
-    And I should see that the "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64 (BETA)" product is "recommended"
+    And I should see that the "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64" product is "recommended"
     When I select "SUSE Linux Enterprise Server 15 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP4 x86_64" selected
     And I should see the "Basesystem Module 15 SP4 x86_64" selected
     And I should see the "Server Applications Module 15 SP4 x86_64" selected
-    And I should see the "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64 (BETA)" selected
+    And I should see the "SUSE Multi-Linux Manager Client Tools for SLE 15 x86_64" selected
     When I select "Desktop Applications Module 15 SP4 x86_64" as a product
     And I select "Development Tools Module 15 SP4 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP4 x86_64" selected
@@ -68,7 +68,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see the "Python 3 Module 15 SP4 x86_64" selected
     When I select "Containers Module 15 SP4 x86_64" as a product
     Then I should see the "Containers Module 15 SP4 x86_64" selected
-    When I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SLE 15 x86_64 (BETA)" beta client tools
+    # When I select or deselect "SUSE Multi-Linux Manager Beta Client Tools for SLE 15 x86_64 (BETA)" beta client tools
     And I select "SUSE Linux Enterprise Server LTSS 15 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 15 SP4 x86_64" selected
     When I click the Add Product button
@@ -155,11 +155,11 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
-    And I select "SUSE Linux Enterprise Server 15 SP7 (BETA)" as a product
-    Then I should see the "SUSE Linux Enterprise Server 15 SP7 (BETA)" selected
+    And I select "SUSE Linux Enterprise Server 15 SP7" as a product
+    Then I should see the "SUSE Linux Enterprise Server 15 SP7" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Linux Enterprise Server 15 SP7 (BETA)" product has been added
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP7" product has been added
     And I wait until all synchronized channels for "sles15-sp7" have finished
 
 @proxy
@@ -173,11 +173,11 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Linux Micro 6.1" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
     And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" product has been added
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
     And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51" have finished
 
 @proxy
@@ -190,11 +190,11 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64 (BETA)" product has been added
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
     And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51-sp7" have finished
 
 @proxy
@@ -208,11 +208,11 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Linux Micro 6.1" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
     And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64 (BETA)" product has been added
+    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" product has been added
     And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-51" have finished
 
 @proxy
@@ -224,7 +224,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
-    When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64 (BETA)"
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
     And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
     Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
     When I click the Add Product button


### PR DESCRIPTION
## What does this PR change?

Remove BETA from product names

**IMPORTANT** if we are going to switch to 5.2 immediately in HEAD, this PR is wrong, and I will just close it. If that is the case, I will do another one, keeping BETA but jumping to 5.2.

In 5.1 branch, it's a different story.


## GUI diff

No difference.

- [x] **DONE**

## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

Cucumber tests were modified

- [x] **DONE**

## Links

Head and 5.1 only

Ports:
 * 5.1:  https://github.com/SUSE/spacewalk/pull/27988

- [x] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
