### PR TITLE
remove duplicate product install state

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -2,19 +2,6 @@ include:
   - util.syncstates
   - .packages_{{ grains['machine_id'] }}
 
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3' %}
-mgr_install_products:
-  product.all_installed:
-    - refresh: True
-    - require:
-      - file: mgrchannels_*
-{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
-      - saltutil: sync_states
-{%- else %}
-      - mgrcompat: sync_states
-{%- endif %}
-{%- endif %}
-
 {%- if grains['os_family'] == 'Suse' and grains['instance_id'] is defined and "openSUSE" not in grains['oscodename'] %}
 {# install flavor check tool in cloud instances to be able to detect payg instances #}
 mgr_install_flavor_check:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.remove-duplicate-product-install
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.remove-duplicate-product-install
@@ -1,0 +1,2 @@
+- Remove product installation state from packages as it is
+  already available in the channels state


### PR DESCRIPTION
## What does this PR change?

The product install state is implemented at 2 places.
channels/init.sls and packages/init.sls

We only need it at 1 place and channels is the better place as we want to install products when we switch channels.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): TBD

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
