### PR TITLE
QE: Set user/pass global variables before trying to login via WebUI

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -556,6 +556,9 @@ end
 # login, logout steps
 
 Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd|
+  # Save the user and password in global variables to be used by the API calls
+  $current_user = user
+  $current_password = passwd
   begin
     page.reset!
   rescue NoMethodError => e
@@ -567,7 +570,7 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
   ensure
     visit Capybara.app_host
   end
-  next if all(:xpath, "//header//span[text()='#{user}']", wait: 0).any?
+  next if all(:xpath, "//header//span[text()='#{$current_user}']", wait: 0).any?
 
   begin
     find(:xpath, '//header//i[@class=\'fa fa-sign-out\']').click
@@ -577,13 +580,11 @@ Given(/^I am authorized as "([^"]*)" with password "([^"]*)"$/) do |user, passwd
 
   raise ScriptError, 'Login page is not correctly loaded' unless has_field?('username')
 
-  fill_in('username', with: user)
-  fill_in('password', with: passwd)
+  fill_in('username', with: $current_user)
+  fill_in('password', with: $current_password)
   click_button_and_wait('Sign In', match: :first)
 
   step 'I should be logged in'
-  $current_user = user
-  $current_password = passwd
 end
 
 Given(/^I am authorized$/) do


### PR DESCRIPTION
## What does this PR change?

Fix: https://github.com/SUSE/spacewalk/issues/27150

Set user/pass global variables before trying to login via WebUI, so in case we don't need to login again. We assure it use the right user/pass on API Calls.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were fixed

- [x] **DONE**

## Links

POrts:
- Manager-4.3
- Manager-5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
