### PR TITLE
QE: Add tumbleweed as OS for suse minions activations keys

### DIFF
--- a/testsuite/features/github_validation/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/github_validation/init_clients/sle_ssh_minion.feature
@@ -24,10 +24,10 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
-    And I check radio button "openSUSE Leap 15.6 (x86_64)"
+    And I check radio button "openSUSE Tumbleweed (x86_64)"
     And I wait until I do not see "Loading..." text
     And I check "Fake-RPM-SUSE-Channel"
-    And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)"
+    And I check "Uyuni Client Tools for openSUSE Tumbleweed (x86_64) (Development)"
     And I click on "Next"
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -36,13 +36,13 @@ Feature: Update activation keys
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
 @uyuni
-  Scenario: Update openSUSE Leap key with synced base product
+  Scenario: Update openSUSE Tumbleweed key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
     And I wait until I do not see "Loading..." text
     And I select the parent channel for the "sle_minion" from "selectedBaseChannel"
     And I wait until I do not see "Loading..." text
-    And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)"
+    And I check "Uyuni Client Tools for openSUSE Tumbleweed (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
@@ -69,13 +69,13 @@ Feature: Update activation keys
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
 
 @uyuni
-  Scenario: Update openSUSE Leap SSH key with synced base product
+  Scenario: Update openSUSE Tumbleweed SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Test Key x86_64" in the content area
     And I wait until I do not see "Loading..." text
     And I select the parent channel for the "sle_minion" from "selectedBaseChannel"
     And I wait until I do not see "Loading..." text
-    And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)"
+    And I check "Uyuni Client Tools for openSUSE Tumbleweed (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
@@ -102,13 +102,13 @@ Feature: Update activation keys
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
 
 @uyuni
-  Scenario: Update openSUSE Leap SSH tunnel key with synced base product
+  Scenario: Update openSUSE Tumbleweed SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area
     And I wait until I do not see "Loading..." text
     And I select the parent channel for the "sle_minion" from "selectedBaseChannel"
     And I wait until I do not see "Loading..." text
-    And I check "Uyuni Client Tools for openSUSE Leap 15.6 (x86_64) (Development)"
+    And I check "Uyuni Client Tools for openSUSE Tumbleweed (x86_64) (Development)"
     And I check "Fake-RPM-SUSE-Channel"
     And I wait until "Fake-RPM-SUSE-Channel" has been checked
     And I click on "Update Activation Key"
@@ -160,7 +160,7 @@ Feature: Update activation keys
     And I wait for child channels to appear
     And I select the parent channel for the "proxy_container" from "selectedBaseChannel"
     And I wait for child channels to appear
-     And I check "Uyuni Client Tools for openSUSE Tumbleweed (x86_64) (Development)"
+    And I check "Uyuni Client Tools for openSUSE Tumbleweed (x86_64) (Development)"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -90,7 +90,7 @@ Feature: Manipulate activation keys
     And I enter "SUSE Test PKG Key x86_64" as "description"
     And I enter "SUSE-TEST-x86_64" as "key"
     And I enter "20" as "usageLimit"
-    And I select "openSUSE Leap 15.6 (x86_64)" from "selectedBaseChannel"
+    And I select "openSUSE Tumbleweed (x86_64) (x86_64)" from "selectedBaseChannel"
     And I click on "Create Activation Key"
     And I follow "Packages"
     And I enter "sed" as "packages"


### PR DESCRIPTION
## What does this PR change?

 Add tumbleweed as OS for suse minions activations keys

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): None
Port(s): None, just for uyuni

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
