### PR TITLE
Reject proxy channel for slmicro61 client

### DIFF
--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -312,11 +312,27 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
     child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-updates-x86_64' }
   end
 
+  # filter out wrong child channels for SLES15sp6 as normal Minion
+  if client.include? 'sle15sp6'
+    child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-pool-x86_64-sp6' }
+    child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-updates-x86_64-sp6' }
+    child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-pool-x86_64-sp6' }
+    child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-updates-x86_64-sp6' }
+  end
+
   # filter out wrong child channels for SL Micro 6.1 as normal Minion
   if client.include? 'slmicro61'
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-5.1-x86_64' }
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-5.1-x86_64' }
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-server-5.1-x86_64' }
+  end
+
+  # filter out wrong child channels for SLES15SP7 as normal Minion
+  if client.include? 'sle15sp7'
+    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-sle-5.1-pool-x86_64-sp7' }
+    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-sle-5.1-updates-x86_64-sp7' }
+    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-sle-5.1-pool-x86_64-sp7' }
+    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-sle-5.1-updates-x86_64-sp7' }
   end
 
   $stdout.puts "Child_channels for #{key}: <#{child_channels}>"


### PR DESCRIPTION
## What does this PR change?

In BV, when creating the slmicro61 minion activation keys, the proxy products are added as child channels.
Update the api command to reject the proxy channels for slmicro61 minion.
Also add sles15sp6 and sles15sp7 extensions to the excluded repo

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered


- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28737
Port(s): 
 - 5.1: https://github.com/uyuni-project/uyuni/pull/11091
 - 5.0: https://github.com/SUSE/spacewalk/pull/28784

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
