### PR TITLE
Rename entitlement Proxy to Proxy Entitled Servers (bsc#1250641)

### DIFF
--- a/schema/spacewalk/common/data/rhnServerGroupType.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupType.sql
@@ -112,7 +112,7 @@ commit;
 
 insert into rhnServerGroupType ( id, label, name, permanent, is_base)
    values ( sequence_nextval('rhn_servergroup_type_seq'),
-      'proxy_entitled', 'Proxy',
+      'proxy_entitled', 'Proxy Entitled Servers',
       'N', 'N'
    );
 

--- a/schema/spacewalk/susemanager-schema.changes.nadvornik.fix_proxy_db
+++ b/schema/spacewalk/susemanager-schema.changes.nadvornik.fix_proxy_db
@@ -1,0 +1,1 @@
+- Rename "Proxy" to "Proxy Entitled Servers" (bsc#1250641)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/600-proxy-fix.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/600-proxy-fix.sql
@@ -1,0 +1,16 @@
+-- rename rhnServerGroupType entry
+UPDATE rhnServerGroupType SET name = 'Proxy Entitled Servers' WHERE name = 'Proxy' AND label = 'proxy_entitled';
+
+-- rename rhnServerGroup entry (do not rename normal groups named "Proxy" which have NULL group_type)
+UPDATE rhnServerGroup SET name = 'Proxy Entitled Servers', description = 'Proxy Entitled Servers'
+  WHERE group_type = (SELECT id from rhnServerGroupType WHERE label = 'proxy_entitled');
+
+-- create rhnServerGroup entry if it does not exist
+-- this is the case after conflict with normal group named "Proxy" - bsc#1250641
+INSERT INTO rhnServerGroup ( id, name, description, group_type, org_id )
+SELECT nextval('rhn_server_group_id_seq'), sgt.name, sgt.name, sgt.id, org.id
+FROM rhnServerGroupType sgt, web_customer org
+WHERE sgt.label = 'proxy_entitled' AND org.id NOT IN (
+    SELECT sg.org_id from rhnServerGroup sg
+    WHERE sg.name = 'Proxy Entitled Servers'
+);


### PR DESCRIPTION
## What does this PR change?

Group name "Proxy" causes conflicts during migration if a group with the same name already exists.
In such case, the migration silently fails and the entitlement is not created.

This PR renames the entitlement and fixes possible consequences of previous failed migration.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: fix

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28486
https://bugzilla.suse.com/show_bug.cgi?id=1250641

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
