### PR TITLE
Fix typo: minimum required memory is in MB

### DIFF
--- a/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
+++ b/containers/server-postgresql-image/root/docker-entrypoint-initdb.d/uyuni-postgres-config.sh
@@ -20,7 +20,7 @@ postgres_reconfig() {
 # Get total memory in KB
 TOTAL_MEM_KB=$(sed -n -e '/MemTotal:/{s|MemTotal:[[:space:]]*\([0-9]*\).*|\1| p}' /proc/meminfo)
 
-# Check minimum memory requirement (255KB)
+# Check minimum memory requirement (255MB)
 if [ "$TOTAL_MEM_KB" -lt $((0xff * 1024)) ]; then
     echo "WARNING: low memory: $TOTAL_MEM_KB"
     TOTAL_MEM_KB=$((0xff * 1024))


### PR DESCRIPTION
## What does this PR change?

Fixes a typo in a comment. The minimum required memory is calculated memory is in KB. But the result is 255MB instead of 255KB 

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: just a typo fix in a comment

- [x] **DONE**

## Links

Issue(s): none
Port(s): none

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
