### PR TITLE
SonarCloud error reduction fix, miscellaneous 6 rules

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/test/ConfigTest.java
+++ b/java/code/src/com/redhat/rhn/common/conf/test/ConfigTest.java
@@ -311,7 +311,7 @@ public class ConfigTest extends RhnBaseTestCase {
         c.setBoolean("prefix.boolean_true", Boolean.FALSE.toString());
         assertFalse(c.getBoolean("prefix.boolean_true"));
         assertEquals("0", c.getString("prefix.boolean_true"));
-        c.setBoolean("prefix.boolean_true", Boolean.valueOf(oldValue).toString());
+        c.setBoolean("prefix.boolean_true", Boolean.toString(oldValue));
     }
 
     @Test

--- a/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.java
@@ -63,7 +63,6 @@ public class ServerSnapshot extends BaseDomainHelper {
     private Set<ServerGroup> groups = new HashSet<>();
     private Set<PackageNevra> packages = new HashSet<>();
     private InvalidSnapshotReason invalidReason;
-    private static final DateFormat DF = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
     /**
      * @return Returns the channels.
@@ -282,7 +281,8 @@ public class ServerSnapshot extends BaseDomainHelper {
      * @return Returns date in format yyyy-MM-dd HH:mm:ss so it can be used as a name
      */
     public String getName() {
-        return DF.format(this.getCreated());
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        return dateFormat.format(this.getCreated());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfSearchHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/scap/XccdfSearchHelper.java
@@ -76,7 +76,7 @@ public class XccdfSearchHelper extends RhnAction {
             identIds.add(id);
         }
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("user_id", context.getCurrentUser().getId());
         if (SYSTEM_LIST.equals(whereToSearch)) {
             params.put("slabel", SYSTEM_LIST);

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/ChannelDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/ChannelDetailsAction.java
@@ -114,13 +114,9 @@ public class ChannelDetailsAction extends RhnAction {
 
         request.setAttribute("gpg_check", chan.isGPGCheck());
 
-        if ((chan.getOrg() == null && user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN)) ||
-                UserManager.verifyChannelAdmin(user, chan)) {
-            request.setAttribute("has_access", true);
-        }
-        else {
-            request.setAttribute("has_access", false);
-        }
+        boolean hasAccess = (chan.getOrg() == null && user.isMemberOf(AccessGroupFactory.CHANNEL_ADMIN)) ||
+                UserManager.verifyChannelAdmin(user, chan);
+        request.setAttribute("has_access", hasAccess);
 
         return getStrutsDelegate().forwardParams(
                 mapping.findForward(fwd), params);

--- a/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgCreateAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/multiorg/OrgCreateAction.java
@@ -125,13 +125,8 @@ public class OrgCreateAction extends RhnAction {
                             firstOrgMode);
 
                     //Should this user use pam authentication?
-                    if (dynaForm.get("usepam") != null &&
-                            (Boolean) dynaForm.get("usepam")) {
-                        cmd.setUsePam(true);
-                    }
-                    else {
-                        cmd.setUsePam(false);
-                    }
+                    boolean usePam = dynaForm.get("usepam") != null && (Boolean) dynaForm.get("usepam");
+                    cmd.setUsePam(usePam);
 
                     cmd.setFirstName(fname);
                     cmd.setLastName(lname);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -454,7 +454,7 @@ public class SPMigrationAction extends RhnAction {
         Optional<Set<String>> missingSuccessorExtensions = Optional.of(new HashSet<String>());
         DistUpgradeManager.removeIncompatibleTargets(sourceProducts,
                 targetProducts, missingSuccessorExtensions);
-        request.setAttribute(MISSING_SUCCESSOR_EXTENSIONS, missingSuccessorExtensions.orElse(new HashSet<String>()));
+        request.setAttribute(MISSING_SUCCESSOR_EXTENSIONS, missingSuccessorExtensions.orElse(new HashSet<>()));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/kickstart/SessionStatusAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/kickstart/SessionStatusAction.java
@@ -90,8 +90,8 @@ public class SessionStatusAction extends RhnAction {
                     kss.getModified().getTime();
                 long nowMillis = System.currentTimeMillis();
                 long timeoutMillis = GUEST_TIME_OUT_MINUTES * // minutes
-                                     60                     * // seconds
-                                     1000;                    // millis
+                                     60L                     * // seconds
+                                     1000L;                    // millis
 
                 // check timout and file requested time is current
                 long sinceLastFileRequestMillis = nowMillis - lastFileRequestMillis;

--- a/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
@@ -57,12 +57,8 @@ public class CreateUserAction extends RhnAction {
         command.setLastName(form.getString("lastName"));
 
         //Should this user use pam authentication?
-        if (form.get("usepam") != null && (Boolean) form.get("usepam")) {
-            command.setUsePamAuthentication(true);
-        }
-        else {
-            command.setUsePamAuthentication(false);
-        }
+        boolean usePam = form.get("usepam") != null && (Boolean) form.get("usepam");
+        command.setUsePamAuthentication(usePam);
 
         // Check passwords
         String passwd = (String)form.get(UserActionHelper.DESIRED_PASS);

--- a/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/UserEditActionHelper.java
@@ -115,13 +115,8 @@ public abstract class UserEditActionHelper extends RhnAction {
         String pamAuthService = Config.get().getString(ConfigDefaults.WEB_PAM_AUTH_SERVICE);
         if (pamAuthService != null && !pamAuthService.trim().isEmpty() &&
                 loggedInUser.hasRole(RoleFactory.ORG_ADMIN)) {
-            if (form.get("usepam") != null &&
-                    (Boolean) form.get("usepam")) {
-                targetUser.setUsePamAuthentication(true);
-            }
-            else {
-                targetUser.setUsePamAuthentication(false);
-            }
+            boolean usePam = form.get("usepam") != null && (Boolean) form.get("usepam");
+            targetUser.setUsePamAuthentication(usePam);
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/dto/ChannelTreeNode.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ChannelTreeNode.java
@@ -57,7 +57,7 @@ public class ChannelTreeNode extends BaseDto implements BaseListDto,
      */
     public static void processList(DataResult<ChannelTreeNode> result) {
         DataResult<ChannelTreeNode> toReturn =
-                new DataResult<ChannelTreeNode>(new ArrayList<>());
+                new DataResult<>(new ArrayList<>());
             toReturn.setFilter(true);
             toReturn.setFilterData(result.getFilterData());
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7501,7 +7501,7 @@ public class SystemHandler extends BaseHandler {
     @ReadOnly
     public List<Map<String, Object>> listMigrationTargets(User loggedInUser,
             Integer sid, boolean excludeTargetWhereMissingSuccessors) {
-        List<Map<String, Object>> returnList = new ArrayList<Map<String, Object>>();
+        List<Map<String, Object>> returnList = new ArrayList<>();
         Server server = lookupServer(loggedInUser, sid);
         Optional<SUSEProductSet> installedProducts = server.getInstalledProductSet();
         if (!installedProducts.isPresent()) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
@@ -672,12 +672,8 @@ public class UserHandler extends BaseHandler {
         ensureOrgAdmin(loggedInUser);
         User target = XmlRpcUserHelper.getInstance().lookupTargetUser(loggedInUser, login);
 
-        if (val.equals(1)) {
-            target.setUsePamAuthentication(true);
-        }
-        else {
-            target.setUsePamAuthentication(false);
-        }
+        boolean usePam = val.equals(1);
+        target.setUsePamAuthentication(usePam);
 
         UserManager.storeUser(target);
 

--- a/java/code/src/com/redhat/rhn/manager/audit/AuditChannelInfo.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/AuditChannelInfo.java
@@ -144,9 +144,6 @@ public class AuditChannelInfo {
             return false;
         }
         AuditChannelInfo other = (AuditChannelInfo) obj;
-        if (id != other.id) {
-            return false;
-        }
-        return true;
+        return id == other.id;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -45,7 +45,6 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -862,7 +861,7 @@ public class CVEAuditManager {
      * @throws UnknownCVEIdentifierException if the CVE number is not known
      */
     public static List<CVEAuditServer> listSystemsByPatchStatus(User user,
-        String cveIdentifier, EnumSet<PatchStatus> patchStatuses)
+        String cveIdentifier, Set<PatchStatus> patchStatuses)
             throws UnknownCVEIdentifierException {
         if (isCVEIdentifierUnknown(cveIdentifier)) {
             throw new UnknownCVEIdentifierException();
@@ -892,7 +891,7 @@ public class CVEAuditManager {
      * @throws UnknownCVEIdentifierException if the CVE number is not known
      */
     public static List<CVEAuditImage> listImagesByPatchStatus(User user,
-            String cveIdentifier, EnumSet<PatchStatus> patchStatuses)
+            String cveIdentifier, Set<PatchStatus> patchStatuses)
             throws UnknownCVEIdentifierException {
         if (isCVEIdentifierUnknown(cveIdentifier)) {
             throw new UnknownCVEIdentifierException();
@@ -933,7 +932,7 @@ public class CVEAuditManager {
      * @return list of system records with patch status
      */
     private static List<CVEAuditSystemBuilder> listSystemsByPatchStatus(Stream<CVEPatchStatus> results,
-            EnumSet<PatchStatus> patchStatuses) {
+            Set<PatchStatus> patchStatuses) {
 
         List<CVEAuditSystemBuilder> ret = new LinkedList<>();
 

--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManagerOVAL.java
@@ -43,7 +43,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -77,7 +76,7 @@ public class CVEAuditManagerOVAL {
      * @throws UnknownCVEIdentifierException if the CVE number is not known
      */
     public static List<CVEAuditServer> listSystemsByPatchStatus(User user, String cveIdentifier,
-                                                                EnumSet<PatchStatus> patchStatuses)
+                                                                Set<PatchStatus> patchStatuses)
             throws UnknownCVEIdentifierException {
         if (isCVEIdentifierUnknown(cveIdentifier)) {
             throw new UnknownCVEIdentifierException();
@@ -355,7 +354,7 @@ public class CVEAuditManagerOVAL {
      * @throws UnknownCVEIdentifierException if the CVE number is not known
      */
     public static List<CVEAuditImage> listImagesByPatchStatus(User user,
-                                                              String cveIdentifier, EnumSet<PatchStatus> patchStatuses)
+                                                              String cveIdentifier, Set<PatchStatus> patchStatuses)
             throws UnknownCVEIdentifierException {
         return CVEAuditManager.listImagesByPatchStatus(user, cveIdentifier, patchStatuses);
     }

--- a/java/code/src/com/redhat/rhn/manager/audit/ErrataIdAdvisoryPair.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ErrataIdAdvisoryPair.java
@@ -101,9 +101,6 @@ public class ErrataIdAdvisoryPair {
             return false;
         }
         ErrataIdAdvisoryPair other = (ErrataIdAdvisoryPair) obj;
-        if (id != other.id) {
-            return false;
-        }
-        return true;
+        return id == other.id;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/audit/ServerChannelIdPair.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ServerChannelIdPair.java
@@ -122,9 +122,6 @@ public class ServerChannelIdPair {
         if (cid != other.cid) {
             return false;
         }
-        if (sid != other.sid) {
-            return false;
-        }
-        return true;
+        return sid == other.sid;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -787,7 +787,7 @@ public class ContentSyncManager {
         Optional<Date> lastRefreshDate = ManagerInfoFactory.getLastMgrSyncRefresh();
         if (Config.get().getString(ContentSyncManager.RESOURCE_PATH, null) != null) {
             LOG.debug("Syncing from dir");
-            long hours24 = 24 * 60 * 60 * 1000;
+            long hours24 = 24L * 60L * 60L * 1000L;
             Timestamp t = new Timestamp(System.currentTimeMillis() - hours24);
 
             return Opt.fold(

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -375,8 +375,7 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
      */
     public DataResult<KickstartDto> getKickstartProfiles() {
         log.debug("getKickstartProfiles()");
-        DataResult<KickstartDto> retval = new DataResult<KickstartDto>(
-                Collections.emptyList());
+        DataResult<KickstartDto> retval = new DataResult<>(Collections.emptyList());
 
         // Profiles are associated with the host; the target system might not be created
         // yet.  Also, the host will be the one performing the kickstart, so the profile

--- a/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsDto.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/ProxySettingsDto.java
@@ -113,10 +113,7 @@ public class ProxySettingsDto {
         if (!Objects.equals(this.username, other.username)) {
             return false;
         }
-        if (!Objects.equals(this.password, other.password)) {
-            return false;
-        }
-        return true;
+        return Objects.equals(this.password, other.password);
     }
 
     @Override

--- a/java/code/src/com/suse/manager/maintenance/IcalUtils.java
+++ b/java/code/src/com/suse/manager/maintenance/IcalUtils.java
@@ -135,7 +135,7 @@ public class IcalUtils {
                 .orElse(allEvents);
 
         // we will look a year and month to the future
-        Period period = new Period(new DateTime(startDate.toEpochMilli()), Duration.ofDays(365 + 31));
+        Period period = new Period(new DateTime(startDate.toEpochMilli()), Duration.ofDays(365L + 31L));
 
         List<PeriodList> periodLists = filteredEvents.stream()
                 .map(c -> c.calculateRecurrenceSet(period))

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -620,7 +620,7 @@ public class MaintenanceManager {
         }
         else {
             rangeStart = rangeStart.getDayOfWeek().equals(DayOfWeek.SUNDAY) ? rangeStart.minusDays(6) :
-                    rangeStart.minusDays(rangeStart.getDayOfWeek().getValue() - 1);
+                    rangeStart.minusDays((long)rangeStart.getDayOfWeek().getValue() - 1);
         }
 
         ZonedDateTime rangeEnd = rangeStart.plusDays(42);

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -730,13 +730,9 @@ public class MaintenanceManager {
                     // test them, when they require maintenance mode
                     return true;
                 }
-                if (ActionFactory.lookupDependentActions(a)
-                        .anyMatch(da -> da.getActionType().isMaintenancemodeOnly())) {
-                    // check actions where a depended action in the chain requires
-                    // maintenance mode
-                    return true;
-                }
-                return false;
+                // check actions where a depended on action in the chain requires maintenance mode
+                return ActionFactory.lookupDependentActions(a)
+                        .anyMatch(da -> da.getActionType().isMaintenancemodeOnly());
             })
             .filter(Opt.fold(calendarOpt,
                     () -> (sa -> true),

--- a/java/code/src/com/suse/manager/model/gatherer/GathererModule.java
+++ b/java/code/src/com/suse/manager/model/gatherer/GathererModule.java
@@ -98,9 +98,6 @@ public class GathererModule {
             return false;
         }
         GathererModule other = (GathererModule) obj;
-        if (!name.equals(other.name)) {
-            return false;
-        }
-        return true;
+        return name.equals(other.name);
     }
 }

--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -953,10 +953,10 @@ public class HardwareMapper {
     }
 
     private boolean notLocalhost(NetworkInterface netIf) {
-        return !netIf.getIPv4Addresses().stream()
-                .anyMatch(addr -> "127.0.0.1".equals(addr.getAddress())) &&
-                !netIf.getIPv6Addresses().stream()
-                .anyMatch(addr -> "::1".equals(addr.getAddress()));
+        return netIf.getIPv4Addresses().stream()
+                .noneMatch(addr -> "127.0.0.1".equals(addr.getAddress())) &&
+                netIf.getIPv6Addresses().stream()
+                .noneMatch(addr -> "::1".equals(addr.getAddress()));
     }
 
     /**

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -533,8 +533,8 @@ public class SaltUtils {
             return Opt.fold(
                 SaltUtils.jsonEventToStateApplyResults(rawResult),
                 () -> true,
-                results -> results.values().stream().filter(
-                    result -> !result.isResult()).findAny().isPresent());
+                results -> results.values().stream()
+                        .anyMatch(result -> !result.isResult()));
         }
         return !(success && retcode == 0);
     }

--- a/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/CVEAuditController.java
@@ -114,7 +114,7 @@ public class CVEAuditController {
             this.target = targetIn;
         }
 
-        public EnumSet<PatchStatus> getStatuses() {
+        public Set<PatchStatus> getStatuses() {
             return statuses;
         }
 

--- a/java/code/src/com/suse/manager/webui/controllers/utils/ImagesUtil.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/ImagesUtil.java
@@ -36,8 +36,7 @@ public class ImagesUtil {
     public static boolean isImageRuntimeInfoEnabled() {
         Map<String, GathererModule> modules = new GathererRunner().listModules();
         return modules.keySet().stream()
-                .filter(VirtualHostManagerFactory.KUBERNETES::equalsIgnoreCase)
-                .findFirst().isPresent();
+                .anyMatch(VirtualHostManagerFactory.KUBERNETES::equalsIgnoreCase);
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -203,8 +203,8 @@ public enum SaltStateGeneratorService {
         Map<String, Object> bootImagePillarSync = new TreeMap<>();
 
         // We are interested only if bundles are present, not actual value
-        Boolean isBundle = imageInfo.getImageFiles().stream().filter(
-                f -> f.getType().equals("bundle")).findFirst().isPresent();
+        Boolean isBundle = imageInfo.getImageFiles().stream()
+                .anyMatch(f -> f.getType().equals("bundle"));
 
         bootImagePillarBase.put("arch", bootImage.getArch());
         bootImagePillarBase.put("basename", bootImage.getBasename());

--- a/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/SparkApplicationHelper.java
@@ -809,7 +809,7 @@ public class SparkApplicationHelper {
      * @return a JSON string
      */
     public static String unprocessableEntity(Response response, String... messages) {
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
         response.status(HttpStatus.SC_UNPROCESSABLE_ENTITY);
         return GSON.toJson(ResultJson.error(messages).toSccResult());
     }

--- a/java/code/src/org/cobbler/CobblerObject.java
+++ b/java/code/src/org/cobbler/CobblerObject.java
@@ -583,7 +583,7 @@ public abstract class CobblerObject {
      */
     public void setCreated(Date createdIn) {
         // cobbler deals with seconds since epoch, Date returns milliseconds. Convert.
-        modify(CTIME, (double) (createdIn.getTime() / 1000));
+        modify(CTIME, (double) (createdIn.getTime() / 1000F));
     }
 
     /**
@@ -604,7 +604,7 @@ public abstract class CobblerObject {
      */
     public void setModified(Date modifiedIn) {
         // cobbler deals with seconds since epoch, Date returns milliseconds. Convert.
-        modify(MTIME, (double) (modifiedIn.getTime() / 1000));
+        modify(MTIME, (double) (modifiedIn.getTime() / 1000F));
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

SonarCloud error reduction fix, rules:

[SonarCloud fix: java:S2184 Math operands should be cast before assignment](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS2184&rule_key=java%3AS2184)
[SonarCloud fix: java:S4034 Stream call chains should be simplified when possible](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS4034&rule_key=java%3AS4034)
[SonarCloud fix: java:S1126 Return of boolean expressions should not be wrapped into an if-then-else statement](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1126&rule_key=java%3AS1126)
[SonarCloud fix: java:S1319 Declarations should use Java collection interfaces rather than specific implementation classes](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1319&rule_key=java%3AS1319)
[SonarCloud fix: java:S1158 Primitive wrappers should not be instantiated only for toString or compareTo calls](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1158&rule_key=java%3AS1158)
[SonarCloud fix: java:S2293 The diamond operator should be used](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS2293&rule_key=java%3AS2293)
[SonarCloud fix: java:S1192 String literals should not be duplicated](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1192&rule_key=java%3AS1192)
[SonarCloud fix: java:S2885 Non-thread-safe fields should not be static](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS2885&rule_key=java%3AS2885)


## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s):
- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

