### PR TITLE
Fix building uyuni-cobbler-helper on Leap 15.6

### DIFF
--- a/python/uyuni-cobbler-helper/uyuni-cobbler-helper.spec
+++ b/python/uyuni-cobbler-helper/uyuni-cobbler-helper.spec
@@ -18,6 +18,7 @@
 ## The productprettyname macros is controlled in the prjconf. If not defined, we fallback here
 %{!?productprettyname: %global productprettyname Uyuni}
 
+%{?!python_module:%define python_module() python-%{**} python3-%{**}}
 Name:           uyuni-cobbler-helper
 Version:        5.1.0
 Release:        0


### PR DESCRIPTION
## What does this PR change?
In contrast to the documentation in the packaging wiki [0], the compatibility shim is still required in Leap 15.6.

[0]: https://en.opensuse.org/openSUSE:Packaging_Python#Compatibility_shim



## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
