### PR TITLE
Create activation key tunnel ssh add check

### DIFF
--- a/testsuite/features/reposync/srv_create_activationkey.feature
+++ b/testsuite/features/reposync/srv_create_activationkey.feature
@@ -95,6 +95,7 @@ Feature: Create activation keys
     And I enter "20" as "usageLimit"
     And I select "Push via SSH tunnel" from "contact-method"
     And I click on "Create Activation Key"
+    Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been created" text
 
 @proxy
   Scenario: Create an activation key for the proxy


### PR DESCRIPTION
## What does this PR change?

Improve stability of Create an activation key with a channel for salt-ssh via tunnel
Add a check verifying the key was creating.
Doing so will avoid issue when using this key and also avoid a situation where we close the page before the creation was finished.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
