### PR TITLE
Fix password policy form (bsc#1244430)

### DIFF
--- a/web/html/src/manager/admin/password-policy/password-policy.tsx
+++ b/web/html/src/manager/admin/password-policy/password-policy.tsx
@@ -24,7 +24,7 @@ const PasswordPolicy = (prop: PasswordPolicyProps) => {
         <MessagesContainer />
         <p>{t("Set up your server local users password policy.")}</p>
       </div>
-      <Form model={policy}>
+      <Form model={policy} onChange={(model) => setPolicy({ ...model })}>
         <Panel headingLevel="h2" title={t("Password Policy Settings")}>
           {/* Minimum Length */}
           <Text

--- a/web/spacewalk-web.changes.bisht-richa.fix-password-policy-form
+++ b/web/spacewalk-web.changes.bisht-richa.fix-password-policy-form
@@ -1,0 +1,2 @@
+- Checked options immediately enable linked password policy
+  fields. (bsc#1244430)


### PR DESCRIPTION
## What does this PR change?

Input fields activate instantly when their options are checked in the Password Policy form.

Fix: https://github.com/SUSE/spacewalk/issues/27493

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**


- [x] **DONE**

## Links

Issue(s): [27493](https://github.com/SUSE/spacewalk/issues/27493)
Port(s): [ 5.1](https://github.com/SUSE/spacewalk/pull/28477)
 [ 5.0](https://github.com/SUSE/spacewalk/pull/28476)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
