### PR TITLE
Fix methods in api namespace in spacecmd (bsc#1249532)

### DIFF
--- a/spacecmd/spacecmd.changes.cbbayburt.bsc1249532
+++ b/spacecmd/spacecmd.changes.cbbayburt.bsc1249532
@@ -1,0 +1,1 @@
+- Fix methods in api namespace in spacecmd (bsc#1249532)

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -100,7 +100,13 @@ def do_api(self, args):
         return
 
     try:
-        if api_name in ["api.getVersion", "api.systemVersion"]:
+        if api_name in [
+            "api.getVersion",
+            "api.systemVersion",
+            "api.getApiNamespaces",
+            "api.getApiCallList",
+            "api.getApiNamespaceCallList",
+        ]:
             res = api(*api_args)
         else:
             res = api(self.session, *api_args)


### PR DESCRIPTION
As part of the RBAC implementation, some API methods in the `api` namespace has been changed to not require authentication (see: b023419ebd4039e67164668088b95441d8da9292).

This PR fixes calls to these methods in `spacecmd`

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28366

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
