### PR TITLE
Fix activation key for proxy

### DIFF
--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -125,9 +125,8 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I select the parent channel for the "proxy_container" from "selectedBaseChannel"
     And I wait for child channels to appear
-    # TODO: WORKAROUND: When they are ready add them again
-    # And I include the recommended child channels
-    # And I wait until "SUSE Multi-Linux Manager Client Tools for SL Micro 6 x86_64" has been checked
+    And I include the recommended child channels
+    And I wait until "ManagerTools-SL-Micro-6.1 for x86_64" has been checked
     And I check "SUSE-Multi-Linux-Manager-Proxy-5.1 for x86_64"
     And I check "SUSE-Multi-Linux-Manager-Retail-Branch-Server-5.1 for x86_64"
     And I click on "Update Activation Key"


### PR DESCRIPTION
## What does this PR change?

Fix activation key for proxy

The activation key was missing the tools.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

No ports, Head only.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
