### PR TITLE
Add support for a timeout config of the proxy

### DIFF
--- a/containers/proxy-httpd-image/proxy-httpd-image.changes.cbosdo.proxy-timeout
+++ b/containers/proxy-httpd-image/proxy-httpd-image.changes.cbosdo.proxy-timeout
@@ -1,0 +1,2 @@
+- Add support for a timeout property in the configuration
+  (bsc#1252020)

--- a/containers/proxy-httpd-image/uyuni-configure.py
+++ b/containers/proxy-httpd-image/uyuni-configure.py
@@ -165,8 +165,12 @@ with open(config_path + "httpd.yaml", encoding="utf-8") as httpdSource:
         tftpsync.proxy_ip = {proxy_ipv4}
         tftpsync.proxy_ip6 = {proxy_ipv6}
         tftpsync.proxy_fqdn = {config['proxy_fqdn']}
-        tftpsync.tftpboot = /srv/tftpboot"""
+        tftpsync.tftpboot = /srv/tftpboot
+        """
         )
+
+        if "timeout" in config:
+            file.write(f"proxy.timeout = {config['timeout']}")
 
     with open(
         "/etc/apache2/conf.d/smlm-proxy-forwards.conf", "r+", encoding="utf-8"


### PR DESCRIPTION
## What does this PR change?

In order to tune the XML-RPC timeout on the containerized proxy, a new `timeout` property is read from the config.yaml and stored in the generated `rhn.conf`. (bsc#1252020)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/4418)

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: proxy config
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28639
Port(s): https://github.com/SUSE/spacewalk/pull/28706

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
