### PR TITLE
Force listening to changes on legacy forms

### DIFF
--- a/web/html/src/components/hub/AddTokenButton.tsx
+++ b/web/html/src/components/hub/AddTokenButton.tsx
@@ -122,7 +122,11 @@ export class AddTokenButton extends React.Component<Props, State> {
         isOpen={this.state.createRequest !== undefined}
         onClose={() => this.setState({ createRequest: undefined })}
         content={
-          <Form model={this.state.createRequest} onValidate={(valid) => this.setState({ createRequestValid: valid })}>
+          <Form
+            model={this.state.createRequest}
+            onChange={(model) => this.setState({ createRequest: { ...model } })}
+            onValidate={(valid) => this.setState({ createRequestValid: valid })}
+          >
             <Text
               name="fqdn"
               label={t("Server FQDN")}

--- a/web/html/src/components/hub/ModalEditButton.tsx
+++ b/web/html/src/components/hub/ModalEditButton.tsx
@@ -65,7 +65,11 @@ export class ModalEditButton extends React.Component<Props, State> {
           isOpen={this.state.model !== undefined}
           onClose={() => this.setState({ model: undefined })}
           content={
-            <Form model={this.state.model} onValidate={(valid) => this.setState({ valid })}>
+            <Form
+              model={this.state.model}
+              onChange={(model) => this.setState({ model: { ...model } })}
+              onValidate={(valid) => this.setState({ valid })}
+            >
               <Text
                 name="value"
                 label={this.props.fieldLabel}

--- a/web/html/src/components/input/form/Form.tsx
+++ b/web/html/src/components/input/form/Form.tsx
@@ -6,12 +6,25 @@ import { InputBase } from "../InputBase";
 
 type InputBaseRef = React.ElementRef<typeof InputBase>;
 
-type Props = {
+// If a model is specified, you must listen to changes as well (bsc#1244430)
+type WithModel = {
   /** Object storing the data of the form.
    *  Each field name in the form needs to map to a property of this
    *  object. The value is the one displayed in the form */
-  model?: any;
+  model: any;
 
+  /** Function called when the model has been changed.
+   * Takes a new model as single parameter.
+   */
+  onChange: (model: any) => void;
+};
+
+type WithoutModel = {
+  model?: never;
+  onChange?: never;
+};
+
+type Props = (WithModel | WithoutModel) & {
   /** Object storing form field errors */
   errors?: object;
 
@@ -32,11 +45,6 @@ type Props = {
 
   /** Children elements of the form. Usually includes fields and a submit button */
   children?: React.ReactNode;
-
-  /** Function called when the model has been changed.
-   * Takes a new model as single parameter.
-   */
-  onChange?: (model: any) => void;
 
   /** Function called after having validated the form.
    * Takes a single parameter indicating whether the form is valid or not.

--- a/web/html/src/manager/admin/password-policy/password-policy.tsx
+++ b/web/html/src/manager/admin/password-policy/password-policy.tsx
@@ -24,7 +24,7 @@ const PasswordPolicy = (prop: PasswordPolicyProps) => {
         <MessagesContainer />
         <p>{t("Set up your server local users password policy.")}</p>
       </div>
-      <Form model={policy}>
+      <Form model={policy} onChange={(model) => setPolicy({ ...model })}>
         <Panel headingLevel="h2" title={t("Password Policy Settings")}>
           {/* Minimum Length */}
           <Text


### PR DESCRIPTION
## What does this PR change?

This is a followup to https://github.com/uyuni-project/uyuni/pull/10906, fixing other places where the same bug might possibly be present. This only affects legacy forms, not the new Formik based forms.

Previously it was valid to specify a form model but not listen to the changes. This change adds a type check that changes are always listened to.

I could use some help verifying this change since I'm not familiar with the hub functionality.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: must pass existing tests

- [x] **DONE**

## Links

Followup to https://github.com/uyuni-project/uyuni/pull/10906

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
