### PR TITLE
Fix MLM admin status display in Users pages (bsc#1244321)

### DIFF
--- a/java/code/webapp/WEB-INF/pages/admin/multiorg/sat_org_users.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/multiorg/sat_org_users.jsp
@@ -78,22 +78,22 @@
               </c:otherwise>
                 </c:choose>
         </rl:column>
-                <rl:column bound="false"
+        <rl:column bound="false"
                    sortable="false"
                    headerkey="satadmin.displayname"
-                   attr="orgAdmin">
-            <c:choose>
-              <c:when test="${current.satAdmin == 1}">
-                <a href="/rhn/admin/multiorg/ToggleSatAdmin.do?uid=${current.id}">
+                   attr="satAdmin">
+          <c:choose>
+            <c:when test="${current.satAdmin == 1}">
+              <a href="/rhn/admin/multiorg/ToggleSatAdmin.do?uid=${current.id}">
                 <rhn:icon type="item-enabled" />
-                </a>
-              </c:when>
-              <c:otherwise>
-                <a href="/rhn/admin/multiorg/ToggleSatAdmin.do?uid=${current.id}">
+              </a>
+            </c:when>
+            <c:otherwise>
+              <a href="/rhn/admin/multiorg/ToggleSatAdmin.do?uid=${current.id}">
                 <rhn:icon type="item-disabled" />
-                </a>
-              </c:otherwise>
-                </c:choose>
+              </a>
+            </c:otherwise>
+          </c:choose>
         </rl:column>
 
 </rl:list>

--- a/java/spacewalk-java.changes.cbbayburt.bsc1244321
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1244321
@@ -1,0 +1,1 @@
+- Fix MLM admin status display in Users pages (bsc#1244321)

--- a/schema/spacewalk/postgres/packages/rhn_user.pkb
+++ b/schema/spacewalk/postgres/packages/rhn_user.pkb
@@ -26,7 +26,7 @@ check_role(user_id_in in numeric, role_in in varchar)
     	throwaway numeric;
     begin
         -- the idea: if we get past this query, the org has the setting, else catch the exception and return 0
-        if role_in = 'org_admin' or role_in = 'sat_admin' then
+        if role_in = 'org_admin' or role_in = 'satellite_admin' then
             select 1 into throwaway
               from rhnUserGroupType UGT,
                    rhnUserGroup UG,

--- a/schema/spacewalk/susemanager-schema.changes.cbbayburt.bsc1244321
+++ b/schema/spacewalk/susemanager-schema.changes.cbbayburt.bsc1244321
@@ -1,0 +1,1 @@
+- Fix MLM admin status display in Users pages (bsc#1244321)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/520-check_role-sat-admin.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/520-check_role-sat-admin.sql
@@ -1,0 +1,48 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+set search_path to rhn_user, current;
+
+create or replace function
+check_role(user_id_in in numeric, role_in in varchar)
+    returns numeric as $$
+    declare
+        throwaway numeric;
+    begin
+        -- the idea: if we get past this query, the org has the setting, else catch the exception and return 0
+        if role_in = 'org_admin' or role_in = 'satellite_admin' then
+            select 1 into throwaway
+              from rhnUserGroupType UGT,
+                   rhnUserGroup UG,
+                   rhnUserGroupMembers UGM
+             where UGM.user_id = user_id_in
+               and UGM.user_group_id = UG.id
+               and UG.group_type = UGT.id
+               and UGT.label = role_in;
+        else
+            select 1 into throwaway
+              from access.accessGroup ag
+              join access.userAccessGroup uag on ag.id = uag.group_id
+             where ag.label = role_in
+               and uag.user_id = user_id_in;
+        end if;
+
+        if not found then
+            return 0;
+        end if;
+
+	return 1;
+    end;
+$$ language plpgsql;


### PR DESCRIPTION
### Issue

> ... try to mark any user as "SUSE Multi-Linux Manager Admin" and you will notice the checkbox will still shown as disabled.

### Changes

- Fix 'check_role' plsql function to look for `'satellite_admin'` instead of `'sat_admin'`
- Fix the JSP for Admin > Users table view

Port of: https://github.com/SUSE/spacewalk/pull/28544

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
