### PR TITLE
Fix authentication for spaceapi search module (bsc#1250424)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -111,12 +111,16 @@ public class BaseHandler implements XmlRpcInvocationHandler {
         WebSession session = null;
         User user = null;
 
-        if (!params.isEmpty() && params.get(0) instanceof String p0 && isSessionKey(p0) &&
-                !myClass.getName().endsWith("AuthHandler") && !myClass.getName().endsWith("SearchHandler")) {
+        if (!params.isEmpty() && params.get(0) instanceof String p0 && isSessionKey(p0)) {
 
             session = SessionManager.loadSession((String) params.get(0));
             user = getLoggedInUser((String) params.get(0));
-            params.set(0, user);
+
+            if (!myClass.getName().endsWith("AuthHandler") && !myClass.getName().endsWith("SearchHandler")) {
+                // Auth and Search handlers require raw session keys
+                // Set the first param to the user object for all others
+                params.set(0, user);
+            }
         }
         else if (!params.isEmpty() && params.get(0) instanceof User) {
             user = (User) params.get(0);

--- a/java/spacewalk-java.changes.cbbayburt.bsc1250424
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1250424
@@ -1,0 +1,1 @@
+- Fix authentication for spaceapi search module (bsc#1250424)


### PR DESCRIPTION
Fix RBAC authentication for search API methods that authenticate with raw session keys.

https://bugzilla.suse.com/show_bug.cgi?id=1250424

## Documentation
- No documentation needed: bugfix

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28435

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
