### PR TITLE
added spacecmd subcommand to show whether a reboot would be needed if available patches were applied

### DIFF
--- a/spacecmd/spacecmd.changes.tobias-d-oe.system_needrebootafterupdate
+++ b/spacecmd/spacecmd.changes.tobias-d-oe.system_needrebootafterupdate
@@ -1,1 +1,2 @@
-- Subcommand if reboot is needed after applying available patches
+- Add subcommand to check if reboot is needed
+  after applying all available patches

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -5060,6 +5060,7 @@ def help_system_needrebootafterupdate(self):
         )
     )
     print("")
+    print(self.HELP_SYSTEM_OPTS)
 
 
 def complete_system_needrebootafterupdate(self, text, line, beg, end):
@@ -5110,10 +5111,10 @@ def do_system_needrebootafterupdate(self, args, short=False):
                 # pylint: disable-next=consider-using-f-string
                 print("{}: 0".format(system))
             else:
-                # pylint: disable-next=consider-using-f-string
                 print(
                     _(
-                        "No reboot needed for system '{}' after appying available updates".format(
+                        # pylint: disable-next=consider-using-f-string
+                        "No reboot needed for system '{}' after applying available updates".format(
                             system
                         )
                     )


### PR DESCRIPTION
This PR brings https://github.com/uyuni-project/uyuni/pull/8016 to `master` branch.

---

## What does this PR change?

added spacecmd subcommand to show whether a reboot would be needed if available patches were applied

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- Documentation PR: https://github.com/uyuni-project/uyuni-docs/pull/2675

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
