### PR TITLE
Only display subscription warning to authorized users (bsc#1253127)

### DIFF
--- a/java/spacewalk-java.changes.parlt.master
+++ b/java/spacewalk-java.changes.parlt.master
@@ -1,0 +1,1 @@
+- Only show subscription warning to authorized users (bsc#1253127)

--- a/java/webapp/src/main/webapp/WEB-INF/pages/common/fragments/yourrhn/subwarn.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/common/fragments/yourrhn/subwarn.jsp
@@ -3,9 +3,10 @@
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 
-
-<c:if test="${requestScope.subscriptionwarning}">
-  <div class="alert alert-warning">
-    <bean:message key="notification.subscriptionwarning.detail" />
-  </div>
-</c:if>
+<rhn:require acl="authorized_for(admin.config)">
+  <c:if test="${requestScope.subscriptionwarning}">
+    <div class="alert alert-warning">
+      <bean:message key="notification.subscriptionwarning.detail" />
+    </div>
+  </c:if>
+</rhn:require>


### PR DESCRIPTION
## What does this PR change?

Don't display the subscription warning on the overview page if the user doesn't have access to the `admin.config` namspace.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **BUGFIX**

- [x] **DONE**

## Test coverage
- No tests: **BUGFIX**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28863

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
