### PR TITLE
Add flag to bootstrap script ot generate machine_id for uyuni

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -119,6 +119,11 @@ USING_GPG={using_gpg}
 
 REGISTER_THIS_BOX=1
 
+# Flag to generate a custom machine_id to be used in the context of uyuni server.
+# This will ignore the existing machine_id and generate a grain based machine_id
+# using uuidgen.
+GENERATE_OWN_MACHINEID=0
+
 # Set if you want to specify profilename for client systems.
 # NOTE: Make sure it's set correctly if any external command is used.
 #
@@ -1002,6 +1007,15 @@ system-environment:
       _:
         SALT_RUNNING: 1
 EOF
+
+if [ $GENERATE_OWN_MACHINEID -eq 1 ]; then
+    echo "* generating machine ID file"
+    NEW_MACHINID=$(uuidgen | sed 's/-//g')
+    cat <<EOF >> "${{MINION_CONFIG_DIR}}/machine_id.conf"
+grains:
+    machine_id: $NEW_MACHINID
+EOF
+fi
 
 if [ -n "$SNAPSHOT_ID" ]; then
     cat <<EOF >> "${{MINION_CONFIG_DIR}}/transactional_update.conf"

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.rmateus.uyuni_machine_id_generation_bootsrap
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.rmateus.uyuni_machine_id_generation_bootsrap
@@ -1,0 +1,1 @@
+- Add flag to bootstrap script ot generate machine_id for uyuni


### PR DESCRIPTION
## What does this PR change?

Customers may have machines on their landscape with the same machine id. This can happen for a variety of reasons, and sometimes customers are aware of the problem but cannot simply regenerate the machine id.

In uyuni/MLM servers, machines with the same machine ID are seen as being the same machine. However, in the scenario above, that is not the case.

To overcome this issue, we are adding a new flag to the bootstrap template ($GENERATE_OWN_MACHINEID) where users can saif they want to create a "fake" machine ID to be used in the context of uyuni/MLM.

This fake machine id will be placed in a configuration file on the machine and will overwrite the grain `machine_id`. This does not affect the ream machine ID.

This method should be avoided, and customers should follow the path of not having duplicated machine ID's.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference. Script only.

- [ ] **DONE**

## Documentation

Documentation is needed and will be provided in a follow-up PR.

- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: No tests for the bootstrap script template
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28726
Port(s): 
- Manager 5.1
- Manager 5.0

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
