### PR TITLE
chore(java): document intentional no-op test endpoints (S1186)

### DIFF
--- a/java/code/src/com/suse/manager/api/test/HttpApiRegistryTest.java
+++ b/java/code/src/com/suse/manager/api/test/HttpApiRegistryTest.java
@@ -37,12 +37,24 @@ public class HttpApiRegistryTest extends RhnJmockBaseTestCase {
      * Stub API handler for testing
      */
     public static class RegistryTestHandler extends BaseHandler {
-        private void notExposed() { }
-        @ReadOnly public void myFirstEndpoint() { }
-        public void mySecondEndpoint() { }
-        @ReadOnly @ApiIgnore public void ignored() { }
-        @ApiIgnore(ApiType.HTTP) public void alsoIgnored() { }
-        @ApiIgnore(ApiType.XMLRPC) public void notIgnored() { }
+        private void notExposed() {
+            // Intentionally empty: test helper method; presence is required for registry discovery tests.
+        }
+        @ReadOnly public void myFirstEndpoint() {
+            // Intentionally empty: test endpoint stub; route registration is validated by expectations.
+        }
+        public void mySecondEndpoint() {
+            // Intentionally empty: second test endpoint stub; behavior is validated elsewhere.
+        }
+        @ReadOnly @ApiIgnore public void ignored() {
+            // Intentionally empty: ignored endpoint used to verify ApiIgnore handling.
+        }
+        @ApiIgnore(ApiType.HTTP) public void alsoIgnored() {
+            // Intentionally empty: ignored for HTTP; ensures only expected routes are registered.
+        }
+        @ApiIgnore(ApiType.XMLRPC) public void notIgnored() {
+            // Intentionally empty: not ignored for HTTP; included to assert correct registration.
+        }
     }
 
     @BeforeEach


### PR DESCRIPTION
Add explanatory comments to empty methods in `HttpApiRegistryTest` so that Sonar rule **S1186** is satisfied without changing test behavior.  
See: [Sonar rule S1186 — “Methods should not be empty”](https://rules.sonarsource.com/java/tag/suspicious/rspec-1186/) and Uyuni tracker [#9945](https://github.com/uyuni-project/uyuni/issues/9945).  [oai_citation:0‡rules.sonarsource.com](https://rules.sonarsource.com/java/tag/suspicious/rspec-1186/?utm_source=chatgpt.com)

## What does this PR change?

Adds explicit “intentionally empty / no-op” comments to test endpoint stubs in `HttpApiRegistryTest.RegistryTestHandler`:

- `myFirstEndpoint`
- `mySecondEndpoint`
- `ignored`
- `alsoIgnored`
- `notIgnored`
 - `notExposed`


These methods are used only as fixtures to verify route registration and `@ApiIgnore` handling; no functional behavior changes.

## GUI diff

No difference.

**Before:**

**After:**

- [x] **DONE**

## Documentation

- No documentation needed: this is a test-only, developer-facing cleanup to satisfy a Sonar rule (no user-visible or API changes).
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: 
- API documentation added:
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage

- No tests: this PR modifies only test fixtures (adds comments to empty methods) and does not alter production code or test logic; existing tests already cover the behavior under verification.

- [x] **DONE**

## Links

- Issue(s): [#9939  — SonarCloud error reduction: java rule S1186](https://github.com/uyuni-project/uyuni/issues/9939)  
- Port(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with  
https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and  
https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

---

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!