### PR TITLE
Fix Sonar cloud warnings

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/test/NamedPreparedStatementTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/test/NamedPreparedStatementTest.java
@@ -42,7 +42,7 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
     private static final int FIRST_POS = 2;
     private static final int SECOND_POS = 3;
 
-
+    @SuppressWarnings("unchecked")
     private String SIMPLE_QUERY = "SELECT wc.id AS ID, " +
                                   "wc.login, " +
                                   "wc.login_uc " +
@@ -50,6 +50,7 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
                                   " WHERE wc.org_id = :org_id " +
                                   " ORDER BY wc.login_uc, wc.id";
 
+    @SuppressWarnings("unchecked")
     private String SIMPLE_QUERY_SUBST = "SELECT wc.id AS ID, " +
                                         "wc.login, " +
                                         "wc.login_uc " +
@@ -57,6 +58,7 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
                                         " WHERE wc.org_id = ? " +
                                         " ORDER BY wc.login_uc, wc.id";
 
+    @SuppressWarnings("unchecked")
     private String TWO_VAR_QUERY = "SELECT DISTINCT E.id, E.update_date " +
                                    "FROM rhnErrata E, " +
                                    "rhnServerNeededCache SNC " +
@@ -68,6 +70,7 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
                                    "AND SNC.errata_id = E.id " +
                                    "ORDER BY E.update_date, E.id";
 
+    @SuppressWarnings("unchecked")
     private String TWO_VAR_QUERY_SUBST = "SELECT DISTINCT E.id, " +
                                          "E.update_date " +
                                          "FROM rhnErrata E, " +
@@ -80,6 +83,7 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
                                          "AND SNC.errata_id = E.id " +
                                          "ORDER BY E.update_date, E.id";
 
+    @SuppressWarnings("unchecked")
     private String COLON_IN_QUOTES = "SELECT 'FOO:BAR:MI:SS' " +
                                      "FROM FOOBAR";
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/AbstractConnectionManager.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AbstractConnectionManager.java
@@ -46,6 +46,7 @@ import io.prometheus.client.hibernate.HibernateStatisticsCollector;
  */
 abstract class AbstractConnectionManager implements ConnectionManager {
 
+    @SuppressWarnings("unchecked")
     protected final Logger LOG;
 
     protected SessionFactory sessionFactory;

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -96,12 +96,16 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     private Date endOfLife;
     @Column(name = "gpg_check")
     @Type(type = "yes_no")
+    @SuppressWarnings("unchecked")
     private boolean GPGCheck;
     @Column(name = "gpg_key_url")
+    @SuppressWarnings("unchecked")
     private String GPGKeyUrl;
     @Column(name = "gpg_key_id")
+    @SuppressWarnings("unchecked")
     private String GPGKeyId;
     @Column(name = "gpg_key_fp")
+    @SuppressWarnings("unchecked")
     private String GPGKeyFp;
     @Column
     private String label;
@@ -1178,4 +1182,3 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
         return this.channelSyncFlag;
     }
 }
-

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ReleaseChannelMapTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ReleaseChannelMapTest.java
@@ -27,8 +27,13 @@ import org.junit.jupiter.api.Test;
  */
 public class ReleaseChannelMapTest extends BaseTestCaseWithUser {
 
+    @SuppressWarnings("unchecked")
     private final String PRODUCT = "RHEL";
+
+    @SuppressWarnings("unchecked")
     private final String VERSION = "5Server";
+
+    @SuppressWarnings("unchecked")
     private final String RELEASE = "5.0.0";
 
     @Test

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularSourcesValidatorTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularSourcesValidatorTest.java
@@ -28,7 +28,11 @@ public class ModularSourcesValidatorTest extends ContentValidatorTestBase {
     private ModularSourcesValidator validator;
 
     private static final String ENTITY_SOURCES = "softwareSources";
+
+    @SuppressWarnings("unchecked")
     private final String MSG_NOMODULEFILTERS = getLoc().getMessage("contentmanagement.validation.nomodulefilters");
+
+    @SuppressWarnings("unchecked")
     private final String MSG_NOMODULARSOURCES = getLoc().getMessage("contentmanagement.validation.nomodularsources");
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -94,6 +94,7 @@ import java.util.TreeMap;
 public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
     @RegisterExtension
+    @SuppressWarnings("unchecked")
     protected final JUnit5Mockery CONTEXT = new JUnit5Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};

--- a/java/code/src/com/redhat/rhn/domain/server/CPU.java
+++ b/java/code/src/com/redhat/rhn/domain/server/CPU.java
@@ -62,7 +62,7 @@ public class CPU extends BaseDomainHelper {
     @Column
     private String family;
     @Column(name = "mhz")
-    private String MHz;
+    private String mhz;
     @Column
     private String stepping;
     @Column
@@ -244,15 +244,15 @@ public class CPU extends BaseDomainHelper {
     /**
      * @return Returns the mHz.
      */
-    public String getMHz() {
-        return MHz;
+    public String getMhz() {
+        return mhz;
     }
 
     /**
      * @param mhzIn The mHz to set.
      */
-    public void setMHz(String mhzIn) {
-        MHz = mhzIn;
+    public void setMhz(String mhzIn) {
+        mhz = mhzIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/state/VersionConstraints.java
+++ b/java/code/src/com/redhat/rhn/domain/state/VersionConstraints.java
@@ -26,10 +26,10 @@ public enum VersionConstraints {
     LATEST(0), ANY(1);
 
     /** This ID corresponds to the id column in the database */
-    private final int ID;
+    private final int id;
 
     VersionConstraints(int id) {
-        ID = id;
+        this.id = id;
     }
 
     /**
@@ -38,7 +38,7 @@ public enum VersionConstraints {
      * @return the id
      */
     public int id() {
-        return ID;
+        return id;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/SSMGroupConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/SSMGroupConfirmAction.java
@@ -55,9 +55,16 @@ public class SSMGroupConfirmAction extends RhnAction
     implements Listable<SystemGroupOverview> {
 
     // must match rl:list dataset and name tags!!
+    @SuppressWarnings("unchecked")
     private String ADD_DATA = "addSet";
+
+    @SuppressWarnings("unchecked")
     private String ADD_LIST = "addList";
+
+    @SuppressWarnings("unchecked")
     private String RMV_DATA = "removeSet";
+
+    @SuppressWarnings("unchecked")
     private String RMV_LIST = "removeList";
 
     private static final ServerGroupManager SERVER_GROUP_MANAGER = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
@@ -153,4 +160,3 @@ public class SSMGroupConfirmAction extends RhnAction
         return null;
     }
 }
-

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartDeleteActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartDeleteActionTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class KickstartDeleteActionTest extends BaseKickstartEditTestCase {
 
+    @SuppressWarnings("unchecked")
     private final String KICKSTART_ID = "ksid";
 
     @Test

--- a/java/code/src/com/redhat/rhn/frontend/dto/FilePreservationDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/FilePreservationDto.java
@@ -21,7 +21,7 @@ import java.util.Date;
  */
 public class FilePreservationDto extends BaseDto {
     private Long id;
-    private Long org_id;
+    private Long orgId;
     private String label;
     private Date created;
     private Date modified;
@@ -77,17 +77,17 @@ public class FilePreservationDto extends BaseDto {
     }
 
     /**
-     * @return Returns The FileList org_id.
+     * @return Returns The FileList orgId.
      */
     public Long getOrgId() {
-        return org_id;
+        return orgId;
     }
 
     /**
      * @param orgIn The orgIn to set.
      */
     public void setOrgId(Long orgIn) {
-        this.org_id = orgIn;
+        this.orgId = orgIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListCommand.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListCommand.java
@@ -29,10 +29,10 @@ public enum ListCommand {
     AFTER_RENDER("__tbl__after_render__"),
     TBL_FOOTER("__tbl_footer__");
 
-    private String _cmd;
+    private String cmd;
 
     ListCommand(String cmd) {
-        _cmd = cmd;
+        this.cmd = cmd;
     }
 
     /**
@@ -40,6 +40,6 @@ public enum ListCommand {
      */
     @Override
     public String toString() {
-        return _cmd;
+        return cmd;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/taskomatic/TaskomaticHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/taskomatic/TaskomaticHandler.java
@@ -40,7 +40,8 @@ import redstone.xmlrpc.XmlRpcFault;
  */
 public class TaskomaticHandler extends BaseHandler {
 
-    private String TASKOMATIC_NAMESPACE = "tasko";
+    @SuppressWarnings("unchecked")
+    private final String TASKOMATIC_NAMESPACE = "tasko";
     private XmlRpcClient client;
     private static Logger log = LogManager.getLogger(TaskomaticHandler.class);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/RhnSAXParser.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/RhnSAXParser.java
@@ -31,7 +31,8 @@ import org.xml.sax.SAXNotSupportedException;
  */
 public class RhnSAXParser extends SAXParser {
     // This is unnecessary functionality for XMLRPC XML parser.
-    private String DISALLOW_DOCTYPE_DECL
+    @SuppressWarnings("unchecked")
+    private final String DISALLOW_DOCTYPE_DECL
         = "http://apache.org/xml/features/disallow-doctype-decl";
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -39,6 +39,8 @@ public class CloneChannelCommand extends CreateChannelCommand {
 
     private CloneBehavior cloneBehavior;
     private Channel original;
+
+    @SuppressWarnings("unchecked")
     private String DEFAULT_PREFIX = "clone-of-";
     private boolean stripModularMetadata = false;
     private CloudPaygManager cloudPaygManager;

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -56,7 +56,7 @@ public abstract class BaseRepoCommand {
     private Set<SslContentSource> sslSetsToAdd = new HashSet<>();
     private Set<SslContentSource> sslSetsToDelete = new HashSet<>();
     private Org org;
-    private boolean metadata_signed;
+    private boolean metadataSigned;
 
     /**
      *
@@ -178,7 +178,7 @@ public abstract class BaseRepoCommand {
      * @return true if metadata should be signed
      */
     public boolean getMetadataSigned() {
-        return metadata_signed;
+        return metadataSigned;
     }
 
     /**
@@ -186,7 +186,7 @@ public abstract class BaseRepoCommand {
      * @param md set if metadata are signed
      */
     public void setMetadataSigned(boolean md) {
-        this.metadata_signed = md;
+        this.metadataSigned = md;
     }
 
     /**
@@ -267,7 +267,7 @@ public abstract class BaseRepoCommand {
                 repo.setType(cst);
             }
         }
-        repo.setMetadataSigned(this.metadata_signed);
+        repo.setMetadataSigned(this.metadataSigned);
 
         ChannelFactory.save(repo);
         HibernateFactory.commitTransaction();

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 public class BaseRepoCommandTest extends RhnBaseTestCase {
 
     private BaseRepoCommand ccc = null;
-    private int label_count = 0;
+    private int labelCount = 0;
 
     @Override
     @BeforeEach
@@ -115,7 +115,7 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
         // give it a valid url
         ccc.setUrl(url);
         // need to create unique label names.
-        ccc.setLabel("valid-label-name-" + label_count++);
+        ccc.setLabel("valid-label-name-" + labelCount++);
         // need to specify a type
         ccc.setType(type);
         // need to specify MetadataSigned
@@ -164,7 +164,7 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
 
     private void validRepoLabelInput(String label) {
         // give it a valid url
-        ccc.setUrl("http://localhost/" + label_count++);
+        ccc.setUrl("http://localhost/" + labelCount++);
         // need to create unique label names.
         ccc.setLabel(label);
         // need to specify a type

--- a/java/code/src/com/redhat/rhn/manager/channel/test/CreateCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/CreateCommandTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class CreateCommandTest extends RhnBaseTestCase {
 
     private CreateChannelCommand ccc = null;
-    private int label_count = 0;
+    private int labelCount = 0;
     private User user = null;
 
     @Override
@@ -111,7 +111,7 @@ public class CreateCommandTest extends RhnBaseTestCase {
         // Give it an valid name
         ccc.setName(cname);
         // need to create unique label names.
-        ccc.setLabel("valid-label-name-" + label_count++);
+        ccc.setLabel("valid-label-name-" + labelCount++);
         // need to specify a checksum type
         ccc.setChecksumLabel("sha256");
 
@@ -197,7 +197,7 @@ public class CreateCommandTest extends RhnBaseTestCase {
         // Give it an valid label
         ccc.setLabel(clabel);
         // need to create unique label names.
-        ccc.setName("Valid Name" + label_count++);
+        ccc.setName("Valid Name" + labelCount++);
         // need to specify a checksum type
         ccc.setChecksumLabel("sha256");
 

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -175,7 +175,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
     }
 
-    private ExpectationsFunction SLES_EXPECTATIONS = (key) ->
+    private ExpectationsFunction  = (key) ->
             new Expectations() {{
                 allowing(saltServiceMock).getSystemInfoFull(MINION_ID);
                 will(returnValue(getSystemInfo(MINION_ID, null, key)));
@@ -183,7 +183,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
             }};
 
-    private ExpectationsFunction SLES_EXPECTATIONS_NO_STARTUPGRAINS = (key) ->
+    private ExpectationsFunction _NO_STARTUPGRAINS = (key) ->
             new Expectations() {{
                 allowing(saltServiceMock)
                         .getGrains(with(any(String.class)), with(any(TypeToken.class)), with(any(String[].class)));
@@ -194,13 +194,13 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
             }};
 
-    private ExpectationsFunction SLES_EXPECTATIONS_ALREADY_REGISTERED = (key) ->
+    private ExpectationsFunction _ALREADY_REGISTERED = (key) ->
             new Expectations() {{
                 allowing(saltServiceMock).updateSystemInfo(with(any(MinionList.class)));
             }};
 
     @SuppressWarnings("unchecked")
-    private final ExpectationsFunction SLES_NO_AK_EXPECTATIONS = (key) ->
+    private final ExpectationsFunction slesNoAkExpectations = (key) ->
             new Expectations() {{
                 allowing(saltServiceMock)
                         .getGrains(with(any(String.class)), with(any(TypeToken.class)), with(any(String[].class)));
@@ -211,7 +211,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 will(returnValue(Optional.empty()));
             }};
 
-    private ActivationKeySupplier ACTIVATION_KEY_SUPPLIER = (contactMethod) -> {
+    private ActivationKeySupplier activationKeySupplier = (contactMethod) -> {
         Channel baseChannel = ChannelFactoryTest.createBaseChannel(user, "channel-x86_64");
         ActivationKey key = ActivationKeyTest.createTestActivationKey(user);
         key.setBaseChannel(baseChannel);
@@ -225,7 +225,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         return key.getKey();
     };
 
-    private Assertions SLES_ASSERTIONS = (optMinion, machineId, key) -> {
+    private Assertions slesAssertions = (optMinion, machineId, key) -> {
         assertTrue(optMinion.isPresent());
         MinionServer minion = optMinion.get();
         assertEquals(MINION_ID, minion.getName());
@@ -270,8 +270,6 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         }
     };
 
-    private Consumer<Void> CLEANUP = (arg) -> MinionServerFactory.findByMachineId(MACHINE_ID)
-            .ifPresent(ServerFactory::delete);
 
     @Override
     @BeforeEach
@@ -316,14 +314,14 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     @Test
     public void testDoExecute() throws Exception {
         executeTest(
-                SLES_EXPECTATIONS,
-                ACTIVATION_KEY_SUPPLIER,
-                SLES_ASSERTIONS,
+                slesExpectations,
+                activationKeySupplier,
+                slesAssertions,
                 DEFAULT_CONTACT_METHOD);
     }
     public void executeTest(ExpectationsFunction expectations, ActivationKeySupplier keySupplier,
-                            Assertions assertions, String contactMethod) throws Exception {
-        executeTest(expectations, keySupplier, assertions, CLEANUP, contactMethod);
+                            Assertions assertions, Consumer<Void> cleanup, String contactMethod) throws Exception {
+        executeTest(expectations, keySupplier, assertions, cleanup, contactMethod);
     }
 
     public void executeTest(ExpectationsFunction expectations, ActivationKeySupplier keySupplier,
@@ -339,9 +337,9 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     }
 
     public void executeTest(ExpectationsFunction expectations, ActivationKeySupplier keySupplier,
-                            Assertions assertions, String contactMethod,
+                            Assertions assertions, Consumer<Void> cleanup, String contactMethod,
                             Optional<MinionStartupGrains> startupGrains) throws Exception {
-        executeTest(expectations, keySupplier, assertions, CLEANUP, contactMethod, startupGrains, MACHINE_ID);
+        executeTest(expectations, keySupplier, assertions, cleanup, contactMethod, startupGrains, MACHINE_ID);
     }
 
 
@@ -398,8 +396,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ActivationKey activationKey = ActivationKeyTest.createTestActivationKey(user);
         activationKey.getToken().getActivatedServers().add(server);
 
-        executeTest(SLES_EXPECTATIONS, ACTIVATION_KEY_SUPPLIER, (optMinion, machineId, key) -> {
-            SLES_ASSERTIONS.accept(optMinion, machineId, key);
+        executeTest(slesExpectations, activationKeySupplier, (optMinion, machineId, key) -> {
+            slesAssertions.accept(optMinion, machineId, key);
             MinionServer minion = optMinion.get();
             assertEquals(server.getId(), minion.getId());
             assertEquals(1, ActivationKeyFactory.lookupByActivatedServer(minion).size());
@@ -420,7 +418,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
         try {
             attestationManager.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, false);
-            executeTest(SLES_EXPECTATIONS_ALREADY_REGISTERED, null, (minion, machineId, key) -> {
+            executeTest(_ALREADY_REGISTERED, null, (minion, machineId, key) -> {
                 assertTrue(MinionServerFactory.findByMachineId(MACHINE_ID).isPresent());
                 MinionServerFactory.findByMachineId(MACHINE_ID).ifPresentOrElse(
                         m -> {
@@ -445,7 +443,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
         try {
             attestationManager.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true);
-            executeTest(SLES_EXPECTATIONS_ALREADY_REGISTERED, null, (minion, machineId, key) -> {
+            executeTest(_ALREADY_REGISTERED, null, (minion, machineId, key) -> {
                 assertTrue(MinionServerFactory.findByMachineId(MACHINE_ID).isPresent());
                 MinionServerFactory.findByMachineId(MACHINE_ID).ifPresentOrElse(
                         m -> {
@@ -470,7 +468,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
 
         try {
             attestationManager.createConfig(user, server, CoCoEnvironmentType.KVM_AMD_EPYC_GENOA, true, true);
-            executeTest(SLES_EXPECTATIONS_ALREADY_REGISTERED, null, (minion, machineId, key) -> {
+            executeTest(_ALREADY_REGISTERED, null, (minion, machineId, key) -> {
                 assertTrue(MinionServerFactory.findByMachineId(MACHINE_ID).isPresent());
                 MinionServerFactory.findByMachineId(MACHINE_ID).ifPresentOrElse(
                         m -> {
@@ -499,7 +497,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         server.setMinionId(MINION_ID);
         server.setHostname(MINION_ID);
         try {
-            executeTest(SLES_EXPECTATIONS_ALREADY_REGISTERED, ACTIVATION_KEY_SUPPLIER, (minion, machineId, key) -> {
+            executeTest(_ALREADY_REGISTERED, , (minion, machineId, key) -> {
                 assertTrue(MinionServerFactory.findByMachineId(MACHINE_ID).isPresent());
                 MinionServerFactory.findByMachineId(MACHINE_ID).ifPresentOrElse(
                         m -> {
@@ -523,7 +521,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(user);
         server.setMinionId(MINION_ID);
         server.setMachineId(MACHINE_ID);
-        executeTest(SLES_EXPECTATIONS_ALREADY_REGISTERED, ACTIVATION_KEY_SUPPLIER,
+        executeTest(_ALREADY_REGISTERED, ,
                 (minion, machineId, key) -> MinionServerFactory.findByMachineId(MACHINE_ID).ifPresentOrElse(
                 m -> {
                     assertEquals(m.getCreated(), server.getCreated());
@@ -552,7 +550,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                 allowing(saltServiceMock).removeSaltSSHKnownHost(with(any(String.class)));
                 will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
                 allowing(saltServiceMock).deleteKey(server2.getMinionId());
-            }}, ACTIVATION_KEY_SUPPLIER, (optMinion, machineId, key) -> assertFalse(optMinion.isPresent()),
+            }}, , (optMinion, machineId, key) -> assertFalse(optMinion.isPresent()),
                     null, DEFAULT_CONTACT_METHOD);
         }
         catch (RegisterMinionEventMessageAction.RegisterMinionException e) {
@@ -628,8 +626,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         ServerFactory.save(server);
         SystemManager.giveCapability(server.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
 
-        executeTest(SLES_EXPECTATIONS, ACTIVATION_KEY_SUPPLIER, (optMinion, machineId, key) -> {
-            SLES_ASSERTIONS.accept(optMinion, machineId, key);
+        executeTest(slesExpectations, activationKeySupplier, (optMinion, machineId, key) -> {
+            sles_assertions.accept(optMinion, machineId, key);
             MinionServer minion = optMinion.get();
             assertEquals(server.getId(), minion.getId());
             assertEquals(minion.getContactMethod().getLabel(), DEFAULT_CONTACT_METHOD);
@@ -1126,7 +1124,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         MinionPendingRegistrationService.addMinion(creator, MINION_ID, ContactMethodUtil.DEFAULT);
         try {
             executeTest(
-                    SLES_NO_AK_EXPECTATIONS,
+                    slesNoAkExpectations,
                     (cm) -> null,
                     (minion, machineId, key) -> assertEquals(creator.getOrg(), minion.get().getOrg()),
                     DEFAULT_CONTACT_METHOD
@@ -1150,8 +1148,8 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         MinionPendingRegistrationService.addMinion(creator, MINION_ID, ContactMethodUtil.DEFAULT);
         try {
             executeTest(
-                    SLES_EXPECTATIONS,
-                    ACTIVATION_KEY_SUPPLIER,
+                    slesExpectations,
+                    activationKeySupplier,
                     (minion, machineId, key) -> assertEquals(ActivationKeyFactory.lookupByKey(key).getOrg(),
                             minion.get().getOrg()),
                     DEFAULT_CONTACT_METHOD
@@ -1865,7 +1863,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         allowing(saltServiceMock).getProducts(with(any(String.class)));
                         will(returnValue(Optional.of(pil)));
                     }},
-                    ACTIVATION_KEY_SUPPLIER,
+                    ,
                     (optMinion, machineId, key) -> assertTrue(optMinion.isEmpty()),
                     DEFAULT_CONTACT_METHOD);
         }
@@ -1909,7 +1907,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         allowing(saltServiceMock).getProducts(with(any(String.class)));
                         will(returnValue(Optional.of(pil)));
                     }},
-                    ACTIVATION_KEY_SUPPLIER,
+                    ,
                     (optMinion, machineId, key) -> assertTrue(optMinion.isEmpty()),
                     DEFAULT_CONTACT_METHOD);
         }
@@ -1951,7 +1949,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getProducts(with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                ACTIVATION_KEY_SUPPLIER,
+                ,
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     assertFalse(optMinion.get().isPayg(), "Unexpected: instance is PAYG");
@@ -1994,7 +1992,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getProducts(with(any(String.class)));
                     will(returnValue(Optional.of(pil)));
                 }},
-                ACTIVATION_KEY_SUPPLIER,
+                ,
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     assertFalse(optMinion.get().isPayg(), "Unexpected: instance is PAYG");
@@ -2016,7 +2014,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     allowing(saltServiceMock).getInstanceFlavor(MINION_ID);
                     will(returnValue(SumaUtil.PublicCloudInstanceFlavor.PAYG));
                 }},
-                ACTIVATION_KEY_SUPPLIER,
+                ,
                 (optMinion, machineId, key) -> {
                     assertTrue(optMinion.isPresent());
                     assertTrue(optMinion.get().isPayg(), "Unexpected: instance is not PAYG");

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
@@ -59,7 +59,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     private TaskomaticApi taskomaticMock;
     private static final Gson GSON = new GsonBuilder().create();
 
-    private PaygApiContoller PaygApiContoller;
+    private PaygApiContoller paygApiContoller;
     private User satAdmin;
 
     @Override
@@ -73,7 +73,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
 
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         taskomaticMock = context.mock(TaskomaticApi.class);
-        PaygApiContoller = new PaygApiContoller(new PaygAdminManager(taskomaticMock));
+        paygApiContoller = new PaygApiContoller(new PaygAdminManager(taskomaticMock));
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageInspectSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageInspectSlsResult.java
@@ -36,7 +36,7 @@ public class OSImageInspectSlsResult {
         @SerializedName("hash")
         private Checksum checksum;
         private String compression;
-        private String compressed_hash;
+        private String compressedHash;
         private String name;
         private String filepath;
         private String type;
@@ -45,7 +45,7 @@ public class OSImageInspectSlsResult {
         private String version;
         private String filename;
         private String arch;
-        private String build_id;
+        private String buildId;
         private Long size;
 
         /**
@@ -66,7 +66,7 @@ public class OSImageInspectSlsResult {
          * @return the compression checksum
          */
         public String getCompressedHash() {
-            return compressed_hash;
+            return compressedHash;
         }
 
         /**
@@ -129,7 +129,7 @@ public class OSImageInspectSlsResult {
          * @return the build id
          */
         public String getId() {
-            return build_id;
+            return buildId;
         }
 
         /**
@@ -337,7 +337,7 @@ public class OSImageInspectSlsResult {
     }
 
     private Image image;
-    @SerializedName("boot_image")
+    @SerializedName("bootImage")
     private BootImage bootImage;
     private Bundle bundle;
     private List<Bundle> bundles;

--- a/search-server/spacewalk-search/src/java/com/redhat/satellite/search/index/ngram/tests/NGramTestSetup.java
+++ b/search-server/spacewalk-search/src/java/com/redhat/satellite/search/index/ngram/tests/NGramTestSetup.java
@@ -46,9 +46,9 @@ public class NGramTestSetup extends TestCase {
     protected RAMDirectory ngramDir;
     protected RAMDirectory stanDir;
 
-    protected double score_threshold = .10;
-    protected int min_ngram = 1;
-    protected int max_ngram = 5;
+    protected double scoreThreshold = .10;
+    protected int minNgram = 1;
+    protected int maxNgram = 5;
 
     protected List<Map<String,String>> items =
         new LinkedList<Map<String, String>>();
@@ -109,7 +109,7 @@ public class NGramTestSetup extends TestCase {
         IndexWriter stanWriter = new IndexWriter(this.stanDir, new StandardAnalyzer(), true);
 
         this.ngramDir = new RAMDirectory();
-        IndexWriter ngramWriter = new IndexWriter(this.ngramDir, new NGramAnalyzer(min_ngram, max_ngram), true);
+        IndexWriter ngramWriter = new IndexWriter(this.ngramDir, new NGramAnalyzer(minNgram, maxNgram), true);
 
         for (Map<String, String> item: items) {
             String name = item.get("name");
@@ -140,7 +140,7 @@ public class NGramTestSetup extends TestCase {
          */
         int counter = 0;
         for (int i=0; i < hits.length(); i++) {
-            if (hits.score(i) >= score_threshold) {
+            if (hits.score(i) >= scoreThreshold) {
                 counter++;
             }
             else {


### PR DESCRIPTION
Sonar reported a bunch of non compliant variables so they've fixed with either ``@SuppressWarnings("unchecked")` or they've been renamed properly using camel case.

Fix for #9937 
