### PR TITLE
QE: Configure the interface of pxeboot for each product

### DIFF
--- a/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
@@ -74,9 +74,21 @@ Feature: PXE boot a terminal with Cobbler and containerized proxy
     When I restart cobbler on the server
     Then service "cobblerd" is active on "server"
 
+# Workaround to ssh the pxeboot minions through different interfaces for each product,
+#  maybe in the future we can rename the interfaces directly in sumaform
+@uyuni
   Scenario: PXE boot the PXE boot minion
     When I set the default PXE menu entry to the target profile on the "server"
-    And I reboot the Cobbler terminal "pxeboot_minion"
+    And I reboot the Cobbler terminal "pxeboot_minion" through the interface "ens4"
+    And I wait for "60" seconds
+    And I set the default PXE menu entry to the local boot on the "server"
+    And I wait at most 1200 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
+    And I accept "pxeboot_minion" key in the Salt master
+
+@susemanager
+  Scenario: PXE boot the PXE boot minion
+    When I set the default PXE menu entry to the target profile on the "server"
+    And I reboot the Cobbler terminal "pxeboot_minion" through the interface "eth0"
     And I wait for "60" seconds
     And I set the default PXE menu entry to the local boot on the "server"
     And I wait at most 1200 seconds until Salt master sees "pxeboot_minion" as "unaccepted"

--- a/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_retail_pxeboot.feature
@@ -125,8 +125,17 @@ Feature: PXE boot a Retail terminal behind a containerized proxy
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 
+# Workaround to ssh the pxeboot minions through different interfaces for each product,
+#  maybe in the future we can rename the interfaces directly in sumaform
+@uyuni
   Scenario: PXE boot the PXE boot minion
-    When I reboot the Retail terminal "pxeboot_minion"
+    When I reboot the Retail terminal "pxeboot_minion" through the interface "ens4"
+    And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
+    And I accept "pxeboot_minion" key in the Salt master
+
+@susemanager
+  Scenario: PXE boot the PXE boot minion
+    When I reboot the Retail terminal "pxeboot_minion" through the interface "eth0"
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
 

--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -183,7 +183,7 @@ When(/^I restart the network on the PXE boot minion$/) do
   get_target('proxy').run("expect -f /tmp/#{file} #{ipv6}")
 end
 
-When(/^I reboot the (Retail|Cobbler) terminal "([^"]*)"$/) do |context, host|
+When(/^I reboot the (Retail|Cobbler) terminal "([^"]*)" through the interface "([^"]*)"$/) do |context, host, interface|
   # we might have no or any IPv4 address on that machine
   # convert MAC address to IPv6 link-local address
   case host
@@ -196,7 +196,7 @@ When(/^I reboot the (Retail|Cobbler) terminal "([^"]*)"$/) do |context, host|
   end
   mac = mac.tr(':', '')
   hex = (("#{mac[0..5]}fffe#{mac[6..11]}").to_i(16) ^ 0x0200000000000000).to_s(16)
-  ipv6 = "fe80::#{hex[0..3]}:#{hex[4..7]}:#{hex[8..11]}:#{hex[12..15]}%eth1"
+  ipv6 = "fe80::#{hex[0..3]}:#{hex[4..7]}:#{hex[8..11]}:#{hex[12..15]}%#{interface}"
   log "Rebooting #{ipv6}..."
   file = 'reboot-pxeboot.exp'
   source = "#{File.dirname(__FILE__)}/../upload_files/#{file}"


### PR DESCRIPTION
## What does this PR change?

TW by default is naming the interfaces as ensx instead of ethx, given that I'm going to do a different version of the step to ssh the pxeboot minion for each of the products. Maybe this is just a workaround and in the future we can rename the interfaces in TW instead, but currently is a good solution because the release of uyuni is near, we have to into account that this change in sumaform is going to be tricky and maybe we break more things in the CI with this change.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): none.
Port(s): 
- Manager 5.1: https://github.com/SUSE/spacewalk/pull/28790
- Manager 5.0: https://github.com/SUSE/spacewalk/pull/28791
- Manager 4.3: https://github.com/SUSE/spacewalk/pull/28792

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
