### PR TITLE
Port: Fix wrong header in old changelog entry

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1821,7 +1821,7 @@ Mon Feb  6 17:40:11 CET 2012 - ug@suse.de
 - added cracklib check to DB password dialog (bnc#744983)
 
 -------------------------------------------------------------------
-Tue Jan 31 16:40:59 CET 2012 . mantel@suse.de
+Tue Jan 31 16:40:59 CET 2012 - mantel@suse.de
 
 - fix spelling in
   /etc/sysconfig/SuSEfirewall2.d/services/suse-manager-server

--- a/susemanager/susemanager.changes.raul.fix_susemanager_511
+++ b/susemanager/susemanager.changes.raul.fix_susemanager_511
@@ -1,0 +1,1 @@
+- Fix wrong header in old changelog entry


### PR DESCRIPTION
## What does this PR change?

Fix wrong header in old changelog entry

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): #
Port(s): https://github.com/SUSE/spacewalk/pull/28312

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
