### PR TITLE
Revert testsuite using proxy 5.2

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -803,20 +803,20 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @susemanager
 @proxy
 @transactional_server
-  Scenario: Add SUSE Manager Proxy Extension 5.2 on top of SUSE Linux Enterprise Micro 6.1
+  Scenario: Add SUSE Manager Proxy Extension 5.1 on top of SUSE Linux Enterprise Micro 6.1
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Proxy Extension 5.2" as the filtered product description
+    And I enter "SUSE Multi-Linux Manager Proxy Extension 5.1" as the filtered product description
     Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51" have finished
 
 @uyuni
 @proxy
@@ -827,58 +827,58 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @susemanager
 @proxy
 @skip_if_transactional_server
-  Scenario: Add SUSE Multi-Linux Manager Proxy Extension 5.2 on top of SUSE Linux Enterprise Server 15 SP7
+  Scenario: Add SUSE Multi-Linux Manager Proxy Extension 5.1 on top of SUSE Linux Enterprise Server 15 SP7
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64" as the filtered product description
+    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
     And I open the sub-list of the product "Basesystem Module 15 SP7 x86_64"
     And I select "Containers Module 15 SP7 x86_64" as a product
     Then I should see the "Containers Module 15 SP7 x86_64" selected
     When I open the sub-list of the product "Containers Module 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52-sp7" have finished
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51-sp7" have finished
 
 @susemanager
 @proxy
 @transactional_server
-  Scenario: Add SUSE Manager Retail Branch Server Extension 5.2 on top of SUSE Linux Enterprise Micro 6.1
+  Scenario: Add SUSE Manager Retail Branch Server Extension 5.1 on top of SUSE Linux Enterprise Micro 6.1
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2" as the filtered product description
+    And I enter "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1" as the filtered product description
     Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-52" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-51" have finished
 
 @susemanager
 @proxy
 @skip_if_transactional_server
-  Scenario: Add SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 on top of SUSE Linux Enterprise Server 15 SP7
+  Scenario: Add SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 on top of SUSE Linux Enterprise Server 15 SP7
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.2 x86_64" as the filtered product description
+    And I enter "SUSE Multi-Linux Manager Proxy Extension for SLE 5.1 x86_64" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
     And I open the sub-list of the product "Basesystem Module 15 SP7 x86_64"
     And I open the sub-list of the product "Containers Module 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.2 x86_64 " as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.2 x86_64 " selected
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.1 x86_64 " as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.1 x86_64 " selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-52-sp7" have finished
+    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-51-sp7" have finished
 
 # There are no channels for Retail under Uyuni
 

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -125,10 +125,11 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I select the parent channel for the "proxy_container" from "selectedBaseChannel"
     And I wait for child channels to appear
-    And I include the recommended child channels
-    And I wait until "SUSE Multi-Linux Manager Client Tools for SL Micro 6 x86_64" has been checked
-    And I check "SUSE-Multi-Linux-Manager-Proxy-5.2 for x86_64"
-    And I check "SUSE-Multi-Linux-Manager-Retail-Branch-Server-5.2 for x86_64"
+    # TODO: WORKAROUND: When they are ready add them again
+    # And I include the recommended child channels
+    # And I wait until "SUSE Multi-Linux Manager Client Tools for SL Micro 6 x86_64" has been checked
+    And I check "SUSE-Multi-Linux-Manager-Proxy-5.1 for x86_64"
+    And I check "SUSE-Multi-Linux-Manager-Retail-Branch-Server-5.1 for x86_64"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 
@@ -145,8 +146,8 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I include the recommended child channels
     And I wait until "ManagerTools-SLE15-Pool for x86_64 SP7" has been checked
-    And I check "SUSE-Manager-Proxy-5.2-Pool for x86_64"
-    And I check "SUSE-Manager-Proxy-5.2-Updates for x86_64"
+    And I check "SUSE-Manager-Proxy-5.1-Pool for x86_64"
+    And I check "SUSE-Manager-Proxy-5.1-Updates for x86_64"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -165,7 +165,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @proxy
 @susemanager
 @transactional_server
-  Scenario: Add SUSE MLM Proxy Extension 5.2 with SL Micro 6.1 as base OS
+  Scenario: Add SUSE MLM Proxy Extension 5.1 with SL Micro 6.1 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
@@ -173,34 +173,34 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Linux Micro 6.1" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
     And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51" have finished
 
 @proxy
 @susemanager
 @skip_if_transactional_server
-  Scenario: Add SUSE MLM Proxy Extension 5.2 with SLES 15 SP7 as base OS
+  Scenario: Add SUSE MLM Proxy Extension 5.1 with SLES 15 SP7 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (BETA)" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52-sp7" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51-sp7" have finished
 
 @proxy
 @susemanager
 @transactional_server
-  Scenario: Add SUSE MLM Retail Branch Server Extension 5.2 with SL Micro 6.1 as base OS
+  Scenario: Add SUSE MLM Retail Branch Server Extension 5.1 with SL Micro 6.1 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
@@ -208,29 +208,29 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I enter "SUSE Linux Micro 6.1" as the filtered product description
     When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
     And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" selected
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (BETA)" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-52" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-51" have finished
 
 @proxy
 @susemanager
 @skip_if_transactional_server
-  Scenario: Add SUSE MLM Retail Branch Server Extension 5.2 with SLES 15 SP7 as base OS
+  Scenario: Add SUSE MLM Retail Branch Server Extension 5.1 with SLES 15 SP7 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
-    When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64 (BETA)"
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64" selected
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP7 x86_64"
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64" product has been added
-    And I wait until all synchronized channels for "suma-retail-branch-server-extension-52-sp7" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" product has been added
+    And I wait until all synchronized channels for "suma-retail-branch-server-extension-51-sp7" have finished
 
 @scc_credentials
 @susemanager


### PR DESCRIPTION
## What does this PR change?

partially reverts https://github.com/uyuni-project/uyuni/pull/10735 because the proxy 5.2 is not yet ready in SCC or sumatoolbox. It will come October or November and we can not wait until then. We will use proxy 5.1 until it's ready

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): no issue directly from testsuite review and slack
Port(s): no ports, it's only for head, only that uses server 5.2

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
