### PR TITLE
SonarCloud fix: java:S1874 Deprecated code should not be used

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -33,13 +33,13 @@ import com.suse.matcher.json.ProductJson;
 import com.suse.matcher.json.SystemJson;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -65,7 +65,7 @@ public class SubscriptionMatchProcessor {
             return new MatcherUiData(true,
                     latestStart,
                     latestEnd,
-                    messages(input.get(), output.get()),
+                    messages(output.get()),
                     subscriptions(output.get()),
                     products,
                     unmatchedProductIds(products),
@@ -146,7 +146,7 @@ public class SubscriptionMatchProcessor {
         return "unsatisfied";
     }
 
-    private List<MessageJson> messages(InputJson input, OutputJson output) {
+    private List<MessageJson> messages(OutputJson output) {
         return output.getMessages().stream()
                 .filter(m -> !m.getType().equals("unsatisfied_pinned_match"))
                 .map(m -> new MessageJson(m.getType(), m.getData())) .collect(toList());
@@ -226,96 +226,5 @@ public class SubscriptionMatchProcessor {
                 .map(Map.Entry::getKey)
                 .map(Long::valueOf)
                 .collect(toSet());
-    }
-
-    /**
-     * Immutable class representing a pair.
-     *
-     * @deprecated This class must be replaced by its Apache Commons Lang 3 utils equivalent
-     * as soon as the library is upgraded.
-     *
-     * @param <L> left value type
-     * @param <R> right value type
-     */
-    @Deprecated
-    public static class Pair<L, R> {
-
-        private L left;
-        private R right;
-
-        /**
-         * Standard constructor.
-         * @param leftIn the left value
-         * @param rightIn the right value
-         */
-        private Pair(L leftIn, R rightIn) {
-            left = leftIn;
-            right = rightIn;
-        }
-
-        /**
-         * Return a new Pair instance based on given arguments
-         *
-         * @param left the left value
-         * @param right the right value
-         * @param <L> the type of the left value
-         * @param <R> the type of the right value
-         * @return the new Pair instance
-         */
-        public static <L, R> Pair<L, R> of(L left, R right) {
-            return new Pair<>(left, right);
-        }
-
-        /**
-         * Gets the left.
-         *
-         * @return left
-         */
-        public L getLeft() {
-            return left;
-        }
-
-        /**
-         * Gets the right.
-         *
-         * @return right
-         */
-        public R getRight() {
-            return right;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public String toString() {
-            return "Pair{" +
-                    "right=" + right +
-                    ", left=" + left +
-                    '}';
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            Pair<?, ?> pair = (Pair<?, ?>) o;
-            return Objects.equals(left, pair.left) && Objects.equals(right, pair.right);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public int hashCode() {
-            return Objects.hash(left, right);
-        }
     }
 }

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
@@ -325,7 +325,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
     }
 
     @Test
-    public void testConfirmedPin() throws Exception {
+    public void testConfirmedPin() throws ParseException {
         // setup a confirmed match of one system and one subscription
         input.setSystems(Arrays.asList(new SystemJson(100L, "my system", 1, true, false,
                 new HashSet<>(), new HashSet<>())));
@@ -356,7 +356,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
 
 
     @Test
-    public void testUnsatisfiedPin() throws Exception {
+    public void testUnsatisfiedPin() throws ParseException {
         // setup a  of one system and one subscription
         input.setSystems(Arrays.asList(new SystemJson(100L, "my system", 1, true, false,
                 new HashSet<>(), new HashSet<>())));
@@ -434,7 +434,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
         systems.add(new SystemJson(10L, "system 10", 1, true, false, new HashSet<>(),
                 Collections.singleton(1000L)));
 
-        Set prods = new HashSet<>();
+        Set<Long> prods = new HashSet<>();
         prods.add(1000L);
         prods.add(1004L);
         systems.add(new SystemJson(20L,


### PR DESCRIPTION
## What does this PR change?

[SonarCloud fix: java:S1874 Deprecated code should not be used](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS1874)
a local deprecated class Pair has been removed and substituted with org.apache.commons.lang3.tuple.Pair

## GUI diff
No difference.
Before:
After:
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

