### PR TITLE
Bump Web UI version to 2025.10 and check schema migrations

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -63,7 +63,7 @@ web.version = 5.2.0 Alpha1
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni = 2025.07
+web.version.uyuni = 2025.10
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 


### PR DESCRIPTION
## What does this PR change?

**add description**
* Bump Web UI version to 2025.10
No changelog added as there are other changelogs in the spacewalk-web package

* Check schema migrations
Both susemanager-schema and reportdb had changes to be tagged. However, nothing was needed, as the migrations already existed (or at least there was already a .gitkeep file). Here what was checked:

susemanager-schema:

```
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 *$)$ grep ^Version schema/spacewalk/susemanager-schema.spec 
Version:        5.2.0
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 *$)$ ls -la schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/
total 140
drwxr-xr-x 1 raul raul  1420 oct 23 16:28 .
drwxr-xr-x 1 raul raul 31408 oct 23 16:28 ..
-rw-r--r-- 1 raul raul  7441 oct 23 16:28 001-drop-receiving_updates-from-view.sql
-rw-r--r-- 1 raul raul   142 oct 23 16:28 002-rhnChannel-drop-receiving_updates.sql
-rw-r--r-- 1 raul raul   468 oct 23 16:28 004_add_index_token_channel.sql
-rw-r--r-- 1 raul raul  2047 oct 23 16:28 010-suseContentEnvironmentDiff.sql
-rw-r--r-- 1 raul raul  1541 oct 23 16:28 011-clm-channel-diff-task.sql
-rw-r--r-- 1 raul raul  4160 oct 23 16:28 012-clm-diff-rbac.sql
-rw-r--r-- 1 raul raul 28401 oct 23 16:28 030-change-unsubscribe-proxy-channel.sql
-rw-r--r-- 1 raul raul  1744 oct 23 16:28 100-create-proc-clone-channel-appstreams.sql
-rw-r--r-- 1 raul raul  1224 oct 23 16:28 200-ssm-product-migration.sql
-rw-r--r-- 1 raul raul  8809 oct 23 16:28 201-update-delete-server.sql
-rw-r--r-- 1 raul raul  2828 oct 23 16:28 202-ssm-rbac-endpoints.sql
-rw-r--r-- 1 raul raul   694 oct 23 16:28 300-remove-scap-filesize-limit-from-db.sql
-rw-r--r-- 1 raul raul   805 oct 23 16:28 400-add-missing-indexes.sql
-rw-r--r-- 1 raul raul 13784 oct 23 16:28 401-optimize-overview-function.sql
-rw-r--r-- 1 raul raul  1117 oct 23 16:28 500-topbar-search-rbac.sql
-rw-r--r-- 1 raul raul  1062 oct 23 16:28 510-configchannel-post-rbac.sql
-rw-r--r-- 1 raul raul  1685 oct 23 16:28 520-check_role-sat-admin.sql
-rw-r--r-- 1 raul raul   512 oct 23 16:28 530-rhnAction-created-idx.sql
-rw-r--r-- 1 raul raul  1849 oct 23 16:28 531-rhnActionOverview-drop-count-columns.sql
-rw-r--r-- 1 raul raul   807 oct 23 16:28 600-add-missing-dates-to-action-tables.sql
-rw-r--r-- 1 raul raul   916 oct 23 16:28 600-proxy-fix.sql
-rw-r--r-- 1 raul raul  1252 oct 23 16:28 700-package-search-rbac.sql
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 *$)$ git stash
Directorio de trabajo y estado de índice WIP on bump_2025.10: ff56ea04d8b Merge pull request #11058 from rjmateus/uyuni_machine_id_generation_bootsrap guardados
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 $)$ git checkout Manager-5.1
Cambiado a rama 'Manager-5.1'
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (Manager-5.1 $<)$ git pull
....
.....
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (Manager-5.1 $=)$ grep ^Version schema/spacewalk/susemanager-schema.spec 
Version:        5.1.12
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (Manager-5.1 $=)$ git checkout bump_2025.10
Cambiado a rama 'bump_2025.10'
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 $)$ ls -la schema/spacewalk/upgrade/susemanager-schema-5.1.12-to-susemanager-schema-5.2.0/
total 0
drwxr-xr-x 1 raul raul    16 oct 24 07:36 .
drwxr-xr-x 1 raul raul 31408 oct 24 07:36 ..
-rw-r--r-- 1 raul raul     0 oct 24 07:36 .gitkeep
```

Reportdb:

```
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 $)$ git checkout Manager-5.1
Cambiado a rama 'Manager-5.1'
Tu rama está actualizada con 'suma/Manager-5.1'.
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (Manager-5.1 $=)$ grep ^Version schema/reportdb/uyuni-reportdb-schema.spec 
Version:        5.1.5
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (Manager-5.1 $=)$ git checkout bump_2025.10
Cambiado a rama 'bump_2025.10'
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 *$)$ grep ^Version schema/reportdb/uyuni-reportdb-schema.spec 
Version:        5.2.0
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 *$)$ ls -la schema/reportdb/upgrade/uyuni-reportdb-schema-5.2.0-to-uyuni-reportdb-schema-5.2.1/
total 4
drwxr-xr-x 1 raul raul    64 oct 24 07:38 .
drwxr-xr-x 1 raul raul 14102 oct 24 07:38 ..
-rw-r--r-- 1 raul raul  1338 oct 24 07:38 010-CLMEnvironmentDifference.sql
raul@mordor:~/Documentos/gh-repos/git-repos-initial-clone/spacewalk_initial_clone/spacewalk (bump_2025.10 *$)$ ls -la schema/reportdb/upgrade/uyuni-reportdb-schema-5.1.5-to-uyuni-reportdb-schema-5.2.0/
total 0
drwxr-xr-x 1 raul raul    16 oct 24 07:38 .
drwxr-xr-x 1 raul raul 14102 oct 24 07:38 ..
-rw-r--r-- 1 raul raul     0 oct 24 07:38 .gitkeep
```


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

Before: Uyuni 2025.07

After: Uyuni 2025.10

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/27973

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [x] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [x] Re-run test "schema_migration_test_pgsql"
- [x] Re-run test "susemanager_unittests"
- [x] Re-run test "frontend_checks"
- [x] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
