### PR TITLE
SonarCloud fix: java:S3878 Arrays should not be created for varargs parameters

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/CachedStatement.java
@@ -811,7 +811,7 @@ public class CachedStatement implements Serializable {
             if (isList) { // requires matching get method returning the same
                 // list
                 Collection<Object> c = (Collection<Object>) MethodUtil.callMethod(obj,
-                        getName, new Object[0]);
+                        getName);
                 if (c == null) {
                     c = new ArrayList<>();
                 }
@@ -903,7 +903,7 @@ public class CachedStatement implements Serializable {
         if (obj instanceof Map) {
             return ((Map<String, Object>) obj).get(key);
         }
-        return MethodUtil.callMethod(obj, StringUtil.beanify("get " + key), new Object[0]);
+        return MethodUtil.callMethod(obj, StringUtil.beanify("get " + key));
     }
 
     private Map<Object, Integer> generatePointers(List<Object> dr, String key) {
@@ -920,7 +920,7 @@ public class CachedStatement implements Serializable {
             }
             else {
                 Object keyData = MethodUtil.callMethod(row,
-                        StringUtil.beanify("get " + key), new Object[0]);
+                        StringUtil.beanify("get " + key));
                 pointers.put(keyData, pos);
             }
             pos++;

--- a/java/code/src/com/redhat/rhn/common/util/AttributeCopyRule.java
+++ b/java/code/src/com/redhat/rhn/common/util/AttributeCopyRule.java
@@ -33,8 +33,7 @@ public class AttributeCopyRule extends Rule {
         Object param = digester.peek();
         Method me;
         try {
-            me = param.getClass().getMethod("put",
-                                            new Class[] { Object.class, Object.class });
+            me = param.getClass().getMethod("put", Object.class, Object.class);
         }
         catch (NoSuchMethodException e) {
             return;

--- a/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/virtualhostmanager/VirtualHostManagerFactory.java
@@ -66,8 +66,7 @@ public class VirtualHostManagerFactory extends HibernateFactory {
     public static final String CONFIG_PASS = "password";
     public static final String CONFIG_KUBECONFIG = "kubeconfig";
 
-    private static final List<String> CONFIGS_TO_SKIP = Arrays.asList(
-            new String[] {CONFIG_USER, CONFIG_PASS, "id", "module"});
+    private static final List<String> CONFIGS_TO_SKIP = Arrays.asList(CONFIG_USER, CONFIG_PASS, "id", "module");
 
     /**
      * Default constructor.

--- a/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/BaseSearchAction.java
@@ -61,8 +61,8 @@ public abstract class BaseSearchAction extends RhnAction {
             "channel-ppc64le"};
 
     /** List of channel arches we don't really support any more. */
-    public static final List<String> EXCLUDED_ARCHES = Arrays.asList(new String[]
-        {"channel-sparc", "channel-alpha", "channel-iSeries", "channel-pSeries"});
+    public static final List<String> EXCLUDED_ARCHES = Arrays.asList(
+        "channel-sparc", "channel-alpha", "channel-iSeries", "channel-pSeries");
 
     // combinedSearchForm common keys
     public static final String FINE_GRAINED = "fineGrained";

--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigActionHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/ConfigActionHelper.java
@@ -278,12 +278,12 @@ public abstract class ConfigActionHelper {
             return service.getMessage(key);
         }
 
-        String message = service.getMessage(key, new Object[] {
+        String message = service.getMessage(key,
             String.valueOf(slsCount),
             String.valueOf(fileCount),
             String.valueOf(dirCount),
-            String.valueOf(symlinkCount),
-        });
+            String.valueOf(symlinkCount)
+        );
         if (url != null) {
             HtmlTag a = new HtmlTag("a");
             a.setAttribute("href", url);
@@ -322,7 +322,7 @@ public abstract class ConfigActionHelper {
         String key = "config.channels_" + suffix;
         String message;
         if (suffix == PLURAL) {
-            message = service.getMessage(key, new Object[] {count});
+            message = service.getMessage(key, count);
         }
         else {
             message = service.getMessage(key);

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/ErrataListConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/ErrataListConfirmAction.java
@@ -142,12 +142,11 @@ public class ErrataListConfirmAction extends RhnAction implements
             createMessage(
                 request,
                 "ssm.errata.message.scheduled",
-                new String[] {LocalizationService.getInstance().formatDate(earliest,
-                    request.getLocale())});
+                LocalizationService.getInstance().formatDate(earliest, request.getLocale()));
         }
         else {
-            createMessage(request, "ssm.errata.message.queued", new String[] {
-                actionChain.getId().toString(), actionChain.getLabel()});
+            createMessage(request, "ssm.errata.message.queued",
+                actionChain.getId().toString(), actionChain.getLabel());
         }
 
         RhnSet set = getSetDecl().get(context.getCurrentUser());

--- a/java/code/src/com/redhat/rhn/frontend/action/ssm/RebootSystemConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/ssm/RebootSystemConfirmAction.java
@@ -129,13 +129,13 @@ public class RebootSystemConfirmAction extends RhnAction
 
         if (actionChain == null) {
             createMessage(request, "ssm.misc.reboot.message.success." + messageKeySuffix,
-                    new String[] {ls.formatNumber(n, request.getLocale()),
-                            ls.formatDate(earliest, request.getLocale())});
+                    ls.formatNumber(n, request.getLocale()),
+                            ls.formatDate(earliest, request.getLocale()));
         }
         else {
             createMessage(request, "ssm.misc.reboot.message.queued." + messageKeySuffix,
-                    new String[] {ls.formatNumber(n, request.getLocale()),
-                            actionChain.getId().toString(), actionChain.getLabel()});
+                    ls.formatNumber(n, request.getLocale()),
+                            actionChain.getId().toString(), actionChain.getLabel());
         }
 
         set.clear();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SystemSearchAction.java
@@ -104,7 +104,7 @@ public class SystemSearchAction extends BaseSearchAction implements Listable<Sys
                                     SystemSearchHelper.LOC_RACK } };
 
     public static final List<String> VALID_WHERE_STRINGS =
-                    Arrays.asList(new String[] {WHERE_ALL, WHERE_SSM});
+                    Arrays.asList(WHERE_ALL, WHERE_SSM);
 
     private static final Logger LOG = LogManager.getLogger(SystemSearchAction.class);
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/ConfigChannelDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ConfigChannelDto.java
@@ -271,8 +271,7 @@ public class ConfigChannelDto extends BaseDto {
         if (count == null) {
             count = 0;
         }
-        return service.getMessage("system.common.numsystems",
-                                        new Object[] {count});
+        return service.getMessage("system.common.numsystems", count);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/filter/StringMatcher.java
+++ b/java/code/src/com/redhat/rhn/frontend/filter/StringMatcher.java
@@ -32,12 +32,11 @@ class StringMatcher implements Matcher {
 
         if (StringUtils.isBlank(filterData) ||
                     StringUtils.isBlank(filterColumn)) {
-            return true; ///show all if I entered a blank value
+            return true; //show all if I entered a blank value
         }
         String value = ((String)MethodUtil.callMethod(obj,
                 StringUtil.beanify("get " +
-                                    filterColumn),
-                                new Object[0]));
+                                    filterColumn)));
         if (!StringUtils.isBlank(value)) {
             return value.toUpperCase().contains(filterData.toUpperCase());
         }

--- a/java/code/src/com/redhat/rhn/frontend/listview/ListControl.java
+++ b/java/code/src/com/redhat/rhn/frontend/listview/ListControl.java
@@ -123,8 +123,7 @@ public class ListControl {
         while (di.hasNext()) {
             Object inputRow = di.next();
             String value = (String)MethodUtil.callMethod(inputRow,
-                                                StringUtil.beanify("get " + filterColumn),
-                                                new Object[0]);
+                                                StringUtil.beanify("get " + filterColumn));
             // Make sure that the alpha inputs are converted
             // to uppercase
             if (value != null) {

--- a/java/code/src/com/redhat/rhn/frontend/struts/RhnAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RhnAction.java
@@ -77,8 +77,8 @@ public abstract class RhnAction extends Action {
         List retval = new LinkedList<>();
         while (i.hasNext()) {
             Object o = i.next();
-            String name = (String) MethodUtil.callMethod(o, nameMethod, new Object[0]);
-            Object value = MethodUtil.callMethod(o, valueMethod, new Object[0]);
+            String name = (String) MethodUtil.callMethod(o, nameMethod);
+            Object value = MethodUtil.callMethod(o, valueMethod);
             LabelValueBean lb = lv(name, value.toString());
             if (!retval.contains(lb)) {
                 retval.add(lb);

--- a/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/StrutsDelegate.java
@@ -114,7 +114,7 @@ public class StrutsDelegate {
      */
     // TODO Write unit tests for addError(String, ActionErrors)
     public void addError(String msgKey, ActionErrors errors) {
-        addError(errors, msgKey, new Object[0]);
+        addError(errors, msgKey);
     }
 
     /**
@@ -140,7 +140,7 @@ public class StrutsDelegate {
      * @param messages Messages set
      */
     public void addInfo(String msgKey, ActionMessages messages) {
-        this.addInfo(messages, msgKey, new Object[0]);
+        this.addInfo(messages, msgKey);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ChannelSubscriptionException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ChannelSubscriptionException.java
@@ -30,8 +30,7 @@ public class ChannelSubscriptionException extends FaultException  {
      */
     public ChannelSubscriptionException(String reason) {
         super(1230, "channelSubscriptoin" , LocalizationService.getInstance().
-                getMessage("api.channel.software.channelsubscription",
-                        new Object [] {reason}));
+                getMessage("api.channel.software.channelsubscription", reason));
     }
 
     /**
@@ -41,8 +40,7 @@ public class ChannelSubscriptionException extends FaultException  {
      */
     public ChannelSubscriptionException(String reason, Throwable cause) {
         super(1230, "channelSubscriptoin" , LocalizationService.getInstance().
-                getMessage("api.channel.software.channelsubscription",
-                        new Object [] {reason}), cause);
+                getMessage("api.channel.software.channelsubscription", reason), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/DeleteUserException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/DeleteUserException.java
@@ -32,7 +32,7 @@ public class DeleteUserException extends FaultException  {
      */
     public DeleteUserException(String resourceKey) {
         super(2000, "Error deleting user", LocalizationService.getInstance().
-                getMessage(resourceKey, new Object [] {}));
+                getMessage(resourceKey));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/DuplicateChannelLabelException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/DuplicateChannelLabelException.java
@@ -30,7 +30,7 @@ public class DuplicateChannelLabelException extends FaultException  {
      */
     public DuplicateChannelLabelException(String label) {
         super(1206, "duplicateChannelLabel" , LocalizationService.getInstance().
-                getMessage("api.channel.duplicatechannellabel", new Object [] {label}));
+                getMessage("api.channel.duplicatechannellabel", label));
     }
 
     /**
@@ -40,7 +40,7 @@ public class DuplicateChannelLabelException extends FaultException  {
      */
     public DuplicateChannelLabelException(String label, Throwable cause) {
         super(1206, "duplicateChannelLabel" , LocalizationService.getInstance().
-                getMessage("api.channel.duplicatechannellabel", new Object [] {label}),
+                getMessage("api.channel.duplicatechannellabel", label),
                 cause);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/DuplicateChannelNameException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/DuplicateChannelNameException.java
@@ -29,6 +29,6 @@ public class DuplicateChannelNameException extends FaultException  {
      */
     public DuplicateChannelNameException(String name) {
         super(1215, "duplicateChannelName", LocalizationService.getInstance().getMessage(
-                "api.channel.duplicatechannelname", new Object [] {name}));
+                "api.channel.duplicatechannelname", name));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/DuplicateErrataException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/DuplicateErrataException.java
@@ -30,7 +30,7 @@ public class DuplicateErrataException extends FaultException  {
      */
     public DuplicateErrataException(String advisory) {
         super(2601, "Errata already exists" + advisory, LocalizationService.getInstance().
-                getMessage("api.errata.duplicateerrata", new Object [] {advisory}));
+                getMessage("api.errata.duplicateerrata", advisory));
     }
 
     /**
@@ -40,7 +40,7 @@ public class DuplicateErrataException extends FaultException  {
      */
     public DuplicateErrataException(String advisory, Throwable cause) {
         super(2601, "Errata already exists" , LocalizationService.getInstance().
-                getMessage("api.errata.duplicateerrata", new Object [] {advisory}), cause);
+                getMessage("api.errata.duplicateerrata", advisory), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ExternalGroupAlreadyExistsException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ExternalGroupAlreadyExistsException.java
@@ -30,6 +30,6 @@ public class ExternalGroupAlreadyExistsException extends FaultException  {
      */
     public ExternalGroupAlreadyExistsException(String value) {
         super(9514, "External Group Already Exists", LocalizationService.getInstance()
-                .getMessage("extgrouplabel.already.exists", new Object[] { value }));
+                .getMessage("extgrouplabel.already.exists", value));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/FileListAlreadyExistsException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/FileListAlreadyExistsException.java
@@ -29,6 +29,6 @@ public class FileListAlreadyExistsException extends FaultException {
      */
     public FileListAlreadyExistsException(String label) {
         super(1067, "FileListAlreadyExists", LocalizationService.getInstance().
-                getMessage("api.kickstart.filelist.exists", new Object[] {label}));
+                getMessage("api.kickstart.filelist.exists", label));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/FileListNotFoundException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/FileListNotFoundException.java
@@ -29,6 +29,6 @@ public class FileListNotFoundException extends FaultException {
      */
     public FileListNotFoundException(String label) {
         super(1068, "FileListNotFoundException", LocalizationService.getInstance().
-                getMessage("api.kickstart.filelist.notfound", new Object[] {label}));
+                getMessage("api.kickstart.filelist.notfound", label));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidAccessValueException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidAccessValueException.java
@@ -30,7 +30,7 @@ public class InvalidAccessValueException extends FaultException  {
      */
     public InvalidAccessValueException(String value) {
         super(1064, "Invalid Access Value" , LocalizationService.getInstance().
-                getMessage("api.channel.access.invalidaccessvalue", new Object [] {value}));
+                getMessage("api.channel.access.invalidaccessvalue", value));
     }
 
     /**
@@ -40,7 +40,7 @@ public class InvalidAccessValueException extends FaultException  {
      */
     public InvalidAccessValueException(String value, Throwable cause) {
         super(1064, "Invalid Access Value" , LocalizationService.getInstance().
-                getMessage("api.channel.access.invalidaccessvalue", new Object [] {value}),
+                getMessage("api.channel.access.invalidaccessvalue", value),
                 cause);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidAdvisoryReleaseException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidAdvisoryReleaseException.java
@@ -32,7 +32,7 @@ public class InvalidAdvisoryReleaseException extends FaultException  {
     public InvalidAdvisoryReleaseException(long value) {
         super(1070, "Invalid Advisory Release" , LocalizationService.getInstance().
             getMessage("api.errata.invalidadvisoryrelease",
-                new Object [] {value, ErrataManager.MAX_ADVISORY_RELEASE}));
+                value, ErrataManager.MAX_ADVISORY_RELEASE));
     }
 
     /**
@@ -43,7 +43,7 @@ public class InvalidAdvisoryReleaseException extends FaultException  {
     public InvalidAdvisoryReleaseException(long value, Throwable cause) {
         super(1070, "Invalid Advisory Release" , LocalizationService.getInstance().
             getMessage("api.errata.invalidadvisoryrelease",
-               new Object [] {value, ErrataManager.MAX_ADVISORY_RELEASE}), cause);
+               value, ErrataManager.MAX_ADVISORY_RELEASE), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidAdvisoryTypeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidAdvisoryTypeException.java
@@ -30,7 +30,7 @@ public class InvalidAdvisoryTypeException extends FaultException  {
      */
     public InvalidAdvisoryTypeException(String arch) {
         super(1062, "Invalid Errata Type" , LocalizationService.getInstance().
-                getMessage("api.errata.invalidadvisorytype", new Object [] {arch}));
+                getMessage("api.errata.invalidadvisorytype", arch));
     }
 
     /**
@@ -40,7 +40,7 @@ public class InvalidAdvisoryTypeException extends FaultException  {
      */
     public InvalidAdvisoryTypeException(String arch, Throwable cause) {
         super(1062, "Invalid Errata Type" , LocalizationService.getInstance().
-                getMessage("api.errata.invalidadvisorytype", new Object [] {arch}), cause);
+                getMessage("api.errata.invalidadvisorytype", arch), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidChannelAccessException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidChannelAccessException.java
@@ -30,7 +30,7 @@ public class InvalidChannelAccessException extends FaultException  {
      */
     public InvalidChannelAccessException(String access) {
         super(1206, "invalidChannelAccess" , LocalizationService.getInstance().
-                getMessage("api.channel.invalidchannelaccess", new Object [] {access}));
+                getMessage("api.channel.invalidchannelaccess", access));
     }
 
     /**
@@ -40,7 +40,7 @@ public class InvalidChannelAccessException extends FaultException  {
      */
     public InvalidChannelAccessException(String access, Throwable cause) {
         super(1206, "invalidChannelAccess" , LocalizationService.getInstance().
-                getMessage("api.channel.invalidchannelaccess", new Object [] {access}),
+                getMessage("api.channel.invalidchannelaccess", access),
                 cause);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidChannelArchException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidChannelArchException.java
@@ -30,7 +30,7 @@ public class InvalidChannelArchException extends FaultException  {
      */
     public InvalidChannelArchException(String label) {
         super(1205, "invalidChannelArch" , LocalizationService.getInstance().
-                getMessage("channel.invalidchannelarch", new Object [] {label}));
+                getMessage("channel.invalidchannelarch", label));
     }
 
     /**
@@ -43,7 +43,7 @@ public class InvalidChannelArchException extends FaultException  {
      */
     public InvalidChannelArchException(String label, Throwable cause) {
         super(1205, "invalidChannelArch" , LocalizationService.getInstance().
-                getMessage("channel.invalidchannelarch", new Object [] {label}) , cause);
+                getMessage("channel.invalidchannelarch", label) , cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidErrataException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidErrataException.java
@@ -36,7 +36,7 @@ public class InvalidErrataException extends FaultException {
      */
     public InvalidErrataException(String errata) {
         super(2600, "invalidErrata" , LocalizationService.getInstance().
-                getMessage("api.errata.invaliderrata", new Object [] {errata}));
+                getMessage("api.errata.invaliderrata", errata));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidIpAddressException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidIpAddressException.java
@@ -30,8 +30,7 @@ public class InvalidIpAddressException extends FaultException  {
      */
     public InvalidIpAddressException(String range) {
         super(2787, "ipAddress" , LocalizationService.getInstance().
-                getMessage("api.kickstart.ip.invalid",
-                        new Object [] {range}));
+                getMessage("api.kickstart.ip.invalid", range));
     }
 
     /**
@@ -41,8 +40,7 @@ public class InvalidIpAddressException extends FaultException  {
      */
     public InvalidIpAddressException(String range, Throwable cause) {
         super(2787, "ipAddress" , LocalizationService.getInstance().
-                getMessage("api.kickstart.ip.invalid",
-                        new Object [] {range}), cause);
+                getMessage("api.kickstart.ip.invalid", range), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidOperationException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidOperationException.java
@@ -39,7 +39,7 @@ public class InvalidOperationException extends FaultException {
      */
     public InvalidOperationException(String message, String param1) {
         super(1233, "invalidOperation", LocalizationService.getInstance().getMessage(
-                message, new Object[] { param1 }));
+                message, param1));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageArchException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageArchException.java
@@ -32,7 +32,7 @@ public class InvalidPackageArchException extends FaultException  {
      */
     public InvalidPackageArchException(String label) {
         super(2301 , "invalidPackageArch" , LocalizationService.getInstance().
-                getMessage("api.package.invalidpackagearch", new Object [] {label}));
+                getMessage("api.package.invalidpackagearch", label));
         // begin member variable initialization
     }
 
@@ -46,8 +46,7 @@ public class InvalidPackageArchException extends FaultException  {
      */
     public InvalidPackageArchException(String label, Throwable cause) {
         super(2301 , "invalidPackageArch" , LocalizationService.getInstance().
-                getMessage("api.package.invalidpackagearch", new Object [] {label})
-                , cause);
+                getMessage("api.package.invalidpackagearch", label), cause);
         // begin member variable initialization
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageException.java
@@ -30,7 +30,7 @@ public class InvalidPackageException extends FaultException  {
      */
     public InvalidPackageException(String pkg) {
         super(2300, "invalidPackage" , LocalizationService.getInstance().
-                getMessage("api.package.invalidpackage", new Object [] {pkg}));
+                getMessage("api.package.invalidpackage", pkg));
     }
 
     /**
@@ -40,7 +40,7 @@ public class InvalidPackageException extends FaultException  {
      */
     public InvalidPackageException(String pkg, Throwable cause) {
         super(2300, "invalidPackage" , LocalizationService.getInstance().
-                getMessage("api.package.invalidpackage", new Object [] {pkg}), cause);
+                getMessage("api.package.invalidpackage", pkg), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageKeyTypeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageKeyTypeException.java
@@ -30,7 +30,7 @@ public class InvalidPackageKeyTypeException extends FaultException  {
      */
     public InvalidPackageKeyTypeException(String label) {
         super(2350, "invalidPackageKeyType" , LocalizationService.getInstance().
-                getMessage("api.package.provider.invalidKeyType", new Object [] {label}));
+                getMessage("api.package.provider.invalidKeyType", label));
     }
 
     /**
@@ -43,8 +43,7 @@ public class InvalidPackageKeyTypeException extends FaultException  {
      */
     public InvalidPackageKeyTypeException(String label, Throwable cause) {
         super(2350, "invalidPackageKeyType" , LocalizationService.getInstance().
-                getMessage("api.package.provider.invalidKeyType",
-                        new Object [] {label}) , cause);
+                getMessage("api.package.provider.invalidKeyType", label) , cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageProviderException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidPackageProviderException.java
@@ -30,7 +30,7 @@ public class InvalidPackageProviderException extends FaultException  {
      */
     public InvalidPackageProviderException(String label) {
         super(2349, "invalidPackageProvider" , LocalizationService.getInstance().
-                getMessage("api.package.provider.invalidProvider", new Object [] {label}));
+                getMessage("api.package.provider.invalidProvider", label));
     }
 
     /**
@@ -43,8 +43,7 @@ public class InvalidPackageProviderException extends FaultException  {
      */
     public InvalidPackageProviderException(String label, Throwable cause) {
         super(2349, "invalidPackageProvider" , LocalizationService.getInstance().
-                getMessage("api.package.provider.invalidProvider",
-                        new Object [] {label}) , cause);
+                getMessage("api.package.provider.invalidProvider", label) , cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidProfileLabelException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidProfileLabelException.java
@@ -30,7 +30,7 @@ public class InvalidProfileLabelException extends FaultException  {
      */
     public InvalidProfileLabelException(String label) {
         super(2756, "invalidPackageProfileLabel" , LocalizationService.getInstance().
-                getMessage("api.system.invalidprofilelabel", new Object [] {label}));
+                getMessage("api.system.invalidprofilelabel", label));
     }
 
     /**
@@ -43,8 +43,7 @@ public class InvalidProfileLabelException extends FaultException  {
      */
     public InvalidProfileLabelException(String label, Throwable cause) {
         super(2756, "invalidPackageProfileLabel" , LocalizationService.getInstance().
-                getMessage("api.system.invalidprofilelabel",
-                new Object [] {label}) , cause);
+                getMessage("api.system.invalidprofilelabel", label) , cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidRoleException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidRoleException.java
@@ -29,7 +29,7 @@ public class InvalidRoleException extends FaultException {
      */
     public InvalidRoleException(String role) {
         super(4856, "invalidErrata", LocalizationService.getInstance().getMessage(
-                "api.externalgroup.invalidrole", new Object[] { role }));
+                "api.externalgroup.invalidrole", role));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidServerGroupException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/InvalidServerGroupException.java
@@ -37,7 +37,7 @@ public class InvalidServerGroupException extends FaultException  {
      */
     public InvalidServerGroupException(String name) {
         super(2200, "invalidServerGroup", LocalizationService.getInstance().getMessage(
-                "api.externalgroup.nosuchservergroup", new Object[] { name }));
+                "api.externalgroup.nosuchservergroup", name));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/IpRangeConflictException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/IpRangeConflictException.java
@@ -30,8 +30,7 @@ public class IpRangeConflictException extends FaultException  {
      */
     public IpRangeConflictException(String range) {
         super(2785, "ipRange" , LocalizationService.getInstance().
-                getMessage("api.kickstart.iprange.duplicate",
-                        new Object [] {range}));
+                getMessage("api.kickstart.iprange.duplicate", range));
     }
 
     /**
@@ -41,8 +40,7 @@ public class IpRangeConflictException extends FaultException  {
      */
     public IpRangeConflictException(String range, Throwable cause) {
         super(2785, "ipRange" , LocalizationService.getInstance().
-                getMessage("api.kickstart.iprange.duplicate",
-                        new Object [] {range}), cause);
+                getMessage("api.kickstart.iprange.duplicate", range), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/MultipleBaseChannelException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/MultipleBaseChannelException.java
@@ -31,8 +31,7 @@ public class MultipleBaseChannelException extends FaultException  {
      */
     public MultipleBaseChannelException(String chan1, String chan2) {
         super(1203, "Multiple Base Channels Selected" , LocalizationService.getInstance().
-                getMessage("api.channel.software.multiplebasechannel",
-                        new Object [] {chan1, chan2}));
+                getMessage("api.channel.software.multiplebasechannel", chan1, chan2));
     }
 
     /**
@@ -43,8 +42,7 @@ public class MultipleBaseChannelException extends FaultException  {
      */
     public MultipleBaseChannelException(String chan1, String chan2, Throwable cause) {
         super(1203, "multipleBaseChannelSelected" , LocalizationService.getInstance().
-                getMessage("api.channel.software.multiplebasechannel",
-                        new Object [] {chan1, chan2}), cause);
+                getMessage("api.channel.software.multiplebasechannel", chan1, chan2), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoChannelsSelectedException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoChannelsSelectedException.java
@@ -29,7 +29,7 @@ public class NoChannelsSelectedException extends FaultException  {
      */
     public NoChannelsSelectedException() {
         super(2603, "No Channels Selected" , LocalizationService.getInstance().
-                getMessage("api.errata.nochannelsselected", new Object [] {}));
+                getMessage("api.errata.nochannelsselected"));
     }
 
     /**
@@ -39,8 +39,7 @@ public class NoChannelsSelectedException extends FaultException  {
      */
     public NoChannelsSelectedException(String advisory, Throwable cause) {
         super(2603, "No Channels Selected" , LocalizationService.getInstance().
-                getMessage("api.errata.nochannelsselected",
-                new Object [] {advisory}), cause);
+                getMessage("api.errata.nochannelsselected", advisory), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchActionChainException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchActionChainException.java
@@ -37,8 +37,7 @@ public class NoSuchActionChainException extends FaultException {
         super(NoSuchActionChainException.ERROR_CODE,
               NoSuchActionChainException.ERROR_LABEL,
               LocalizationService.getInstance().
-                      getMessage("api.action.nosuchactionchain",
-                                 new Object[] {actionChainLabel}));
+                      getMessage("api.action.nosuchactionchain", actionChainLabel));
     }
 
     /**
@@ -53,7 +52,6 @@ public class NoSuchActionChainException extends FaultException {
         super(NoSuchActionChainException.ERROR_CODE,
               NoSuchActionChainException.ERROR_LABEL,
               LocalizationService.getInstance().
-                      getMessage("api.action.nosuchactionchain",
-                                 new Object[] {actionChainLabel}), cause);
+                      getMessage("api.action.nosuchactionchain", actionChainLabel), cause);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchActionException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchActionException.java
@@ -29,7 +29,7 @@ public class NoSuchActionException extends FaultException  {
      */
     public NoSuchActionException(String action) {
         super(2700, "noSuchAction", LocalizationService.getInstance().
-                getMessage("api.action.nosuchaction", new Object[] {action}));
+                getMessage("api.action.nosuchaction", action));
     }
 
     /**
@@ -41,6 +41,6 @@ public class NoSuchActionException extends FaultException  {
      */
     public NoSuchActionException(String action, Throwable cause) {
         super(2700, "noSuchAction", LocalizationService.getInstance().
-                getMessage("api.action.nosuchaction", new Object[] {action}), cause);
+                getMessage("api.action.nosuchaction", action), cause);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchExternalGroupToRoleMapException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchExternalGroupToRoleMapException.java
@@ -32,6 +32,6 @@ public class NoSuchExternalGroupToRoleMapException extends FaultException  {
     public NoSuchExternalGroupToRoleMapException(String group) {
         super(2856, "noSuchExternalGroupToRoleMap", LocalizationService.getInstance()
                 .getMessage(
-                "api.externalgroup.nosuchgroup", new Object[] { group }));
+                "api.externalgroup.nosuchgroup", group));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchExternalGroupToServerGroupMapException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchExternalGroupToServerGroupMapException.java
@@ -31,7 +31,6 @@ public class NoSuchExternalGroupToServerGroupMapException extends FaultException
      */
     public NoSuchExternalGroupToServerGroupMapException(String group) {
         super(6845, "noSuchExternalGroupToServerGroupMap", LocalizationService
-                .getInstance().getMessage("api.externalgroup.nosuchgrouptoservergroup",
-                        new Object[] { group }));
+                .getInstance().getMessage("api.externalgroup.nosuchgrouptoservergroup", group));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchNetworkInterfaceException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchNetworkInterfaceException.java
@@ -30,7 +30,6 @@ public class NoSuchNetworkInterfaceException extends FaultException  {
      */
     public NoSuchNetworkInterfaceException(String interfaceName) {
         super(1072, "No Such Network Interface" , LocalizationService.getInstance().
-                getMessage("api.system.nosuchnetiface",
-                new Object [] {interfaceName}));
+                getMessage("api.system.nosuchnetiface", interfaceName));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchOrgException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchOrgException.java
@@ -29,7 +29,7 @@ public class NoSuchOrgException extends FaultException  {
      */
     public NoSuchOrgException(String orgId) {
         super(2850, "noSuchOrg", LocalizationService.getInstance().
-                getMessage("api.org.nosuchorg", new Object[] {orgId}));
+                getMessage("api.org.nosuchorg", orgId));
     }
 
     /**
@@ -41,6 +41,6 @@ public class NoSuchOrgException extends FaultException  {
      */
     public NoSuchOrgException(String orgId, Throwable cause) {
         super(2850, "noSuchOrg", LocalizationService.getInstance().
-                getMessage("api.org.nosuchorg", new Object[] {orgId}), cause);
+                getMessage("api.org.nosuchorg", orgId), cause);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchSnapshotTagException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchSnapshotTagException.java
@@ -34,6 +34,6 @@ public class NoSuchSnapshotTagException extends FaultException {
      */
     public NoSuchSnapshotTagException(String tagName) {
         super(1212, "NoSuchSnapshotTag", LocalizationService.getInstance().
-                getMessage("api.provisioning.snapshot.nosuchtag", new Object [] {tagName}));
+                getMessage("api.provisioning.snapshot.nosuchtag", tagName));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NotPermittedByOrgException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NotPermittedByOrgException.java
@@ -31,8 +31,7 @@ public class NotPermittedByOrgException extends FaultException  {
      */
     public NotPermittedByOrgException(String orgId, String request, String targetOrgId) {
         super(1066, "notPermittedByOrg", LocalizationService.getInstance().
-                getMessage("api.org.notpermittedbyorg", new Object[] {orgId, request,
-                        targetOrgId}));
+                getMessage("api.org.notpermittedbyorg", orgId, request, targetOrgId));
     }
 
     /**
@@ -47,7 +46,6 @@ public class NotPermittedByOrgException extends FaultException  {
     public NotPermittedByOrgException(String orgId, String request, String targetOrgId,
             Throwable cause) {
         super(1066, "notPermittedByOrg", LocalizationService.getInstance().
-                getMessage("api.org.notpermittedbyorg", new Object[] {orgId, request,
-                        targetOrgId}), cause);
+                getMessage("api.org.notpermittedbyorg", orgId, request, targetOrgId), cause);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/OrgNotInTrustException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/OrgNotInTrustException.java
@@ -52,7 +52,7 @@ public class OrgNotInTrustException extends FaultException  {
      */
     public OrgNotInTrustException(Integer value) {
         super(2854, "Organization Not In Trust" , LocalizationService.getInstance().
-                getMessage("api.org.notintrust", new Object [] {value}));
+                getMessage("api.org.notintrust", value));
     }
 
     /**
@@ -62,8 +62,7 @@ public class OrgNotInTrustException extends FaultException  {
      */
     public OrgNotInTrustException(Integer value, Throwable cause) {
         super(2854, "Organization Not In Trust" , LocalizationService.getInstance().
-                getMessage("api.org.notintrust", new Object [] {value}),
-                cause);
+                getMessage("api.org.notintrust", value), cause);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/SnapshotLookupException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/SnapshotLookupException.java
@@ -34,7 +34,6 @@ public class SnapshotLookupException extends FaultException {
      */
     public SnapshotLookupException(Integer tagId) {
         super(1212, "SnapshotLookupException", LocalizationService.getInstance().
-                getMessage("api.provisioning.snapshot.nosuchsnapshot",
-                        new Object [] {tagId}));
+                getMessage("api.provisioning.snapshot.nosuchsnapshot", tagId));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/TaskomaticApiException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/TaskomaticApiException.java
@@ -28,6 +28,6 @@ public class TaskomaticApiException extends FaultException {
      */
     public TaskomaticApiException(String message) {
         super(2802, "taskomaticAPIException", LocalizationService.getInstance().getMessage(
-                "taskomatic.notavailable", new Object [] {message}));
+                "taskomatic.notavailable", message));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidKickstartLabelException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidKickstartLabelException.java
@@ -29,8 +29,7 @@ public class InvalidKickstartLabelException extends FaultException {
      */
     public InvalidKickstartLabelException(String virtType) {
         super(2753, "invalidKickstartLabel" , LocalizationService.getInstance().
-                getMessage("api.kickstart.invalidkickstartlabel",
-                        new Object [] {virtType}));
+                getMessage("api.kickstart.invalidkickstartlabel", virtType));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidUpdateTypeAndKickstartTreeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidUpdateTypeAndKickstartTreeException.java
@@ -29,8 +29,7 @@ public class InvalidUpdateTypeAndKickstartTreeException extends FaultException {
      */
     public InvalidUpdateTypeAndKickstartTreeException(String tree) {
         super(6134, "invalidKickstartLabel", LocalizationService.getInstance()
-                .getMessage("api.kickstart.invalidUpdateTypeAndTree",
-                        new Object[] { tree }));
+                .getMessage("api.kickstart.invalidUpdateTypeAndTree", tree));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidUpdateTypeAndNoBaseTreeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidUpdateTypeAndNoBaseTreeException.java
@@ -29,8 +29,7 @@ public class InvalidUpdateTypeAndNoBaseTreeException extends FaultException {
      */
     public InvalidUpdateTypeAndNoBaseTreeException(String tree) {
         super(6134, "invalidKickstartLabel", LocalizationService.getInstance()
-                .getMessage("api.kickstart.invalidUpdateTypeAndNoBase",
-                        new Object[] { tree }));
+                .getMessage("api.kickstart.invalidUpdateTypeAndNoBase", tree));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidUpdateTypeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidUpdateTypeException.java
@@ -29,8 +29,7 @@ public class InvalidUpdateTypeException extends FaultException {
      */
     public InvalidUpdateTypeException(String updateType) {
         super(6134, "invalidKickstartLabel", LocalizationService.getInstance()
-                .getMessage("api.kickstart.invalidUpdateType",
-                        new Object[] { updateType }));
+                .getMessage("api.kickstart.invalidUpdateType", updateType));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidVirtualizationTypeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/InvalidVirtualizationTypeException.java
@@ -29,7 +29,7 @@ public class InvalidVirtualizationTypeException extends FaultException {
      */
     public InvalidVirtualizationTypeException(String virtType) {
         super(2751, "invalidVirtType" , LocalizationService.getInstance().
-                getMessage("api.kickstart.invalidvirttype", new Object [] {virtType}));
+                getMessage("api.kickstart.invalidvirttype", virtType));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/NoSuchKickstartTreeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/NoSuchKickstartTreeException.java
@@ -29,8 +29,7 @@ public class NoSuchKickstartTreeException extends FaultException {
      */
     public NoSuchKickstartTreeException(String treeLabel) {
         super(2752, "invalidKickstartTreeLabel" , LocalizationService.getInstance().
-                getMessage("api.kickstart.nosuchkickstarttreelabel",
-                        new Object [] {treeLabel}));
+                getMessage("api.kickstart.nosuchkickstarttreelabel", treeLabel));
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/NoSuchKickstartInstallTypeException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/kickstart/tree/NoSuchKickstartInstallTypeException.java
@@ -29,7 +29,6 @@ public class NoSuchKickstartInstallTypeException extends FaultException {
      */
     public NoSuchKickstartInstallTypeException(String installType) {
         super(2756, "invalidKickstartLabel" , LocalizationService.getInstance().
-                getMessage("api.kickstart.invalidkickstartinstalltype",
-                        new Object [] {installType}));
+                getMessage("api.kickstart.invalidkickstartinstalltype", installType));
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2445,7 +2445,7 @@ public class SystemManager extends BaseManager {
         if (0 > proposedVcpuSetting || proposedVcpuSetting > 32) {
             result.addError(new ValidatorError(
                     "systems.details.virt.vcpu.limit.msg",
-                    new Object [] {"32", guest.getName()}));
+                    "32", guest.getName()));
         }
 
         if (result.getErrors().isEmpty()) {
@@ -2456,7 +2456,7 @@ public class SystemManager extends BaseManager {
                 if (proposedVcpuSetting > hostCpu.getNrCPU().intValue()) {
                     result.addWarning(new ValidatorWarning(
                             "systems.details.virt.vcpu.exceeds.host.cpus",
-                            new Object [] {host.getCpu().getNrCPU(), guest.getName()}));
+                            host.getCpu().getNrCPU(), guest.getName()));
                 }
             }
 
@@ -2472,8 +2472,7 @@ public class SystemManager extends BaseManager {
                         currentGuestCpus) {
                     result.addWarning(new ValidatorWarning(
                             "systems.details.virt.vcpu.increase.warning",
-                            new Object [] {proposedVcpuSetting,
-                                guest.getName()}));
+                            proposedVcpuSetting, guest.getName()));
                 }
             }
         }
@@ -2522,7 +2521,7 @@ public class SystemManager extends BaseManager {
                         // for the settings to take effect:
                         warnings.add(new ValidatorWarning(
                                 "systems.details.virt.memory.warning",
-                                new Object[]{guest.getName()}));
+                                guest.getName()));
                     }
                 }
                 else {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataMailer.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataMailer.java
@@ -222,7 +222,7 @@ public class ErrataMailer extends RhnJavaJob {
         }
         else {
             buffy.append(ls.getMessage("email.errata.notification.body.numsystems",
-                    new Object[] {String.valueOf(servers.size())}));
+                    String.valueOf(servers.size())));
         }
         buffy.append("\n").append("\n");
 


### PR DESCRIPTION
## What does this PR change?

Fix for rule: [SonarCloud fix: java:S3878 Arrays should not be created for varargs parameters](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS3878&rule_key=java%3AS3878)


## GUI diff
No difference.
Before:
After:
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

