### PR TITLE
Update netty related dependencies

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -62,13 +62,13 @@
         <dependency org="suse" name="jsch" rev="0.2.22" />
         <dependency org="suse" name="jctools-core" rev="4.0.5" />
         <dependency org="suse" name="mchange-commons-java" rev="0.2.20" />
-        <dependency org="suse" name="netty-buffer" rev="4.1.118" />
-        <dependency org="suse" name="netty-codec" rev="4.1.118" />
-        <dependency org="suse" name="netty-common" rev="4.1.118" />
-        <dependency org="suse" name="netty-handler" rev="4.1.118" />
-        <dependency org="suse" name="netty-resolver" rev="4.1.118" />
-        <dependency org="suse" name="netty-transport" rev="4.1.118" />
-        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.118" />
+        <dependency org="suse" name="netty-buffer" rev="4.1.126" />
+        <dependency org="suse" name="netty-codec" rev="4.1.126" />
+        <dependency org="suse" name="netty-common" rev="4.1.126" />
+        <dependency org="suse" name="netty-handler" rev="4.1.126" />
+        <dependency org="suse" name="netty-resolver" rev="4.1.126" />
+        <dependency org="suse" name="netty-transport" rev="4.1.126" />
+        <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.126" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.7" />
         <dependency org="suse" name="postgresql-jdbc" rev="42.2.25" />

--- a/java/spacewalk-java.changes.rjpmestre.update-netty-dependencies
+++ b/java/spacewalk-java.changes.rjpmestre.update-netty-dependencies
@@ -1,0 +1,1 @@
+- Update netty related dependencies to 4.1.126


### PR DESCRIPTION
## What does this PR change?

Update netty related dependencies from 4.1.118 to 4.1.126

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
