### PR TITLE
For compatibility with existing AutoYast profiles, redirect old branding tools repo name to the new one.

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -77,6 +77,9 @@ SSLProxyEngine on
 RewriteRule ^/ks/cfg([-a-zA-Z0-9\._/\%\ ]*)$ /rhn/kickstart/DownloadFile.do?ksurl=$1
 RewriteRule ^/download/(.*)$ /rhn/common/DownloadFile.do?url=/$1
 RewriteRule ^/rpc/api /rhn/rpc/api
+
+# Old branding AutoYast compatiblity link. Intentionally as redirect.
+RewriteRule ^/ks/dist/child/sle-manager-tools(.*)$ /ks/dist/child/managertools-sle$1 [R,L]
 RewriteRule ^/ks/dist(.*)$ /rhn/common/DownloadFile.do?url=/ks/dist$1 "[B= ?+,BNP]"
 RewriteRule ^(/ty/.*)$ /rhn/common/DownloadFile.do?url=$1
 RewriteRule ^/index\.html$ /rhn/manager/login

--- a/spacewalk/config/spacewalk-config.changes.oholecek.redirect_old_branding
+++ b/spacewalk/config/spacewalk-config.changes.oholecek.redirect_old_branding
@@ -1,0 +1,2 @@
+- For compatibility with existing AutoYast profiles, redirect
+  old branding tools repo name to the new one.


### PR DESCRIPTION
## What does this PR change?

With rebranding we changed the name of the tools repository. Existing AutoYast profiles are thus rendered invalid. To lessen the negative feedback, this PR adds a compatibility redirect from the old repo to the new one.
It is intentionally done as a redirect instead of silent rewrite to indicate to the client there is a change.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
