### PR TITLE
Updated knowledgebase menu with new URL (bsc#1250557)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/core/src/main/java/com/suse/manager/webui/menu/MenuTree.java
@@ -601,7 +601,7 @@ public class MenuTree {
     private MenuItem getExternalLinksNode(String docsLocale) {
         return new MenuItem("External Links").withIcon("fa-link")
             .addChild(new MenuItem("header.jsp.knowledgebase")
-                    .withPrimaryUrl("https://www.suse.com/support/kb/?id=SUSE+Manager")
+                    .withPrimaryUrl("https://www.suse.com/support/kb/?id=SUSE+Manager+Server")
                     .withTarget("_blank"))
             .addChild(new MenuItem("header.jsp.documentation")
                     .withPrimaryUrl(ConfigDefaults.get().isUyuni() ?

--- a/java/spacewalk-java.changes.bisht-richa.update-knowledgebase-link
+++ b/java/spacewalk-java.changes.bisht-richa.update-knowledgebase-link
@@ -1,0 +1,1 @@
+- Knowledgebase menu updated to point to new URL. (bsc#1250557)


### PR DESCRIPTION
## What does this PR change?

Updated knowledgebase menu with new URL
Fix: https://github.com/SUSE/spacewalk/issues/28459


## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes: [#28459](https://github.com/SUSE/spacewalk/issues/28459)
Port(s): [5.1](https://github.com/SUSE/spacewalk/pull/28505)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
