### PR TITLE
SonarCloud fix: java:S116 Field names should comply with a naming convention

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/test/NamedPreparedStatementTest.java
+++ b/java/code/src/com/redhat/rhn/common/db/test/NamedPreparedStatementTest.java
@@ -43,21 +43,21 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
     private static final int SECOND_POS = 3;
 
 
-    private String SIMPLE_QUERY = "SELECT wc.id AS ID, " +
+    private static final String SIMPLE_QUERY = "SELECT wc.id AS ID, " +
                                   "wc.login, " +
                                   "wc.login_uc " +
                                   " FROM web_contact wc " +
                                   " WHERE wc.org_id = :org_id " +
                                   " ORDER BY wc.login_uc, wc.id";
 
-    private String SIMPLE_QUERY_SUBST = "SELECT wc.id AS ID, " +
+    private static final String SIMPLE_QUERY_SUBST = "SELECT wc.id AS ID, " +
                                         "wc.login, " +
                                         "wc.login_uc " +
                                         " FROM web_contact wc " +
                                         " WHERE wc.org_id = ? " +
                                         " ORDER BY wc.login_uc, wc.id";
 
-    private String TWO_VAR_QUERY = "SELECT DISTINCT E.id, E.update_date " +
+    private static final String TWO_VAR_QUERY = "SELECT DISTINCT E.id, E.update_date " +
                                    "FROM rhnErrata E, " +
                                    "rhnServerNeededCache SNC " +
                                    "WHERE EXISTS (SELECT server_id FROM " +
@@ -68,7 +68,7 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
                                    "AND SNC.errata_id = E.id " +
                                    "ORDER BY E.update_date, E.id";
 
-    private String TWO_VAR_QUERY_SUBST = "SELECT DISTINCT E.id, " +
+    private static final String TWO_VAR_QUERY_SUBST = "SELECT DISTINCT E.id, " +
                                          "E.update_date " +
                                          "FROM rhnErrata E, " +
                                          "rhnServerNeededCache SNC " +
@@ -80,7 +80,7 @@ public class NamedPreparedStatementTest extends RhnBaseTestCase {
                                          "AND SNC.errata_id = E.id " +
                                          "ORDER BY E.update_date, E.id";
 
-    private String COLON_IN_QUOTES = "SELECT 'FOO:BAR:MI:SS' " +
+    private static final String COLON_IN_QUOTES = "SELECT 'FOO:BAR:MI:SS' " +
                                      "FROM FOOBAR";
 
 

--- a/java/code/src/com/redhat/rhn/common/hibernate/AbstractConnectionManager.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AbstractConnectionManager.java
@@ -41,7 +41,7 @@ import io.prometheus.client.hibernate.HibernateStatisticsCollector;
  */
 abstract class AbstractConnectionManager implements ConnectionManager {
 
-    protected final Logger LOG;
+    protected final Logger log;
 
     protected SessionFactory sessionFactory;
 
@@ -55,7 +55,7 @@ abstract class AbstractConnectionManager implements ConnectionManager {
      *
      */
     protected AbstractConnectionManager() {
-        this.LOG = LogManager.getLogger(getClass());
+        this.log = LogManager.getLogger(getClass());
         this.configurators = new ArrayList<>();
         this.sessionInfoThreadLocal = new ThreadLocal<>();
     }
@@ -118,7 +118,7 @@ abstract class AbstractConnectionManager implements ConnectionManager {
             }
         }
         catch (HibernateException e) {
-            LOG.debug("Could not close the SessionFactory", e);
+            log.debug("Could not close the SessionFactory", e);
         }
         finally {
             sessionFactory = null;
@@ -171,7 +171,7 @@ abstract class AbstractConnectionManager implements ConnectionManager {
              * Let's ask the RHN Config for all properties that begin with
              * hibernate.*
              */
-            LOG.info("Adding hibernate properties to hibernate Configuration");
+            log.info("Adding hibernate properties to hibernate Configuration");
             config.addProperties(getConfigurationProperties());
 
             // Invoke each configurator to add additional entries to Hibernate config
@@ -186,7 +186,7 @@ abstract class AbstractConnectionManager implements ConnectionManager {
             sessionFactory = config.buildSessionFactory();
         }
         catch (HibernateException e) {
-            LOG.error("FATAL ERROR creating HibernateFactory", e);
+            log.error("FATAL ERROR creating HibernateFactory", e);
             throw e;
         }
     }
@@ -245,11 +245,11 @@ abstract class AbstractConnectionManager implements ConnectionManager {
         SessionInfo info = threadSessionInfo();
         if (info == null || info.getSession() == null) {
             try {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("YYY Opening Hibernate Session");
+                if (log.isDebugEnabled()) {
+                    log.debug("YYY Opening Hibernate Session");
                 }
                 info = new SessionInfo(sessionFactory.openSession());
-                LOG.debug("YYY Opened Hibernate session {}", info.getSession());
+                log.debug("YYY Opened Hibernate session {}", info.getSession());
             }
             catch (HibernateException e) {
                 throw new HibernateRuntimeException("couldn't open session", e);
@@ -290,21 +290,21 @@ abstract class AbstractConnectionManager implements ConnectionManager {
                 txn.commit();
             }
             catch (RuntimeException commitException) {
-                LOG.warn("Unable to commit transaction", commitException);
+                log.warn("Unable to commit transaction", commitException);
 
                 try {
                     txn.rollback();
                 }
                 catch (RuntimeException rollbackException) {
-                    LOG.warn("Unable to rollback transaction", rollbackException);
+                    log.warn("Unable to rollback transaction", rollbackException);
                 }
             }
         }
 
         try {
             if (session != null && session.isOpen()) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("YYY Closing Hibernate Session: {}", session);
+                if (log.isDebugEnabled()) {
+                    log.debug("YYY Closing Hibernate Session: {}", session);
                 }
                 session.close();
             }

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ReleaseChannelMapTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ReleaseChannelMapTest.java
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.Test;
  */
 public class ReleaseChannelMapTest extends BaseTestCaseWithUser {
 
-    private final String PRODUCT = "RHEL";
-    private final String VERSION = "5Server";
-    private final String RELEASE = "5.0.0";
+    private static final String PRODUCT = "RHEL";
+    private static final String VERSION = "5Server";
+    private static final String RELEASE = "5.0.0";
 
     @Test
     public void testCreate() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularSourcesValidatorTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularSourcesValidatorTest.java
@@ -28,8 +28,8 @@ public class ModularSourcesValidatorTest extends ContentValidatorTestBase {
     private ModularSourcesValidator validator;
 
     private static final String ENTITY_SOURCES = "softwareSources";
-    private final String MSG_NOMODULEFILTERS = getLoc().getMessage("contentmanagement.validation.nomodulefilters");
-    private final String MSG_NOMODULARSOURCES = getLoc().getMessage("contentmanagement.validation.nomodularsources");
+    private final String msgNoModuleFilters = getLoc().getMessage("contentmanagement.validation.nomodulefilters");
+    private final String msgNoModularSources = getLoc().getMessage("contentmanagement.validation.nomodularsources");
 
     @Override
     @BeforeEach
@@ -68,15 +68,15 @@ public class ModularSourcesValidatorTest extends ContentValidatorTestBase {
     @Test
     public void testModularSourcesWithNoModuleFilters() throws Exception {
         attachModularSource();
-        assertSingleMessage(MSG_NOMODULEFILTERS, TYPE_INFO, ENTITY_SOURCES, validator.validate(getProject()));
+        assertSingleMessage(msgNoModuleFilters, TYPE_INFO, ENTITY_SOURCES, validator.validate(getProject()));
         attachFilter();
-        assertSingleMessage(MSG_NOMODULEFILTERS, TYPE_INFO, ENTITY_SOURCES, validator.validate(getProject()));
+        assertSingleMessage(msgNoModuleFilters, TYPE_INFO, ENTITY_SOURCES, validator.validate(getProject()));
     }
 
     @Test
     public void testNonModularSourcesWithModuleFilters() throws Exception {
         attachSource();
         attachModularFilter();
-        assertSingleMessage(MSG_NOMODULARSOURCES, TYPE_WARN, ENTITY_SOURCES, validator.validate(getProject()));
+        assertSingleMessage(msgNoModularSources, TYPE_WARN, ENTITY_SOURCES, validator.validate(getProject()));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -94,7 +94,7 @@ import java.util.TreeMap;
 public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
     @RegisterExtension
-    protected final JUnit5Mockery CONTEXT = new JUnit5Mockery() {{
+    protected final JUnit5Mockery context = new JUnit5Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};
 
@@ -110,8 +110,8 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
-        CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
-        saltApiMock = CONTEXT.mock(TestSaltApi.class);
+        context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        saltApiMock = context.mock(TestSaltApi.class);
     }
 
     @Test
@@ -542,7 +542,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
     @Test
     public void testDelete() {
-        CONTEXT.checking(new Expectations() {{
+        context.checking(new Expectations() {{
             allowing(saltApiMock).removeFile(
                     with(equal(Paths.get(String.format("/srv/www/os-images/%d/test-1.0.0.tgz",
                                              user.getOrg().getId())))));
@@ -579,7 +579,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
     @Test
     public void testDeltaImage() {
-        CONTEXT.checking(new Expectations() {{
+        context.checking(new Expectations() {{
             allowing(saltApiMock).removeFile(
                     with(equal(Paths.get(String.format("/srv/www/os-images/%d/delta1.tgz",
                                              user.getOrg().getId())))));
@@ -646,8 +646,8 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
     private TaskomaticApi getTaskomaticApi() throws TaskomaticApiException {
         if (taskomaticApi == null) {
-            taskomaticApi = CONTEXT.mock(TaskomaticApi.class);
-            CONTEXT.checking(new Expectations() {
+            taskomaticApi = context.mock(TaskomaticApi.class);
+            context.checking(new Expectations() {
                 {
                     allowing(taskomaticApi)
                             .scheduleActionExecution(with(any(Action.class)));

--- a/java/code/src/com/redhat/rhn/domain/server/CPU.java
+++ b/java/code/src/com/redhat/rhn/domain/server/CPU.java
@@ -69,7 +69,7 @@ public class CPU extends BaseDomainHelper {
     @Column
     private String family;
     @Column(name = "mhz")
-    private String MHz;
+    private String mhz;
     @Column
     private String stepping;
     @Column
@@ -252,14 +252,14 @@ public class CPU extends BaseDomainHelper {
      * @return Returns the mHz.
      */
     public String getMHz() {
-        return MHz;
+        return mhz;
     }
 
     /**
      * @param mhzIn The mHz to set.
      */
     public void setMHz(String mhzIn) {
-        MHz = mhzIn;
+        mhz = mhzIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/state/PackageState.java
+++ b/java/code/src/com/redhat/rhn/domain/state/PackageState.java
@@ -162,7 +162,7 @@ public class PackageState {
      * @param packageState the packageState to set
      */
     public void setPackageState(PackageStates packageState) {
-        this.packageStateTypeId = packageState.id();
+        this.packageStateTypeId = packageState.getId();
     }
 
     /**
@@ -191,7 +191,7 @@ public class PackageState {
      * @param versionConstraint the versionConstraint to set
      */
     public void setVersionConstraint(VersionConstraints versionConstraint) {
-        versionConstraintId = versionConstraint.id();
+        versionConstraintId = versionConstraint.getId();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/state/PackageStates.java
+++ b/java/code/src/com/redhat/rhn/domain/state/PackageStates.java
@@ -25,10 +25,10 @@ public enum PackageStates {
     INSTALLED(0), REMOVED(1), PURGED(2);
 
     /** This ID corresponds to the id column in the database */
-    private final int ID;
+    private final int id;
 
-    PackageStates(int id) {
-        ID = id;
+    PackageStates(int idIn) {
+        id = idIn;
     }
 
     /**
@@ -36,19 +36,19 @@ public enum PackageStates {
      *
      * @return the id
      */
-    public int id() {
-        return ID;
+    public int getId() {
+        return id;
     }
 
     /**
      * Get enum value for a given ID.
      *
-     * @param id the ID
+     * @param idIn the ID
      * @return enum value or empty if the given id is invalid
      */
-    public static Optional<PackageStates> byId(int id) {
+    public static Optional<PackageStates> byId(int idIn) {
         return Arrays.asList(PackageStates.values()).stream()
-                .filter(state -> state.ID == id).findFirst();
+                .filter(state -> state.id == idIn).findFirst();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/state/VersionConstraints.java
+++ b/java/code/src/com/redhat/rhn/domain/state/VersionConstraints.java
@@ -26,10 +26,10 @@ public enum VersionConstraints {
     LATEST(0), ANY(1);
 
     /** This ID corresponds to the id column in the database */
-    private final int ID;
+    private final int id;
 
-    VersionConstraints(int id) {
-        ID = id;
+    VersionConstraints(int idIn) {
+        id = idIn;
     }
 
     /**
@@ -37,18 +37,18 @@ public enum VersionConstraints {
      *
      * @return the id
      */
-    public int id() {
-        return ID;
+    public int getId() {
+        return id;
     }
 
     /**
      * Get enum value for a given ID.
      *
-     * @param id the ID
+     * @param idIn the ID
      * @return enum value or empty if the given id is invalid
      */
-    public static Optional<VersionConstraints> byId(int id) {
+    public static Optional<VersionConstraints> byId(int idIn) {
         return Arrays.asList(VersionConstraints.values()).stream()
-                .filter(constraint -> constraint.ID == id).findFirst();
+                .filter(constraint -> constraint.id == idIn).findFirst();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/SSMGroupConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/SSMGroupConfirmAction.java
@@ -54,10 +54,10 @@ public class SSMGroupConfirmAction extends RhnAction
     implements Listable<SystemGroupOverview> {
 
     // must match rl:list dataset and name tags!!
-    private String ADD_DATA = "addSet";
-    private String ADD_LIST = "addList";
-    private String RMV_DATA = "removeSet";
-    private String RMV_LIST = "removeList";
+    private static final String ADD_DATA = "addSet";
+    private static final String ADD_LIST = "addList";
+    private static final String RMV_DATA = "removeSet";
+    private static final String RMV_LIST = "removeList";
 
     private static final ServerGroupManager SERVER_GROUP_MANAGER = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
@@ -147,7 +147,6 @@ public class SSMGroupConfirmAction extends RhnAction
 
     @Override
     public List getResult(RequestContext context) {
-        // TODO Auto-generated method stub
         return null;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartDeleteActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/test/KickstartDeleteActionTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 public class KickstartDeleteActionTest extends BaseKickstartEditTestCase {
 
-    private final String KICKSTART_ID = "ksid";
+    private static final String KICKSTART_ID = "ksid";
 
     @Test
     public void testExecute() {

--- a/java/code/src/com/redhat/rhn/frontend/dto/FilePreservationDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/FilePreservationDto.java
@@ -21,7 +21,7 @@ import java.util.Date;
  */
 public class FilePreservationDto extends BaseDto {
     private Long id;
-    private Long org_id;
+    private Long orgId;
     private String label;
     private Date created;
     private Date modified;
@@ -80,14 +80,14 @@ public class FilePreservationDto extends BaseDto {
      * @return Returns The FileList org_id.
      */
     public Long getOrgId() {
-        return org_id;
+        return orgId;
     }
 
     /**
      * @param orgIn The orgIn to set.
      */
     public void setOrgId(Long orgIn) {
-        this.org_id = orgIn;
+        this.orgId = orgIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListCommand.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/ListCommand.java
@@ -16,7 +16,7 @@
 package com.redhat.rhn.frontend.taglibs.list;
 
 /**
- * Describes the various states the ListTag moves thru as it renders a list
+ * Describes the various states the ListTag moves through as it renders a list
  */
 
 public enum ListCommand {
@@ -29,10 +29,10 @@ public enum ListCommand {
     AFTER_RENDER("__tbl__after_render__"),
     TBL_FOOTER("__tbl_footer__");
 
-    private String _cmd;
+    private String cmd;
 
-    ListCommand(String cmd) {
-        _cmd = cmd;
+    ListCommand(String cmdIn) {
+        cmd = cmdIn;
     }
 
     /**
@@ -40,6 +40,6 @@ public enum ListCommand {
      */
     @Override
     public String toString() {
-        return _cmd;
+        return cmd;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/NavDialogMenuTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/NavDialogMenuTagTest.java
@@ -40,9 +40,9 @@ import javax.servlet.jsp.tagext.Tag;
  */
 public class NavDialogMenuTagTest extends RhnBaseTestCase {
 
-    private final String NAV_XML = "sitenav-test.xml";
+    private static final String NAV_XML = "sitenav-test.xml";
     private URL url;
-    private final String DIALOG_NAV = "com.redhat.rhn.frontend.nav.DialognavRenderer";
+    private static final String DIALOG_NAV = "com.redhat.rhn.frontend.nav.DialognavRenderer";
     private NavDialogMenuTag nmt;
 
     @Override

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -3545,8 +3545,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         Set<PackageState> packageStates = systemHandler.listPackageState(admin, server.getId().intValue());
         assertNotEmpty(packageStates);
         assertEquals(1, packageStates.size());
-        assertEquals(PackageStates.REMOVED.id(), packageStates.iterator().next().getPackageStateTypeId());
-        assertEquals(VersionConstraints.LATEST.id(), packageStates.iterator().next().getVersionConstraintId());
+        assertEquals(PackageStates.REMOVED.getId(), packageStates.iterator().next().getPackageStateTypeId());
+        assertEquals(VersionConstraints.LATEST.getId(), packageStates.iterator().next().getVersionConstraintId());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/taskomatic/TaskomaticHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/taskomatic/TaskomaticHandler.java
@@ -40,7 +40,7 @@ import redstone.xmlrpc.XmlRpcFault;
  */
 public class TaskomaticHandler extends BaseHandler {
 
-    private String TASKOMATIC_NAMESPACE = "tasko";
+    private static final String TASKOMATIC_NAMESPACE = "tasko";
     private XmlRpcClient client;
     private static Logger log = LogManager.getLogger(TaskomaticHandler.class);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/RhnSAXParser.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/util/RhnSAXParser.java
@@ -31,7 +31,7 @@ import org.xml.sax.SAXNotSupportedException;
  */
 public class RhnSAXParser extends SAXParser {
     // This is unnecessary functionality for XMLRPC XML parser.
-    private String DISALLOW_DOCTYPE_DECL
+    private static final String DISALLOW_DOCTYPE_DECL
         = "http://apache.org/xml/features/disallow-doctype-decl";
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -90,8 +90,8 @@ import java.util.Map;
  */
 public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
-    private final String SALT_CONTENT_STAGING_WINDOW = "salt_content_staging_window";
-    private final String SALT_CONTENT_STAGING_ADVANCE = "salt_content_staging_advance";
+    private static final String SALT_CONTENT_STAGING_WINDOW = "salt_content_staging_window";
+    private static final String SALT_CONTENT_STAGING_ADVANCE = "salt_content_staging_advance";
 
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();

--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -39,7 +39,7 @@ public class CloneChannelCommand extends CreateChannelCommand {
 
     private CloneBehavior cloneBehavior;
     private Channel original;
-    private String DEFAULT_PREFIX = "clone-of-";
+    private static final String DEFAULT_PREFIX = "clone-of-";
     private boolean stripModularMetadata = false;
     private CloudPaygManager cloudPaygManager;
 

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -56,7 +56,7 @@ public abstract class BaseRepoCommand {
     private Set<SslContentSource> sslSetsToAdd = new HashSet<>();
     private Set<SslContentSource> sslSetsToDelete = new HashSet<>();
     private Org org;
-    private boolean metadata_signed;
+    private boolean metadataSigned;
 
     /**
      *
@@ -178,7 +178,7 @@ public abstract class BaseRepoCommand {
      * @return true if metadata should be signed
      */
     public boolean getMetadataSigned() {
-        return metadata_signed;
+        return metadataSigned;
     }
 
     /**
@@ -186,7 +186,7 @@ public abstract class BaseRepoCommand {
      * @param md set if metadata are signed
      */
     public void setMetadataSigned(boolean md) {
-        this.metadata_signed = md;
+        this.metadataSigned = md;
     }
 
     /**
@@ -267,7 +267,7 @@ public abstract class BaseRepoCommand {
                 repo.setType(cst);
             }
         }
-        repo.setMetadataSigned(this.metadata_signed);
+        repo.setMetadataSigned(this.metadataSigned);
 
         ChannelFactory.save(repo);
         HibernateFactory.commitTransaction();

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 public class BaseRepoCommandTest extends RhnBaseTestCase {
 
     private BaseRepoCommand ccc = null;
-    private int label_count = 0;
+    private int labelCount = 0;
 
     @Override
     @BeforeEach
@@ -115,7 +115,7 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
         // give it a valid url
         ccc.setUrl(url);
         // need to create unique label names.
-        ccc.setLabel("valid-label-name-" + label_count++);
+        ccc.setLabel("valid-label-name-" + labelCount++);
         // need to specify a type
         ccc.setType(type);
         // need to specify MetadataSigned
@@ -164,7 +164,7 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
 
     private void validRepoLabelInput(String label) {
         // give it a valid url
-        ccc.setUrl("http://localhost/" + label_count++);
+        ccc.setUrl("http://localhost/" + labelCount++);
         // need to create unique label names.
         ccc.setLabel(label);
         // need to specify a type

--- a/java/code/src/com/redhat/rhn/manager/channel/test/CreateCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/CreateCommandTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public class CreateCommandTest extends RhnBaseTestCase {
 
     private CreateChannelCommand ccc = null;
-    private int label_count = 0;
+    private int labelCount = 0;
     private User user = null;
 
     @Override
@@ -111,7 +111,7 @@ public class CreateCommandTest extends RhnBaseTestCase {
         // Give it an valid name
         ccc.setName(cname);
         // need to create unique label names.
-        ccc.setLabel("valid-label-name-" + label_count++);
+        ccc.setLabel("valid-label-name-" + labelCount++);
         // need to specify a checksum type
         ccc.setChecksumLabel("sha256");
 
@@ -197,7 +197,7 @@ public class CreateCommandTest extends RhnBaseTestCase {
         // Give it an valid label
         ccc.setLabel(clabel);
         // need to create unique label names.
-        ccc.setName("Valid Name" + label_count++);
+        ccc.setName("Valid Name" + labelCount++);
         // need to specify a checksum type
         ccc.setChecksumLabel("sha256");
 

--- a/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
@@ -76,8 +76,8 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
 
     private SUSEProduct product2;
     private Channel baseChannel2;
-    private Channel childChannel2_1;
-    private Channel childChannel2_2;
+    private Channel childChannel2Child1;
+    private Channel childChannel2Child2;
 
     private TaskomaticApi taskomaticMock;
 
@@ -128,21 +128,21 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
 
         UserManager.addChannelPerm(user, baseChannel2.getId(), "subscribe");
         UserManager.addChannelPerm(user, baseChannel2.getId(), "manage");
-        childChannel2_1 = createTestVendorChildChannel(baseChannel2, channelProduct);
-        UserManager.addChannelPerm(user, childChannel2_1.getId(), "subscribe");
-        UserManager.addChannelPerm(user, childChannel2_1.getId(), "manage");
-        childChannel2_2 = createTestVendorChildChannel(baseChannel2, channelProduct);
-        UserManager.addChannelPerm(user, childChannel2_2.getId(), "subscribe");
-        UserManager.addChannelPerm(user, childChannel2_2.getId(), "manage");
+        childChannel2Child1 = createTestVendorChildChannel(baseChannel2, channelProduct);
+        UserManager.addChannelPerm(user, childChannel2Child1.getId(), "subscribe");
+        UserManager.addChannelPerm(user, childChannel2Child1.getId(), "manage");
+        childChannel2Child2 = createTestVendorChildChannel(baseChannel2, channelProduct);
+        UserManager.addChannelPerm(user, childChannel2Child2.getId(), "subscribe");
+        UserManager.addChannelPerm(user, childChannel2Child2.getId(), "manage");
 
         baseChannel2.setOrg(user.getOrg());
-        childChannel2_1.setOrg(user.getOrg());
-        childChannel2_2.setOrg(user.getOrg());
+        childChannel2Child1.setOrg(user.getOrg());
+        childChannel2Child2.setOrg(user.getOrg());
 
         // Assign channels to SUSE product
         createTestSUSEProductChannel(baseChannel2, product2, true);
-        createTestSUSEProductChannel(childChannel2_1, product2, true);
-        createTestSUSEProductChannel(childChannel2_2, product2, true);
+        createTestSUSEProductChannel(childChannel2Child1, product2, true);
+        createTestSUSEProductChannel(childChannel2Child2, product2, true);
     }
 
     /**
@@ -675,8 +675,8 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         change2.setOldBaseId(Optional.of(server2.getBaseChannel().getId()));
         change2.setNewBaseDefault(true);
         change2.setNewBaseId(Optional.of(baseChannel2.getId()));
-        change2.getChildChannelActions().put(childChannel2_1.getId(), ChannelChangeAction.SUBSCRIBE);
-        change2.getChildChannelActions().put(childChannel2_2.getId(), ChannelChangeAction.SUBSCRIBE);
+        change2.getChildChannelActions().put(childChannel2Child1.getId(), ChannelChangeAction.SUBSCRIBE);
+        change2.getChildChannelActions().put(childChannel2Child2.getId(), ChannelChangeAction.SUBSCRIBE);
         changes.add(change2);
 
         Date earliest = new Date();
@@ -719,11 +719,11 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals((Integer)2, details2.map(d -> d.getChannels().size()).get());
         assertTrue(details2
                 .flatMap(d -> d.getChannels().stream()
-                        .filter(c -> c.getId().equals(childChannel2_1.getId())).findFirst())
+                        .filter(c -> c.getId().equals(childChannel2Child1.getId())).findFirst())
                 .isPresent());
         assertTrue(details2
                 .flatMap(d -> d.getChannels().stream()
-                        .filter(c -> c.getId().equals(childChannel2_2.getId())).findFirst())
+                        .filter(c -> c.getId().equals(childChannel2Child2.getId())).findFirst())
                 .isPresent());
     }
 

--- a/java/code/src/com/suse/manager/saltboot/PXEEventMessage.java
+++ b/java/code/src/com/suse/manager/saltboot/PXEEventMessage.java
@@ -21,7 +21,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public class PXEEventMessage implements EventMessage {
 
-    private PXEEvent PXEEvent;
+    private PXEEvent pxeEvent;
 
     /**
      * Standard constructor.
@@ -29,7 +29,7 @@ public class PXEEventMessage implements EventMessage {
      * @param pxeEventIn - 'Saltboot PXE' event
      */
     public PXEEventMessage(PXEEvent pxeEventIn) {
-        this.PXEEvent = pxeEventIn;
+        this.pxeEvent = pxeEventIn;
     }
 
     /**
@@ -38,7 +38,7 @@ public class PXEEventMessage implements EventMessage {
      * @return PXEEvent
      */
     public PXEEvent getPXEEventMessage() {
-        return PXEEvent;
+        return pxeEvent;
     }
 
     @Override
@@ -49,7 +49,7 @@ public class PXEEventMessage implements EventMessage {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .append("PXEEvent", PXEEvent)
+                .append("PXEEvent", pxeEvent)
                 .toString();
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/admin/handlers/test/PaygApiControllerTest.java
@@ -59,7 +59,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     private TaskomaticApi taskomaticMock;
     private static final Gson GSON = new GsonBuilder().create();
 
-    private PaygApiContoller PaygApiContoller;
+    private PaygApiContoller paygApiContoller;
     private User satAdmin;
 
     @Override
@@ -73,7 +73,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
 
         context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         taskomaticMock = context.mock(TaskomaticApi.class);
-        PaygApiContoller = new PaygApiContoller(new PaygAdminManager(taskomaticMock));
+        paygApiContoller = new PaygApiContoller(new PaygAdminManager(taskomaticMock));
     }
 
     @Override
@@ -107,7 +107,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     public void testRemovePermitionCheck() {
         try {
             PaygSshData paygInfo = createPaygSshData();
-            PaygApiContoller.removePaygInstance(
+            paygApiContoller.removePaygInstance(
                     getRequestWithCsrf("/manager/api/admin/config/payg/:id", paygInfo.getId()),
                     response, user);
             fail("permission check not ok");
@@ -120,7 +120,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     @Test
     public void testRemove() {
         PaygSshData paygInfo = createPaygSshData();
-        String json = PaygApiContoller.removePaygInstance(
+        String json = paygApiContoller.removePaygInstance(
                 getRequestWithCsrf("/manager/api/admin/config/payg/:id", paygInfo.getId()),
                 response, satAdmin);
         ResultJson resultJson = GSON.fromJson(json, ResultJson.class);
@@ -134,7 +134,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     public void testUpdatePaygPermitionCheck() {
         try {
             PaygSshData paygInfo = createPaygSshData();
-            PaygApiContoller.updatePayg(
+            paygApiContoller.updatePayg(
                     getRequestWithCsrf("/manager/api/admin/config/payg/:id", paygInfo.getId()),
                     response, user);
             fail("permission check not ok");
@@ -147,7 +147,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     @Test
     public void testUpdatePayg1() throws UnsupportedEncodingException {
         PaygSshData paygInfo = createPaygSshData();
-        String dataJson = PaygApiContoller.updatePayg(
+        String dataJson = paygApiContoller.updatePayg(
                 getPostRequestWithCsrfAndBody("/manager/api/admin/config/payg/:id",
                         "",
                         paygInfo.getId()),
@@ -171,7 +171,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
                 "u", "p", "k", "kp",
                 "bh", "8002", "bu", "bp", "bk", "bkp", true, true);
 
-        String dataJson = PaygApiContoller.updatePayg(
+        String dataJson = paygApiContoller.updatePayg(
                 getPostRequestWithCsrfAndBody("/manager/api/admin/config/payg/:id",
                         GSON.toJson(properties),
                         paygInfo.getId()),
@@ -204,7 +204,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
     @Test
     public void testCreatePaygPermitionCheck() {
         try {
-            PaygApiContoller.createPayg(
+            paygApiContoller.createPayg(
                     getRequestWithCsrf("/manager/api/admin/config/payg"),
                     response, user);
             fail("permission check not ok");
@@ -227,7 +227,7 @@ public class PaygApiControllerTest extends BaseControllerTestCase {
                 "u", "p", "k", "kp",
                 "bh", "8002", "bu", "bp", "bk", "bkp", true, true);
 
-        String dataJson = PaygApiContoller.createPayg(
+        String dataJson = paygApiContoller.createPayg(
                 getPostRequestWithCsrfAndBody("/manager/api/admin/config/payg",
                         GSON.toJson(properties)),
                 response, satAdmin);

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -145,9 +145,10 @@ public class SaltSSHService {
             "services.salt-minion",
             "services.docker");
     private static final String SALT_USER = "admin";
-    private final String SALT_PASSWORD = com.redhat.rhn.common.conf.Config.get().getString("server.secret_key");
+    private static final String SALT_PASSWORD = com.redhat.rhn.common.conf.Config.get().getString("server.secret_key");
 
-    private final AuthMethod PW_AUTH = new AuthMethod(new PasswordAuth(SALT_USER, SALT_PASSWORD, AuthModule.FILE));
+    private static final AuthMethod PW_AUTH =
+            new AuthMethod(new PasswordAuth(SALT_USER, SALT_PASSWORD, AuthModule.FILE));
 
     // Shared salt client instance
     private final SaltClient saltClient;


### PR DESCRIPTION
## What does this PR change?
Fix for rule: [SonarCloud fix: java:S116 Field names should comply with a naming convention](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS116&rule_key=java%3AS116)



## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/9878
Port(s): 
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
