### PR TITLE
Add needed channels to activation key in testsuite

### DIFF
--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -257,6 +257,8 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I check "Fake-RPM-Terminal-Channel"
     And I wait until "Fake-RPM-Terminal-Channel" has been checked
+    And I check "Uyuni Client Tools for SLES15 SP4 x86_64 (Development)"
+    And I wait until "Uyuni Client Tools for SLES15 SP4 x86_64 (Development)" has been checked
     And I click on "Update Activation Key"
     Then I should see a "Activation key Terminal Key x86_64 has been modified" text
 


### PR DESCRIPTION
## What does this PR change?

Adds the "Uyuni Client Tools for SLES15 SP4 x86_64 (Development)" for the terminal activation key because it's needed to install packages from. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): Fixes https://github.com/SUSE/spacewalk/issues/19181
Port(s): not needed only fails in uyuni

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
