### PR TITLE
Switch from Disable to Delete Schedule in confirmation panel

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_disable_scheduled_reposync.feature
+++ b/testsuite/features/build_validation/reposync/srv_disable_scheduled_reposync.feature
@@ -11,11 +11,13 @@ Feature: Do not let Taskomatic tasks interfere with our BV tests
     And I follow "mgr-sync-refresh-default"
     And I choose "disabled"
     And I click on "Update Schedule"
-    And I click on "Disable Schedule"
+    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
+    And I click on "Delete Schedule"
 
   Scenario: Disable scheduled Cobbler syncs
     When I follow the left menu "Admin > Task Schedules"
     And I follow "cobbler-sync-default"
     And I choose "disabled"
     And I click on "Update Schedule"
-    And I click on "Disable Schedule"
+    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
+    And I click on "Delete Schedule"

--- a/testsuite/features/reposync/srv_disable_scheduled_reposync.feature
+++ b/testsuite/features/reposync/srv_disable_scheduled_reposync.feature
@@ -11,11 +11,13 @@ Feature: Do not let Taskomatic tasks interfere with our CI tests
     And I follow "mgr-sync-refresh-default"
     And I choose "disabled"
     And I click on "Update Schedule"
-    And I click on "Disable Schedule"
+    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
+    And I click on "Delete Schedule"
 
   Scenario: Disable scheduled Cobbler syncs
     When I follow the left menu "Admin > Task Schedules"
     And I follow "cobbler-sync-default"
     And I choose "disabled"
     And I click on "Update Schedule"
-    And I click on "Disable Schedule"
+    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
+    And I click on "Delete Schedule"


### PR DESCRIPTION
## What does this PR change?

In 5.0 SLE MU pipeline, disabling schedule fails:

<details>

```
13:53:19  Scenario: Disable scheduled reposyncs                  # features/build_validation/reposync/srv_disable_scheduled_reposync.feature:9
13:53:19  This scenario ran at: 2025-08-08 13:48:49 +0200
13:53:19  When I follow the left menu "Admin > Task Schedules" # features/step_definitions/navigation_steps.rb:371
13:53:19  And I follow "mgr-sync-refresh-default"              # features/step_definitions/navigation_steps.rb:316
13:53:19  And I choose "disabled"                              # features/step_definitions/navigation_steps.rb:230
13:53:19  And I click on "Update Schedule"                     # features/step_definitions/navigation_steps.rb:277
13:53:19  And I click on "Disable Schedule"                    # features/step_definitions/navigation_steps.rb:277
13:53:19        Unable to find button "Disable Schedule" that is not disabled (Capybara::ElementNotFound)
13:53:19        ./features/support/commonlib.rb:189:in `click_button_and_wait'
13:53:19        ./features/step_definitions/navigation_steps.rb:278:in `/^I click on "([^"]*)"$/'
13:53:19        features/build_validation/reposync/srv_disable_scheduled_reposync.feature:14:in `I click on "Disable Schedule"'
13:53:19  => /var/log/rhn/rhn_web_ui.log
13:53:19  
13:53:19  => /var/log/rhn/rhn_web_api.log
13:53:19  
13:53:19  This scenario took: 61 seconds
13:53:19  
13:53:19  Scenario: Disable scheduled Cobbler syncs              # features/build_validation/reposync/srv_disable_scheduled_reposync.feature:16
13:53:19  This scenario ran at: 2025-08-08 13:50:52 +0200
13:53:19  When I follow the left menu "Admin > Task Schedules" # features/step_definitions/navigation_steps.rb:371
13:53:19  And I follow "cobbler-sync-default"                  # features/step_definitions/navigation_steps.rb:316
13:53:19  And I choose "disabled"                              # features/step_definitions/navigation_steps.rb:230
13:53:19  And I click on "Update Schedule"                     # features/step_definitions/navigation_steps.rb:277
13:53:19  And I click on "Disable Schedule"                    # features/step_definitions/navigation_steps.rb:277
13:53:19        Unable to find button "Disable Schedule" that is not disabled (Capybara::ElementNotFound)
13:53:19        ./features/support/commonlib.rb:189:in `click_button_and_wait'
13:53:19        ./features/step_definitions/navigation_steps.rb:278:in `/^I click on "([^"]*)"$/'
13:53:19        features/build_validation/reposync/srv_disable_scheduled_reposync.feature:21:in `I click on "Disable Schedule"'
13:53:19  => /var/log/rhn/rhn_web_ui.log
```

</details>

The following passes:

<details>

```
Feature: Do not let Taskomatic tasks interfere with our BV tests

  Scenario: Log in as admin user                  # features/build_validation/reposync/srv_disable_scheduled_reposync.feature:6
      This scenario ran at: 2025-08-08 15:24:12 +0200
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:435
      This scenario took: 12 seconds

  Scenario: Disable scheduled reposyncs                  # features/build_validation/reposync/srv_disable_scheduled_reposync.feature:9
      This scenario ran at: 2025-08-08 15:24:24 +0200
    When I follow the left menu "Admin > Task Schedules" # features/step_definitions/navigation_steps.rb:371
    And I follow "mgr-sync-refresh-default"              # features/step_definitions/navigation_steps.rb:316
    And I choose "disabled"                              # features/step_definitions/navigation_steps.rb:230
    And I click on "Update Schedule"                     # features/step_definitions/navigation_steps.rb:277
    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
    And I click on "Delete Schedule"                     # features/step_definitions/navigation_steps.rb:277
      This scenario took: 2 seconds

  Scenario: Disable scheduled Cobbler syncs              # features/build_validation/reposync/srv_disable_scheduled_reposync.feature:17
      This scenario ran at: 2025-08-08 15:24:26 +0200
    When I follow the left menu "Admin > Task Schedules" # features/step_definitions/navigation_steps.rb:371
    And I follow "cobbler-sync-default"                  # features/step_definitions/navigation_steps.rb:316
    And I choose "disabled"                              # features/step_definitions/navigation_steps.rb:230
    And I click on "Update Schedule"                     # features/step_definitions/navigation_steps.rb:277
    # Workaround https://bugzilla.suse.com/show_bug.cgi?id=1225740
    And I click on "Delete Schedule"                     # features/step_definitions/navigation_steps.rb:277
      This scenario took: 1 seconds

```

</details>

## GUI diff

Above are no longer in `SUSE Manager Schedules` under Admin > Task Schedules.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): #
Port(s):
* 5.1: https://github.com/SUSE/spacewalk/pull/28052
* 5.0: https://github.com/SUSE/spacewalk/pull/28053
* 4.3: https://github.com/SUSE/spacewalk/pull/28054

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
