### PR TITLE
QE: fix navigation to Prometheus' formulas configuration tabs

### DIFF
--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -26,7 +26,7 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
 
   Scenario: Configure Prometheus formula
     When I follow "Formulas" in the content area
-    And I click on "Prometheus" in the content area
+    And I follow "Prometheus" in the content area
     And I click on "Expand All Sections"
     And I enter "admin" as "Username"
     And I enter "admin" as "Password"
@@ -35,7 +35,7 @@ Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
 
   Scenario: Configure Prometheus exporter formula
     When I follow "Formulas" in the content area
-    And I click on "Prometheus Exporters" in the content area
+    And I follow "Prometheus Exporters" in the content area
     And I click on "Expand All Sections"
     And I should see a "Enable and configure Prometheus exporters for managed systems." text
     And I check "node" exporter


### PR DESCRIPTION
## What does this PR change?

The current step does not exist, causing the apache exporter to never be actually configured.

<img width="2542" height="990" alt="Screenshot From 2025-09-29 15-52-09" src="https://github.com/user-attachments/assets/9fe77415-0419-47b5-a84a-b57b76f1cdd8" />


## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests were modified

- [x] **DONE**

## Links

Port(s):  not needed

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
