### PR TITLE
chore: replaced all improper usages of replaceAll with replace

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/filediff/RhnHtmlDiffWriter.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/filediff/RhnHtmlDiffWriter.java
@@ -136,7 +136,7 @@ public class RhnHtmlDiffWriter implements DiffWriter, DiffVisitor {
                 //myself, ... the easy way.
                 buffy.append(StringEscapeUtils
                         .escapeHtml4(line.substring(0, CHARS_PER_LINE))
-                        .replaceAll(" ", "&nbsp;"));
+                        .replace(" ", "&nbsp;"));
                 buffy.append("<br />");
                 for (int p = 0; p < formatter.getMinimumIntegerDigits() + 1; p++) {
                     buffy.append("&nbsp;");
@@ -145,7 +145,7 @@ public class RhnHtmlDiffWriter implements DiffWriter, DiffVisitor {
                 numWritten++;
             }
             buffy.append(StringEscapeUtils.escapeHtml4(line)
-                    .replaceAll(" ", "&nbsp;"));
+                    .replace(" ", "&nbsp;"));
             buffy.append("<br />");
             numWritten++;
             linenum++;

--- a/java/core/src/main/java/com/redhat/rhn/domain/action/salt/StateResult.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/salt/StateResult.java
@@ -66,7 +66,7 @@ public class StateResult {
                 }
                 else {
                     changes = YamlHelper.INSTANCE.dump(val);
-                    changes = changes.replaceAll("\\\\n", "\n");
+                    changes = changes.replace("\\\\n", "\n");
                 }
                 break;
             case "comment":

--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupAction.java
@@ -123,7 +123,7 @@ public class ErrataDetailsSetupAction extends RhnAction {
         StringBuilder buf = new StringBuilder();
         buf.append("<a href=\"/rhn/oval?errata=").append(errataId).append("\">");
         String name = ef.getOwningErrata().getAdvisoryName().toLowerCase();
-        name = name.replaceAll(":", "");
+        name = name.replace(":", "");
         buf.append("com.redhat.").append(name).append(".xml");
         buf.append("</a>");
         retval = buf.toString();

--- a/java/core/src/main/java/com/redhat/rhn/frontend/dto/kickstart/KickstartOptionValue.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/dto/kickstart/KickstartOptionValue.java
@@ -76,7 +76,7 @@ public class KickstartOptionValue implements Comparable<KickstartOptionValue> {
      */
     public String getArg() {
         if (arg != null) {
-            return arg.replaceAll("\"", "&quot;");
+            return arg.replace("\"", "&quot;");
         }
         return arg;
     }

--- a/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
@@ -113,9 +113,9 @@ public class DateTimePickerTag extends TagSupport {
             .replaceAll("(^|[^M])MM([^M]|$)", "$1mm$2")
             .replaceAll("(^|[^M])M([^M]|$)", "$1m$2")
             .replaceAll("MMMM+", "MM")
-            .replaceAll("MMM", "M")
+            .replace("MMM", "M")
             .replaceAll("DD+", "dd")
-            .replaceAll("D", "d")
+            .replace("D", "d")
             .replaceAll("EEEE+", "DD")
             .replaceAll("E+", "D")
             .replaceAll("(^|[^y])y{1,3}([^y]|$)", "$1yy$2")
@@ -140,10 +140,10 @@ public class DateTimePickerTag extends TagSupport {
             .replaceAll("hh+", "h")
             // k (1-24) not supported, convert to the 0-23 format
             .replaceAll("kk+", "H")
-            .replaceAll("k", "G")
+            .replace("k", "G")
             // K (0-11) not supported, convert to the 1-12 format
             .replaceAll("KK+", "h")
-            .replaceAll("K", "g")
+            .replace("K", "g")
             .replaceAll("m+", "i")
             .replaceAll("s+", "s")
             // ignore others

--- a/java/core/src/main/java/com/suse/manager/errata/AlibabaErrataParser.java
+++ b/java/core/src/main/java/com/suse/manager/errata/AlibabaErrataParser.java
@@ -31,6 +31,6 @@ public class AlibabaErrataParser extends AbstractSimpleErrataParser {
     // Alibaba does not use ':' in the url and uses lower case
     @Override
     protected String getAdvisoryCode(String errataAdvisory) {
-        return errataAdvisory.toLowerCase().replaceAll(":", "");
+        return errataAdvisory.toLowerCase().replace(":", "");
     }
 }

--- a/java/core/src/main/java/com/suse/manager/errata/AlmaLinuxErrataParser.java
+++ b/java/core/src/main/java/com/suse/manager/errata/AlmaLinuxErrataParser.java
@@ -36,6 +36,6 @@ public class AlmaLinuxErrataParser extends AbstractSimpleErrataParser {
     // AlmaLinux is using '-' in place of ':' in the url
     @Override
     protected String getAdvisoryCode(String errataAdvisory) {
-        return errataAdvisory.replaceAll(":", "-");
+        return errataAdvisory.replace(":", "-");
     }
 }

--- a/java/core/src/main/java/com/suse/manager/utils/SaltUtils.java
+++ b/java/core/src/main/java/com/suse/manager/utils/SaltUtils.java
@@ -882,7 +882,7 @@ public class SaltUtils {
         target.rewind();
 
         UUID uuidSwap = new UUID(target.getLong(), target.getLong());
-        return uuidSwap.toString().replaceAll("-", "");
+        return uuidSwap.toString().replace("-", "");
     }
 
     private static JsonElement parseJsonError(SaltError message) {

--- a/java/core/src/main/java/com/suse/manager/webui/Languages.java
+++ b/java/core/src/main/java/com/suse/manager/webui/Languages.java
@@ -46,7 +46,7 @@ public enum Languages {
      */
     public static String t(String key, Object... args) {
         /* Short-circuit LocalizationService.getMessage() assuming always en_US */
-        String escapedKey = key.replaceAll("'", "''");
+        String escapedKey = key.replace("'", "''");
         return new MessageFormat(escapedKey, Locale.US).format(args);
     }
 }


### PR DESCRIPTION
## What does this PR change?

The pr changes all improper String#replaceAll usages in the codebase as signaled by sonarcloud.
I ignored proper usages stated by the [sonar rule](https://sonarcloud.io/organizations/uyuni-project/rules?open=java%3AS5361&rule_key=java%3AS5361), aka usages where first argument is actually a regular expression, which were not included in the [issues](https://sonarcloud.io/project/issues?languages=java&issueStatuses=OPEN%2CCONFIRMED&id=uyuni-project_uyuni&rules=java%3AS5361) in any case. 

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: tests still passing

- [x] **DONE**

## Links

Issue(s): #9945

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
