### PR TITLE
Bump Kiwi schema version of our JeOS 7 profile from 6.1 to 7.4.

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_head">
+<image schemaversion="7.4" name="POS_Image_JeOS7_head">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -61,7 +56,6 @@
     <repository type="rpm-md">  <!-- head development client toools -->
         <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -82,7 +76,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -116,10 +110,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_uyuni">
+<image schemaversion="7.4" name="POS_Image_JeOS7_uyuni">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -58,7 +53,6 @@
     <repository type="rpm-md">
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -79,7 +73,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -113,10 +107,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_head">
+<image schemaversion="7.4" name="POS_Image_JeOS7_head">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -61,7 +56,6 @@
     <repository type="rpm-md">  <!-- head development client toools -->
         <source path="http://ip-172-16-1-175.eu-central-1.compute.internal/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -82,7 +76,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -116,10 +110,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_uyuni">
+<image schemaversion="7.4" name="POS_Image_JeOS7_uyuni">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -58,7 +53,6 @@
     <repository type="rpm-md">
         <source path="http://ip-172-16-1-175.eu-central-1.compute.internal/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -79,7 +73,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -113,10 +107,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_head">
+<image schemaversion="7.4" name="POS_Image_JeOS7_head">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -61,7 +56,6 @@
     <repository type="rpm-md">  <!-- head development client toools -->
         <source path="http://minima-mirror-ci-bv.mgr.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -82,7 +76,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -116,10 +110,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_uyuni">
+<image schemaversion="7.4" name="POS_Image_JeOS7_uyuni">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -58,7 +53,6 @@
     <repository type="rpm-md">
         <source path="http://minima-mirror-ci-bv.mgr.suse.de/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -79,7 +73,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -113,10 +107,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_head">
+<image schemaversion="7.4" name="POS_Image_JeOS7_head">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -61,7 +56,6 @@
     <repository type="rpm-md">  <!-- head development client toools -->
         <source path="http://minima-mirror-ci-bv.mgr.prv.suse.net/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -82,7 +76,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -116,10 +110,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_uyuni">
+<image schemaversion="7.4" name="POS_Image_JeOS7_uyuni">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
@@ -11,20 +11,15 @@
         <packagemanager>zypper</packagemanager>
         <bootsplash-theme>SLE</bootsplash-theme>
         <bootloader-theme>SLE</bootloader-theme>
-
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>Europe/Berlin</timezone>
-        <hwclock>utc</hwclock>
-
         <rpm-excludedocs>true</rpm-excludedocs>
         <type filesystem="ext3" image="pxe" initrd_system="dracut" compressed="true"/>
     </preferences>
-
     <drivers>
-      <file name="drivers/block/virtio_blk.ko" />
+        <file name="drivers/block/virtio_blk.ko"/>
     </drivers>
-
     <!-- remove all the following repositories if you want to get their packages through Uyuni;
          in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
@@ -58,7 +53,6 @@
     <repository type="rpm-md">
         <source path="http://minima-mirror-ci-bv.mgr.prv.suse.net/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
-
     <packages type="image">
         <package name="patterns-base-minimal_base"/>
         <package name="aaa_base-extras"/>
@@ -79,7 +73,7 @@
         <package name="grub2"/>
         <package name="grub2-x86_64-efi" arch="x86_64"/>
         <package name="haveged"/>
-        <package name="less" />
+        <package name="less"/>
         <package name="tar"/>
         <package name="parted"/>
         <package name="SUSEConnect"/>
@@ -113,10 +107,9 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    <users>
+        <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash" groups="root"/>
     </users>
-
     <packages type="bootstrap">
         <package name="udev"/>
         <package name="filesystem"/>


### PR DESCRIPTION

## What does this PR change?
This PR bumps Kiwi schema version of our JeOS 7 profile from 6.1 to 7.4.

This is needed for Kiwi 10 to be able to run, and Kiwi 10 is what the containerized Kiwi feature uses. Kiwi 9 should still work with the new schema version.

The new files have been generated with the command:
```
  xsltproc /usr/share/kiwi/xsl_to_v74/update.xsl config.xml
```


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were added

- [x] **DONE**


## Links

No ports, uyuni branch only, even though these files are used by all 3 branches.


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
