### PR TITLE
Fix scheduling of channel sync

### DIFF
--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -272,7 +272,7 @@ public class Router implements SparkApplication {
         StorybookController.initRoutes(jade);
 
         // ISSv3 Sync
-        initISSv3Routes();
+        initISSv3Routes(taskomaticApi);
 
         // Validate RBAC endpoints
         RbacRouteValidator.validateEndpoints();
@@ -312,15 +312,15 @@ public class Router implements SparkApplication {
         ImageBuildController.initRoutes(jade, imageBuildController);
     }
 
-    private static void initISSv3Routes() {
+    private static void initISSv3Routes(TaskomaticApi taskomaticApiIn) {
         HubManager hubManager = new HubManager();
 
         // ISS v3 Internal APIs
-        HubController hubController = new HubController(hubManager, new TaskomaticApi());
+        HubController hubController = new HubController(hubManager, taskomaticApiIn);
         hubController.initRoutes();
 
         // API for the web interface
-        HubApiController hubApiController = new HubApiController(hubManager, new IssMigratorFactory());
+        HubApiController hubApiController = new HubApiController(hubManager, new IssMigratorFactory(), taskomaticApiIn);
         hubApiController.initRoutes();
     }
 }

--- a/java/spacewalk-java.changes.mcalmer.fix-scheduling-of-channel-sync
+++ b/java/spacewalk-java.changes.mcalmer.fix-scheduling-of-channel-sync
@@ -1,0 +1,1 @@
+- Fix scheduling of channel sync


### PR DESCRIPTION
## What does this PR change?

The Sync Channels button in Hub Details only create a Task Schedule, but does not create the quartz job.
This defines only the job, but does not execute it.
Using the taskomatic API to schedule the bunch works.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/28274

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
