### PR TITLE
add logrotate to Ubuntu bootstrap repositories

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -66,17 +66,11 @@ PKGLIST15_PPC = [
 
 PKGLIST15_Z = []
 
-PKGLISTUBUNTU2004 = [
-    "venv-salt-minion",
-]
+PKGLISTUBUNTU2004 = ["venv-salt-minion", "logrotate"]
 
-PKGLISTUBUNTU2204 = [
-    "venv-salt-minion",
-]
+PKGLISTUBUNTU2204 = ["venv-salt-minion", "logrotate"]
 
-PKGLISTUBUNTU2404 = [
-    "venv-salt-minion",
-]
+PKGLISTUBUNTU2404 = ["venv-salt-minion", "logrotate"]
 
 PKGLISTDEBIAN11 = [
     # gnupg dependencies

--- a/susemanager/susemanager.changes.mcalmer.bootstrap-repo-ubuntu-logrotate
+++ b/susemanager/susemanager.changes.mcalmer.bootstrap-repo-ubuntu-logrotate
@@ -1,0 +1,1 @@
+- Add logrotate to Ubuntu bootstrap repositories


### PR DESCRIPTION
## What does this PR change?

Minimal Ubuntu installation does not have logrotate installed which is required by venv-salt-minion.
Adding logrotate to bootstrap repo solve the issue

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): TBD

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
