### PR TITLE
QE: Add a step that waits until a task is completed in cobbler

### DIFF
--- a/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_container_cobbler_pxeboot.feature
@@ -130,6 +130,7 @@ Feature: PXE boot a terminal with Cobbler and containerized proxy
     And I follow "Delete Autoinstallation"
     And I click on "Delete Autoinstallation"
     And I wait until I do not see "15-sp4-cobbler" text
+    And I wait up to 5 minutes to see "TASK COMPLETE" in the last lines of "var/log/cobbler/cobbler.log" on "server"
 
   Scenario: Cleanup: remove the auto installation distribution
     When I follow the left menu "Systems > Autoinstallation > Distributions"
@@ -137,6 +138,7 @@ Feature: PXE boot a terminal with Cobbler and containerized proxy
     And I follow "Delete Distribution"
     And I click on "Delete Distribution"
     And I wait until I do not see "SLE-15-SP4-TFTP" text
+    And I wait up to 5 minutes to see "TASK COMPLETE" in the last lines of "var/log/cobbler/cobbler.log" on "server"
 
   Scenario: Cleanup: remove the auto installation files
     When I remove packages "tftpboot-installation-SLE-15-SP4-x86_64 expect" from this "build_host"

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -25,7 +25,7 @@ Feature: Manipulate activation keys
     And I wait until I do not see "Loading..." text
     And I enter "20" as "usageLimit"
     And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
+    Then I wait until I see "Activation key SUSE Test Key i586 has been modified." text
     And I should see "20" in field identified by "usageLimit"
 
   Scenario: Change the base channel of the i586 activation key
@@ -34,7 +34,7 @@ Feature: Manipulate activation keys
     And I wait until I do not see "Loading..." text
     And I select "Fake-Base-Channel-i586" from "selectedBaseChannel"
     And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
+    Then I wait until I see "Activation key SUSE Test Key i586 has been modified." text
 
   Scenario: Delete the i586 activation key
     When I follow the left menu "Systems > Activation Keys"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -188,6 +188,14 @@ When(/^I wait until I see the event "([^"]*)" completed during last minute, refr
   end
 end
 
+When(/^I wait up to (\d+) minutes to see "([^"]*)" in the last lines of "([^"]*)" on "([^"]*)"$/) do |waiting_time, text, file, host|
+  node = get_target(host)
+  timeout_seconds = waiting_time.to_i * 60
+  # The grep command returns 0 (success) only if the text is found.
+  # node.run_until_ok waits until the command returns an exit code of 0.
+  node.run_until_ok("tail -n 10 #{file} | grep -E '#{text}'", timeout: timeout_seconds)
+end
+
 When(/^I follow the event "([^"]*)" completed during last minute$/) do |event|
   now = Time.now
   current_minute = now.strftime('%H:%M')


### PR DESCRIPTION
## What does this PR change?

In this Pr I'm adding a step to the retail features that waits until the deletion of the profiles is finished.
I know that we don't want to have synchronous steps, we are validating the product and we don't want to get into check the logs, but cobbler and retail are triggering errors that are increasing a lot the failures of our testsuites because we are not really waiting until the deleting of the profiles is finished. If we do an exception in these features we are going to reduce the flakiness of our pipelines, and we are going to reduce the time to analyze the errors in cobler/retail.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were edited

- [x] **DONE**

## Links

Issue(s): None
Port(s):
- Manager 5.1: https://github.com/SUSE/spacewalk/pull/28809
- Manager 5.0: https://github.com/SUSE/spacewalk/pull/28811
- Manager 4.3: https://github.com/SUSE/spacewalk/pull/28812

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
