### PR TITLE
Install python-ldap into the server-image (bsc#1245702)

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -21,6 +21,7 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         ${PRODUCT_PATTERN_PREFIX}_server \
         ${PRODUCT_PATTERN_PREFIX}_retail \
         ${USEPYTHON}-pygit2 \
+        ${USEPYTHON}-ldap \
         billing-data-service \
         drbd-formula \
         ed \

--- a/containers/server-image/server-image.changes.deneb-alpha.python-ldap-master
+++ b/containers/server-image/server-image.changes.deneb-alpha.python-ldap-master
@@ -1,0 +1,1 @@
+- Install python-ldap into the server-image (bsc#1245702)


### PR DESCRIPTION
## What does this PR change?

Install python3-ldap or python311-ldap into the server-image (bsc#1245702)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: just  a new dependency  added to the Dockerfile
- master:  https://build.opensuse.org/package/show/home:deneb_alpha:branches:systemsmanagement:Uyuni:Master_bsc1245702/server-image
- Head: https://build.suse.de/package/show/home:deneb_alpha:branches:Devel:Galaxy:Manager:Head_bsc1245702/server-image

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27724
Port(s): 
* 5.1 : https://github.com/SUSE/spacewalk/pull/28275
* 5.0: https://github.com/SUSE/spacewalk/pull/28276

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
