### PR TITLE
Use JSON instead of pickle for spacecmd cache (bsc#1227579)

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.mczernek-fsck-removal-fix
+++ b/spacecmd/spacecmd.changes.mczernek.mczernek-fsck-removal-fix
@@ -1,0 +1,2 @@
+- Use JSON instead of pickle for spacecmd
+  cache (bsc#1227579)


### PR DESCRIPTION
## What does this PR change?

In this PR, we remove pickle for internal spacecmd cache in favor of using basic JSON files.

Looking at https://github.com/m-czernek/uyuni/blob/edf004ebeee0e0d763bb1a3b906664c315b30b5f/spacecmd/src/spacecmd/misc.py#L137, I believe only errata, systems, and packages use this particular caching mechanism, which all seem to work.

An open question is Python 2.7, which I haven't tried. Spacecmd seems to be compatible with Py 2.7 in case it is execute from a client. Not sure if this is still a concern - if so, let me know, I'll have to do additional testing.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/24760
Port(s):
5.1 - https://github.com/SUSE/spacewalk/pull/28184
5.0 - https://github.com/SUSE/spacewalk/pull/28185
4.3 - https://github.com/SUSE/spacewalk/pull/28188

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"     

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
