### PR TITLE
Testsuite workaround for bsc#1249127

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1401,7 +1401,9 @@ When(/^I export config channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channe
 end
 
 When(/^I import data with ISS v2 from "([^"]*)"$/) do |path|
-  get_target('server').run("inter-server-sync import --importDir=#{path}")
+  # WORKAROUND for bsc#1249127
+  # Remove "echo UglyWorkaround |" when the product issue is solved
+  get_target('server').run("echo UglyWorkaround | inter-server-sync import --importDir=#{path}")
 end
 
 Then(/^"(.*?)" folder on server is ISS v2 export directory$/) do |folder|


### PR DESCRIPTION
## What does this PR change?

Testsuite workaround for bsc#1249127

Provides something on stdin for "inter-server-sync import" that would hang forever otherwise.

Please remove when product issue is fixed.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified.

- [x] **DONE**


## Links

No ports, head only.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
