### PR TITLE
Initial setup for search server GH action

### DIFF
--- a/.github/workflows/search-server-compile.yml
+++ b/.github/workflows/search-server-compile.yml
@@ -1,0 +1,41 @@
+name: Search server compile
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'search-server/spacewalk-search/**.java'
+      - 'search-server/spacewalk-search/**.xml'
+      - '.github/workflows/search-server-compile.yml'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - 'search-server/spacewalk-search/**.java'
+      - 'search-server/spacewalk-search/**.xml'
+      - '.github/workflows/search-server-compile.yml'
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    container: registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/uyuni-master-pgsql:latest
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
+      with:
+        path: search-server/spacewalk-search/buildconf
+        key: ${{ runner.os }}-spacewalk-search-buildconf-${{ hashFiles('search-server/spacewalk-search/buildconf/*.*') }}
+
+    - name: Resolve dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: ant -f search-server/spacewalk-search/build.xml resolve
+
+    - name: Compile
+      run: ant -f search-server/spacewalk-search/build.xml compile


### PR DESCRIPTION
## What does this PR change?

Add a basic compile check GH action for spacewalk-search, see https://github.com/uyuni-project/uyuni/actions/runs/17041530779/job/48306235437?pr=10741.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: GH action

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: Needs to compile

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
