### PR TITLE
Bugfix L3: Changing configuration channel ranking in activation key results in internal server error (bsc#1249059)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/token/Token.java
+++ b/java/code/src/com/redhat/rhn/domain/token/Token.java
@@ -143,6 +143,9 @@ public class Token implements Identifiable {
     )
     @OrderColumn(name = "position") // Handles list indexing.
     @ListIndexBase(1)
+    @org.hibernate.annotations.CollectionType(
+            type = "com.redhat.rhn.common.hibernate.ForceRecreationListType"
+    )
     private List<ConfigChannel> configChannels  = new ArrayList<>();
     /**
      * @return Returns the entitlements.

--- a/java/spacewalk-java.changes.carlo.uyuni-1249059-configuration-channel-ranking
+++ b/java/spacewalk-java.changes.carlo.uyuni-1249059-configuration-channel-ranking
@@ -1,0 +1,2 @@
+- Fixes bug: Changing configuration channel ranking in
+  activation key results in internal server error (bsc#1249059)


### PR DESCRIPTION
## What does this PR change?
Fixes Bug 1249059 - L3: Changing Configuration Channel Ranking in Activation Key results in 'Internal Server Error'

The table `rhnRegTokenConfigChannels` contains 3 columns: `token_id`, `config_channel_id` and `position`.
There is a unique index defined on the pair  `(token_id, config_channel_id)`

> `CREATE UNIQUE INDEX rhn_regtok_confchan_t_cc_uq   ON rhnRegTokenConfigChannels (token_id, config_channel_id);`

This constraint creates trouble when the ranking (i.e. position) is changed, resulting in an error like:

> duplicate key value violates unique constraint "rhn_regtok_confchan_t_cc_uq"  Detail: Key (token_id, config_channel_id)=(1, 1) already exists.

the annotation in `Token` class solves the problem:
```
@org.hibernate.annotations.CollectionType(
            type = "com.redhat.rhn.common.hibernate.ForceRecreationListType"
    )
```

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28277
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/28322, not backported to 5.0 and 4.3 (bug from 5.1 forward)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
