### PR TITLE
Fix schema migration tests

### DIFF
--- a/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
@@ -171,6 +171,7 @@ def create_fake_migration_path(schema_path, new_version, pr_file=None, version=N
 
 def run_command(command):
     """Run a shell command"""
+    # print(f"Run: {command}")
     try:
         subprocess.check_call(command, shell=True)
         return True
@@ -227,6 +228,11 @@ def dump_database(dump_name, excluded_tables=None):
     else:
         # pylint: disable-next=consider-using-f-string
         raise RuntimeError("Could not dump %s!" % db_name)
+    cleanup_cmd = f"/usr/bin/sed -i 's/^\(\\\\u\?n\?restrict \).*$/\\1/g' {dump_name}"
+    if run_command(cleanup_cmd):
+        print(f"{dump_name} cleanuped")
+    else:
+        raise RuntimeError(f"Could not cleanup {dump_name}")
 
 
 def run_upgrade(upgrade_script, new_version):

--- a/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
@@ -172,7 +172,6 @@ def create_fake_migration_path(schema_path, new_version, pr_file=None, version=N
 
 def run_command(command):
     """Run a shell command"""
-    # print(f"Run: {command}")
     try:
         subprocess.check_call(command, shell=True)
         return True
@@ -231,7 +230,7 @@ def dump_database(dump_name, excluded_tables=None):
         raise RuntimeError("Could not dump %s!" % db_name)
     cleanup_cmd = f"/usr/bin/sed -i 's/^\(\\\\u\?n\?restrict \).*$/\\1/g' {dump_name}"
     if run_command(cleanup_cmd):
-        print(f"{dump_name} cleanuped")
+        print(f"Cleaned unrestrict/restrict tokens from {dump_name} ")
     else:
         raise RuntimeError(f"Could not cleanup {dump_name}")
 

--- a/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/reportdb_schema_idempotency_test_pgsql.py
@@ -132,6 +132,7 @@ def create_fake_migration_path(schema_path, new_version, pr_file=None, version=N
     """Create a fake migration path with the next version after the last, adding
     all SQL files from a PR or since the version where all scripts started to be
     idempotent"""
+    files = []
     if pr_file:
         print("Creating migration path with the scripts from the PR")
         files = get_all_files_from_pr(pr_file, schema_path)
@@ -290,7 +291,7 @@ def diff_dumps(initial_dump, migrated_dump):
                 if line.endswith("FROM stdin;"):
                     in_table = True
             else:
-                if line == "\.":
+                if line == "\\.":
                     res += sorted(table)
                     res.append(line)
                     in_table = False

--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -171,7 +171,6 @@ def create_fake_migration_path(schema_path, new_version, pr_file=None, version=N
 
 def run_command(command):
     """Run a shell command"""
-    # print(f"Run: {command}")
     try:
         subprocess.check_call(command, shell=True)
         return True
@@ -230,7 +229,7 @@ def dump_database(dump_name, excluded_tables=None):
         raise RuntimeError("Could not dump %s!" % db_name)
     cleanup_cmd = f"/usr/bin/sed -i 's/^\(\\\\u\?n\?restrict \).*$/\\1/g' {dump_name}"
     if run_command(cleanup_cmd):
-        print(f"{dump_name} cleanuped")
+        print(f"Cleaned unrestrict/restrict tokens from {dump_name} ")
     else:
         raise RuntimeError(f"Could not cleanup {dump_name}")
 

--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -170,6 +170,7 @@ def create_fake_migration_path(schema_path, new_version, pr_file=None, version=N
 
 def run_command(command):
     """Run a shell command"""
+    # print(f"Run: {command}")
     try:
         subprocess.check_call(command, shell=True)
         return True
@@ -226,6 +227,11 @@ def dump_database(dump_name, excluded_tables=None):
     else:
         # pylint: disable-next=consider-using-f-string
         raise RuntimeError("Could not dump %s!" % db_name)
+    cleanup_cmd = f"/usr/bin/sed -i 's/^\(\\\\u\?n\?restrict \).*$/\\1/g' {dump_name}"
+    if run_command(cleanup_cmd):
+        print(f"{dump_name} cleanuped")
+    else:
+        raise RuntimeError(f"Could not cleanup {dump_name}")
 
 
 def run_upgrade(upgrade_script, new_version):

--- a/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
+++ b/susemanager-utils/testing/docker/scripts/schema_idempotency_test_pgsql.py
@@ -132,6 +132,7 @@ def create_fake_migration_path(schema_path, new_version, pr_file=None, version=N
     """Create a fake migration path with the next version after the last, adding
     all SQL files from a PR or since the version where all scripts started to be
     idempotent"""
+    files = []
     if pr_file:
         print("Creating migration path with the scripts from the PR")
         files = get_all_files_from_pr(pr_file, schema_path)
@@ -288,7 +289,7 @@ def diff_dumps(initial_dump, migrated_dump):
                 if line.endswith("FROM stdin;"):
                     in_table = True
             else:
-                if line == "\.":
+                if line == "\\.":
                     res += sorted(table)
                     res.append(line)
                     in_table = False


### PR DESCRIPTION
## What does this PR change?

New postgres 16.10 database changed the pg_dump command and add a \restrict \unrestrict with a unique token to the output. This let the test fail.
Use sed to remove the token to fix the migration tests

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/28241

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
