### PR TITLE
Adapt test suites to new text labels

### DIFF
--- a/testsuite/features/build_validation/migration/migration_salt_migration_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_salt_migration_minion.feature
@@ -95,7 +95,7 @@ Feature: Migrate Salt to bundled Salt on a SLES 15 SP5 minion
     And I click on the filter button
     And I wait until I see "adobe-sourcecodepro-fonts" text
     And I check "adobe-sourcecodepro-fonts" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
     Then "adobe-sourcecodepro-fonts" should be installed on "salt_migration_minion"

--- a/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_terminal_deploy.feature
@@ -45,7 +45,7 @@ Feature: PXE boot a SLES 12 SP5 retail terminal
     And I enter "gcc" as the filtered package name
     And I click on the filter button
     And I check "gcc-4.8" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_terminal_deploy.feature
@@ -45,7 +45,7 @@ Feature: PXE boot a SLES 15 SP4 retail terminal
     And I enter "rust" as the filtered package name
     And I click on the filter button
     And I check "rust-1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -90,7 +90,7 @@ Feature: Smoke tests for <client>
     And I enter the package for "<client>" as the filtered package name
     And I click on the filter button
     And I check the package last version for "<client>" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled by <client>" is completed
@@ -179,7 +179,7 @@ Feature: Smoke tests for <client>
     And I enter "spacecmd" as the filtered package name
     And I click on the filter button
     And I check "spacecmd" last version in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled by <client>" is completed

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -108,7 +108,7 @@ Feature: Manage a group of systems and the Systems Set Manager
     And I enter "virgo-dummy" as the filtered package name
     And I click on the filter button
     And I check "virgo-dummy-2.0-1.1" in the list
-    And I click on "Remove Selected Packages"
+    And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "Package removals are being scheduled, it may take several minutes for this to complete." text
 
@@ -123,7 +123,7 @@ Feature: Manage a group of systems and the Systems Set Manager
     And I enter "virgo-dummy" as the filtered package name
     And I click on the filter button
     When I check "virgo-dummy-2.0-1.1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "Package installations are being scheduled, it may take several minutes for this to complete." text
 

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -84,7 +84,7 @@ Feature: Register a Salt minion with a bootstrap script
    And I enter "orion-dummy" as the filtered package name
    And I click on the filter button
    And I check row with "orion-dummy" and arch of "sle_minion"
-   And I click on "Install Selected Packages"
+   And I click on "Install Packages"
    And I click on "Confirm"
    Then I should see a "1 package install has been scheduled for" text
    When I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/secondary/min_project_lotus.feature
+++ b/testsuite/features/secondary/min_project_lotus.feature
@@ -95,7 +95,7 @@ Feature: Project Lotus
     And I enter "ptf-24894-3-0" as the filtered package name
     And I click on the filter button
     And I check "ptf-24894-3-0" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/secondary/min_rhlike_appstreams.feature
+++ b/testsuite/features/secondary/min_rhlike_appstreams.feature
@@ -110,7 +110,7 @@ Feature: Native AppStreams support for Red Hat-like Salt minion
     And I should not see a "scorpio-dummy-2.0" text
     And I should not see a "scorpio-dummy-1.0" text
     When I check "scorpio-dummy-2.1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/secondary/min_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_salt_install_package_and_patch.feature
@@ -62,7 +62,7 @@ Feature: Install a package and a patch on the SUSE client via Salt through the U
     And I enter "andromeda" as the filtered package name
     And I click on the filter button
     And I check "andromeda-dummy-2.0-1.1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait for "andromeda-dummy-2.0-1.1" to be installed on "sle_minion"

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -46,13 +46,13 @@ Feature: Install a package on the SLES minion with staging enabled
 
   Scenario: Install package in the future and check for staging
     Given I am on the Systems overview page of this "sle_minion"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "Packages" in the content area
     And I follow "Install" in the content area
     And I enter "orion-dummy-1.1-1.1" as the filtered package name
     And I click on the filter button
-    When I check row with "orion-dummy-1.1-1.1" and arch of "sle_minion"
-    And I click on "Install Selected Packages"
+    And I check row with "orion-dummy-1.1-1.1" and arch of "sle_minion"
+    And I click on "Install Packages"
     And I pick 3 minutes from now as schedule time
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -100,7 +100,7 @@ Feature: OpenSCAP audit of Salt minion
     And I follow "OpenSCAP" in the content area
     And I follow "List Scans" in the content area
     And I click on "Select All"
-    And I click on "Compare Selected Scans"
+    And I click on "Compare"
     Then I should see a "XCCDF Rule Results" text
     And I should see a "None" text
 

--- a/testsuite/features/secondary/minssh_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package_and_patch.feature
@@ -62,7 +62,7 @@ Feature: Install a package and a patch on the SUSE SSH client via Salt through t
     And I enter "andromeda" as the filtered package name
     And I click on the filter button
     And I check "andromeda-dummy-2.0-1.1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait for "andromeda-dummy-2.0-1.1" to be installed on "ssh_minion"

--- a/testsuite/features/secondary/minssh_tunnel.feature
+++ b/testsuite/features/secondary/minssh_tunnel.feature
@@ -51,7 +51,7 @@ Feature: Register a Salt system to be managed via SSH tunnel
     And I click on the filter button
     And I wait until I see "milkyway-dummy" text
     And I check row with "milkyway-dummy" and arch of "ssh_minion"
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     Then I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
@@ -100,7 +100,7 @@ Feature: PXE boot a terminal with Cobbler and containerized proxy
     And I enter "virgo-dummy-2.0-1.1" as the filtered package name
     And I click on the filter button
     And I check "virgo-dummy-2.0-1.1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed

--- a/testsuite/features/secondary/proxy_container_retail_mass_import.feature
+++ b/testsuite/features/secondary/proxy_container_retail_mass_import.feature
@@ -51,7 +51,7 @@ Feature: Mass import of Retail terminals behind a containerized proxy
     And I enter "virgo" as the filtered package name
     And I click on the filter button
     And I check "virgo-dummy-2.0-1.1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed

--- a/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
@@ -158,7 +158,7 @@ Feature: PXE boot a Retail terminal behind a containerized proxy
     And I enter "virgo" as the filtered package name
     And I click on the filter button
     And I check "virgo-dummy-2.0-1.1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed

--- a/testsuite/features/secondary/srv_cobbler_distro.feature
+++ b/testsuite/features/secondary/srv_cobbler_distro.feature
@@ -149,7 +149,7 @@ Feature: Cobbler and distribution autoinstallation
   Scenario: Delete a snippet
     When I follow the left menu "Systems > Autoinstallation > Autoinstallation Snippets"
     And I follow "created_test_snippet"
-    And I follow "delete snippet"
+    And I follow "Delete Snippet"
     And I click on "Delete Snippet"
     Then I should see a "created_test_snippet deleted successfully." text
 

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -21,7 +21,7 @@ Feature: Push a package with unset vendor
     And I enter "mgr-push" as the filtered package name
     And I click on the filter button
     And I check "mgr-push" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled" is completed


### PR DESCRIPTION
## What does this PR change?

Adapt test suites to new text labels as redefined in https://github.com/uyuni-project/uyuni/pull/9485.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**

## Links

No ports

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
