### PR TITLE
Maintenance window waits

### DIFF
--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -16,6 +16,7 @@ Feature: Maintenance windows
 
   Scenario: Create a single calendar
     When I follow the left menu "Schedule > Maintenance Windows > Calendars"
+    And I wait for "1" second
     Then I should see a "No calendars created" text
     When I click on "Create" in element "maintenance-windows"
     Then I should see a "Calendar Name" text
@@ -26,6 +27,7 @@ Feature: Maintenance windows
 
   Scenario: Create a multi calendar
     When I follow the left menu "Schedule > Maintenance Windows > Calendars"
+    And I wait for "1" second
     Then I should see a "Items 1 - 1 of 1" text
     When I click on "Create" in element "maintenance-windows"
     Then I should see a "Calendar Name" text
@@ -36,6 +38,7 @@ Feature: Maintenance windows
 
   Scenario: Create a single schedule
     When I follow the left menu "Schedule > Maintenance Windows > Schedules"
+    And I wait for "1" second
     Then I should see a "No schedules created" text
     When I click on "Create" in element "maintenance-windows"
     Then I should see a "Schedule Name" text
@@ -48,6 +51,7 @@ Feature: Maintenance windows
 
   Scenario: Create a multi schedule
     When I follow the left menu "Schedule > Maintenance Windows > Schedules"
+    And I wait for "1" second
     Then I should see a "Items 1 - 1 of 1" text
     When I click on "Create" in element "maintenance-windows"
     Then I should see a "Schedule Name" text
@@ -60,6 +64,7 @@ Feature: Maintenance windows
 
   Scenario: Create another multi schedule
     When I follow the left menu "Schedule > Maintenance Windows > Schedules"
+    And I wait for "1" second
     Then I should see a "Items 1 - 2 of 2" text
     When I click on "Create"
     And I enter "Core Server Window" as "name"

--- a/testsuite/features/secondary/srv_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_maintenance_windows.feature
@@ -121,7 +121,7 @@ Feature: Maintenance windows
     And I enter "virgo-dummy" as the filtered package name
     And I click on the filter button
     And I check "virgo-dummy" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I select the next maintenance window
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text


### PR DESCRIPTION
## What does this PR change?

This PR contains 2 commits:

1. Wait until page has fully loaded before pressing button

I have tried very hard, but I have found no other way to make sure the page has fully loaded than to wait for 1 second.

Strangely enough, this affects only Uyuni. All other branches are okay with just waiting for some text to appear.

2. Rename button

For whatever reason, "Install Selected Packages" has become "Install Packages".


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

No ports, Head only.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
