### PR TITLE
Adjust some timings

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -683,6 +683,8 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         managertools-beta-sle15-updates-x86_64-sp4
         sle-module-devtools15-sp4-updates-x86_64
         sle-module-devtools15-sp4-pool-x86_64
+        sle-module-python3-15-sp4-pool-x86_64
+        sle-module-python3-15-sp4-updates-x86_64
         sle-module-containers15-sp4-pool-x86_64
         sle-module-containers15-sp4-updates-x86_64
         sle-product-sles15-sp4-ltss-updates-x86_64
@@ -804,6 +806,8 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         managertools-beta-sle15-updates-x86_64-sp4
         sle-module-devtools15-sp4-updates-x86_64
         sle-module-devtools15-sp4-pool-x86_64
+        sle-module-python3-15-sp4-pool-x86_64
+        sle-module-python3-15-sp4-updates-x86_64
         sle-module-containers15-sp4-pool-x86_64
         sle-module-containers15-sp4-updates-x86_64
       ],
@@ -1548,6 +1552,8 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sle-module-public-cloud15-sp6-updates-x86_64' => 60,
   'sle-module-public-cloud15-sp7-pool-x86_64' => 60,
   'sle-module-public-cloud15-sp7-updates-x86_64' => 60,
+  'sle-module-python3-15-sp4-pool-x86_64' => 60,
+  'sle-module-python3-15-sp4-updates-x86_64' => 60,
   'sle-module-python3-15-sp5-pool-x86_64' => 60,
   'sle-module-python3-15-sp5-updates-x86_64' => 60,
   'sle-module-python3-15-sp6-pool-x86_64' => 60,


### PR DESCRIPTION
## What does this PR change?

Adjust some timings according to values measured with `gather_timings.py` script in `/var/log/rhn/reposync`.

Some repositories grow over time, and therefore we must adjust the timings accordingly. The python script leaves a 100 % margin, which means that we have some buffer, and need update this only from time to time.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/27999
           https://github.com/SUSE/spacewalk/pull/28032
 * 5.0: https://github.com/SUSE/spacewalk/pull/27998
           https://github.com/SUSE/spacewalk/pull/28031
 * 5.1: https://github.com/SUSE/spacewalk/pull/27997

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
