### PR TITLE
Adjusted spacing and alignment in Password Policy page

### DIFF
--- a/web/html/src/manager/admin/password-policy/password-policy.tsx
+++ b/web/html/src/manager/admin/password-policy/password-policy.tsx
@@ -26,131 +26,133 @@ const PasswordPolicy = (prop: PasswordPolicyProps) => {
       </div>
       <Form model={policy}>
         <Panel headingLevel="h2" title={t("Password Policy Settings")}>
-          <div className="col-md-8">
-            {/* Minimum Length */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="minLength">{t("Min Password Length")}</label>
-              </div>
-              <Text required name="minLength" divClass="col-md-2" type="number" />
+          {/* Minimum Length */}
+          <Text
+            label={t("Min Password Length")}
+            required name="minLength" 
+            labelClass="col-md-4 text-left"
+            divClass="col-md-2"
+            type="number"
+          />
+          {/* Maximum Length */}
+          <Text
+            label={t("Max Password Length")}
+            required
+            name="maxLength"
+            labelClass="col-md-4 text-left"
+            divClass="col-md-2"
+            type="number"
+          />
+          <div className="row">
+            <div className="col-md-4 text-right">
+              <label className="control-label">Password Complexity:</label>
             </div>
-            {/* Maximum Length */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="maxLength">{t("Max Password Length")}</label>
-              </div>
-              <Text required name="maxLength" divClass="col-md-2" type="number" />
-            </div>
-            {/* Require Digits */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="digitFlag">{t("Require Digits")}</label>
-              </div>
-              <DEPRECATED_Check name="digitFlag" key="digitFlag" divClass="col-md-2" />
-            </div>
-            {/* Require Lowercase Characters */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="lowerCharFlag">{t("Require Lowercase Characters")}</label>
-              </div>
-              <DEPRECATED_Check name="lowerCharFlag" key="lowerCharFlag" divClass="col-md-2" />
-            </div>
-            {/* Require Uppercase Characters */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="upperCharFlag">{t("Require Uppercase Characters")}</label>
-              </div>
-              <DEPRECATED_Check name="upperCharFlag" key="upperCharFlag" divClass="col-md-2" />
-            </div>
-            {/* Restrict Consecutive Characters */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="consecutiveCharsFlag">{t("Restrict Consecutive Characters")}</label>
-              </div>
-              <DEPRECATED_Check name="consecutiveCharsFlag" key="consecutiveCharsFlag" divClass="col-md-2" />
-            </div>
-            {/* Require Special Characters */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="specialCharFlag">{t("Require Special Characters")}</label>
-              </div>
-              <DEPRECATED_Check name="specialCharFlag" key="specialCharFlag" divClass="col-md-2" />
-            </div>
-            {/* Allowed Special Characters */}
-            <div className="row form-group">
-              <div className="col-md-4 text-left">
-                <label htmlFor="specialChars">{t("Allowed Special Characters")}</label>
-              </div>
-              <Text
-                disabled={!policy.specialCharFlag}
-                name="specialChars"
-                divClass="col-md-4"
-                defaultValue={defaults.specialChars?.toLocaleString()}
+            <div className="col-md-8">
+              {/* Require Digits */}
+              <DEPRECATED_Check
+                label={t("Require Digits")}
+                name="digitFlag"
+                key="digitFlag"
+                divClass="col-md-6"
+              />
+              {/* Require Lowercase Characters */}
+              <DEPRECATED_Check
+                label={t("Require Lowercase Characters")}
+                name="lowerCharFlag"
+                key="lowerCharFlag"
+                divClass="col-md-6"
+              />
+              {/* Require Uppercase Characters */}
+              <DEPRECATED_Check
+                label={t("Require Uppercase Characters")}
+                name="upperCharFlag"
+                key="upperCharFlag"
+                divClass="col-md-6"
+              />
+              {/* Restrict Consecutive Characters */}
+              <DEPRECATED_Check
+                label={t("Restrict Consecutive Characters")}
+                name="consecutiveCharsFlag"
+                key="consecutiveCharsFlag"
+                divClass="col-md-6"
+              />
+              {/* Require Special Characters */}
+              <DEPRECATED_Check
+                label={t("Require Special Characters")}
+                name="specialCharFlag"
+                key="specialCharFlag"
+                divClass="col-md-6"
               />
             </div>
-            {/* Restrict Character Occurrence */}
-            <div className="row">
-              <div className="col-md-4 text-left">
-                <label htmlFor="restrictedOccurrenceFlag">{t("Restrict Characters Occurrences")}</label>
-              </div>
-              <DEPRECATED_Check key="restrictedOccurrenceFlag" name="restrictedOccurrenceFlag" divClass="col-md-2" />
-            </div>
-            {/* Maximum Character Occurrence */}
-            <div className="row form-group">
-              <div className="col-md-4 text-left">
-                <label htmlFor="maxCharacterOccurrence">{t("Max Characters Occurrences")}</label>
-              </div>
-              <Text
-                disabled={!policy.restrictedOccurrenceFlag}
-                name="maxCharacterOccurrence"
-                divClass="col-md-2"
-                type="number"
-                defaultValue={defaults.maxCharacterOccurrence.toLocaleString()}
-              />
-            </div>
-            <div className="row">
-              <div className="col-md-4 text-left"></div>
-              <div className="col-md-4 text-left">
-                <div className="btn-group">
-                  <AsyncButton
-                    id="saveButton"
-                    className="btn-primary btn-large"
-                    title={t("Save Password Policy")}
-                    text={t("Save")}
-                    icon="fa-save"
-                    action={() => {
-                      Network.post(policy_endpoint, policy)
-                        .then(() => {
-                          showSuccessToastr(t("Password Policy Changed"));
-                        })
-                        .catch((error) => {
-                          showErrorToastr(error);
-                        });
-                    }}
-                  />
-                  <AsyncButton
-                    id="resetButton"
-                    className="btn-secondary btn-large"
-                    title={t("Reset")}
-                    text={t("Reset")}
-                    icon="fa-refresh"
-                    action={() => {
-                      const default_policy_endpoint = "/rhn/manager/api/admin/config/password-policy/default";
-                      Network.get(default_policy_endpoint)
-                        .then((resp) => {
-                          const defaults: PasswordPolicyData = JSON.parse(resp.data);
-                          Network.post(policy_endpoint, defaults)
-                            .then(() => showSuccessToastr(t("Password Policy Reset to Default")))
-                            .catch((error) => showErrorToastr(error));
-                          setDefaults(defaults);
-                          setPolicy(defaults);
-                        })
-                        .catch((error) => {
-                          showErrorToastr(error);
-                        });
-                    }}
-                  />
-                </div>
+          </div>
+
+          {/* Allowed Special Characters */}
+          <Text
+            label={t("Allowed Special Characters")}
+            disabled={!policy.specialCharFlag}
+            name="specialChars"
+            labelClass="col-md-4 text-left"
+            divClass="col-md-4"
+            defaultValue={defaults.specialChars?.toLocaleString()}
+          />
+          {/* Restrict Character Occurrence */}
+          <DEPRECATED_Check
+            label={t("Restrict Characters Occurrences")}
+            key="restrictedOccurrenceFlag"
+            name="restrictedOccurrenceFlag"
+            divClass="col-md-6 col-md-offset-4 offset-md-4"
+          />
+          {/* Maximum Character Occurrence */}
+          <Text
+            label={t("Max Characters Occurrences")}
+            disabled={!policy.restrictedOccurrenceFlag}
+            name="maxCharacterOccurrence"
+            labelClass="col-md-4 text-left"
+            divClass="col-md-2"
+            type="number"
+            defaultValue={defaults.maxCharacterOccurrence.toLocaleString()}
+          />
+          <div className="row">
+            <div className="col-md-4 text-left col-md-offset-4 offset-md-4">
+              <div className="btn-group">
+                <AsyncButton
+                  id="saveButton"
+                  className="btn-primary btn-large"
+                  title={t("Save Password Policy")}
+                  text={t("Save")}
+                  icon="fa-save"
+                  action={() => {
+                    Network.post(policy_endpoint, policy)
+                      .then(() => {
+                        showSuccessToastr(t("Password Policy Changed"));
+                      })
+                      .catch((error) => {
+                        showErrorToastr(error);
+                      });
+                  }}
+                />
+                <AsyncButton
+                  id="resetButton"
+                  className="btn-secondary btn-large"
+                  title={t("Reset")}
+                  text={t("Reset")}
+                  icon="fa-refresh"
+                  action={() => {
+                    const default_policy_endpoint = "/rhn/manager/api/admin/config/password-policy/default";
+                    Network.get(default_policy_endpoint)
+                      .then((resp) => {
+                        const defaults: PasswordPolicyData = JSON.parse(resp.data);
+                        Network.post(policy_endpoint, defaults)
+                          .then(() => showSuccessToastr(t("Password Policy Reset to Default")))
+                          .catch((error) => showErrorToastr(error));
+                        setDefaults(defaults);
+                        setPolicy(defaults);
+                      })
+                      .catch((error) => {
+                        showErrorToastr(error);
+                      });
+                  }}
+                />
               </div>
             </div>
           </div>

--- a/web/spacewalk-web.changes.bisht-richa.ui-password-policy-form
+++ b/web/spacewalk-web.changes.bisht-richa.ui-password-policy-form
@@ -1,0 +1,1 @@
+- Refined UI spacing and alignment in password policy form.


### PR DESCRIPTION
## What does this PR change?

Adjusted spacing and alignment for a cleaner password policy form UI.

## GUI diff

No difference.

Before:

<img width="912" height="803" alt="Screenshot 2025-09-04 at 11 05 44" src="https://github.com/user-attachments/assets/7c4c9dc7-6ef0-4e26-ba06-8efd9748f7e9" />


After:

<img width="923" height="587" alt="Screenshot 2025-09-04 at 11 05 55" src="https://github.com/user-attachments/assets/4775f1dd-468d-4730-97dd-84ef115637ed" />


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
