### PR TITLE
fix assignment to servergroups

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -366,8 +366,17 @@ public class ServerFactory extends HibernateFactory {
     public static void addServersToGroup(Collection<Server> servers, ServerGroup serverGroup) {
         List<Long> serverIdsToAdd = servers.stream()
                 .filter(s -> s.getOrgId().equals(serverGroup.getOrgId()))
-                .map(Server::getId).collect(Collectors.toList());
+                .map(Server::getId).toList();
 
+        if (serverIdsToAdd.size() != servers.size()) {
+            String incompatible = servers.stream()
+                    .filter(s -> !s.getOrgId().equals(serverGroup.getOrgId()))
+                    .map(Server::getName)
+                    .collect(Collectors.joining(", "));
+
+            LOG.error("Unable to set group '{}' for systems in different organization: {}",
+                    serverGroup.getName(), incompatible);
+        }
         boolean serversUpdated = insertServersToGroup(serverIdsToAdd, serverGroup.getId());
 
         if (serversUpdated) {
@@ -452,7 +461,7 @@ public class ServerFactory extends HibernateFactory {
     public static void removeServersFromGroup(Collection<Server> servers, ServerGroup serverGroup) {
         List<Long> serverIdsToAdd = servers.stream()
                 .filter(s -> s.getOrgId().equals(serverGroup.getOrgId()))
-                .map(Server::getId).collect(Collectors.toList());
+                .map(Server::getId).toList();
 
         boolean serversUpdated = removeServersFromGroup(serverIdsToAdd, serverGroup.getId());
 

--- a/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-servergroup-assignment
+++ b/java/spacewalk-java.changes.mcalmer.Manager-5.0-fix-servergroup-assignment
@@ -1,0 +1,2 @@
+- Before assigning groups to a server filter out groups from
+  incompatible organizations


### PR DESCRIPTION
## What does this PR change?

fix was done before. This add the logging to be alligned with 5.1 and 5.0 branch

## Links

Port(s): https://github.com/SUSE/spacewalk/pull/28252

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
