### PR TITLE
Fix: Broken URL in API docs (bsc#1244177)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/errata/ErrataHandler.java
@@ -588,7 +588,7 @@ public class ErrataHandler extends BaseHandler {
      * @throws FaultException A FaultException is thrown if the errata corresponding to the
      * given advisoryName cannot be found
      *
-     * @apidoc.doc Returns a list of <a href="http://cve.mitre.org/" target="_blank">CVE</a>s applicable to the errata
+     * @apidoc.doc Returns a list of CVEs (http://cve.mitre.org/) applicable to the errata
      * with the given advisory name. For those errata that are present in both vendor and user organizations under the
      * same advisory name, this method retrieves the list of CVEs of both of them.
      * @apidoc.param #session_key()

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/packages/search/PackagesSearchHandler.java
@@ -142,12 +142,11 @@ public class PackagesSearchHandler extends BaseHandler {
      *
      * @apidoc.doc Advanced method to search lucene indexes with a passed in query written
      * in Lucene Query Parser syntax.<br>
-     * Lucene Query Parser syntax is defined at
-     * <a href="http://lucene.apache.org/java/3_5_0/queryparsersyntax.html" target="_blank">
-     * lucene.apache.org</a>.<br>
-     * Fields searchable for Packages:
-     * name, epoch, version, release, arch, description, summary<br>
-     * Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"
+     *Lucene Query Parser syntax is defined at lucene.apache.org
+     * (http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).
+     *
+     *Fields searchable for Packages: name, epoch, version, release, arch, description, summary.<br>
+     *Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("string", "luceneQuery", "a query written in the form of Lucene QueryParser Syntax")
      * @apidoc.returntype
@@ -183,12 +182,11 @@ public class PackagesSearchHandler extends BaseHandler {
      * @apidoc.doc Advanced method to search lucene indexes with a passed in query written
      * in Lucene Query Parser syntax, additionally this method will limit results to those
      * which are in the passed in channel label.<br>
-     * Lucene Query Parser syntax is defined at
-     * <a href="http://lucene.apache.org/java/3_5_0/queryparsersyntax.html" target="_blank">
-     * lucene.apache.org</a>.<br>
-     * Fields searchable for Packages:
-     * name, epoch, version, release, arch, description, summary<br>
-     * Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"
+     *Lucene Query Parser syntax is defined at lucene.apache.org
+     * (http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).
+     *
+     *Fields searchable for Packages: name, epoch, version, release, arch, description, summary.<br>
+     *Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("string", "luceneQuery", "a query written in the form of Lucene QueryParser Syntax")
      * @apidoc.param #param_desc("string", "channelLabel", "the channel Label")
@@ -246,12 +244,11 @@ public class PackagesSearchHandler extends BaseHandler {
      * @apidoc.doc Advanced method to search lucene indexes with a passed in query written
      * in Lucene Query Parser syntax, additionally this method will limit results to those
      * which are associated with a given activation key.<br>
-     * Lucene Query Parser syntax is defined at
-     * <a href="http://lucene.apache.org/java/3_5_0/queryparsersyntax.html" target="_blank">
-     * lucene.apache.org</a>.<br>
-     * Fields searchable for Packages:
-     * name, epoch, version, release, arch, description, summary<br>
-     * Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"
+     *Lucene Query Parser syntax is defined at lucene.apache.org
+     * (http://lucene.apache.org/java/3_5_0/queryparsersyntax.html).
+     *
+     *Fields searchable for Packages: name, epoch, version, release, arch, description, summary.<br>
+     *Lucene Query Example: "name:kernel AND version:2.6.18 AND -description:devel"
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("string", "luceneQuery", "a query written in the form of Lucene QueryParser Syntax")
      * @apidoc.param #param_desc("string", "activationKey", "activation key to look for packages in")

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3367,10 +3367,8 @@ public class SystemHandler extends BaseHandler {
      * @return an array of Integers containing the system Ids
      *
      * @apidoc.doc Returns a list of system IDs whose name matches
-     *  the supplied regular expression(defined by
-     *  <a href="http://docs.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html"
-     *  target="_blank">
-     * Java representation of regular expressions</a>)
+     *  the supplied regular expression defined by Java representation of regular expressions
+     *  (http://docs.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html)
      *
      * @apidoc.param #session_key()
      * @apidoc.param #param_desc("string", "regexp",  "A regular expression")

--- a/java/spacewalk-java.changes.carlo.uyuni-1244177-broken-url-api-docs
+++ b/java/spacewalk-java.changes.carlo.uyuni-1244177-broken-url-api-docs
@@ -1,0 +1,1 @@
+- Fix: Broken URL in API docs (bsc#1244177)


### PR DESCRIPTION
## What does this PR change?
Fixes broken URLs in API docs. This happened in 5 places, wherever the apidoc is referencing an external URL with "target=_blank" tag.

Examples of asciidoc before the change
<img width="1135" height="276" alt="LucenePreAsciiDoc" src="https://github.com/user-attachments/assets/8e6ab076-e099-4971-abee-3a3f45b62dd2" />
<img width="1110" height="267" alt="ErrataPreAscii" src="https://github.com/user-attachments/assets/bb281573-fabd-41dc-95a7-aa66b9e1b8bb" />
<img width="1124" height="287" alt="SystemHandlerPreAsciiDoc" src="https://github.com/user-attachments/assets/768a8e55-2193-44fa-87ab-e28ceae512be" />


After the change:
<img width="1141" height="370" alt="LucenePostAsciiDoc" src="https://github.com/user-attachments/assets/a6dfeaaa-b2d0-4ceb-a5d6-6a650e035c15" />
<img width="1091" height="282" alt="ErrataPostAscii" src="https://github.com/user-attachments/assets/3dfcce01-0ef5-41f3-8e38-914e43c80ef2" />
<img width="1123" height="252" alt="SystemHandlerPostAsciiDoc" src="https://github.com/user-attachments/assets/cd7a24b2-d06a-4896-b082-eefe1392014b" />

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: not needed
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27443
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/29084
5.0: https://github.com/SUSE/spacewalk/pull/29083
4.3: https://github.com/SUSE/spacewalk/pull/29082
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

