### PR TITLE
QE: wait event completion after applying patches through SSM

### DIFF
--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -84,6 +84,8 @@ Feature: Manage a group of systems and the Systems Set Manager
     And I click on "Apply Patches"
     And I click on "Confirm"
     Then I should see a "Patch virgo-dummy-3456 has been scheduled for 1 system" text
+    And I am on the Systems overview page of this "sle_minion"
+    And I wait until event "Patch Update: virgo-dummy-3456 - Test update for virgo-dummy scheduled by admin" is completed
 
   Scenario: Apply a patch to systems in the SSM
     When I follow the left menu "Systems > System Set Manager > Overview"
@@ -98,6 +100,8 @@ Feature: Manage a group of systems and the Systems Set Manager
     And I click on "Apply Patches"
     And I click on "Confirm"
     Then I should see a "Patch andromeda-dummy-6789 has been scheduled for 1 system" text
+    And I am on the Systems overview page of this "sle_minion"
+    And I wait until event "Patch Update: andromeda-dummy-6789 - Test update for andromeda-dummy scheduled by admin" is completed
 
 @skip_if_github_validation
   Scenario: Delete a package from systems in the SSM


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/27650

I think those issues may be caused by the fact that we schedule the patches to be applied but do not explicitly wait for the corresponding event to be completed.
So, the following tests may try to remove a patched package version that has not been installed yet at that point.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27650
Port(s): 

5.0 - https://github.com/SUSE/spacewalk/pull/28482
5.1 - https://github.com/SUSE/spacewalk/pull/28481

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
