### PR TITLE
fix reebot needed detection of transaction update systems

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
+++ b/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
@@ -9,6 +9,9 @@ mgr_reboot_if_needed:
 {%- elif grains['os_family'] == 'Debian' %}
     - onlyif:
       - /usr/bin/test -e /var/run/reboot-required
+{%- elif grains.get('transactional', False) and grains['os_family'] == 'Suse' %}
+    - onlyif:
+      - /usr/bin/snapper list --columns number 2>/dev/null | /usr/bin/grep '+'
 {%- elif grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
     - onlyif:
       - /usr/bin/test -e /boot/do_purge_kernels

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-rebootneeded-detection-transactional
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-rebootneeded-detection-transactional
@@ -1,0 +1,1 @@
+- Fix reebot needed detection of transaction update systems


### PR DESCRIPTION
## What does this PR change?

Transaction systems need to reboot after every package installation.
Our reebotifneeded state just detect patches and packages which require a reboot.

This change should trigger a reboot for transactional systems as soon as there will be a new default snapshot booted.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Port(s): TBD

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
