### PR TITLE
QE: update selectors for Salt keys related buttons

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2015-2024 SUSE LLC
+# Copyright 2015-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ### This file contains all step definitions concerning Salt and bootstrapping
@@ -439,13 +439,13 @@ end
 # Perform actions
 When(/^I reject "([^"]*)" from the Pending section$/) do |host|
   system_name = get_system_name(host)
-  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Reject']"
+  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@aria-label = 'Reject']"
   raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
 When(/^I delete "([^"]*)" from the Rejected section$/) do |host|
   system_name = get_system_name(host)
-  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Delete']"
+  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@aria-label = 'Delete']"
   raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
@@ -459,7 +459,7 @@ end
 
 When(/^I accept "([^"]*)" key$/) do |host|
   system_name = get_system_name(host)
-  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@title = 'Accept']"
+  xpath_query = "//tr[td[contains(.,'#{system_name}')]]//button[@aria-label = 'Accept']"
   raise ScriptError, "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 


### PR DESCRIPTION
## What does this PR change?

Updates selectors for UI buttons to Accept, Reject and Delete a Salt key.
Some scenarios are failing in HEAD CI because they cannot be located.

<img width="2491" height="570" alt="Screenshot From 2025-09-26 12-14-07" src="https://github.com/user-attachments/assets/81d8a48d-4b54-41eb-99a6-cd3d06e0ca16" />


## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- Cucumber steps were modified

- [ ] **DONE**

## Links

Port(s):  needs checks

4.3 -
5.0 -
5.1 -

- [ ] **DONE**

## Changelogs

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"