### PR TITLE
Enhance cucumber rake namespace to export html output

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -13,34 +13,45 @@ build_number = ENV.fetch('BUILD_NUMBER', nil)
 result_folder = build_number.nil? ? 'results' : "results/#{build_number}"
 
 namespace :cucumber do
+  # Define the timestamp before the loop starts.
+  timestamp = Time.now.strftime('%Y%m%d%H%M%S')
+  node_name = ENV.fetch('NODE', nil)
+  node_result_extension = node_name.nil? ? '' : "_#{node_name}"
   # Create results folder
   sh "mkdir -p #{result_folder}", verbose: false
   Dir.glob(File.join(Dir.pwd, 'run_sets', '**', '*.yml')).each do |entry|
-    Cucumber::Rake::Task.new(File.basename(entry, '.yml').to_sym) do |t|
-      features = YAML.safe_load(File.read(entry))
-      fail "Skipping rake task for #{entry}, the YAML file is empty." if features.nil? || features.empty? # rubocop:disable Style/SignalException
-
-      filename = File.basename(entry, '.yml').to_sym
-      timestamp = Time.now.strftime('%Y%m%d%H%M%S')
-      node_name = ENV.fetch('NODE', nil)
-      node_result_extension = node_name.nil? ? '' : "_#{node_name}"
-      json_results = "-f json -o #{result_folder}/output#{node_result_extension}_#{timestamp}-#{filename}.json"
-      html_results = "-f html -o #{result_folder}/output#{node_result_extension}_#{timestamp}-#{filename}.html"
-      profiles = ENV.fetch('PROFILE', nil)
+    features = YAML.safe_load(File.read(entry))
+    fail "Skipping rake task for #{entry}, the YAML file is empty." if features.nil? || features.empty?
+    filename = File.basename(entry, '.yml').to_sym
+    task_name = "cucumber:#{filename}"
+    html_results = "#{result_folder}/output#{node_result_extension}_#{timestamp}-#{filename}.html"
+    # Declare file export path to match the html report
+    path_export_file = "#{result_folder}/#{filename}_html_path.txt"
+    html_option = "-f html -o #{html_results}"
+    # Define the Cucumber Task
+    Cucumber::Rake::Task.new(filename) do |t|
       # Our profiles include a --tags keyword in all of them, if we have multiple profiles in the list
       # it will act as an intersection of tags, not as an union of them.
+      profiles = ENV.fetch('PROFILE', nil)
       include_profiles = profiles.nil? ? '--profile default' : "--profile #{profiles.gsub(',', ' --profile ')}"
-      tags = ENV.fetch('TAGS', nil)
       # We provide the list of tags including the '@', so if necessary we can provide a negative tag '~@' on this list.
       # We generate the tags list as an union of tags (using 'or' between them),
       # not as an intersection of them (using 'and')
+      tags = ENV.fetch('TAGS', nil)
       include_tags = tags.nil? ? [] : ['--tags', tags]
-      cucumber_opts = %W[#{include_profiles} #{html_results} #{json_results} #{junit_results}] + %w[-f pretty -r features] + include_tags
-      # Publish the results in reports.cucumber.io if the environment variable PUBLISH_CUCUMBER_REPORT is set
+      json_results = "-f json -o #{result_folder}/output#{node_result_extension}_#{timestamp}-#{filename}.json"
+      cucumber_opts = %W[#{include_profiles} #{html_option} #{json_results} #{junit_results}] + %w[-f pretty -r features] + include_tags
       cucumber_opts << ' --publish' if ENV['PUBLISH_CUCUMBER_REPORT'] == 'true'
-      # Immediately fail a feature if a scenario on it fails
       cucumber_opts << ' --fail-fast' if filename.to_s.include?('core') || filename.to_s.include?('build_validation_init')
+      # Cucumber is now configured to use the consistent path/timestamp
       t.cucumber_opts = cucumber_opts + features unless features.nil?
+    end
+    # This block executes when the task runs and uses the exact same `html_results` path.
+    # This file is used to expose the cucumber html report in Jenkins
+    Rake::Task[task_name].enhance do
+      # Write the final HTML path (without the option flag) to the file
+      # This uses the CONSISTENT, PRE-CALCULATED 'html_results' variable
+      sh "echo '#{html_results}' > #{path_export_file}", verbose: false
     end
   end
 end


### PR DESCRIPTION
## What does this PR change?

To improve the user experience with BV, expose the html report for each task (stage in Jenkins) in a txt file with fix name that can be use by Jenkins to show the report in the Jenkins interface.

Adding this new file required some refactoring, indeed the txt file was created for all tasks with the dir loop.
Use the enhance method to generate the file only once the task is executed.


<img width="1873" height="381" alt="image" src="https://github.com/user-attachments/assets/4ed9c0de-af14-43de-8d66-bd38fe452e0b" />

This will help to debug a specific stage without the need of opening the full report.


Solution2: 
We could simplify the export by removing the timestamp and so having a predictable name but it will overwrite the previous results when running locally (without build number).
## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Depend on: 
Port(s): 
 - 4.3: https://github.com/SUSE/spacewalk/pull/28607
 - 5.0: https://github.com/SUSE/spacewalk/pull/28608
 - 5.1: https://github.com/SUSE/spacewalk/pull/28609

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
