### PR TITLE
Fix code for determining private interface

### DIFF
--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -54,9 +54,16 @@ class RemoteNode
 
     if (PRIVATE_ADDRESSES.key? host) && !$private_net.nil?
       @private_ip = net_prefix + PRIVATE_ADDRESSES[host]
-      @private_interface = 'eth1'
-      _out, _err, code = ssh('ip address show ens4')
-      @private_interface = 'ens4' if code.zero?
+      @private_interface = nil
+      %w[eth1 ens4].each do |dev|
+        _output, code = run_local("ip address show dev #{dev}")
+
+        if code.zero?
+          @private_interface = dev
+          break
+        end
+      end
+      raise StandardError, "No private interface for '#{@hostname}'." if @private_interface.nil?
     end
 
     ip = client_public_ip


### PR DESCRIPTION
## What does this PR change?

This PR fixes the code for determining private interface

It uses the same method as for the public interface: test one interface after the other, stopping at the first one that matches. This allows to consider priorities.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s): none, Head only

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
