### PR TITLE
Fix the regex

### DIFF
--- a/spacecmd/spacecmd.changes.vzhestkov.fix-the-regex
+++ b/spacecmd/spacecmd.changes.vzhestkov.fix-the-regex
@@ -1,0 +1,1 @@
+- Fix the regular expression leading to exception in spacecmd

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -130,7 +130,7 @@ class SpacewalkShell(Cmd):
         try:
             # don't split on hyphens or colons during tab completion
             newdelims = readline.get_completer_delims()
-            newdelims = re.sub("[:-/]", "", newdelims)
+            newdelims = re.sub(r"[:\-/]", "", newdelims)
             readline.set_completer_delims(newdelims)
 
             if not options.nohistory:


### PR DESCRIPTION
## What does this PR change?

Fixes the regession caused by https://github.com/uyuni-project/uyuni/commit/4bf8ea8684fc718991e87ae23c3c3aee1ea31d26 from https://github.com/uyuni-project/uyuni/pull/10330

There was an escape for `-` missing causing parsing a part of regexp as a range.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered by testsuite

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" 

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
