### PR TITLE
Fix nmcli binary detection

### DIFF
--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -111,9 +111,8 @@ end
 
 When(/^I connect the second interface of the proxy to the private network$/) do
   node = get_target('proxy')
-  _result, return_code = node.run('which nmcli')
+  _result, return_code = node.run('which nmcli', check_errors: false)
   if return_code.zero?
-
     # Network manager: we give second interface precedence over first interface
     #                  otherwise the name server we get from DHCP is lost at the end of the list
     #                  (the name servers list in resolv.conf is limited to 3 entries)


### PR DESCRIPTION
## What does this PR change?
When setting up the proxy pxe network, depending on the host system, we use nmcli or script to setup the private network.
The command to verify the binary nmcli presence is failing the step definition if the command return 1.
Error details:

<details>

```

FAIL: which nmcli returned status code = 1.
Output:
 (ScriptError)
./features/support/remote_node.rb:123:in `run_local'
./features/support/remote_node.rb:107:in `run'
./features/step_definitions/retail_steps.rb:114:in `/^I connect the second interface of the proxy to the private network$/'
features/build_validation/retail/proxy_container_branch_network.feature:14:in `I connect the second interface of the proxy to the private network'
```

</details>

Change the binary detection to correctly handle the code exit.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered


- [x] **DONE**

## Links

Issue(s): #
Port(s): 
 - 5.0: https://github.com/SUSE/spacewalk/pull/28668
 - 5.1: https://github.com/SUSE/spacewalk/pull/28667

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
