### PR TITLE
Migrate from javax.websocket to jakarta.websocket API

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -146,9 +146,9 @@
              ${commons-compress} ${javamail} smtp jdom ${jmock-jars}
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars} ${tomcat-jars}
              bcprov bcpg postgresql-jdbc ongres-scram/client ongres-scram/common
-             ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
+             ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel jakarta-websocket
              taglibs-standard-spec logdriver quartz slf4j-api log4j/log4j-slf4j-impl
-             velocity-engine-core simple-core strutstest" />
+             velocity-engine-core simple-core strutstest " />
 
   <!-- deps needed for testing, but required to build -->
   <property name="test.build.jar.dependencies" value="junit ${log4j-jars} regexp ${jmock-jars} postgresql-jdbc" />
@@ -170,7 +170,7 @@
 
   <property name="run.jar.dependencies"
       value="antlr objectweb-asm/asm ${cglib-jar} ${c3p0} commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
-             taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
+             taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec jakarta-websocket
              xalan-j2 xalan-j2-serializer xerces-j2 ${common.jar.dependencies}" />
 
   <!-- =================== RPM build, use jpackage syntax ======================= -->
@@ -192,7 +192,7 @@
 
   <property name="install.run.jar.dependencies"
       value="antlr objectweb-asm/asm ${cglib-jar} ${c3p0} commons-discovery dom4j ${jaf} ${jta11-jars} sitemesh
-             taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
+             taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec jakarta-websocket
              xalan-j2 xalan-j2-serializer xerces-j2 ${install.common.jar.dependencies}" />
 
   <property name="install.common.jar.dependencies"
@@ -202,7 +202,7 @@
              ${commons-compress} ${tomcat-jars} ${javamail} jdom jsch
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars}
              postgresql-jdbc ongres-scram/client ongres-scram/common
-             ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel
+             ${stringprep-jars} taglibs-standard-impl taglibs-standard-jstlel jakarta-websocket
              taglibs-standard-spec quartz ${suse-common-jars} velocity-engine-core
              simple-core snakeyaml simple-xml ${commons-jexl}" />
 
@@ -215,7 +215,7 @@
              ${jaf} ${jasper-jars} ${javamail} ${jaxb} jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
              oro quartz sitemesh ${struts-jars}
-             taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
+             taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec jakarta-websocket
              postgresql-jdbc ongres-scram/client ongres-scram/common ${stringprep-jars}
              snakeyaml simple-xml ${suse-common-jars} ${suse-runtime-jars}
 	     xalan-j2 xalan-j2-serializer xerces-j2 simple-core ${ehcache}" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -138,7 +138,8 @@
         <dependency org="org.jmock" name="jmock-junit5" rev="2.12.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock-imposters" rev="2.12.0" transitive="false"/>
         <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>
-        <dependency org="javax.websocket" name="javax.websocket-api" rev="1.1" transitive="false"/>
+        <dependency org="jakarta.websocket" name="jakarta.websocket-api" rev="2.2.0" transitive="false"/>
+        <dependency org="jakarta.websocket" name="jakarta.websocket-client-api" rev="2.2.0" transitive="false"/>
         <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.7" transitive="false">
            <artifact name="nodeps" type="jar" url="https://repo1.maven.org/maven2/org/jacoco/org.jacoco.ant/0.8.7/org.jacoco.ant-0.8.7-nodeps.jar"/>
         </dependency>

--- a/java/code/src/com/suse/manager/webui/websocket/Notification.java
+++ b/java/code/src/com/suse/manager/webui/websocket/Notification.java
@@ -46,13 +46,13 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.websocket.EndpointConfig;
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 /**
  * WebSocket EndPoint for showing notifications real-time in web UI.

--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -63,12 +63,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import javax.websocket.OnClose;
-import javax.websocket.OnError;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 /**
  * Websocket endpoint for executing remote commands on Salt minions.

--- a/java/code/src/com/suse/manager/webui/websocket/WebsocketHeartbeatService.java
+++ b/java/code/src/com/suse/manager/webui/websocket/WebsocketHeartbeatService.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import javax.websocket.Session;
+import jakarta.websocket.Session;
 
 /**
  * Service that sends periodic pings to all the registered websocket connections, making sure the connections are kept

--- a/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
+++ b/java/code/src/com/suse/manager/webui/websocket/WebsocketSessionConfigurator.java
@@ -19,9 +19,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.servlet.http.HttpSession;
-import javax.websocket.HandshakeResponse;
-import javax.websocket.server.HandshakeRequest;
-import javax.websocket.server.ServerEndpointConfig;
+
+import jakarta.websocket.HandshakeResponse;
+import jakarta.websocket.server.HandshakeRequest;
+import jakarta.websocket.server.ServerEndpointConfig;
 
 /**
  * A WebSocket Session configuration manager

--- a/java/spacewalk-java.changes.rjpmestre.migrate_from_javax_websocket_to_jakarta_websocket
+++ b/java/spacewalk-java.changes.rjpmestre.migrate_from_javax_websocket_to_jakarta_websocket
@@ -1,0 +1,1 @@
+- Migrate from javax websocket to jakarta websocket api

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -109,6 +109,7 @@ BuildRequires:  httpcomponents-client
 BuildRequires:  ical4j
 BuildRequires:  istack-commons-runtime
 BuildRequires:  jade4j
+BuildRequires:  jakarta-websocket >= 2.2.0
 BuildRequires:  java-%{java_version}-openjdk-devel
 BuildRequires:  java-saml
 BuildRequires:  javamail
@@ -194,6 +195,7 @@ Requires:       httpcomponents-client
 Requires:       ical4j
 Requires:       istack-commons-runtime
 Requires:       jade4j
+Requires:       jakarta-websocket >= 2.2.0
 Requires:       java-%{java_version}-openjdk
 Requires:       java-saml
 Requires:       javamail


### PR DESCRIPTION
## What does this PR change?

This PR is part of the [Tomcat major upgrade](https://github.com/SUSE/spacewalk/issues/25547)
 and updates the project to use the Jakarta WebSocket API instead of the old javax.websocket-api as tracked in [#28299](https://github.com/SUSE/spacewalk/issues/28299)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28299

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
