### PR TITLE
Ensure Proxy Extension Channel is present when converting to proxy (bsc#1249438)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/ErrorReportingStrategies.java
+++ b/java/code/src/com/redhat/rhn/common/ErrorReportingStrategies.java
@@ -68,4 +68,19 @@ public class ErrorReportingStrategies {
             return new RhnRuntimeException(message);
         };
     }
+
+    /**
+     * All errors are logged using the logger of the provided object
+     * @param obj Object to log
+     * @return UyuniReportStrategy
+     */
+    public static UyuniReportStrategy<UyuniError> logReportingStrategy(Object obj) {
+        Logger logger = OBJ_LOGGER.computeIfAbsent(obj, key -> LogManager.getLogger(obj.getClass().getName()));
+
+        return errors -> {
+            for (UyuniError error : errors) {
+                logger.error(error.getMessage());
+            }
+        };
+    }
 }

--- a/java/code/src/com/redhat/rhn/common/UyuniErrorReport.java
+++ b/java/code/src/com/redhat/rhn/common/UyuniErrorReport.java
@@ -7,14 +7,11 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.redhat.rhn.common;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +29,17 @@ public class UyuniErrorReport {
      */
     public void register(String message) {
         errors.add(new UyuniError(message));
+    }
+
+    /**
+     * Registers a new error in the error report with formatted message.
+     *
+     * @param format    The format string with {} placeholders.
+     * @param arguments The arguments to substitute into the placeholders.
+     */
+    public void register(String format, Object... arguments) {
+        String formattedMessage = format == null ? null : MessageFormat.format(format, arguments);
+        errors.add(new UyuniError(formattedMessage));
     }
 
     /**
@@ -65,6 +73,14 @@ public class UyuniErrorReport {
      */
     public void report() {
         ErrorReportingStrategies.validationReportingStrategy().report(errors);
+    }
+
+    /**
+     * Returns all error messages as a string array
+     * @return String array of error messages
+     */
+    public String[] getErrorMessages() {
+        return errors.stream().map(UyuniError::getMessage).toList().toArray(new String[0]);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -2873,12 +2873,13 @@ public class Server extends BaseDomainHelper implements Identifiable {
 
     /**
      * Checks if a server in convertible to a proxy.
-     * Servers that are already proxies are not convertible. For the remaining, SUSE Manager considers only:
+     * Servers that are already proxies or are manager servers are not convertible.
+     * For the remaining, SUSE Manager considers only:
      * SE Micro 6.1 and SLE15 SP7.
      * @return true if the server is convertible to a proxy, false otherwise
      */
     public boolean isConvertibleToProxy() {
-        return !isProxy() && (
+        return !isProxy() && !isMgrServer() && (
                 ConfigDefaults.get().isUyuni() ||
                         (ServerConstants.SLMICRO.equalsIgnoreCase(getOs()) && getRelease().equals("6.1")) ||
                         (isSLES() && getRelease().equals("15.7"))

--- a/java/code/src/com/suse/manager/webui/controllers/ProxyConfigurationController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ProxyConfigurationController.java
@@ -25,6 +25,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserAndSer
 import static spark.Spark.get;
 import static spark.Spark.post;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.RhnRuntimeException;
 import com.redhat.rhn.common.UyuniGeneralException;
 import com.redhat.rhn.domain.server.Server;
@@ -125,7 +126,9 @@ public class ProxyConfigurationController {
      * @return the ModelAndView object to render the page
      */
     public ModelAndView getProxyConfiguration(Request request, Response response, User user, Server server) {
-        return new ModelAndView(proxyConfigGetFacade.getFormData(user, server), "templates/minion/proxy-config.jade");
+        return new ModelAndView(
+                proxyConfigGetFacade.getFormData(user, server, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER),
+                "templates/minion/proxy-config.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/templates/minion/proxy-config.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/proxy-config.jade
@@ -14,7 +14,7 @@ script(type='text/javascript').
                 serverId: "#{server.id}",
                 parents: JSON.parse('!{parents}'),
                 currentConfig: !{currentConfig},
-                initFailMessage: "#{initFailMessage}",
+                validationErrors: JSON.parse('!{validationErrors}'),
                 registryUrlExample: "#{registryUrlExample}",
                 registryTagExample: "#{registryTagExample}",
                 hasCertificates: JSON.parse("#{hasCertificates}")

--- a/java/code/src/com/suse/proxy/get/ProxyConfigGetFacade.java
+++ b/java/code/src/com/suse/proxy/get/ProxyConfigGetFacade.java
@@ -17,6 +17,7 @@ package com.suse.proxy.get;
 
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.proxy.model.ProxyConfig;
 
@@ -36,10 +37,12 @@ public interface ProxyConfigGetFacade {
 
     /**
      * Get the data to be rendered in the form
-     * @param user the user
-     * @param server the server
+     *
+     * @param user                       the user
+     * @param server                     the server
+     * @param systemEntitlementManagerIn the systemEntitlementManager
      * @return the form data
      */
-    Map<String, Object> getFormData(User user, Server server);
+    Map<String, Object> getFormData(User user, Server server, SystemEntitlementManager systemEntitlementManagerIn);
 
 }

--- a/java/code/src/com/suse/proxy/get/formdata/ProxyConfigGetFormDataContext.java
+++ b/java/code/src/com/suse/proxy/get/formdata/ProxyConfigGetFormDataContext.java
@@ -15,31 +15,38 @@
 
 package com.suse.proxy.get.formdata;
 
+import com.redhat.rhn.common.UyuniErrorReport;
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.proxy.model.ProxyConfig;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * This class holds relevant data through the steps for acquiding the form data for the proxy config.
+ * This class holds relevant data through the steps for acquiring the form data for the proxy config.
  */
 public class ProxyConfigGetFormDataContext {
 
+    private final UyuniErrorReport errorReport = new UyuniErrorReport();
+    private final SystemEntitlementManager systemEntitlementManager;
     private final User user;
     private final Server server;
     private final ProxyConfig proxyConfig;
 
     private final Map<String, Object> proxyConfigAsMap = new HashMap<>();
     private final List<String> electableParentsFqdn = new ArrayList<>();
-    private String initFailMessage;
     private String registryUrlExample;
     private String registryTagExample;
     private boolean hasCertificates = false;
+    private Set<Channel> subscribableChannels = new HashSet<>();
 
     /**
      * Constructor
@@ -47,11 +54,18 @@ public class ProxyConfigGetFormDataContext {
      * @param userIn        the user
      * @param serverIn      the server
      * @param proxyConfigIn the current proxy configuration
+     * @param systemEntitlementManagerIn the system entitlement manager
      */
-    public ProxyConfigGetFormDataContext(User userIn, Server serverIn, ProxyConfig proxyConfigIn) {
+    public ProxyConfigGetFormDataContext(
+            User userIn,
+            Server serverIn,
+            ProxyConfig proxyConfigIn,
+            SystemEntitlementManager systemEntitlementManagerIn
+    ) {
         this.user = userIn;
         this.server = serverIn;
         this.proxyConfig =  proxyConfigIn;
+        this.systemEntitlementManager = systemEntitlementManagerIn;
     }
 
     public User getUser() {
@@ -70,16 +84,8 @@ public class ProxyConfigGetFormDataContext {
         return electableParentsFqdn;
     }
 
-    public void setInitFailMessage(String initFailMessageIn) {
-        this.initFailMessage = initFailMessageIn;
-    }
-
     public ProxyConfig getProxyConfig() {
         return proxyConfig;
-    }
-
-    public String getInitFailMessage() {
-        return initFailMessage;
     }
 
     public String getRegistryUrlExample() {
@@ -109,5 +115,21 @@ public class ProxyConfigGetFormDataContext {
 
     public void setHasCertificates(boolean hasCertificatesIn) {
         hasCertificates = hasCertificatesIn;
+    }
+
+    public UyuniErrorReport getErrorReport() {
+        return errorReport;
+    }
+
+    public SystemEntitlementManager getSystemEntitlementManager() {
+        return systemEntitlementManager;
+    }
+
+    public Set<Channel> getSubscribableChannels() {
+        return subscribableChannels;
+    }
+
+    public void setSubscribableChannels(Set<Channel> subscribableChannelsIn) {
+        subscribableChannels = subscribableChannelsIn;
     }
 }

--- a/java/code/src/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditions.java
+++ b/java/code/src/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditions.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.proxy.get.formdata;
+
+import static com.suse.proxy.get.ProxyConfigGetFacadeImpl.MGRPXY;
+import static com.suse.utils.Predicates.isAbsent;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Pre-condition checks before handling Proxy Config Get Form Data
+ * The main goal is to detect blockers that would prevent a server from being converted to a proxy.
+ * These may be:
+ * a) Server does not have the proxy entitlement and is not entitleable for it.
+ * b) Server is not subscribed to the appropriate proxy extension channel (ie, at least one containing the mgrpxy
+ * package), it is subscribed to it.
+ */
+public class ProxyConfigGetFormDataPreConditions implements ProxyConfigGetFormDataContextHandler {
+
+    @Override
+    public void handle(ProxyConfigGetFormDataContext context) {
+        Server server = context.getServer();
+
+        if (isAbsent(server)) {
+            context.getErrorReport().register("Server not found");
+            return;
+        }
+
+        if (server.isMgrServer()) {
+            context.getErrorReport().register("The system is a Management Server and cannot be converted to a Proxy");
+            return;
+        }
+
+        if (!server.hasProxyEntitlement() &&
+                !context.getSystemEntitlementManager().canEntitleServer(server, EntitlementManager.PROXY)) {
+            context.getErrorReport().register("Cannot entitle server ID: {0}", server.getId());
+        }
+
+        if (ConfigDefaults.get().isUyuni() || isMgrpxyInstalled(server)) {
+            return;
+        }
+
+        Set<Channel> subscribableMgrpxyChannels = getSubscribableMgrpxyChannels(server, context.getUser());
+        context.setSubscribableChannels(subscribableMgrpxyChannels);
+        if (subscribableMgrpxyChannels == null) {
+            context.getErrorReport().register(
+                    "No channel with mgrpxy package found for server ID: {0}", server.getId());
+        }
+
+    }
+
+    /**
+     * Check if mgrpxy is installed on the server
+     * @param server the server to check
+     * @return true if installed, false otherwise
+     */
+    private boolean isMgrpxyInstalled(Server server) {
+        return PackageManager.shallowSystemPackageList(server.getId())
+                .stream().anyMatch(p -> p.getName().equals(MGRPXY));
+    }
+
+    /**
+     * Returns the set of channels providing the mgrpxy package that should be subscribed to.
+     * Logic:
+     * - If mgrpxy is already available from a subscribed channel, returns an empty set.
+     * - If mgrpxy is available only from non-subscribed channels, returns those channels.
+     * - If no channels provide mgrpxy at all, returns {@code null}.
+     *
+     * @param server the server to inspect
+     * @param user   the user requesting the channels
+     * @return set of subscribable channels providing mgrpxy, an empty set if already subscribed,
+     * or {@code null} if unavailable
+     */
+    private Set<Channel> getSubscribableMgrpxyChannels(Server server, User user) {
+        Channel baseChannel = server.getBaseChannel();
+        if (baseChannel == null) {
+            return null;
+        }
+
+        Map<Boolean, Set<Channel>> channelsBySubscription =
+                collectAccessibleChannels(baseChannel, user).stream()
+                        .filter(c -> !ChannelManager.listLatestPackagesEqual(c.getId(), MGRPXY).isEmpty())
+                        .collect(Collectors.partitioningBy(
+                                server::isSubscribed,
+                                Collectors.toSet()
+                        ));
+
+        Set<Channel> subscribed = channelsBySubscription.getOrDefault(true, Set.of());
+        Set<Channel> unsubscribed = channelsBySubscription.getOrDefault(false, Set.of());
+
+        if (!subscribed.isEmpty()) {
+            return Set.of();
+        }
+
+        return unsubscribed.isEmpty() ? null : unsubscribed;
+    }
+
+    /**
+     * Recursively collects accessible channels for a given user.
+     * @param channel the channel to check
+     * @param user the user requesting access
+     * @return a set of accessible channels
+     */
+    private Set<Channel> collectAccessibleChannels(Channel channel, User user) {
+        Set<Channel> collected = new HashSet<>();
+        collected.add(channel);
+        for (Channel child : channel.getAccessibleChildrenFor(user)) {
+            collected.addAll(collectAccessibleChannels(child, user));
+        }
+        return collected;
+    }
+
+}

--- a/java/code/src/com/suse/proxy/get/formdata/test/ProxyConfigGetFormDataPreConditionsTest.java
+++ b/java/code/src/com/suse/proxy/get/formdata/test/ProxyConfigGetFormDataPreConditionsTest.java
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+
+package com.suse.proxy.get.formdata.test;
+
+import static com.suse.proxy.get.ProxyConfigGetFacadeImpl.MGRPXY;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.SERVER_ID;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertErrors;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertNoErrors;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.setConfigDefaultsInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
+import com.redhat.rhn.testing.ServerTestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.proxy.get.formdata.ProxyConfigGetFormDataContext;
+import com.suse.proxy.get.formdata.ProxyConfigGetFormDataPreConditions;
+
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests for ProxyConfigGetFormDataProxyInitializer.
+ */
+public class ProxyConfigGetFormDataPreConditionsTest extends RhnJmockBaseTestCase {
+
+    private static final String JAVA_TEST = "java::test";
+    public static final String SERVER_NOT_FOUND = "Server not found";
+    public static final String NO_CHANNEL_WITH_MGRPXY_PACKAGE_FOUND = "No channel with mgrpxy package found";
+    public static final String CANNOT_ENTITLE_SERVER = "Cannot entitle server";
+    public static final String SYSTEM_IS_MGR_SERVER =
+            "The system is a Management Server and cannot be converted to a Proxy";
+
+    private final ConfigDefaults configDefaults = ConfigDefaults.get();
+    private final SaltApi saltApi = new TestSaltApi();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
+    );
+    private final ProxyConfigGetFormDataPreConditions preConditions = new ProxyConfigGetFormDataPreConditions();
+
+    private Server mockServer;
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        this.mockServer = mock(Server.class);
+        this.user = UserTestUtils.createUser();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        try {
+            setConfigDefaultsInstance(configDefaults);
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Error resetting ConfigDefaults instance", e);
+        }
+    }
+
+    /**
+     * Test failure when manager is uyuni and server is null
+     * Expects matching error
+     */
+    @Test
+    public void testFailureWithNullServer() {
+        ProxyConfigGetFormDataContext getFormDataContext =
+                new ProxyConfigGetFormDataContext(null, null,  null, null);
+
+        preConditions.handle(getFormDataContext);
+        assertErrors(getFormDataContext.getErrorReport(), SERVER_NOT_FOUND);
+    }
+
+    /**
+     * Test failure when converting a manager server
+     * Expects matching error
+     */
+    @Test
+    public void testFailureWithManagerServer() {
+        context().checking(new Expectations() {{
+            oneOf(mockServer).isMgrServer();
+            will(returnValue(true));
+        }});
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext();
+
+        preConditions.handle(getFormDataContext);
+        assertErrors(getFormDataContext.getErrorReport(), SYSTEM_IS_MGR_SERVER);
+    }
+
+    // Tests focusing proxy entitlement
+
+    /**
+     * Test success scenario where:
+     * - manager is uyuni
+     * - server has proxy entitlement
+     * Expects no errors
+     */
+    @Test
+    public void testSuccessWhenHasEntitlement() {
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, true);
+
+        context().checking(new Expectations() {{
+            oneOf(mockServer).isMgrServer();
+            will(returnValue(false));
+            oneOf(mockServer).hasProxyEntitlement();
+            will(returnValue(true));
+        }});
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext();
+
+        preConditions.handle(getFormDataContext);
+        assertNoErrors(getFormDataContext.getErrorReport());
+    }
+
+    /**
+     * Test success scenario where:
+     * - manager is uyuni
+     * - server does not have proxy entitlement
+     * - server can be entitled
+     * Expects no errors
+     */
+    @Test
+    public void testSuccessWhenCanEntitleServer() {
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, true);
+
+        SystemEntitlementManager mockSystemEntitlementManager = mock(SystemEntitlementManager.class);
+        context().checking(new Expectations() {{
+            oneOf(mockServer).isMgrServer();
+            will(returnValue(false));
+            oneOf(mockServer).hasProxyEntitlement();
+            will(returnValue(false));
+            allowing(mockServer).getId();
+            will(returnValue(SERVER_ID));
+            oneOf(mockSystemEntitlementManager).canEntitleServer(mockServer, EntitlementManager.PROXY);
+            will(returnValue(true));
+        }});
+
+        ProxyConfigGetFormDataContext getFormDataContext =
+                new ProxyConfigGetFormDataContext(user, mockServer, null, mockSystemEntitlementManager);
+
+        preConditions.handle(getFormDataContext);
+        assertNoErrors(getFormDataContext.getErrorReport());
+    }
+
+    /**
+     * Test failure when:
+     * - manager is MLM
+     * - cannot entitle server
+     * - no subscribable channels are found
+     * Expects matching error messages for both conditions.
+     */
+    @Test
+    public void testFailureWhenCannotEntitleServerAndNoSubscribableChannelsFound() throws Exception {
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        context().checking(new Expectations() {{
+            oneOf(mockServer).isMgrServer();
+            will(returnValue(false));
+            oneOf(mockServer).hasProxyEntitlement();
+            will(returnValue(false));
+            oneOf(mockServer).getEntitlements();
+            will(returnValue(new HashSet<>()));
+            allowing(mockServer).getId();
+            will(returnValue(SERVER_ID));
+            allowing(mockServer).getBaseChannel();
+            will(returnValue(ChannelFactoryTest.createTestChannel(user)));
+        }});
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext();
+
+        preConditions.handle(getFormDataContext);
+        assertErrors(getFormDataContext.getErrorReport(), CANNOT_ENTITLE_SERVER, NO_CHANNEL_WITH_MGRPXY_PACKAGE_FOUND);
+    }
+
+    // Tests focusing mgrpxy package access
+
+    /**
+     * Test success scenario where:
+     * - manager is MLM
+     * - can entitle server
+     * - mgrpxy is installed on server
+     * Expects no errors
+     */
+    @Test
+    public void testSuccessWhenMgrpxyIsInstalled() throws Exception {
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        // setup installed package
+        Server server = ServerTestUtils.createTestSystem(user);
+        Channel channelWithMgrpxy = ChannelFactoryTest.createTestChannel(user);
+        PackageManagerTest.addPackageToSystemAndChannel(MGRPXY, server, channelWithMgrpxy);
+
+        // assert preconditions
+        assertTrue(systemEntitlementManager.canEntitleServer(server, EntitlementManager.PROXY));
+        assertTrue(isMgrpxyInstalled(server));
+        assertFalse(isMgrpxyAvailable(server));
+
+        //
+        ProxyConfigGetFormDataContext getFormDataContext = createContext(server);
+
+        preConditions.handle(getFormDataContext);
+        assertNoErrors(getFormDataContext.getErrorReport());
+    }
+
+    /**
+     * Test success scenario where:
+     * - manager is MLM
+     * - can entitle server
+     * - mgrpxy can be installed
+     * Expects no errors
+     */
+    @Test
+    public void testSuccessWhenMgrpxyIsAvailable() throws Exception {
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        // setup installed package
+        Server server = ServerTestUtils.createTestSystem(user);
+        Channel channelWithMgrpxy = createChannelWithPackage(MGRPXY, server);
+        SystemManager.subscribeServerToChannel(user, server, channelWithMgrpxy);
+        ChannelFactory.refreshNewestPackageCache(channelWithMgrpxy, JAVA_TEST);
+
+        // assert preconditions
+        assertTrue(systemEntitlementManager.canEntitleServer(server, EntitlementManager.PROXY));
+        assertFalse(isMgrpxyInstalled(server));
+        assertTrue(isMgrpxyAvailable(server));
+
+        //
+        ProxyConfigGetFormDataContext getFormDataContext = createContext(server);
+
+        preConditions.handle(getFormDataContext);
+        assertTrue(getFormDataContext.getSubscribableChannels().isEmpty());
+        assertNoErrors(getFormDataContext.getErrorReport());
+    }
+
+    /**
+     * Test success scenario where:
+     * - manager is MLM
+     * - can entitle server
+     * - subscribable channels with mgrpxy found
+     * Expects:
+     * - no errors
+     * - childChannel is in subscribableChannels
+     */
+    @Test
+    public void testSuccessWhenSubscribableChannelsFound() throws Exception {
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        // setup installed package
+        Server server = ServerTestUtils.createTestSystem(user);
+        Channel channelWithMgrpxy = createChannelWithPackage(MGRPXY, server);
+        ChannelFactory.refreshNewestPackageCache(channelWithMgrpxy, JAVA_TEST);
+
+        // assert preconditions
+        assertTrue(systemEntitlementManager.canEntitleServer(server, EntitlementManager.PROXY));
+        assertFalse(isMgrpxyInstalled(server));
+        assertFalse(isMgrpxyAvailable(server));
+
+        //
+        ProxyConfigGetFormDataContext getFormDataContext = createContext(server);
+
+        preConditions.handle(getFormDataContext);
+        assertNoErrors(getFormDataContext.getErrorReport());
+        Set<Channel> subscribableChannels = getFormDataContext.getSubscribableChannels();
+        assertEquals(1, subscribableChannels.size());
+        assertEquals(channelWithMgrpxy, subscribableChannels.iterator().next());
+    }
+
+    /**
+     * Test failure scenario where:
+     * - manager is MLM
+     * - can entitle server
+     * - subscribable channels but none with mgrpxy
+     * Expects:
+     * - no errors
+     * - childChannel is in subscribableChannels
+     */
+    @Test
+    public void testFailureWhenNoSubscribableChannelsFound() throws Exception {
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        // setup installed package
+        Server server = ServerTestUtils.createTestSystem(user);
+        Channel channelWithMgrpxy = createChannelWithPackage("mgrpxy-lang", server);
+        SystemManager.subscribeServerToChannel(user, server, channelWithMgrpxy);
+
+        // assert preconditions
+        assertTrue(systemEntitlementManager.canEntitleServer(server, EntitlementManager.PROXY));
+        assertFalse(isMgrpxyInstalled(server));
+        assertFalse(isMgrpxyAvailable(server));
+
+        //
+        ProxyConfigGetFormDataContext getFormDataContext =
+                new ProxyConfigGetFormDataContext(user, server,  null, systemEntitlementManager);
+
+        preConditions.handle(getFormDataContext);
+        assertNull(getFormDataContext.getSubscribableChannels());
+        assertErrors(getFormDataContext.getErrorReport(), NO_CHANNEL_WITH_MGRPXY_PACKAGE_FOUND);
+    }
+
+    /**
+     * Helper method to set up a base channel and a child channel with the given package, and subscribes the server to
+     * the base channel.
+     * @param packageName the name of the package
+     * @param server the server to subscribe
+     * @return the created child channel
+     * @throws Exception on errors
+     */
+    private Channel createChannelWithPackage(String packageName, Server server) throws Exception {
+        Package pkg = PackageTest.createTestPackage(user.getOrg(), packageName);
+        Channel childChannel = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());
+        childChannel.getPackages().add(pkg);
+        return childChannel;
+    }
+
+    /**
+     * Helper method to create ProxyConfigGetFormDataContext with default system entitlement manager
+     * @return the created context
+     */
+    private ProxyConfigGetFormDataContext createContext() {
+        return createContext(mockServer);
+    }
+
+    /**
+     * Helper method to create ProxyConfigGetFormDataContext with custom system entitlement manager
+     * @param server the server to use in the context
+     * @return the created context
+     */
+    private ProxyConfigGetFormDataContext createContext(Server server) {
+        return new ProxyConfigGetFormDataContext(user, server, null, systemEntitlementManager);
+    }
+
+    /**
+     * Helper method to check if mgrpxy is installed on server
+     * @param server the server to check
+     * @return true if installed, false otherwise
+     */
+    private boolean isMgrpxyInstalled(Server server) {
+        return PackageManager.shallowSystemPackageList(server.getId())
+                .stream().anyMatch(p -> p.getName().equals(MGRPXY));
+    }
+
+    /**
+     * Helper method to check if mgrpxy is available on server on a subscribed channel
+     * @param server the server to check
+     * @return true if available, false otherwise
+     */
+    private boolean isMgrpxyAvailable(Server server) {
+        return server.getChildChannels().stream()
+                .flatMap(c -> c.getPackages().stream())
+                .anyMatch(p -> MGRPXY.equals(p.getPackageName().getName()));
+    }
+
+}

--- a/java/code/src/com/suse/proxy/get/formdata/test/ProxyConfigGetFormDataProxyInitializerTest.java
+++ b/java/code/src/com/suse/proxy/get/formdata/test/ProxyConfigGetFormDataProxyInitializerTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.proxy.get.formdata.test;
+
+import static com.suse.proxy.get.ProxyConfigGetFacadeImpl.MGRPXY;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.SERVER_ID;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertErrors;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertNoErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.redhat.rhn.common.validator.ValidatorResult;
+import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.ProxyInfo;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.action.ActionChainManager;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
+import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.redhat.rhn.taskomatic.TaskomaticApiException;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
+import com.redhat.rhn.testing.ServerTestUtils;
+import com.redhat.rhn.testing.UserTestUtils;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.proxy.get.formdata.ProxyConfigGetFormDataContext;
+import com.suse.proxy.get.formdata.ProxyConfigGetFormDataProxyInitializer;
+
+import org.jmock.Expectations;
+import org.jmock.api.Invocation;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.jmock.lib.action.CustomAction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for ProxyConfigGetFormDataProxyInitializer.
+ */
+public class ProxyConfigGetFormDataProxyInitializerTest extends RhnJmockBaseTestCase {
+
+    private static final String FAILED_TO_ADD_PROXY_ENTITLEMENT = "Failed to add proxy entitlement to server";
+    private static final String FAILED_TO_SUBSCRIBE_CHANNEL =
+            "Failed to subscribe to appropriate proxy extension channel for server";
+
+    private final SaltApi saltApi = new TestSaltApi();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(saltApi), new SystemEntitler(saltApi)
+    );
+    private final ProxyConfigGetFormDataProxyInitializer initializer = new ProxyConfigGetFormDataProxyInitializer();
+
+    private Server mockServer;
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        this.mockServer = mock(Server.class);
+        this.user = UserTestUtils.createUser();
+    }
+
+
+    /**
+     * Test success scenario where:
+     * - server has a ProxyInfo
+     * - server has proxy entitlement
+     * - no subscribableChannels retrieved
+     * Expects no errors
+     */
+    @Test
+    public void testSuccessWhenExistingProxy() {
+        context().checking(new Expectations() {{
+            oneOf(mockServer).getProxyInfo();
+            will(returnValue(new ProxyInfo()));
+            oneOf(mockServer).hasProxyEntitlement();
+            will(returnValue(true));
+        }});
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext();
+
+        initializer.handle(getFormDataContext);
+        assertNoErrors(getFormDataContext.getErrorReport());
+    }
+
+    /**
+     * Test success scenario where:
+     * - server does not have a ProxyInfo
+     * Expects:
+     * - to create a ProxyInfo for the server
+     * - no errors
+     */
+    @Test
+    public void testSuccessWhenCreateProxyInfo() {
+        context().checking(new Expectations() {{
+           oneOf(mockServer).getProxyInfo();
+           will(returnValue(null));
+           oneOf(mockServer).hasProxyEntitlement();
+           will(returnValue(true));
+           allowing(mockServer).getId();
+           will(returnValue(SERVER_ID));
+
+            // assert setProxyInfo is invoked once
+            oneOf(mockServer).setProxyInfo(with(aNonNull(ProxyInfo.class)));
+       }});
+        ProxyConfigGetFormDataContext getFormDataContext = createContext();
+
+        initializer.handle(getFormDataContext);
+        assertNoErrors(getFormDataContext.getErrorReport());
+    }
+
+    /**
+     * Test success scenario where:
+     * - server does not have a proxy entitlement
+     * Expects:
+     * - to add the proxy entitlement to the server
+     * - no errors
+     */
+    @Test
+    public void testSuccessWhenEntitlementAddedToServer() {
+        SystemEntitlementManager mockSystemEntitlementManager = mock(SystemEntitlementManager.class);
+        context().checking(new Expectations() {{
+            oneOf(mockServer).getProxyInfo();
+            will(returnValue(new ProxyInfo()));
+            oneOf(mockServer).hasProxyEntitlement();
+            will(returnValue(false));
+            allowing(mockServer).getId();
+            will(returnValue(SERVER_ID));
+
+            // assert addEntitlementToServer is invoked once
+            oneOf(mockSystemEntitlementManager).addEntitlementToServer(mockServer, EntitlementManager.PROXY);
+        }});
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext(mockSystemEntitlementManager);
+
+        initializer.handle(getFormDataContext);
+        assertFalse(getFormDataContext.getErrorReport().hasErrors());
+    }
+
+    /**
+     * Test failure over a scenario where:
+     * - server does not have a proxy entitlement
+     * Expects:
+     * - fails while adding the proxy entitlement to the server
+     * - matching error
+     */
+    @Test
+    public void testFailureWhenEntitlementAddedToServer() {
+        ValidatorResult expectedAddEntitlementToServerResult = new ValidatorResult();
+        expectedAddEntitlementToServerResult.addError("dummy");
+
+        SystemEntitlementManager mockSystemEntitlementManager = mock(SystemEntitlementManager.class);
+        context().checking(new Expectations() {{
+            oneOf(mockServer).getProxyInfo();
+            will(returnValue(new ProxyInfo()));
+            oneOf(mockServer).hasProxyEntitlement();
+            will(returnValue(false));
+            allowing(mockServer).getId();
+            will(returnValue(SERVER_ID));
+
+            // assert addEntitlementToServer is invoked once
+            oneOf(mockSystemEntitlementManager).addEntitlementToServer(mockServer, EntitlementManager.PROXY);
+            will(returnValue(expectedAddEntitlementToServerResult));
+        }});
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext(mockSystemEntitlementManager);
+
+        initializer.handle(getFormDataContext);
+        assertErrors(getFormDataContext.getErrorReport(), FAILED_TO_ADD_PROXY_ENTITLEMENT);
+    }
+
+    /**
+     * Test a scenario where:
+     * - mgrpxy was identified in a subscribable channel
+     * Expects:
+     * - server successfully subscribes the channel
+     * - no errors
+     */
+    @Test
+    public void testSuccessWhenChannelIsSubscribed() throws Exception {
+        Channel channelWithMgrpxy = setupChannelWithMgrpxy();
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionChainManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() {{
+            allowing(taskomaticMock).scheduleSubscribeChannels(
+                    with(user),
+                    with(any(SubscribeChannelsAction.class))
+            );
+            will(new CustomAction("capture SubscribeChannelsAction") {
+                @Override
+                public Object invoke(Invocation invocation) {
+                    SubscribeChannelsAction action = (SubscribeChannelsAction) invocation.getParameter(1);
+                    // assert the captured SubscribedChannelsAction content channel matches the generated channel
+                    assertEquals(
+                            channelWithMgrpxy.getId(),
+                            action.getDetails().getChannels().iterator().next().getId()
+                    );
+                    return null;
+                }
+            });
+        }});
+
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext();
+        getFormDataContext.getSubscribableChannels().add(channelWithMgrpxy);
+
+        initializer.handle(getFormDataContext);
+        assertNoErrors(getFormDataContext.getErrorReport());
+    }
+
+    /**
+     * Test a scenario where:
+     * - mgrpxy was identified in a subscribable channel
+     * Expects:
+     * - server fails while subscribing the channel
+     * - matching error
+     */
+    @Test
+    public void testFailureWhenChannelSubscriptionFails() throws Exception {
+        Channel channelWithMgrpxy = setupChannelWithMgrpxy();
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionChainManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() {{
+            allowing(taskomaticMock).scheduleSubscribeChannels(
+                    with(user),
+                    with(any(SubscribeChannelsAction.class))
+            );
+            will(throwException(new TaskomaticApiException(new RuntimeException())));
+        }});
+
+
+        ProxyConfigGetFormDataContext getFormDataContext = createContext();
+        getFormDataContext.getSubscribableChannels().add(channelWithMgrpxy);
+
+        initializer.handle(getFormDataContext);
+        assertErrors(getFormDataContext.getErrorReport(), FAILED_TO_SUBSCRIBE_CHANNEL);
+    }
+
+    /**
+     * Helper method to create ProxyConfigGetFormDataContext with default system entitlement manager
+     * @return the created context
+     */
+    private ProxyConfigGetFormDataContext createContext() {
+        return createContext(systemEntitlementManager);
+    }
+
+    /**
+     * Helper method to create ProxyConfigGetFormDataContext with custom system entitlement manager
+     * @param customManager the custom system entitlement manager
+     * @return the created context
+     */
+    private ProxyConfigGetFormDataContext createContext(SystemEntitlementManager customManager) {
+        return new ProxyConfigGetFormDataContext(user, mockServer, null, customManager);
+    }
+
+    /**
+     * Helper method to set up a subscribable channel containing mgrpxy package
+     */
+    private Channel setupChannelWithMgrpxy() throws Exception {
+        Server server = ServerTestUtils.createTestSystem(user);
+        Package pkg = PackageTest.createTestPackage(user.getOrg(), MGRPXY);
+        Channel channelWithMgrpxy = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());
+        channelWithMgrpxy.getPackages().add(pkg);
+
+        context().checking(new Expectations() {{
+            oneOf(mockServer).getProxyInfo();
+            will(returnValue(new ProxyInfo()));
+            oneOf(mockServer).hasProxyEntitlement();
+            will(returnValue(true));
+            allowing(mockServer).getId();
+            will(returnValue(server.getId()));
+
+            oneOf(mockServer).getBaseChannel();
+            will(returnValue(server.getBaseChannel()));
+            oneOf(mockServer).getChildChannels();
+            will(returnValue(server.getChildChannels()));
+        }});
+        return channelWithMgrpxy;
+    }
+
+}

--- a/java/code/src/com/suse/proxy/get/formdata/test/ProxyConfigGetFormTestUtils.java
+++ b/java/code/src/com/suse/proxy/get/formdata/test/ProxyConfigGetFormTestUtils.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.proxy.get.formdata.test;
+
+import static com.redhat.rhn.common.ExceptionMessage.NOT_INSTANTIABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.common.UyuniError;
+import com.redhat.rhn.common.UyuniErrorReport;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+
+import org.jmock.Expectations;
+import org.jmock.api.Invocation;
+import org.jmock.junit5.JUnit5Mockery;
+import org.jmock.lib.action.CustomAction;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+public class ProxyConfigGetFormTestUtils {
+
+    public static final Long SERVER_ID = 123L;
+
+    /**
+     * Overrides the {@link ConfigDefaults#isUyuni()} method for mocking purposes
+     *
+     * @param context the JUnit5Mockery context
+     * @param expectedIsUyuni return value for the isUyuni method
+     */
+    @SuppressWarnings({"java:S1171", "java:S3599"})
+    public static void mockConfigDefaults(JUnit5Mockery context, boolean expectedIsUyuni) {
+        ConfigDefaults configDefaults = ConfigDefaults.get();
+        ConfigDefaults mockConfigDefaults = context.mock(ConfigDefaults.class);
+
+        context.checking(new Expectations() {{
+            allowing(mockConfigDefaults).isUyuni();
+            will(returnValue(expectedIsUyuni));
+
+            allowing(mockConfigDefaults);
+            will(new CustomAction("delegate to real object") {
+                public Object invoke(Invocation invocation) throws Throwable {
+                    Method m = invocation.getInvokedMethod();
+                    return m.invoke(configDefaults, invocation.getParametersAsArray());
+                }
+            });
+        }});
+
+        try {
+            setConfigDefaultsInstance(mockConfigDefaults);
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Overrides the ConfigDefaults instance
+     * @param configDefaults the ConfigDefaults instance
+     * @throws NoSuchFieldException if a field with the specified name is not found.
+     * @throws IllegalAccessException if the field is not accessible.
+     */
+    public static void setConfigDefaultsInstance(ConfigDefaults configDefaults)
+            throws NoSuchFieldException, IllegalAccessException {
+        Field field = ConfigDefaults.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        field.set(null, configDefaults);
+    }
+
+    /**
+     * Helper method to assert no errors in error report
+     * @param errorReport the error report to check
+     */
+    public static void assertNoErrors(UyuniErrorReport errorReport) {
+        assertFalse(errorReport.hasErrors(),
+                "Expected no errors but found: " + errorReport.getErrors());
+    }
+
+    /**
+     * Helper method to assert errors in context
+     * @param errorReport the error report to check
+     * @param expectedMessages the expected error messages
+     */
+    public static void assertErrors(UyuniErrorReport errorReport, String... expectedMessages) {
+        List<UyuniError> errors = errorReport.getErrors();
+        assertEquals(expectedMessages.length, errors.size());
+        for (UyuniError error : errors) {
+            assertTrue(Arrays.stream(expectedMessages).anyMatch(message -> error.getMessage().startsWith(message)),
+                    "Expected error message to start with one of '" + Arrays.toString(expectedMessages) +
+                            "' but was: " + error.getMessage());
+        }
+    }
+
+    /**
+     * Private constructor to avoid instantiation
+     */
+    private ProxyConfigGetFormTestUtils() {
+        throw new UnsupportedOperationException(NOT_INSTANTIABLE);
+    }
+}

--- a/java/code/src/com/suse/proxy/test/ProxyConfigGetFormDataAcquisitorTest.java
+++ b/java/code/src/com/suse/proxy/test/ProxyConfigGetFormDataAcquisitorTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -61,8 +62,8 @@ public class ProxyConfigGetFormDataAcquisitorTest extends BaseTestCaseWithUser {
     @Test
     public void testWhenNoProxyConfigAndNoProxies() {
         final String expectedElectableParent = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
-        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext =
-                new ProxyConfigGetFormDataContext(user, testMinionServer, null);
+        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
+                testMinionServer, null, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
 
         //
         new ProxyConfigGetFormDataAcquisitor().handle(proxyConfigGetFormDataContext);
@@ -104,8 +105,8 @@ public class ProxyConfigGetFormDataAcquisitorTest extends BaseTestCaseWithUser {
                 proxyB.getName(),
         };
 
-        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext =
-                new ProxyConfigGetFormDataContext(user, testMinionServer, new ProxyConfig());
+        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
+                testMinionServer, new ProxyConfig(), GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
 
         //
         new ProxyConfigGetFormDataAcquisitor().handle(proxyConfigGetFormDataContext);

--- a/java/code/src/com/suse/proxy/test/ProxyConfigGetFormDefaultsTest.java
+++ b/java/code/src/com/suse/proxy/test/ProxyConfigGetFormDefaultsTest.java
@@ -27,6 +27,7 @@ import static com.suse.proxy.get.formdata.ProxyConfigGetFormDefaults.MLM_REGISTR
 import static com.suse.proxy.get.formdata.ProxyConfigGetFormDefaults.UYUNI_REGISTRY_URL_EXAMPLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ServerFactory;
@@ -98,8 +99,8 @@ public class ProxyConfigGetFormDefaultsTest extends BaseTestCaseWithUser {
         setConfigDefaultsInstance(mockConfigDefaults);
 
         //
-        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext =
-                new ProxyConfigGetFormDataContext(user, testMinionServer, null);
+        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
+                testMinionServer, null, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
 
         //
         new ProxyConfigGetFormDefaults().handle(proxyConfigGetFormDataContext);
@@ -136,8 +137,8 @@ public class ProxyConfigGetFormDefaultsTest extends BaseTestCaseWithUser {
 
 
         //
-        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext =
-                new ProxyConfigGetFormDataContext(user, testMinionServer, null);
+        ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
+                testMinionServer, null, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
 
         //
         new ProxyConfigGetFormDefaults().handle(proxyConfigGetFormDataContext);

--- a/java/spacewalk-java.changes.rjpmestre.bsc1249438
+++ b/java/spacewalk-java.changes.rjpmestre.bsc1249438
@@ -1,0 +1,2 @@
+- Ensure proxy extension channel is checked and installed
+  when converting to proxy (bsc#1249438)

--- a/web/html/src/manager/minion/proxy/proxy-config-types.ts
+++ b/web/html/src/manager/minion/proxy/proxy-config-types.ts
@@ -39,18 +39,18 @@ export type ProxyConfigModel = {
   registryTftpdTag: string;
 };
 
-export type Parent = {
+export interface Parent {
   id: number;
   name: string;
   selected: boolean;
   disabled: boolean;
-};
+}
 
 export type ProxyConfigProps = {
   serverId: string;
   parents: Parent[];
   currentConfig: ProxyConfigModel;
-  initFailMessage?: string;
+  validationErrors?: string[];
   registryUrlExample?: string;
   registryTagExample?: string;
   hasCertificates?: boolean;

--- a/web/html/src/manager/minion/proxy/proxy-config.renderer.tsx
+++ b/web/html/src/manager/minion/proxy/proxy-config.renderer.tsx
@@ -8,7 +8,7 @@ export const renderer = (
     serverId,
     parents,
     currentConfig,
-    initFailMessage,
+    validationErrors,
     registryUrlExample,
     registryTagExample,
     hasCertificates,
@@ -16,7 +16,7 @@ export const renderer = (
     serverId: string;
     parents: any[];
     currentConfig: any;
-    initFailMessage: string;
+    validationErrors?: any[];
     registryUrlExample: string;
     registryTagExample: string;
     hasCertificates?: boolean;
@@ -27,7 +27,7 @@ export const renderer = (
       serverId={serverId}
       parents={parents}
       currentConfig={currentConfig}
-      initFailMessage={initFailMessage}
+      validationErrors={validationErrors}
       registryUrlExample={registryUrlExample}
       registryTagExample={registryTagExample}
       hasCertificates={hasCertificates}

--- a/web/html/src/manager/minion/proxy/proxy-config.tsx
+++ b/web/html/src/manager/minion/proxy/proxy-config.tsx
@@ -22,7 +22,7 @@ export function ProxyConfig({
   serverId,
   parents,
   currentConfig,
-  initFailMessage,
+  validationErrors,
   registryUrlExample,
   registryTagExample,
   hasCertificates,
@@ -46,9 +46,9 @@ export function ProxyConfig({
   useEffect(() => {
     setModel((prev) => ({ ...prev }));
 
-    if (initFailMessage) {
+    if (validationErrors && validationErrors.length > 0) {
       setSuccess(false);
-      setMessages([initFailMessage]);
+      setMessages(validationErrors);
     }
   }, [currentConfig]);
 
@@ -141,7 +141,7 @@ export function ProxyConfig({
     >
       <p>{t("Convert an already onboarded minion to a proxy or update the configuration of an existing proxy.")}</p>
       {ContainerConfigMessages(success, messages, loading)}
-      {!initFailMessage && (
+      {(!validationErrors || validationErrors.length === 0) && (
         <Form
           className=""
           divClass="row"


### PR DESCRIPTION
## What does this PR change?

According to documentation, converting a client to a proxy requires the client to be subscribed to the appropriate Proxy Extension Channel or have the `mgrpxy` tool already installed.  

The reason is that applying a proxy configuration triggers a `mgrpxy` installation if it is not already present.
In scenarios where `mgrpxy` is missing and there is no appropriate Proxy Extension Channel subscribed, the installation will fail 

This PR ensures that when entering the proxy configuration (which triggers the same mechanism as clicking the "Convert to Proxy" button),  the system checks if mgrpxy is (or can be) installed. If is not, will look for and automatically automatically for suitable channels.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28398

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
