### PR TITLE
Do not re-raise exceptions in spacecmd

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.py2-spacecmd
+++ b/spacecmd/spacecmd.changes.mczernek.py2-spacecmd
@@ -1,0 +1,1 @@
+- Python 2.7 cannot re-raise exceptions

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -161,8 +161,8 @@ def save_cache(cachefile, data, expire=None):
             raise ValueError("expire must be datetime.datetime or str object")
         try:
             datetime.strptime(str(expire), _CACHE_DATE_FORMAT)
-        except ValueError as e:
-            raise ValueError("Provided expire parameter must conform to {}".format(_CACHE_DATE_FORMAT)) from e
+        except ValueError:
+            raise ValueError("Provided expire parameter must conform to {}".format(_CACHE_DATE_FORMAT))
 
     if expire:
         data['expire'] = expire


### PR DESCRIPTION
## What does this PR change?

Fix build failures on Python 2.7.

With this change, the pkg finally builds for `systemsmanagement:Uyuni:Master:CentOS7-Uyuni-Client-Tools/spacecmd`

```
$ osc build
...
[    6s] + cd /home/abuild/rpmbuild/BUILD
[    6s] + cd spacecmd-git-507.8fccef7
[    6s] + /usr/bin/rm -rf /home/abuild/rpmbuild/BUILDROOT/spacecmd-5.2.0-0.x86_64
[    6s] + exit 0
[    6s] ... checking for files with abuild user/group
[    6s] 
[    6s] t14s finished "build spacecmd.spec" at Thu Sep  4 08:46:43 UTC 2025.
[    6s] 
/var/tmp/build-root/CentOS_7-x86_64/home/abuild/rpmbuild/SRPMS/spacecmd-5.2.0-0.src.rpm

/var/tmp/build-root/CentOS_7-x86_64/home/abuild/rpmbuild/RPMS/noarch/spacecmd-5.2.0-0.noarch.rpm
```

## Links

Issue(s): Related to https://github.com/SUSE/spacewalk/issues/24760
Port(s):

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" 

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
