### PR TITLE
Add repos needed for exporter packages in testsuite

### DIFF
--- a/testsuite/features/secondary/min_deblike_monitoring.feature
+++ b/testsuite/features/secondary/min_deblike_monitoring.feature
@@ -35,6 +35,9 @@ Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
     And I click on "Save"
     Then I should see a "Formula saved" text
 
+  Scenario: Enable tools_update_repo tools_pool_repo so the exporters packages are available
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion" without error control
+
 @skip_if_github_validation
   Scenario: Apply highstate for Prometheus exporters on the Debian-like minion
     When I follow "States" in the content area
@@ -65,3 +68,6 @@ Feature: Monitor SUMA environment with Prometheus on a Debian-like Salt minion
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled" is completed
+
+  Scenario: Cleanup: Disable tools_update_repo tools_pool_repo because they are no longer needed
+    When I disable the repositories "tools_update_repo tools_pool_repo" on this "deblike_minion" without error control

--- a/testsuite/features/secondary/min_rhlike_monitoring.feature
+++ b/testsuite/features/secondary/min_rhlike_monitoring.feature
@@ -35,6 +35,9 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
     And I click on "Save"
     Then I should see a "Formula saved" text
 
+  Scenario: Enable tools_update_repo tools_pool_repo so the exporters packages are available
+    When I enable the repositories "tools_update_repo tools_pool_repo" on this "rhlike_minion" without error control
+
 @skip_if_github_validation
   Scenario: Apply highstate for Prometheus exporters on the Red Hat-like minion
     When I follow "States" in the content area
@@ -65,3 +68,6 @@ Feature: Monitor SUMA environment with Prometheus on a Red Hat-like Salt minion
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled" is completed
+
+  Scenario: Cleanup: Disable tools_update_repo tools_pool_repo because they are no longer needed
+    When I disable the repositories "tools_update_repo tools_pool_repo" on this "rhlike_minion" without error control


### PR DESCRIPTION
## What does this PR change?

Add repos needed for exporter packages in testsuite. Because we are using fake base channels in RH and Deb we don't have them available. In SLE minion we use real channels and the packages are available.  This is tested and works on 5.1. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/21393
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
