### PR TITLE
Drop deprecated java unit test methods

### DIFF
--- a/java/code/src/com/redhat/rhn/common/errors/test/BadParameterExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/BadParameterExceptionHandlerTest.java
@@ -86,9 +86,9 @@ public class BadParameterExceptionHandlerTest extends MockObjectTestCase {
             // jmock RULES!
             RhnMockHttpServletRequest request = TestUtils
                     .getRequestWithSessionAndUser();
-            request.setupGetMethod("POST");
-            request.setupGetRequestURI("http://localhost:8080");
-            request.setupGetParameterNames(new Vector<String>().elements());
+            request.setMethod("POST");
+            request.setRequestURI("http://localhost:8080");
+            request.setParameterNames(new Vector<String>().elements());
             RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
             RhnMockDynaActionForm form = new RhnMockDynaActionForm();
 

--- a/java/code/src/com/redhat/rhn/common/errors/test/LookupExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/LookupExceptionHandlerTest.java
@@ -84,9 +84,9 @@ public class LookupExceptionHandlerTest extends MockObjectTestCase {
 
             RhnMockHttpServletRequest request = TestUtils
                     .getRequestWithSessionAndUser();
-            request.setupGetMethod("POST");
-            request.setupGetRequestURI("http://localhost:8080");
-            request.setupGetParameterNames(new Vector<String>().elements());
+            request.setMethod("POST");
+            request.setRequestURI("http://localhost:8080");
+            request.setParameterNames(new Vector<String>().elements());
 
             RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
             RhnMockDynaActionForm form = new RhnMockDynaActionForm();

--- a/java/code/src/com/redhat/rhn/common/errors/test/PermissionExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/PermissionExceptionHandlerTest.java
@@ -84,9 +84,9 @@ public class PermissionExceptionHandlerTest extends MockObjectTestCase {
 
             RhnMockHttpServletRequest request = TestUtils
                     .getRequestWithSessionAndUser();
-            request.setupGetMethod("POST");
-            request.setupGetRequestURI("http://localhost:8080");
-            request.setupGetParameterNames(new Vector<String>().elements());
+            request.setMethod("POST");
+            request.setRequestURI("http://localhost:8080");
+            request.setParameterNames(new Vector<String>().elements());
 
             HttpServletResponse response = mock(HttpServletResponse.class);
             context.checking(new Expectations() {{

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/test/AllChannelTreeActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/test/AllChannelTreeActionTest.java
@@ -45,7 +45,7 @@ public class AllChannelTreeActionTest extends RhnBaseTestCase {
         };
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action, RhnHelper.DEFAULT_FORWARD);
-        sah.getRequest().setupAddParameter(RequestContext.FILTER_STRING, (String) null);
+        sah.getRequest().addParameter(RequestContext.FILTER_STRING, (String) null);
 
         User user = sah.getUser();
         Channel channel = ChannelFactoryTest.createTestChannel(user);

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/test/RetiredChannelTreeActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/test/RetiredChannelTreeActionTest.java
@@ -46,7 +46,7 @@ public class RetiredChannelTreeActionTest extends RhnBaseTestCase {
         };
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action, RhnHelper.DEFAULT_FORWARD);
-        sah.getRequest().setupAddParameter(RequestContext.FILTER_STRING, (String) null);
+        sah.getRequest().addParameter(RequestContext.FILTER_STRING, (String) null);
 
         User user = sah.getUser();
         Channel channel = ChannelFactoryTest.createTestChannel(user);

--- a/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/test/RhnSetActionTest.java
@@ -68,10 +68,10 @@ public class RhnSetActionTest extends RhnBaseTestCase {
         sah.setUpAction(action);
         sah.setupClampListBounds();
         sah.getRequest().setRequestURL("foo");
-        sah.getRequest().setupAddParameter("items_selected",
+        sah.getRequest().addParameter("items_selected",
             new String[] {"10", "20", "30"});
-        sah.getRequest().setupAddParameter("newset", (String)null);
-        sah.getRequest().setupAddParameter("items_on_page", (String)null);
+        sah.getRequest().addParameter("newset", (String)null);
+        sah.getRequest().addParameter("items_on_page", (String)null);
         ActionForward forward = sah.executeAction("updatelist");
 
         // let's go find the data
@@ -85,10 +85,10 @@ public class RhnSetActionTest extends RhnBaseTestCase {
         sah.setUpAction(action);
         sah.setupClampListBounds();
         sah.getRequest().setRequestURL("foo");
-        sah.getRequest().setupAddParameter("items_selected",
+        sah.getRequest().addParameter("items_selected",
             new String[] {"777|999", "99|555", "666|77656"});
-        sah.getRequest().setupAddParameter("newset", (String)null);
-        sah.getRequest().setupAddParameter("items_on_page", (String)null);
+        sah.getRequest().addParameter("newset", (String)null);
+        sah.getRequest().addParameter("items_on_page", (String)null);
         sah.executeAction("updatelist");
 
         // let's go find the data
@@ -151,7 +151,7 @@ public class RhnSetActionTest extends RhnBaseTestCase {
     public void testFilter() throws Exception {
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action);
-        sah.getRequest().setupAddParameter(RequestContext.FILTER_STRING, "zzzz");
+        sah.getRequest().addParameter(RequestContext.FILTER_STRING, "zzzz");
         sah.setupClampListBounds();
 
         ActionForward forward = sah.executeAction("filter");
@@ -164,10 +164,10 @@ public class RhnSetActionTest extends RhnBaseTestCase {
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action);
         sah.setupClampListBounds();
-        sah.getRequest().setupAddParameter("items_selected",
+        sah.getRequest().addParameter("items_selected",
             new String[] {"10", "20", "30"});
-        sah.getRequest().setupAddParameter("newset", (String)null);
-        sah.getRequest().setupAddParameter("items_on_page", (String)null);
+        sah.getRequest().addParameter("newset", (String)null);
+        sah.getRequest().addParameter("items_on_page", (String)null);
         ActionForward forward  = sah.executeAction("unspecified");
 
         verifyParam(forward.getPath(), "newset", "[10, 20, 30]");

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
@@ -67,11 +67,11 @@ public class AffectedSystemsActionTest extends MockObjectTestCase {
             will(returnValue(forward));
         } });
 
-        request.setupAddParameter("items_selected", (String[]) null);
-        request.setupAddParameter("items_on_page", (String[]) null);
+        request.addParameter("items_selected", (String[]) null);
+        request.addParameter("items_on_page", (String[]) null);
         addPagination(request);
-        request.setupAddParameter("filter_string", "");
-        request.setupAddParameter("eid", "12345");
+        request.addParameter("filter_string", "");
+        request.addParameter("eid", "12345");
 
         ActionForward sameForward = action.applyErrata(mapping, form, request, response);
         assertTrue(sameForward.getPath().startsWith("path?"));
@@ -84,24 +84,24 @@ public class AffectedSystemsActionTest extends MockObjectTestCase {
             will(returnValue(forward));
         } });
 
-        request.setupAddParameter("items_selected", "123456");
-        request.setupAddParameter("items_on_page", (String[]) null);
-        request.setupAddParameter("eid", "54321");
+        request.addParameter("items_selected", "123456");
+        request.addParameter("items_on_page", (String[]) null);
+        request.addParameter("eid", "54321");
 
         sameForward = action.applyErrata(mapping, form, request, response);
         assertEquals("path?eid=54321", sameForward.getPath());
     }
 
     private void addPagination(RhnMockHttpServletRequest r) {
-        r.setupAddParameter(Pagination.FIRST.getElementName(), "someValue");
-        r.setupAddParameter(Pagination.FIRST.getLowerAttributeName(), "10");
-        r.setupAddParameter(Pagination.PREV.getElementName(), "0");
-        r.setupAddParameter(Pagination.PREV.getLowerAttributeName(), "");
-        r.setupAddParameter(Pagination.NEXT.getElementName(), "20");
-        r.setupAddParameter(Pagination.NEXT.getLowerAttributeName(), "");
-        r.setupAddParameter(Pagination.LAST.getElementName(), "");
-        r.setupAddParameter(Pagination.LAST.getLowerAttributeName(), "20");
-        r.setupAddParameter("lower", "10");
+        r.addParameter(Pagination.FIRST.getElementName(), "someValue");
+        r.addParameter(Pagination.FIRST.getLowerAttributeName(), "10");
+        r.addParameter(Pagination.PREV.getElementName(), "0");
+        r.addParameter(Pagination.PREV.getLowerAttributeName(), "");
+        r.addParameter(Pagination.NEXT.getElementName(), "20");
+        r.addParameter(Pagination.NEXT.getLowerAttributeName(), "");
+        r.addParameter(Pagination.LAST.getElementName(), "");
+        r.addParameter(Pagination.LAST.getLowerAttributeName(), "20");
+        r.addParameter("lower", "10");
     }
 
     @Test
@@ -123,10 +123,10 @@ public class AffectedSystemsActionTest extends MockObjectTestCase {
                     server.getId(), errata.getId());
         }
 
-        ah.getRequest().setupAddParameter("eid", errata.getId().toString());
-        ah.getRequest().setupAddParameter("eid", errata.getId().toString()); // stupid mock
-        ah.getRequest().setupAddParameter("items_on_page", (String[]) null);
-        ah.getRequest().setupAddParameter("items_selected", (String[]) null);
+        ah.getRequest().addParameter("eid", errata.getId().toString());
+        ah.getRequest().addParameter("eid", errata.getId().toString()); // stupid mock
+        ah.getRequest().addParameter("items_on_page", (String[]) null);
+        ah.getRequest().addParameter("items_selected", (String[]) null);
         ah.executeAction("selectall");
 
         RhnSetActionTest.verifyRhnSetData(ah.getUser().getId(),

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/BaseErrataActionTestCase.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/BaseErrataActionTestCase.java
@@ -43,9 +43,9 @@ public abstract class BaseErrataActionTestCase extends RhnBaseTestCase {
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(getAction(), "delete");
         sah.getRequest().setRequestURL("foo");
-        sah.getRequest().setupAddParameter("items_selected",
+        sah.getRequest().addParameter("items_selected",
             new String[] {"10", "20", "30"});
-        sah.getRequest().setupAddParameter("items_on_page", (String)null);
+        sah.getRequest().addParameter("items_on_page", (String)null);
         sah.setupClampListBounds();
         ActionForward testforward = sah.executeAction("deleteErrata");
 
@@ -63,8 +63,8 @@ public abstract class BaseErrataActionTestCase extends RhnBaseTestCase {
             createErrata(user);
         }
 
-        ah.getRequest().setupAddParameter("items_on_page", (String[])null);
-        ah.getRequest().setupAddParameter("items_selected", (String[])null);
+        ah.getRequest().addParameter("items_on_page", (String[])null);
+        ah.getRequest().addParameter("items_selected", (String[])null);
         ah.executeAction("selectall");
 
         RhnSet set = RhnSetDecl.ERRATA_TO_DELETE.get(user);

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/BaseErrataSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/BaseErrataSetupActionTest.java
@@ -57,7 +57,7 @@ public class BaseErrataSetupActionTest extends RhnBaseTestCase {
         Errata published = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
 
         //test lookup exception
-        request.setupAddParameter("eid", Long.valueOf(-92861).toString());
+        request.addParameter("eid", Long.valueOf(-92861).toString());
         try {
             action.execute(mapping, form, request, response);
             fail();
@@ -67,7 +67,7 @@ public class BaseErrataSetupActionTest extends RhnBaseTestCase {
         }
 
         //test default case
-        request.setupAddParameter("eid", published.getId().toString());
+        request.addParameter("eid", published.getId().toString());
         ActionForward result = action.execute(mapping, form, request, response);
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
         assertNotNull(request.getAttribute("advisory"));

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelActionTest.java
@@ -63,7 +63,7 @@ public class ChannelActionTest extends RhnBaseTestCase {
         RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
         RhnMockHttpSession session = new RhnMockHttpSession();
         request.setSession(session);
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
         RhnMockDynaActionForm form = new RhnMockDynaActionForm();
 
         RequestContext requestContext = new RequestContext(request);
@@ -74,9 +74,9 @@ public class ChannelActionTest extends RhnBaseTestCase {
         Errata errata = ErrataFactoryTest.createTestErrata(usr.getOrg().getId());
 
         //We can't publish without selecting channels. Make sure we get an error.
-        request.setupAddParameter("eid", errata.getId().toString());
-        request.setupAddParameter("items_on_page", "");
-        request.setupAddParameter("items_selected", new String[0]);
+        request.addParameter("eid", errata.getId().toString());
+        request.addParameter("items_on_page", "");
+        request.addParameter("items_selected", new String[0]);
 
         ActionForward result = action.publish(mapping, form, request, response);
         assertEquals("failure", result.getName());
@@ -85,9 +85,9 @@ public class ChannelActionTest extends RhnBaseTestCase {
         Channel c1 = ChannelFactoryTest.createTestChannel(usr);
 
         //setup the request
-        request.setupAddParameter("eid", errata.getId().toString());
-        request.setupAddParameter("items_on_page", "");
-        request.setupAddParameter("items_selected", c1.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
+        request.addParameter("items_on_page", "");
+        request.addParameter("items_selected", c1.getId().toString());
 
         result = action.publish(mapping, form, request, response);
         assertEquals(result.getName(), "publish");
@@ -109,7 +109,7 @@ public class ChannelActionTest extends RhnBaseTestCase {
         RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
         RhnMockHttpSession session = new RhnMockHttpSession();
         request.setSession(session);
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
         RhnMockDynaActionForm form = new RhnMockDynaActionForm();
 
         RequestContext requestContext = new RequestContext(request);
@@ -124,9 +124,9 @@ public class ChannelActionTest extends RhnBaseTestCase {
         flushAndEvict(errata);
 
         //We can't take away all channels. make sure we get an error
-        request.setupAddParameter("eid", id.toString());
-        request.setupAddParameter("items_on_page", "");
-        request.setupAddParameter("items_selected", new String[0]);
+        request.addParameter("eid", id.toString());
+        request.addParameter("items_on_page", "");
+        request.addParameter("items_selected", new String[0]);
 
         ActionForward result = action.publish(mapping, form, request, response);
         assertEquals("failure", result.getName());
@@ -139,9 +139,9 @@ public class ChannelActionTest extends RhnBaseTestCase {
 
         //setup the request
         String[] selected = {c1.getId().toString(), c2.getId().toString()};
-        request.setupAddParameter("eid", id.toString());
-        request.setupAddParameter("items_on_page", "");
-        request.setupAddParameter("items_selected", selected);
+        request.addParameter("eid", id.toString());
+        request.addParameter("items_on_page", "");
+        request.addParameter("items_selected", selected);
 
         result = action.updateChannels(mapping, form, request, response);
         assertEquals("push", result.getName());
@@ -159,9 +159,9 @@ public class ChannelActionTest extends RhnBaseTestCase {
         //make sure we can take away channels
         //setup the request
         String[] selected2 = {c2.getId().toString()};
-        request.setupAddParameter("eid", id.toString());
-        request.setupAddParameter("items_on_page", "");
-        request.setupAddParameter("items_selected", selected2);
+        request.addParameter("eid", id.toString());
+        request.addParameter("items_on_page", "");
+        request.addParameter("items_selected", selected2);
         result = action.updateChannels(mapping, form, request, response);
 
         assertEquals("push", result.getName());
@@ -185,10 +185,10 @@ public class ChannelActionTest extends RhnBaseTestCase {
             ChannelFactoryTest.createTestChannel(user);
         }
 
-        ah.getRequest().setupAddParameter("eid", errata.getId().toString());
-        ah.getRequest().setupAddParameter("items_on_page", (String[])null);
-        ah.getRequest().setupAddParameter("items_selected", (String[])null);
-        ah.getRequest().setupAddParameter("returnvisit", "false");
+        ah.getRequest().addParameter("eid", errata.getId().toString());
+        ah.getRequest().addParameter("items_on_page", (String[])null);
+        ah.getRequest().addParameter("items_selected", (String[])null);
+        ah.getRequest().addParameter("returnvisit", "false");
         ah.executeAction("selectall");
 
         //satellite could already have some channels

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelSetupActionTest.java
@@ -72,10 +72,10 @@ public class ChannelSetupActionTest extends RhnBaseTestCase {
         e.addChannel(c1);
         ErrataFactory.save(e);
         //setup the request object
-        sah.getRequest().setupAddParameter("eid", e.getId().toString());
-        sah.getRequest().setupAddParameter("newset", (String) null);
-        sah.getRequest().setupAddParameter("returnvisit", (String) null);
-        sah.getRequest().setupAddParameter("returnvisit", (String) null);
+        sah.getRequest().addParameter("eid", e.getId().toString());
+        sah.getRequest().addParameter("newset", (String) null);
+        sah.getRequest().addParameter("returnvisit", (String) null);
+        sah.getRequest().addParameter("returnvisit", (String) null);
         sah.executeAction();
 
         RequestContext requestContext = new RequestContext(sah.getRequest());

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/CreateActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/CreateActionTest.java
@@ -56,7 +56,7 @@ public class CreateActionTest extends RhnBaseTestCase {
         RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
         RhnMockHttpSession session = new RhnMockHttpSession();
         request.setSession(session);
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
 
         RhnMockDynaActionForm form = fillOutForm();
         form.set("synopsis", ""); //required field, so we should get a validation error
@@ -70,10 +70,10 @@ public class CreateActionTest extends RhnBaseTestCase {
         RhnSetManager.store(destinationChannels);
         String destinationId = destination.getId().toString();
         // both read twice
-        request.setupAddParameter("items_on_page", new String[]{destinationId});
-        request.setupAddParameter("items_on_page", new String[]{destinationId});
-        request.setupAddParameter("items_selected", new String[]{destinationId});
-        request.setupAddParameter("items_selected", new String[]{destinationId});
+        request.addParameter("items_on_page", new String[]{destinationId});
+        request.addParameter("items_on_page", new String[]{destinationId});
+        request.addParameter("items_selected", new String[]{destinationId});
+        request.addParameter("items_selected", new String[]{destinationId});
 
         ActionForward result = action.create(mapping, form, request, response);
         assertEquals(result.getName(), "failure");

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/DeleteBugActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/DeleteBugActionTest.java
@@ -55,7 +55,7 @@ public class DeleteBugActionTest extends RhnBaseTestCase {
         RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
         RhnMockHttpSession session = new RhnMockHttpSession();
         request.setSession(session);
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
 
         RhnMockDynaActionForm form = new RhnMockDynaActionForm();
 
@@ -73,8 +73,8 @@ public class DeleteBugActionTest extends RhnBaseTestCase {
 
         assertEquals(1, e.getBugs().size());
         //setup the request
-        request.setupAddParameter("eid", eid.toString());
-        request.setupAddParameter("bid", bugId.toString());
+        request.addParameter("eid", eid.toString());
+        request.addParameter("bid", bugId.toString());
 
         ActionForward result = action.execute(mapping, form, request, response);
         assertEquals(result.getName(), RhnHelper.DEFAULT_FORWARD);

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/EditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/EditActionTest.java
@@ -54,7 +54,7 @@ public class EditActionTest extends RhnBaseTestCase {
         RhnMockHttpServletRequest request = TestUtils.getRequestWithSessionAndUser();
         RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
         RhnMockDynaActionForm form = new RhnMockDynaActionForm("errataEditForm");
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
 
         RequestContext requestContext = new RequestContext(request);
 
@@ -64,8 +64,8 @@ public class EditActionTest extends RhnBaseTestCase {
         //Create another for checking adv name uniqueness constraint
         Errata errata2 = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
 
-        request.setupAddParameter("eid", errata.getId().toString());
-        request.setupAddParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
 
         //Execute setupAction to fillout form
         ActionForward result = action.unspecified(mapping, form, request, response);
@@ -78,20 +78,20 @@ public class EditActionTest extends RhnBaseTestCase {
         form.set("buglistUrlNew", "");
 
         //make sure we still get validation errors
-        request.setupAddParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
         form.set("synopsis", ""); //required field, so we should get a validation error
         result = action.update(mapping, form, request, response);
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
 
         //make sure adv name has to be unique
-        request.setupAddParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
         form.set("synopsis", "this errata has been edited");
         form.set("advisoryName", errata2.getAdvisoryName());
         result = action.update(mapping, form, request, response);
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
 
         //make sure adv name cannot start with rh
-        request.setupAddParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
         form.set("advisoryName", "rh" + TestUtils.randomString());
         result = action.update(mapping, form, request, response);
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
@@ -101,8 +101,8 @@ public class EditActionTest extends RhnBaseTestCase {
         /*
          * I hate it when Mock Objects don't act like the objects they mock
          */
-        request.setupAddParameter("eid", errata.getId().toString());
-        request.setupAddParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
         form.set("advisoryName", newAdvisoryName);
         //add a bug
         form.set("buglistIdNew", "123");
@@ -110,13 +110,13 @@ public class EditActionTest extends RhnBaseTestCase {
         form.set("buglistUrlNew", "https://bugzilla.redhat.com/show_bug.cgi?id=123");
         //edit the keywords
         form.set("keywords", "yankee, hotel, foxtrot");
-        request.setupAddParameter("eid", errata.getId().toString());
-        request.setupAddParameter("buglistIdNew", "123");
-        request.setupAddParameter("buglistSummaryNew", "test bug for a test errata");
-        request.setupAddParameter("buglistUrlNew", "https://bugzilla.redhat.com/show_bug.cgi?id=123");
-        request.setupAddParameter("buglistIdNew", "123");
-        request.setupAddParameter("buglistSummaryNew", "test bug for a test errata");
-        request.setupAddParameter("buglistUrlNew",
+        request.addParameter("eid", errata.getId().toString());
+        request.addParameter("buglistIdNew", "123");
+        request.addParameter("buglistSummaryNew", "test bug for a test errata");
+        request.addParameter("buglistUrlNew", "https://bugzilla.redhat.com/show_bug.cgi?id=123");
+        request.addParameter("buglistIdNew", "123");
+        request.addParameter("buglistSummaryNew", "test bug for a test errata");
+        request.addParameter("buglistUrlNew",
                 "https://bugzilla.redhat.com/show_bug.cgi?id=123");
         result = action.update(mapping, form, request, response);
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
@@ -150,7 +150,7 @@ public class EditActionTest extends RhnBaseTestCase {
         User user = requestContext.getCurrentUser();
         Errata errata = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
 
-        request.setupAddParameter("eid", errata.getId().toString());
+        request.addParameter("eid", errata.getId().toString());
 
         //make sure our form vars are null
         assertNull(form.get("synopsis"));

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataDetailsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataDetailsSetupActionTest.java
@@ -91,7 +91,7 @@ public class ErrataDetailsSetupActionTest extends RhnBaseTestCase {
 
         ErrataFactory.save(errata);
 
-        sah.getRequest().setupAddParameter("eid", errata.getId().toString());
+        sah.getRequest().addParameter("eid", errata.getId().toString());
 
         sah.executeAction();
 

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataPackagesSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataPackagesSetupActionTest.java
@@ -39,7 +39,7 @@ public class ErrataPackagesSetupActionTest extends RhnBaseTestCase {
         Errata e = ErrataFactoryTest.createTestErrata(
                 sah.getUser().getOrg().getId());
 
-        sah.getRequest().setupAddParameter("eid", e.getId().toString());
+        sah.getRequest().addParameter("eid", e.getId().toString());
 
         sah.executeAction();
 

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataSearchActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataSearchActionTest.java
@@ -47,16 +47,16 @@ public class ErrataSearchActionTest extends RhnBaseTestCase {
         ah.setUpAction(action, RhnHelper.DEFAULT_FORWARD);
         ah.getForm().set(BaseSearchAction.VIEW_MODE, BaseSearchAction.OPT_ADVISORY);
         ah.getForm().set(RhnAction.SUBMITTED, Boolean.TRUE);
-        ah.getRequest().setupAddParameter(BaseSearchAction.SEARCH_STR, name);
-        ah.getRequest().setupAddParameter(BaseSearchAction.VIEW_MODE, BaseSearchAction.OPT_ADVISORY);
-        ah.getRequest().setupAddParameter(BaseSearchAction.FINE_GRAINED, "on");
+        ah.getRequest().addParameter(BaseSearchAction.SEARCH_STR, name);
+        ah.getRequest().addParameter(BaseSearchAction.VIEW_MODE, BaseSearchAction.OPT_ADVISORY);
+        ah.getRequest().addParameter(BaseSearchAction.FINE_GRAINED, "on");
 
         Map<String, String> paramnames = new HashMap<>();
         paramnames.put(BaseSearchAction.SEARCH_STR, name);
         paramnames.put(BaseSearchAction.VIEW_MODE, BaseSearchAction.OPT_ADVISORY);
         paramnames.put(BaseSearchAction.FINE_GRAINED, "on");
         paramnames.put(RhnAction.SUBMITTED, "true");
-        ah.getRequest().setupGetParameterNames(
+        ah.getRequest().setParameterNames(
                 IteratorUtils.asEnumeration(paramnames.keySet().iterator()));
 
         ah.setupClampListBounds();

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/NotifyActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/NotifyActionTest.java
@@ -59,7 +59,7 @@ public class NotifyActionTest extends RhnBaseTestCase {
         published.addChannel(c);
 
         //test default case
-        request.setupAddParameter("eid", published.getId().toString());
+        request.addParameter("eid", published.getId().toString());
         ActionForward result = action.execute(mapping, form, request, response);
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
 

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/NotifySetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/NotifySetupActionTest.java
@@ -55,8 +55,8 @@ public class NotifySetupActionTest extends RhnBaseTestCase {
         Errata published = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
 
         //test default case
-        request.setupAddParameter("eid", published.getId().toString());
-        request.setupAddParameter("eid", published.getId().toString());
+        request.addParameter("eid", published.getId().toString());
+        request.addParameter("eid", published.getId().toString());
         ActionForward result = action.execute(mapping, form, request, response);
         assertEquals(RhnHelper.DEFAULT_FORWARD, result.getName());
         assertNotNull(request.getAttribute("advisory"));

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartHelperTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartHelperTest.java
@@ -63,7 +63,7 @@ public class KickstartHelperTest extends BaseTestCaseWithUser {
         UserFactory.save(user);
         ksdata = KickstartDataTest.createKickstartWithOptions(user.getOrg());
         mockRequest = new RhnMockHttpServletRequest();
-        mockRequest.setupGetRemoteAddr("127.0.0.1");
+        mockRequest.setRemoteAddr("127.0.0.1");
         request = new RhnHttpServletRequest(mockRequest);
         helper = new KickstartHelper(request);
     }
@@ -177,7 +177,7 @@ public class KickstartHelperTest extends BaseTestCaseWithUser {
                 ",1006678487::1152567362.02:21600.0:t15lgsaTRKpX6AxkUFQ11A==:f" +
                 "js-0-12.rhndev.redhat.com";
 
-        mockRequest.setupGetHeader(KickstartHelper.XRHNPROXYAUTH, proxyheader);
+        mockRequest.setHeader(KickstartHelper.XRHNPROXYAUTH, proxyheader);
         helper = new KickstartHelper(request);
         assertEquals("fjs-0-08.rhndev.redhat.com", helper.getKickstartHost());
 

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/test/PackageIndexActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/test/PackageIndexActionTest.java
@@ -44,7 +44,7 @@ public class PackageIndexActionTest extends RhnBaseTestCase {
         ah.getUser().addPermanentRole(RoleFactory.ORG_ADMIN);
 
         Server svr = ServerFactoryTest.createTestServer(ah.getUser(), true);
-        ah.getRequest().setupAddParameter("sid", svr.getId().toString());
+        ah.getRequest().addParameter("sid", svr.getId().toString());
         ah.executeAction("update");
 
         SelectMode m = ModeFactory.getMode("test_queries", "scheduled_actions");

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/ActionDetailsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/ActionDetailsSetupActionTest.java
@@ -39,7 +39,7 @@ public class ActionDetailsSetupActionTest extends RhnBaseTestCase {
         User user = sah.getUser();
         Action a1 = ActionFactoryTest.createAction(user, ActionFactory.TYPE_REBOOT);
         a1.setSchedulerUser(user);
-        sah.getRequest().setupAddParameter("aid", a1.getId().toString());
+        sah.getRequest().addParameter("aid", a1.getId().toString());
 
 
         sah.executeAction();

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/ActionSystemsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/ActionSystemsSetupActionTest.java
@@ -45,7 +45,7 @@ public class ActionSystemsSetupActionTest extends RhnBaseTestCase {
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action);
 
-        sah.getRequest().setupAddParameter("aid", (String)null);
+        sah.getRequest().addParameter("aid", (String)null);
         try {
             sah.executeAction();
             fail();
@@ -54,7 +54,7 @@ public class ActionSystemsSetupActionTest extends RhnBaseTestCase {
             //no op
         }
 
-        sah.getRequest().setupAddParameter("aid", "-99999");
+        sah.getRequest().addParameter("aid", "-99999");
         try {
             sah.executeAction();
             fail();
@@ -71,10 +71,10 @@ public class ActionSystemsSetupActionTest extends RhnBaseTestCase {
         ActionFactory.save(a);
 
         sah.setupClampListBounds();
-        sah.getRequest().setupAddParameter("aid", a.getId().toString());
-        sah.getRequest().setupAddParameter("filter_string", "");
-        sah.getRequest().setupAddParameter("newset", (String)null);
-        sah.getRequest().setupAddParameter("returnvisit", (String) null);
+        sah.getRequest().addParameter("aid", a.getId().toString());
+        sah.getRequest().addParameter("filter_string", "");
+        sah.getRequest().addParameter("newset", (String)null);
+        sah.getRequest().addParameter("returnvisit", (String) null);
 
         sah.executeAction();
         assertNotNull(sah.getRequest().getAttribute(RequestContext.PAGE_LIST));

--- a/java/code/src/com/redhat/rhn/frontend/action/schedule/test/InProgressSystemsActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/schedule/test/InProgressSystemsActionTest.java
@@ -52,10 +52,10 @@ public class InProgressSystemsActionTest extends RhnBaseTestCase {
             ServerActionTest.createServerAction(server, a);
         }
 
-        ah.getRequest().setupAddParameter("aid", a.getId().toString());
-        ah.getRequest().setupAddParameter("aid", a.getId().toString()); //stupid mock
-        ah.getRequest().setupAddParameter("items_on_page", (String[])null);
-        ah.getRequest().setupAddParameter("items_selected", (String[])null);
+        ah.getRequest().addParameter("aid", a.getId().toString());
+        ah.getRequest().addParameter("aid", a.getId().toString()); //stupid mock
+        ah.getRequest().addParameter("items_on_page", (String[])null);
+        ah.getRequest().addParameter("items_selected", (String[])null);
         ah.executeAction("selectall");
 
         RhnSetActionTest.verifyRhnSetData(user.getId(), "unscheduleaction", 4);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/test/PreservationListConfirmDeleteActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/test/PreservationListConfirmDeleteActionTest.java
@@ -71,9 +71,9 @@ public class PreservationListConfirmDeleteActionTest extends RhnBaseTestCase {
 
         RhnSetManager.store(set);
         ah.setupClampListBounds();
-        ah.getRequest().setupAddParameter("newset", (String)null);
-        ah.getRequest().setupAddParameter("returnvisit", (String) null);
-        ah.getRequest().setupAddParameter("submitted", "false");
+        ah.getRequest().addParameter("newset", (String)null);
+        ah.getRequest().addParameter("returnvisit", (String) null);
+        ah.getRequest().addParameter("submitted", "false");
         ah.executeAction();
 
         RhnMockHttpServletRequest request = ah.getRequest();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/test/PreservationListDeleteActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/test/PreservationListDeleteActionTest.java
@@ -56,8 +56,8 @@ public class PreservationListDeleteActionTest extends RhnBaseTestCase {
         ah.setUpAction(action);
         ah.setupClampListBounds();
         ah.getRequest().setRequestURL("");
-        ah.getRequest().setupAddParameter("newset", (String)null);
-        ah.getRequest().setupAddParameter("items_on_page", (String)null);
+        ah.getRequest().addParameter("newset", (String)null);
+        ah.getRequest().addParameter("items_on_page", (String)null);
         List ids = new LinkedList<>();
 
         // give list some FileLists
@@ -68,7 +68,7 @@ public class PreservationListDeleteActionTest extends RhnBaseTestCase {
             ids.add(fl.getId().toString());
         }
 
-        ah.getRequest().setupAddParameter("items_selected",
+        ah.getRequest().addParameter("items_selected",
                                          (String[]) ids.toArray(new String[0]));
 
         ActionForward testforward = ah.executeAction("operateOnSelectedSet");

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/test/PreservationListDeleteSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/provisioning/test/PreservationListDeleteSubmitActionTest.java
@@ -54,8 +54,8 @@ public class PreservationListDeleteSubmitActionTest extends RhnBaseTestCase {
         ActionHelper ah = new ActionHelper();
         ah.setUpAction(action, "delete");
         ah.getRequest().setRequestURL("");
-        ah.getRequest().setupAddParameter("newset", (String)null);
-        ah.getRequest().setupAddParameter("items_on_page", (String)null);
+        ah.getRequest().addParameter("newset", (String)null);
+        ah.getRequest().addParameter("items_on_page", (String)null);
         List ids = new LinkedList<>();
 
         // give list some FileLists
@@ -69,7 +69,7 @@ public class PreservationListDeleteSubmitActionTest extends RhnBaseTestCase {
             CommonFactory.removeFileList(fl);
         }
 
-        ah.getRequest().setupAddParameter("items_selected",
+        ah.getRequest().addParameter("items_selected",
                 (String[]) ids.toArray(new String[0]));
         ah.setupClampListBounds();
         ActionForward testforward = ah.executeAction("forwardToConfirm");
@@ -86,9 +86,9 @@ public class PreservationListDeleteSubmitActionTest extends RhnBaseTestCase {
         ActionHelper ah = new ActionHelper();
         ah.setUpAction(action, RhnHelper.DEFAULT_FORWARD);
         ah.getRequest().setRequestURL("");
-        ah.getRequest().setupAddParameter("newset", (String)null);
-        ah.getRequest().setupAddParameter("items_on_page", (String)null);
-        ah.getRequest().setupAddParameter("items_selected", (String[]) null);
+        ah.getRequest().addParameter("newset", (String)null);
+        ah.getRequest().addParameter("items_on_page", (String)null);
+        ah.getRequest().addParameter("items_selected", (String[]) null);
         ah.setupClampListBounds();
         ActionForward testforward = ah.executeAction("forwardToConfirm");
         assertEquals("path?lower=10", testforward.getPath());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/BaseSystemListActionTestCase.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/BaseSystemListActionTestCase.java
@@ -51,8 +51,8 @@ public abstract class BaseSystemListActionTestCase extends RhnBaseTestCase {
                 ServerConstants.getServerGroupTypeEnterpriseEntitled());
         UserManager.storeUser(user);
         String sid = server.getId().toString();
-        ah.getRequest().setupAddParameter("items_on_page", (String[])null);
-        ah.getRequest().setupAddParameter("items_selected", new String[] { sid });
+        ah.getRequest().addParameter("items_on_page", (String[])null);
+        ah.getRequest().addParameter("items_selected", new String[] { sid });
         ah.executeAction("updatelist");
 
         RhnSetActionTest.verifyRhnSetData(ah.getUser(), RhnSetDecl.SYSTEMS, 1);
@@ -68,8 +68,8 @@ public abstract class BaseSystemListActionTestCase extends RhnBaseTestCase {
         User user = ah.getUser();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         UserManager.storeUser(user);
-        ah.getRequest().setupAddParameter("items_on_page", (String[])null);
-        ah.getRequest().setupAddParameter("items_selected", (String[]) null);
+        ah.getRequest().addParameter("items_on_page", (String[])null);
+        ah.getRequest().addParameter("items_selected", (String[]) null);
         ah.executeAction("selectall");
         // This test only ensures that 'Select All' doesn't blow up.
         // To really test that something got selected, we would have to create an

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/SPMigrationActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/SPMigrationActionTest.java
@@ -85,8 +85,8 @@ public class SPMigrationActionTest {
         ActionForward target = new ActionForward("schedule", "path", false);
 
         String sid = server.getId().toString();
-        request.setupAddParameter("sid", sid);
-        request.setupAddParameter(RequestContext.DISPATCH, "schedule");
+        request.addParameter("sid", sid);
+        request.addParameter(RequestContext.DISPATCH, "schedule");
         RhnMockHttpServletResponse response = new RhnMockHttpServletResponse();
         mapping.addForwardConfig(target);
         SPMigrationAction action = new SPMigrationAction();

--- a/java/code/src/com/redhat/rhn/frontend/action/test/ResetLinkActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/test/ResetLinkActionTest.java
@@ -61,7 +61,7 @@ public class ResetLinkActionTest extends BaseTestCaseWithUser {
     public void testPerformInvalidToken() {
         ResetPassword rp = ResetPasswordFactory.createNewEntryFor(user);
         ResetPasswordFactory.invalidateToken(rp.getToken());
-        request.setupAddParameter("token", rp.getToken());
+        request.addParameter("token", rp.getToken());
         ActionForward rc = action.execute(mapping, form, request, response);
         assertEquals(invalid, rc);
     }
@@ -69,7 +69,7 @@ public class ResetLinkActionTest extends BaseTestCaseWithUser {
     @Test
     public void testPerformValidToken() {
         ResetPassword rp = ResetPasswordFactory.createNewEntryFor(user);
-        request.setupAddParameter("token", rp.getToken());
+        request.addParameter("token", rp.getToken());
         ActionForward rc = action.execute(mapping, form, request, response);
         assertEquals(valid, rc);
     }
@@ -88,10 +88,10 @@ public class ResetLinkActionTest extends BaseTestCaseWithUser {
         response = new RhnMockHttpServletResponse();
 
         RhnMockHttpSession mockSession = new RhnMockHttpSession();
-        mockSession.setupGetAttribute("token", null);
-        mockSession.setupGetAttribute("request_method", "GET");
+        mockSession.setAttribute("token", null);
+        mockSession.setAttribute("request_method", "GET");
         request.setSession(mockSession);
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
 
         mapping.addForwardConfig(valid);
         mapping.addForwardConfig(invalid);

--- a/java/code/src/com/redhat/rhn/frontend/action/test/ResetPasswordSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/test/ResetPasswordSubmitActionTest.java
@@ -123,10 +123,10 @@ public class ResetPasswordSubmitActionTest extends BaseTestCaseWithUser {
         RequestContext requestContext = new RequestContext(request);
 
         RhnMockHttpSession mockSession = new RhnMockHttpSession();
-        mockSession.setupGetAttribute("token", null);
-        mockSession.setupGetAttribute("request_method", "GET");
+        mockSession.setAttribute("token", null);
+        mockSession.setAttribute("request_method", "GET");
         request.setSession(mockSession);
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
         requestContext.getWebSession();
 
         mapping.addForwardConfig(mismatch);

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/AddressesActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/AddressesActionTest.java
@@ -54,7 +54,7 @@ public class AddressesActionTest extends RhnBaseTestCase {
         sah.setUpAction(action);
         sah.getRequest().setRequestURL("rdu.redhat.com/rhn/users/Adresses.do");
 
-        sah.getRequest().setupAddParameter("uid", (String)null);
+        sah.getRequest().addParameter("uid", (String)null);
         sah.getRequest().getParameterValues("uid"); //now uid = null
 
         try {
@@ -74,7 +74,7 @@ public class AddressesActionTest extends RhnBaseTestCase {
         sah.setUpAction(action);
         sah.getRequest().setRequestURL("foo");
         sah.getRequest().getParameter("uid");
-        sah.getRequest().setupAddParameter("uid", (String) null);
+        sah.getRequest().addParameter("uid", (String) null);
 
         sah.executeAction();
 

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/ChangeEmailActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/ChangeEmailActionTest.java
@@ -48,7 +48,7 @@ public class ChangeEmailActionTest extends RhnBaseTestCase {
 
         TestUtils.disableLocalizationDebugMode();
 
-        sah.getRequest().setupAddParameter("uid", sah.getUser().getId().toString());
+        sah.getRequest().addParameter("uid", sah.getUser().getId().toString());
         sah.getForm().set("email", "differentEmailTest@redhat.com");
         sah.executeAction();
 

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/ChangeEmailSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/ChangeEmailSetupActionTest.java
@@ -41,7 +41,7 @@ public class ChangeEmailSetupActionTest extends RhnBaseTestCase {
         LocalizationService ls = LocalizationService.getInstance();
         User user = sah.getUser();
         //Test verified
-        sah.getRequest().setupAddParameter("uid", "");
+        sah.getRequest().addParameter("uid", "");
 
         user.setEmail("myemail@somewhere.com");
         UserManager.storeUser(user);

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/DeleteUserActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/DeleteUserActionTest.java
@@ -62,7 +62,7 @@ public class DeleteUserActionTest extends RhnBaseTestCase {
         RequestContext requestContext = new RequestContext(request);
 
         Long uid = Long.parseLong(request.getParameter("uid"));
-        request.setupAddParameter("uid", uid.toString()); //put it back
+        request.addParameter("uid", uid.toString()); //put it back
         assertNotNull(UserFactory.lookupById(uid));
 
 
@@ -77,7 +77,7 @@ public class DeleteUserActionTest extends RhnBaseTestCase {
 
         //Null parameter
         request.getParameter("uid");
-        request.setupAddParameter("uid", (String)null);
+        request.addParameter("uid", (String)null);
         requestContext.getCurrentUser().addPermanentRole(
                 RoleFactory.lookupByLabel("org_admin"));
         try {
@@ -89,14 +89,14 @@ public class DeleteUserActionTest extends RhnBaseTestCase {
         }
 
         //try to delete self
-        request.setupAddParameter("uid", uid.toString());
+        request.addParameter("uid", uid.toString());
         forward = action.execute(mapping, form, request, response);
         failure.setPath("path?uid=" + uid);
         assertEquals(failure.getName(), forward.getName());
         assertEquals(failure.getPath(), forward.getPath());
 
         //try to delete non-existing user
-        request.setupAddParameter("uid", "-9999");
+        request.addParameter("uid", "-9999");
         try {
             action.execute(mapping, form, request, response);
             fail();
@@ -110,7 +110,7 @@ public class DeleteUserActionTest extends RhnBaseTestCase {
         User usr = UserTestUtils.createUser("testUser",
                 requestContext.getCurrentUser().getOrg().getId());
         usr.addPermanentRole(RoleFactory.lookupByLabel("org_admin"));
-        request.setupAddParameter("uid", usr.getId().toString());
+        request.addParameter("uid", usr.getId().toString());
         forward = action.execute(mapping, form, request, response);
         failure.setPath("path?uid=" + usr.getId());
         assertEquals(failure.getName(), forward.getName());
@@ -119,7 +119,7 @@ public class DeleteUserActionTest extends RhnBaseTestCase {
         //successful delete
         User usr2 = UserTestUtils.createUser("testUser",
                 requestContext.getCurrentUser().getOrg().getId());
-        request.setupAddParameter("uid", usr2.getId().toString());
+        request.addParameter("uid", usr2.getId().toString());
         forward = action.execute(mapping, form, request, response);
         assertEquals(success, forward);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/EditAddressActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/EditAddressActionTest.java
@@ -65,7 +65,7 @@ public class EditAddressActionTest extends RhnBaseTestCase {
         String userIdRaw = request.getParameter("uid");
         userIdRaw = usr.getId().toString();
         // Put it back into the Request
-        request.setupAddParameter("uid", userIdRaw);
+        request.addParameter("uid", userIdRaw);
     }
 
     private void setUpSuccess() {
@@ -89,7 +89,7 @@ public class EditAddressActionTest extends RhnBaseTestCase {
         String userIdRaw = request.getParameter("uid");
         userIdRaw = usr.getId().toString();
         // Put it back into the Request
-        request.setupAddParameter("uid", userIdRaw);
+        request.addParameter("uid", userIdRaw);
     }
 
     private void executeAction(String addressType) {

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/EditAddressSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/EditAddressSetupActionTest.java
@@ -36,7 +36,7 @@ public class EditAddressSetupActionTest extends RhnBaseTestCase {
         EditAddressSetupAction action = new EditAddressSetupAction();
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action);
-        sah.getRequest().setupAddParameter("type", Address.TYPE_MARKETING);
+        sah.getRequest().addParameter("type", Address.TYPE_MARKETING);
 
         User user = sah.getUser();
         user.setPhone("555-1212");

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/EnableConfirmSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/EnableConfirmSetupActionTest.java
@@ -79,11 +79,11 @@ public class EnableConfirmSetupActionTest extends RhnBaseTestCase {
         //Add parameter for list.
         String listName = TagHelper.generateUniqueName(EnableConfirmSetupAction.LIST_NAME);
 
-        ah.getRequest().setupAddParameter(ListTagUtil.
+        ah.getRequest().addParameter(ListTagUtil.
                                     makeSelectedItemsName(listName), "0");
-        ah.getRequest().setupAddParameter(ListTagUtil.
+        ah.getRequest().addParameter(ListTagUtil.
                                         makePageItemsName(listName), "0");
-        ah.getRequest().setupAddParameter("dispatch", "dummyValue");
+        ah.getRequest().addParameter("dispatch", "dummyValue");
         ActionForward af = ah.executeAction("execute", false);
         assertEquals("enabled", af.getName());
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/UserEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/UserEditActionTest.java
@@ -67,7 +67,7 @@ public class UserEditActionTest extends RhnBaseTestCase {
         request.setAttribute(RhnHelper.TARGET_USER, user);
 
         //Try password mismatch
-        request.setupAddParameter("uid", user.getId().toString());
+        request.addParameter("uid", user.getId().toString());
         form.set("prefix", user.getPrefix());
         form.set("firstNames", user.getFirstNames());
         form.set("lastName", user.getLastName());
@@ -79,7 +79,7 @@ public class UserEditActionTest extends RhnBaseTestCase {
         assertEquals("failure", result.getName());
 
         //Try validation errors
-        request.setupAddParameter("uid", user.getId().toString());
+        request.addParameter("uid", user.getId().toString());
         form.set(UserActionHelper.DESIRED_PASS_CONFIRM, "foobar");
         form.set("firstNames", "");
 
@@ -87,7 +87,7 @@ public class UserEditActionTest extends RhnBaseTestCase {
         assertEquals("failure", result.getName());
 
         //Try Valid edit
-        request.setupAddParameter("uid", user.getId().toString());
+        request.addParameter("uid", user.getId().toString());
         form.set("firstNames", "Larry");
 
         result = action.execute(mapping, form, request, response);
@@ -145,19 +145,19 @@ public class UserEditActionTest extends RhnBaseTestCase {
 
     private void setupRoleParameters(RhnMockHttpServletRequest request,
             User user) {
-        request.setupAddParameter("uid", user.getId().toString());
-        request.setupAddParameter("disabledRoles", "");
-        request.setupAddParameter("role_" + RoleFactory.ORG_ADMIN.getLabel(),
+        request.addParameter("uid", user.getId().toString());
+        request.addParameter("disabledRoles", "");
+        request.addParameter("role_" + RoleFactory.ORG_ADMIN.getLabel(),
                 (String)null);
-        request.setupAddParameter("role_" + RoleFactory.CHANNEL_ADMIN.getLabel(),
+        request.addParameter("role_" + RoleFactory.CHANNEL_ADMIN.getLabel(),
                 (String)null);
-        request.setupAddParameter("role_" + RoleFactory.SAT_ADMIN.getLabel(),
+        request.addParameter("role_" + RoleFactory.SAT_ADMIN.getLabel(),
                 (String)null);
-        request.setupAddParameter("role_" + RoleFactory.ACTIVATION_KEY_ADMIN.getLabel(),
+        request.addParameter("role_" + RoleFactory.ACTIVATION_KEY_ADMIN.getLabel(),
                 (String)null);
-        request.setupAddParameter("role_" + RoleFactory.SYSTEM_GROUP_ADMIN.getLabel(),
+        request.addParameter("role_" + RoleFactory.SYSTEM_GROUP_ADMIN.getLabel(),
                 (String)null);
-        request.setupAddParameter("role_" + RoleFactory.CONFIG_ADMIN.getLabel(),
+        request.addParameter("role_" + RoleFactory.CONFIG_ADMIN.getLabel(),
                 (String)null);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/UserEditSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/UserEditSetupActionTest.java
@@ -101,7 +101,7 @@ public class UserEditSetupActionTest extends RhnBaseTestCase {
         sah.setUpAction(action);
         sah.getRequest().setRequestURL("rdu.redhat.com/rhn/users/UserDetails.do");
 
-        sah.getRequest().setupAddParameter("uid", (String)null);
+        sah.getRequest().addParameter("uid", (String)null);
         sah.getRequest().getParameterValues("uid"); //now uid = null
 
         try {

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/UserPrefActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/UserPrefActionTest.java
@@ -66,7 +66,7 @@ public class UserPrefActionTest extends RhnBaseTestCase {
         // a second time.  The MockRequest counts the number of times getParamter
         // is called.
 
-        request.setupAddParameter("uid", user.getId().toString());
+        request.addParameter("uid", user.getId().toString());
         // populate with any set of information
         // then get the verify the user was changed correctly.
         form.set("emailNotif", Boolean.FALSE);

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/UserPrefSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/UserPrefSetupActionTest.java
@@ -60,7 +60,7 @@ public class UserPrefSetupActionTest extends RhnBaseTestCase {
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action);
         sah.getRequest().setRequestURL("rdu.redhat.com/rhn/users/UserPreferences.do");
-        sah.getRequest().setupAddParameter("uid", (String)null);
+        sah.getRequest().addParameter("uid", (String)null);
         sah.getRequest().getParameterValues("uid"); //now uid = null
 
         try {

--- a/java/code/src/com/redhat/rhn/frontend/action/user/test/VisibleSystemsListActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/test/VisibleSystemsListActionTest.java
@@ -45,10 +45,10 @@ public class VisibleSystemsListActionTest extends RhnBaseTestCase {
         ServerFactoryTest.createTestServer(user, true,
                         ServerConstants.getServerGroupTypeEnterpriseEntitled());
 
-        ah.getRequest().setupAddParameter("newset", (String[]) null);
-        ah.getRequest().setupAddParameter("items_on_page", (String[]) null);
-        ah.getRequest().setupAddParameter("items_selected", (String[]) null);
-        ah.getRequest().setupAddParameter("uid", user.getId().toString());
+        ah.getRequest().addParameter("newset", (String[]) null);
+        ah.getRequest().addParameter("items_on_page", (String[]) null);
+        ah.getRequest().addParameter("items_selected", (String[]) null);
+        ah.getRequest().addParameter("uid", user.getId().toString());
 
         RhnSetDecl.SYSTEMS.clear(user);
         assertTrue(RhnSetDecl.SYSTEMS.get(user).isEmpty());

--- a/java/code/src/com/redhat/rhn/frontend/events/test/NewUserEventTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/NewUserEventTest.java
@@ -101,8 +101,8 @@ public class NewUserEventTest extends RhnBaseTestCase {
             }
         };
         request.setSession(new RhnMockHttpSession());
-        request.setupGetRequestURI("http://localhost:8080");
-        request.setupGetMethod("POST");
+        request.setRequestURI("http://localhost:8080");
+        request.setMethod("POST");
         User usr = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
 

--- a/java/code/src/com/redhat/rhn/frontend/events/test/TraceBackEventTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/TraceBackEventTest.java
@@ -173,8 +173,8 @@ public class TraceBackEventTest extends RhnBaseTestCase {
     private TraceBackEvent createTestEventWithValue(String paramIn, String valueIn) {
         TraceBackEvent evt = new TraceBackEvent();
         RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
-        request.setupGetRequestURI("http://localhost:8080");
-        request.setupAddParameter(paramIn, valueIn);
+        request.setRequestURI("http://localhost:8080");
+        request.addParameter(paramIn, valueIn);
         evt.setUser(user);
         evt.setRequest(request);
         Throwable e = new RuntimeException(MSG_OUTER_EXC);

--- a/java/code/src/com/redhat/rhn/frontend/security/test/PxtAuthenticationServiceTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/test/PxtAuthenticationServiceTest.java
@@ -63,7 +63,7 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
         } });
     }
 
-    private void setupGetRequestURI(final String requestUri) {
+    private void setRequestURI(final String requestUri) {
         context().checking(new Expectations() { {
             allowing(mockRequest).getRequestURI();
             will(returnValue(requestUri));
@@ -93,42 +93,42 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
     @Test
     public final void testValidateFailsWhenPxtSessionKeyIsInvalid() {
         setupPxtDelegate(false, false, 1234L);
-        setupGetRequestURI("/rhn/YourRhn.do");
+        setRequestURI("/rhn/YourRhn.do");
         runValidateFailsTest();
     }
 
     @Test
     public final void testValidateFailsWhenPxtSessionExpired() {
         setupPxtDelegate(true, true, 1234L);
-        setupGetRequestURI("/rhn/YourRhn.do");
+        setRequestURI("/rhn/YourRhn.do");
         runValidateFailsTest();
     }
 
     @Test
     public final void testValidateFailsWhenWebUserIdIsNull() {
         setupPxtDelegate(true, false, null);
-        setupGetRequestURI("/rhn/YourRhn.do");
+        setRequestURI("/rhn/YourRhn.do");
         runValidateFailsTest();
     }
 
     @Test
     public final void testValidateSucceedsWhenRequestURIUnprotected() {
         setupPxtDelegate(false, false, 1234L);
-        setupGetRequestURI("/rhn/manager/login");
+        setRequestURI("/rhn/manager/login");
         assertTrue(service.validate(getRequest(), getResponse()));
     }
 
     @Test
     public final void testValidateSucceeds() {
         setupPxtDelegate(true, false, 1234L);
-        setupGetRequestURI("/rhn/YourRhn.do");
+        setRequestURI("/rhn/YourRhn.do");
         runValidateSucceedsTest();
     }
 
     @Test
     public final void testInvalidate() {
         setupPxtDelegate(true, false, 1234L);
-        setupGetRequestURI("/rhn/YourRhn.do");
+        setRequestURI("/rhn/YourRhn.do");
 
         context().checking(new Expectations() { {
             atLeast(1).of(mockPxtDelegate).invalidatePxtSession(
@@ -167,7 +167,7 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
     @Test
     public final void testRedirectoToLoginForwardsRequest() throws Exception {
         setupPxtDelegate(true, false, 1234L);
-        setupGetRequestURI("/rhn/YourRhn.do");
+        setRequestURI("/rhn/YourRhn.do");
 
         URIBuilder uriBuilder = new URIBuilder("/rhn/manager/login");
         uriBuilder.addParameter("url_bounce", "/rhn/YourRhn.do");
@@ -204,7 +204,7 @@ public class PxtAuthenticationServiceTest extends AuthenticationServiceAbstractT
     @Test
     public final void testRedirectToLoginSetsURLBounceRequestAttribute() throws Exception {
         setupPxtDelegate(true, false, 1234L);
-        setupGetRequestURI("/rhn/YourRhn.do");
+        setRequestURI("/rhn/YourRhn.do");
         setUpRedirectToLogin();
 
         URIBuilder uriBounceBuilder = new URIBuilder();

--- a/java/code/src/com/redhat/rhn/frontend/servlets/ajax/test/AjaxHandlerServletTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/ajax/test/AjaxHandlerServletTest.java
@@ -57,7 +57,7 @@ public class AjaxHandlerServletTest extends AjaxHandlerServlet {
         request = new RhnMockHttpServletRequest();
 
         request.addAttribute("session", session);
-        request.setupGetRequestDispatcher(new MockRequestDispatcher());
+        request.setRequestDispatcher(new MockRequestDispatcher());
         response = new RhnMockHttpServletResponse();
         servlet = new AjaxHandlerServlet();
     }
@@ -74,7 +74,7 @@ public class AjaxHandlerServletTest extends AjaxHandlerServlet {
         );
         for (String uri : uris) {
             // setup request URI
-            request.setupGetRequestURI(uri);
+            request.setRequestURI(uri);
 
             // parentURL is not set before handling the request
             assertNotEquals(uri, request.getAttribute("parentUrl"));
@@ -90,7 +90,7 @@ public class AjaxHandlerServletTest extends AjaxHandlerServlet {
     public void testInactiveSystems() {
         // setup request URI
         String uri = "/rhn/ajax/inactive-systems";
-        request.setupGetRequestURI(uri);
+        request.setRequestURI(uri);
 
         // inactiveSystemsClass is not set before handling the request
         assertNull(request.getAttribute("inactiveSystemsClass"));
@@ -108,7 +108,7 @@ public class AjaxHandlerServletTest extends AjaxHandlerServlet {
     public void testPendingActions() {
         // setup request URI
         String uri = "/rhn/ajax/pending-actions";
-        request.setupGetRequestURI(uri);
+        request.setRequestURI(uri);
 
         // showPendingActions is not set before handling the request
         assertNull(request.getAttribute("showPendingActions"));
@@ -123,7 +123,7 @@ public class AjaxHandlerServletTest extends AjaxHandlerServlet {
     public void testLatestErrata() {
         // setup request URI
         String uri = "/rhn/ajax/latest-errata";
-        request.setupGetRequestURI(uri);
+        request.setRequestURI(uri);
 
         // showErrata is not set before handling the request
         assertNull(request.getAttribute("showErrata"));
@@ -141,7 +141,7 @@ public class AjaxHandlerServletTest extends AjaxHandlerServlet {
     public void testHandlerWithRequestBody() throws IOException {
         // setup request URI
         String uri = "/rhn/ajax/action-chain-entries";
-        request.setupGetRequestURI(uri);
+        request.setRequestURI(uri);
 
         // setup data
         Integer sortOrder = 13;
@@ -149,7 +149,7 @@ public class AjaxHandlerServletTest extends AjaxHandlerServlet {
 
         // setup request body
         Reader input = new StringReader("{ \"actionChainId\":" + a.getId() + ", \"sortOrder\": 13 }");
-        request.setupGetReader(new BufferedReader(input));
+        request.setReader(new BufferedReader(input));
 
         // sortOrder is not set before handling the request
         assertNull(request.getAttribute("sortOrder"));

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/BaseFilterTst.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/BaseFilterTst.java
@@ -47,9 +47,9 @@ public abstract class BaseFilterTst extends RhnJmockBaseTestCase {
         PxtCookieManager pcm = new PxtCookieManager();
         RequestContext requestContext = new RequestContext(request);
 
-        request.setupServerName("mymachine.rhndev.redhat.com");
+        request.setServerName("mymachine.rhndev.redhat.com");
         request.setSession(session);
-        request.setupGetRequestURI("http://localhost:8080");
+        request.setRequestURI("http://localhost:8080");
         WebSession s = requestContext.getWebSession();
         request.addCookie(pcm.createPxtCookie(s.getId(), request, 10));
         response = new RhnMockHttpServletResponse();

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/EnvironmentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/EnvironmentFilterTest.java
@@ -55,10 +55,10 @@ public class EnvironmentFilterTest extends BaseFilterTst {
     public void testNonSSLUrls() throws Exception {
 
         EnvironmentFilter filter = new EnvironmentFilter();
-        request.setupAddParameter("message", "some.key.to.localize");
-        request.setupAddParameter("messagep1", "param value");
-        request.setupAddParameter("messagep2", "param value");
-        request.setupAddParameter("messagep3", "param value");
+        request.addParameter("message", "some.key.to.localize");
+        request.addParameter("messagep1", "param value");
+        request.addParameter("messagep2", "param value");
+        request.addParameter("messagep3", "param value");
         filter.init(null);
 
         filter.doFilter(request, response, chain);
@@ -67,17 +67,17 @@ public class EnvironmentFilterTest extends BaseFilterTst {
         String expectedRedir = "https://mymachine.rhndev.redhat.com/rhn/manager/login";
         assertEquals(expectedRedir, response.getRedirect());
 
-        request.setupGetRequestURI("/rhn/kickstart/DownloadFile");
+        request.setRequestURI("/rhn/kickstart/DownloadFile");
         response.clearRedirect();
-        request.setupAddParameter("message", "some.key.to.localize");
-        request.setupAddParameter("messagep1", "param value");
-        request.setupAddParameter("messagep2", "param value");
-        request.setupAddParameter("messagep3", "param value");
+        request.addParameter("message", "some.key.to.localize");
+        request.addParameter("messagep1", "param value");
+        request.addParameter("messagep2", "param value");
+        request.addParameter("messagep3", "param value");
         filter.doFilter(request, response, chain);
         assertNull(response.getRedirect());
         assertNotEquals(expectedRedir, response.getRedirect());
 
-        request.setupGetRequestURI("/rhn/rpc/api");
+        request.setRequestURI("/rhn/rpc/api");
         response.clearRedirect();
         filter.doFilter(request, response, chain);
         assertNull(response.getRedirect());
@@ -87,11 +87,11 @@ public class EnvironmentFilterTest extends BaseFilterTst {
     public void testAddAMessage() throws Exception {
         EnvironmentFilter filter = new EnvironmentFilter();
         filter.init(null);
-        this.request.setupIsSecure(true);
-        request.setupAddParameter("message", "some.key.to.localize");
-        request.setupAddParameter("messagep1", "param value");
-        request.setupAddParameter("messagep2", "param value");
-        request.setupAddParameter("messagep3", "param value");
+        this.request.setSecure(true);
+        request.addParameter("message", "some.key.to.localize");
+        request.addParameter("messagep1", "param value");
+        request.addParameter("messagep2", "param value");
+        request.addParameter("messagep3", "param value");
 
         filter.doFilter(request, response, chain);
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/RhnHttpServletRequestTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/RhnHttpServletRequestTest.java
@@ -44,8 +44,8 @@ public class RhnHttpServletRequestTest extends MockObjectTestCase {
      */
     @Test
     public void testNoHeaders() {
-        mockRequest.setupServerName("localhost");
-        mockRequest.setupGetServerPort(8080);
+        mockRequest.setServerName("localhost");
+        mockRequest.setServerPort(8080);
         assertEquals("localhost", request.getServerName());
         assertEquals(8080, request.getServerPort());
     }
@@ -55,9 +55,9 @@ public class RhnHttpServletRequestTest extends MockObjectTestCase {
      */
     @Test
     public void testOverrideServerName() {
-        mockRequest.setupServerName("localhost");
-        mockRequest.setupGetServerPort(8080);
-        mockRequest.setupGetHeader("X-Server-Hostname", "testServer.redhat.com");
+        mockRequest.setServerName("localhost");
+        mockRequest.setServerPort(8080);
+        mockRequest.setHeader("X-Server-Hostname", "testServer.redhat.com");
         assertEquals("testServer.redhat.com", request.getServerName());
         assertEquals(8080, request.getServerPort());
     }
@@ -67,7 +67,7 @@ public class RhnHttpServletRequestTest extends MockObjectTestCase {
      */
     @Test
     public void testNoOverrideSecure() {
-        mockRequest.setupIsSecure(false);
+        mockRequest.setSecure(false);
         assertFalse(request.isSecure());
     }
 
@@ -77,8 +77,8 @@ public class RhnHttpServletRequestTest extends MockObjectTestCase {
     @Test
     public void testOverrideSecureHosted() {
 
-        mockRequest.setupIsSecure(false);
-        mockRequest.setupGetHeader("X-ENV-HTTPS", "on");
+        mockRequest.setSecure(false);
+        mockRequest.setHeader("X-ENV-HTTPS", "on");
 
         // We expect this to be false, because this isn't a satellite.
         assertFalse(request.isSecure());

--- a/java/code/src/com/redhat/rhn/frontend/struts/test/BaseSetListActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/test/BaseSetListActionTest.java
@@ -52,7 +52,7 @@ public class BaseSetListActionTest extends RhnBaseTestCase {
         sah = new ActionHelper();
         sah.setUpAction(tla);
         sah.setupClampListBounds();
-        sah.getRequest().setupAddParameter("submitted", "false");
+        sah.getRequest().addParameter("submitted", "false");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/struts/test/RequestContextTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/test/RequestContextTest.java
@@ -57,10 +57,10 @@ public class RequestContextTest extends MockObjectTestCase {
         mockRequest.setSession(session);
 
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod("POST");
         mockRequest.setMethod("POST");
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
-        mockRequest.setupAddParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
+        mockRequest.setMethod("POST");
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
+        mockRequest.addParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
 
         Response response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
         // logging in
@@ -80,8 +80,8 @@ public class RequestContextTest extends MockObjectTestCase {
     /*public void testProcessPaginationFirst() {
         MockHttpServletRequest request =
             new MockHttpServletRequest();
-        request.setupAddParameter("First", "1");
-        request.setupAddParameter("first_lower", "1");
+        request.addParameter("First", "1");
+        request.addParameter("first_lower", "1");
         RequestContext requestContext = new RequestContext(request);
         String rc = requestContext.processPagination();
         assertEquals("1", rc);
@@ -93,9 +93,9 @@ public class RequestContextTest extends MockObjectTestCase {
     /*public void testProcessPaginationPrev() {
         MockHttpServletRequest request =
             new MockHttpServletRequest();
-        request.setupAddParameter("First", (String) null);
-        request.setupAddParameter("Prev", "1");
-        request.setupAddParameter("prev_lower", "10");
+        request.addParameter("First", (String) null);
+        request.addParameter("Prev", "1");
+        request.addParameter("prev_lower", "10");
         RequestContext requestContext = new RequestContext(request);
         String rc = requestContext.processPagination();
         assertEquals("10", rc);
@@ -107,11 +107,11 @@ public class RequestContextTest extends MockObjectTestCase {
     /*public void testProcessPaginationLast() {
         MockHttpServletRequest request =
             new MockHttpServletRequest();
-        request.setupAddParameter("First", (String)null);
-        request.setupAddParameter("Prev", (String)null);
-        request.setupAddParameter("Next", (String)null);
-        request.setupAddParameter("Last", "1");
-        request.setupAddParameter("last_lower", "30");
+        request.addParameter("First", (String)null);
+        request.addParameter("Prev", (String)null);
+        request.addParameter("Next", (String)null);
+        request.addParameter("Last", "1");
+        request.addParameter("last_lower", "30");
         RequestContext requestContext = new RequestContext(request);
         String rc = requestContext.processPagination();
         assertEquals("30", rc);
@@ -123,10 +123,10 @@ public class RequestContextTest extends MockObjectTestCase {
     /*public void testProcessPaginationNext() {
         MockHttpServletRequest request =
             new MockHttpServletRequest();
-        request.setupAddParameter("First", (String)null);
-        request.setupAddParameter("Prev", (String)null);
-        request.setupAddParameter("Next", "1");
-        request.setupAddParameter("next_lower", "20");
+        request.addParameter("First", (String)null);
+        request.addParameter("Prev", (String)null);
+        request.addParameter("Next", "1");
+        request.addParameter("next_lower", "20");
         RequestContext requestContext = new RequestContext(request);
         String rc = requestContext.processPagination();
         assertEquals("20", rc);
@@ -137,8 +137,8 @@ public class RequestContextTest extends MockObjectTestCase {
     @Test
     public void testbuildPageLink() {
         RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
-        request.setupAddParameter("someparam", "value");
-        request.setupQueryString("otherparam=foo&barparam=beer");
+        request.addParameter("someparam", "value");
+        request.setQueryString("otherparam=foo&barparam=beer");
         request.addAttribute("requestedUri", "http://localhost/rhn/somePage.do");
 
         RequestContext requestContext = new RequestContext(request);
@@ -146,7 +146,7 @@ public class RequestContextTest extends MockObjectTestCase {
         String url = requestContext.buildPageLink("someparam", "value");
         assertEquals("http://localhost/rhn/somePage.do?" +
                 "someparam=value&otherparam=foo&barparam=beer", url);
-        request.setupQueryString("otherparam=foo&barparam=beer&someparam=value");
+        request.setQueryString("otherparam=foo&barparam=beer&someparam=value");
         url = requestContext.buildPageLink("someparam", "zzzzz");
 
         assertEquals("http://localhost/rhn/somePage.do?" +

--- a/java/code/src/com/redhat/rhn/frontend/struts/test/RhnHelperTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/test/RhnHelperTest.java
@@ -61,27 +61,27 @@ public class RhnHelperTest extends RhnBaseTestCase {
     @Test
     public void testGetParameterWithSpecialCharacters() {
         RhnMockHttpServletRequest request = new RhnMockHttpServletRequest();
-        request.setupQueryString("   ");
+        request.setQueryString("   ");
         assertNull(RhnHelper.getParameterWithSpecialCharacters(request, "zzzz"));
 
-        request.setupQueryString(null);
+        request.setQueryString(null);
         assertNull(RhnHelper.getParameterWithSpecialCharacters(request, "zzzz"));
 
-        request.setupQueryString("asdf12354");
+        request.setQueryString("asdf12354");
         assertNull(RhnHelper.getParameterWithSpecialCharacters(request, "zzzz"));
 
-        request.setupQueryString("foo=bar");
+        request.setQueryString("foo=bar");
         assertNull(RhnHelper.getParameterWithSpecialCharacters(request, "zzzz"));
 
-        request.setupQueryString("foo=bar");
+        request.setQueryString("foo=bar");
         assertEquals("bar", RhnHelper.
                 getParameterWithSpecialCharacters(request, "foo"));
 
-        request.setupQueryString("foo=bar&baz=bloop&blippy=blorg");
+        request.setQueryString("foo=bar&baz=bloop&blippy=blorg");
         assertEquals("bar", RhnHelper.
                 getParameterWithSpecialCharacters(request, "foo"));
 
-        request.setupQueryString("foo=bar+++&baz=bloop&blippy=blorg");
+        request.setQueryString("foo=bar+++&baz=bloop&blippy=blorg");
         assertEquals("bar+++", RhnHelper.
                     getParameterWithSpecialCharacters(request, "foo"));
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/BaseTestToolbarTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/BaseTestToolbarTag.java
@@ -50,7 +50,7 @@ public abstract class BaseTestToolbarTag extends RhnBaseTestCase {
         tth = TagTestUtils.setupTagTest(tt, null);
         out = (RhnMockJspWriter) tth.getPageContext().getOut();
         RhnMockHttpServletRequest req = tth.getRequest();
-        req.setupGetAttribute(new HashMap<>());
+        req.setAttributes(new HashMap<>());
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/ColumnTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/ColumnTagTest.java
@@ -151,7 +151,7 @@ public class ColumnTagTest extends RhnBaseTestCase {
         TagTestHelper tth = TagTestUtils.setupTagTest(ct, null);
         RhnMockHttpServletRequest mockRequest = (RhnMockHttpServletRequest)
                 tth.getPageContext().getRequest();
-        mockRequest.setupAddParameter("order", "asc");
+        mockRequest.addParameter("order", "asc");
 
         RhnMockPageContext mpc = tth.getPageContext();
         mpc.setAttribute("current", new Object());

--- a/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartOptionsCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/test/KickstartOptionsCommandTest.java
@@ -42,7 +42,7 @@ public class KickstartOptionsCommandTest extends BaseTestCaseWithUser {
         User ksUser = UserTestUtils.createUser("testuser", k.getOrg().getId());
 
         mockRequest = new RhnMockHttpServletRequest();
-        mockRequest.setupGetRemoteAddr("127.0.0.1");
+        mockRequest.setRemoteAddr("127.0.0.1");
 
         KickstartOptionsCommand command = new KickstartOptionsCommand(k.getId(), ksUser);
 

--- a/java/code/src/com/redhat/rhn/testing/AbstractServletTestHelper.java
+++ b/java/code/src/com/redhat/rhn/testing/AbstractServletTestHelper.java
@@ -31,7 +31,7 @@ public abstract class AbstractServletTestHelper {
     public AbstractServletTestHelper() {
         request.setSession(httpSession);
         servletContext.setRequestDispatcher(requestDispatcher);
-        request.setupGetRequestDispatcher(requestDispatcher);
+        request.setRequestDispatcher(requestDispatcher);
         httpSession.setServletContext(servletContext);
     }
 

--- a/java/code/src/com/redhat/rhn/testing/ActionHelper.java
+++ b/java/code/src/com/redhat/rhn/testing/ActionHelper.java
@@ -80,7 +80,7 @@ public class ActionHelper  {
         // we have to get the actual user here so we can call setupAddParamter
         // a second time.  The MockRequest counts the number of times getParamter
         // is called.
-        request.setupAddParameter("uid", user.getId().toString());
+        request.addParameter("uid", user.getId().toString());
 
     }
 
@@ -201,10 +201,10 @@ public class ActionHelper  {
      * @param filterString the filter string we want to test out.
      */
     public void setupClampListBounds(String filterString) {
-        getRequest().setupAddParameter(RequestContext.FILTER_STRING, filterString);
-        getRequest().setupAddParameter(RequestContext.PREVIOUS_FILTER_STRING, filterString);
-        getRequest().setupAddParameter("newset", (String)null);
-        getRequest().setupAddParameter("returnvisit", (String) null);
+        getRequest().addParameter(RequestContext.FILTER_STRING, filterString);
+        getRequest().addParameter(RequestContext.PREVIOUS_FILTER_STRING, filterString);
+        getRequest().addParameter("newset", (String)null);
+        getRequest().addParameter("returnvisit", (String) null);
         setupProcessPagination();
     }
 
@@ -213,15 +213,15 @@ public class ActionHelper  {
      * listview Actions.
      */
     public void setupProcessPagination() {
-        getRequest().setupAddParameter(Pagination.FIRST.getElementName(), "someValue");
-        getRequest().setupAddParameter(Pagination.FIRST.getLowerAttributeName(), "10");
-        getRequest().setupAddParameter(Pagination.PREV.getElementName(), "0");
-        getRequest().setupAddParameter(Pagination.PREV.getLowerAttributeName(), "");
-        getRequest().setupAddParameter(Pagination.NEXT.getElementName(), "20");
-        getRequest().setupAddParameter(Pagination.NEXT.getLowerAttributeName(), "");
-        getRequest().setupAddParameter(Pagination.LAST.getElementName(), "");
-        getRequest().setupAddParameter(Pagination.LAST.getLowerAttributeName(), "20");
-        getRequest().setupAddParameter("lower", "10");
+        getRequest().addParameter(Pagination.FIRST.getElementName(), "someValue");
+        getRequest().addParameter(Pagination.FIRST.getLowerAttributeName(), "10");
+        getRequest().addParameter(Pagination.PREV.getElementName(), "0");
+        getRequest().addParameter(Pagination.PREV.getLowerAttributeName(), "");
+        getRequest().addParameter(Pagination.NEXT.getElementName(), "20");
+        getRequest().addParameter(Pagination.NEXT.getLowerAttributeName(), "");
+        getRequest().addParameter(Pagination.LAST.getElementName(), "");
+        getRequest().addParameter(Pagination.LAST.getLowerAttributeName(), "20");
+        getRequest().addParameter("lower", "10");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/MockServletContext.java
+++ b/java/code/src/com/redhat/rhn/testing/MockServletContext.java
@@ -59,7 +59,6 @@ public class MockServletContext implements ServletContext {
         return Collections.emptyEnumeration();
     }
 
-
     /**
      * Sets the resource to be returned by getResource().
      * @param resourceIn the URL resource to set
@@ -67,18 +66,6 @@ public class MockServletContext implements ServletContext {
     public void setResource(URL resourceIn) {
         this.resource = resourceIn;
     }
-
-    /**
-     * Sets the resource to be returned by getResource().
-     * @param resourceIn the URL resource to set
-     * @deprecated replaced by {@link #setResource(URL)}
-     */
-    @Deprecated
-    public void setupGetResource(URL resourceIn) {
-        this.resource = resourceIn;
-    }
-
-
 
     /**
      * Gets a URL to the resource mapped to the specified path.
@@ -106,11 +93,11 @@ public class MockServletContext implements ServletContext {
         return resourcePaths;
     }
 
-    @Override
     /**
      * Gets the context path of the web application.
      * @return empty string for mock implementation
      */
+    @Override
     public String getContextPath() {
         return "";
     }
@@ -322,51 +309,50 @@ public class MockServletContext implements ServletContext {
         return null;
     }
 
-    @Override
     /**
      * Adds a servlet with the given name and class name to this servlet context.
      * @param sIn the servlet name
      * @param sIn1 the servlet class name
      * @return null for mock implementation
      */
+    @Override
     public ServletRegistration.Dynamic addServlet(String sIn, String sIn1) {
         return null;
     }
 
-    @Override
     /**
      * Adds a servlet with the given name and servlet instance to this servlet context.
      * @param sIn the servlet name
      * @param servletIn the servlet instance
      * @return null for mock implementation
      */
+    @Override
     public ServletRegistration.Dynamic addServlet(String sIn, Servlet servletIn) {
         return null;
     }
 
-    @Override
     /**
      * Adds a servlet with the given name and servlet class to this servlet context.
      * @param sIn the servlet name
      * @param classIn the servlet class
      * @return null for mock implementation
      */
+    @Override
     public ServletRegistration.Dynamic addServlet(String sIn, Class<? extends Servlet> classIn) {
         return null;
     }
 
-    @Override
     /**
      * Adds a JSP file with the given name and file path to this servlet context.
      * @param sIn the servlet name
      * @param sIn1 the JSP file path
      * @return null for mock implementation
      */
+    @Override
     public ServletRegistration.Dynamic addJspFile(String sIn, String sIn1) {
         return null;
     }
 
-    @Override
     /**
      * Creates a servlet of the given class.
      * @param classIn the servlet class
@@ -374,63 +360,64 @@ public class MockServletContext implements ServletContext {
      * @return null for mock implementation
      * @throws ServletException if servlet creation fails
      */
+    @Override
     public <T extends Servlet> T createServlet(Class<T> classIn) throws ServletException {
         return null;
     }
 
-    @Override
     /**
      * Gets the servlet registration for the servlet with the given servlet name.
      * @param sIn the servlet name
      * @return null for mock implementation
      */
+    @Override
     public ServletRegistration getServletRegistration(String sIn) {
         return null;
     }
 
-    @Override
     /**
      * Gets a map containing the servlet registrations for all servlets.
      * @return empty map for mock implementation
      */
+    @Override
     public Map<String, ? extends ServletRegistration> getServletRegistrations() {
         return Map.of();
     }
 
-    @Override
     /**
      * Adds a filter with the given name and class name to this servlet context.
-     * @param sIn the filter name
+     *
+     * @param sIn  the filter name
      * @param sIn1 the filter class name
      * @return null for mock implementation
      */
+    @Override
     public FilterRegistration.Dynamic addFilter(String sIn, String sIn1) {
         return null;
     }
 
-    @Override
     /**
      * Adds a filter with the given name and filter instance to this servlet context.
      * @param sIn the filter name
      * @param filterIn the filter instance
      * @return null for mock implementation
      */
+    @Override
     public FilterRegistration.Dynamic addFilter(String sIn, Filter filterIn) {
         return null;
     }
 
-    @Override
     /**
      * Adds a filter with the given name and filter class to this servlet context.
      * @param sIn the filter name
      * @param classIn the filter class
      * @return null for mock implementation
      */
+    @Override
     public FilterRegistration.Dynamic addFilter(String sIn, Class<? extends Filter> classIn) {
         return null;
     }
 
-    @Override
     /**
      * Creates a filter of the given class.
      * @param classIn the filter class
@@ -438,95 +425,95 @@ public class MockServletContext implements ServletContext {
      * @return null for mock implementation
      * @throws ServletException if filter creation fails
      */
+    @Override
     public <T extends Filter> T createFilter(Class<T> classIn) throws ServletException {
         return null;
     }
 
-    @Override
     /**
      * Gets the filter registration for the filter with the given filter name.
      * @param sIn the filter name
      * @return null for mock implementation
      */
+    @Override
     public FilterRegistration getFilterRegistration(String sIn) {
         return null;
     }
 
-    @Override
     /**
      * Gets a map containing the filter registrations for all filters.
      * @return empty map for mock implementation
      */
+    @Override
     public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
         return Map.of();
     }
 
-    @Override
     /**
      * Gets the session cookie configuration for this servlet context.
      * @return null for mock implementation
      */
+    @Override
     public SessionCookieConfig getSessionCookieConfig() {
         return null;
     }
 
-    @Override
     /**
      * Sets the session tracking modes for this servlet context.
      * @param setIn the set of session tracking modes
      */
+    @Override
     public void setSessionTrackingModes(Set<SessionTrackingMode> setIn) {
         // Mock implementation does nothing
     }
 
-    @Override
     /**
      * Gets the default session tracking modes for this servlet context.
      * @return empty set for mock implementation
      */
+    @Override
     public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
         return Set.of();
     }
 
-    @Override
     /**
      * Gets the effective session tracking modes for this servlet context.
      * @return empty set for mock implementation
      */
+    @Override
     public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
         return Set.of();
     }
 
-    @Override
     /**
      * Adds a listener with the given class name to this servlet context.
      * @param sIn the listener class name
      */
+    @Override
     public void addListener(String sIn) {
         // Mock implementation does nothing
     }
 
-    @Override
     /**
      * Adds a listener instance to this servlet context.
      * @param tIn the listener instance
      * @param <T> the listener type
      */
+    @Override
     public <T extends EventListener> void addListener(T tIn) {
         // Mock implementation does nothing
     }
 
-    @Override
     /**
      * Adds a listener with the given listener class to this servlet context.
      * @param classIn the listener class
      */
+    @Override
     public void addListener(Class<? extends EventListener> classIn) {
         // Mock implementation does nothing
         // Mock implementation does nothing
     }
 
-    @Override
     /**
      * Creates a listener of the given class.
      * @param classIn the listener class
@@ -534,15 +521,16 @@ public class MockServletContext implements ServletContext {
      * @return null for mock implementation
      * @throws ServletException if listener creation fails
      */
+    @Override
     public <T extends EventListener> T createListener(Class<T> classIn) throws ServletException {
         return null;
     }
 
-    @Override
     /**
      * Gets the JSP configuration descriptor for this servlet context.
      * @return null for mock implementation
      */
+    @Override
     public JspConfigDescriptor getJspConfigDescriptor() {
         return null;
     }

--- a/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletRequest.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletRequest.java
@@ -179,25 +179,12 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
     }
 
     /**
-     * @param headerName name of header to be added
-     * @param value      value of header to be added.
-     * @deprecated replaced by {@link #setHeader(String, String)}
-     * <p>
-     * Add a GET header to the request.
-     */
-    @Deprecated
-    public void setupGetHeader(String headerName, String value) {
-        headers.put(headerName, value);
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
     public Enumeration<String> getHeaderNames() {
         return Collections.enumeration(headers.keySet());
     }
-
 
     /**
      * {@inheritDoc}
@@ -247,34 +234,12 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
     }
 
     /**
-     * Set the parameter map for this request
-     * @param map map of parameters
-     * @deprecated replaced by {@link #setParameters(Map)}
-     */
-    @Deprecated
-    public void setupGetParameterMap(Map<String, String[]> map) {
-        parameters = map;
-    }
-
-
-
-    /**
      * Add a parameter to the request
      *
      * @param name  parameter name
      * @param value parameter value
      */
     public void addParameter(String name, String value) {
-        addParameter(name, new String[]{value});
-    }
-
-    /**
-     * @param name  parameter name
-     * @param value parameter value
-     * @deprecated replaced by {@link #addParameter(String, String)}
-     */
-    @Deprecated
-    public void setupAddParameter(String name, String value) {
         addParameter(name, new String[]{value});
     }
 
@@ -296,16 +261,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
         }
     }
 
-    /**
-     * @param name   parameter name
-     * @param values parameter values
-     * @deprecated replaced by {@link #addParameter(String, String[])}
-     */
-    @Deprecated
-    public void setupAddParameter(String name, String[] values) {
-        this.addParameter(name, values);
-    }
-
 
     @Override
     public Enumeration<String> getParameterNames() {
@@ -321,15 +276,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
         while (names.hasMoreElements()) {
             parameters.put(names.nextElement(), new String[]{""});
         }
-    }
-
-    /**
-     * @param names parameter names
-     * @deprecated replaced by {@link #setParameterNames(Enumeration)}
-     */
-    @Deprecated
-    public void setupGetParameterNames(Enumeration<String> names) {
-        this.setParameterNames(names);
     }
 
     /**
@@ -407,33 +353,11 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
     }
 
     /**
-     * @param p Port
-     * @deprecated replaced by {@link #setServerPort(int)}
-     * <p>
-     * Sets the server port for this request.
-     */
-    @Deprecated
-    public void setupGetServerPort(int p) {
-        port = p;
-    }
-
-    /**
      * Configures whether this request is secure.
      *
      * @param s Flag indicating whether request is secure.
      */
-    public void setIsSecure(boolean s) {
-        secure = s;
-    }
-
-    /**
-     * @param s Flag indicating whether request is secure.
-     * @deprecated replaced by {@link #setIsSecure(boolean)}
-     * <p>
-     * Configures whether this request is secure.
-     */
-    @Deprecated
-    public void setupIsSecure(boolean s) {
+    public void setSecure(boolean s) {
         secure = s;
     }
 
@@ -479,15 +403,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
     }
 
     /**
-     * @param methodIn The method to set.
-     * @deprecated replaced by {@link #setMethod(String)}
-     */
-    @Deprecated
-    public void setupGetMethod(String methodIn) {
-        this.method = methodIn;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @Override
@@ -520,15 +435,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
         this.pathInfo = pathInfoIn;
     }
 
-    /**
-     * @param pathInfoIn The request URI to set.
-     * @deprecated replaced by {@link #setPathInfo(String)}
-     */
-    @Deprecated
-    public void setupPathInfo(String pathInfoIn) {
-        this.pathInfo = pathInfoIn;
-    }
-
     @Override
     public String getPathTranslated() {
         throw new UnsupportedOperationException();
@@ -548,15 +454,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
         this.queryString = queryStringIn;
     }
 
-    /**
-     * @param queryStringIn query string to set.
-     * @deprecated replaced by {@link #setQueryString(String)}
-     */
-    @Deprecated
-    public void setupQueryString(String queryStringIn) {
-        this.queryString = queryStringIn;
-    }
-
     @Override
     public String getRequestURI() {
         return requestURI;
@@ -568,15 +465,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
      * @param requestURIIn request URI to set.
      */
     public void setRequestURI(String requestURIIn) {
-        this.requestURI = requestURIIn;
-    }
-
-    /**
-     * @param requestURIIn The request URI to set.
-     * @deprecated replaced by {@link #setRequestURI(String)}
-     */
-    @Deprecated
-    public void setupGetRequestURI(String requestURIIn) {
         this.requestURI = requestURIIn;
     }
 
@@ -735,18 +623,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
         this.inputStream = inputStreamIn;
     }
 
-    /**
-     * Set the input stream for this request.
-     * @param inputStreamIn input stream
-     * @deprecated replaced by {@link #setInputStream(ServletInputStream)}
-     */
-    @Deprecated
-    public void setupGetInputStream(ServletInputStream inputStreamIn) {
-        this.inputStream = inputStreamIn;
-    }
-
-
-
     @Override
     public String getProtocol() {
         return protocol;
@@ -771,31 +647,12 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
         this.serverName = serverNameIn;
     }
 
-    /**
-     * Set the server name for this request.
-     * @param serverNameIn The method to set.
-     * @deprecated replaced by {@link #setServerName(String)}
-     */
-    @Deprecated
-    public void setupServerName(String serverNameIn) {
-        this.serverName = serverNameIn;
-    }
-
     @Override
     public BufferedReader getReader() throws IOException {
         return reader;
     }
 
     public void setReader(BufferedReader readerIn) {
-        this.reader = readerIn;
-    }
-
-    /**
-     * @param readerIn reader to set
-     * @deprecated replaced by {@link #setReader(BufferedReader)}
-     */
-    @Deprecated
-    public void setupGetReader(BufferedReader readerIn) {
         this.reader = readerIn;
     }
 
@@ -812,15 +669,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
         remoteAddr = remoteAddrIn;
     }
 
-    /**
-     * @param remoteAddrIn remote address
-     * @deprecated replaced by {@link #setRemoteAddr(String)}
-     */
-    @Deprecated
-    public void setupGetRemoteAddr(String remoteAddrIn) {
-        remoteAddr = remoteAddrIn;
-    }
-
     public String getRemoteHost() {
         return remoteHost;
     }
@@ -831,15 +679,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
      * @param map map of attributes to set
      */
     public void setAttributes(Map<String, Object> map) {
-        this.attributes = map;
-    }
-
-    /**
-     * @param map map of attributes to set
-     * @deprecated replaced by {@link #setAttributes(Map)}
-     */
-    @Deprecated
-    public void setupGetAttribute(Map<String, Object> map) {
         this.attributes = map;
     }
 
@@ -854,16 +693,6 @@ public class RhnMockHttpServletRequest implements HttpServletRequest {
      * @param requestDispatcherIn the RequestDispatcher to return
      */
     public void setRequestDispatcher(RequestDispatcher requestDispatcherIn) {
-        this.requestDispatcher = requestDispatcherIn;
-    }
-
-
-    /**
-     * @param requestDispatcherIn the RequestDispatcher to set
-     * @deprecated replaced by {@link #setRequestDispatcher(RequestDispatcher)}
-     */
-    @Deprecated
-    public void setupGetRequestDispatcher(RequestDispatcher requestDispatcherIn) {
         this.requestDispatcher = requestDispatcherIn;
     }
 

--- a/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletResponse.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockHttpServletResponse.java
@@ -146,15 +146,6 @@ public class RhnMockHttpServletResponse implements HttpServletResponse {
         this.status = statusIn;
     }
 
-    /**
-     * @param statusIn the status to set
-     * @deprecated replaced by {@link #setStatus(int)}
-     */
-    @Deprecated
-    public void setExpectedStatus(int statusIn) {
-        this.status = statusIn;
-    }
-
     @Override
     public int getStatus() {
         return status;
@@ -247,15 +238,6 @@ public class RhnMockHttpServletResponse implements HttpServletResponse {
      */
     @Override
     public void setContentType(String type) {
-        this.contentType = type;
-    }
-
-    /**
-     * @param type the content type to set
-     * @deprecated replaced by {@link #setContentType(String)}
-     */
-    @Deprecated
-    public void setExpectedContentType(String type) {
         this.contentType = type;
     }
 

--- a/java/code/src/com/redhat/rhn/testing/RhnMockHttpSession.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockHttpSession.java
@@ -176,7 +176,7 @@ public class RhnMockHttpSession implements HttpSession {
      * @param value the attribute value
      */
     public void putValue(String name, Object value) {
-        setupGetAttribute(name, value);
+        this.setAttribute(name, value);
     }
 
     /**
@@ -212,17 +212,6 @@ public class RhnMockHttpSession implements HttpSession {
         else {
             attributes.put(name, value);
         }
-    }
-
-    /**
-     * @deprecated replaced by {@link #setAttribute(String, Object)}
-     *
-     * @param key  parameter name
-     * @param value parameter value
-     */
-    @Deprecated
-    public void setupGetAttribute(String key, Object value) {
-        this.setAttribute(key, value);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/SparkTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/SparkTestUtils.java
@@ -76,11 +76,11 @@ public class SparkTestUtils {
         final RhnMockHttpServletRequest mockRequest = new RhnMockHttpServletRequest();
         mockRequest.setSession(new RhnMockHttpSession());
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod("GET");
-        mockRequest.setupGetInputStream(new MockServletInputStream());
+        mockRequest.setMethod("GET");
+        mockRequest.setInputStream(new MockServletInputStream());
         setQueryParams(mockRequest, queryParams);
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
-        httpHeaders.forEach(mockRequest::setupGetHeader);
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
+        httpHeaders.forEach(mockRequest::setHeader);
 
         return RequestResponseFactory.create(match, mockRequest);
     }
@@ -124,11 +124,11 @@ public class SparkTestUtils {
         final RhnMockHttpServletRequest mockRequest = new RhnMockHttpServletRequest();
         mockRequest.setSession(new RhnMockHttpSession());
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod("GET");
-        mockRequest.setupGetInputStream(new MockServletInputStream());
+        mockRequest.setMethod("GET");
+        mockRequest.setInputStream(new MockServletInputStream());
         setMultiValueQueryParams(mockRequest, queryParams);
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
-        httpHeaders.forEach(mockRequest::setupGetHeader);
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
+        httpHeaders.forEach(mockRequest::setHeader);
 
         return RequestResponseFactory.create(match, mockRequest);
     }
@@ -209,17 +209,17 @@ public class SparkTestUtils {
         final RhnMockHttpServletRequest mockRequest = new RhnMockHttpServletRequest();
         mockRequest.setSession(new RhnMockHttpSession());
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod(method);
+        mockRequest.setMethod(method);
         MockServletInputStream in = new MockServletInputStream();
         in.setupRead(body.getBytes(
                 mockRequest.getCharacterEncoding() != null ?
                         mockRequest.getCharacterEncoding() : "UTF-8"));
-        mockRequest.setupGetInputStream(in);
+        mockRequest.setInputStream(in);
         setQueryParams(mockRequest, queryParams);
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
 
         httpHeaders.forEach(
-                (name, val) -> mockRequest.setupGetHeader(name, val));
+                (name, val) -> mockRequest.setHeader(name, val));
 
         return RequestResponseFactory.create(match, mockRequest);
     }
@@ -254,31 +254,31 @@ public class SparkTestUtils {
         final RhnMockHttpServletRequest mockRequest = new RhnMockHttpServletRequest();
         mockRequest.setSession(new RhnMockHttpSession());
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod(method);
+        mockRequest.setMethod(method);
         MockServletInputStream in = new MockServletInputStream();
         in.setupRead(body.getBytes(
                 mockRequest.getCharacterEncoding() != null ?
                         mockRequest.getCharacterEncoding() : "UTF-8"));
-        mockRequest.setupGetInputStream(in);
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
+        mockRequest.setInputStream(in);
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
 
         httpHeaders.forEach(
-                mockRequest::setupGetHeader);
+                mockRequest::setHeader);
 
         return RequestResponseFactory.create(match, mockRequest);
     }
 
     private static void setQueryParams(RhnMockHttpServletRequest request, Map<String, String> queryParams) {
-        queryParams.forEach((name, val) -> request.setupAddParameter(name, new String[]{val}));
+        queryParams.forEach((name, val) -> request.addParameter(name, new String[]{val}));
         // we must convert to a "multi-value map"
-        request.setupGetParameterMap(queryParams.entrySet().stream().collect(
+        request.setParameters(queryParams.entrySet().stream().collect(
                 Collectors.toMap(v -> v.getKey(), v -> new String[]{v.getValue()})));
     }
 
     private static void setMultiValueQueryParams(RhnMockHttpServletRequest request,
                                                  Map<String, List<String>> queryParams) {
-        queryParams.forEach((name, val) -> request.setupAddParameter(name, val.toArray(new String[0])));
-        request.setupGetParameterMap(queryParams.entrySet().stream().collect(
+        queryParams.forEach((name, val) -> request.addParameter(name, val.toArray(new String[0])));
+        request.setParameters(queryParams.entrySet().stream().collect(
                 Collectors.toMap(v -> v.getKey(), v -> v.getValue().toArray(new String[0]))));
     }
 }

--- a/java/code/src/com/redhat/rhn/testing/TagTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/TagTestUtils.java
@@ -53,7 +53,7 @@ public class TagTestUtils {
         mpc.setJspWriter(new RhnMockJspWriter());
 
         if (url != null) {
-            ctx.setupGetResource(url);
+            ctx.setResource(url);
         }
         return tth;
     }

--- a/java/code/src/com/redhat/rhn/testing/TestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/TestUtils.java
@@ -204,7 +204,7 @@ public class TestUtils {
         RhnMockHttpServletRequest req = new RhnMockHttpServletRequest();
         RhnMockHttpServletResponse resp = new RhnMockHttpServletResponse();
         RhnMockHttpSession session = new RhnMockHttpSession();
-        req.setupServerName("mlm.dev.suse.com");
+        req.setServerName("mlm.dev.suse.com");
         req.setSession(session);
 
         // Create a test user
@@ -224,7 +224,7 @@ public class TestUtils {
 
         // Set the uid parameter
         req.addCookie(resp.getCookie("pxt-session-cookie"));
-        req.setupAddParameter("uid", userid.toString());
+        req.addParameter("uid", userid.toString());
 
         return req;
     }

--- a/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
@@ -68,9 +68,9 @@ public class LoginControllerTest extends BaseControllerTestCase {
         mockRequest.setSession(session);
 
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod("POST");
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
-        mockRequest.setupAddParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
+        mockRequest.setMethod("POST");
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
+        mockRequest.addParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
 
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
         // logging in
@@ -90,9 +90,9 @@ public class LoginControllerTest extends BaseControllerTestCase {
         RhnMockHttpSession session = new RhnMockHttpSession();
         mockRequest.setSession(session);
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod("POST");
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
-        mockRequest.setupAddParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
+        mockRequest.setMethod("POST");
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
+        mockRequest.addParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
 
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
         ModelAndView result = LoginController.loginView(RequestResponseFactory.create(match, mockRequest), response);
@@ -112,9 +112,9 @@ public class LoginControllerTest extends BaseControllerTestCase {
         mockRequest.setSession(session);
 
         mockRequest.setRequestURL(requestUrl);
-        mockRequest.setupGetMethod("POST");
-        mockRequest.setupPathInfo(URI.create(requestUrl).getPath());
-        mockRequest.setupAddParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
+        mockRequest.setMethod("POST");
+        mockRequest.setPathInfo(URI.create(requestUrl).getPath());
+        mockRequest.addParameter("url_bounce", "/rhn/users/UserDetails.do?uid=1");
 
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
         ModelAndView result = LoginController.loginView(RequestResponseFactory.create(match, mockRequest), response);

--- a/java/spacewalk-java.changes.rjpmestre.drop-deprecated-java-unit-test-methods
+++ b/java/spacewalk-java.changes.rjpmestre.drop-deprecated-java-unit-test-methods
@@ -1,0 +1,1 @@
+- Drop deprecated java unit test methods


### PR DESCRIPTION
## What does this PR change?

In this PR we address the deprecated methods we had to introduce when removing the mockobjects package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28386
Port(s): #

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
