### PR TITLE
Incorrect href usages

### DIFF
--- a/web/html/src/branding/css/base/components/panels.suma.scss
+++ b/web/html/src/branding/css/base/components/panels.suma.scss
@@ -13,10 +13,15 @@
 
     .list-group-item {
       border-bottom: 1px solid $eos-bc-gray-100;
+      text-align: left;
 
       &:last-child {
         border-bottom: none;
       }
+    }
+
+    .ui-sortable .list-group-item {
+      cursor: grab;
     }
 
     > .panel-body .list-group {

--- a/web/html/src/branding/css/base/components/panels.uyuni.scss
+++ b/web/html/src/branding/css/base/components/panels.uyuni.scss
@@ -15,6 +15,7 @@
 
     .list-group-item {
       border-bottom: 1px solid $eos-bc-gray-100;
+      text-align: left;
 
       &:last-child {
         border-bottom: none;
@@ -28,6 +29,10 @@
         background-color: $eos-bc-gray-50;
         text-decoration: none;
       }
+    }
+
+    .ui-sortable .list-group-item {
+      cursor: grab;
     }
   }
 

--- a/web/html/src/branding/css/base/components/tables.scss
+++ b/web/html/src/branding/css/base/components/tables.scss
@@ -44,6 +44,13 @@ tbody tr td,
   background: transparent !important;
 }
 
+tbody tr td .modal-link {
+  border: 0;
+  color: $eos-bc-blue-500;
+  font-weight: 600;
+  background: transparent;
+}
+
 .display-number {
   height: 30px;
   padding: 5px 10px;

--- a/web/html/src/components/formula-selection.tsx
+++ b/web/html/src/components/formula-selection.tsx
@@ -138,9 +138,7 @@ class FormulaSelection extends React.Component<Props, State> {
       );
       groups.groupless.forEach(function (this: FormulaSelection, formula) {
         list.push(
-          // eslint-disable-next-line jsx-a11y/anchor-is-valid
-          <a
-            href="#"
+          <button
             onClick={this.onListItemClick}
             id={formula.name}
             key={formula.name}
@@ -154,7 +152,7 @@ class FormulaSelection extends React.Component<Props, State> {
               <i id={"info_button_" + formula.name} className="fa fa-lg fa-info-circle pull-right" />
             ) : null}
             {this.getDescription(formula)}
-          </a>
+          </button>
         );
       }, this);
     }
@@ -163,9 +161,7 @@ class FormulaSelection extends React.Component<Props, State> {
       const group = groups[group_name];
       const group_state = this.getGroupItemState(group);
       list.push(
-        // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a
-          href="#"
+        <button
           onClick={this.onGroupItemClick}
           id={"group_" + group_name}
           key={"group_" + group_name}
@@ -175,13 +171,11 @@ class FormulaSelection extends React.Component<Props, State> {
             <i className={this.getListIcon(group_state)} />
             {" " + capitalize(group_name)}
           </strong>
-        </a>
+        </button>
       );
       group.forEach(function (this: FormulaSelection, formula) {
         list.push(
-          // eslint-disable-next-line jsx-a11y/anchor-is-valid
-          <a
-            href="#"
+          <button
             onClick={this.onListItemClick}
             id={formula.name}
             key={formula.name}
@@ -195,7 +189,7 @@ class FormulaSelection extends React.Component<Props, State> {
               <i id={"info_button_" + formula.name} className="fa fa-lg fa-info-circle pull-right" />
             ) : null}
             {this.getDescription(formula)}
-          </a>
+          </button>
         );
       }, this);
     }

--- a/web/html/src/components/ranking-table.tsx
+++ b/web/html/src/components/ranking-table.tsx
@@ -43,7 +43,7 @@ type RankingTableState = {
 class RankingTable extends React.Component<RankingTableProps, RankingTableState> {
   defaultEmptyMsg = t("There are no entries to show.");
   node: Element | null = null;
-
+  
   constructor(props) {
     super(props);
     this.state = {
@@ -86,7 +86,7 @@ class RankingTable extends React.Component<RankingTableProps, RankingTableState>
 
     jQuery(this.node).sortable({
       update: this.handleUpdate.bind(this),
-      items: "a",
+      items: ".list-group-item",
     });
 
     this.handleUpdate();
@@ -105,12 +105,11 @@ class RankingTable extends React.Component<RankingTableProps, RankingTableState>
       // TODO: Provide a callback as prop for optional mapping and generify this default implementation
       const icon = channelIcon(i);
       return (
-        // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" className="list-group-item" key={i.label} data-id={i.label}>
+        <div className="list-group-item" key={i.label} data-id={i.label}>
           <i className="fa fa-sort" />
           {icon}
           {i.name} ({i.label})
-        </a>
+        </div>
       );
     });
   }

--- a/web/html/src/components/states-picker.tsx
+++ b/web/html/src/components/states-picker.tsx
@@ -264,9 +264,8 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
           <td>
             {channelIcon(currentChannel)}
             {currentChannel.type !== "internal_state" ? (
-              /* eslint-disable-next-line jsx-a11y/anchor-is-valid */
-              <a
-                href="#"
+              <button
+                className="modal-link"
                 data-bs-toggle="modal"
                 data-bs-target="#saltStatePopUp"
                 onClick={() => {
@@ -274,7 +273,7 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
                 }}
               >
                 {currentChannel.name}
-              </a>
+              </button>
             ) : (
               currentChannel.name
             )}

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/child-channel.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/child-channel.tsx
@@ -61,10 +61,10 @@ const ChildChannel = (props: Props) => {
         <Highlight enabled={props.search?.length > 0} text={name} highlight={props.search}></Highlight>
       </label>
       <span>
-        {tooltip ? ( // eslint-disable-next-line jsx-a11y/anchor-is-valid
-          <a href="#">
+        {tooltip ? (
+          <span>
             <i className="fa fa-info-circle spacewalk-help-link" title={tooltip}></i>
-          </a>
+          </span>
         ) : null}
         {recommended ? (
           <span className="recommended-tag-base" title={t("This channel is recommended")}>

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
@@ -65,9 +65,7 @@ const renderSourceEntry = (source) => {
 
   if (source.state === statesEnum.enum.ATTACHED.key) {
     return (
-      // TODO: If you touch this code, please make sure the `href` property here is obsolete and remove it
-      // @ts-expect-error
-      <div className={`text-success ${styles.attached}`} href="#">
+      <div className={`text-success ${styles.attached}`}>
         <i className="fa fa-plus" />
         <b>{source.name}</b>
         &nbsp;

--- a/web/html/src/manager/systems/activation-key/child-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/child-channels.tsx
@@ -133,10 +133,9 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
               </label>
               &nbsp;
               {toolTip ? (
-                // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                <a href="#">
+                <span>
                   <i className="fa fa-info-circle spacewalk-help-link" title={toolTip}></i>
-                </a>
+                </span>
               ) : null}
               &nbsp;
               {c.recommended ? (

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
@@ -182,15 +182,14 @@ class BaseChannelPage extends React.Component<BaseChannelProps, BaseChannelState
             comparator={Utils.sortByText}
             header={t("Systems")}
             cell={(channel: SsmAllowedBaseChannelsJson) => (
-              // eslint-disable-next-line jsx-a11y/anchor-is-valid
-              <a
-                href="#"
+              <button
+                className="modal-link"
                 data-bs-toggle="modal"
                 data-bs-target="#channelServersPopup"
                 onClick={() => this.showServersListPopUp(channel)}
               >
                 {channel.servers.length}
-              </a>
+              </button>
             )}
           />
           <Column
@@ -438,9 +437,9 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
             <div className="col-md-4 text-right">
               <strong>
                 {allowed.servers && allowed.servers.length > 0 ? (
-                  // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                  <a
-                    href="#"
+                  //TODO: Need to replace btn-link with btn-tertiary css class
+                  <button
+                    className="btn-link"
                     data-bs-toggle="modal"
                     data-bs-target="#channelServersPopup"
                     onClick={() =>
@@ -451,12 +450,12 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
                     }
                   >
                     {allowed.servers.length} {t("system(s) to subscribe")}
-                  </a>
+                  </button>
                 ) : null}
                 {allowed.incompatibleServers && allowed.incompatibleServers.length > 0 ? (
-                  // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                  <a
-                    href="#"
+                  //TODO: Need to replace btn-link with btn-tertiary css class
+                  <button
+                    className="btn-link"
                     data-bs-toggle="modal"
                     data-bs-target="#channelServersPopup"
                     onClick={() =>
@@ -468,7 +467,7 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
                   >
                     <i className="fa fa-exclamation-triangle fa-1-5x" aria-hidden="true"></i>
                     {allowed.incompatibleServers.length} {t("system(s) incompatible")}
-                  </a>
+                  </button>
                 ) : null}
               </strong>
             </div>
@@ -483,13 +482,12 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
                   </ChannelLink>{" "}
                   &nbsp;
                   {this.dependenciesTooltip(child.id) ? (
-                    // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                    <a href="#">
+                    <span>
                       <i
                         className="fa fa-info-circle spacewalk-help-link"
                         title={this.dependenciesTooltip(child.id)}
                       ></i>
-                    </a>
+                    </span>
                   ) : null}
                   &nbsp;
                   {child.recommended ? (
@@ -668,27 +666,27 @@ class SummaryPage extends React.Component<SummaryPageProps, SummaryPageState> {
             <div className="col-md-4 text-right">
               <strong>
                 {allowed.servers && allowed.servers.length > 0 ? (
-                  // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                  <a
-                    href="#"
+                   //TODO: Need to replace btn-link with btn-tertiary css class
+                  <button
+                    className="btn-link"
                     data-bs-toggle="modal"
                     data-bs-target="#channelServersPopup"
                     onClick={() => this.showServersListPopUp(newBaseName, allowed.servers)}
                   >
                     {allowed.servers.length} {t("system(s) to subscribe")}
-                  </a>
+                  </button>
                 ) : null}
                 {allowed.incompatibleServers && allowed.incompatibleServers.length > 0 ? (
-                  // eslint-disable-next-line jsx-a11y/anchor-is-valid
-                  <a
-                    href="#"
+                  //TODO: Need to replace btn-link with btn-tertiary css class
+                  <button
+                    className="btn-link"
                     data-bs-toggle="modal"
                     data-bs-target="#channelServersPopup"
                     onClick={() => this.showServersListPopUp(newBaseName, allowed.incompatibleServers)}
                   >
                     <i className="fa fa-exclamation-triangle fa-1-5x" aria-hidden="true"></i>
                     {allowed.incompatibleServers.length} {t("system(s) incompatible")}
-                  </a>
+                  </button>
                 ) : null}
               </strong>
             </div>

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -536,10 +536,9 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
           </label>{" "}
           &nbsp;
           {this.dependenciesTooltip(c.id) ? (
-            // eslint-disable-next-line jsx-a11y/anchor-is-valid
-            <a href="#">
+            <span>
               <i className="fa fa-info-circle spacewalk-help-link" title={this.dependenciesTooltip(c.id)}></i>
-            </a>
+            </span>
           ) : null}
           &nbsp;
           {c.recommended ? (

--- a/web/spacewalk-web.changes.bisht-richa.incorrect-href-usages
+++ b/web/spacewalk-web.changes.bisht-richa.incorrect-href-usages
@@ -1,0 +1,2 @@
+- Replaced href links with buttons to enhance clarity and
+  accessibility.


### PR DESCRIPTION
## What does this PR change?

Fixed incorrect href usages

Added a new .modal-link class to improve the look and feel of modal triggers in tables, making them more intuitive to click while separating them from traditional link styling. For modal buttons outside tables, continue using standard button styles.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**

- [x] **DONE**

## Links

Fixes: https://github.com/uyuni-project/uyuni/issues/7972
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
