### PR TITLE
Fix issues building some packages for openSUSE Tumbleweed

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools-rpmlintrc
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools-rpmlintrc
@@ -1,1 +1,2 @@
 addFilter("suse-filelist-forbidden-sysconfig .*/sysconfig")
+addFilter("filelist-forbidden-sysconfig .*/sysconfig")

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.meaksh.master-fix-builds-for-tumbleweed
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes.meaksh.master-fix-builds-for-tumbleweed
@@ -1,1 +1,2 @@
 - Do not build python2 flavor for openSUSE Tumbleweed
+- Fix spacewalk-client-tools-rpmlintrc for Tumbleweed

--- a/client/tools/mgr-push/__init__.py
+++ b/client/tools/mgr-push/__init__.py
@@ -13,4 +13,4 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
-...  # needed by pylint to parse the disable comment
+pass  # needed by pylint to parse the disable comment

--- a/client/tools/mgr-push/mgr-push-rpmlintrc
+++ b/client/tools/mgr-push/mgr-push-rpmlintrc
@@ -1,1 +1,2 @@
 addFilter("suse-filelist-forbidden-sysconfig .*/sysconfig")
+addFilter("filelist-forbidden-sysconfig .*/sysconfig")

--- a/client/tools/mgr-push/mgr-push.changes.meaksh.master-fix-builds-for-tumbleweed
+++ b/client/tools/mgr-push/mgr-push.changes.meaksh.master-fix-builds-for-tumbleweed
@@ -1,1 +1,2 @@
 - Do not build python2 flavor for openSUSE Tumbleweed
+- Make package to build on openSUSE Tumbleweed

--- a/client/tools/mgr-push/mgr-push.changes.meaksh.master-fix-builds-for-tumbleweed
+++ b/client/tools/mgr-push/mgr-push.changes.meaksh.master-fix-builds-for-tumbleweed
@@ -1,2 +1,3 @@
 - Do not build python2 flavor for openSUSE Tumbleweed
 - Make package to build on openSUSE Tumbleweed
+- Do not break syntax for Python 2.7

--- a/python/rhn/rhnlib.changes.meaksh.master-fix-builds-for-tumbleweed
+++ b/python/rhn/rhnlib.changes.meaksh.master-fix-builds-for-tumbleweed
@@ -1,1 +1,2 @@
 - Do not build python2 flavor for openSUSE Tumbleweed
+- Migrate rhnlib building to setuptools

--- a/python/rhn/rhnlib.spec
+++ b/python/rhn/rhnlib.spec
@@ -74,6 +74,7 @@ Requires:       python2-pyOpenSSL
 Requires:       python2-defusedxml
 %else
 BuildRequires:  python-devel
+BuildRequires:  python-setuptools
 Requires:       python-defusedxml
 %if 0%{?suse_version}
 %if 0%{?suse_version} > 1200
@@ -90,6 +91,7 @@ Requires:       pyOpenSSL
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires:  python-dev
+BuildRequires:  python-setuptools
 BuildRequires:  rpm
 Requires(preun):python-minimal
 Requires(post): python-minimal
@@ -122,6 +124,7 @@ Group:          python
 
 %if "%{_vendor}" != "debbuild"
 BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
 %if 0%{?suse_version}
 BuildRequires:  python-rpm-macros
 %endif
@@ -131,6 +134,7 @@ Requires:       python3-defusedxml
 
 %if "%{_vendor}" == "debbuild"
 BuildRequires:  python3-dev
+BuildRequires:  python3-setuptools
 BuildRequires:  rpm
 Requires(preun): python3-minimal
 Requires(post): python3-minimal

--- a/python/rhn/setup.py.in
+++ b/python/rhn/setup.py.in
@@ -2,7 +2,7 @@
 #
 #
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name = "@NAME@",
       version = "@VERSION@",

--- a/python/uyuni/Makefile.defs
+++ b/python/uyuni/Makefile.defs
@@ -12,7 +12,10 @@ ifeq ("$(PYTHON_BIN)", "")
     PYTHON_BIN = "python"
 endif
 
-SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/uyuni
+ifeq ("$(SPACEWALK_ROOT)", "")
+    SPACEWALK_ROOT	?= $(shell $(PYTHON_BIN) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/uyuni
+endif
+
 export SPACEWALK_ROOT
 
 PREFIX		?=

--- a/python/uyuni/uyuni-common-libs.changes.meaksh.master-fix-builds-for-tumbleweed
+++ b/python/uyuni/uyuni-common-libs.changes.meaksh.master-fix-builds-for-tumbleweed
@@ -1,1 +1,2 @@
 - Do not build python2 flavor for openSUSE Tumbleweed
+- Fix building for openSUSE Tumbleweed

--- a/spacecmd/spacecmd.changes.meaksh.master-fix-builds-for-tumbleweed
+++ b/spacecmd/spacecmd.changes.meaksh.master-fix-builds-for-tumbleweed
@@ -1,0 +1,1 @@
+- Do not break syntax for Python 2.7

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -5024,7 +5024,7 @@ def do_system_bootstrap(self, args):
             options.ssh_user,
             options.ssh_password,
             options.activation_key,
-            *args,
+            *args  # fmt: skip
         )
     else:
         # pylint: disable-next=unspecified-encoding
@@ -5040,7 +5040,7 @@ def do_system_bootstrap(self, args):
                 pkey,
                 options.ssh_privatekey_password,
                 options.activation_key,
-                *args,
+                *args  # fmt: skip
             )
     print(
         _(


### PR DESCRIPTION
## What does this PR change?

This PR fixes some issues when building couple of packages for openSUSE Tumbleweed.

Additionally, it also fixes two syntax errors found in `spacecmd` and `mgr-push`, breaking syntax on Python 2.7, which is still used in some Client Tools channels (CentOS7 and SLE12).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
