### PR TITLE
Fix systems list when entitlement is undefined (bsc#1248661)

### DIFF
--- a/web/html/src/components/systems.tsx
+++ b/web/html/src/components/systems.tsx
@@ -9,7 +9,7 @@ export type SystemOverview = {
   serverName: string;
   isVirtualGuest: boolean;
   isVirtualHost: boolean;
-  entitlement: string[];
+  entitlement?: string[];
   proxy: boolean;
   mgrServer: boolean;
 };
@@ -19,7 +19,7 @@ export function iconAndName(system: SystemOverview) {
     {
       iconType: "system-bare-metal",
       iconTitle: t("Unprovisioned System"),
-      condition: (sys: SystemOverview) => sys.entitlement.includes("bootstrap_entitled"),
+      condition: (sys: SystemOverview) => sys.entitlement?.includes("bootstrap_entitled"),
     },
     {
       iconType: "system-virt-guest",

--- a/web/spacewalk-web.changes.welder.bsc1248661
+++ b/web/spacewalk-web.changes.welder.bsc1248661
@@ -1,0 +1,1 @@
+- Fix physical systems list (bsc#1248661)


### PR DESCRIPTION
## What does this PR change?

Prevent TypeError on 'includes' when 'entitlement' is undefined.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: small UI fix

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28192


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
