### PR TITLE
Adds provisionSystem API call without a proxy and with kernel_options (bsc#1245528)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -2773,7 +2773,7 @@ public class SystemHandler extends BaseHandler {
      */
     @ApiIgnore(ApiType.HTTP)
     public int provisionSystem(User loggedInUser, Integer sid, String profileName)
-            throws FaultException {
+    throws FaultException {
        return provisionSystem(
                loggedInUser, RhnXmlRpcServer.getRequest(), sid, null, profileName, new Date(), new HashMap<>()
        );
@@ -2968,6 +2968,72 @@ public class SystemHandler extends BaseHandler {
                                Integer proxy, String profileName, Date earliestDate)
         throws FaultException {
         return provisionSystem(loggedInUser, request, sid, proxy, profileName, earliestDate, new HashMap<>());
+    }
+
+    /**
+     * Provision a system using the specified kickstart/autoinstallation profile at specified time.
+     *
+     * @param loggedInUser The current user
+     * @param sid of the system to be provisioned
+     * @param profileName of Profile to be used.
+     * @param earliestDate when the autoinstallation needs to be scheduled
+     * @param advancedOptions custom kernel or post kernel options
+     * @return Returns id of the action if successful, exception otherwise
+     * @throws FaultException A FaultException is thrown if the server corresponding to
+     * id cannot be found or profile is not found.
+     *
+     * @apidoc.doc Provision a system using the specified kickstart/autoinstallation profile.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("int", "sid", "ID of the system to be provisioned.")
+     * @apidoc.param #param_desc("string", "profileName", "Profile to use.")
+     * @apidoc.param #param("$date", "earliestDate")
+     * @apidoc.param
+     *  #struct_begin("advancedOptions")
+     *      #prop_desc("string", "kernel_options", "custom kernel options")
+     *      #prop_desc("string", "post_kernel_options", "custom post kernel options")
+     *  #struct_end()
+     * @apidoc.returntype #param_desc("int", "id", "ID of the action scheduled, otherwise exception thrown
+     * on error")
+     */
+    @ApiIgnore(ApiType.HTTP)
+    public int provisionSystem(User loggedInUser, Integer sid, String profileName,
+                               Date earliestDate, Map<String, String> advancedOptions)
+            throws FaultException {
+        HttpServletRequest request = RhnXmlRpcServer.getRequest();
+        return provisionSystem(loggedInUser, request, sid, null, profileName, earliestDate, advancedOptions);
+    }
+
+    /**
+     * Provision a system using the specified kickstart/autoinstallation profile at specified time.
+     *
+     * @param loggedInUser The current user
+     * @param request the request
+     * @param sid of the system to be provisioned
+     * @param profileName of Profile to be used.
+     * @param earliestDate when the autoinstallation needs to be scheduled
+     * @param advancedOptions custom kernel or post kernel options
+     * @return Returns id of the action if successful, exception otherwise
+     * @throws FaultException A FaultException is thrown if the server corresponding to
+     * id cannot be found or profile is not found.
+     *
+     * @apidoc.doc Provision a system using the specified kickstart/autoinstallation profile.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param_desc("int", "sid", "ID of the system to be provisioned.")
+     * @apidoc.param #param_desc("string", "profileName", "Profile to use.")
+     * @apidoc.param #param("$date", "earliestDate")
+     * @apidoc.param
+     *  #struct_begin("advancedOptions")
+     *      #prop_desc("string", "kernel_options", "custom kernel options")
+     *      #prop_desc("string", "post_kernel_options", "custom post kernel options")
+     *  #struct_end()
+     * @apidoc.returntype #param_desc("int", "id", "ID of the action scheduled, otherwise exception thrown
+     * on error")
+     */
+    @ApiIgnore(ApiType.XMLRPC)
+    public int provisionSystem(User loggedInUser, HttpServletRequest request, Integer sid,
+                               String profileName, Date earliestDate, Map<String, String> advancedOptions)
+            throws FaultException {
+        return provisionSystem(loggedInUser, request, sid, null, profileName, earliestDate, advancedOptions);
     }
 
     /**

--- a/java/spacewalk-java.changes.carlo.uyuni-1245528-api-system-provision-system
+++ b/java/spacewalk-java.changes.carlo.uyuni-1245528-api-system-provision-system
@@ -1,0 +1,2 @@
+- Adds provisionSystem API call without a proxy and with
+  kernel_options (bsc#1245528)


### PR DESCRIPTION
## What does this PR change?

The API call provisionSystem with kernel_options only allows to provision systems through a proxy but does not allow to provision systems from SMLM itself.

There are customers using SMLM without a proxy that need to provision systems through the API that require kernel_options and post_kernel_options.

This PR adds provisionSystem API call without a proxy and with kernel_options

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- Unit tests were added
- Cucumber tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/27699
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/28479, 5.0: https://github.com/SUSE/spacewalk/pull/28480
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

