### PR TITLE
QE: Revert Docker image building changes

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -4,6 +4,8 @@
 # This feature depends on:
 # - features/secondary/min_docker_api.feature
 
+# TODO: Review why this test is failing now on GH validation, and have it back ASAP
+@skip_if_github_validation
 @build_host
 @scope_building_container_images
 @auth_registry

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -12,6 +12,8 @@
 # - features/secondary/min_salt_install_with_staging.feature
 # Due to the images listed in the CVE Audit images
 
+# TODO: Review why this test is failing now on GH validation, and have it back ASAP
+@skip_if_github_validation
 @build_host
 @scope_building_container_images
 @scope_cve_audit


### PR DESCRIPTION
## What does this PR change?

This pull request temporarily disables two test scenarios that are currently failing during GitHub validation. The tests have been marked with a skip tag and a TODO comment to prompt future review and re-enablement.

Test scenario adjustments:

* Added the `@skip_if_github_validation` tag and a TODO comment to the `buildhost_docker_auth_registry.feature` scenario to skip it during GitHub validation.
* Added the `@skip_if_github_validation` tag and a TODO comment to the `buildhost_docker_build_image.feature` scenario to skip it during GitHub validation.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were skipped

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
