### PR TITLE
Correctly handles http proxy empty passwords (bsc#1249502)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/satellite/ProxySettingsConfigureSatelliteCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/satellite/ProxySettingsConfigureSatelliteCommand.java
@@ -61,11 +61,12 @@ public class ProxySettingsConfigureSatelliteCommand extends ConfigureSatelliteCo
         if (optionMap.containsKey(ConfigDefaults.HTTP_PROXY_PASSWORD)) {
             String passwordEnvVariable = RHN_CONFIG_SATELLITE_ENV_PREFIX + PWD_PLACEHOLDER;
             String passwordValue = optionMap.get(ConfigDefaults.HTTP_PROXY_PASSWORD);
+            if (null == passwordValue) {
+                passwordValue = "";
+            }
 
             optionMap.put(ConfigDefaults.HTTP_PROXY_PASSWORD, PWD_PLACEHOLDER);
 
-            environmentVars = new String[1];
-            environmentVars[0] = "%s=%s".formatted(passwordEnvVariable, passwordValue);
             environmentVars = new String[]{"%s=%s".formatted(passwordEnvVariable, passwordValue)};
 
             return getCommandArguments(true, configFilePath, optionMap, removals);

--- a/java/code/src/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/test/ProxySettingsManagerTest.java
@@ -199,4 +199,25 @@ public class ProxySettingsManagerTest extends RhnBaseTestCase {
 
         assertEquals("UYUNICFG_PWD_PLACEHOLDER=%s".formatted(TEST_PASSWD), configCommand.getFirstEnvironmentVar());
     }
+
+    @Test
+    public void testProxySettingsConfigureSatelliteCommandArgumentsOnlyEmptyPasswd() {
+        MockProxySettingsConfigureCommand configCommand = new MockProxySettingsConfigureCommand(satAdmin);
+
+        proxySettingsDto.setPassword("");
+        configCommand.updateString(ConfigDefaults.HTTP_PROXY_PASSWORD, proxySettingsDto.getPassword());
+
+        String[] cmdArgs = configCommand.getCommandArguments();
+        assertEquals(8, cmdArgs.length);
+        assertEquals("/usr/bin/sudo", cmdArgs[0]);
+        assertEquals("-E", cmdArgs[1]);
+        assertEquals("/usr/bin/rhn-config-satellite.pl", cmdArgs[2]);
+        assertTrue(cmdArgs[3].startsWith("--target="));
+        assertEquals("--option=server.satellite.http_proxy_password=PWD_PLACEHOLDER", cmdArgs[4]);
+        assertEquals("2>&1", cmdArgs[5]);
+        assertEquals(">", cmdArgs[6]);
+        assertEquals("/dev/null", cmdArgs[7]);
+
+        assertEquals("UYUNICFG_PWD_PLACEHOLDER=", configCommand.getFirstEnvironmentVar());
+    }
 }

--- a/java/spacewalk-java.changes.carlo.uyuni-1249502-proxy-empty-password
+++ b/java/spacewalk-java.changes.carlo.uyuni-1249502-proxy-empty-password
@@ -1,0 +1,1 @@
+- Correctly handles http proxy empty passwords (bsc#1249502)

--- a/spacewalk/admin/rhn-config-satellite.pl
+++ b/spacewalk/admin/rhn-config-satellite.pl
@@ -73,7 +73,7 @@ foreach my $opt_name (keys %options) {
   my $val = $options{$opt_name};
   if ($val =~ /^[A-Z0-9_]+$/) {
     my $envkey = "UYUNICFG_" . $val;
-    if (exists $ENV{$envkey} && defined $ENV{$envkey} && $ENV{$envkey} ne '') {
+    if (exists $ENV{$envkey} && defined $ENV{$envkey}) {
       $options{$opt_name} = $ENV{$envkey};
     }
   }

--- a/spacewalk/admin/spacewalk-admin.changes.carlo.Manager-5.0-1249502-proxy-empty-password
+++ b/spacewalk/admin/spacewalk-admin.changes.carlo.Manager-5.0-1249502-proxy-empty-password
@@ -1,0 +1,1 @@
+- Correctly handles http proxy empty passwords (bsc#1249502)


### PR DESCRIPTION
## What does this PR change?

This fix is a followup of [Fix store proxy passwd (bsc#1242148)](https://github.com/SUSE/spacewalk/pull/27471).
It fixes the case in which the http proxy password is empty

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28349
Port(s): # 5.1: https://github.com/SUSE/spacewalk/pull/28820, 5.0: https://github.com/SUSE/spacewalk/pull/28449, 4.3: https://github.com/SUSE/spacewalk/pull/28819

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
