### PR TITLE
Fix build GH containers on ARM

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -83,7 +83,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ env.PLATFORMS }}
+          platforms: linux/amd64
 
   build-and-push-opensuse-minion-image:
     runs-on: ubuntu-latest

--- a/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
@@ -2,31 +2,43 @@ ARG BASE
 ARG VERSION
 FROM ${BASE}:${VERSION}
 
+# Set build argument for target architecture, defaulting to amd64 if not explicitly set.
+ARG TARGETARCH=amd64
+
 RUN echo "Check GH Runner IP: " && curl https://api.ipify.org
-RUN zypper -n rr -a && \
-    zypper addrepo https://installer-updates.suse.com/SUSE/Products/SLE-BCI/15-SP6/x86_64/product/ SLE_BCI && \
+
+# Fix 1: Dynamically add the SLE-BCI repository based on TARGETARCH.
+# SLE-BCI uses 'x86_64' for amd64 and 'aarch64' for arm64.
+RUN ARCH_PATH="" && \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+        ARCH_PATH="x86_64"; \
+    elif [ "${TARGETARCH}" = "arm64" ]; then \
+        ARCH_PATH="aarch64"; \
+    else \
+        echo "Unsupported TARGETARCH: ${TARGETARCH}. Exiting." && exit 1; \
+    fi && \
+    zypper -n rr -a && \
+    zypper addrepo https://installer-updates.suse.com/SUSE/Products/SLE-BCI/15-SP6/${ARCH_PATH}/product/ SLE_BCI && \
+    zypper addrepo http://download.opensuse.org/distribution/leap/15.6/repo/oss/ openSUSE_Leap_15.6_OSS && \
+    zypper addrepo http://download.opensuse.org/update/leap/15.6/oss/ openSUSE_Leap_15.6_Updates && \
     zypper -n --gpg-auto-import-keys ref && \
+    zypper -n install --allow-downgrade --allow-vendor-change java-17-openjdk-devel && \
     zypper -n install \
       git \
       hostname \
-      java-17-openjdk-devel \
-      rsync \
       apache-ivy \
       ant \
-      ant-junit \
-      servletapi5 \
-      cpio \
-      spacecmd && \
+      ant-junit && \
     zypper addrepo --no-gpgcheck --refresh https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Utils/SLE_15_SP6/ systemsmanagement:uyuni:utils && \
     zypper addrepo --no-gpgcheck --refresh https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/systemsmanagement:Uyuni:Stable:SLE15-Uyuni-Client-Tools.repo && \
-    zypper -n install obs-to-maven nodejs22 npm22 prometheus && \
+    zypper -n install obs-to-maven prometheus && \
     zypper clean -a
 
 COPY minima.yaml /etc/minima.yaml
 
 RUN mkdir /tmp/minima && \
-    curl -L -o /tmp/minima/minima-linux-amd64.tar.gz https://github.com/moio/minima/releases/download/v0.10/minima-linux-amd64.tar.gz && \
-    tar -zxvf /tmp/minima/minima-linux-amd64.tar.gz -C /tmp/minima && \
+    curl -L -o /tmp/minima/minima-linux-${TARGETARCH}.tar.gz https://github.com/uyuni-project/minima/releases/download/v0.25/minima_0.25_linux_${TARGETARCH}.tar.gz && \
+    tar -zxvf /tmp/minima/minima-linux-${TARGETARCH}.tar.gz -C /tmp/minima && \
     cp /tmp/minima/minima /usr/bin/minima && \
     rm -rf /tmp/minima
 
@@ -42,19 +54,31 @@ RUN ln -s /srv/www/htdocs/pub/TestRepoRpmUpdates /srv/www/htdocs/pub/AnotherRepo
 RUN mkdir -p /etc/pki/rpm-gpg && \
     curl -fsSL -o /etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/repodata/repomd.xml.key
 
-COPY mirror /mirror
-
-RUN export SUSE_REPO="https://download.opensuse.org/tumbleweed/repo/oss/" && \
-    export RPM_DIR="/mirror/tumbleweed/repo/oss/x86_64" && \
+# Fix 3: Dynamically set the architecture for the Tumbleweed RPM mirroring, including the 'ports/aarch64' path for both URL and local directory.
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+        ARCH_FOR_RPM="aarch64"; \
+        TUMBLEWEED_PATH="ports/aarch64/tumbleweed"; \
+        RPM_PATH_SUFFIX="aarch64"; \
+        RPM_DIR_PREFIX="/mirror/ports/aarch64/tumbleweed/repo/oss"; \
+    elif [ "${TARGETARCH}" = "amd64" ]; then \
+        ARCH_FOR_RPM="x86_64"; \
+        TUMBLEWEED_PATH="tumbleweed"; \
+        RPM_PATH_SUFFIX="x86_64"; \
+        RPM_DIR_PREFIX="/mirror/tumbleweed/repo/oss"; \
+    else \
+        echo "Unsupported TARGETARCH for RPM: ${TARGETARCH}. Exiting." && exit 1; \
+    fi && \
+    export SUSE_REPO="https://download.opensuse.org/${TUMBLEWEED_PATH}/repo/oss/" && \
+    export RPM_DIR="${RPM_DIR_PREFIX}/${RPM_PATH_SUFFIX}" && \
     mkdir -p "${RPM_DIR}" && \
     cd "${RPM_DIR}" && \
-    for PACKAGE in openSUSE-release-20 dmidecode libunwind golang-github-prometheus-node_exporter golang-github-lusitaniae-apache_exporter prometheus-postgres_exporter golang-github-QubitProducts-exporter_exporter; do \
+    for PACKAGE in openSUSE-release-20 nodejs22 npm22 dmidecode libunwind golang-github-prometheus-node_exporter golang-github-lusitaniae-apache_exporter prometheus-postgres_exporter golang-github-QubitProducts-exporter_exporter; do \
         echo "Searching for latest version of ${PACKAGE}..." && \
         FULL_URL=$( \
-            curl -sL "${SUSE_REPO}x86_64/" | \
+            curl -sL "${SUSE_REPO}${RPM_PATH_SUFFIX}/" | \
             grep -oP "${PACKAGE}[^\"']+\.rpm" | \
             head -n 1 | \
-            awk -v repo="${SUSE_REPO}x86_64/" '{print repo $1}' \
+            awk -v repo="${SUSE_REPO}${RPM_PATH_SUFFIX}/" '{print repo $1}' \
         ) && \
         if [ -n "$FULL_URL" ]; then \
             echo "Downloading ${FULL_URL}..." && \
@@ -63,7 +87,7 @@ RUN export SUSE_REPO="https://download.opensuse.org/tumbleweed/repo/oss/" && \
             echo "Warning: Could not find RPM for ${PACKAGE}. Skipping."; \
         fi \
     done && \
-    export METADATA_DIR="/mirror/tumbleweed/repo/oss/repodata" && \
+    export METADATA_DIR="${RPM_DIR_PREFIX}/repodata" && \
     mkdir -p "${METADATA_DIR}" && \
     cd "${METADATA_DIR}" && \
     echo "Downloading repomd.xml..." && \


### PR DESCRIPTION
## What does this PR change?

This pull request introduces improvements to the Docker build process for the development server image, enhancing support for multiple architectures (amd64 and arm64) and ensuring correct repository and package handling for each architecture. The changes dynamically adjust repository URLs, package downloads, and other build steps based on the target architecture, improving compatibility and reliability of container builds.

**Architecture-aware build improvements:**

* The Dockerfile now sets and uses a `TARGETARCH` build argument (defaulting to `amd64`) to dynamically select the appropriate architecture-specific repository paths and packages throughout the build process.
* The SLE-BCI repository URL is dynamically constructed based on `TARGETARCH`, using `x86_64` for `amd64` and `aarch64` for `arm64`, ensuring the correct packages are installed for each architecture.
* The Minima binary download and extraction steps now use the correct architecture-specific tarball and release URL, supporting both `amd64` and `arm64` builds.

**Repository and package management enhancements:**

* The mirroring and downloading of Tumbleweed RPMs is now architecture-aware, including support for the `ports/aarch64` path for `arm64`, and correctly sets local directory paths and URLs for both architectures.
* The metadata directory for mirrored RPMs is dynamically set based on the architecture, ensuring correct placement and retrieval of repository data.

**Workflow configuration update:**

* The GitHub Actions workflow for building containers now explicitly sets the build platform to `linux/amd64` for the relevant job, instead of using a variable, clarifying the intended build architecture.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
