### PR TITLE
Fix: potential problem with JobReturnEventMessageActionTest.testPackagesProfileUpdateLivePatching

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.reactor.messaging.test;
 
+import static java.lang.Math.abs;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -510,7 +511,14 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         // Verify Uptime is set
         Date bootTime = new Date(System.currentTimeMillis() - (600 * 1000));
-        assertEquals((long) minion.getLastBoot(), (bootTime.getTime() / 1000));
+        long expectedBootTimeSeconds = bootTime.getTime() / 1000;
+        long actualBootTimeSeconds = minion.getLastBoot();
+        // Minion's lastBoot is stored in seconds, and it is usually set as System.currentTimeMillis()/1000.
+        // This means that there can be 1 second approximation when setting it and 1 when computing expected value
+        // from System.currentTimeMillis(). Add to this at least 1 second of potential computing delay, so it all
+        // sums up to 3: this does not change the aim of the test
+        long bootTimeDiffSeconds = 3;
+        assertTrue(abs(expectedBootTimeSeconds - actualBootTimeSeconds) <= bootTimeDiffSeconds);
 
         //Switch back from live patching
         message = new JobReturnEventMessage(JobReturnEvent


### PR DESCRIPTION
## What does this PR change?

`JobReturnEventMessageActionTest.testPackagesProfileUpdateLivePatching` has a potential problem due to the fact that it is relying on `System.currentTimeMillis()`.

Minion's `lastBoot` member is stored in seconds, and it is usually set as `System.currentTimeMillis()/1000`.
This means that there can be 1 second approximation when setting it and 1 when computing expected value from `System.currentTimeMillis()`. 
Add to this at least 1 second of potential computing delay, so it all sums up to a max of 3 seconds that have to be considered when checking for equality between the last boot actual and expected value.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
Issue(s): 
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

