### PR TITLE
Fix forward registration task test

### DIFF
--- a/java/spacewalk-java.changes.carlo.uyuni-fix-forward-registration-task-test
+++ b/java/spacewalk-java.changes.carlo.uyuni-fix-forward-registration-task-test
@@ -1,0 +1,1 @@
+- Fix intermittently failing test in ForwardRegistrationTaskTest


### PR DESCRIPTION
## What does this PR change?
This PR fixes a bug in `ForwardRegistrationTaskTest.testSuccessSystemRegistration()`.

The mock object of type `MockSCCWebClientWithCount` simulates a response of SCC to a subscription.

The test `testSuccessSystemRegistration` simulates the registration failure of 9 minions.

The implementation was using a flag, letting fail the first SCC simulated call, made in batches of 9 systems.

However, other tests may leave some system leftovers (minions that are found on the database cache) and hence some of the systems in the first failing SCC simulated call could not be one of the testing systems, therefore letting the test system count failing.

The test was not failing consistently and in particular was not failing locally: the reason is because when splitting the system list into batches to be sent to the SCC (see `SCCSystemRegistrationCreateUpdateSystems.handle`), it all depended if the leftover systems were included in the first "failing" batch or not.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): #
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/28824, 5.0, 4.3 not backported
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
