### PR TITLE
delete actions which use a virtualization action type (bsc#1249178)

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes.mcalmer.fix-schema-migration-virt-removal
+++ b/schema/spacewalk/susemanager-schema.changes.mcalmer.fix-schema-migration-virt-removal
@@ -1,0 +1,2 @@
+- Fix schema migration when removing the dropped
+  virtualization action types (bsc#1249178)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.1.0-to-susemanager-schema-5.1.1/003-virt-removal.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.1.0-to-susemanager-schema-5.1.1/003-virt-removal.sql
@@ -33,4 +33,6 @@ DROP TABLE IF EXISTS rhnVirtualInstanceEventLog,
                      rhnActionVirtVcpu,
                      rhnActionVirtVolDelete CASCADE;
 
-DELETE FROM rhnActionType WHERE label LIKE 'virt.%';
+DELETE FROM rhnAction WHERE action_type IN (SELECT id FROM rhnActionType WHERE label LIKE 'virt.%' AND label <> 'virt.refresh_list');
+
+DELETE FROM rhnActionType WHERE label LIKE 'virt.%' AND label <> 'virt.refresh_list';


### PR DESCRIPTION
## What does this PR change?

The action_type reference in rhnAction does not have a "ON DELETE CASCADE".
When we remove action types, we need to remove the actions manually before we can remove the types.

This change an old migration to fix the problem for all which execute this after updating to this version.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manually**

- [x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1249178
Port(s): https://github.com/SUSE/spacewalk/pull/28292

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
