### PR TITLE
fix Sync Channels button on peripheral server (bsc#1249030)

### DIFF
--- a/web/html/src/manager/admin/hub/hub-details.tsx
+++ b/web/html/src/manager/admin/hub/hub-details.tsx
@@ -101,7 +101,7 @@ export class HubDetails extends React.Component<Props, State> {
   }
 
   private onConfirmSyncBunch(): void {
-    const resource = `/manager/api/admin/hub/sync-bunch`;
+    const resource = `/rhn/manager/api/admin/hub/sync-bunch`;
     Network.post(resource)
       .then(
         (_response) => {

--- a/web/spacewalk-web.changes.mcalmer.fix-hub-sync-channels
+++ b/web/spacewalk-web.changes.mcalmer.fix-hub-sync-channels
@@ -1,0 +1,1 @@
+- Fix Sync Channels button on peripheral server (bsc#1249030)


### PR DESCRIPTION
## What does this PR change?

Clicking on the "Sync Channels" button on the Peripheral Configuration page result in a Resource not found error.
We used the wrong URL which was not redirected to tomcat.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Port(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
