### PR TITLE
use new tumbleweed-client-tools repos

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -735,21 +735,21 @@ name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = x86_64, s390x, aarch64, ppc64le
 base_channels = opensuse_tumbleweed-%(arch)s
 checksum = sha512
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/repodata/repomd.xml.key
-gpgkey_id = E6E5A213
-gpgkey_fingerprint = 50E6 0431 5448 5D99 0732 B5D6 ACAA 9CF7 E6E5 A213
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+# Change URL to Stable: as soon as the first version is released
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Tumbleweed-Uyuni-Client-Tools/openSUSE_Tumbleweed/
 
-# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
 [opensuse_tumbleweed-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64, s390x, aarch64, ppc64le
 base_channels = opensuse_tumbleweed-%(arch)s
 checksum = sha512
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/repodata/repomd.xml.key
-gpgkey_id = E6E5A213
-gpgkey_fingerprint = 50E6 0431 5448 5D99 0732 B5D6 ACAA 9CF7 E6E5 A213
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Tumbleweed-Uyuni-Client-Tools/openSUSE_Tumbleweed/
 
 [opensuse_microos]
 checksum = sha512
@@ -789,21 +789,21 @@ name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = x86_64, aarch64, ppc64le
 base_channels = opensuse_microos-%(arch)s
 checksum = sha512
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/repodata/repomd.xml.key
-gpgkey_id = E6E5A213
-gpgkey_fingerprint = 50E6 0431 5448 5D99 0732 B5D6 ACAA 9CF7 E6E5 A213
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+# Change URL to Stable: as soon as the first version is released
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Tumbleweed-Uyuni-Client-Tools/openSUSE_Tumbleweed/
 
-# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap Micro 5.X release
 [opensuse_microos-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = x86_64, aarch64, ppc64le
 base_channels = opensuse_microos-%(arch)s
 checksum = sha512
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/repodata/repomd.xml.key
-gpgkey_id = E6E5A213
-gpgkey_fingerprint = 50E6 0431 5448 5D99 0732 B5D6 ACAA 9CF7 E6E5 A213
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/
+gpgkey_url = %(_uyuni_gpgkey_url)s
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Tumbleweed-Uyuni-Client-Tools/openSUSE_Tumbleweed/
 
 [sles12-sp5-uyuni-client]
 name     = Uyuni Client Tools for SLES12 SP5 %(arch)s


### PR DESCRIPTION
## What does this PR change?

After creation of the first Tumbleweed Uyuni Client Tools repos change spacewalk-common-channels.ini to use them
instead of the old saltbundle repo directly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): no ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
