### PR TITLE
Fix problem syncing custom modules to Salt Master (bsc#1251796)

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -50,8 +50,9 @@ reactor:
   - 'salt/minion/*/start':
     - /usr/share/susemanager/reactor/resume_action_chain.sls
 
-# Extension modules path
-extension_modules: /usr/share/susemanager/modules
+# Extra modules path
+module_dirs:
+  - /usr/share/susemanager/modules
 
 # Runner modules
 runner_dirs:

--- a/spacewalk/setup/spacewalk-setup.changes.meaksh.master-fix-salt-master-config
+++ b/spacewalk/setup/spacewalk-setup.changes.meaksh.master-fix-salt-master-config
@@ -1,0 +1,1 @@
+- Fix problem syncing custom modules to Salt Master (bsc#1251796)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in the Salt Master configuration provided by Uyuni, that prevents custom modules to be synced by the user in their Salt Master, i.a. a custom runner placed at `/srv/salt/_runners/` directory.

When running `salt-run saltutil.sync_runners` we get the following error:

```
[INFO    ] Syncing runners for environment 'base'
[INFO    ] Loading cache from salt://_runners, for base
[INFO    ] Caching directory '_runners/' for environment 'base'
[DEBUG   ] In saltenv 'base', looking at rel_path '_runners/testrunner.py' to resolve 'salt://_runners/testrunner.py'
[DEBUG   ] In saltenv 'base', ** considering ** path '/var/cache/salt/master/files/base/_runners/testrunner.py' to resolve 'salt://_runners/testrunner.py'
[DEBUG   ] Local cache dir: '/var/cache/salt/master/files/base/_runners'
[INFO    ] Copying '/var/cache/salt/master/files/base/_runners/testrunner.py' to '/usr/share/susemanager/modules/runners/testrunner.py'
[ERROR   ] Failed to sync runners module: [Errno 13] Permission denied: '/usr/share/susemanager/modules/runners/testrunner.py'
```

There is currently a misusage of the `extensions_module` setting on the Salt Master configuration. At the moment, we wrongly use it to provide a path where the Salt Master can locate the modules provided by Uyuni itself, but in reality, according to Salt Master documentation [0], this is "the directory where custom modules are synced to.".

We should use `module_dirs` instead, which is meant to provide "extra directories to search for Salt modules" [1].

[0] https://docs.saltproject.io/en/3006/ref/configuration/master.html#extension-modules
[1] https://docs.saltproject.io/en/3006/ref/configuration/master.html#module-dirs

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28574

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
