### PR TITLE
OpenID login endpoint for MCP security integration

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -403,6 +403,68 @@ public class ConfigDefaults {
      */
     private static final String ERRATA_ADVISORY_MAP_CSV_DOWNLOAD_URL = "java.errata_advisory_map_csv_download_url";
 
+    /**
+     * OpenID Connect authorization parameters
+     */
+    public static final String OIDC_ENABLED = "web.oidc.enabled";
+    public static final String OIDC_IDP_ISSUER = "web.oidc.idp.issuer";
+    public static final String OIDC_IDP_JWKS_PATH = "web.oidc.idp.jwks_path";
+    public static final String OIDC_JWT_AUDIENCE = "web.oidc.jwt.audience";
+    public static final String OIDC_JWT_USERNAME_CLAIM = "web.oidc.jwt.username_claim";
+
+    /**
+     * Returns true if OIDC authorization is enabled
+     * @return true if OIDC authorization is enabled
+     */
+    public boolean isOidcEnabled() {
+        return Config.get().getBoolean(OIDC_ENABLED, false);
+    }
+
+    /**
+     * Returns the JWT issuer (the identity provider) URI
+     * <p>
+     * By OIDC specification, the URI must match the `iss` claim in the JWT token.
+     * @see <a href=https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationValidation>
+     *     OpenID Connect Discovery 1.0, Section 4.2
+     *     </a>
+     * @return the JWT issuer URI
+     */
+    public String getOidcIssuer() {
+        return Config.get().getString(OIDC_IDP_ISSUER, "");
+    }
+
+    /**
+     * Returns the JSON Web Key Set (JWKS) endpoint of the idP
+     * <p>
+     * The path is appended to the issuer URL to get the complete URI.
+     * <p>
+     * If not provided, it will be resolved from the OIDC discovery endpoint of the idP.
+     * @return the JWKS path
+     */
+    public String getOidcJwksPath() {
+        return Config.get().getString(OIDC_IDP_JWKS_PATH, "");
+    }
+
+    /**
+     * The audience to which the JWT is issued
+     * <p>
+     * It will be validated against the 'aud' claim in the JWT.
+     * @return the JWT audience
+     */
+    public String getOidcAudience() {
+        return Config.get().getString(OIDC_JWT_AUDIENCE, "uyuni-server");
+    }
+
+    /**
+     * The name of the claim that provides the internal Uyuni username
+     * <p>
+     * This claim is used to match a user of the idP to a user in Uyuni.
+     * @return the name of the Uyuni username claim
+     */
+    public String getOidcUsernameClaim() {
+        return Config.get().getString(OIDC_JWT_USERNAME_CLAIM, "preferred_username");
+    }
+
 
     private ConfigDefaults() {
     }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/servlets/AuthenticationFilter.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/servlets/AuthenticationFilter.java
@@ -126,7 +126,8 @@ public class AuthenticationFilter implements Filter {
             // Ignore requests to the download and login endpoints
             if (servletRequest.getServletPath().startsWith("/manager/download/") ||
                     servletRequest.getServletPath().equals("/manager/api/login") ||
-                    servletRequest.getServletPath().equals("/manager/api/auth/login")) {
+                    servletRequest.getServletPath().equals("/manager/api/auth/login") ||
+                    servletRequest.getServletPath().equals("/manager/api/oidcLogin")) {
                 chain.doFilter(request, response);
             }
             // Send 401 for unauthorized API requests and senna SPA requests, else redirect to login

--- a/java/core/src/main/java/com/redhat/rhn/manager/user/UserManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/user/UserManager.java
@@ -583,6 +583,36 @@ public class UserManager extends BaseManager {
         return user;
     }
 
+    /**
+     * Login the user
+     * <p>
+     * This method does not perform any authentication.
+     * It should be used together with a proper authentication mechanism (e.g. OIDC)
+     *
+     * @param login the username to log in
+     * @return Returns the user if login is successful, or null otherwise.
+     * @throws LoginException if login fails.  The message is a string resource key.
+     */
+    public static User loginUser(String login) throws LoginException {
+        String exceptionType = null;
+        try {
+            User user = UserFactory.lookupByLogin(login);
+            if (user.isDisabled()) {
+                exceptionType = "account.disabled";
+            }
+            else if (user.isReadOnly()) {
+                exceptionType = "error.user_readonly";
+            }
+            else {
+                return performLoginActions(user);
+            }
+        }
+        catch (LookupException le) {
+            exceptionType = "error.invalid_login";
+        }
+
+        throw new LoginException(exceptionType);
+    }
 
     /**
      * Login the user with the given username and password.

--- a/java/core/src/main/java/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/login/LoginController.java
@@ -31,6 +31,8 @@ import com.redhat.rhn.frontend.security.AuthenticationServiceFactory;
 import com.redhat.rhn.manager.acl.AclManager;
 import com.redhat.rhn.manager.user.UserManager;
 
+import com.suse.manager.webui.services.OidcAuthException;
+import com.suse.manager.webui.services.OidcAuthHandler;
 import com.suse.manager.webui.utils.LoginHelper;
 import com.suse.manager.webui.utils.SparkApplicationHelper;
 import com.suse.utils.Json;
@@ -66,6 +68,7 @@ public class LoginController {
     private static Logger log = LogManager.getLogger(LoginController.class);
     private static final Gson GSON = Json.GSON;
     private static final String URL_CREATE_FIRST_USER = "/rhn/newlogin/CreateFirstUser.do";
+    private static final OidcAuthHandler OIDC_AUTH_HANDLER = new OidcAuthHandler();
 
     private LoginController() { }
 
@@ -76,6 +79,7 @@ public class LoginController {
     public static void initRoutes(JadeTemplateEngine jade) {
         get("/manager/login", withCsrfToken(LoginController::loginView), jade);
         post("/manager/api/login", LoginController::login);
+        post("/manager/api/oidcLogin", LoginController::performOidcLogin);
         // TODO: Use this endpoint with the "Logout" button
         get("/manager/api/logout", withUser(LoginController::logout));
     }
@@ -219,6 +223,61 @@ public class LoginController {
             response.status(HttpServletResponse.SC_UNAUTHORIZED);
             return SparkApplicationHelper.json(response, new LoginResult(false, errorMsg.get()), new TypeToken<>() { });
         }
+    }
+
+    /**
+     * Perform an OpenID connect authorization, if enabled and properly configured.
+     * @param request the request object
+     * @param response the response object
+     * @return the JSON result of the login operation
+     */
+    private static String performOidcLogin(Request request, Response response) {
+        if (!OIDC_AUTH_HANDLER.isOidcEnabled()) {
+            log.error("OIDC AUTH FAILURE: OpenID Connect authorization is disabled.");
+            response.status(HttpServletResponse.SC_UNAUTHORIZED);
+            return SparkApplicationHelper.json(response, new LoginResult(false,
+                    "OpenID Connect authorization is disabled."), new TypeToken<>() { });
+        }
+
+        // Validate Authorization header
+        String authHeader = request.headers("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            log.error("OIDC AUTH FAILURE: Missing or invalid Authorization header.");
+            response.status(HttpServletResponse.SC_UNAUTHORIZED);
+            return SparkApplicationHelper.json(response, new LoginResult(false,
+                    "Missing or invalid Authorization header."), new TypeToken<>() { });
+        }
+
+        String token = authHeader.substring(7); // Removes "Bearer "
+        String username;
+        User user;
+
+        // Handle OIDC login and get username from the JWT
+        try {
+            username = OIDC_AUTH_HANDLER.handleOidcLogin(token);
+        }
+        catch (OidcAuthException e) {
+            // Log the full exception for debugging, but provide a generic message to the user/log
+            log.error("OIDC AUTH FAILURE: Error during OIDC token handling.", e);
+            response.status(HttpServletResponse.SC_UNAUTHORIZED);
+            return SparkApplicationHelper.json(response, new LoginResult(false,
+                    "OpenID Connect authorization failed."), new TypeToken<>() { });
+        }
+
+        // Log in the user with username
+        try {
+            user = UserManager.loginUser(username);
+            log.info("OIDC AUTH SUCCESS: [{}]", user.getLogin());
+        }
+        catch (LoginException e) {
+            log.error("OIDC AUTH FAILURE: User login failed for user [{}].", username, e);
+            response.status(HttpServletResponse.SC_UNAUTHORIZED);
+            return SparkApplicationHelper.json(response, new LoginResult(false,
+                    LocalizationService.getInstance().getMessage(e.getMessage())), new TypeToken<>() { });
+        }
+
+        LoginHelper.successfulLogin(request.raw(), response.raw(), user);
+        return SparkApplicationHelper.json(response, new LoginResult(true, null), new TypeToken<>() { });
     }
 
     /**

--- a/java/core/src/main/java/com/suse/manager/webui/services/OidcAuthException.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/OidcAuthException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services;
+
+/**
+ * Exception for OIDC authorization failures.
+ */
+public class OidcAuthException extends Exception {
+    /**
+     * Constructs an OidcAuthException with the specified detail message.
+     * @param message the detail message.
+     */
+    public OidcAuthException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs an OidcAuthException with the specified detail message and cause.
+     * @param message the detail message.
+     * @param cause the cause.
+     */
+    public OidcAuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/java/core/src/main/java/com/suse/manager/webui/services/OidcAuthHandler.java
+++ b/java/core/src/main/java/com/suse/manager/webui/services/OidcAuthHandler.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.conf.ConfigException;
+import com.redhat.rhn.common.util.http.HttpClientAdapter;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jose4j.jwa.AlgorithmConstraints;
+import org.jose4j.jwk.HttpsJwks;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.jose4j.keys.resolvers.HttpsJwksVerificationKeyResolver;
+import org.jose4j.keys.resolvers.VerificationKeyResolver;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Handles OpenID Connect (OIDC) authorization.
+ */
+public class OidcAuthHandler {
+
+    public static final String OIDC_DISCOVERY_PATH = "/.well-known/openid-configuration";
+
+    private static final Logger LOG = LogManager.getLogger(OidcAuthHandler.class);
+
+    private boolean oidcEnabled;
+    private String issuer;
+    private String jwksUri;
+    private String audience;
+    private String usernameClaim;
+
+    private JwtConsumer jwtConsumer;
+    private HttpClientAdapter httpClient;
+
+    /**
+     * Constructs an OidcAuthHandler and loads configuration.
+     */
+    public OidcAuthHandler() {
+        this(null, new HttpClientAdapter());
+    }
+
+    /**
+     * Constructs an OidcAuthHandler with a custom {@link VerificationKeyResolver}.
+     *
+     * @param keyResolver the verification key resolver, if {@code null} a default one is created
+     * @param httpClientIn the HTTP client to use when fetching from the discovery endpoint
+     */
+    public OidcAuthHandler(VerificationKeyResolver keyResolver, HttpClientAdapter httpClientIn) {
+        httpClient = httpClientIn;
+
+        try {
+            loadConfiguration();
+            if (!isOidcEnabled()) {
+                return;
+            }
+        }
+        catch (URISyntaxException eIn) {
+            throw new ConfigException("Malformed URI in the OIDC configuration.");
+        }
+        VerificationKeyResolver resolver = keyResolver;
+        if (resolver == null) {
+            HttpsJwks httpsJwks = new HttpsJwks(jwksUri);
+
+            // No proxy support in jose4j
+            // HttpsJwks can be subclassed for proxy support
+            resolver = new HttpsJwksVerificationKeyResolver(httpsJwks);
+        }
+
+        AlgorithmConstraints jwsAlgConstraints = new AlgorithmConstraints(
+                AlgorithmConstraints.ConstraintType.PERMIT,
+                AlgorithmIdentifiers.RSA_USING_SHA256,
+                AlgorithmIdentifiers.RSA_USING_SHA384,
+                AlgorithmIdentifiers.RSA_USING_SHA512,
+                AlgorithmIdentifiers.RSA_PSS_USING_SHA256,
+                AlgorithmIdentifiers.RSA_PSS_USING_SHA384,
+                AlgorithmIdentifiers.RSA_PSS_USING_SHA512,
+                AlgorithmIdentifiers.ECDSA_USING_P256_CURVE_AND_SHA256,
+                AlgorithmIdentifiers.ECDSA_USING_P384_CURVE_AND_SHA384
+        );
+
+        jwtConsumer = new JwtConsumerBuilder()
+                .setVerificationKeyResolver(resolver)
+                .setJweAlgorithmConstraints(jwsAlgConstraints)
+                .setRequireExpirationTime()
+                .setAllowedClockSkewInSeconds(5)
+                .setRequireSubject()
+                .setExpectedIssuer(true, issuer)
+                .setSkipDefaultAudienceValidation()
+                .build();
+
+        LOG.info("OIDC authorization is enabled. Issuer: {}, Audience: {}, Username attribute: {}",
+                issuer, audience, usernameClaim);
+    }
+
+    /**
+     * Loads OIDC configuration from {@link ConfigDefaults}.
+     * @throws URISyntaxException if a malformed URI is encountered.
+     */
+    private void loadConfiguration() throws URISyntaxException {
+        LOG.debug("Loading OIDC configuration.");
+        oidcEnabled = ConfigDefaults.get().isOidcEnabled();
+
+        if (!oidcEnabled) {
+            LOG.debug("OIDC authorization is disabled.");
+            return;
+        }
+
+        issuer = ConfigDefaults.get().getOidcIssuer();
+        if (StringUtils.isEmpty(issuer)) {
+            throw new ConfigException("OIDC issuer URI cannot be empty.");
+        }
+        URI issuerUri = new URI(issuer);
+
+        audience = ConfigDefaults.get().getOidcAudience();
+        if (StringUtils.isEmpty(audience)) {
+            throw new ConfigException("OIDC audience cannot be empty.");
+        }
+
+        usernameClaim = ConfigDefaults.get().getOidcUsernameClaim();
+        if (StringUtils.isEmpty(usernameClaim)) {
+            throw new ConfigException("OIDC username claim name cannot be empty.");
+        }
+
+        String jwksPath = ConfigDefaults.get().getOidcJwksPath();
+        if (StringUtils.isEmpty(jwksPath)) {
+            LOG.info("JWKS path not provided. Trying to fetch from the OIDC discovery endpoint.");
+            jwksUri = fetchJwksUri(issuerUri);
+        }
+        else {
+            jwksUri = appendUriPath(issuerUri, jwksPath).toString();
+        }
+    }
+
+    /**
+     * Fetches the JWKS URI from the OIDC discovery endpoint of the issuing identity provider.
+     * @param issuerIn The OIDC issuer URI.
+     * @return The JWKS URI.
+     * @throws URISyntaxException if a malformed URI is encountered.
+     */
+    private String fetchJwksUri(URI issuerIn) throws URISyntaxException {
+        URI discoveryEndpoint = appendUriPath(issuerIn, OIDC_DISCOVERY_PATH);
+        LOG.warn("Fetching JWKS path from OIDC discovery endpoint: {}", discoveryEndpoint);
+
+        HttpGet request = new HttpGet(discoveryEndpoint);
+        HttpResponse response;
+        String uri;
+
+        try {
+            response = httpClient.executeRequest(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+
+            if (statusCode != 200) {
+                throw new ConfigException("Failed to fetch OIDC discovery document from " + discoveryEndpoint +
+                        ". HTTP status code: " + statusCode);
+            }
+
+            String jsonResponse = EntityUtils.toString(response.getEntity());
+            JsonObject jsonObject = new Gson().fromJson(jsonResponse, JsonObject.class);
+            uri = jsonObject.get("jwks_uri").getAsString();
+
+            if (StringUtils.isEmpty(uri)) {
+                throw new ConfigException("JWKS URI not found in the OIDC discovery document from " +
+                        discoveryEndpoint);
+            }
+        }
+        catch (IOException e) {
+            throw new ConfigException("Error while fetching OIDC discovery document from " + discoveryEndpoint, e);
+        }
+        finally {
+            request.releaseConnection();
+        }
+
+        LOG.debug("Successfully fetched JWKS URI: {}", uri);
+        return uri;
+    }
+
+    /**
+     * Appends a path to a base URI.
+     * <p>
+     * If the base URI includes a path itself, it is concatenated with the path to be appended.
+     * @param base The base URI.
+     * @param path The path to append.
+     * @return The new URI with the appended path.
+     * @throws URISyntaxException if a malformed URI is encountered.
+     */
+    private static URI appendUriPath(URI base, String path) throws URISyntaxException {
+        if (StringUtils.isEmpty(path)) {
+            return base;
+        }
+
+        String basePath = base.getPath();
+        if (!basePath.endsWith("/")) {
+            basePath += "/";
+        }
+
+        // Remove trailing slashes in path
+        String normalizedPath = path.replaceAll("^/+", "");
+
+        return new URIBuilder(base)
+                .setPath(basePath + normalizedPath)
+                .build();
+    }
+
+    /**
+     * Handles OIDC login by verifying the provided token using a {@link JwtConsumer}.
+     * <p>
+     * Following validations are applied to the token:
+     * <ul>
+     *     <li>Signature verification using keys from the JWKS URI.</li>
+     *     <li>Allowed JWS algorithms: RSA/PSS SHA-256, SHA-384, SHA-512 and ESDCA SHA-256, SHA-384.</li>
+     *     <li>Requires an expiration time claim.</li>
+     *     <li>Allows for a 5-second clock skew.</li>
+     *     <li>Requires a subject claim.</li>
+     *     <li>Validates the issuer claim against the configured OIDC issuer.</li>
+     *     <li>Custom audience validation against the configured OIDC audience.</li>
+     *     <li>Matches the configured Uyuni username claim to an existing user.</li>
+     * </ul>
+     * @param token The OIDC token.
+     * @return The username claim.
+     * @throws OidcAuthException if token verification fails or OIDC is not enabled.
+     */
+    public String handleOidcLogin(String token) throws OidcAuthException {
+        if (!isOidcEnabled()) {
+            throw new OidcAuthException("OIDC authorization is not enabled.");
+        }
+
+        try {
+            JwtClaims claims = jwtConsumer.processToClaims(token);
+            if (!claims.getAudience().contains(audience)) {
+                throw new OidcAuthException("Token verification failed. Missing '" + audience +
+                        "' in the audience claim.");
+            }
+            if (!claims.hasClaim(usernameClaim)) {
+                throw new OidcAuthException("Token verification failed. Missing '" + usernameClaim + "' claim.");
+            }
+            return claims.getClaimValueAsString(usernameClaim);
+        }
+        catch (InvalidJwtException | MalformedClaimException e) {
+            throw new OidcAuthException("Token verification failed.", e);
+        }
+    }
+
+    /**
+     * Checks if OIDC authorization is enabled by configuration.
+     * @return {@code true} if OIDC is enabled, {@code false} otherwise.
+     */
+    public boolean isOidcEnabled() {
+        return oidcEnabled;
+    }
+
+    /**
+     * Gets the configured JWKS URI
+     * @return the JWKS URI
+     */
+    public String getJwksUri() {
+        return jwksUri;
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/webui/services/test/OidcAuthHandlerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/test/OidcAuthHandlerTest.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.services.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.util.http.HttpClientAdapter;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+
+import com.suse.manager.webui.services.OidcAuthException;
+import com.suse.manager.webui.services.OidcAuthHandler;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import org.jose4j.base64url.Base64Url;
+import org.jose4j.json.JsonUtil;
+import org.jose4j.jwa.AlgorithmConstraints;
+import org.jose4j.jwk.JsonWebKeySet;
+import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.jws.AlgorithmIdentifiers;
+import org.jose4j.jws.JsonWebSignature;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.InvalidJwtException;
+import org.jose4j.keys.resolvers.JwksVerificationKeyResolver;
+import org.jose4j.keys.resolvers.VerificationKeyResolver;
+import org.jose4j.lang.InvalidAlgorithmException;
+import org.jose4j.lang.JoseException;
+import org.jose4j.lang.UnresolvableKeyException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class OidcAuthHandlerTest extends JMockBaseTestCaseWithUser {
+
+    private static final String ISSUER = "https://auth.localhost";
+    private static final String TEST_KID = "test-key-id";
+    private static final String MCP_AUDIENCE = "mcp-server-uyuni";
+    private static final String MLM_AUDIENCE = ConfigDefaults.get().getOidcAudience();
+    private static final String USERNAME_CLAIM = ConfigDefaults.get().getOidcUsernameClaim();
+    private static final String JWKS_URI = "/.well-known/jwks.json";
+    private KeyPair rsaKeyPair;
+
+
+    @Override
+    @BeforeEach
+    public void setUp() throws Exception {
+        super.setUp();
+        enableOidcLogin();
+        rsaKeyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+    }
+
+    @Test
+    public void testOidcDisabled() throws JoseException {
+        String token = issueValidToken();
+
+        Config.get().setBoolean(ConfigDefaults.OIDC_ENABLED, "false");
+        OidcAuthHandler handler = getHandler();
+
+        Exception e = assertThrows(OidcAuthException.class, () -> handler.handleOidcLogin(token));
+        assertEquals("OIDC authorization is not enabled.", e.getMessage());
+    }
+
+    @Test
+    public void testHandleSuccessfulLogin() throws JoseException, OidcAuthException {
+        String token = issueValidToken();
+
+        OidcAuthHandler handler = getHandler();
+        String username = handler.handleOidcLogin(token);
+
+        Assertions.assertEquals(user.getLogin(), username);
+    }
+
+    @Test
+    public void testIssuerMismatch() throws JoseException {
+        String token = issueToken(rsaKeyPair.getPrivate(), AlgorithmIdentifiers.RSA_USING_SHA256,
+                "https://not-me.localhost", List.of(MCP_AUDIENCE, MLM_AUDIENCE), Map.of(USERNAME_CLAIM, user.getId()));
+
+        OidcAuthHandler handler = getHandler();
+
+        Exception e = assertThrows(OidcAuthException.class, () -> handler.handleOidcLogin(token));
+        Throwable cause = e.getCause();
+
+        assertEquals(InvalidJwtException.class, cause.getClass());
+        assertTrue(cause.getMessage().contains("Issuer (iss) claim value (https://not-me.localhost) " +
+                "doesn't match expected value of " + ISSUER));
+    }
+
+    @Test
+    public void testAudienceMismatch() throws JoseException {
+        String token = issueToken(rsaKeyPair.getPrivate(), AlgorithmIdentifiers.RSA_USING_SHA256, ISSUER,
+                List.of(MCP_AUDIENCE), Map.of(USERNAME_CLAIM, user.getId()));
+
+        OidcAuthHandler handler = getHandler();
+
+        Exception e = assertThrows(OidcAuthException.class, () -> handler.handleOidcLogin(token));
+        assertTrue(e.getMessage().contains("Missing '" + MLM_AUDIENCE + "' in the audience claim."));
+    }
+
+    @Test
+    public void testUsernameClaimMismatch() throws JoseException {
+        String token = issueToken(rsaKeyPair.getPrivate(), AlgorithmIdentifiers.RSA_USING_SHA256, ISSUER,
+                List.of(MCP_AUDIENCE, MLM_AUDIENCE), Map.of("not_uyuni_username", user.getLogin()));
+
+        OidcAuthHandler handler = getHandler();
+
+        Exception e = assertThrows(OidcAuthException.class, () -> handler.handleOidcLogin(token));
+        assertTrue(e.getMessage().contains("Missing '" + USERNAME_CLAIM + "' claim."));
+    }
+
+    @Test
+    public void testAlternativeAlgoritm() throws JoseException, NoSuchAlgorithmException, OidcAuthException,
+            InvalidAlgorithmParameterException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("EC");
+        ECGenParameterSpec ecSpec = new ECGenParameterSpec("secp256r1");
+        keyPairGenerator.initialize(ecSpec);
+        KeyPair ecdsaKeyPair = keyPairGenerator.generateKeyPair();
+
+        String token = issueValidToken(ecdsaKeyPair.getPrivate(),
+                AlgorithmIdentifiers.ECDSA_USING_P256_CURVE_AND_SHA256, user.getLogin());
+
+        OidcAuthHandler handler = getHandler(ecdsaKeyPair.getPublic());
+        String username = handler.handleOidcLogin(token);
+
+        Assertions.assertEquals(user.getLogin(), username);
+    }
+
+    @Test
+    public void testInsecureHash() throws NoSuchAlgorithmException, SignatureException, InvalidKeyException,
+            JoseException {
+        // Token with insecure signing hash
+        String token = signTokenWithRs1(generateValidClaims(), (RSAPrivateKey) rsaKeyPair.getPrivate());
+
+        OidcAuthHandler handler = getHandler();
+
+        Exception e = assertThrows(OidcAuthException.class, () -> handler.handleOidcLogin(token));
+        Throwable cause = e.getCause();
+
+        assertEquals(InvalidJwtException.class, cause.getClass());
+        cause = cause.getCause();
+        assertEquals(UnresolvableKeyException.class, cause.getClass());
+        cause = cause.getCause();
+        assertEquals(InvalidAlgorithmException.class, cause.getClass());
+        assertTrue(cause.getMessage().contains("RS1 is an unknown, unsupported or unavailable alg algorithm"));
+    }
+
+    @Test
+    public void testUnsecuredToken() throws JoseException {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(generateValidClaims().toJson());
+        jws.setAlgorithmConstraints(AlgorithmConstraints.NO_CONSTRAINTS);
+        jws.setAlgorithmHeaderValue(AlgorithmIdentifiers.NONE);
+        String token = jws.getCompactSerialization();
+        OidcAuthHandler handler = getHandler();
+
+        Exception e = assertThrows(OidcAuthException.class, () -> handler.handleOidcLogin(token));
+        Throwable cause = e.getCause();
+
+        assertEquals(InvalidJwtException.class, cause.getClass());
+        cause = cause.getCause();
+        assertEquals(UnresolvableKeyException.class, cause.getClass());
+        assertTrue(cause.getMessage().contains("Unable to find a suitable verification key"));
+    }
+
+    @Test
+    public void testFetchJwksUri() {
+        WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+        try {
+            String issuer = wireMockServer.baseUrl();
+            String jwksUri = issuer + "/.not-so-well-known/jwks.json";
+            String oidcConfig = String.format("{\"jwks_uri\":\"%s\"}", jwksUri);
+
+            wireMockServer.stubFor(WireMock.get(OidcAuthHandler.OIDC_DISCOVERY_PATH)
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(oidcConfig)));
+
+            Config.get().setString(ConfigDefaults.OIDC_IDP_ISSUER, issuer);
+            Config.get().setString(ConfigDefaults.OIDC_IDP_JWKS_PATH, "");
+
+            // keyResolver is not used when only fetching the jwks uri
+            OidcAuthHandler handler = new OidcAuthHandler(null, new HttpClientAdapter());
+            assertEquals(jwksUri, handler.getJwksUri());
+        }
+        finally {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    public void testValidJwksUri() throws JoseException, OidcAuthException {
+        WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+        try {
+            String issuer = wireMockServer.baseUrl();
+
+            // Generate the JWKS to serve
+            PublicJsonWebKey jwk = PublicJsonWebKey.Factory.newPublicJwk(rsaKeyPair.getPublic());
+            jwk.setKeyId(TEST_KID);
+            String jwks = new JsonWebKeySet(jwk).toJson();
+
+            wireMockServer.stubFor(WireMock.get(JWKS_URI)
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(jwks)));
+
+            Config.get().setString(ConfigDefaults.OIDC_IDP_ISSUER, issuer);
+            OidcAuthHandler handler = new OidcAuthHandler();
+
+            String token = issueToken(rsaKeyPair.getPrivate(), AlgorithmIdentifiers.RSA_USING_SHA256, issuer,
+                    List.of(MCP_AUDIENCE, MLM_AUDIENCE), Map.of(USERNAME_CLAIM, user.getLogin()));
+            String username = handler.handleOidcLogin(token);
+
+            assertEquals(user.getLogin(), username);
+        }
+        finally {
+            wireMockServer.stop();
+        }
+    }
+
+    @Test
+    public void testInvalidJwksUri() {
+        WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMockServer.start();
+        try {
+            String issuer = wireMockServer.baseUrl();
+
+            wireMockServer.stubFor(WireMock.get(JWKS_URI)
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")));
+
+            Config.get().setString(ConfigDefaults.OIDC_IDP_ISSUER, issuer);
+            Config.get().setString(ConfigDefaults.OIDC_IDP_JWKS_PATH, "/.not-so-well-known/jwks.json");
+            OidcAuthHandler handler = new OidcAuthHandler();
+
+            Exception e = assertThrows(OidcAuthException.class, () -> handler.handleOidcLogin(issueValidToken()));
+            Throwable cause = e.getCause();
+            assertEquals(InvalidJwtException.class, cause.getClass());
+            cause = cause.getCause();
+            assertEquals(UnresolvableKeyException.class, cause.getClass());
+            cause = cause.getCause();
+            assertEquals(IOException.class, cause.getClass());
+            assertTrue(cause.getMessage().contains("404 Not Found"));
+        }
+        finally {
+            wireMockServer.stop();
+        }
+    }
+
+    private OidcAuthHandler getHandler() throws JoseException {
+        return getHandler(rsaKeyPair.getPublic());
+    }
+
+    private OidcAuthHandler getHandler(PublicKey publicKey) throws JoseException {
+        return getHandler(publicKey, new HttpClientAdapter());
+    }
+
+    private OidcAuthHandler getHandler(PublicKey publicKey, HttpClientAdapter httpClient) throws JoseException {
+        PublicJsonWebKey jwk = PublicJsonWebKey.Factory.newPublicJwk(publicKey);
+        jwk.setKeyId(TEST_KID);
+        VerificationKeyResolver keyResolver = new JwksVerificationKeyResolver(new JsonWebKeySet(jwk).getJsonWebKeys());
+        return new OidcAuthHandler(keyResolver, httpClient);
+    }
+
+    private void enableOidcLogin() {
+        Config.get().setBoolean(ConfigDefaults.OIDC_ENABLED, "true");
+        Config.get().setString(ConfigDefaults.OIDC_IDP_ISSUER, ISSUER);
+        Config.get().setString(ConfigDefaults.OIDC_IDP_JWKS_PATH, JWKS_URI);
+    }
+
+    private String signToken(JwtClaims claims, Key signingKey, String algorithm) throws JoseException {
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setPayload(claims.toJson());
+        jws.setKey(signingKey);
+        jws.setKeyIdHeaderValue(TEST_KID);
+        jws.setAlgorithmHeaderValue(algorithm);
+
+        return jws.getCompactSerialization();
+    }
+
+    private String issueToken(PrivateKey privateKey, String algorithm, String issuer, List<String> audienceList,
+            Map<String, Object> extraClaims) throws JoseException {
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer(issuer);
+        claims.setSubject(UUID.randomUUID().toString());
+        claims.setExpirationTimeMinutesInTheFuture(10);
+        claims.setGeneratedJwtId();
+        claims.setIssuedAtToNow();
+        claims.setAudience(audienceList);
+        extraClaims.forEach(claims::setClaim);
+
+        return signToken(claims, privateKey, algorithm);
+    }
+
+    private String issueValidToken() throws JoseException {
+        return issueValidToken(rsaKeyPair.getPrivate(), AlgorithmIdentifiers.RSA_USING_SHA256, user.getLogin());
+    }
+
+    private String issueValidToken(PrivateKey privateKey, String algorithm, String username) throws JoseException {
+        return issueToken(privateKey, algorithm, ISSUER, List.of(MCP_AUDIENCE, MLM_AUDIENCE),
+                Map.of(USERNAME_CLAIM, username));
+    }
+
+    private JwtClaims generateValidClaims() {
+        JwtClaims claims = new JwtClaims();
+        claims.setIssuer(ISSUER);
+        claims.setSubject(UUID.randomUUID().toString());
+        claims.setExpirationTimeMinutesInTheFuture(10);
+        claims.setGeneratedJwtId();
+        claims.setIssuedAtToNow();
+        claims.setAudience(List.of("uyuni-server"));
+        claims.setClaim(USERNAME_CLAIM, user.getId());
+        return claims;
+    }
+
+    /**
+     * Sign a JWT insecurely with RSA SHA-1 to test rejection.
+     * @param claims the jwt claims object
+     * @param privateKey the RSA private key
+     * @return the JWT signed with RSA + SHA-1
+     */
+    private static String signTokenWithRs1(JwtClaims claims, RSAPrivateKey privateKey) throws NoSuchAlgorithmException,
+            InvalidKeyException, SignatureException {
+        // jose4j doesn't allow signing keys insecurely so this method does it manually.
+        String headerJson = "{\"alg\":\"RS1\",\"typ\":\"JWT\"}";
+
+        String payloadJson = JsonUtil.toJson(claims.getClaimsMap());
+
+        String headerB64 = Base64Url.encode(headerJson.getBytes(StandardCharsets.UTF_8));
+        String payloadB64 = Base64Url.encode(payloadJson.getBytes(StandardCharsets.UTF_8));
+
+        String signingInput = headerB64 + "." + payloadB64;
+
+        Signature signature = Signature.getInstance("SHA1withRSA");
+        signature.initSign(privateKey);
+        signature.update(signingInput.getBytes(StandardCharsets.UTF_8));
+        byte[] sigBytes = signature.sign();
+
+        String sigB64 = Base64Url.encode(sigBytes);
+
+        // Compact serialization
+        return signingInput + "." + sigB64;
+    }
+}

--- a/java/spacewalk-java.changes.cbbayburt.oidc-login
+++ b/java/spacewalk-java.changes.cbbayburt.oidc-login
@@ -1,0 +1,1 @@
+- Add OpenID Connect login endpoint for MCP security integration

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -3558,6 +3558,9 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('com.suse.manager.webui.controllers.login.LoginController', '/manager/api/login', 'POST', 'A', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('com.suse.manager.webui.controllers.login.LoginController', '/manager/api/oidcLogin', 'GET', 'A', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('com.suse.manager.webui.controllers.login.LoginController', '/manager/api/logout', 'GET', 'A', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)

--- a/schema/spacewalk/susemanager-schema.changes.cbbayburt.oidc-login
+++ b/schema/spacewalk/susemanager-schema.changes.cbbayburt.oidc-login
@@ -1,0 +1,1 @@
+- Add OpenID Connect login endpoint for MCP security integration

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/540-oidc-login-rbac.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.0-to-susemanager-schema-5.2.1/540-oidc-login-rbac.sql
@@ -1,0 +1,14 @@
+--
+-- Copyright (c) 2025 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/manager/api/oidcLogin', 'GET', 'A', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/api/oidcLogin' AND http_method = 'GET');


### PR DESCRIPTION
Adds `/manager/api/oicdLogin` endpoint that accepts JWTs forwarded by the MCP server from an external idP with strict token verification and explicit user matching.

Related PR for the MCP server: https://github.com/uyuni-project/mcp-server-uyuni/pull/33

### Authentication flow

1. Following the OAuth 2.0 exchange between the user, Uyuni MCP server, and the idP, the MCP server forwards the JWT issued by the idP to the `/manager/api/oidcLogin` endpoint of MLM API (downstream resource server) in the "Authorization" header.
2. MLM validates the token against idP's public JWK (see below)
3. MLM extracts the `preferred_username` value that is included in the JWT
4. MLM matches the username to an existing active user in MLM and logs the user in
5. In response, MLM returns a session key inteded to be used for subsequent API calls
6. Uyuni MCP server puts the session key in a cookie to make subsequent API calls

### Security overview

MLM validates the JWTs according to the following rules:

- Signature verification using keys from the idP's JWKS URI.
- Allowed JWS algorithms: RSA/PSS SHA-256, SHA-384, SHA-512 and ESDCA SHA-256, SHA-384.
- Requires an expiration time claim.
- Allows for a 5-second clock skew.
- Requires a subject claim (any).
- Validates the issuer claim against the configured OIDC issuer.
- Custom audience validation against the configured OIDC audience. Uyuni MCP server and the MLM require different `aud` claims to accept the JWT: respectively `mcp-server-uyuni` and `uyuni-server`. Therefore, to explicitly permit the JWTs to be forwarded downstream, a JWT must be configured to include `aud = ['mcp-server-uyuni', 'uyuni-server']`
- Matches the `preferred_username` claim to an existing user.

### New configuration variables (with defaults)

```properties
# OpenID Connect authorization
web.oidc.enabled = false
# The identity provider URI
web.oidc.idp.issuer =
# The JWKS endpoint of the identity provider (path only)
# If not provided, the server will fetch it from the OIDC discovery endpoint of the idP.
web.oidc.idp.jwks_path =
# Expected audience to which the JWT is issued
web.oidc.jwt.audience = uyuni-server
# The name of the Uyuni username claim
web.oidc.jwt.username_claim = preferred_username
```

Minimal configuration using defaults:

```properties
# OpenID Connect authorization
web.oidc.enabled = true
# The identity provider URI
web.oidc.idp.issuer = https://auth.example.com
```

## Documentation (TODO)
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/28483

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
