### PR TITLE
minor changes to keep code consistent with backports

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
@@ -567,7 +567,7 @@ public class UserHandler extends BaseHandler {
                     errorString.append(" :: ");
                 }
             }
-            //Throw a InvalidParameterException with our message string
+
             throw new InvalidParameterException(errorString.toString());
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
@@ -27,7 +27,6 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
-import com.redhat.rhn.frontend.action.common.BadParameterException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidServerGroupException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchRoleException;
@@ -255,7 +254,7 @@ public class UserHandlerTest extends BaseHandlerTestCase {
                     "And Ted", "iron.maiden@rufus.com");
             assertEquals(1, rc);
         }
-        catch (BadParameterException e) {
+        catch (InvalidParameterException e) {
             fail(login + " cause an error");
         }
     }


### PR DESCRIPTION
## What does this PR change?
While backporting code for bug [Bug 1246454](https://bugzilla.suse.com/show_bug.cgi?id=1246454) - Creating a password not compliant with the password policy ends up in stack trace, I discovered the modification was already done in commit fd3ecce1 Michael Calmer <michael.calmer@suse.com> on 14/07/25 at 15:31
Change throwing BadParameterException to InvalidParameterException which is a FaultException

I made small changes in the test to let the code be consistent with the backports

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27866
Port(s):  5.0: https://github.com/SUSE/spacewalk/pull/28329, 5.1: https://github.com/SUSE/spacewalk/pull/28325
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

