### PR TITLE
enhance API documentation about errata cloning (bsc#1244519)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -1695,12 +1695,13 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
     /**
      * Merge a channel's errata into another channel.
+     * It does not associate the packages with the channel.
      * @param loggedInUser The current user
      * @param mergeFromLabel the label of the channel to pull the errata from
      * @param mergeToLabel the label of the channel to push errata into
      * @return A list of errata that were merged.
      *
-     * @apidoc.doc Merges all errata from one channel into another
+     * @apidoc.doc Merges all errata from one channel into another. It does not associate the packages with the channel.
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("string", "mergeFromLabel", "the label of the
      * channel to pull errata from")
@@ -1729,6 +1730,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
     /**
      * Merge a channel's errata into another channel based upon a given start/end date.
+     * It does not associate the packages with the channel.
      * @param loggedInUser The current user
      * @param mergeFromLabel the label of the channel to pull the errata from
      * @param mergeToLabel the label of the channel to push errata into
@@ -1737,7 +1739,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
      * @return A list of errata that were merged.
      *
      * @apidoc.doc Merges all errata from one channel into another based upon a
-     * given start/end date.
+     * given start/end date. It does not associate the packages with the channel.
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("string", "mergeFromLabel", "the label of the
      * channel to pull errata from")
@@ -1770,14 +1772,16 @@ public class ChannelSoftwareHandler extends BaseHandler {
     }
 
     /**
-     * Merge a list of errata from one channel into another channel
+     * Merge a list of errata from one channel into another channel.
+     * It does not associate the packages with the channel.
      * @param loggedInUser The current user
      * @param mergeFromLabel the label of the channel to pull the errata from
      * @param mergeToLabel the label of the channel to push errata into
      * @param errataNames the list of errata to merge
      * @return A list of errata that were merged.
      *
-     * @apidoc.doc Merges a list of errata from one channel into another
+     * @apidoc.doc Merges a list of errata from one channel into another.
+     * It does not associate the packages with the channel.
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("string", "mergeFromLabel", "the label of the
      * channel to pull errata from")

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -796,7 +796,9 @@ public class ErrataHandler extends BaseHandler {
 
     /**
      * Clones a list of errata into a specified channel
-     *
+     * It only links the packages if the destination channel already contains an older version of the
+     * same package (same name and architecture). If the package is completely new to that channel,
+     * it will not be linked and the resulting behaviour will be the same as a channel.software.mergeErrata call.
      * @param loggedInUser The current user
      * @param channelLabel the channel's label that we are cloning into
      * @param advisoryNames an array of String objects containing the advisory name
@@ -804,7 +806,9 @@ public class ErrataHandler extends BaseHandler {
      * @return Returns an array of Errata objects, which get serialized into XMLRPC
      *
      * @apidoc.doc Clone a list of errata into the specified channel.
-     *
+     * It only links the packages if the destination channel already contains an older version of the
+     * same package (same name and architecture). If the package is completely new to that channel,
+     * it will not be linked and the resulting behaviour will be the same as a channel.software.mergeErrata call.
      * @apidoc.param #session_key()
      * @apidoc.param #param("string", "channelLabel")
      * @apidoc.param #array_single_desc("string", "advisoryNames", "the advisory names of the errata to clone")
@@ -927,7 +931,8 @@ public class ErrataHandler extends BaseHandler {
 
     /**
      * Clones a list of errata into a specified cloned channel
-     * according the original erratas
+     * according the original erratas.
+     * It always links the packages to the target channel by searching all related packages among all the parent clones.
      *
      * @param loggedInUser The current user
      * @param channelLabel the cloned channel's label that we are cloning into
@@ -936,7 +941,7 @@ public class ErrataHandler extends BaseHandler {
      * @return Returns an array of Errata objects, which get serialized into XMLRPC
      *
      * @apidoc.doc Clones a list of errata into a specified cloned channel according the original erratas.
-     *
+     * It always links the packages to the target channel by searching all related packages among all the parent clones.
      * @apidoc.param #session_key()
      * @apidoc.param #param("string", "channelLabel")
      * @apidoc.param #array_single_desc("string", "advisoryNames", "the advisory names of the errata to clone")
@@ -951,7 +956,8 @@ public class ErrataHandler extends BaseHandler {
 
     /**
      * Asynchronously clones a list of errata into a specified cloned channel
-     * according the original erratas
+     * according the original erratas.
+     * It always links the packages to the target channel by searching all related packages among all the parent clones.
      *
      * @param loggedInUser The current user
      * @param channelLabel the cloned channel's label that we are cloning into
@@ -960,7 +966,8 @@ public class ErrataHandler extends BaseHandler {
      * @return 1 on success, exception thrown otherwise.
      *
      * @apidoc.doc Asynchronously clones a list of errata into a specified cloned channel
-     * according the original erratas
+     * according the original erratas.
+     * It always links the packages to the target channel by searching all related packages among all the parent clones.
      *
      * @apidoc.param #session_key()
      * @apidoc.param #param("string", "channelLabel")

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.0-doc-errata-api
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.0-doc-errata-api
@@ -1,0 +1,1 @@
+- Enhance API documentation about errata cloning (bsc#1244519)


### PR DESCRIPTION
## What does this PR change?

API doc enhancement.

## Documentation
- API documentation added

- [x] **DONE**

## Test coverage
- No tests: **only doc**

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/28199

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
