### PR TITLE
Adjust squid.conf  (bsc#1250940, bsc#1247644)

### DIFF
--- a/containers/proxy-squid-image/proxy-squid-image.changes.nadvornik.proxy_conf
+++ b/containers/proxy-squid-image/proxy-squid-image.changes.nadvornik.proxy_conf
@@ -1,0 +1,2 @@
+- Allow override all parameters in squid conf (bsc#1250940)
+- Set the default timeout for /pub to 30min (bsc#1247644)

--- a/containers/proxy-squid-image/squid.conf
+++ b/containers/proxy-squid-image/squid.conf
@@ -2,6 +2,8 @@
 # To be used for Spacewalk Proxy servers.
 #
 
+## Part 1: Default settings
+# -----------------------------------------------------------------------------
 http_port 8080
 
 cache_mem 400 MB
@@ -19,11 +21,34 @@ cache_dir aufs /var/cache/squid 15000 16 256
 # cache can hold.  The default is 13 KB.
 store_avg_object_size 817 KB
 
-# We want to keep the largest objects around longer, and just download the smaller objects if we can. 
+# We want to keep the largest objects around longer, and just download the smaller objects if we can.
 cache_replacement_policy heap LFUDA
 
 memory_replacement_policy heap GDSF
 
+# if transport is canceled, finish downloading anyway
+quick_abort_pct -1
+quick_abort_min -1 KB
+
+# when range is required, download whole file anyway
+# when we request rpm header, we will nearly always get
+# request for the rest of the file
+range_offset_limit none
+
+# we download only from 1 server, default is 1024
+# which is too much for us
+fqdncache_size 4
+
+pid_filename /run/squid/squid.pid
+
+## Part 2: Include custom overrides
+# Settings in these files will override the defaults above and will be
+# processed before the access rules and refresh patterns below.
+# -----------------------------------------------------------------------------
+include /etc/squid/conf.d/*
+
+## Part 3: Ordered rules
+# -----------------------------------------------------------------------------
 # cache repodata only few minutes and then query parent whether it is fresh
 refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 5 reload-into-ims refresh-ims
 refresh_pattern /ks/.*/repodata/.*$ 0 1% 5 reload-into-ims refresh-ims
@@ -32,6 +57,7 @@ refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 5 reload-into-ims ref
 # bootstrap repos needs to be handled as well
 refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 5 reload-into-ims refresh-ims
 refresh_pattern /pub/repositories/.*/venv-enabled-.*.txt$ 0 1% 5 reload-into-ims refresh-ims
+refresh_pattern /pub/.*$ 0 1% 30 reload-into-ims refresh-ims
 # rpm will hardly ever change, force to cache it for very long time
 refresh_pattern  \.rpm$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
 refresh_pattern  \.deb$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
@@ -58,18 +84,3 @@ http_access allow localhost
 http_access deny all
 icp_access allow all
 miss_access allow all
-
-# if transport is canceled, finish downloading anyway
-quick_abort_pct -1
-quick_abort_min -1 KB
-
-# when range is required, download whole file anyway
-# when we request rpm header, we will nearly always get
-# request for the rest of the file
-range_offset_limit none
-
-# we download only from 1 server, default is 1024
-# which is too much for us
-fqdncache_size 4
-
-pid_filename /run/squid/squid.pid

--- a/containers/proxy-squid-image/uyuni-configure.py
+++ b/containers/proxy-squid-image/uyuni-configure.py
@@ -22,7 +22,6 @@ with open("/etc/uyuni/config.yaml", encoding="utf-8") as source:
         file_content = re.sub(
             r"access_log .*", "access_log stdio:/proc/self/fd/1 squid", file_content
         )
-        file_content += "\n" + "include /etc/squid/conf.d/*" + "\n"
         # writing back the content
         config_file.seek(0, 0)
         config_file.write(file_content)


### PR DESCRIPTION
## What does this PR change?

This PR adjusts the default  squid.conf:
- reorder squid.conf so the included custom file can override all parameters (bsc#1250940)
- set the default timeout for /pub to 30min (bsc#1247644)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

## Documentation
-  TBD

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces) 

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/mbussolotto/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28029
https://bugzilla.suse.com/show_bug.cgi?id=1247644
https://bugzilla.suse.com/show_bug.cgi?id=1250940

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
