### PR TITLE
Fix bug 1246035: Correct PROFILE_NAME variable definition in bootstrap script

### DIFF
--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -577,6 +577,11 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         server.setMachineId(MACHINE_ID);
         executeTest((key) -> new Expectations() {{
             allowing(saltServiceMock).updateSystemInfo(with(any(MinionList.class)));
+            allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
+            will(returnValue(getSystemInfo(MINION_ID, null, key)));
+            allowing(saltServiceMock)
+                    .getGrains(with(any(String.class)), with(any(TypeToken.class)), with(any(String[].class)));
+            will(returnValue(Optional.of(DEFAULT_MINION_START_UP_GRAINS)));
             exactly(1).of(saltServiceMock).deleteKey(server.getMinionId());
         }}, null, (minion, machineId, key) -> assertTrue(MinionServerFactory.findByMinionId(MINION_ID).isPresent()),
                 null, DEFAULT_CONTACT_METHOD);

--- a/java/spacewalk-java.changes.carlo.uyuni-1246035-bootstrap-script-profile-name-var
+++ b/java/spacewalk-java.changes.carlo.uyuni-1246035-bootstrap-script-profile-name-var
@@ -1,0 +1,2 @@
+- Using corrected PROFILE_NAME variable definition in bootstrap
+  script (bsc#1246035)

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -122,10 +122,10 @@ REGISTER_THIS_BOX=1
 # Set if you want to specify profilename for client systems.
 # NOTE: Make sure it's set correctly if any external command is used.
 #
-# ex. PROFILENAME="foo.example.com"  # For specific client system
-#     PROFILENAME=`hostname -s`      # Short hostname
-#     PROFILENAME=`hostname -f`      # FQDN
-PROFILENAME=""   # Empty by default to let it be set automatically.
+# ex. PROFILE_NAME="foo.example.com"  # For specific client system
+#     PROFILE_NAME=`hostname -s`      # Short hostname
+#     PROFILE_NAME=`hostname -f`      # FQDN
+PROFILE_NAME=""   # Empty by default to let it be set automatically.
 
 # SUSE Multi-Linux Manager Specific settings:
 #

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.carlo.uyuni-1246035-bootstrap-script-profile-name-var
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.carlo.uyuni-1246035-bootstrap-script-profile-name-var
@@ -1,0 +1,2 @@
+- Correct PROFILE_NAME variable definition in bootstrap script
+  (bsc#1246035)


### PR DESCRIPTION
## What does this PR change?

The bootstrap script has defined a variable named PROFILENAME to specify profilename for client systems. However later in the script, a variable named PROFILE_NAME is addressed. The variable name  has been changed to match the code by adding the underscore separator.

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: not needed
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27853
Port(s): 5.0: https://github.com/SUSE/spacewalk/pull/28535, 5.1: https://github.com/SUSE/spacewalk/pull/28536
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)

