### PR TITLE
testsuite: re-enable tests for gitfs

### DIFF
--- a/testsuite/features/secondary/srv_salt_git_pillar.feature
+++ b/testsuite/features/secondary/srv_salt_git_pillar.feature
@@ -1,9 +1,6 @@
 # Copyright (c) 2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-# workaround for bsc#1240645
-@bug_reported
-@skip
 @skip_if_github_validation
 @sle_minion
 @scope_salt


### PR DESCRIPTION
## What does this PR change?

This PR re-enables the acceptance tests for testing gitfs, that was disabled in the past for `Uyuni` and `Manager-5.1`.

NOTE: Theses tests are enabled in `Manager-5.0`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28381

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
