### PR TITLE
Optimize schedule page queries for better performance (bsc#1244641)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Action_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Action_queries.xml
@@ -12,37 +12,33 @@ SELECT EVENT_ID as ID,
        HISTORY_STATUS,
        DETAILS
   FROM (SELECT SH.id EVENT_ID,
-               SH.summary SUMMARY,
-               TO_TIMESTAMP(NULL,NULL) AS created,
-               TO_TIMESTAMP(NULL,NULL) AS picked_up,
-               SH.created as completed,  -- view this as the "completed" date for sorting reasons
+               SH.summary AS SUMMARY,
+               NULL::timestamptz AS created,
+               NULL::timestamptz AS picked_up,
+               SH.created AS completed, -- view this as the "completed" date for sorting reasons
                NULL AS history_status,
                NULL AS history_type,
                NULL AS history_type_name,
-           SH.details
+               SH.details
           FROM rhnServerHistory SH
          WHERE SH.server_id = :sid
-         UNION
-        SELECT SA.action_id EVENT_ID,
-               AType.name || ' scheduled by ' || NVL(U.login, '(system)') AS SUMMARY,
+         UNION ALL
+        SELECT SA.action_id AS EVENT_ID,
+               AType.name || ' scheduled by ' || COALESCE(U.login, '(system)') AS SUMMARY,
                SA.created,
                SA.pickup_time AS picked_up,
                SA.completion_time AS completed,
                AStat.name AS history_status,
                AType.label AS history_type,
                AType.name AS history_type_name,
-           NULL AS details
-          FROM rhnActionType AType,
-               rhnActionStatus AStat,
-               rhnAction A
-          LEFT JOIN web_contact U
-            ON A.scheduler = U.id,
-               rhnServerAction SA
+               NULL AS details
+          FROM rhnServerAction SA
+          JOIN rhnAction A ON SA.action_id = A.id
+          JOIN rhnActionType AType ON A.action_type = AType.id
+          JOIN rhnActionStatus AStat ON SA.status = AStat.id
+          LEFT JOIN web_contact U ON A.scheduler = U.id
          WHERE SA.server_id = :sid
-           AND SA.action_id = A.id
-           AND ATYPE.id = A.action_type
-           AND AStat.id = SA.status
-           AND AStat.id IN (1, 2, 3)
+           AND SA.status IN (1, 2, 3)
        ) X
 ORDER BY COMPLETED DESC, PICKED_UP DESC, CREATED DESC, EVENT_ID DESC
   </query>
@@ -58,59 +54,67 @@ SELECT UAO.id,
    AND UAO.id IN (%s)
 </query>
 
-
-
-
 <mode name="recently_scheduled_action_list"
       class="com.redhat.rhn.frontend.dto.ScheduledAction">
   <query params="user_id, org_id, age">
-select
-    distinct a.id as id,
-   a.earliest_action as earliest,
-    at.name as type_name,
-    nvl(a.name, at.name) as action_name,
-    a.scheduler as scheduler,
-    sa.status as action_status_id
-from
-    rhnServerAction sa,
-    rhnActionType at,
-    rhnAction a
-where
-    a.org_id = :org_id
-    and sa.action_id = a.id
-    and a.action_type = at.id
-    and exists (select 1
-                    from rhnUserServerPerms usp
-                    where usp.user_id = :user_id
-                    and usp.server_id = sa.server_id)
-    and a.created &gt; current_timestamp - numtodsinterval(:age * 86400, 'second')
-order by id desc
+SELECT
+    DISTINCT A.id AS id,
+    A.earliest_action AS earliest,
+    AT.name AS type_name,
+    COALESCE(A.name, AT.name) AS action_name,
+    A.scheduler AS scheduler,
+    SA.status AS action_status_id
+FROM
+    rhnAction A
+    JOIN rhnActionType AT ON A.action_type = AT.id
+    JOIN rhnServerAction SA ON A.id = SA.action_id
+WHERE
+    A.org_id = :org_id
+    AND EXISTS (SELECT 1
+                    FROM rhnUserServerPerms USP
+                    WHERE USP.user_id = :user_id
+                    AND USP.server_id = SA.server_id)
+    AND A.created &gt; current_timestamp - (:age * interval '1 day')
+ORDER BY id DESC
   </query>
 </mode>
-
 
 <mode name="pending_action_list"
       class="com.redhat.rhn.frontend.dto.ScheduledAction">
   <query params="user_id, org_id">
+WITH userActionOverviewData AS (
+    SELECT * FROM rhnUserActionOverview
+    WHERE user_id = :user_id AND org_id = :org_id
+), actionCounts AS (
+    SELECT
+        id AS action_id,
+        SUM(tally) AS total_systems,
+        SUM(tally) FILTER (WHERE action_status_id IN (0, 1)) AS in_progress_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 2) AS completed_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 3) AS failed_systems
+    FROM userActionOverviewData
+    GROUP BY id
+)
 SELECT  DISTINCT UAO.id AS ID,
         UAO.earliest_action AS EARLIEST,
         A.prerequisite AS PREREQUISITE,
-        (SELECT COUNT(*) = COUNT(*) FILTER (WHERE status = 3) FROM rhnserveraction WHERE action_id = A.prerequisite) AS PREREQUISITE_ALL_FAILED,
+        COALESCE(PS.total_systems = PS.failed_systems, FALSE) AS PREREQUISITE_ALL_FAILED,
         UAO.type_name,
-        (CASE WHEN UAO.action_name IS NULL THEN UAO.type_name ELSE UAO.action_name END) || ' scheduled by ' || (CASE WHEN WC.login IS NULL THEN '(unknown)' ELSE WC.login END) AS ACTION_NAME,
+        (CASE WHEN UAO.action_name IS NULL THEN UAO.type_name ELSE UAO.action_name END)
+            || ' scheduled by '
+            || (CASE WHEN WC.login IS NULL THEN '(unknown)' ELSE WC.login END) AS ACTION_NAME,
         UAO.scheduler,
         WC.login AS SCHEDULER_NAME,
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status IN (0,1)) AS "IN_PROGRESS_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 2) AS "COMPLETED_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 3) AS "FAILED_SYSTEMS"
-  FROM  rhnUserActionOverview UAO left join
-        web_contact WC on UAO.scheduler = WC.id,
-        rhnAction A
- WHERE  UAO.org_id = :org_id
-   AND  UAO.user_id = :user_id
-   AND  UAO.action_status_id IN (0,1)
+        COALESCE(AC.in_progress_systems, 0) AS "IN_PROGRESS_SYSTEMS",
+        COALESCE(AC.completed_systems, 0) AS "COMPLETED_SYSTEMS",
+        COALESCE(AC.failed_systems, 0) AS "FAILED_SYSTEMS"
+  FROM  userActionOverviewData UAO
+  JOIN rhnAction A ON UAO.id = A.id
+  LEFT JOIN web_contact WC on UAO.scheduler = WC.id
+  LEFT JOIN actionCounts AC ON UAO.id = AC.action_id
+  LEFT JOIN actionCounts PS ON A.prerequisite = PS.action_id
+ WHERE  UAO.action_status_id IN (0,1)
    AND  UAO.archived = 0
-   AND  UAO.id = A.id
 ORDER BY EARLIEST DESC
   </query>
   <elaborator name="action_overview_elab" />
@@ -119,125 +123,173 @@ ORDER BY EARLIEST DESC
 <mode name="pending_actions_in_set"
       class="com.redhat.rhn.frontend.dto.ScheduledAction">
   <query params="user_id, org_id, set_label">
+WITH userActionOverviewData AS (
+    SELECT * FROM rhnUserActionOverview
+    WHERE user_id = :user_id AND org_id = :org_id
+), actionCounts AS (
+    SELECT
+        id AS action_id,
+        SUM(tally) AS total_systems,
+        SUM(tally) FILTER (WHERE action_status_id IN (0, 1)) AS in_progress_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 2) AS completed_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 3) AS failed_systems
+    FROM userActionOverviewData
+    GROUP BY id
+)
 SELECT  DISTINCT UAO.id AS ID,
         UAO.earliest_action AS EARLIEST,
         A.prerequisite AS PREREQUISITE,
-        (SELECT COUNT(*) = COUNT(*) FILTER (WHERE status = 3) FROM rhnserveraction WHERE action_id = A.prerequisite) AS PREREQUISITE_ALL_FAILED,
+        COALESCE(PS.total_systems = PS.failed_systems, FALSE) AS PREREQUISITE_ALL_FAILED,
         UAO.type_name,
         (CASE WHEN UAO.action_name IS NULL THEN UAO.type_name ELSE UAO.action_name END) AS ACTION_NAME,
         UAO.scheduler,
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status IN (0,1)) AS "IN_PROGRESS_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 2) AS "COMPLETED_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 3) AS "FAILED_SYSTEMS"
-  FROM  rhnUserActionOverview UAO, rhnAction A, rhnSet ST
- WHERE  UAO.org_id = :org_id
-   AND  UAO.user_id = :user_id
-   AND  UAO.action_status_id IN (0,1)
+        COALESCE(AC.in_progress_systems, 0) AS "IN_PROGRESS_SYSTEMS",
+        COALESCE(AC.completed_systems, 0) AS "COMPLETED_SYSTEMS",
+        COALESCE(AC.failed_systems, 0) AS "FAILED_SYSTEMS"
+  FROM  userActionOverviewData UAO
+  JOIN rhnAction A ON UAO.id = A.id
+  JOIN rhnSet ST ON ST.element = A.id
+  LEFT JOIN actionCounts AC ON UAO.id = AC.action_id
+  LEFT JOIN actionCounts PS ON A.prerequisite = PS.action_id
+ WHERE  UAO.action_status_id IN (0,1)
    AND  UAO.archived = 0
-   AND  UAO.id = A.id
    AND  ST.user_id = :user_id
    AND  ST.label = :set_label
-   AND  ST.element = A.id
 ORDER BY EARLIEST DESC
   </query>
-
   <elaborator name="action_overview_elab" />
 </mode>
-
 
 <mode name="all_action_list"
       class="com.redhat.rhn.frontend.dto.ScheduledAction">
   <query params="user_id, org_id">
+WITH userActionOverviewData AS (
+    SELECT * FROM rhnUserActionOverview
+    WHERE user_id = :user_id AND org_id = :org_id
+), actionCounts AS (
+    SELECT
+        id AS action_id,
+        SUM(tally) FILTER (WHERE action_status_id IN (0, 1)) AS in_progress_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 2) AS completed_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 3) AS failed_systems
+    FROM userActionOverviewData
+    GROUP BY id
+)
 SELECT  DISTINCT UAO.id AS ID,
         UAO.earliest_action AS EARLIEST,
         UAO.type_name,
         (CASE WHEN UAO.action_name IS NULL THEN UAO.type_name ELSE UAO.action_name END) || ' scheduled by ' || (CASE WHEN WC.login IS NULL THEN '(unknown)' ELSE WC.login END) AS ACTION_NAME,
         UAO.scheduler,
         WC.login AS SCHEDULER_NAME,
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status IN (0,1)) AS "IN_PROGRESS_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 2) AS "COMPLETED_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 3) AS "FAILED_SYSTEMS"
-  FROM  rhnUserActionOverview UAO left join
-        web_contact WC on UAO.scheduler = WC.id
- WHERE  UAO.org_id = :org_id
-   AND  UAO.user_id = :user_id
+        COALESCE(AC.in_progress_systems, 0) AS "IN_PROGRESS_SYSTEMS",
+        COALESCE(AC.completed_systems, 0) AS "COMPLETED_SYSTEMS",
+        COALESCE(AC.failed_systems, 0) AS "FAILED_SYSTEMS"
+  FROM  userActionOverviewData UAO
+  LEFT JOIN web_contact WC on UAO.scheduler = WC.id
+  LEFT JOIN actionCounts AC ON UAO.id = AC.action_id
 ORDER BY EARLIEST DESC
   </query>
-
   <elaborator name="action_overview_elab" />
 </mode>
-
 
 <mode name="completed_action_list"
       class="com.redhat.rhn.frontend.dto.ScheduledAction">
   <query params="user_id, org_id">
+WITH userActionOverviewData AS (
+    SELECT * FROM rhnUserActionOverview
+    WHERE user_id = :user_id AND org_id = :org_id
+), actionCounts AS (
+    SELECT
+        id AS action_id,
+        SUM(tally) FILTER (WHERE action_status_id IN (0, 1)) AS in_progress_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 2) AS completed_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 3) AS failed_systems
+    FROM userActionOverviewData
+    GROUP BY id
+)
 SELECT  DISTINCT UAO.id AS ID,
         UAO.earliest_action AS EARLIEST,
         UAO.type_name,
         (CASE WHEN UAO.action_name IS NULL THEN UAO.type_name ELSE UAO.action_name END) || ' scheduled by ' || (CASE WHEN WC.login IS NULL THEN '(unknown)' ELSE WC.login END) AS ACTION_NAME,
         UAO.scheduler,
         WC.login AS SCHEDULER_NAME,
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status IN (0,1)) AS "IN_PROGRESS_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 2) AS "COMPLETED_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 3) AS "FAILED_SYSTEMS"
-  FROM  rhnUserActionOverview UAO left join
-        web_contact WC on UAO.scheduler = WC.id
- WHERE  UAO.org_id = :org_id
-   AND  UAO.user_id = :user_id
-   AND  UAO.action_status_id = 2
+        COALESCE(AC.in_progress_systems, 0) AS "IN_PROGRESS_SYSTEMS",
+        COALESCE(AC.completed_systems, 0) AS "COMPLETED_SYSTEMS",
+        COALESCE(AC.failed_systems, 0) AS "FAILED_SYSTEMS"
+  FROM  userActionOverviewData UAO
+  LEFT JOIN web_contact WC on UAO.scheduler = WC.id
+  LEFT JOIN actionCounts AC ON UAO.id = AC.action_id
+ WHERE  UAO.action_status_id = 2
    AND  UAO.archived = 0
 ORDER BY EARLIEST DESC
   </query>
-
   <elaborator name="action_overview_elab" />
 </mode>
-
 
 <mode name="failed_action_list"
     class="com.redhat.rhn.frontend.dto.ScheduledAction">
   <query params="user_id, org_id">
+WITH userActionOverviewData AS (
+    SELECT * FROM rhnUserActionOverview
+    WHERE user_id = :user_id AND org_id = :org_id
+), actionCounts AS (
+    SELECT
+        id AS action_id,
+        SUM(tally) FILTER (WHERE action_status_id IN (0, 1)) AS in_progress_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 2) AS completed_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 3) AS failed_systems
+    FROM userActionOverviewData
+    GROUP BY id
+)
 SELECT  DISTINCT UAO.id AS ID,
         UAO.earliest_action AS EARLIEST,
         UAO.type_name,
         (CASE WHEN UAO.action_name IS NULL THEN UAO.type_name ELSE UAO.action_name END) || ' scheduled by ' || (CASE WHEN WC.login IS NULL THEN '(unknown)' ELSE WC.login END) AS ACTION_NAME,
         UAO.scheduler,
         WC.login AS SCHEDULER_NAME,
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status IN (0,1)) AS "IN_PROGRESS_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 2) AS "COMPLETED_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 3) AS "FAILED_SYSTEMS"
-  FROM  rhnUserActionOverview UAO left join
-        web_contact WC on UAO.scheduler = WC.id
- WHERE  UAO.org_id = :org_id
-   AND  UAO.user_id = :user_id
-   AND  UAO.action_status_id  = 3
+        COALESCE(AC.in_progress_systems, 0) AS "IN_PROGRESS_SYSTEMS",
+        COALESCE(AC.completed_systems, 0) AS "COMPLETED_SYSTEMS",
+        COALESCE(AC.failed_systems, 0) AS "FAILED_SYSTEMS"
+  FROM  userActionOverviewData UAO
+  LEFT JOIN web_contact WC on UAO.scheduler = WC.id
+  LEFT JOIN actionCounts AC ON UAO.id = AC.action_id
+ WHERE  UAO.action_status_id  = 3
    AND  UAO.archived = 0
 ORDER BY EARLIEST DESC
   </query>
-
   <elaborator name="action_overview_elab" />
 </mode>
-
-
 
 <mode name="archived_action_list"
       class="com.redhat.rhn.frontend.dto.ScheduledAction">
   <query params="user_id, org_id, include_orphans">
+WITH userActionOverviewData AS (
+    SELECT * FROM rhnUserActionOverview
+    WHERE org_id = :org_id
+      AND (user_id = :user_id OR (:include_orphans = 'Y' AND user_id IS NULL))
+), actionCounts AS (
+    SELECT
+        id AS action_id,
+        SUM(tally) FILTER (WHERE action_status_id IN (0, 1)) AS in_progress_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 2) AS completed_systems,
+        SUM(tally) FILTER (WHERE action_status_id = 3) AS failed_systems
+    FROM userActionOverviewData
+    GROUP BY id
+)
 SELECT  DISTINCT UAO.id AS ID,
         UAO.earliest_action AS EARLIEST,
         UAO.type_name,
         (CASE WHEN UAO.action_name IS NULL THEN UAO.type_name ELSE UAO.action_name END) || ' scheduled by ' || (CASE WHEN WC.login IS NULL THEN '(unknown)' ELSE WC.login END) AS ACTION_NAME,
         WC.login AS SCHEDULER_NAME,
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status IN (0,1)) AS "IN_PROGRESS_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 2) AS "COMPLETED_SYSTEMS",
-        (SELECT COUNT(server_id) FROM rhnServerAction WHERE action_id = UAO.id AND status = 3) AS "FAILED_SYSTEMS"
-  FROM  rhnUserActionOverview UAO left join
-        web_contact WC on UAO.scheduler = WC.id
- WHERE  UAO.org_id = :org_id
-   AND  (UAO.user_id = :user_id OR (:include_orphans = 'Y' AND UAO.user_id IS NULL))
-   AND  UAO.archived = 1
+        COALESCE(AC.in_progress_systems, 0) AS "IN_PROGRESS_SYSTEMS",
+        COALESCE(AC.completed_systems, 0) AS "COMPLETED_SYSTEMS",
+        COALESCE(AC.failed_systems, 0) AS "FAILED_SYSTEMS"
+  FROM  userActionOverviewData UAO
+  LEFT JOIN web_contact WC on UAO.scheduler = WC.id
+  LEFT JOIN actionCounts AC ON UAO.id = AC.action_id
+ WHERE  UAO.archived = 1
 ORDER BY EARLIEST DESC
   </query>
-
   <elaborator name="action_overview_elab" />
 </mode>
 

--- a/java/spacewalk-java.changes.cbbayburt.bsc1244641
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1244641
@@ -1,0 +1,2 @@
+- Optimize schedule page queries for better performance
+  (bsc#1244641)

--- a/schema/spacewalk/common/tables/rhnAction.sql
+++ b/schema/spacewalk/common/tables/rhnAction.sql
@@ -51,19 +51,16 @@ CREATE TABLE rhnAction
 ;
 
 CREATE INDEX rhn_action_oid_idx
-    ON rhnAction (org_id)
-    
-    ;
+    ON rhnAction(org_id);
 
 CREATE INDEX rhn_action_scheduler_idx
-    ON rhnAction (scheduler)
-    
-    ;
+    ON rhnAction(scheduler);
 
 CREATE INDEX rhn_action_prereq_id_idx
-    ON rhnAction (prerequisite, id)
-    
-    ;
+    ON rhnAction(prerequisite, id);
+
+CREATE INDEX rhn_action_created_idx
+    ON rhnAction(created);
 
 CREATE SEQUENCE rhn_event_id_seq;
 

--- a/schema/spacewalk/common/views/rhnActionOverview.sql
+++ b/schema/spacewalk/common/views/rhnActionOverview.sql
@@ -25,10 +25,6 @@ rhnActionOverview
     	scheduler,
 	scheduler_login,
 	earliest_action,
-	total_count,
-	successful_count,
-	failed_count,
-	in_progress_count,
 	archived
 )
 AS
@@ -40,10 +36,6 @@ SELECT    A.org_id,
 	  A.scheduler,
 	  U.login,
 	  A.earliest_action,
-	  (SELECT COUNT(*) FROM rhnServerAction WHERE action_id = A.id),
-	  (SELECT COUNT(*) FROM rhnServerAction WHERE action_id = A.id AND status = 2), -- XXX: don''t hard code status here :)
-	  (SELECT COUNT(*) FROM rhnServerAction WHERE action_id = A.id AND status = 3),
-	  (SELECT COUNT(*) FROM rhnServerAction WHERE action_id = A.id AND status NOT IN (2, 3)),
 	  A.archived
 FROM
 	  rhnActionType AT,

--- a/schema/spacewalk/susemanager-schema.changes.cbbayburt.Manager-5.0-bsc1244641
+++ b/schema/spacewalk/susemanager-schema.changes.cbbayburt.Manager-5.0-bsc1244641
@@ -1,0 +1,2 @@
+- Optimize schedule page queries for better performance
+  (bsc#1244641)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/530-rhnAction-created-idx.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/530-rhnAction-created-idx.sql
@@ -1,0 +1,15 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+--
+
+CREATE INDEX IF NOT EXISTS rhn_action_created_idx
+    ON rhnAction(created);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/531-rhnActionOverview-drop-count-columns.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/531-rhnActionOverview-drop-count-columns.sql
@@ -1,0 +1,77 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+--
+
+DROP VIEW rhnUserActionOverview;
+DROP VIEW rhnActionOverview;
+
+CREATE OR REPLACE VIEW rhnActionOverview (
+    org_id,
+    action_id,
+    type_id,
+    type_name,
+    name,
+    scheduler,
+    scheduler_login,
+    earliest_action,
+    archived
+) AS
+SELECT
+    A.org_id,
+    A.id,
+    AT.id,
+    AT.name,
+    A.name,
+    A.scheduler,
+    U.login,
+    A.earliest_action,
+    A.archived
+FROM
+    rhnActionType AT,
+    rhnAction A
+    LEFT JOIN web_contact U ON A.scheduler = U.id
+WHERE
+    A.action_type = AT.id
+ORDER BY
+    A.earliest_action;
+
+CREATE OR REPLACE VIEW rhnUserActionOverview AS
+SELECT
+    ao.org_id AS org_id,
+    usp.user_id AS user_id,
+    ao.action_id AS id,
+    ao.type_name AS type_name,
+    ao.scheduler AS scheduler,
+    ao.earliest_action AS earliest_action,
+    COALESCE(ao.name, ao.type_name) AS action_name,
+    sa.status AS action_status_id,
+    astat.name AS action_status,
+    COUNT(sa.action_id) AS tally,
+    ao.archived AS archived
+FROM
+    rhnActionOverview ao
+    LEFT JOIN rhnServerAction sa ON ao.action_id = sa.action_id
+    LEFT JOIN rhnActionStatus astat ON sa.status = astat.id
+    LEFT JOIN rhnUserServerPerms usp ON sa.server_id = usp.server_id
+GROUP BY
+    ao.org_id,
+    usp.user_id,
+    ao.action_id,
+    ao.type_name,
+    ao.scheduler,
+    ao.earliest_action,
+    COALESCE(ao.name, ao.type_name),
+    sa.status,
+    astat.name,
+    ao.archived
+ORDER BY
+    earliest_action;
+


### PR DESCRIPTION
Refactors queries for the "Schedule" pages with the following changes:

 - Rewrite with explicit JOIN syntax for clarity and performance
 - Replace Oracle-specific syntax with standard counterparts
 - Replace slow correlated subqueries with CTEs for aggregation
 - Unify syntax, casing, and indentation
 
 Port of: https://github.com/SUSE/spacewalk/pull/28529

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
