### PR TITLE
Add "susemanager", "susemanager-tools" and "susemanager-tools-salt" packages to server-image

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -50,11 +50,13 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         spacecmd \
         spacewalk-backend-sql-postgresql \
         spacewalk-java-postgresql \
-        susemanager-tools-salt \
         sssd \
         sssd-ad \
         sssd-dbus \
         sssd-ipa \
+        susemanager \
+        susemanager-tools \
+        susemanager-tools-salt \
         sssd-krb5 \
         sssd-ldap \
         sssd-tools \

--- a/containers/server-image/server-image.changes.meaksh.master-add-susemanager-tools-salt
+++ b/containers/server-image/server-image.changes.meaksh.master-add-susemanager-tools-salt
@@ -1,1 +1,2 @@
-- Add "susemanager-tools-salt" package to server-image
+- Add "susemanager-tools", "susemanager" and
+  "susemanager-tools-salt" packages to server-image


### PR DESCRIPTION
## What does this PR change?

As a continuation of https://github.com/uyuni-project/uyuni/pull/10321, this PR adds the new `susemanager-tools-salt` package to the `server-image`.

NOTE: The `susemanager-tools-salt` package is only required at the `server-image`.
 
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/26773

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
