### PR TITLE
Fix the refactor on Dockerfile to support dynamic architecture

### DIFF
--- a/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
+++ b/testsuite/dockerfiles/server-all-in-one-dev/Dockerfile
@@ -2,35 +2,38 @@ ARG BASE
 ARG VERSION
 FROM ${BASE}:${VERSION}
 
-# Set build argument for target architecture, defaulting to amd64 if not explicitly set.
-ARG TARGETARCH=amd64
+ARG TARGETPLATFORM
+ENV TARGETARCH=${TARGETPLATFORM#*/}
+RUN echo "TARGETPLATFORM=${TARGETPLATFORM}; TARGETARCH=${TARGETARCH}"
 
-RUN echo "Check GH Runner IP: " && curl https://api.ipify.org
-
-# Fix 1: Dynamically add the SLE-BCI repository based on TARGETARCH.
-# SLE-BCI uses 'x86_64' for amd64 and 'aarch64' for arm64.
-RUN ARCH_PATH="" && \
-    if [ "${TARGETARCH}" = "amd64" ]; then \
-        ARCH_PATH="x86_64"; \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        export ARCH_PATH="x86_64"; \
+        export TUMBLEWEED_PATH="tumbleweed"; \
+        export NODE_REPO_PATH="15.6"; \
     elif [ "${TARGETARCH}" = "arm64" ]; then \
-        ARCH_PATH="aarch64"; \
+        export ARCH_PATH="aarch64"; \
+        export TUMBLEWEED_PATH="ports/aarch64/tumbleweed"; \
+        export NODE_REPO_PATH="openSUSE_Factory_ARM"; \
     else \
         echo "Unsupported TARGETARCH: ${TARGETARCH}. Exiting." && exit 1; \
     fi && \
+    export TUMBLEWEED_REPO="http://download.opensuse.org/${TUMBLEWEED_PATH}/repo/oss/" && \
     zypper -n rr -a && \
-    zypper addrepo https://installer-updates.suse.com/SUSE/Products/SLE-BCI/15-SP6/${ARCH_PATH}/product/ SLE_BCI && \
-    zypper addrepo http://download.opensuse.org/distribution/leap/15.6/repo/oss/ openSUSE_Leap_15.6_OSS && \
-    zypper addrepo http://download.opensuse.org/update/leap/15.6/oss/ openSUSE_Leap_15.6_Updates && \
-    zypper -n --gpg-auto-import-keys ref && \
-    zypper -n install --allow-downgrade --allow-vendor-change java-17-openjdk-devel && \
-    zypper -n install \
+    zypper addrepo --no-gpgcheck --refresh https://installer-updates.suse.com/SUSE/Products/SLE-BCI/15-SP6/${ARCH_PATH}/product/ SLE_BCI && \
+    zypper addrepo --no-gpgcheck --refresh http://download.opensuse.org/distribution/leap/15.6/repo/oss/ openSUSE_Leap_15.6_OSS && \
+    zypper addrepo --no-gpgcheck --refresh http://download.opensuse.org/update/leap/15.6/oss/ openSUSE_Leap_15.6_Updates && \
+    zypper -n install --allow-downgrade --allow-vendor-change \
       git \
       hostname \
       apache-ivy \
       ant \
       ant-junit && \
-    zypper addrepo --no-gpgcheck --refresh https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Utils/SLE_15_SP6/ systemsmanagement:uyuni:utils && \
-    zypper addrepo --no-gpgcheck --refresh https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/systemsmanagement:Uyuni:Stable:SLE15-Uyuni-Client-Tools.repo && \
+    zypper addrepo --no-gpgcheck --refresh ${TUMBLEWEED_REPO} tumbleweed_repo && \
+    zypper -n install --allow-downgrade --allow-vendor-change java-17-openjdk-devel && \
+    zypper addrepo --no-gpgcheck --refresh http://download.opensuse.org/repositories/devel:/languages:/nodejs/${NODE_REPO_PATH}/ nodejs && \
+    zypper -n install --allow-downgrade --allow-vendor-change nodejs22 npm && \
+    zypper addrepo --no-gpgcheck --refresh http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Utils/SLE_15_SP6/ uyuni_utils && \
+    zypper addrepo --no-gpgcheck --refresh http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/ SLE15-Uyuni-Client-Tools && \
     zypper -n install obs-to-maven prometheus && \
     zypper clean -a
 
@@ -54,31 +57,29 @@ RUN ln -s /srv/www/htdocs/pub/TestRepoRpmUpdates /srv/www/htdocs/pub/AnotherRepo
 RUN mkdir -p /etc/pki/rpm-gpg && \
     curl -fsSL -o /etc/pki/rpm-gpg/uyuni-tools-gpg-pubkey-0d20833e.key http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/repodata/repomd.xml.key
 
-# Fix 3: Dynamically set the architecture for the Tumbleweed RPM mirroring, including the 'ports/aarch64' path for both URL and local directory.
-RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-        ARCH_FOR_RPM="aarch64"; \
-        TUMBLEWEED_PATH="ports/aarch64/tumbleweed"; \
-        RPM_PATH_SUFFIX="aarch64"; \
-        RPM_DIR_PREFIX="/mirror/ports/aarch64/tumbleweed/repo/oss"; \
-    elif [ "${TARGETARCH}" = "amd64" ]; then \
-        ARCH_FOR_RPM="x86_64"; \
-        TUMBLEWEED_PATH="tumbleweed"; \
-        RPM_PATH_SUFFIX="x86_64"; \
-        RPM_DIR_PREFIX="/mirror/tumbleweed/repo/oss"; \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        export TUMBLEWEED_PATH="tumbleweed"; \
+        export RPM_PATH_SUFFIX="x86_64"; \
+        export RPM_DIR_PREFIX="/mirror/tumbleweed/repo/oss"; \
+    elif [ "${TARGETARCH}" = "arm64" ]; then \
+        export TUMBLEWEED_PATH="ports/aarch64/tumbleweed"; \
+        export RPM_PATH_SUFFIX="aarch64"; \
+        export RPM_DIR_PREFIX="/mirror/ports/aarch64/tumbleweed/repo/oss"; \
     else \
-        echo "Unsupported TARGETARCH for RPM: ${TARGETARCH}. Exiting." && exit 1; \
+        echo "Unsupported TARGETARCH: ${TARGETARCH}. Exiting." && exit 1; \
     fi && \
-    export SUSE_REPO="https://download.opensuse.org/${TUMBLEWEED_PATH}/repo/oss/" && \
+    export TUMBLEWEED_REPO="http://download.opensuse.org/${TUMBLEWEED_PATH}/repo/oss/" && \
+    \
     export RPM_DIR="${RPM_DIR_PREFIX}/${RPM_PATH_SUFFIX}" && \
     mkdir -p "${RPM_DIR}" && \
     cd "${RPM_DIR}" && \
-    for PACKAGE in openSUSE-release-20 nodejs22 npm22 dmidecode libunwind golang-github-prometheus-node_exporter golang-github-lusitaniae-apache_exporter prometheus-postgres_exporter golang-github-QubitProducts-exporter_exporter; do \
+    for PACKAGE in openSUSE-release-20 dmidecode libunwind golang-github-prometheus-node_exporter golang-github-lusitaniae-apache_exporter prometheus-postgres_exporter golang-github-QubitProducts-exporter_exporter; do \
         echo "Searching for latest version of ${PACKAGE}..." && \
         FULL_URL=$( \
-            curl -sL "${SUSE_REPO}${RPM_PATH_SUFFIX}/" | \
+            curl -sL "${TUMBLEWEED_REPO}${RPM_PATH_SUFFIX}/" | \
             grep -oP "${PACKAGE}[^\"']+\.rpm" | \
             head -n 1 | \
-            awk -v repo="${SUSE_REPO}${RPM_PATH_SUFFIX}/" '{print repo $1}' \
+            awk -v repo="${TUMBLEWEED_REPO}${RPM_PATH_SUFFIX}/" '{print repo $1}' \
         ) && \
         if [ -n "$FULL_URL" ]; then \
             echo "Downloading ${FULL_URL}..." && \
@@ -91,14 +92,14 @@ RUN if [ "${TARGETARCH}" = "arm64" ]; then \
     mkdir -p "${METADATA_DIR}" && \
     cd "${METADATA_DIR}" && \
     echo "Downloading repomd.xml..." && \
-    curl -L -O "${SUSE_REPO}repodata/repomd.xml" && \
+    curl -L -O "${TUMBLEWEED_REPO}repodata/repomd.xml" && \
     for METADATA_TYPE in primary filelists other; do \
         echo "Searching for latest ${METADATA_TYPE}.xml.zst..." && \
         FULL_URL=$( \
-            curl -sL "${SUSE_REPO}repodata/" | \
+            curl -sL "${TUMBLEWEED_REPO}repodata/" | \
             grep -oP '[0-9a-f]{40}-'"${METADATA_TYPE}"'\.xml\.zst' | \
             head -n 1 | \
-            awk -v repo="${SUSE_REPO}repodata/" '{print repo $1}' \
+            awk -v repo="${TUMBLEWEED_REPO}repodata/" '{print repo $1}' \
         ) && \
         if [ -n "$FULL_URL" ]; then \
             echo "Downloading ${FULL_URL}..." && \


### PR DESCRIPTION
## What does this PR change?

This pull request updates the `server-all-in-one-dev/Dockerfile` to improve platform-specific handling for repository setup and RPM mirroring. The main focus is on making architecture and platform detection more robust and dynamic, reducing duplication and errors, and ensuring that the correct repositories and packages are used for both `amd64` and `arm64` builds.

**Platform and architecture handling:**

* Switched from using `TARGETARCH` to `TARGETPLATFORM` for architecture detection, and now dynamically derives `TARGETARCH` from `TARGETPLATFORM` for better compatibility with Docker build arguments.
* Refactored environment variable setup and repository paths to use dynamic exports based on the detected architecture, ensuring correct repository URLs and package selection for both `amd64` and `arm64`. [[1]](diffhunk://#diff-9bc837d1bb5e3d1b4e816df9aafa5661efe74befed7a8d3883aa347e0c2ce7acL5-R36) [[2]](diffhunk://#diff-9bc837d1bb5e3d1b4e816df9aafa5661efe74befed7a8d3883aa347e0c2ce7acL57-R82)

**Repository and package management:**

* Updated all `zypper addrepo` commands to use `--no-gpgcheck --refresh` for more reliable repository addition, and added new logic to select the correct Node.js and Tumbleweed repositories based on the architecture.
* Improved RPM mirroring logic to dynamically set the correct paths and repository URLs for both architectures, and removed Node.js and npm from the package mirroring loop (these are now installed via zypper).

**Metadata download fixes:**

* Replaced all usage of the old `SUSE_REPO` variable with the new `TUMBLEWEED_REPO` for metadata downloads, ensuring consistency and correctness in fetching `repomd.xml` and related files.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
