### PR TITLE
SLE15 SP7 updates are not empty anymore

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1673,16 +1673,9 @@ TIMEOUT_BY_CHANNEL_NAME = {
 }.freeze
 
 EMPTY_CHANNELS = %w[
-  sle-product-sles15-sp7-updates-x86_64
-  sle-module-basesystem15-sp7-updates-x86_64
-  sle-module-containers15-sp7-updates-x86_64
   suse-multi-linux-manager-proxy-sle-5.1-updates-x86_64-sp7
   suse-multi-linux-manager-retail-branch-server-sle-5.1-updates-x86_64-sp7
   managertools-sle15-updates-x86_64-sp7
-  sle-module-python3-15-sp7-updates-x86_64
-  sle-module-server-applications15-sp7-updates-x86_64
-  sle-module-desktop-applications15-sp7-updates-x86_64
-  sle-module-devtools15-sp7-updates-x86_64
   suse-manager-proxy-5.0-updates-x86_64
   suse-manager-retail-branch-server-5.0-updates-x86_64
   sle-module-suse-manager-retail-branch-server-4.3-updates-x86_64


### PR DESCRIPTION
## What does this PR change?

SLE 15 SP7 was published and should start getting updates.

This PR removes its channels from the empty channels list.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified:

- [x] **DONE**


## Links

Port(s):
 * 4.3: not appliable (missing backport?)
 * 5.0: not appliable (missing backport?)
 * 5.1: https://github.com/SUSE/spacewalk/pull/28098

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
