### PR TITLE
Prevent npe compare package type

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * PackageEvr
@@ -360,10 +361,10 @@ public class PackageEvr implements Comparable<PackageEvr>, Serializable {
      * @return package type
      */
     public PackageType getPackageType() {
-        if (type.equals(PackageType.DEB.getDbString())) {
+        if (Objects.equals(type, PackageType.DEB.getDbString())) {
             return PackageType.DEB;
         }
-        else if (type.equals(PackageType.RPM.getDbString())) {
+        else if (Objects.equals(type, PackageType.RPM.getDbString())) {
             return PackageType.RPM;
         }
         else {

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.0-prevent-NPE-compare-package-type
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.0-prevent-NPE-compare-package-type
@@ -1,0 +1,1 @@
+- Prevent a NPE when comparing package types


### PR DESCRIPTION
## What does this PR change?

As package type can be NULL, we need a better way to compare package types

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/28195

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
