### PR TITLE
Use existing certificates if they are already present (bsc#1246789)

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.support_predeployed_systemid
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.oholecek.support_predeployed_systemid
@@ -1,0 +1,1 @@
+- Use existing systemid in proxy httpd if present (bsc#1246789)

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -85,26 +85,30 @@ with open(config_path + "httpd.yaml", encoding="utf-8") as httpdSource:
             )
             sys.exit(1)
 
-    # store the systemid content
-    with open("/etc/sysconfig/rhn/systemid", "w", encoding="utf-8") as file:
-        file.write(httpdConfig.get("system_id"))
+    # store the systemid content, but only if it does not exist already
+    if not os.path.exists("/etc/sysconfig/rhn/systemid"):
+        with open("/etc/sysconfig/rhn/systemid", "w", encoding="utf-8") as file:
+            file.write(httpdConfig.get("system_id"))
 
-    # store SSL CA certificate
-    with open(
-        "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT", "w", encoding="utf-8"
-    ) as file:
-        file.write(config.get("ca_crt"))
+    # store SSL CA certificate, if it does not exist already
+    if not os.path.exists("/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT"):
+        with open(
+            "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT", "w", encoding="utf-8"
+        ) as file:
+            file.write(config.get("ca_crt"))
+    # however always prepare link
     os.symlink(
         "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
         "/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT",
     )
     os.system("/usr/sbin/update-ca-certificates")
 
-    # store server certificate files
-    with open("/etc/apache2/ssl.crt/server.crt", "w", encoding="utf-8") as file:
-        file.write(httpdConfig.get("server_crt"))
-    with open("/etc/apache2/ssl.key/server.key", "w", encoding="utf-8") as file:
-        file.write(httpdConfig.get("server_key"))
+    # store server certificate files, if cert does not exist already
+    if not os.path.exists("/etc/apache2/ssl.crt/server.crt"):
+        with open("/etc/apache2/ssl.crt/server.crt", "w", encoding="utf-8") as file:
+            file.write(httpdConfig.get("server_crt"))
+        with open("/etc/apache2/ssl.key/server.key", "w", encoding="utf-8") as file:
+            file.write(httpdConfig.get("server_key"))
 
     with open("/etc/apache2/httpd.conf", "r+", encoding="utf-8") as file:
         file_content = file.read()


### PR DESCRIPTION
## What does this PR change?

SystemID (and in the future certificates) can be passed using podman secrets so they would already exist on the system. Do not overwrite them then.

See also https://github.com/uyuni-project/uyuni-tools/pull/642

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27874
Port(s): https://github.com/SUSE/spacewalk/pull/28006

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
