### PR TITLE
Revert the removal of gpg helper for Kiwi

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF

--- a/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/cloud_aws/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_uyuni/config.sh
@@ -60,6 +60,11 @@ suseSetupProduct
 baseSetRunlevel 3
 
 #======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
 # Enable DHCP on eth0
 #--------------------------------------
 cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF


### PR DESCRIPTION
## What does this PR change?

The original email from Kiwi team had an error, the GPG keys helper that is part of Kiwi profiles should not be removed.

Resurrecting the call to the helper in `config.sh`.


## GUI diff

No difference.

- [x] **DONE**


## Documentation
No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage
Cucumber tests were modified

- [x] **DONE**


## Links

No port, all branches use the profiles in head branch.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
