### PR TITLE
Ignore HTTP proxy for server healthcheck

### DIFF
--- a/containers/server-image/root/usr/bin/healthcheck.sh
+++ b/containers/server-image/root/usr/bin/healthcheck.sh
@@ -2,4 +2,4 @@
 set -e
 /usr/bin/systemctl is-active multi-user.target
 salt-call --local --no-color status.ping_master localhost |grep -q True
-curl --fail http://localhost/rhn/manager/login
+curl --noproxy localhost --fail http://localhost/rhn/manager/login

--- a/containers/server-image/server-image.changes.cbosdo.healthcheck-http-proxy
+++ b/containers/server-image/server-image.changes.cbosdo.healthcheck-http-proxy
@@ -1,0 +1,1 @@
+- Ignore http proxy for localhost in healthcheck (bsc#1249155)


### PR DESCRIPTION
## What does this PR change?

If an HTTP proxy is set on the host, the healthcheck of the containers is also affected. Disabling the use of the proxy for localhost gets the healthcheck to work in such situation. bsc#1249155

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: image healthcheck in special setup

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28308
Port(s): https://github.com/SUSE/spacewalk/pull/28327  https://github.com/SUSE/spacewalk/pull/28326

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
