### PR TITLE
Remove misleading arrow icons

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -14437,7 +14437,7 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </context-group>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.deploy" xml:space="preserve">
-        <source>Deploy Files</source>
+        <source>Deploy Files:</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/configuration/ChannelOverview.do</context>
         </context-group>
@@ -14467,7 +14467,7 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </context-group>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.compare" xml:space="preserve">
-        <source>Compare Files</source>
+        <source>Compare Files:</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/configuration/ChannelOverview.do</context>
         </context-group>
@@ -14479,7 +14479,7 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </context-group>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modify" xml:space="preserve">
-        <source>Add/Create Files</source>
+        <source>Add/Create Files:</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/configuration/ChannelOverview.do</context>
         </context-group>
@@ -24717,7 +24717,7 @@ given channel.</source>
         </context-group>
       </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.initsls" xml:space="preserve">
-        <source>State File</source>
+        <source>State File:</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/configuration/ChannelOverview.do</context>
         </context-group>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/configuration/channel/tasks.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/configuration/channel/tasks.jspf
@@ -13,7 +13,6 @@
             <c:set var="tableshown" scope="request" value="true" />
             <li class="list-group-item">
                 <strong>
-                    <rhn:icon type="nav-bullet"/>
                     <bean:message key="channelOverview.jsp.tasks.initsls" />
                 </strong>
             </li>
@@ -31,7 +30,6 @@
 
             <li class="list-group-item">
                 <strong>
-                    <rhn:icon type="nav-bullet"/>
                     <bean:message key="channelOverview.jsp.tasks.deploy" />
                 </strong>
             </li>
@@ -64,7 +62,6 @@
             <!-- Compare Files table -->
             <div class="list-group-item">
                 <strong>
-                    <rhn:icon type="nav-bullet"/>
                     <bean:message key="channelOverview.jsp.tasks.compare" />
                 </strong>
             </div>
@@ -80,7 +77,6 @@
             <!-- Add/Create Files table -->
             <div class="list-group-item">
                 <strong>
-                    <rhn:icon type="nav-bullet"/>
                     <bean:message key="channelOverview.jsp.tasks.modify" />
                 </strong>
             </div>


### PR DESCRIPTION
## What does this PR change?

This PR removes some misleading arrows in the WebUI at channel configuration and adds some colons instead to improve usability, addressing https://github.com/SUSE/spacewalk/issues/3688 .

## GUI diff

Before: 
<img width="929" height="589" alt="image" src="https://github.com/user-attachments/assets/72a2bcbd-bd58-4685-bccc-0d8984069ae0" />


After:
<img width="929" height="589" alt="image (1)" src="https://github.com/user-attachments/assets/9d3283d0-1d25-409e-9f5a-f0ec4ee7d582" />

- [x] **DONE**

## Documentation
- No documentation needed: Cosmetic changes

- [x] **DONE**

## Test coverage
- No tests: Cosmetic changes

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/3688
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [x] Re-run test "susemanager_unittests"
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
