### PR TITLE
Fix gen-test-cert-chain.sh to work with DB

### DIFF
--- a/spacewalk/certs-tools/gen-test-cert-chain.sh
+++ b/spacewalk/certs-tools/gen-test-cert-chain.sh
@@ -14,9 +14,9 @@ ROOTCA="RootCA"
 ORGCA="OrgCa"
 TEAMCA="TeamCA"
 SRVCRT="server"
-SRVALTNAME="DNS:uyuni-server"
+SRVALTNAME="DNS:server.fqdn"
 DBCRT="db"
-DBALTNAME="DNS:uyuni-db,DNS:uyuni-reportdb"
+DBALTNAME="DNS:db,DNS:reportdb,$SRVALTNAME"
 
 export country="DE"
 export state="STATE"
@@ -187,11 +187,11 @@ openssl ca -config $DIR/openssl.cnf -create_serial -extensions req_server_x509_e
 mkdir -p $DIR/package
 openssl x509 -text -in $DIR/$ROOTCA.crt > $DIR/package/root-ca.crt
 cat $DIR/certs/$ORGCA.crt $DIR/certs/$TEAMCA.crt > $DIR/package/intermediate-ca.crt
-cp $DIR/certs/$SRVCRT.crt $DIR/package/db.crt
+cp $DIR/certs/$DBCRT.crt $DIR/package/db.crt
 if [ $PKEYALGO = "rsa" ]; then
-  openssl rsa -passin pass:$PASSWORD -in $DIR/private/$SRVCRT.key -out $DIR/package/db.key
+  openssl rsa -passin pass:$PASSWORD -in $DIR/private/$DBCRT.key -out $DIR/package/db.key
 else
-  openssl ec -passin pass:$PASSWORD -in $DIR/private/$SRVCRT.key -out $DIR/package/db.key
+  openssl ec -passin pass:$PASSWORD -in $DIR/private/$DBCRT.key -out $DIR/package/db.key
 fi
 
 echo "Test Certificates in $DIR/package/"


### PR DESCRIPTION
## What does this PR change?

The generated certificate of the database doesn't have the expected SANs and is thus not usable for real install tests.

Adjusting the script to make it easy to generate certificates to test third-party certificates on install / migration.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: internal tool, not even used in CI
- [x] **DONE**

## Test coverage
- No tests: internal tool, not even used in CI

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
