### PR TITLE
Add selinux label to python linting script

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -65,7 +65,7 @@ linting/lint.sh -a
 Alternatively, you can use the provided container to run `pylint` and `black` manually:
 
 ```
-podman run --rm -it -v $UYUNI_ROOT:/mgr registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers_tw/uyuni-master-python:latest bash
+podman run --rm -it -v $UYUNI_ROOT:/mgr:z registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers_tw/uyuni-master-python:latest bash
 black -t py36 path/to/file.py
 pylint --rcfile=/root/.pylintrc /path/to/file.py
 ```

--- a/python/linting/lint.sh
+++ b/python/linting/lint.sh
@@ -48,11 +48,11 @@ function ensure_latest_container_image() {
 }
 
 function execute_black() {
-  $ENGINE run --rm -v ${GITROOT}:${MOUNT} ${IMAGE}:${TAG} black -t py36 "$@"
+  $ENGINE run --rm -v ${GITROOT}:${MOUNT}:z ${IMAGE}:${TAG} black -t py36 "$@"
 }
 
 function execute_lint() {
-  $ENGINE run --rm -v ${GITROOT}:${MOUNT} ${IMAGE}:${TAG} pylint --rcfile /root/.pylintrc "$@"
+  $ENGINE run --rm -v ${GITROOT}:${MOUNT}:z ${IMAGE}:${TAG} pylint --rcfile /root/.pylintrc "$@"
 }
 
 function get_all_py_files() {


### PR DESCRIPTION
## What does this PR change?
- Add `:z` option to container volumes for Python linting.
- Document `:z` option for container volumes for Python linting in readme.

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
