### PR TITLE
QE: More debug log for an ISSv2 test

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1347,21 +1347,21 @@ When(/^I copy vCenter configuration file on server$/) do
 end
 
 When(/^I export software channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
-  get_target('server').run("inter-server-sync export --channels=#{channel} --outputDir=#{path}")
+  get_target('server').run("inter-server-sync export --channels=#{channel} --outputDir=#{path}", verbose: true)
 end
 
 When(/^I export config channels "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
-  get_target('server').run("inter-server-sync export --configChannels=#{channel} --outputDir=#{path}")
+  get_target('server').run("inter-server-sync export --configChannels=#{channel} --outputDir=#{path}", verbose: true)
 end
 
 When(/^I import data with ISS v2 from "([^"]*)"$/) do |path|
   # WORKAROUND for bsc#1249127
-  # Remove "echo UglyWorkaround |" when the product issue is solved
-  get_target('server').run("echo UglyWorkaround | inter-server-sync import --importDir=#{path}")
+  # Remove "echo admin |" when the product issue is solved
+  get_target('server').run("echo admin | inter-server-sync import --importDir=#{path}", verbose: true)
 end
 
 Then(/^"(.*?)" folder on server is ISS v2 export directory$/) do |folder|
-  raise ScriptError, "Folder #{folder} not found" unless file_exists?(get_target('server'), "#{folder}/sql_statements.sql.gz")
+  raise ScriptError, "Folder #{folder} not found" unless get_target('server').file_exists?("#{folder}/sql_statements.sql.gz")
 end
 
 When(/^I ensure folder "(.*?)" doesn't exist on "(.*?)"$/) do |folder, host|


### PR DESCRIPTION
## What does this PR change?

This pull request introduces minor improvements to the ISS v2 export and import test steps by enabling verbose output for command execution and refactoring a file existence check for clarity.

* Test step enhancements:
  * Added the `verbose: true` option to the `run` method for ISS v2 export and import commands in `command_steps.rb`, ensuring command output is more detailed during test execution.

* Code clarity:
  * Refactored the folder existence check to use the `file_exists?` method directly on the target object, improving readability and consistency.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests logs added

- [x] **DONE**

## Links

Ports:
- Manager-5.0
- Manager-5.1

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
