### PR TITLE
Fix schema migration script for multi-org setups (bsc#1247773)

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.welder.bsc1247773
+++ b/schema/spacewalk/susemanager-schema.changes.welder.bsc1247773
@@ -1,0 +1,1 @@
+- Fix schema migration script for multi-org setups (bsc#1247773)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.7-to-susemanager-schema-5.1.8/200-proxy-server-group-members.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.7-to-susemanager-schema-5.1.8/200-proxy-server-group-members.sql
@@ -2,19 +2,23 @@
 -- Ensure existing proxies get the proxy_entitled and update the group count ---
 --------------------------------------------------------------------------------
 INSERT INTO rhnservergroupmembers (server_id, server_group_id)
-    SELECT rpi.server_id, (SELECT id FROM rhnservergroup WHERE name = 'Proxy')
-    FROM rhnproxyinfo rpi
-    WHERE NOT EXISTS (
+SELECT rpi.server_id, sg.id
+FROM rhnproxyinfo rpi
+JOIN rhnServer s ON rpi.server_id = s.id
+JOIN rhnservergroup sg ON sg.name = 'Proxy'
+WHERE
+    s.org_id = sg.org_id
+    AND NOT EXISTS (
         SELECT 1
-        FROM rhnservergroupmembers sg
-        WHERE sg.server_id = rpi.server_id
-          AND sg.server_group_id = (SELECT id FROM rhnservergroup WHERE name = 'Proxy')
+        FROM rhnservergroupmembers sgm
+        WHERE sgm.server_id = rpi.server_id
+          AND sgm.server_group_id = sg.id
     );
 
-UPDATE rhnservergroup
-    SET current_members = (
-        SELECT COUNT(*)
-        FROM rhnservergroupmembers
-        WHERE server_group_id = (SELECT id FROM rhnservergroup WHERE name = 'Proxy')
-    )
-    WHERE id = (SELECT id FROM rhnservergroup WHERE name = 'Proxy');
+UPDATE rhnservergroup sg
+SET current_members = (
+    SELECT COUNT(*)
+    FROM rhnservergroupmembers sgm
+    WHERE sgm.server_group_id = sg.id
+)
+WHERE sg.name = 'Proxy';


### PR DESCRIPTION
## What does this PR change?

The migration queries failed when multiple organizations had a 'Proxy' server group, as subqueries selecting `id` by name returned more than one row. 

Updated INSERT and UPDATE statements to:
- Match 'Proxy' groups by org_id to ensure correct association.
- Replace subqueries with joins to avoid multi-row errors.

This makes the migration compatible with multi-org environments.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: migration script change

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/10686

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
