### PR TITLE
Add the last checked in column back to the systems list page

### DIFF
--- a/web/html/src/manager/systems/all-list.tsx
+++ b/web/html/src/manager/systems/all-list.tsx
@@ -153,6 +153,12 @@ export function AllSystems(props: Props) {
           }}
         />
         <Column
+          columnKey="last_checkin"
+          comparator={Utils.sortByText}
+          header={t("Last Checked In")}
+          cell={(item) => item.lastCheckin}
+        />
+        <Column
           columnKey="channel_labels"
           comparator={Utils.sortByText}
           header={t("Base Channel")}

--- a/web/spacewalk-web.changes.cbosdo.last-checkin
+++ b/web/spacewalk-web.changes.cbosdo.last-checkin
@@ -1,0 +1,2 @@
+- Add the last checked in column back to the system lists
+  (bsc#1248411)


### PR DESCRIPTION
## What does this PR change?

Before the rewrite of the systems list page there was a column showing when systems last checked in. This column has been forgotten in the refactoring, add it back. (bsc#1248411)

## GUI diff

Adds  a `Last checked in` column to the systems list page.

- [x] **DONE**

## Documentation
- No documentation needed: just one more column of data in an existing page
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: only data added to an existing page

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28153
Port(s): https://github.com/SUSE/spacewalk/pull/28307 https://github.com/SUSE/spacewalk/pull/28306
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
