### PR TITLE
Make spacecmd code compatible with Py 2.7

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.cache-fix-py27
+++ b/spacecmd/spacecmd.changes.mczernek.cache-fix-py27
@@ -1,0 +1,1 @@
+- Make caching code Py 2.7 compatible

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -124,7 +124,7 @@ def is_interactive(options):
 
 def load_cache(cachefile):
     data = {}
-    cachefile = f"{cachefile}.json"
+    cachefile = "{}.json".format(cachefile)
     expire = datetime.now()
 
     logging.debug('Loading cache from %s', cachefile)
@@ -162,11 +162,11 @@ def save_cache(cachefile, data, expire=None):
         try:
             datetime.strptime(str(expire), _CACHE_DATE_FORMAT)
         except ValueError as e:
-            raise ValueError(f"Provided expire parameter must conform to {_CACHE_DATE_FORMAT}") from e
+            raise ValueError("Provided expire parameter must conform to {}".format(_CACHE_DATE_FORMAT)) from e
 
     if expire:
         data['expire'] = expire
-    cachefile = f"{cachefile}.json"
+    cachefile = "{}.json".format(cachefile)
 
     try:
         with open(cachefile, 'w', encoding='utf-8') as f:

--- a/spacecmd/tests/test_utils.py
+++ b/spacecmd/tests/test_utils.py
@@ -72,7 +72,7 @@ class TestSCUtilsCacheIntegration:
                                       data=self.data, expire=self.expiration)
         assert logger.error.called
         assert_args_expect(logger.error.call_args_list,
-                           [(("Couldn't write to %s.json", self.cachefile,), {})])
+                           [(("Couldn't write to %s", "{}.json".format(self.cachefile),), {})])
 
     def test_load_cache(self):
         """

--- a/spacecmd/tests/test_utils.py
+++ b/spacecmd/tests/test_utils.py
@@ -50,8 +50,8 @@ class TestSCUtilsCacheIntegration:
         :return:
         """
         spacecmd.utils.save_cache(cachefile=self.cachefile, data=self.data, expire=self.expiration)
-        assert os.path.exists(f"{self.cachefile}.json")
-        with open(f"{self.cachefile}.json", "r") as f:
+        assert os.path.exists("{}.json".format(self.cachefile))
+        with open("{}.json".format(self.cachefile), "r") as f:
             out = json.loads(f.read())
 
         assert "expire" in out
@@ -72,7 +72,7 @@ class TestSCUtilsCacheIntegration:
                                       data=self.data, expire=self.expiration)
         assert logger.error.called
         assert_args_expect(logger.error.call_args_list,
-                           [(("Couldn't write to %s", f"{self.cachefile}.json",), {})])
+                           [(("Couldn't write to %s.json", self.cachefile,), {})])
 
     def test_load_cache(self):
         """
@@ -82,7 +82,7 @@ class TestSCUtilsCacheIntegration:
         """
         spacecmd.utils.save_cache(cachefile=self.cachefile, data=self.data, expire=self.expiration)
 
-        assert os.path.exists(f"{self.cachefile}.json")
+        assert os.path.exists("{}.json".format(self.cachefile))
 
         out, expiration = spacecmd.utils.load_cache(self.cachefile)
 
@@ -104,7 +104,7 @@ class TestSCUtilsCacheIntegration:
 
         assert out == {}
         assert expiration != self.expiration is not None
-        assert not os.path.exists(f"{self.cachefile}.json")
+        assert not os.path.exists("{}.json".format(self.cachefile))
 
 
 class TestSCUtils:


### PR DESCRIPTION
## What does this PR change?

Spacecmd still supports python 2.7. In this PR, I'm removing Py 2.7 incompatible code. 

Porting of https://github.com/SUSE/spacewalk/pull/28219

## Links

Issue(s): Related to https://github.com/SUSE/spacewalk/issues/24760
Port(s): 
- 4.3: https://github.com/SUSE/spacewalk/pull/28219
- 5.0: https://github.com/SUSE/spacewalk/pull/28234
- 5.1: added the commit to still-open original PR at https://github.com/SUSE/spacewalk/pull/28184

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"  

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
