### PR TITLE
QE:  refactor built Kiwi OS images' checks

### DIFF
--- a/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle12sp5_buildhost_build_kiwi_image.feature
@@ -10,7 +10,7 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     Given I am authorized for the "Admin" section
 
   Scenario: Create the bootstrap repository for a SLES 12 SP5 build host
-     When I create the bootstrap repository for "sle12sp5_buildhost" on the server
+    When I create the bootstrap repository for "sle12sp5_buildhost" on the server
 
   Scenario: Clean up sumaform leftovers on a SLES 12 SP5 build host
     When I perform a full salt minion cleanup on "sle12sp5_buildhost"
@@ -55,14 +55,18 @@ Feature: Prepare buildhost and build OS image for SLES 12 SP5
     And I select the hostname of "sle12sp5_buildhost" from "buildHostId"
     And I click on "submit-btn"
 
-  Scenario: Check the built SLES 12 SP5 OS image
+  Scenario: Wait for the built SLES 12 SP5 OS image
     Given I am on the Systems overview page of this "sle12sp5_buildhost"
     When I wait until I see "[OS Image Build Host]" text
     And I wait until the image build "suse_os_image_12" is completed
     And I wait until the image inspection for "sle12sp5_terminal" is completed
     And I wait until no Salt job is running on "sle12sp5_buildhost"
-    And I am on the image store of the Kiwi image for organization "1"
-    Then I should see the name of the image for "sle12sp5_terminal"
+    And I follow the left menu "Images > Image List"
+    Then I should see the image for "sle12sp5_terminal" is built
+
+  Scenario: Check the built SLES 12 SP5 OS image
+    When I open the details page of the image for "sle12sp5_terminal"
+    Then I should see a link to download the image for "sle12sp5_terminal"
 
 @skip_if_containerized_server
   Scenario: Move the SLES 12 SP5 image to the branch server

--- a/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/sle15sp4_buildhost_build_kiwi_image.feature
@@ -10,7 +10,7 @@ Feature: Prepare buildhost and build OS image for SLES 15 SP4
     Given I am authorized for the "Admin" section
 
   Scenario: Create the bootstrap repository for a SLES 15 SP4 build host
-     When I create the bootstrap repository for "sle15sp4_buildhost" on the server
+    When I create the bootstrap repository for "sle15sp4_buildhost" on the server
 
   Scenario: Clean up sumaform leftovers on a SLES 15 SP4 build host
     When I perform a full salt minion cleanup on "sle15sp4_buildhost"
@@ -55,14 +55,18 @@ Feature: Prepare buildhost and build OS image for SLES 15 SP4
     And I select the hostname of "sle15sp4_buildhost" from "buildHostId"
     And I click on "submit-btn"
 
-  Scenario: Check the built SLES 15 SP4 OS image
+  Scenario: Wait for the built SLES 15 SP4 OS image
     Given I am on the Systems overview page of this "sle15sp4_buildhost"
     When I wait until I see "[OS Image Build Host]" text
     And I wait until the image build "suse_os_image_15" is completed
     And I wait until the image inspection for "sle15sp4_terminal" is completed
     And I wait until no Salt job is running on "sle15sp4_buildhost"
-    And I am on the image store of the Kiwi image for organization "1"
-    Then I should see the name of the image for "sle15sp4_terminal"
+    And I follow the left menu "Images > Image List"
+    Then I should see the image for "sle15sp4_terminal" is built
+
+  Scenario: Check the built SLES 15 SP4 OS image
+    When I open the details page of the image for "sle15sp4_terminal"
+    Then I should see a link to download the image for "sle15sp4_terminal"
 
 @skip_if_containerized_server
   Scenario: Move the SLES 15 SP4 image to the branch server

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -46,14 +46,18 @@ Feature: Build OS images
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Check the built OS image
+  Scenario: Wait for the built OS image
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image" is completed
     And I wait until the image inspection for "pxeboot_minion" is completed
     And I wait until no Salt job is running on "build_host"
-    And I am on the image store of the Kiwi image for organization "1"
-    Then I should see the name of the image for "pxeboot_minion"
+    And I follow the left menu "Images > Image List"
+    Then I should see the image for "pxeboot_minion" is built
+
+  Scenario: Check the built OS image
+    When I open the details page of the image for "pxeboot_minion"
+    Then I should see a link to download the image for "pxeboot_minion"
 
   Scenario: Cleanup: remove remaining systems from SSM after OS image tests
     When I go to the home page


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/19181

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): #
Port(s):

4.3 -  https://github.com/SUSE/spacewalk/pull/28467 - not strictly needed because without containers we probably do not get in the same situation. Might be nice to have for aligning code.
5.0 - https://github.com/SUSE/spacewalk/pull/28468
5.1 - https://github.com/SUSE/spacewalk/pull/28471

- [x] **DONE**

## Changelogs

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"