### PR TITLE
Fix cobbler setup: cheeta's whitelist is empty

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup-cobbler
+++ b/spacewalk/setup/bin/spacewalk-setup-cobbler
@@ -99,7 +99,7 @@ def manipulate_cobbler_settings(config_dir: str, settings_yaml: str, fqdn: str):
     filecontent["redhat_management_server"] = fqdn or socket.getfqdn()
     filecontent["client_use_localhost"] = True
     filecontent["uyuni_authentication_endpoint"] = "http://localhost"
-    filecontent["cheetah_import_whitelist"].append("uyuni_cobbler_helper")
+    filecontent["cheetah_import_whitelist"] = ["random", "re", "time", "netaddr", "uyuni_cobbler_helper"]
     yaml_dump = yaml.safe_dump(filecontent)
     # pylint: disable-next=unspecified-encoding
     with open(full_path, "w") as settings_file:


### PR DESCRIPTION
## What does this PR change?

See title: fix setup failure introduced by the new cobbler templates python helper

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: setup broke

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
