### PR TITLE
ISS Server deregister when not reachable

### DIFF
--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -782,6 +782,32 @@ public class SparkApplicationHelper {
      * @param messages messages
      * @return a JSON string
      */
+    public static String serviceUnavailable(Response response, String... messages) {
+        response.type(APPLICATION_JSON);
+        response.status(HttpStatus.SC_SERVICE_UNAVAILABLE);
+        return GSON.toJson(ResultJson.error(messages));
+    }
+
+    /**
+     * Serialize the result and set the response content type to JSON
+     * and the http status code to bad request.
+     * @param response the http response
+     * @param messages messages
+     * @return a JSON string
+     */
+    public static String badGateway(Response response, String... messages) {
+        response.type(APPLICATION_JSON);
+        response.status(HttpStatus.SC_BAD_GATEWAY);
+        return GSON.toJson(ResultJson.error(messages));
+    }
+
+    /**
+     * Serialize the result and set the response content type to JSON
+     * and the http status code to bad request.
+     * @param response the http response
+     * @param messages messages
+     * @return a JSON string
+     */
     public static String badRequest(Response response, String... messages) {
         response.type(APPLICATION_JSON);
         response.status(HttpStatus.SC_BAD_REQUEST);

--- a/java/spacewalk-java.changes.serpico.issv3-peripheral-deregister-without-cleanup
+++ b/java/spacewalk-java.changes.serpico.issv3-peripheral-deregister-without-cleanup
@@ -1,0 +1,2 @@
+- Added the possibility to deregister an unreachable ISS Hub
+  or Peripheral server

--- a/web/html/src/components/hub/DeregisterServer.tsx
+++ b/web/html/src/components/hub/DeregisterServer.tsx
@@ -20,13 +20,14 @@ type Props = {
 
 type State = {
   confirmDeregistration: boolean;
+  showDeleteErrorModal: boolean;
 };
 
 export class DeregisterServer extends React.Component<Props, State> {
   public constructor(props: Props) {
     super(props);
 
-    this.state = { confirmDeregistration: false };
+    this.state = { confirmDeregistration: false, showDeleteErrorModal: false };
   }
 
   public render(): React.ReactNode {
@@ -46,11 +47,25 @@ export class DeregisterServer extends React.Component<Props, State> {
           isOpen={this.state.confirmDeregistration}
           submitText={t("Deregister")}
           submitIcon="fa-trash"
-          onConfirm={() => this.onConfirmDeregistration()}
+          onConfirm={() => this.onConfirmDeregistration(false)}
           onClose={() => this.setState({ confirmDeregistration: false })}
+        />
+        <DangerDialog
+          id="deregister-error-modal"
+          title={t("Error deregistering server")}
+          content={this.renderDeregisterErrorModal()}
+          isOpen={this.state.showDeleteErrorModal}
+          onConfirm={() => this.onConfirmDeregistration(true)}
+          onClose={() => this.setState({ showDeleteErrorModal: false })}
+          submitText={t("Deregister without cleanup")}
+          submitIcon={"fa-trash"}
         />
       </>
     );
+  }
+
+  private renderDeregisterErrorModal() {
+    return <span>{t("Cleanup timed out. Please check if the machine is reachable.")}</span>;
   }
 
   private getConfirmationMessage(): string {
@@ -75,21 +90,32 @@ export class DeregisterServer extends React.Component<Props, State> {
     }
   }
 
-  private onConfirmDeregistration(): void {
-    const resource =
+  private onConfirmDeregistration(only_local: boolean): void {
+    let resource =
       this.props.role === IssRole.Hub
         ? `/rhn/manager/api/admin/hub/${this.props.id}`
         : `/rhn/manager/api/admin/hub/peripherals/${this.props.id}`;
+    if (only_local) {
+      resource += `?only_local=true`;
+    }
     Network.del(resource)
       .then(
         (_response) => {
-          showInfoToastr(t("The server {fqdn} has been successfully deregistered.", { fqdn: this.props.fqdn }));
-
-          // Invoke the callback if present
-          this.props.onDeregistered?.();
+          this.onSuccessfullDeregister();
         },
-        (xhr) => Network.showResponseErrorToastr(xhr)
+        (xhr) => {
+          if (xhr && xhr.status === 503) {
+            this.setState({ confirmDeregistration: false, showDeleteErrorModal: true });
+          } else {
+            Network.showResponseErrorToastr(xhr);
+          }
+        }
       )
       .finally(() => this.setState({ confirmDeregistration: false }));
+  }
+
+  private onSuccessfullDeregister() {
+    showInfoToastr(t("The server {fqdn} has been successfully deregistered.", { fqdn: this.props.fqdn }));
+    this.props.onDeregistered?.();
   }
 }

--- a/web/spacewalk-web.changes.serpico.issv3-peripheral-deregister-without-cleanup
+++ b/web/spacewalk-web.changes.serpico.issv3-peripheral-deregister-without-cleanup
@@ -1,0 +1,2 @@
+- Added the possibility to deregister an unreachable ISS Hub
+  or Peripheral server


### PR DESCRIPTION
## What does this PR change?

When an ISS server is not reachable force the deregistration of the server (both for peripheral/hub) locally.

## GUI diff

Before:
Not Present

After:
<img width="977" height="231" alt="image" src="https://github.com/user-attachments/assets/b2c328a2-6cdd-4a22-b7e2-ddb052c13267" />


- [X] **DONE**

## Documentation
- No documentation needed: improvement on documented feature

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27541
Port(s): # [5.1](https://github.com/SUSE/spacewalk/pull/28358)

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
