### PR TITLE
Remove deprecated helpers from JeOS 7 profile

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2025 SUSE LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,15 +50,6 @@ rm -f /etc/machine-id \
       /var/lib/dbus/machine-id
 
 #======================================
-# SuSEconfig
-#--------------------------------------
-echo "** Running suseConfig..."
-suseConfig
-
-echo "** Running ldconfig..."
-/sbin/ldconfig
-
-#======================================
 # Setup baseproduct link
 #--------------------------------------
 suseSetupProduct
@@ -67,11 +58,6 @@ suseSetupProduct
 # Specify default runlevel
 #--------------------------------------
 baseSetRunlevel 3
-
-#======================================
-# Add missing gpg keys to rpm
-#--------------------------------------
-suseImportBuildKey
 
 #======================================
 # Enable DHCP on eth0
@@ -89,11 +75,6 @@ EOF
 # Enable sshd
 #--------------------------------------
 chkconfig sshd on
-
-#======================================
-# Remove doc files
-#--------------------------------------
-baseStripDocs
 
 #======================================
 # Sysconfig Update
@@ -121,10 +102,5 @@ update-ca-certificates
 if [ ! -s /var/log/zypper.log ]; then
 	> /var/log/zypper.log
 fi
-
-# only for debugging
-#systemctl enable debug-shell.service
-
-baseCleanMount
 
 exit 0


### PR DESCRIPTION
## What does this PR change?

This PR removes deprecated helpers from JeOS 7 profile.

This is needed for Kiwi 10. Kiwi 9 should continue working without them.

Reference: [Heads up deprecated config.sh methods](https://groups.google.com/g/kiwi-images/c/LJr0riSDPkY) from Marcus Schäfer on 2021-06-07.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were added

- [x] **DONE**


## Links

No ports, uyuni branch only, although those files are used by all 3 branches.


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
