### PR TITLE
QE: Refactor the AK creation to use API calls

### DIFF
--- a/testsuite/features/reposync/srv_create_activationkey.feature
+++ b/testsuite/features/reposync/srv_create_activationkey.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2024 SUSE LLC
+# Copyright (c) 2010-2025 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature can cause failures in:
@@ -26,9 +26,11 @@
 # - features/secondary/minssh_tunnel.feature
 # - features/secondary/minssh_move_from_and_to_proxy.feature
 
+# The WebUI coverage of Activation keys is covered in:
+# - features/secondary/srv_manage_activationkey.feature
 
 Feature: Create activation keys
-  In order to register systems to the spacewalk server
+  In order to register systems to the server
   As the testing user
   I want to use activation keys
 
@@ -37,94 +39,41 @@ Feature: Create activation keys
 
 @sle_minion
   Scenario: Create an activation key with a channel
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait until I do not see "Loading..." text
-    And I enter "SUSE Test Key x86_64" as "description"
-    And I enter "SUSE-KEY-x86_64" as "key"
-    And I enter "20" as "usageLimit"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key SUSE Test Key x86_64 has been created" text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link
+    When I create an activation key with id "SUSE-KEY-x86_64", description "SUSE Test Key x86_64", limit of 20 and contact method "default"
+    Then I should get the new activation key "1-SUSE-KEY-x86_64"
 
 @rhlike_minion
   Scenario: Create an activation key for RedHat-like minion
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait until I do not see "Loading..." text
-    And I enter "RedHat like Test Key" as "description"
-    And I enter "RH-LIKE-KEY" as "key"
-    And I select "Fake-Base-Channel-RH-like" from "selectedBaseChannel"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key RedHat like Test Key has been created" text
+    When I create an activation key with id "RH-LIKE-KEY", description "RedHat like Test Key", base channel "fake-base-channel-rh-like", limit of 20 and contact method "default"
+    Then I should get the new activation key "1-RH-LIKE-KEY"
 
 @deblike_minion
   Scenario: Create an activation key for Debian-like minion
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait until I do not see "Loading..." text
-    And I enter "Debian-like Test Key" as "description"
-    And I enter "DEBLIKE-KEY" as "key"
-    And I select "Fake-Base-Channel-Debian-like" from "selectedBaseChannel"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key Debian-like Test Key has been created" text
+    When I create an activation key with id "DEBLIKE-KEY", description "Debian-like Test Key", base channel "fake-base-channel-debian-like", limit of 20 and contact method "default"
+    Then I should get the new activation key "1-DEBLIKE-KEY"
 
 @ssh_minion
   Scenario: Create an activation key with a channel for salt-ssh
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait until I do not see "Loading..." text
-    And I enter "SUSE SSH Test Key x86_64" as "description"
-    And I enter "SUSE-SSH-KEY-x86_64" as "key"
-    And I enter "20" as "usageLimit"
-    And I select "Push via SSH" from "contact-method"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key SUSE SSH Test Key x86_64 has been created" text
+    When I create an activation key with id "SUSE-SSH-KEY-x86_64", description "SUSE SSH Test Key x86_64", limit of 20 and contact method "ssh-push"
+    Then I should get the new activation key "1-SUSE-SSH-KEY-x86_64"
 
 @ssh_minion
   Scenario: Create an activation key with a channel for salt-ssh via tunnel
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait until I do not see "Loading..." text
-    And I enter "SUSE SSH Tunnel Test Key x86_64" as "description"
-    And I enter "SUSE-SSH-TUNNEL-KEY-x86_64" as "key"
-    And I enter "20" as "usageLimit"
-    And I select "Push via SSH tunnel" from "contact-method"
-    And I click on "Create Activation Key"
+    When I create an activation key with id "SUSE-SSH-TUNNEL-KEY-x86_64", description "SUSE SSH Tunnel Test Key x86_64", limit of 20 and contact method "ssh-push-tunnel"
+    Then I should get the new activation key "1-SUSE-SSH-TUNNEL-KEY-x86_64"
 
 @proxy
   Scenario: Create an activation key for the proxy
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait until I do not see "Loading..." text
-    And I enter "Proxy Key x86_64" as "description"
-    And I enter "PROXY-KEY-x86_64" as "key"
-    And I enter "1" as "usageLimit"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key Proxy Key x86_64 has been created" text
+    When I create an activation key with id "PROXY-KEY-x86_64", description "Proxy Key x86_64", limit of 1
+    Then I should get the new activation key "1-PROXY-KEY-x86_64"
 
 @build_host
   Scenario: Create an activation key for the build host
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait for child channels to appear
-    And I enter "Build host Key x86_64" as "description"
-    And I enter "BUILD-HOST-KEY-x86_64" as "key"
-    And I check "Container Build Host"
-    And I check "OS Image Build Host"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key Build host Key x86_64 has been created" text
+    When I create an activation key with id "BUILD-HOST-KEY-x86_64", description "Build host Key x86_64"
+    And I set the entitlements of the activation key "1-BUILD-HOST-KEY-x86_64" to "container_build_host, osimage_build_host"
+    Then I should get the new activation key "1-BUILD-HOST-KEY-x86_64"
 
 @scc_credentials
   Scenario: Create an activation key for the terminal
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I wait for child channels to appear
-    And I enter "Terminal Key x86_64" as "description"
-    And I enter "TERMINAL-KEY-x86_64" as "key"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key Terminal Key x86_64 has been created" text
+    When I create an activation key with id "TERMINAL-KEY-x86_64", description "Terminal Key x86_64"
+    Then I should get the new activation key "1-TERMINAL-KEY-x86_64"

--- a/testsuite/features/secondary/srv_activationkey_api.feature
+++ b/testsuite/features/secondary/srv_activationkey_api.feature
@@ -8,7 +8,7 @@ Feature: API "activationkey" namespace
     Then I should get some activation keys
 
   Scenario: Create activation key
-    When I create an activation key with id "testkey", description "Key for testing" and limit of 10
+    When I create an activation key with id "testkey", description "Key for testing", limit of 10 and contact method "default"
     Then I should get the new activation key "1-testkey"
 
   Scenario: Activation key details

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -256,10 +256,35 @@ Then(/^I should get some activation keys$/) do
   raise ScriptError if $api_test.activationkey.get_activation_keys_count < 1
 end
 
-When(/^I create an activation key with id "([^"]*)", description "([^"]*)" and limit of (\d+)$/) do |id, dscr, limit|
-  key = $api_test.activationkey.create(id, dscr, '', limit.to_i)
-  raise ScriptError, 'Key creation failed' if key.nil?
-  raise ScriptError, 'Bad key name' if key != "1-#{id}"
+When(/^I create an activation key with id "([^"]*)", description "([^"]*)"(?:, base channel "([^"]*)")?(?:, limit of (\d+))?(?: and contact method "([^"]*)")?$/) do |id, description, base_channel_label, usage_limit_str, contact_method|
+  base_channel_label ||= ''
+  contact_method     ||= 'default'
+  usage_limit        = usage_limit_str.nil? ? 10 : usage_limit_str.to_i
+
+  activation_key = $api_test.activationkey.create(
+    id,
+    description,
+    base_channel_label,
+    usage_limit
+  )
+
+  raise ScriptError, 'Key creation failed' if activation_key.nil?
+  raise ScriptError, 'Bad key name' unless activation_key == "1-#{id}"
+
+  success = $api_test.activationkey.set_details(
+    activation_key,
+    description,
+    base_channel_label,
+    usage_limit,
+    contact_method
+  )
+
+  raise 'Failed to set activation key details' unless success
+end
+
+When(/^I set the entitlements of the activation key "([^"]*)" to "([^"]*)"$/) do |activation_key, entitlements|
+  entitlements_array = entitlements.split(',').map(&:strip).reject(&:empty?)
+  $api_test.activationkey.set_entitlement(activation_key, entitlements_array)
 end
 
 Then(/^I should get the new activation key "([^"]*)"$/) do |activation_key|


### PR DESCRIPTION
## What does this PR change?

This pull request refactors and enhances the activation key creation steps in the test suite, making them more flexible and maintainable. The main change is the introduction of a new, parameterized step definition for creating activation keys, which replaces multiple hardcoded UI steps in feature files. This allows for easier extension and clearer test scenarios. Additionally, a step for setting activation key entitlements has been added, and some minor documentation and copyright updates were made.

Key changes:

**Test step refactoring and enhancement:**

* Introduced a new, parameterized step definition `When I create an activation key with id ...` in `api_common.rb`, supporting optional parameters for base channel, usage limit, and contact method, and ensuring activation key details are set after creation.
* Added a new step definition `When I set the entitlements of the activation key ...` to allow setting entitlements on activation keys within tests.

**Feature file updates:**

* Refactored all activation key creation scenarios in `srv_create_activationkey.feature` to use the new step, simplifying and unifying the test steps. Also added a step for setting entitlements in relevant scenarios.
* Updated the activation key creation scenario in `srv_activationkey_api.feature` to use the new, more flexible step.

**Documentation and metadata:**

* Added a comment in `srv_create_activationkey.feature` clarifying that WebUI coverage for activation keys is handled in a different feature file.
* Updated copyright year in `srv_create_activationkey.feature`.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.3
- Manager-5.0
- Manager-5.1

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
