### PR TITLE
Change slemicro tag for transactional tag

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -80,7 +80,6 @@ Feature: Smoke tests for <client>
     And I wait until event "Patch Update:" is completed
     And I reboot the "<client>" if it is a transactional system
 
-@skip_for_sle_micro_ssh_minion
   Scenario: Install a package on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
@@ -96,7 +95,6 @@ Feature: Smoke tests for <client>
     And I wait until event "Package Install/Upgrade scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
 
-@skip_for_sle_micro_ssh_minion
   Scenario: Remove package from <client>
     When I follow "Software" in the content area
     And I wait until I see "Upgrade Packages" text
@@ -137,7 +135,7 @@ Feature: Smoke tests for <client>
     Then I should see a "Channel Subscriptions successfully changed for" text
     And I reboot the "<client>" if it is a transactional system
 
-@skip_for_sle_micro
+@skip_for_transactional_minion
   Scenario: Reboot the <client> and wait until reboot is completed
     Given I am on the Systems overview page of this "<client>"
     When I follow first "Schedule System Reboot"
@@ -168,8 +166,7 @@ Feature: Smoke tests for <client>
     Then file "/etc/s-mgr/config" should contain "COLOR=white" on "<client>"
 
 # The client tools of SLE Micro and SL Micro (intentionally) do not contain spacecmd
-@skip_for_sle_micro
-@skip_for_sl_micro
+@skip_for_transactional_minion
   Scenario: Install spacecmd from the client tools on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
@@ -184,7 +181,6 @@ Feature: Smoke tests for <client>
     Then I should see a "1 package install has been scheduled for" text
     And I wait until event "Package Install/Upgrade scheduled by <client>" is completed
 
-@skip_for_sle_micro_ssh_minion
   Scenario: Enable Prometheus Node exporter formula on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
@@ -201,7 +197,7 @@ Feature: Smoke tests for <client>
     And I click on "Save"
     Then I should see a "Formula saved" text
 
-@skip_for_sle_micro
+@skip_for_transactional_minion
   Scenario: Enable Prometheus Apache and Postgres exporter formula on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Formulas" in the content area
@@ -213,7 +209,6 @@ Feature: Smoke tests for <client>
     And I click on "Save"
     Then I should see a "Formula saved" text
 
-@skip_for_sle_micro_ssh_minion
   Scenario: Apply highstate for the Prometheus exporters on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "States" in the content area
@@ -223,26 +218,23 @@ Feature: Smoke tests for <client>
     And I wait until event "Apply highstate scheduled by <client>" is completed
     And I reboot the "<client>" if it is a transactional system
 
-@skip_for_sle_micro_ssh_minion
-@sle_micro_minion
-  # workaround for SLE Micro minion issue bsc#1209374
+@transactional_minion
+  # workaround for SLE Micro and SL Micro minion issue bsc#1209374
   Scenario: Enable and start Prometheus Node Exporter service
     And I start the "prometheus-node_exporter.service" service on "<client>"
     And I enable the "prometheus-node_exporter.service" service on "<client>"
 
-@skip_for_sle_micro_ssh_minion
   Scenario: Visit Node monitoring endpoint on the <client>
     When I wait until "node" exporter service is active on "<client>"
     And I visit "Prometheus node exporter" endpoint of this "<client>"
 
-@skip_for_sle_micro
+@skip_for_transactional_minion
   Scenario: Visit Apache and Postgres monitoring endpoint on the <client>
     When I wait until "apache" exporter service is active on "<client>"
     And I visit "Prometheus apache exporter" endpoint of this "<client>"
     And I wait until "postgres" exporter service is active on "<client>"
     And I visit "Prometheus postgres exporter" endpoint of this "<client>"
 
-@skip_for_sle_micro_ssh_minion
 @monitoring_server
   Scenario: The data from <client> appear on Grafana dashboard
     When I visit the grafana dashboards of this "monitoring_server"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -598,8 +598,8 @@ Before('@suse_minion') do |scenario|
   skip_this_scenario unless (filename.include? 'sle') || (filename.include? 'suse')
 end
 
-Before('@sle_micro_minion') do |scenario|
-  skip_this_scenario unless scenario.location.file.include? 'slemicro'
+Before('@transactional_minion') do |scenario|
+  skip_this_scenario unless (scenario.location.file.include? 'slemicro') || (scenario.location.file.include? 'slmicro')
 end
 
 Before('@skip_for_debianlike') do |scenario|
@@ -619,18 +619,8 @@ Before('@skip_for_minion') do |scenario|
   skip_this_scenario if scenario.location.file.include? 'minion'
 end
 
-Before('@skip_for_sle_micro') do |scenario|
-  skip_this_scenario if scenario.location.file.include? 'slemicro'
-end
-
-Before('@skip_for_sle_micro_ssh_minion') do |scenario|
-  sle_micro_ssh_nodes = %w[slemicro51_ssh_minion slemicro52_ssh_minion slemicro53_ssh_minion slemicro54_ssh_minion slemicro55_ssh_minion slmicro60_ssh_minion slmicro61_ssh_minion]
-  current_feature_node = scenario.location.file.split(%r{(_smoke_tests.feature|/)})[-2]
-  skip_this_scenario if sle_micro_ssh_nodes.include? current_feature_node
-end
-
-Before('@skip_for_sl_micro') do |scenario|
-  skip_this_scenario if scenario.location.file.include? 'slmicro'
+Before('@skip_for_transactional_minion') do |scenario|
+  skip_this_scenario if scenario.location.file.include?('slemicro') || scenario.location.file.include?('slmicro')
 end
 
 # do some tests only if we have SCC credentials


### PR DESCRIPTION
## What does this PR change?
For BV smoke tests, we need to skip and execute the same scenarios for slmicro and slemicro
To make is more comprehensible, use a new generic transactional_minion tag that will group both systems
Also remove ssh_slemicro tag that will never be used.

Note: slmicro and sleminion tags are only use in smoke test template for BV.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered


- [x] **DONE**

## Links

Issue(s): #
Port(s): 
- 5.1: https://github.com/SUSE/spacewalk/pull/28634
- 5.0: https://github.com/SUSE/spacewalk/pull/28654
- 4.3: https://github.com/SUSE/spacewalk/pull/28655

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
