### PR TITLE
Enable and enforce `no-access-state-in-setstate`

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -59,6 +59,7 @@ export default defineConfig([
       "jsx-a11y/anchor-is-valid": "error",
       "react/jsx-no-target-blank": "error",
       "react-hooks/rules-of-hooks": "error",
+      "react/no-access-state-in-setstate": "error",
       eqeqeq: "error",
       radix: ["error", "always"],
       // ESLint doesn't recongize overloads by default

--- a/web/html/src/components/datetime/DEPRECATED_DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DEPRECATED_DateTimePicker.tsx
@@ -277,15 +277,15 @@ export class DEPRECATED_DateTimePicker extends React.Component<DateTimePickerPro
   };
 
   toggleDatepicker = () => {
-    this.setState({
-      dateOpen: !this.state.dateOpen,
-    });
+    this.setState((prevState) => ({
+      dateOpen: !prevState.dateOpen,
+    }));
   };
 
   toggleTimepicker = () => {
-    this.setState({
-      timeOpen: !this.state.timeOpen,
-    });
+    this.setState((prevState) => ({
+      timeOpen: !prevState.timeOpen,
+    }));
   };
 
   onDateChanged = (year: number, month: number, day: number) => {

--- a/web/html/src/components/package/PackageListActionScheduler.tsx
+++ b/web/html/src/components/package/PackageListActionScheduler.tsx
@@ -77,31 +77,32 @@ export class PackageListActionScheduler extends React.Component<Props, State> {
     Network.post(this.props.scheduleActionAPI, requestBody)
       .then((data) => {
         // Notify the successful outcome
-        const msg = MessagesUtils.info(
-          this.state.actionChain ? (
-            <span>
-              {t('Action has been successfully added to the action chain <link>"{name}"</link>.', {
-                name: this.state.actionChain.text,
-                link: (str) => <ActionChainLink id={data}>{str}</ActionChainLink>,
-              })}
-            </span>
-          ) : (
-            <span>
-              {t("The action has been <link>scheduled</link>.", {
-                link: (str) => <ActionLink id={data}>{str}</ActionLink>,
-              })}
-            </span>
-          )
-        );
+        this.setState((prevState) => {
+          const msg = MessagesUtils.info(
+            prevState.actionChain ? (
+              <span>
+                {t('Action has been successfully added to the action chain <link>"{name}"</link>.', {
+                  name: prevState.actionChain.text,
+                  link: (str) => <ActionChainLink id={data}>{str}</ActionChainLink>,
+                })}
+              </span>
+            ) : (
+              <span>
+                {t("The action has been <link>scheduled</link>.", {
+                  link: (str) => <ActionLink id={data}>{str}</ActionLink>,
+                })}
+              </span>
+            )
+          );
+          return {
+            confirmAction: false,
+            messages: msg,
+          };
+        });
 
         // Clear the current selection
         Network.post(`/rhn/manager/api/sets/${this.props.selectionSet}/clear`).catch(() => {
           this.setState({ messages: MessagesUtils.warning(t("Unable to clear selection")) });
-        });
-
-        this.setState({
-          confirmAction: false,
-          messages: msg,
         });
       })
       .catch(() => {

--- a/web/html/src/components/states-picker.tsx
+++ b/web/html/src/components/states-picker.tsx
@@ -81,13 +81,13 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
   init = () => {
     Network.get(this.props.matchUrl()).then((data) => {
       data = this.getSortedList(data);
-      this.setState({
+      this.setState((prevState) => ({
         channels: data,
         search: {
-          filter: this.state.filter,
+          filter: prevState.filter,
           results: data,
         },
-      });
+      }));
     });
   };
 
@@ -156,19 +156,19 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
           this.props.type === "state"
             ? messages
             : messages.concat(MessagesUtils.info(t("State assignments have been saved.")));
-        this.setState({
+        this.setState((prevState) => ({
           changed: new Map(), // clear changed
           // Update the channels with the new data
           channels: _unionBy(
             data,
-            this.state.channels.map((c) => Object.assign(c, { assigned: false, position: undefined })),
+            prevState.channels.map((c) => Object.assign(c, { assigned: false, position: undefined })),
             "name"
           ),
           search: {
-            filter: this.state.search.filter,
+            filter: prevState.search.filter,
             results: this.getSortedList(newSearchResults),
           },
-        });
+        }));
         this.setMessages(messages);
         this.hideRanking();
       },
@@ -197,12 +197,12 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
         this.props.type === "state"
           ? this.stateTypeSearch()
           : Network.get(this.props.matchUrl(this.state.filter)).then((data) => {
-              this.setState({
+              this.setState((prevState) => ({
                 search: {
-                  filter: this.state.filter,
+                  filter: prevState.filter,
                   results: this.getSortedList(data),
                 },
-              });
+              }));
               this.clearMessages();
             });
       }
@@ -210,12 +210,12 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
   };
 
   stateTypeSearch = () => {
-    this.setState({
+    this.setState((prevState) => ({
       search: {
-        filter: this.state.filter,
-        results: this.state.channels.filter((c) => c.name.includes(this.state.filter)),
+        filter: prevState.filter,
+        results: prevState.channels.filter((c) => c.name.includes(prevState.filter)),
       },
-    });
+    }));
     this.clearMessages();
   };
 
@@ -229,9 +229,9 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
         value: Object.assign({}, original, { assigned: selected }),
       });
     }
-    this.setState({
-      changed: this.state.changed,
-    });
+    this.setState((prevState) => ({
+      changed: prevState.changed,
+    }));
   };
 
   handleSelectionChange = (original) => {

--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
@@ -56,11 +56,13 @@ type Props = {
   updateSccSyncRunning: (isRunning: boolean) => void;
 };
 
-class SCCDialog extends React.Component<Props> {
-  state = {
-    steps: _SCC_REFRESH_STEPS,
-    errors: [] as MessageType[],
-  };
+class SCCDialogState {
+  steps = _SCC_REFRESH_STEPS;
+  errors: MessageType[] = [];
+}
+
+class SCCDialog extends React.Component<Props, SCCDialogState> {
+  state = new SCCDialogState();
 
   UNSAFE_componentWillMount() {
     if (
@@ -133,16 +135,18 @@ class SCCDialog extends React.Component<Props> {
 
   handleResponseError = (jqXHR: JQueryXHR, arg = {}) => {
     this.finishSync();
-    const stepList = this.state.steps;
-    const currentStep = stepList.find((s) => s.inProgress);
-    if (currentStep) {
-      currentStep.inProgress = false;
-      currentStep.success = false;
-    }
-    const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
-      messageMap[msg] ? t(messageMap[msg], arg) : null
-    );
-    this.setState({ steps: stepList, errors: this.state.errors.concat(msg) });
+    this.setState((prevState) => {
+      const stepList = prevState.steps;
+      const currentStep = stepList.find((s) => s.inProgress);
+      if (currentStep) {
+        currentStep.inProgress = false;
+        currentStep.success = false;
+      }
+      const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
+        messageMap[msg] ? t(messageMap[msg], arg) : null
+      );
+      return { steps: stepList, errors: prevState.errors.concat(msg) };
+    });
   };
 
   render() {

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -287,13 +287,13 @@ class CVEAudit extends React.Component<Props, State> {
                       checked={this.state.statuses.includes(status)}
                       onChange={() => {
                         if (this.state.statuses.includes(status)) {
-                          this.setState({
-                            statuses: this.state.statuses.filter((x) => x !== status),
-                          });
+                          this.setState((prevState) => ({
+                            statuses: prevState.statuses.filter((x) => x !== status),
+                          }));
                         } else {
-                          this.setState({
-                            statuses: this.state.statuses.concat([status]),
-                          });
+                          this.setState((prevState) => ({
+                            statuses: prevState.statuses.concat([status]),
+                          }));
                         }
                       }}
                     />

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
@@ -21,13 +21,15 @@ type SubscriptionMatchingProps = {
   refreshInterval: number;
 };
 
-class SubscriptionMatching extends React.Component<SubscriptionMatchingProps> {
+class SubscriptionMatchingState {
+  serverData: any | null = null;
+  error: any | null = null;
+}
+
+class SubscriptionMatching extends React.Component<SubscriptionMatchingProps, SubscriptionMatchingState> {
   timerId?: number;
   refreshRequest?: Cancelable;
-  state = {
-    serverData: null as any | null,
-    error: null as any | null,
-  };
+  state = new SubscriptionMatchingState();
 
   UNSAFE_componentWillMount() {
     this.refreshServerData();
@@ -62,9 +64,11 @@ class SubscriptionMatching extends React.Component<SubscriptionMatchingProps> {
     if (this.refreshRequest) {
       this.refreshRequest.cancel();
     }
-    const serverData = this.state.serverData;
-    serverData.pinnedMatches = pinnedMatches;
-    this.setState({ serverData: serverData });
+    this.setState((prevState) => {
+      const serverData = prevState.serverData;
+      serverData.pinnedMatches = pinnedMatches;
+      return { serverData: serverData };
+    });
   };
 
   onMatcherRunSchedule = () => {

--- a/web/html/src/manager/header/search/search.tsx
+++ b/web/html/src/manager/header/search/search.tsx
@@ -19,22 +19,23 @@ const SEARCH_TYPES = [
   },
 ];
 
-export class HeaderSearch extends React.PureComponent {
-  private readonly initialState = {
-    isOpen: false,
-    searchString: "",
-    searchType: SEARCH_TYPES[0].value,
-  };
-  state = this.initialState;
+class HeaderSearchState {
+  isOpen = false;
+  searchString = "";
+  searchType = SEARCH_TYPES[0].value;
+}
+
+export class HeaderSearch extends React.PureComponent<{}, HeaderSearchState> {
+  state = new HeaderSearchState();
 
   onSPAEndNavigation() {
-    this.setState(this.initialState);
+    this.setState(new HeaderSearchState());
   }
 
   onChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     this.setState({
       [event.target.name]: event.target.value,
-    });
+    } as any);
   };
 
   onSubmit = (event: React.SyntheticEvent) => {
@@ -53,7 +54,7 @@ export class HeaderSearch extends React.PureComponent {
           title={t("Open search")}
           tooltipPlacement="bottom"
           className={`is-plain header-non-link manual-toggle-box ${this.state.isOpen ? "open" : ""}`}
-          handler={() => this.setState({ isOpen: !this.state.isOpen })}
+          handler={() => this.setState((prevState) => ({ isOpen: !prevState.isOpen }))}
         />
         {this.state.isOpen ? (
           <form id="search-form" name="form1" className="box-wrapper form-inline" onSubmit={this.onSubmit}>

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -124,9 +124,11 @@ class BuildImage extends React.Component<Props, State> {
       });
 
       if (window.hostId) {
-        const model = this.state.model;
-        model.buildHostId = window.hostId;
-        this.setState({ model: model });
+        this.setState((prevState) => {
+          const model = prevState.model;
+          model.buildHostId = window.hostId;
+          return { model: model };
+        });
       }
     });
   }
@@ -136,14 +138,16 @@ class BuildImage extends React.Component<Props, State> {
   };
 
   changeProfile(id) {
-    const model = Object.assign({}, this.state.model);
-    model.profileId = id;
-    this.setState({ model: model });
+    this.setState((prevState) => {
+      const model = Object.assign({}, prevState.model);
+      model.profileId = id;
+      return { model: model };
+    });
 
     if (id) {
       this.getProfileDetails(id);
     } else {
-      this.setState({ profile: { label: "" } });
+      this.setState(() => ({ profile: { label: "" } }));
     }
   }
 
@@ -175,45 +179,50 @@ class BuildImage extends React.Component<Props, State> {
   };
 
   onDateTimeChanged = (value: moment.Moment) => {
-    const model: State["model"] = Object.assign({}, this.state.model, {
-      earliest: value,
-      actionChain: null,
-    });
-    this.setState({
-      actionChain: null,
-      model,
+    this.setState((prevState) => {
+      const model: State["model"] = Object.assign({}, prevState.model, {
+        earliest: value,
+        actionChain: null,
+      });
+      return {
+        actionChain: null,
+        model,
+      };
     });
   };
 
   onActionChainChanged = (actionChain: ActionChain | null) => {
-    const model: State["model"] = Object.assign({}, this.state.model, {
-      actionChain: actionChain?.text,
-    });
-    this.setState({
-      actionChain,
-      model,
+    this.setState((prevState) => {
+      const model: State["model"] = Object.assign({}, prevState.model, {
+        actionChain: actionChain?.text,
+      });
+      return {
+        actionChain,
+        model,
+      };
     });
   };
 
   onBuild = (model) => {
     Network.post("/rhn/manager/api/cm/build/" + this.state.model.profileId, model).then((data) => {
       if (data.success) {
-        const msg = MessagesUtils.info(
-          this.state.model.actionChain ? (
-            <span>
-              {t("Action has been successfully added to the Action Chain ")}
-              <ActionChainLink id={data.data}>{this.state.model.actionChain}</ActionChainLink>.
-            </span>
-          ) : (
-            <span>
-              {t("Building the image has been ")}
-              <ActionLink id={data.data}>{t("scheduled")}.</ActionLink>
-            </span>
-          )
-        );
-
-        this.setState({
-          messages: msg,
+        this.setState((prevState) => {
+          const msg = MessagesUtils.info(
+            prevState.model.actionChain ? (
+              <span>
+                {t("Action has been successfully added to the Action Chain ")}
+                <ActionChainLink id={data.data}>{prevState.model.actionChain}</ActionChainLink>.
+              </span>
+            ) : (
+              <span>
+                {t("Building the image has been ")}
+                <ActionLink id={data.data}>{t("scheduled")}.</ActionLink>
+              </span>
+            )
+          );
+          return {
+            messages: msg,
+          };
         });
         window.location.href = "/rhn/manager/cm/images";
       } else {

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -148,22 +148,24 @@ class CreateImageProfile extends React.Component<Props, State> {
 
   addCustomData(label) {
     if (label) {
-      const data = this.state.customData;
-      data[label] = "";
-
-      this.setState({
-        customData: data,
+      this.setState((prevState) => {
+        const data = prevState.customData;
+        data[label] = "";
+        return {
+          customData: data,
+        };
       });
     }
   }
 
   removeCustomData(label) {
     if (label) {
-      const data = this.state.customData;
-      delete data[label];
-
-      this.setState({
-        customData: data,
+      this.setState((prevState) => {
+        const data = prevState.customData;
+        delete data[label];
+        return {
+          customData: data,
+        };
       });
     }
   }
@@ -255,14 +257,16 @@ class CreateImageProfile extends React.Component<Props, State> {
 
   getImageStores(type) {
     return Network.get("/rhn/manager/api/cm/imagestores/type/" + type).then((data) => {
-      // Preselect store after retrieval
-      const model = Object.assign({}, this.state.model, { imageStore: data[0] && data[0].label });
-      const storeUri = data[0] && data[0].uri;
+      this.setState((prevState) => {
+        // Preselect store after retrieval
+        const model = Object.assign({}, prevState.model, { imageStore: data[0] && data[0].label });
+        const storeUri = data[0] && data[0].uri;
 
-      this.setState({
-        imageStores: data,
-        model: model,
-        storeUri: storeUri,
+        return {
+          imageStores: data,
+          model: model,
+          storeUri: storeUri,
+        };
       });
 
       return data;
@@ -422,11 +426,12 @@ class CreateImageProfile extends React.Component<Props, State> {
                   onChange={(event) => {
                     const target = event.target;
 
-                    const data = this.state.customData;
-                    data[target.name] = target.value;
-
-                    this.setState({
-                      customData: data,
+                    this.setState((prevState) => {
+                      const data = prevState.customData;
+                      data[target.name] = target.value;
+                      return {
+                        customData: data,
+                      };
                     });
                   }}
                 />

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -93,7 +93,7 @@ class ImageProfiles extends React.Component<Props, State> {
   deleteProfiles = (idList) => {
     return Network.post("/rhn/manager/api/cm/imageprofiles/delete", idList).then((data) => {
       if (data.success) {
-        this.setState({
+        this.setState((prevState) => ({
           messages: (
             <Messages
               items={[
@@ -104,9 +104,9 @@ class ImageProfiles extends React.Component<Props, State> {
               ]}
             />
           ),
-          imageprofiles: this.state.imageprofiles.filter((profile) => !idList.includes(profile.profileId)),
-          selectedItems: this.state.selectedItems.filter((item) => !idList.includes(item)),
-        });
+          imageprofiles: prevState.imageprofiles.filter((profile) => !idList.includes(profile.profileId)),
+          selectedItems: prevState.selectedItems.filter((item) => !idList.includes(item)),
+        }));
       } else {
         this.setState({
           messages: (

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -93,7 +93,7 @@ class ImageStores extends React.Component<Props, State> {
   deleteStores = (idList) => {
     return Network.post("/rhn/manager/api/cm/imagestores/delete", idList).then((data) => {
       if (data.success) {
-        this.setState({
+        this.setState((prevState) => ({
           messages: (
             <Messages
               items={[
@@ -104,9 +104,9 @@ class ImageStores extends React.Component<Props, State> {
               ]}
             />
           ),
-          imagestores: this.state.imagestores.filter((store) => !idList.includes(store.id)),
-          selectedItems: this.state.selectedItems.filter((item) => !idList.includes(item)),
-        });
+          imagestores: prevState.imagestores.filter((store) => !idList.includes(store.id)),
+          selectedItems: prevState.selectedItems.filter((item) => !idList.includes(item)),
+        }));
       } else {
         this.setState({
           messages: (

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -95,23 +95,24 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   }
 
   pushMessages(severity, messages) {
-    const add = this.state.messages;
+    this.setState((prevState) => {
+      const add = prevState.messages;
 
-    const getMsgObj = (msg) => {
-      if (typeof messageMap[msg] === "string") {
-        return { severity: severity, text: messageMap[msg] };
+      const getMsgObj = (msg) => {
+        if (typeof messageMap[msg] === "string") {
+          return { severity: severity, text: messageMap[msg] };
+        } else {
+          return { severity: severity, text: msg };
+        }
+      };
+
+      if (Array.isArray(messages)) {
+        add.concat(messages.map(getMsgObj));
       } else {
-        return { severity: severity, text: msg };
+        add.push(getMsgObj(messages));
       }
-    };
-
-    if (Array.isArray(messages)) {
-      add.concat(messages.map(getMsgObj));
-    } else {
-      add.push(getMsgObj(messages));
-    }
-
-    this.setState({ messages: add });
+      return { messages: add };
+    });
   }
 
   updateView(id, tab) {
@@ -155,7 +156,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
     const msg = Network.responseErrorMessage(jqXHR, (status, msg) =>
       messageMap[msg] ? t(messageMap[msg], { arg }) : null
     );
-    this.setState({ messages: this.state.messages.concat(msg) });
+    this.setState((prevState) => ({ messages: prevState.messages.concat(msg) }));
   }
 
   //Accumulate runtime data from individual clusters into 'toData'
@@ -303,11 +304,11 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
         // Waits for the 'Back' action if not in the list page
         const backAction = this.state.selected ? this.handleBackAction() : Promise.resolve();
         backAction.then(() =>
-          this.setState({
-            images: this.state.images.filter((img) => !idList.includes(img.id)),
-            selectedItems: this.state.selectedItems.filter((item) => !idList.includes(item)),
+          this.setState((prevState) => ({
+            images: prevState.images.filter((img) => !idList.includes(img.id)),
+            selectedItems: prevState.selectedItems.filter((item) => !idList.includes(item)),
             messages: MessagesUtils.info(t("Deleted successfully.")),
-          })
+          }))
         );
       })
       .catch(this.handleResponseError);

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -73,9 +73,11 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
     Network.post("/rhn/manager/api/systems/details/ansible/paths/delete", path.id?.toString()).then((blob) => {
       if (blob.success) {
         if (path.type === "playbook") {
-          this.setState({ playbooksPaths: this.state.playbooksPaths.filter((p) => p.id !== path.id) });
+          this.setState((prevState) => ({ playbooksPaths: prevState.playbooksPaths.filter((p) => p.id !== path.id) }));
         } else {
-          this.setState({ inventoriesPaths: this.state.inventoriesPaths.filter((p) => p.id !== path.id) });
+          this.setState((prevState) => ({
+            inventoriesPaths: prevState.inventoriesPaths.filter((p) => p.id !== path.id),
+          }));
         }
       } else {
         this.setState({ errors: blob.errors.path });
@@ -109,15 +111,15 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
           path: editPath.path,
         });
         if (type === "playbook") {
-          this.setState({
-            playbooksPaths: this.state.playbooksPaths.filter((p) => p.id !== editPath?.id).concat(newPath),
+          this.setState((prevState) => ({
+            playbooksPaths: prevState.playbooksPaths.filter((p) => p.id !== editPath?.id).concat(newPath),
             editPlaybookPath: {},
-          });
+          }));
         } else {
-          this.setState({
-            inventoriesPaths: this.state.inventoriesPaths.filter((p) => p.id !== editPath?.id).concat(newPath),
+          this.setState((prevState) => ({
+            inventoriesPaths: prevState.inventoriesPaths.filter((p) => p.id !== editPath?.id).concat(newPath),
             editInventoryPath: {},
-          });
+          }));
         }
       } else {
         this.setState({ errors: blob.errors.path });
@@ -140,9 +142,15 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
           path: newPath,
         };
         if (type === "playbook") {
-          this.setState({ playbooksPaths: this.state.playbooksPaths.concat(newAnsiblePath), newPlaybookPath: "" });
+          this.setState((prevState) => ({
+            playbooksPaths: prevState.playbooksPaths.concat(newAnsiblePath),
+            newPlaybookPath: "",
+          }));
         } else {
-          this.setState({ inventoriesPaths: this.state.inventoriesPaths.concat(newAnsiblePath), newInventoryPath: "" });
+          this.setState((prevState) => ({
+            inventoriesPaths: prevState.inventoriesPaths.concat(newAnsiblePath),
+            newInventoryPath: "",
+          }));
         }
       } else {
         this.setState({ errors: blob.errors.path });

--- a/web/html/src/manager/notifications/notifications-list.tsx
+++ b/web/html/src/manager/notifications/notifications-list.tsx
@@ -262,10 +262,11 @@ export class NotificationList extends React.Component<Props, State> {
   }
 
   private async refreshServerData(): Promise<void> {
+    const dataType = this.state.dataType;
     this.setState({ loading: true });
 
     try {
-      const response = await Network.get(`/rhn/manager/notification-messages/${this.state.dataType}`);
+      const response = await Network.get(`/rhn/manager/notification-messages/${dataType}`);
 
       this.setState({
         serverData: response.data,

--- a/web/html/src/manager/notifications/notifications.tsx
+++ b/web/html/src/manager/notifications/notifications.tsx
@@ -39,13 +39,15 @@ class Notifications extends React.Component<Props, State> {
       ws.send('["user-notifications"]');
     };
     ws.onclose = () => {
-      const errs = this.state.errors ? this.state.errors : [];
-      if (!this.state.pageUnloading && !this.state.websocketErr) {
-        errs.push(t("Websocket connection closed. Refresh the page to try again."));
-      }
-      this.setState({
-        errors: errs,
-        websocket: null,
+      this.setState((prevState) => {
+        const errs = prevState.errors ? prevState.errors : [];
+        if (!prevState.pageUnloading && !prevState.websocketErr) {
+          errs.push(t("Websocket connection closed. Refresh the page to try again."));
+        }
+        return {
+          errors: errs,
+          websocket: null,
+        };
       });
     };
     ws.onerror = (e) => {

--- a/web/html/src/manager/recurring/recurring-actions-edit.tsx
+++ b/web/html/src/manager/recurring/recurring-actions-edit.tsx
@@ -197,14 +197,14 @@ class RecurringActionsEdit extends React.Component<Props, State> {
   };
 
   onSelectPlaybook = (playbook) => {
-    this.setState({
+    this.setState((prevState) => ({
       details: {
-        ...this.state.details,
+        ...prevState.details,
         playbookPath: playbook?.playbookPath,
         inventoryPath: playbook?.inventoryPath,
         flushCache: playbook?.flushCache,
       },
-    });
+    }));
   };
 
   toggleTestState = () => {

--- a/web/html/src/manager/shared/menu/menu.tsx
+++ b/web/html/src/manager/shared/menu/menu.tsx
@@ -67,11 +67,22 @@ type ElementProps = {
   forceCollapse?: any;
 };
 
-class Element extends React.Component<ElementProps> {
-  state = {
-    open: this.props.element?.active ? true : false,
-    visiblityForcedByParent: false,
-  };
+class ElementState {
+  open: boolean;
+  visiblityForcedByParent = false;
+
+  constructor(props: ElementProps) {
+    this.open = props.element?.active ? true : false;
+  }
+}
+
+class Element extends React.Component<ElementProps, ElementState> {
+  state: ElementState;
+
+  constructor(props: ElementProps) {
+    super(props);
+    this.state = new ElementState(props);
+  }
 
   UNSAFE_componentWillReceiveProps(nextProps: ElementProps) {
     this.setState({
@@ -105,7 +116,7 @@ class Element extends React.Component<ElementProps> {
   };
 
   toggleView = () => {
-    this.setState({ open: !this.state.open });
+    this.setState((prevState) => ({ open: !prevState.open }));
   };
 
   getUrl = (element) => {
@@ -222,8 +233,6 @@ class Nav extends React.Component {
 SpaRenderer.renderGlobalReact(<Nav />, document.getElementById("nav"));
 
 class Breadcrumb extends React.Component {
-  componentDidMount() {}
-
   onSPAEndNavigation() {
     this.forceUpdate();
   }

--- a/web/html/src/manager/state/highstate.tsx
+++ b/web/html/src/manager/state/highstate.tsx
@@ -56,32 +56,34 @@ class Highstate extends React.Component<HighstateProps, HighstateState> {
       test: this.state.test,
     })
       .then((data) => {
-        const msg = MessagesUtils.info(
-          this.state.actionChain ? (
-            <span>
-              {t('Action has been successfully added to the action chain <link>"{name}"</link>.', {
-                name: this.state.actionChain.text,
-                link: (str) => <ActionChainLink id={data}>{str}</ActionChainLink>,
-              })}
-            </span>
-          ) : (
-            <span>
-              {t("Applying the highstate has been <link>scheduled</link>.", {
-                link: (str) => <ActionLink id={data}>{str}</ActionLink>,
-              })}
-            </span>
-          )
-        );
+        this.setState((prevState) => {
+          const msg = MessagesUtils.info(
+            this.state.actionChain ? (
+              <span>
+                {t('Action has been successfully added to the action chain <link>"{name}"</link>.', {
+                  name: this.state.actionChain.text,
+                  link: (str) => <ActionChainLink id={data}>{str}</ActionChainLink>,
+                })}
+              </span>
+            ) : (
+              <span>
+                {t("Applying the highstate has been <link>scheduled</link>.", {
+                  link: (str) => <ActionLink id={data}>{str}</ActionLink>,
+                })}
+              </span>
+            )
+          );
 
-        const msgs = this.state.messages.concat(msg);
+          const msgs = prevState.messages.concat(msg);
 
-        // Do not spam UI showing old messages
-        while (msgs.length > messagesCounterLimit) {
-          msgs.shift();
-        }
+          // Do not spam UI showing old messages
+          while (msgs.length > messagesCounterLimit) {
+            msgs.shift();
+          }
 
-        this.setState({
-          messages: msgs,
+          return {
+            messages: msgs,
+          };
         });
       })
       .catch(this.handleResponseError);
@@ -104,7 +106,7 @@ class Highstate extends React.Component<HighstateProps, HighstateState> {
   };
 
   toggleTestState = () => {
-    this.setState({ test: !this.state.test });
+    this.setState((prevState) => ({ test: !prevState.test }));
   };
 
   isSSM = () => {

--- a/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
@@ -118,11 +118,11 @@ class ActivationKeyChannelsApi extends React.Component<ActivationKeyChannelsProp
       this.setState({ loadingChildren: true });
       future = Network.get(`/rhn/manager/api/activation-keys/base-channels/${baseId}/child-channels`)
         .then((data) => {
-          this.setState({
+          this.setState((prevState) => ({
             availableChannels: data.data,
-            fetchedData: this.state.fetchedData.set(baseId, data.data),
+            fetchedData: prevState.fetchedData.set(baseId, data.data),
             loadingChildren: false,
-          });
+          }));
         })
         .catch(this.handleResponseError);
     }

--- a/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
@@ -45,13 +45,15 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
   };
 
   selectChildChannels = (channelIds: number[], selectedFlag: boolean) => {
-    let selectedIds = [...this.state.currentChildSelectedIds];
-    if (selectedFlag) {
-      selectedIds = [...channelIds.filter((c) => !selectedIds.includes(c)), ...selectedIds];
-    } else {
-      selectedIds = [...selectedIds.filter((c) => !channelIds.includes(c))];
-    }
-    this.setState({ currentChildSelectedIds: selectedIds });
+    this.setState((prevState) => {
+      let selectedIds = [...prevState.currentChildSelectedIds];
+      if (selectedFlag) {
+        selectedIds = [...channelIds.filter((c) => !selectedIds.includes(c)), ...selectedIds];
+      } else {
+        selectedIds = [...selectedIds.filter((c) => !channelIds.includes(c))];
+      }
+      return { currentChildSelectedIds: selectedIds };
+    });
   };
 
   onNewBaseChannel = ({ currentSelectedBaseId, currentChildSelectedIds }: ActivationKeyChannelsState) => {

--- a/web/html/src/manager/systems/activation-key/child-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/child-channels.tsx
@@ -75,7 +75,7 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
   };
 
   toggleChannelVisibility = () => {
-    this.setState({ collapsed: !this.state.collapsed });
+    this.setState((prevState) => ({ collapsed: !prevState.collapsed }));
   };
 
   areRecommendedChildrenSelected = (): boolean => {

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
@@ -113,10 +113,12 @@ class BaseChannelPage extends React.Component<BaseChannelProps, BaseChannelState
   }
 
   onChangeBase = (oldBaseId: string, newBaseId: string) => {
-    const changes = this.state.baseChanges;
-    changes.set(oldBaseId, newBaseId);
-    this.setState({
-      baseChanges: changes,
+    this.setState((prevState) => {
+      const changes = prevState.baseChanges;
+      changes.set(oldBaseId, newBaseId);
+      return {
+        baseChanges: changes,
+      };
     });
     this.props.onSelectBase(oldBaseId, newBaseId);
   };
@@ -347,9 +349,11 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
 
     // change the channel AND its dependencies
     [childId].concat(dependencies).forEach((channelId) => {
-      const allowedId = getAllowedChangeId(allowedChannels, channelId);
-      this.state.selections.set(allowedId, action);
-      this.setState({ selections: this.state.selections });
+      this.setState((prevState) => {
+        const allowedId = getAllowedChangeId(allowedChannels, channelId);
+        prevState.selections.set(allowedId, action);
+        return { selections: prevState.selections };
+      });
       this.props.onChangeChild(allowedChannels, channelId, action);
     });
   };
@@ -914,23 +918,25 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
       }
     }
 
-    this.setState({ messages: this.state.messages.concat(msg) });
+    this.setState((prevState) => ({ messages: prevState.messages.concat(msg) }));
   };
 
   onChangeBase = (oldBaseId: string, newBaseId: string) => {
-    let change = this.state.baseChanges.changes.find((e) => DEPRECATED_unsafeEquals(e.oldBaseId, oldBaseId));
-    if (!change) {
-      change = {
-        oldBaseId: oldBaseId,
-        newBaseId: newBaseId,
-      };
-      this.state.baseChanges.changes.push(change);
-    } else {
-      change.newBaseId = newBaseId;
-    }
+    this.setState((prevState) => {
+      let change = prevState.baseChanges.changes.find((e) => DEPRECATED_unsafeEquals(e.oldBaseId, oldBaseId));
+      if (!change) {
+        change = {
+          oldBaseId: oldBaseId,
+          newBaseId: newBaseId,
+        };
+        prevState.baseChanges.changes.push(change);
+      } else {
+        change.newBaseId = newBaseId;
+      }
 
-    this.setState({
-      baseChanges: this.state.baseChanges,
+      return {
+        baseChanges: prevState.baseChanges,
+      };
     });
   };
 
@@ -1033,23 +1039,25 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
     };
     return Network.post("/rhn/manager/systems/ssm/channels", req)
       .then((data: JsonResult<SsmScheduleChannelChangesResultJson>) => {
-        const msg = MessagesUtils.info(
-          this.state.actionChain ? (
-            <span>
-              {t("Action has been successfully added to the Action Chain ")}
-              <ActionChainLink id={data.data.actionChainId}>
-                {this.state.actionChain ? this.state.actionChain.text : ""}
-              </ActionChainLink>
-              .
-            </span>
-          ) : (
-            <span>{t("Channel changes scheduled.")}</span>
-          )
-        );
-        this.setState({
-          messages: msg,
-          scheduleResults: data.data.result,
-          page: 3,
+        this.setState((prevState) => {
+          const msg = MessagesUtils.info(
+            prevState.actionChain ? (
+              <span>
+                {t("Action has been successfully added to the Action Chain ")}
+                <ActionChainLink id={data.data.actionChainId}>
+                  {prevState.actionChain ? prevState.actionChain.text : ""}
+                </ActionChainLink>
+                .
+              </span>
+            ) : (
+              <span>{t("Channel changes scheduled.")}</span>
+            )
+          );
+          return {
+            messages: msg,
+            scheduleResults: data.data.result,
+            page: 3,
+          };
         });
       })
       .catch(this.handleResponseError);

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
@@ -79,9 +79,9 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
   setKubeconfigContexts = (id) => {
     Network.get("/rhn/manager/api/vhms/kubeconfig/" + id + "/contexts")
       .then((data) => {
-        this.setState({
-          model: Object.assign(this.state.model, { contexts: data.data }),
-        });
+        this.setState((prevState) => ({
+          model: Object.assign(prevState.model, { contexts: data.data }),
+        }));
       })
       .catch(this.handleResponseError);
   };
@@ -152,9 +152,9 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
 
   onValidate = (isValid) => {
     if (this.props.type.toLowerCase() === "kubernetes" && !this.isEdit()) {
-      this.setState({
-        isInvalid: !isValid || !this.state.validKubeconfig,
-      });
+      this.setState((prevState) => ({
+        isInvalid: !isValid || !prevState.validKubeconfig,
+      }));
     } else {
       this.setState({
         isInvalid: !isValid,
@@ -279,14 +279,14 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
           data.currentContext = "<default>";
         }
         if (data.contexts) {
-          this.setState({
+          this.setState((prevState) => ({
             messages: null,
             validKubeconfig: true,
-            model: Object.assign(this.state.model, {
+            model: Object.assign(prevState.model, {
               contexts: data.contexts,
               module_context: data.currentContext,
             }),
-          });
+          }));
         }
       })
       .catch((jqXHR) => {


### PR DESCRIPTION
## What does this PR change?

Enforce the linter rule `react/no-access-state-in-setstate`. This ensures `setState()` is always called with the latest state, not a possibly stale reference. This is also something Sonar checks and this resolves a bunch of errors there.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: must pass existing tests

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
