### PR TITLE
chore: removed all col-xs references and verified there are no visual regressions

### DIFF
--- a/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials-list.jsp
+++ b/java/code/webapp/WEB-INF/pages/admin/setup/mirror-credentials-list.jsp
@@ -12,7 +12,7 @@
         </div>
         <div class="panel-footer">
             <div class="row">
-                <div class="text-left col-10 col-xs-10 d-flex">
+                <div class="text-left col-10 d-flex">
                     <span id="verify-${current.id}" class="d-flex"></span>
                     <span id="primary-${current.id}">
                         <c:if test="${current.primary}">
@@ -44,7 +44,7 @@
                         <rhn:icon type="setup-wizard-creds-edit" title="mirror-credentials.jsp.edit" />
                     </button>
                 </div>
-                <div class="text-right col-2 col-xs-2">
+                <div class="text-right col-2">
                     <span id="delete-${current.id}">
                         <button type="button"
                             data-id="<c:out value='${current.id}' />"

--- a/java/code/webapp/WEB-INF/pages/configuration/files/deletefile.jsp
+++ b/java/code/webapp/WEB-INF/pages/configuration/files/deletefile.jsp
@@ -20,21 +20,21 @@
       <ul class="list-group">
         <li class="list-group-item">
           <div class="row">
-            <div class="col-1 col-xs-1 col-sm-2"><strong><bean:message key="deleterev.jsp.channelname" /></strong></div>
-            <div class="col-11 col-xs-11 col-sm-10">${file.configChannel.displayName}</div>
+            <div class="col-1 col-sm-2"><strong><bean:message key="deleterev.jsp.channelname" /></strong></div>
+            <div class="col-11 col-sm-10">${file.configChannel.displayName}</div>
           </div>
         </li>
         <li class="list-group-item">
           <div class="row">
-            <div class="col-1 col-xs-1 col-sm-2"><strong><bean:message key="deleterev.jsp.revisionpath" /></strong></div>
-            <div class="col-11 col-xs-11 col-sm-10">${file.configFileName.path}</div>
+            <div class="col-1 col-sm-2"><strong><bean:message key="deleterev.jsp.revisionpath" /></strong></div>
+            <div class="col-11 col-sm-10">${file.configFileName.path}</div>
           </div>
         </li>
         <c:if test="${!revision.directory}">
           <li class="list-group-item">
             <div class="row">
-              <div class="col-1 col-xs-1 col-sm-2"><strong><bean:message key="deletefile.jsp.totalspace" /></strong></div>
-              <div class="col-11 col-xs-11 col-sm-10">${storage}</div>
+              <div class="col-1 col-sm-2"><strong><bean:message key="deletefile.jsp.totalspace" /></strong></div>
+              <div class="col-11 col-sm-10">${storage}</div>
             </div>
           </li>
         </c:if>

--- a/java/code/webapp/WEB-INF/pages/configuration/files/deleterev.jsp
+++ b/java/code/webapp/WEB-INF/pages/configuration/files/deleterev.jsp
@@ -24,20 +24,20 @@
       <ul class="list-group">
         <li class="list-group-item">
           <div class="row">
-            <div class="col-1 col-xs-1 col-sm-2"><strong><bean:message key="deleterev.jsp.channelname" /></strong></div>
-            <div class="col-11 col-xs-11 col-sm-10">${file.configChannel.displayName}</div>
+            <div class="col-1 col-sm-2"><strong><bean:message key="deleterev.jsp.channelname" /></strong></div>
+            <div class="col-11 col-sm-10">${file.configChannel.displayName}</div>
           </div>
         </li>
         <li class="list-group-item">
           <div class="row">
-            <div class="col-1 col-xs-1 col-sm-2"><strong><bean:message key="deleterev.jsp.revisionpath" /></strong></div>
-            <div class="col-11 col-xs-11 col-sm-10">${file.configFileName.path}</div>
+            <div class="col-1 col-sm-2"><strong><bean:message key="deleterev.jsp.revisionpath" /></strong></div>
+            <div class="col-11 col-sm-10">${file.configFileName.path}</div>
           </div>
         </li>
         <li class="list-group-item">
           <div class="row">
-            <div class="col-1 col-xs-1 col-sm-2"><strong><bean:message key="deleterev.jsp.revision" /></strong></div>
-            <div class="col-11 col-xs-11 col-sm-10">${revision.revision}</div>
+            <div class="col-1 col-sm-2"><strong><bean:message key="deleterev.jsp.revision" /></strong></div>
+            <div class="col-11 col-sm-10">${revision.revision}</div>
           </div>
         </li>
       </ul>

--- a/web/html/src/manager/admin/payg-shared/info/payg-info-view.tsx
+++ b/web/html/src/manager/admin/payg-shared/info/payg-info-view.tsx
@@ -11,18 +11,18 @@ const PaygInfoView = (props: Props) => {
   return (
     <React.Fragment>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Description")}</dt>
-        <dd className="col-10 col-xs-10">{props.payg.properties.description}</dd>
+        <dt className="col-2">{t("Description")}</dt>
+        <dd className="col-10">{props.payg.properties.description}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Status")}</dt>
-        <dd className="col-10 col-xs-10">
+        <dt className="col-2">{t("Status")}</dt>
+        <dd className="col-10">
           <PaygStatus status={props.payg.status} statusMessage={props.payg.statusMessage} />
         </dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Last Status Update")}</dt>
-        <dd className="col-10 col-xs-10">{props.payg.lastChange}</dd>
+        <dt className="col-2">{t("Last Status Update")}</dt>
+        <dd className="col-10">{props.payg.lastChange}</dd>
       </dl>
     </React.Fragment>
   );

--- a/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-view.tsx
+++ b/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-view.tsx
@@ -12,32 +12,32 @@ const PaygShhDataView = (props: Props) => {
   return (
     <div>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Host")}</dt>
-        <dd className="col-10 col-xs-10">{props.isInstance ? props.payg.host : props.payg.bastion_host}</dd>
+        <dt className="col-2">{t("Host")}</dt>
+        <dd className="col-10">{props.isInstance ? props.payg.host : props.payg.bastion_host}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("SSH Port")}</dt>
-        <dd className="col-10 col-xs-10">{props.isInstance ? props.payg.port : props.payg.bastion_port}</dd>
+        <dt className="col-2">{t("SSH Port")}</dt>
+        <dd className="col-10">{props.isInstance ? props.payg.port : props.payg.bastion_port}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("User")}</dt>
-        <dd className="col-10 col-xs-10">{props.isInstance ? props.payg.username : props.payg.bastion_username}</dd>
+        <dt className="col-2">{t("User")}</dt>
+        <dd className="col-10">{props.isInstance ? props.payg.username : props.payg.bastion_username}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Password")}</dt>
-        <dd className="col-10 col-xs-10">
+        <dt className="col-2">{t("Password")}</dt>
+        <dd className="col-10">
           {(props.isInstance ? props.payg.password : props.payg.bastion_password) || passHidden}
         </dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("SSH Private Key")}</dt>
-        <dd className="col-10 col-xs-10" style={{ whiteSpace: "pre-wrap" }}>
+        <dt className="col-2">{t("SSH Private Key")}</dt>
+        <dd className="col-10" style={{ whiteSpace: "pre-wrap" }}>
           {(props.isInstance ? props.payg.key : props.payg.bastion_key) || passHidden}
         </dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("SSH Private Key Passphrase")}</dt>
-        <dd className="col-10 col-xs-10">
+        <dt className="col-2">{t("SSH Private Key Passphrase")}</dt>
+        <dd className="col-10">
           {(props.isInstance ? props.payg.key_password : props.payg.bastion_key_password) || passHidden}
         </dd>
       </dl>

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
@@ -36,16 +36,16 @@ const EnvironmentView = React.memo((props: Props) => {
   return (
     <React.Fragment>
       <dl className="row">
-        <dt className="col-3 col-xs-3">{t("Label")}:</dt>
-        <dd className="col-9 col-xs-9">{props.environment.label}</dd>
+        <dt className="col-3">{t("Label")}:</dt>
+        <dd className="col-9">{props.environment.label}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-3 col-xs-3">{t("Description")}:</dt>
-        <dd className="col-9 col-xs-9">{props.environment.description}</dd>
+        <dt className="col-3">{t("Description")}:</dt>
+        <dd className="col-9">{props.environment.description}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-3 col-xs-3">{t("Version")}:</dt>
-        <dd className="col-9 col-xs-9">
+        <dt className="col-3">{t("Version")}:</dt>
+        <dd className="col-9">
           <BuildVersion
             id={`${props.environment.version}_${props.environment.id}`}
             text={getVersionMessageByNumber(props.environment.version, props.historyEntries) || t("not built")}
@@ -54,8 +54,8 @@ const EnvironmentView = React.memo((props: Props) => {
       </dl>
       {props.environment.version > 0 ? (
         <dl className="row">
-          <dt className="col-3 col-xs-3">{t("Status")}:</dt>
-          <dd className="col-9 col-xs-9">
+          <dt className="col-3">{t("Status")}:</dt>
+          <dd className="col-9">
             {environmentStatusEnum[props.environment.status].text}
             &nbsp;
             {environmentStatusEnum[props.environment.status].isBuilding && (
@@ -66,8 +66,8 @@ const EnvironmentView = React.memo((props: Props) => {
       ) : null}
       {props.environment.status === environmentStatusEnum.built.key && !_isEmpty(props.environment.builtTime) ? (
         <dl className="row">
-          <dt className="col-3 col-xs-3">{t("Built time")}:</dt>
-          <dd className="col-9 col-xs-9">{props.environment.builtTime}</dd>
+          <dt className="col-3">{t("Built time")}:</dt>
+          <dd className="col-9">{props.environment.builtTime}</dd>
         </dl>
       ) : null}
     </React.Fragment>

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.tsx
@@ -77,8 +77,8 @@ const Promote = (props: Props) => {
           ) : (
             <React.Fragment>
               <dl className="row">
-                <dt className="col-4 col-xs-4">{t("Version")}:</dt>
-                <dd className="col-8 col-xs-8">
+                <dt className="col-4">{t("Version")}:</dt>
+                <dd className="col-8">
                   <BuildVersion
                     id={`${props.environmentPromote.version}_promote_${props.environmentTarget.id}`}
                     text={
@@ -89,8 +89,8 @@ const Promote = (props: Props) => {
                 </dd>
               </dl>
               <dl className="row">
-                <dt className="col-4 col-xs-4">{t("Target environment")}:</dt>
-                <dd className="col-8 col-xs-8">{props.environmentTarget.name}</dd>
+                <dt className="col-4">{t("Target environment")}:</dt>
+                <dd className="col-8">{props.environmentTarget.name}</dd>
               </dl>
             </React.Fragment>
           )

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.tsx
@@ -36,20 +36,20 @@ const PropertiesView = (props: Props) => {
   return (
     <div>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Name")}</dt>
-        <dd className="col-10 col-xs-10">{propertiesToShow.name}</dd>
+        <dt className="col-2">{t("Name")}</dt>
+        <dd className="col-10">{propertiesToShow.name}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Label:")}</dt>
-        <dd className="col-6 col-xs-6">{propertiesToShow.label}</dd>
+        <dt className="col-2">{t("Label:")}</dt>
+        <dd className="col-6">{propertiesToShow.label}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Description")}</dt>
-        <dd className="col-10 col-xs-10">{propertiesToShow.description}</dd>
+        <dt className="col-2">{t("Description")}</dt>
+        <dd className="col-10">{propertiesToShow.description}</dd>
       </dl>
       <dl className="row">
-        <dt className="col-2 col-xs-2">{t("Versions history:")}</dt>
-        <dd className="col-10 col-xs-10">
+        <dt className="col-2">{t("Versions history:")}</dt>
+        <dd className="col-10">
           <PropertiesHistoryEntries
             id="resume"
             entries={propertiesToShow.historyEntries.slice(0, NUMBER_HISTORY_ENTRIES)}

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
@@ -144,16 +144,16 @@ const Sources = (props: SourcesProps) => {
           {messages.messages}
           {props.softwareSources.length > 0 && (
             <Panel headingLevel="h4" title={t("Software Channels")}>
-              <div className="col-12 col-xs-12">
+              <div className="col-12">
                 <React.Fragment>
                   <dl className="row">
-                    <dt className="col-2 col-xs-2">Base Channel:</dt>
-                    <dd className="col-10 col-xs-10">{renderSourceEntry(props.softwareSources[0])}</dd>
+                    <dt className="col-2">Base Channel:</dt>
+                    <dd className="col-10">{renderSourceEntry(props.softwareSources[0])}</dd>
                   </dl>
 
                   <dl className="row">
-                    <dt className="col-2 col-xs-2">Child Channels:</dt>
-                    <dd className="col-6 col-xs-6">
+                    <dt className="col-2">Child Channels:</dt>
+                    <dd className="col-6">
                       <ul className="list-unstyled">
                         {props.softwareSources.slice(1, props.softwareSources.length).map((source) => (
                           <li key={`softwareSources_entry_${source.channelId}`}>{renderSourceEntry(source)}</li>

--- a/web/html/src/manager/minion/ansible/accordion-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/accordion-path-content.tsx
@@ -127,8 +127,8 @@ class AccordionPathContent extends React.Component<PropsType, StateType> {
       <div key={p.toString() + "_" + i.toString()}>
         {i === 0 ? <br /> : null}
         <dl className="row">
-          <dt className="col-2 col-xs-2">{t("Playbook File Name")}:</dt>
-          <dd className="col-8 col-xs-8">
+          <dt className="col-2">{t("Playbook File Name")}:</dt>
+          <dd className="col-8">
             <Button
               icon="fa-file-text-o"
               text={p.name}
@@ -138,12 +138,12 @@ class AccordionPathContent extends React.Component<PropsType, StateType> {
           </dd>
         </dl>
         <dl className="row">
-          <dt className="col-2 col-xs-2">{t("Full Path")}:</dt>
-          <dd className="col-8 col-xs-8">{p.fullPath}</dd>
+          <dt className="col-2">{t("Full Path")}:</dt>
+          <dd className="col-8">{p.fullPath}</dd>
         </dl>
         <dl className="row">
-          <dt className="col-2 col-xs-2">{t("Custom Inventory")}:</dt>
-          <dd className="col-8 col-xs-8">{p.customInventory}</dd>
+          <dt className="col-2">{t("Custom Inventory")}:</dt>
+          <dd className="col-8">{p.customInventory}</dd>
         </dl>
         {i < content.length - 1 ? <hr /> : null}
       </div>
@@ -163,8 +163,8 @@ class AccordionPathContent extends React.Component<PropsType, StateType> {
       <div>
         <br />
         <dl className="row">
-          <dt className="col-2 col-xs-2">{t("Registered Systems")}:</dt>
-          <dd className="col-8 col-xs-8">
+          <dt className="col-2">{t("Registered Systems")}:</dt>
+          <dd className="col-8">
             <ul>
               {content?.knownSystems.map((s) => (
                 <li key={s.id + "_" + s.name}>
@@ -175,8 +175,8 @@ class AccordionPathContent extends React.Component<PropsType, StateType> {
           </dd>
         </dl>
         <dl className="row">
-          <dt className="col-2 col-xs-2">{t("Unknown Hostnames")}:</dt>
-          <dd className="col-8 col-xs-8">
+          <dt className="col-2">{t("Unknown Hostnames")}:</dt>
+          <dd className="col-8">
             <ul>
               {content?.unknownSystems.map((s) => (
                 <li key={s + "_hostname"}>

--- a/web/html/src/manager/systems/details/mgr-server-info.tsx
+++ b/web/html/src/manager/systems/details/mgr-server-info.tsx
@@ -80,30 +80,30 @@ class MgrServer extends React.Component<Props, State> {
           <div className="panel panel-default">
             <div className="panel-body">
               <dl className="row">
-                <dt className="col-2 col-xs-2">{t("Name")}</dt>
-                <dd className="col-10 col-xs-10">{this.props.name}</dd>
+                <dt className="col-2">{t("Name")}</dt>
+                <dd className="col-10">{this.props.name}</dd>
               </dl>
               <dl className="row">
-                <dt className="col-2 col-xs-2">{t("Version")}</dt>
-                <dd className="col-10 col-xs-10">{this.props.version}</dd>
+                <dt className="col-2">{t("Version")}</dt>
+                <dd className="col-10">{this.props.version}</dd>
               </dl>
               <dl className="row">
-                <dt className="col-2 col-xs-2">{t("Report Database Name")}</dt>
-                <dd className="col-10 col-xs-10">{this.props.reportDbName}</dd>
+                <dt className="col-2">{t("Report Database Name")}</dt>
+                <dd className="col-10">{this.props.reportDbName}</dd>
               </dl>
               <dl className="row">
-                <dt className="col-2 col-xs-2">{t("Report Database Host")}</dt>
-                <dd className="col-10 col-xs-10">
+                <dt className="col-2">{t("Report Database Host")}</dt>
+                <dd className="col-10">
                   {this.props.reportDbHost}:{this.props.reportDbPort}
                 </dd>
               </dl>
               <dl className="row">
-                <dt className="col-2 col-xs-2">{t("Report Database User")}</dt>
-                <dd className="col-10 col-xs-10">{this.props.reportDbUser}</dd>
+                <dt className="col-2">{t("Report Database User")}</dt>
+                <dd className="col-10">{this.props.reportDbUser}</dd>
               </dl>
               <dl className="row">
-                <dt className="col-2 col-xs-2">{t("Report Database Last Synced")}</dt>
-                <dd className="col-10 col-xs-10">{this.props.reportDbLastSynced}</dd>
+                <dt className="col-2">{t("Report Database Last Synced")}</dt>
+                <dd className="col-10">{this.props.reportDbLastSynced}</dd>
               </dl>
             </div>
           </div>


### PR DESCRIPTION
## What does this PR change?

This PR deletes the -xs- column modifiers from the codebase where present. I checked bootstrap version and went ahead with the removal of the modifiers since it seems project's using 5.3.2 at the moment.

I also confirmed there are no visual regression, but I think an extra check might be needed just to be sure.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #8949

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
