### PR TITLE
Simplify/improve ContentSyncManager

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/test/FileLocksTest.java
+++ b/java/code/src/com/redhat/rhn/common/util/test/FileLocksTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.common.util.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.redhat.rhn.common.util.FileLocks;
+import com.redhat.rhn.testing.TestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.channels.OverlappingFileLockException;
+
+public class FileLocksTest {
+
+    public static class FileLocksClass {
+        private FileLocks theFileLocks;
+
+        public FileLocksClass(String path) {
+            theFileLocks = new FileLocks(path);
+        }
+
+        public String lockingMethod1() {
+            return theFileLocks.withFileLock(this::method1Core);
+        }
+
+        private String method1Core() {
+            return "method1";
+        }
+
+        public String lockingMethod2() {
+            return theFileLocks.withFileLock(this::method2Core);
+        }
+
+        private String method2Core() {
+            return "method2";
+        }
+
+        public String recursiveLockingMethod3() {
+            return theFileLocks.withFileLock(
+                    () -> {
+                        String r1 = lockingMethod1();
+                        String r2 = lockingMethod2();
+                        return r1 + r2;
+                    }
+            );
+        }
+
+        public String lockingMethod3() {
+            return theFileLocks.withFileLock(
+                    () -> {
+                        String r1 = method1Core();
+                        String r2 = method2Core();
+                        return r1 + r2;
+                    }
+            );
+        }
+    }
+
+    @Test
+    public void testRecursiveLocking() {
+        String path = "/tmp/" + System.currentTimeMillis() + TestUtils.randomString() + ".lock";
+
+        FileLocksClass testClass = new FileLocksClass(path);
+
+        assertEquals("method1", testClass.lockingMethod1());
+        assertEquals("method2", testClass.lockingMethod2());
+        assertThrows(OverlappingFileLockException.class, testClass::recursiveLockingMethod3);
+
+        assertEquals("method1method2", testClass.lockingMethod3());
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -46,6 +46,7 @@ import com.redhat.rhn.manager.content.ContentSyncException;
 import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.content.ProductTreeEntry;
 import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.MockFileLocks;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.salt.netapi.parser.JsonParser;
@@ -77,6 +78,13 @@ import java.util.stream.Collectors;
  * Utility methods for creating SUSE related test data.
  */
 public class SUSEProductTestUtils extends HibernateFactory {
+
+    public static class TestContentSyncManager extends ContentSyncManager {
+        public TestContentSyncManager() {
+            super();
+            setSccRefreshLock(new MockFileLocks());
+        }
+    }
 
     private static final Random RANDOM = new Random();
     private static Logger log = LogManager.getLogger(SUSEProductTestUtils.class);
@@ -565,7 +573,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         }
         repositories.addAll(addRepos);
 
-        ContentSyncManager csm = new ContentSyncManager() {
+        ContentSyncManager csm = new TestContentSyncManager() {
             @Override
             protected boolean accessibleUrl(String url, String user, String password) {
                 // allow all none SCC URLs
@@ -575,7 +583,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         ContentSyncSource contentSyncSource = null;
         if (fromdir) {
             Config.get().setString(ContentSyncManager.RESOURCE_PATH, "sumatest");
-            csm = new ContentSyncManager() {
+            csm = new TestContentSyncManager() {
                 @Override
                 protected boolean accessibleUrl(String url, String user, String password) {
                     // allow all none SCC URLs
@@ -605,7 +613,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
     }
 
     public static void addChannelsForProduct(SUSEProduct product) {
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new TestContentSyncManager();
         product.getChannelTemplates()
         .stream()
         .filter(ChannelTemplate::isMandatory)
@@ -633,7 +641,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
      */
     public static void addChannelsForProductAndParent(SUSEProduct product, SUSEProduct root,
             boolean mandatory, List<Long> optionalChannelIds) {
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new TestContentSyncManager();
         product.getChannelTemplates()
         .stream()
         .filter(pr -> pr.getRootProduct().equals(root))

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/sync/content/ContentSyncHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/sync/content/ContentSyncHandler.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.frontend.xmlrpc.sync.content;
 
-import com.redhat.rhn.common.util.FileLocks;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
 import com.redhat.rhn.domain.credentials.SCCCredentials;
 import com.redhat.rhn.domain.product.ChannelTemplate;
@@ -114,10 +113,8 @@ public class ContentSyncHandler extends BaseHandler {
             throws ContentSyncException {
         ensureSatAdmin(loggedInUser);
         try {
-            FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateChannelFamilies(csm.readChannelFamilies());
-            });
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateChannelFamilies(csm.readChannelFamilies());
             return BaseHandler.VALID;
         }
         catch (com.redhat.rhn.manager.content.ContentSyncException e) {
@@ -141,10 +138,9 @@ public class ContentSyncHandler extends BaseHandler {
     public Integer synchronizeProducts(User loggedInUser) throws ContentSyncException {
         ensureSatAdmin(loggedInUser);
         try {
-            FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateSUSEProducts(csm.getProducts());
-            });
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateSUSEProducts(csm.getProducts());
+
             return BaseHandler.VALID;
         }
         catch (com.redhat.rhn.manager.content.ContentSyncException e) {
@@ -169,10 +165,9 @@ public class ContentSyncHandler extends BaseHandler {
     public Integer synchronizeSubscriptions(User loggedInUser) throws ContentSyncException {
         ensureSatAdmin(loggedInUser);
         try {
-            FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateSubscriptions();
-            });
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateSubscriptions();
+
             return BaseHandler.VALID;
         }
         catch (com.redhat.rhn.manager.content.ContentSyncException e) {
@@ -199,10 +194,9 @@ public class ContentSyncHandler extends BaseHandler {
     public Integer synchronizeRepositories(User loggedInUser, String mirrorUrl) throws ContentSyncException {
         ensureSatAdmin(loggedInUser);
         try {
-            FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateRepositories(mirrorUrl);
-            });
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateRepositories(mirrorUrl);
+
             return BaseHandler.VALID;
         }
         catch (com.redhat.rhn.manager.content.ContentSyncException e) {

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerPaygTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerPaygTest.java
@@ -112,6 +112,8 @@ public class ContentSyncManagerPaygTest extends RhnBaseTestCase {
                 // Nothing to do
             }
         };
+        contentSyncManager.setSccRefreshLock(new MockFileLocks());
+
         PAYG_DATA_TASK.setContentSyncManager(contentSyncManager);
         PAYG_DATA_TASK.setSccRefreshLock(new MockFileLocks());
     }
@@ -164,6 +166,7 @@ public class ContentSyncManagerPaygTest extends RhnBaseTestCase {
 
             // download the product data from Cloud RMT
             ContentSyncManager csm = new ContentSyncManager(tmpLogDir, mgr);
+            csm.setSccRefreshLock(new MockFileLocks());
             ContentSyncManager.setChannelFamiliesJson(new File(TestUtils.findTestData(CHANNEL_FAMILY).getPath()));
             ContentSyncManager.setAdditionalProductsJson(
                     new File(TestUtils.findTestData(ADDITIONAL_PRODUCTS).getPath()));

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -164,7 +164,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         products.add(p);
 
         // Call updateSUSEProducts()
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.setSumaProductTreeJson(Optional.of(new File("/usr/share/susemanager/scc/product_tree.json")));
         csm.updateSUSEProducts(products);
 
@@ -232,7 +232,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
             SCCCachingFactory.clearSubscriptions();
             SUSEProductTestUtils.clearAllProducts();
             SUSEProductTestUtils.createVendorSUSEProducts();
-            ContentSyncManager cm = new ContentSyncManager();
+            ContentSyncManager cm = new SUSEProductTestUtils.TestContentSyncManager();
             Collection<SCCSubscriptionJson> s = cm.updateSubscriptions();
             assertNotNull(s);
             assertFalse(cm.hasToolsChannelSubscription(), "Should no find a SUSE Manager Server Subscription");
@@ -313,7 +313,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
                 .filter(c -> c.getUsername().equals("dummy"))
                 .findFirst().get();
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         // todo i think this doesn't mock correctly and causes timeouts
         csm.refreshRepositoriesAuthentication(repositories, new SCCContentSyncSource(credentials), null);
 
@@ -358,7 +358,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         repo2.setUrl("https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15/x86_64/update/");
         SCCCachingFactory.saveRepository(repo2);
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.refreshRepositoriesAuthentication(repositories, new SCCContentSyncSource(credentials), null);
 
         Optional<SCCRepository> upRepoOpt = SCCCachingFactory.lookupRepositoryBySccId(2705L);
@@ -486,7 +486,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         List<SCCRepositoryJson> additionalRepos = gson.fromJson(inReaderAddRepos,
                 new TypeToken<List<SCCRepositoryJson>>() { }.getType());
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.updateSUSEProducts(productsChanged, staticTreeChanged, additionalRepos);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
@@ -585,7 +585,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         List<SCCRepositoryJson> additionalRepos = gson.fromJson(inReaderAddRepos,
                 new TypeToken<List<SCCRepositoryJson>>() { }.getType());
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.updateSUSEProducts(productsChanged, staticTreeChanged, additionalRepos);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
@@ -679,7 +679,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
 
         SCCCredentials sccCreds = CredentialsFactory.listSCCCredentials().get(0);
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.updateSUSEProducts(productsChanged, staticTreeChanged, additionalRepos);
         csm.refreshRepositoriesAuthentication(repositoriesChanged, new SCCContentSyncSource(sccCreds), null);
         csm.linkAndRefreshContentSource(null);
@@ -737,7 +737,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
                 assertNotNull(cs);
                 assertEquals(bestAuth.getUrl(), cs.getSourceUrl());
             });
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         sles.getChannelTemplates()
         .stream()
         .filter(pr -> pr.getRepository().getSccId().equals(9999L))
@@ -965,7 +965,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         List<SCCRepositoryJson> repositoriesChanged = gson.fromJson(
                 inReaderRepos, new TypeToken<List<SCCRepositoryJson>>() { }.getType());
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.refreshRepositoriesAuthentication(repositoriesChanged, new SCCContentSyncSource(scc2nd), null);
         csm.linkAndRefreshContentSource(null);
 
@@ -1298,7 +1298,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         products.add(p);
 
         // Call updateSUSEProducts()
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.setSumaProductTreeJson(Optional.of(new File("/usr/share/susemanager/scc/product_tree.json")));
         csm.updateSUSEProducts(products);
 
@@ -1352,7 +1352,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         products.add(p);
 
         // Call updateSUSEProducts()
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.setSumaProductTreeJson(Optional.of(new File("/usr/share/susemanager/scc/product_tree.json")));
         csm.updateSUSEProducts(products);
 
@@ -1372,7 +1372,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         List<ChannelTemplate> availableChannels = csm.getAvailableChannels();
 
         List<String> avChanLanbels = availableChannels
@@ -1400,7 +1400,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         List<ChannelTemplate> availableChannels = csm.getAvailableChannels();
 
         List<String> duplicates = new LinkedList<>();
@@ -1479,7 +1479,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
     public void testUpdateChannelFamiliesInsert() {
         // Get test data and insert
         List<ChannelFamilyJson> channelFamilies = getChannelFamilies();
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.updateChannelFamilies(channelFamilies);
 
         // Assert that families have been inserted correctly
@@ -1519,7 +1519,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         int familynumbers = ChannelFamilyFactory.getAllChannelFamilies().size();
 
         List<ChannelFamilyJson> channelFamilies = getChannelFamilies();
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.updateChannelFamilies(channelFamilies);
 
         int newFamilyNumbers = ChannelFamilyFactory.getAllChannelFamilies().size();
@@ -1621,7 +1621,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         }
 
         // Update the upgrade paths
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.updateUpgradePaths(products);
 
         // Check the results
@@ -1673,7 +1673,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         products.add(product2);
 
         // Update SUSE products and upgrade paths
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.setSumaProductTreeJson(Optional.of(new File("/usr/share/susemanager/scc/product_tree.json")));
         csm.updateSUSEProducts(products);
         HibernateFactory.getSession().flush();
@@ -1733,7 +1733,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         products.add(product2);
 
         // Update SUSE products and upgrade paths
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.setSumaProductTreeJson(Optional.of(new File("/usr/share/susemanager/scc/product_tree.json")));
         csm.updateSUSEProducts(products);
 
@@ -1765,7 +1765,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
 
         // List channels and verify status
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         List<MgrSyncChannelDto> channels = csm.listChannels();
         boolean foundPool = false;
         boolean foundDebugPool = false;
@@ -1813,7 +1813,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         Collection<MgrSyncProductDto> products = csm.listProducts();
 
         boolean foundSLES = false;
@@ -1857,7 +1857,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        ContentSyncManager csm = new ContentSyncManager() {
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager() {
             @Override
             protected boolean accessibleUrl(String url) {
                 return true;
@@ -1894,7 +1894,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        ContentSyncManager csm = new ContentSyncManager() {
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager() {
             @Override
             protected boolean accessibleUrl(String url) {
                 return true;
@@ -1921,7 +1921,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
      */
     @Test
     public void testIsRefreshNeededNothingConfigured() throws Exception {
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         assertFalse(csm.isRefreshNeeded(null));
     }
 
@@ -2019,7 +2019,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
 
         try {
             csm.addChannel("non-existing-channel", null);
@@ -2112,7 +2112,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
             List<ChannelFamilyJson> channelFamilies = gson.fromJson(
                     inputStreamReader3, new TypeToken<List<ChannelFamilyJson>>() { }.getType());
 
-            ContentSyncManager csm = new ContentSyncManager();
+            ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
             csm.setSumaProductTreeJson(Optional.of(treeTemp));
             csm.updateChannelFamilies(channelFamilies);
             Config.get().setString(ContentSyncManager.RESOURCE_PATH, fromdir.toString());
@@ -2206,7 +2206,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
             List<ChannelFamilyJson> channelFamilies = gson.fromJson(
                     inputStreamReader3, new TypeToken<List<ChannelFamilyJson>>() { }.getType());
 
-            ContentSyncManager csm = new ContentSyncManager();
+            ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
             csm.setSumaProductTreeJson(Optional.of(treeTemp));
             csm.updateChannelFamilies(channelFamilies);
             Config.get().setString(ContentSyncManager.RESOURCE_PATH, fromdir.toString());
@@ -2228,7 +2228,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
 
             clearSession();
 
-            csm = new ContentSyncManager();
+            csm = new SUSEProductTestUtils.TestContentSyncManager();
             csm.linkAndRefreshContentSource(null);
 
             clearSession();
@@ -2380,7 +2380,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
                 new Gson().fromJson(inputStreamReader,
                         new TypeToken<List<SCCProductJson>>() { } .getType());
 
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
         csm.setSumaProductTreeJson(Optional.of(new File("/usr/share/susemanager/scc/product_tree.json")));
 
         csm.updateSUSEProducts(sccProducts);
@@ -2399,7 +2399,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
         rpmrepo.setDistroTarget("sle-12-x86_64");
 
         String repourl = "http://localhost/pub/myrepo/";
-        ContentSyncManager csm = new ContentSyncManager();
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager();
 
         assertContains(csm.buildRepoFileUrls(repourl, rpmrepo), repourl + "repodata/repomd.xml");
         assertEquals(1, csm.buildRepoFileUrls(repourl, rpmrepo).size());
@@ -2437,7 +2437,7 @@ public class ContentSyncManagerTest extends JMockBaseTestCaseWithUser {
             expectations.never(sccClient).listRepositories();
         });
 
-        ContentSyncManager csm = new ContentSyncManager() {
+        ContentSyncManager csm = new SUSEProductTestUtils.TestContentSyncManager() {
             @Override
             protected SCCClient getSCCClient(ContentSyncSource source) throws SCCClientException {
                 return sccClient;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/payg/test/PaygUpdateAuthTaskTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/payg/test/PaygUpdateAuthTaskTest.java
@@ -202,6 +202,7 @@ public class PaygUpdateAuthTaskTest extends JMockBaseTestCaseWithUser {
         Path tmpLogDir = Files.createTempDirectory("scc-data");
         try {
             ContentSyncManager csm = new ContentSyncManager(tmpLogDir, mgr);
+            csm.setSccRefreshLock(new MockFileLocks());
             csm.updateSUSEProducts(csm.getProducts());
 
             WireMock.verify(WireMock.getRequestedFor(

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -623,7 +623,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
             SUSEProductTestUtils.createVendorSUSEProducts();
             SUSEProductTestUtils.createVendorEntitlementProducts();
 
-            ContentSyncManager cm = new ContentSyncManager();
+            ContentSyncManager cm = new SUSEProductTestUtils.TestContentSyncManager();
 
             // this will also refresh the DB cache of subscriptions
             Collection<SCCSubscriptionJson> s;
@@ -714,7 +714,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
 
             h1.setInstalledProducts(installedProducts);
 
-            ContentSyncManager cm = new ContentSyncManager();
+            ContentSyncManager cm = new SUSEProductTestUtils.TestContentSyncManager();
             Collection<SCCSubscriptionJson> s = cm.updateSubscriptions();
             HibernateFactory.getSession().flush();
 

--- a/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProductsController.java
@@ -169,17 +169,15 @@ public class ProductsController {
      * @return a boolean flag of the success/failed result
      */
     public static boolean doSynchronizeProducts() {
-        return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-            try {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateSUSEProducts(csm.getProducts());
-                return true;
-            }
-            catch (Exception e) {
-                log.fatal(e.getMessage(), e);
-                return false;
-            }
-        });
+        try {
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateSUSEProducts(csm.getProducts());
+            return true;
+        }
+        catch (Exception e) {
+            log.fatal(e.getMessage(), e);
+            return false;
+        }
     }
 
     /**
@@ -200,17 +198,15 @@ public class ProductsController {
      * @return a boolean flag of the success/failed result
      */
     public static boolean doSynchronizeChannelFamilies() {
-        return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-            try {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateChannelFamilies(csm.readChannelFamilies());
-                return true;
-            }
-            catch (Exception e) {
-                log.fatal(e.getMessage(), e);
-                return false;
-            }
-        });
+        try {
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateChannelFamilies(csm.readChannelFamilies());
+            return true;
+        }
+        catch (Exception e) {
+            log.fatal(e.getMessage(), e);
+            return false;
+        }
     }
 
     /**
@@ -231,17 +227,15 @@ public class ProductsController {
      * @return a boolean flag of the success/failed result
      */
     public static boolean doSynchronizeRepositories() {
-        return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-            try {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateRepositories(null);
-                return true;
-            }
-            catch (Exception e) {
-                log.fatal(e.getMessage(), e);
-                return false;
-            }
-        });
+        try {
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateRepositories(null);
+            return true;
+        }
+        catch (Exception e) {
+            log.fatal(e.getMessage(), e);
+            return false;
+        }
     }
 
     /**
@@ -262,17 +256,15 @@ public class ProductsController {
      * @return a boolean flag of the success/failed result
      */
     public static boolean doSynchronizeSubscriptions() {
-        return FileLocks.SCC_REFRESH_LOCK.withFileLock(() -> {
-            try {
-                ContentSyncManager csm = new ContentSyncManager();
-                csm.updateSubscriptions();
-                return true;
-            }
-            catch (Exception e) {
-                log.fatal(e.getMessage(), e);
-                return false;
-            }
-        });
+        try {
+            ContentSyncManager csm = new ContentSyncManager();
+            csm.updateSubscriptions();
+            return true;
+        }
+        catch (Exception e) {
+            log.fatal(e.getMessage(), e);
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?
With reference to https://github.com/SUSE/spacewalk/issues/22584, this PR aims at fixing the external file lock.
The locking mechanism is external of the class implementation. This means that anyone not fully aware of how the process works might call any of the methods without locking, thus leading to concurrency problems and potential inconsistent states.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/22584
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/28116
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

