### PR TITLE
Fix RBAC access of unauthorized XMLRPC methods (bsc#1251814)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -195,10 +195,12 @@ public class BaseHandler implements XmlRpcInvocationHandler {
 
     protected void ensureRoleBasedAccess(User user, String className, String methodName) {
         String apiEndpoint = className + "." + methodName;
+        if (WebEndpointFactory.getUnauthorizedApiMethods().contains(apiEndpoint)) {
+            return;
+        }
+
         if (user == null) {
-            if (!WebEndpointFactory.getUnauthorizedApiMethods().contains(apiEndpoint)) {
-                throw new SecurityException("The " + methodName + " API is not available for unauthenticated users.");
-            }
+            throw new SecurityException("The " + methodName + " API is not available for unauthenticated users.");
         }
         else {
             if (!user.hasRole(RoleFactory.SAT_ADMIN)) {

--- a/java/spacewalk-java.changes.cbbayburt.rbac-unauthorized-xmlrpc
+++ b/java/spacewalk-java.changes.cbbayburt.rbac-unauthorized-xmlrpc
@@ -1,0 +1,1 @@
+- Fix RBAC access of unauthorized XMLRPC methods (bsc#1251814)


### PR DESCRIPTION
Fix the logic error in the RBAC filtering for XMLRPC that denies authorized users from accessing unauthorized endpoints. 

## Test coverage
- No tests: already covered

## Links
https://github.com/SUSE/spacewalk/issues/28580
https://bugzilla.suse.com/show_bug.cgi?id=1251814

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
