### PR TITLE
chore: remove redundant react imports using update-react-imports command

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -107,18 +107,25 @@ export default defineConfig([
               name: "node-gettext",
               message: "Please import from `core/intl/node-gettext` instead.",
             },
+
             {
               name: "formik",
               importNames: ["Field", "Form"],
               message: "Please import from `components/formik` instead.",
             },
+            // TODO: List everything we want to limit once the implementation is done
+            // {
+            //   name: "formik",
+            //   importNames: ["Field", "Form"],
+            //   // TODO: Update message once we move the directory to where it should be
+            //   message: "Please import from `components/formik` instead.",
+            // },
+            {
+              name: "react",
+              importNames: ["default"],
+              message: "Not needed anymore thanks to JSX transform.",
+            },
           ],
-        },
-      ],
-      "react/jsx-pascal-case": [
-        "error",
-        {
-          ignore: ["DEPRECATED_*"],
         },
       ],
     },

--- a/web/html/src/components/CoCoScansList.tsx
+++ b/web/html/src/components/CoCoScansList.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Messages, MessageType, Utils as MessagesUtils } from "components/messages/messages";
 import { TopPanel } from "components/panels/TopPanel";
@@ -32,7 +32,7 @@ type State = {
   activeTab?: string;
 };
 
-class CoCoScansList extends React.Component<Props, State> {
+class CoCoScansList extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Button } from "components/buttons";
 import { Messages, MessageType } from "components/messages/messages";
@@ -75,7 +75,7 @@ type State = {
   loading: boolean;
 };
 
-class FormulaForm extends React.Component<Props, State> {
+class FormulaForm extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/web/html/src/components/action-schedule.tsx
+++ b/web/html/src/components/action-schedule.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { DateTimePicker } from "components/datetime";
 import { Loading } from "components/utils/loading/Loading";
@@ -45,7 +45,7 @@ type ActionScheduleState = {
   actionType: string;
 };
 
-class ActionSchedule extends React.Component<ActionScheduleProps, ActionScheduleState> {
+class ActionSchedule extends Component<ActionScheduleProps, ActionScheduleState> {
   newActionChainOpt = { id: Number(0), text: t("new action chain") };
 
   constructor(props: ActionScheduleProps) {

--- a/web/html/src/components/action/ActionStatus.tsx
+++ b/web/html/src/components/action/ActionStatus.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 type Props = {
   /** ID of the server the action is running on */
   serverId: string;

--- a/web/html/src/components/buttons/index.tsx
+++ b/web/html/src/components/buttons/index.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-
+import { type HTMLProps, type ReactNode, Component } from "react";
 /**
  * Various HTML button components.
  * @module buttons
@@ -7,9 +6,9 @@ import * as React from "react";
 
 type BaseProps = {
   /** Text to display on the button. */
-  text?: React.ReactNode;
+  text?: ReactNode;
   /** Text to display on the button. */
-  children?: React.ReactNode;
+  children?: ReactNode;
   /**
    * FontAwesome icon class of the button. Can also include additional FA classes
    * (sizing, animation etc.).
@@ -38,7 +37,7 @@ type BaseState = Record<string, any>;
 /**
  * Base class for button components.
  */
-class _ButtonBase<P extends BaseProps = BaseProps, S extends BaseState = BaseState> extends React.Component<P, S> {
+class _ButtonBase<P extends BaseProps = BaseProps, S extends BaseState = BaseState> extends Component<P, S> {
   renderIcon() {
     const text = this.props.text ?? this.props.children;
     const margin = text ? "" : " no-margin";
@@ -230,7 +229,7 @@ export class LinkButton extends _ButtonBase<LinkProps> {
         }
       : {};
 
-    const targetProps: Partial<React.HTMLProps<HTMLAnchorElement>> =
+    const targetProps: Partial<HTMLProps<HTMLAnchorElement>> =
       this.props.target === "_blank"
         ? {
             target: "_blank",
@@ -292,7 +291,7 @@ type DropdownProps = BaseProps & {
   /** Callback function to execute on button click. */
   handler?: (...args: any[]) => any;
 
-  items: React.ReactNode[];
+  items: ReactNode[];
 };
 
 /**

--- a/web/html/src/components/coco-attestation/CoCoAttestationTable.tsx
+++ b/web/html/src/components/coco-attestation/CoCoAttestationTable.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { pageSize } from "core/user-preferences";
 
@@ -18,7 +18,7 @@ type Props = {
   onReportDetails: (report: AttestationReport) => void;
 };
 
-class CoCoAttestationTable extends React.Component<Props> {
+class CoCoAttestationTable extends Component<Props> {
   public static readonly defaultProps: Partial<Props> = {
     showSystem: true,
   };

--- a/web/html/src/components/coco-attestation/CoCoReport.tsx
+++ b/web/html/src/components/coco-attestation/CoCoReport.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { ActionLink, SystemLink } from "../links";
 import { TabContainer } from "../tab-container";
@@ -14,7 +14,7 @@ type State = {
   activeTabHash: string;
 };
 
-class CoCoReport extends React.Component<Props, State> {
+class CoCoReport extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/web/html/src/components/coco-attestation/CoCoResult.tsx
+++ b/web/html/src/components/coco-attestation/CoCoResult.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { AttestationResult, renderTime } from "./Utils";
 
@@ -7,7 +7,7 @@ type Props = {
   result: AttestationResult;
 };
 
-class CoCoResult extends React.Component<Props> {
+class CoCoResult extends Component<Props> {
   render = () => {
     const result = this.props.result;
     return (

--- a/web/html/src/components/coco-attestation/CoCoSettingsForm.tsx
+++ b/web/html/src/components/coco-attestation/CoCoSettingsForm.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { AsyncButton, Button } from "../buttons";
 import { BootstrapPanel } from "../panels/BootstrapPanel";
@@ -15,7 +15,7 @@ type Props = {
 
 type State = Settings;
 
-class CoCoSettingsForm extends React.Component<Props, State> {
+class CoCoSettingsForm extends Component<Props, State> {
   public static readonly defaultProps: Partial<Props> = {
     showOnScheduleOption: true,
   };
@@ -68,7 +68,7 @@ class CoCoSettingsForm extends React.Component<Props, State> {
     });
   };
 
-  render(): React.ReactNode {
+  render(): ReactNode {
     return (
       <>
         <BootstrapPanel>

--- a/web/html/src/components/coco-attestation/Utils.tsx
+++ b/web/html/src/components/coco-attestation/Utils.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { ReactNode } from "react";
 
 import { FromNow } from "components/datetime";
 import { CronTimes, RecurringType } from "components/picker/recurring-event-picker";
@@ -44,7 +44,7 @@ export type AttestationReport = {
   results: AttestationResult[];
 };
 
-export function renderTime(time: Date): React.ReactNode {
+export function renderTime(time: Date): ReactNode {
   if (time === null) {
     return t("N/A");
   }
@@ -52,7 +52,7 @@ export function renderTime(time: Date): React.ReactNode {
   return <FromNow value={time} />;
 }
 
-export function renderStatus(status: string, description: string): React.ReactNode {
+export function renderStatus(status: string, description: string): ReactNode {
   let icon, textStyle;
 
   switch (status) {

--- a/web/html/src/components/combobox.tsx
+++ b/web/html/src/components/combobox.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import Creatable from "react-select/creatable";
 
@@ -33,7 +33,7 @@ type ComboboxState = {
   focused: boolean;
 };
 
-export class Combobox extends React.Component<ComboboxProps, ComboboxState> {
+export class Combobox extends Component<ComboboxProps, ComboboxState> {
   onChange = (selectedOption: ReactSelectItem) => {
     if (selectedOption.id && selectedOption.value) {
       return this.props.onSelect({

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { StatesPicker } from "components/states-picker";
 
@@ -14,7 +14,7 @@ class ConfigChannelsState {
   messages: MessageType[] | null = null;
 }
 
-class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannelsState> {
+class ConfigChannels extends Component<ConfigChannelsProps, ConfigChannelsState> {
   state = new ConfigChannelsState();
 
   setMessages = (messages) => {

--- a/web/html/src/components/custom-objects.tsx
+++ b/web/html/src/components/custom-objects.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 type Props = {
   width: string;
@@ -10,7 +10,7 @@ type Props = {
 
   title?: string;
 
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export const CustomDiv = (props: Props) => {

--- a/web/html/src/components/datetime/DEPRECATED_DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DEPRECATED_DateTimePicker.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component, PureComponent } from "react";
 
 import { localizedMoment } from "utils";
 
@@ -54,7 +54,7 @@ type DatePickerProps = {
   onDateChanged: (year: number, month: number, date: number) => void;
 };
 
-class DatePicker extends React.PureComponent<DatePickerProps> {
+class DatePicker extends PureComponent<DatePickerProps> {
   _input: JQuery | null = null;
 
   componentDidMount() {
@@ -147,7 +147,7 @@ type TimePickerProps = {
   onTimeChanged: (hours: number, minutes: number, seconds: number) => void;
 };
 
-class TimePicker extends React.PureComponent<TimePickerProps> {
+class TimePicker extends PureComponent<TimePickerProps> {
   _input: JQuery | null = null;
 
   componentDidMount() {
@@ -252,7 +252,7 @@ type DateTimePickerState = {
   timeZone: typeof localizedMoment.userTimeZone | typeof localizedMoment.serverTimeZone;
 };
 
-export class DEPRECATED_DateTimePicker extends React.Component<DateTimePickerProps, DateTimePickerState> {
+export class DEPRECATED_DateTimePicker extends Component<DateTimePickerProps, DateTimePickerState> {
   constructor(props: DateTimePickerProps) {
     super(props);
     this.state = {

--- a/web/html/src/components/datetime/DateTimePicker.test.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { localizedMoment } from "utils";

--- a/web/html/src/components/datetime/FromNow.test.tsx
+++ b/web/html/src/components/datetime/FromNow.test.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { render, screen } from "utils/test-utils";
 
 import { FromNow } from "./FromNow";

--- a/web/html/src/components/datetime/timeProps.ts
+++ b/web/html/src/components/datetime/timeProps.ts
@@ -1,6 +1,6 @@
-import * as React from "react";
+import type { HTMLProps } from "react";
 
-export const getTimeProps = (value: moment.Moment): Partial<React.HTMLProps<HTMLTimeElement>> => {
+export const getTimeProps = (value: moment.Moment): Partial<HTMLProps<HTMLTimeElement>> => {
   /**
    * NB! This needs to be in sync with java/code/src/com/redhat/rhn/frontend/taglibs/FormatDateTag.java
    * Convert the value to an ISO 8601, keeping the timezone offset.

--- a/web/html/src/components/dialog/ActionConfirm.tsx
+++ b/web/html/src/components/dialog/ActionConfirm.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { DangerDialog } from "./DangerDialog";
 
@@ -13,7 +13,7 @@ type Props = {
   canForce: boolean;
   forceName?: string;
   onClose: () => void;
-  children?: React.ReactNode;
+  children?: ReactNode;
   /** whether the dialog should be shown or hidden */
   isOpen: boolean;
 };
@@ -29,7 +29,7 @@ type State = {
  * Related items are passed to the 'selected' property as an array. Each
  * item is expected to have a 'name' property.
  */
-export class ActionConfirm extends React.Component<Props, State> {
+export class ActionConfirm extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {

--- a/web/html/src/components/dialog/DangerDialog.tsx
+++ b/web/html/src/components/dialog/DangerDialog.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { AsyncButton, Button } from "../buttons";
 import { Dialog, DialogProps } from "./Dialog";
 

--- a/web/html/src/components/dialog/DeleteDialog.tsx
+++ b/web/html/src/components/dialog/DeleteDialog.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { DangerDialog } from "./LegacyDangerDialog";
 import { DialogProps } from "./LegacyDialog";
 

--- a/web/html/src/components/dialog/Dialog.tsx
+++ b/web/html/src/components/dialog/Dialog.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-
+import type { ReactNode } from "react";
 import ReactModal from "react-modal";
 
 export type DialogProps = {
@@ -12,11 +11,11 @@ export type DialogProps = {
   /** The css className for the 'modal-dialog' div */
   className?: string;
   /** Title of the dialog */
-  title?: React.ReactNode;
+  title?: ReactNode;
   /** The body of the popup */
-  content?: React.ReactNode;
+  content?: ReactNode;
   /** The footer content of the dialog. Usually buttons. */
-  footer?: React.ReactNode;
+  footer?: ReactNode;
   /** Should the dialog show a header with a title. Defaults to False */
   hideHeader?: boolean;
   /** Can the modal be closed using the cross button, ESC or by clicking on the overlay? */

--- a/web/html/src/components/dialog/LegacyDangerDialog.tsx
+++ b/web/html/src/components/dialog/LegacyDangerDialog.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { AsyncButton, Button } from "../buttons";
 import { Dialog, DialogProps } from "./LegacyDialog";
 

--- a/web/html/src/components/dialog/LegacyDialog.tsx
+++ b/web/html/src/components/dialog/LegacyDialog.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, useEffect } from "react";
 
 import { PopUp } from "../popup";
 
@@ -25,9 +25,9 @@ export function closeDialog(modalId: string) {
 export type DialogProps = {
   id: string;
   className?: string;
-  title?: React.ReactNode;
-  content?: React.ReactNode;
-  buttons?: React.ReactNode;
+  title?: ReactNode;
+  content?: ReactNode;
+  buttons?: ReactNode;
   closableModal?: boolean;
   /** Whether to automatically focus the first input in the opened modal, true by default */
   autoFocus?: boolean;
@@ -37,7 +37,7 @@ export type DialogProps = {
 export function Dialog(props: DialogProps) {
   const { onClosePopUp, buttons, ...OtherProps } = props;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (props.autoFocus === false) {
       return;
     }

--- a/web/html/src/components/dialog/ModalButton.tsx
+++ b/web/html/src/components/dialog/ModalButton.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Button, ButtonProps } from "../buttons";
 import { showDialog } from "./util";
 

--- a/web/html/src/components/dialog/ModalLink.tsx
+++ b/web/html/src/components/dialog/ModalLink.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { Button } from "components/buttons";
 
@@ -8,7 +8,7 @@ type Props = {
   id?: string;
   className?: string;
   title?: string;
-  text?: React.ReactNode;
+  text?: ReactNode;
   icon?: string;
   disabled?: boolean;
   item?: any;

--- a/web/html/src/components/dialog/action-confirm.example.tsx
+++ b/web/html/src/components/dialog/action-confirm.example.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import { useState } from "react";
 
 import { Button } from "../buttons";
 import { ActionConfirm } from "./ActionConfirm";
 
 export default () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
   const items = [{ name: "Item 1" }, { name: "Item 2" }, { name: "Item 3" }];
   const doAction = (type, toAct, params) => {
     const names = toAct.map((obj) => obj.name).join();

--- a/web/html/src/components/fields.tsx
+++ b/web/html/src/components/fields.tsx
@@ -1,11 +1,10 @@
-import * as React from "react";
-
-type Props = React.InputHTMLAttributes<HTMLInputElement> & {
-  onPressEnter?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+import { type InputHTMLAttributes, type KeyboardEvent, Component } from "react";
+type Props = InputHTMLAttributes<HTMLInputElement> & {
+  onPressEnter?: (event: KeyboardEvent<HTMLInputElement>) => void;
 };
 
-class TextField extends React.Component<Props> {
-  onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+class TextField extends Component<Props> {
+  onKeyPress = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Enter" && this.props.onPressEnter) {
       this.props.onPressEnter(event);
     }

--- a/web/html/src/components/formik/sharedFieldConfig.tsx
+++ b/web/html/src/components/formik/sharedFieldConfig.tsx
@@ -1,5 +1,4 @@
-import React, { createContext, useContext } from "react";
-
+import { type ReactNode, createContext, useContext } from "react";
 export type SharedFieldConfigType = {
   /** CSS class to use for the label */
   labelClass?: string;
@@ -19,7 +18,7 @@ const FormMetadataContext = createContext<Partial<SharedFieldConfigType>>(initia
 export const useSharedFieldConfig = () => useContext(FormMetadataContext);
 
 type Props = Partial<SharedFieldConfigType> & {
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export const SharedFieldConfigProvider = ({ children, ...rest }: Props) => (

--- a/web/html/src/components/formula-selection.tsx
+++ b/web/html/src/components/formula-selection.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { SectionToolbar } from "components/section-toolbar/section-toolbar";
 
@@ -29,7 +29,7 @@ type State = {
   errors?: MessageType[];
 };
 
-class FormulaSelection extends React.Component<Props, State> {
+class FormulaSelection extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
@@ -124,7 +124,7 @@ class FormulaSelection extends React.Component<Props, State> {
   }
 
   generateList = () => {
-    const list: React.ReactNode[] = [];
+    const list: ReactNode[] = [];
     const groups = this.state.groups;
 
     if (groups.groupless.length > 0) {

--- a/web/html/src/components/formulas/EditGroup.tsx
+++ b/web/html/src/components/formulas/EditGroup.tsx
@@ -1,6 +1,6 @@
 import "./formula-form.css";
 
-import * as React from "react";
+import { Component, Fragment } from "react";
 
 import { productName } from "core/user-preferences";
 
@@ -44,7 +44,7 @@ type EditGroupState = {
  * Base class for edit-group.
  * Based on the edit-group data, the corresponing shape of component is used.
  */
-class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
+class EditGroup extends Component<EditGroupProps, EditGroupState> {
   constructor(props: EditGroupProps) {
     super(props);
     this.state = {
@@ -146,7 +146,7 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
         </div>
         <div>
           {this.state.visible ? (
-            <React.Fragment>
+            <Fragment>
               {"$help" in this.props.element ? <p>{this.props.element.$help}</p> : null}
               <Component
                 handleRemoveItem={this.handleRemoveItem}
@@ -159,7 +159,7 @@ class EditGroup extends React.Component<EditGroupProps, EditGroupState> {
                 setSectionsExpanded={this.props.setSectionsExpanded}
                 formulaForm={this.props.formulaForm}
               />
-            </React.Fragment>
+            </Fragment>
           ) : null}
         </div>
       </div>
@@ -180,11 +180,11 @@ type EditPrimitiveGroupProps = {
  * Used for rendering edit-groups in the form of "list of primitive types",
  * to be rendered as a list of simple form elements in the UI.
  */
-class EditPrimitiveGroup extends React.Component<EditPrimitiveGroupProps> {
+class EditPrimitiveGroup extends Component<EditPrimitiveGroupProps> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   simpleWrapper = (name, required, element, help = null) => {
     return (
-      <React.Fragment>
+      <Fragment>
         <div className="col-lg-3">{element}</div>
         {required ? (
           <span className="required-form-field" style={{ float: "left", paddingRight: "10px" }}>
@@ -192,7 +192,7 @@ class EditPrimitiveGroup extends React.Component<EditPrimitiveGroupProps> {
           </span>
         ) : null}
         <HelpIcon text={this.props.element["$help"]} />
-      </React.Fragment>
+      </Fragment>
     );
   };
 
@@ -238,7 +238,7 @@ type EditPrimitiveDictionaryGroupProps = {
  * Used for rendering edit-groups in the form of "dictionary of primitive types",
  * to be rendered as a list of [key, value] in the UI.
  */
-class EditPrimitiveDictionaryGroup extends React.Component<EditPrimitiveDictionaryGroupProps> {
+class EditPrimitiveDictionaryGroup extends Component<EditPrimitiveDictionaryGroupProps> {
   pairElementWrapper(elementName) {
     return (name, required, element) => (
       <div key={elementName}>
@@ -295,7 +295,7 @@ type RemoveButtonProps = {
   handleRemoveItem: (...args: any[]) => any;
 };
 
-class RemoveButton extends React.Component<RemoveButtonProps> {
+class RemoveButton extends Component<RemoveButtonProps> {
   render() {
     return (
       <button
@@ -330,7 +330,7 @@ type EditDictionaryGroupState = {
  * Used for rendering edit-groups that are backed up list of dictionaries
  * to be rendered as a list of key-value groups in the UI.
  */
-class EditDictionaryGroup extends React.Component<EditDictionaryGroupProps, EditDictionaryGroupState> {
+class EditDictionaryGroup extends Component<EditDictionaryGroupProps, EditDictionaryGroupState> {
   constructor(props) {
     super(props);
     this.state = {

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component, createContext, createRef, Fragment } from "react";
 
 import { default as Jexl } from "jexl";
 
@@ -56,7 +56,7 @@ type Context = {
   searchCriteria: string | null | undefined;
 };
 
-export const FormulaFormContext = React.createContext<Context>({
+export const FormulaFormContext = createContext<Context>({
   scope: null,
   layout: {},
   values: {},
@@ -389,7 +389,7 @@ function isVisibleByCriteria(element: any, criteria: string) {
 }
 
 function generateChildrenFormItems(element, value, formulaForm, id, disabled = false) {
-  const child_items: React.ReactNode[] = [];
+  const child_items: ReactNode[] = [];
   for (const child_name in element) {
     if (child_name.startsWith("$")) continue;
     child_items.push(
@@ -400,7 +400,7 @@ function generateChildrenFormItems(element, value, formulaForm, id, disabled = f
 }
 
 function generateSelectList(data) {
-  const options: React.ReactNode[] = [];
+  const options: ReactNode[] = [];
   for (const key in data)
     options.push(
       <option key={key} value={data[key]}>
@@ -414,14 +414,14 @@ function defaultWrapper(elementName, required, element, help = null) {
   return wrapFormGroupWithLabel(
     elementName,
     required,
-    <React.Fragment>
+    <Fragment>
       <div className="col-lg-6">{element}</div>
       <HelpIcon text={help} />
-    </React.Fragment>
+    </Fragment>
   );
 }
 
-function wrapFormGroupWithLabel(element_name: string, required?: boolean, innerHTML?: React.ReactNode) {
+function wrapFormGroupWithLabel(element_name: string, required?: boolean, innerHTML?: ReactNode) {
   return (
     <div className="form-group" key={element_name}>
       {wrapLabel(element_name, required)}
@@ -430,7 +430,7 @@ function wrapFormGroupWithLabel(element_name: string, required?: boolean, innerH
   );
 }
 
-function wrapLabel(text: React.ReactNode, required?: boolean, label_for?: string) {
+function wrapLabel(text: ReactNode, required?: boolean, label_for?: string) {
   return (
     <label htmlFor={label_for} className="col-lg-3 control-label">
       {text}
@@ -487,8 +487,8 @@ type UnwrappedFormulaFormRendererProps = {
 // layout
 // values
 // onValuesChanged
-class UnwrappedFormulaFormRenderer extends React.Component<UnwrappedFormulaFormRendererProps> {
-  submitButton = React.createRef<HTMLInputElement>();
+class UnwrappedFormulaFormRenderer extends Component<UnwrappedFormulaFormRendererProps> {
+  submitButton = createRef<HTMLInputElement>();
 
   handleChange = (event) => {
     let id, value;
@@ -533,7 +533,7 @@ class UnwrappedFormulaFormRenderer extends React.Component<UnwrappedFormulaFormR
       return null;
     }
 
-    const form: React.ReactNode[] = [];
+    const form: ReactNode[] = [];
     for (const key in layout) {
       form.push(generateFormulaComponent(layout[key], values[key], this));
     }
@@ -675,7 +675,7 @@ type FormulaFormContextProviderState = {
 // groupData
 // scope
 // searchCriteria
-export class FormulaFormContextProvider extends React.Component<
+export class FormulaFormContextProvider extends Component<
   FormulaFormContextProviderProps,
   FormulaFormContextProviderState
 > {

--- a/web/html/src/components/formulas/Group.tsx
+++ b/web/html/src/components/formulas/Group.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import { type ReactNode, Fragment, useEffect, useState } from "react";
 
 import { SectionState } from "components/FormulaForm";
 import { Highlight } from "components/table/Highlight";
@@ -11,9 +10,9 @@ type Props = {
   id: string;
   sectionsExpanded: SectionState;
   setSectionsExpanded: (SectionState) => void;
-  header?: React.ReactNode;
-  help?: React.ReactNode;
-  children?: React.ReactNode;
+  header?: ReactNode;
+  help?: ReactNode;
+  children?: ReactNode;
   isVisibleByCriteria?: () => boolean;
   criteria: string;
 };
@@ -57,10 +56,10 @@ const Group = (props: Props) => {
       </SectionToggle>
       <div>
         {visible ? (
-          <React.Fragment>
+          <Fragment>
             {props.help ? <p>{props.help}</p> : null}
             {props.children}
-          </React.Fragment>
+          </Fragment>
         ) : null}
       </div>
     </div>

--- a/web/html/src/components/formulas/PasswordInput.tsx
+++ b/web/html/src/components/formulas/PasswordInput.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Utils } from "../../utils/functions";
 import { ElementDefinition } from "./FormulaComponentGenerator";
@@ -18,7 +18,7 @@ type State = {
   showPassword: boolean;
 };
 
-class PasswordInput extends React.Component<Props, State> {
+class PasswordInput extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/web/html/src/components/formulas/SectionToggle.tsx
+++ b/web/html/src/components/formulas/SectionToggle.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 type Props = {
   index?: any;
   isVisible: (index: any) => boolean;
   setVisible: (index: any, isVisible: boolean) => any;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 const SectionToggle = (props: Props) => {

--- a/web/html/src/components/general/with-page-wrapper.tsx
+++ b/web/html/src/components/general/with-page-wrapper.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import DefaultJsError from "manager/errors/default-js-error";
 
@@ -10,7 +10,7 @@ type Props = {
   children: React.ReactNode;
 };
 
-class ErrorBoundary extends React.Component<Props, State> {
+class ErrorBoundary extends Component<Props, State> {
   state = new State();
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {

--- a/web/html/src/components/hub/AddTokenButton.tsx
+++ b/web/html/src/components/hub/AddTokenButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Button, DropdownButton, LinkButton } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
@@ -28,7 +28,7 @@ type State = {
   generatedToken: string | undefined;
 };
 
-export class AddTokenButton extends React.Component<Props, State> {
+export class AddTokenButton extends Component<Props, State> {
   static defaultProps: Partial<Props> = {
     method: AddTokenMethod.IssueAndStore,
     onCreated: undefined,
@@ -44,7 +44,7 @@ export class AddTokenButton extends React.Component<Props, State> {
     };
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <>
         {this.renderButton()}
@@ -54,7 +54,7 @@ export class AddTokenButton extends React.Component<Props, State> {
     );
   }
 
-  private renderButton(): React.ReactNode {
+  private renderButton(): ReactNode {
     switch (this.props.method) {
       case AddTokenMethod.Issue:
         return (
@@ -108,7 +108,7 @@ export class AddTokenButton extends React.Component<Props, State> {
     }
   }
 
-  private renderCreationForm(): React.ReactNode {
+  private renderCreationForm(): ReactNode {
     if (this.state.createRequest === undefined) {
       return <></>;
     }
@@ -172,7 +172,7 @@ export class AddTokenButton extends React.Component<Props, State> {
     );
   }
 
-  private renderTokenModal(): React.ReactNode {
+  private renderTokenModal(): ReactNode {
     if (this.state.generatedToken === undefined) {
       return <></>;
     }

--- a/web/html/src/components/hub/DeregisterServer.tsx
+++ b/web/html/src/components/hub/DeregisterServer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Button } from "components/buttons";
 import { DangerDialog } from "components/dialog/DangerDialog";
@@ -23,14 +23,14 @@ type State = {
   showDeleteErrorModal: boolean;
 };
 
-export class DeregisterServer extends React.Component<Props, State> {
+export class DeregisterServer extends Component<Props, State> {
   public constructor(props: Props) {
     super(props);
 
     this.state = { confirmDeregistration: false, showDeleteErrorModal: false };
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <>
         <Button

--- a/web/html/src/components/hub/DesyncChannel.tsx
+++ b/web/html/src/components/hub/DesyncChannel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Button } from "components/buttons";
 import { DangerDialog } from "components/dialog/DangerDialog";
@@ -21,13 +21,13 @@ type State = {
   confirmDesync: boolean;
 };
 
-export class DesyncChannel extends React.Component<Props, State> {
+export class DesyncChannel extends Component<Props, State> {
   public constructor(props: Props) {
     super(props);
     this.state = { confirmDesync: false };
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <>
         <Button

--- a/web/html/src/components/hub/HierarchicalChannelsTable.tsx
+++ b/web/html/src/components/hub/HierarchicalChannelsTable.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { type FC, useCallback, useMemo, useState } from "react";
 
 import { DEPRECATED_Select, Form } from "components/input";
 import { Column } from "components/table/Column";
@@ -23,7 +22,7 @@ type ChannelTableProps = {
   availableOrgs: Org[];
 };
 
-const HierarchicalChannelsTable: React.FC<ChannelTableProps> = ({
+const HierarchicalChannelsTable: FC<ChannelTableProps> = ({
   channels,
   onChannelSelect,
   availableOrgs,

--- a/web/html/src/components/hub/MigrateSlavesForm.tsx
+++ b/web/html/src/components/hub/MigrateSlavesForm.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { AsyncButton, Button } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
@@ -35,7 +35,7 @@ type State = {
   migrationResult: MigrationResult | undefined;
 };
 
-export class MigrateSlavesForm extends React.Component<Props, State> {
+export class MigrateSlavesForm extends Component<Props, State> {
   static defaultProps: Partial<Props> = {
     migrationEntries: [],
   };
@@ -54,7 +54,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     };
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <TopPanel
         title={this.props.title}
@@ -79,10 +79,8 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
       >
         {/* Loading banner for when the submit is in progress */}
         {this.state.loading && this.renderLoadingBanner()}
-
         {/* Modal dialog to show the problems happened during migration */}
         {this.state.migrationResult && this.renderMigrationResultDialog()}
-
         {/* When we are migrating from ISSv1 it is possible that we don't have any server to migrate. In this case
          * show an error message instead of the server table. This cannot happen for ISSv2 because the user must always
          * insert the server information manually. */}
@@ -127,7 +125,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     }));
   }
 
-  private renderLoadingBanner(): React.ReactNode {
+  private renderLoadingBanner(): ReactNode {
     return (
       <Messages
         items={[
@@ -140,7 +138,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     );
   }
 
-  private renderMigrationResultDialog(): React.ReactNode {
+  private renderMigrationResultDialog(): ReactNode {
     if (this.state.migrationResult === undefined) {
       return <></>;
     }
@@ -193,7 +191,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     return this.state.tableModel.length === 0;
   }
 
-  private renderNothingToMigrateMessage(): React.ReactNode {
+  private renderNothingToMigrateMessage(): ReactNode {
     return (
       <>
         <Messages
@@ -217,7 +215,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     );
   }
 
-  private renderServerTable(): React.ReactNode {
+  private renderServerTable(): ReactNode {
     return (
       <>
         <Table data={this.state.tableModel} identifier={(row: MigrationEntry) => row.id}>
@@ -258,7 +256,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     );
   }
 
-  private renderSelection(row: MigrationEntry): React.ReactNode {
+  private renderSelection(row: MigrationEntry): ReactNode {
     return (
       <input
         type="checkbox"
@@ -277,7 +275,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     );
   }
 
-  private renderToken(row: MigrationEntry): React.ReactNode {
+  private renderToken(row: MigrationEntry): ReactNode {
     const tokenPresent = row.accessToken !== null && row.accessToken.trim().length > 0;
 
     return (
@@ -315,7 +313,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     });
   }
 
-  private renderRootCA(row: MigrationEntry): React.ReactNode {
+  private renderRootCA(row: MigrationEntry): ReactNode {
     return (
       <div className="container pl-0">
         <div className="row align-items-center">
@@ -355,7 +353,7 @@ export class MigrateSlavesForm extends React.Component<Props, State> {
     );
   }
 
-  private renderResultMessage(message: MigrationMessage): React.ReactNode {
+  private renderResultMessage(message: MigrationMessage): ReactNode {
     let iconClass: string, iconTitle: string;
 
     switch (message.severity) {

--- a/web/html/src/components/hub/ModalEditButton.tsx
+++ b/web/html/src/components/hub/ModalEditButton.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Button } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
@@ -19,7 +19,7 @@ type Props = {
   /** An array of validators to run against the input, either sync or async, resolve with `true` for valid & `false` for invalid */
   validators?: Validator | Validator[];
   /** Hint to display on a validation error */
-  invalidHint?: React.ReactNode;
+  invalidHint?: ReactNode;
   /** true to disable the button and prevent editing */
   disabled: boolean;
   /** The initial value, show when opening the popup */
@@ -34,7 +34,7 @@ type State = {
 };
 
 /** A component that allows to edit a single value with a modal dialog triggered by a button */
-export class ModalEditButton extends React.Component<Props, State> {
+export class ModalEditButton extends Component<Props, State> {
   static defaultProps: Partial<Props> = {
     disabled: false,
     value: "",
@@ -49,7 +49,7 @@ export class ModalEditButton extends React.Component<Props, State> {
     };
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <>
         <Button

--- a/web/html/src/components/hub/PeripheralsList.tsx
+++ b/web/html/src/components/hub/PeripheralsList.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, type RefObject, Component, createRef } from "react";
 
 import { LinkButton } from "components/buttons";
 import { DeregisterServer, IssRole, PeripheralListData } from "components/hub";
@@ -11,16 +11,16 @@ import { Utils } from "utils/functions";
 
 type Props = Record<never, never>;
 
-export class PeripheralsList extends React.Component<Props> {
-  private tableRef: React.RefObject<TableRef>;
+export class PeripheralsList extends Component<Props> {
+  private tableRef: RefObject<TableRef>;
 
   public constructor(props: Props) {
     super(props);
 
-    this.tableRef = React.createRef();
+    this.tableRef = createRef();
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     const componentContent = (
       <Table
         ref={this.tableRef}
@@ -62,7 +62,7 @@ export class PeripheralsList extends React.Component<Props> {
     return componentContent;
   }
 
-  private renderFqdnLink(row: PeripheralListData): React.ReactNode {
+  private renderFqdnLink(row: PeripheralListData): ReactNode {
     return (
       <LinkButton
         className="btn-link"
@@ -73,13 +73,13 @@ export class PeripheralsList extends React.Component<Props> {
     );
   }
 
-  private renderDownloadRootCA(row: PeripheralListData): React.ReactNode {
+  private renderDownloadRootCA(row: PeripheralListData): ReactNode {
     return (
       <LargeTextAttachment value={row.rootCA} filename={row.fqdn + "_CA.pem"} editable={false} hideMessage={true} />
     );
   }
 
-  private renderDeregister(row: PeripheralListData): React.ReactNode {
+  private renderDeregister(row: PeripheralListData): ReactNode {
     return (
       <DeregisterServer
         id={row.id}

--- a/web/html/src/components/hub/RegisterPeripheralForm.tsx
+++ b/web/html/src/components/hub/RegisterPeripheralForm.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { productName } from "core/user-preferences";
 
@@ -43,7 +43,7 @@ type State = {
   validated: boolean;
 };
 
-export class RegisterPeripheralForm extends React.Component<Props, State> {
+export class RegisterPeripheralForm extends Component<Props, State> {
   // Initial form model
   private static readonly INITIAL_MODEL: FormModel = {
     serverFqdn: "",
@@ -131,7 +131,7 @@ export class RegisterPeripheralForm extends React.Component<Props, State> {
     this.setState({ model: { ...RegisterPeripheralForm.INITIAL_MODEL } });
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <TopPanel title={t("Register a new peripheral server")} icon="fa fa-plus">
         {this.state.loading && (

--- a/web/html/src/components/hub/ServerDetailsForm.tsx
+++ b/web/html/src/components/hub/ServerDetailsForm.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { AsyncButton, LinkButton } from "components/buttons";
 import { FromNow, HumanDateTime } from "components/datetime";
@@ -52,7 +52,7 @@ type State = {
   model: IssServerDetailData;
 };
 
-export class ServerDetailsForm extends React.Component<Props, State> {
+export class ServerDetailsForm extends Component<Props, State> {
   public constructor(props: Props) {
     super(props);
 
@@ -61,7 +61,7 @@ export class ServerDetailsForm extends React.Component<Props, State> {
     };
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <div className="panel panel-default" key="overview">
         <ul className="list-group">

--- a/web/html/src/components/hub/SyncOrgsToPeripheralChannels.tsx
+++ b/web/html/src/components/hub/SyncOrgsToPeripheralChannels.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type RefObject, Component, createRef } from "react";
 
 import { Button } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
@@ -67,8 +67,8 @@ function flattenChannels(channels: Channel[]): FlatChannel[] {
   return flatChannels;
 }
 
-export class SyncOrgsToPeripheralChannel extends React.Component<SyncPeripheralsProps, State> {
-  private tableRef: React.RefObject<TableRef> = React.createRef();
+export class SyncOrgsToPeripheralChannel extends Component<SyncPeripheralsProps, State> {
+  private tableRef: RefObject<TableRef> = createRef();
 
   constructor(props: SyncPeripheralsProps) {
     super(props);

--- a/web/html/src/components/hub/TokenTable.tsx
+++ b/web/html/src/components/hub/TokenTable.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, type RefObject, Component, createRef } from "react";
 
 import { pageSize } from "core/user-preferences";
 
@@ -25,13 +25,13 @@ type State = {
   confirmDeleteDialog: boolean;
 };
 
-export class TokenTable extends React.Component<Props, State> {
-  private tableRef: React.RefObject<TableRef>;
+export class TokenTable extends Component<Props, State> {
+  private tableRef: RefObject<TableRef>;
 
   public constructor(props: Props) {
     super(props);
 
-    this.tableRef = React.createRef();
+    this.tableRef = createRef();
     this.state = {
       selectedRow: undefined,
       confirmValidityDialog: false,
@@ -43,7 +43,7 @@ export class TokenTable extends React.Component<Props, State> {
     this.tableRef.current?.refresh();
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <Table
         ref={this.tableRef}
@@ -109,7 +109,7 @@ export class TokenTable extends React.Component<Props, State> {
     );
   }
 
-  private renderExpiration(expirationTime: Date | null): React.ReactNode {
+  private renderExpiration(expirationTime: Date | null): ReactNode {
     if (expirationTime === null) {
       return t("No, never expires");
     }
@@ -124,7 +124,7 @@ export class TokenTable extends React.Component<Props, State> {
     );
   }
 
-  private renderDate(date: Date): React.ReactNode {
+  private renderDate(date: Date): ReactNode {
     return <FromNow value={date} />;
   }
 

--- a/web/html/src/components/icontag.tsx
+++ b/web/html/src/components/icontag.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 type Props = {
   type: string;
   className?: string;

--- a/web/html/src/components/input/FormGroup.tsx
+++ b/web/html/src/components/input/FormGroup.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 
 type Props = {
   isError?: boolean;
-  children: React.ReactNode;
+  children: ReactNode;
 
   /** CSS class name to apply to the component */
   className?: string;

--- a/web/html/src/components/input/InputBase.test.tsx
+++ b/web/html/src/components/input/InputBase.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Children } from "react";
 
 import { render, screen } from "utils/test-utils";
 
@@ -21,7 +21,7 @@ describe("InputBase", () => {
   function renderWithForm(content) {
     return render(
       <Form model={model} onChange={onChange}>
-        {React.Children.toArray(content)}
+        {Children.toArray(content)}
       </Form>
     );
   }

--- a/web/html/src/components/input/InputBase.tsx
+++ b/web/html/src/components/input/InputBase.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import _isNil from "lodash/isNil";
 
@@ -33,7 +33,7 @@ export type InputBaseProps<ValueType = string> = {
   hideLabel?: boolean;
 
   /** Hint string to display */
-  hint?: React.ReactNode;
+  hint?: ReactNode;
 
   /** CSS class to use for the label */
   labelClass?: string;
@@ -54,7 +54,7 @@ export type InputBaseProps<ValueType = string> = {
   children?: (arg0: {
     setValue: (name: string | undefined, value: ValueType) => void;
     onBlur: () => void;
-  }) => React.ReactNode;
+  }) => ReactNode;
 
   /** Indicates whether the field is required in the form */
   required?: boolean;
@@ -66,7 +66,7 @@ export type InputBaseProps<ValueType = string> = {
   validators?: Validator | Validator[];
 
   /** Hint to display on a validation error */
-  invalidHint?: React.ReactNode;
+  invalidHint?: ReactNode;
 
   /** Function to call when the data model needs to be changed.
    *  Takes a name and a value parameter.
@@ -86,7 +86,7 @@ type State = {
   errors?: string[] | object;
 };
 
-export class InputBase<ValueType = string> extends React.Component<InputBaseProps<ValueType>, State> {
+export class InputBase<ValueType = string> extends Component<InputBaseProps<ValueType>, State> {
   static defaultProps = {
     defaultValue: undefined,
     label: undefined,
@@ -267,7 +267,7 @@ export class InputBase<ValueType = string> extends React.Component<InputBaseProp
     if (this.props.onChange) this.props.onChange(name, value);
   };
 
-  pushHint(hints: React.ReactNode[], hint: React.ReactNode) {
+  pushHint(hints: ReactNode[], hint: ReactNode) {
     if (hint) {
       if (hints.length > 0) {
         hints.push(<br key={hints.length} />);
@@ -280,7 +280,7 @@ export class InputBase<ValueType = string> extends React.Component<InputBaseProp
     const isError = this.state.showErrors && !this.state.isValid;
     const requiredHint = this.props.label ? t(`${this.props.label} is required.`) : t("required");
     const invalidHint = isError && (this.props.invalidHint || (this.props.required && requiredHint));
-    const hints: React.ReactNode[] = [];
+    const hints: ReactNode[] = [];
     this.pushHint(hints, this.props.hint);
 
     const errors = Array.isArray(this.state.errors) ? this.state.errors : this.state.errors ? [this.state.errors] : [];

--- a/web/html/src/components/input/Label.tsx
+++ b/web/html/src/components/input/Label.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 type Props = {
   name?: string;
   htmlFor?: string;

--- a/web/html/src/components/input/check/DEPRECATED_Check.tsx
+++ b/web/html/src/components/input/check/DEPRECATED_Check.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, useContext } from "react";
 
 import { ControlledInput } from "../ControlledInput";
 import { FormContext } from "../form/Form";
@@ -12,7 +12,7 @@ type Props = Omit<InputBaseProps, "label"> & {
   name: string;
 
   /** for historical reasons, label handles differently here  */
-  label: React.ReactNode;
+  label: ReactNode;
 };
 
 /**
@@ -20,7 +20,7 @@ type Props = Omit<InputBaseProps, "label"> & {
  */
 export function DEPRECATED_Check({ required = false, disabled = false, ...props }: Props) {
   const { label, inputClass, ...propsToPass } = props;
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
 
   return (
     <InputBase required={required} disabled={disabled} {...propsToPass}>

--- a/web/html/src/components/input/datetime/DateTime.tsx
+++ b/web/html/src/components/input/datetime/DateTime.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useContext } from "react";
 
 import { DateTimePicker } from "components/datetime";
 
@@ -13,7 +13,7 @@ type Props = InputBaseProps<moment.Moment> & {
 };
 
 export function DateTime({ required = false, disabled = false, ...props }: Props) {
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   return (
     <InputBase<moment.Moment> required={required} disabled={disabled} {...props}>
       {({ setValue }) => {

--- a/web/html/src/components/input/form-multi-input/FormMultiInput.tsx
+++ b/web/html/src/components/input/form-multi-input/FormMultiInput.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, useContext } from "react";
 
 import { Button } from "components/buttons";
 import { Panel } from "components/panels/Panel";
@@ -34,7 +34,7 @@ type Props = {
    * A function that renders the fields of one row given it's index.
    * The index parameter should be used for the field names.
    */
-  children: (index: number) => React.ReactNode;
+  children: (index: number) => ReactNode;
 
   /** Whether the fields are enabled or not. */
   disabled?: boolean;
@@ -50,7 +50,7 @@ type Props = {
   panelTitle?: (idx: number) => string;
 
   /** Content to display between the title and the first fields */
-  header?: React.ReactNode;
+  header?: ReactNode;
 
   /** CSS class for the row containing the fields of one item */
   rowClass?: string;
@@ -133,7 +133,7 @@ export function getOrderedItemsFromModel(model: any, prefix: string): number[] {
  * ```
  */
 export function FormMultiInput({ disabled = false, ...props }: Props) {
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   const items = getOrderedItemsFromModel(formContext.model, props.prefix);
   const new_index = (items.length > 0 && items[items.length - 1] + 1) || 0;
   return (

--- a/web/html/src/components/input/form/Form.tsx
+++ b/web/html/src/components/input/form/Form.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import { type ElementRef, type LegacyRef, type ReactNode, Component, createContext } from "react";
 
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 
 import { InputBase } from "../InputBase";
 
-type InputBaseRef = React.ElementRef<typeof InputBase>;
+type InputBaseRef = ElementRef<typeof InputBase>;
 
 // If a model is specified, you must listen to changes as well (bsc#1244430)
 type WithModel = {
@@ -32,7 +32,7 @@ type Props = (WithModel | WithoutModel) & {
   onSubmit?: (...args: any[]) => any;
 
   /** A reference to pass to the <form> element */
-  formRef?: React.LegacyRef<HTMLFormElement>;
+  formRef?: LegacyRef<HTMLFormElement>;
 
   /** CSS class of the form */
   className?: string;
@@ -44,7 +44,7 @@ type Props = (WithModel | WithoutModel) & {
   formDirection?: string;
 
   /** Children elements of the form. Usually includes fields and a submit button */
-  children?: React.ReactNode;
+  children?: ReactNode;
 
   /** Function called after having validated the form.
    * Takes a single parameter indicating whether the form is valid or not.
@@ -66,9 +66,9 @@ type FormContextType = {
   validateForm: () => void;
 };
 
-export const FormContext = React.createContext<Partial<FormContextType>>({});
+export const FormContext = createContext<Partial<FormContextType>>({});
 
-export class Form extends React.Component<Props> {
+export class Form extends Component<Props> {
   static defaultProps = {
     model: {},
     onSubmit: undefined,

--- a/web/html/src/components/input/password/Password.tsx
+++ b/web/html/src/components/input/password/Password.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { InputBaseProps } from "../InputBase";
 import { Text } from "../text/Text";
 

--- a/web/html/src/components/input/radio/Radio.tsx
+++ b/web/html/src/components/input/radio/Radio.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type ReactNode, useContext, useState } from "react";
 
 import { ControlledInput } from "../ControlledInput";
 import { FormContext } from "../form/Form";
@@ -8,7 +7,7 @@ import styles from "./Radio.module.scss";
 
 type RadioOption = {
   /** The label of this option */
-  label: React.ReactNode;
+  label: ReactNode;
   /** The value to set when this option is selected */
   value: string;
   /** Specific title of this option */
@@ -38,7 +37,7 @@ export function Radio({ inline = false, openOption = false, required = false, di
   const [isPristine, setIsPristine] = useState(true);
 
   const { items, inputClass, ...propsToPass } = props;
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   return (
     <InputBase required={required} disabled={disabled} {...propsToPass}>
       {({ setValue, onBlur }) => {

--- a/web/html/src/components/input/range/Range.test.tsx
+++ b/web/html/src/components/input/range/Range.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Children } from "react";
 
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import { clear, render, screen, type, waitForElementToBeRemoved } from "utils/test-utils";
@@ -19,7 +19,7 @@ describe("Range", () => {
   function renderWithForm(content) {
     return render(
       <Form model={model} onChange={onChange}>
-        {React.Children.toArray(content)}
+        {Children.toArray(content)}
       </Form>
     );
   }

--- a/web/html/src/components/input/range/Range.tsx
+++ b/web/html/src/components/input/range/Range.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useContext } from "react";
 
 import { ControlledInput } from "../ControlledInput";
 import { FormContext } from "../form/Form";
@@ -24,7 +24,7 @@ type Props = InputBaseProps & {
 
 export const Range = ({ required = false, disabled = false, ...props }: Props) => {
   const { placeholder, inputClass, ...propsToPass } = props;
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   return (
     <InputBase
       required={required}

--- a/web/html/src/components/input/select/DEPRECATED_Select.tsx
+++ b/web/html/src/components/input/select/DEPRECATED_Select.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect } from "react";
+import { type ReactNode, useContext, useEffect } from "react";
 
 import ReactSelect from "react-select";
 import AsyncSelect from "react-select/async";
@@ -32,10 +31,10 @@ type CommonSelectProps = (SingleMode | MultiMode) & {
   getOptionLabel?: (option: any) => string;
 
   /** Formats option labels in the menu and control as React components */
-  formatOptionLabel?: (option: any, meta: any) => React.ReactNode;
+  formatOptionLabel?: (option: any, meta: any) => ReactNode;
 
   /** Placeholder for the select value */
-  placeholder?: React.ReactNode;
+  placeholder?: ReactNode;
 
   /** whether the component's data is loading or not (async) */
   isLoading?: boolean;
@@ -114,7 +113,7 @@ export function DEPRECATED_Select(props: Props) {
     ...propsToPass
   } = props;
 
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   const isAsync = (props: Props): props is AsyncSelectProps | AsyncPaginateSelectProps => {
     return (props as AsyncSelectProps).loadOptions !== undefined;
   };

--- a/web/html/src/components/input/select/Select.test.tsx
+++ b/web/html/src/components/input/select/Select.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { SubmitButton } from "components/buttons";

--- a/web/html/src/components/input/select/Select.tsx
+++ b/web/html/src/components/input/select/Select.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import _isEqual from "lodash/isEqual";

--- a/web/html/src/components/input/text-area/TextArea.tsx
+++ b/web/html/src/components/input/text-area/TextArea.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useContext } from "react";
 
 import { FormContext } from "../form/Form";
 import { InputBase, InputBaseProps } from "../InputBase";
@@ -22,7 +22,7 @@ type Props = InputBaseProps & {
 
 export const TextArea = (props: Props) => {
   const { required = false, disabled = false, rows, cols, placeholder, inputClass, ...propsToPass } = props;
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   return (
     <InputBase required={required} disabled={disabled} {...propsToPass}>
       {({ setValue, onBlur }) => {

--- a/web/html/src/components/input/text/Text.tsx
+++ b/web/html/src/components/input/text/Text.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useContext } from "react";
 
 import { ControlledInput } from "../ControlledInput";
 import { FormContext } from "../form/Form";
@@ -31,7 +31,7 @@ export const Text = (props: Props) => {
     inputClass,
     ...propsToPass
   } = props;
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   return (
     <InputBase required={required} disabled={disabled} {...propsToPass}>
       {({ setValue, onBlur }) => {

--- a/web/html/src/components/large-text-attachment.tsx
+++ b/web/html/src/components/large-text-attachment.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Button, LinkButton } from "components/buttons";
 import { DangerDialog } from "components/dialog/DangerDialog";
@@ -64,7 +64,7 @@ type State = {
 /**
  * Component to handle large text data. It allows the user to download, edit and delete the text data.
  */
-export class LargeTextAttachment extends React.Component<Props, State> {
+export class LargeTextAttachment extends Component<Props, State> {
   private static readonly INITAL_MODEL: EditFormModel = { method: EditMethod.Upload };
 
   static defaultProps: Partial<Props> = {
@@ -94,7 +94,7 @@ export class LargeTextAttachment extends React.Component<Props, State> {
     };
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     const valueObject = new Blob([this.props.value ?? ""], { type: "text/plain" });
     const valuePresent = this.props.value !== null;
     const downloadUrl = URL.createObjectURL(valueObject);

--- a/web/html/src/components/links.tsx
+++ b/web/html/src/components/links.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
+import type { HTMLProps, ReactNode } from "react";
 
 type LinkProps = {
   id: string | number;
   newWindow?: boolean;
-  children?: React.ReactNode;
+  children?: ReactNode;
   className?: string;
   title?: string;
 };
 
-const targetProps = (props: LinkProps): Partial<React.HTMLProps<HTMLAnchorElement>> => {
+const targetProps = (props: LinkProps): Partial<HTMLProps<HTMLAnchorElement>> => {
   const target = props.newWindow ? "_blank" : "_self";
   const rel = props.newWindow ? "noopener noreferrer" : undefined;
   return { target, rel };

--- a/web/html/src/components/messages/messages.tsx
+++ b/web/html/src/components/messages/messages.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-
+import { type ReactNode, Component } from "react";
 export type Severity = "info" | "success" | "warning" | "error";
 
 export type ServerMessageType = {
@@ -10,7 +9,7 @@ export type ServerMessageType = {
 
 export type MessageType = {
   severity: Severity;
-  text: React.ReactNode;
+  text: ReactNode;
 };
 
 type Props = {
@@ -55,24 +54,24 @@ const _classNames = {
   warning: "warning",
 };
 
-export class Messages extends React.Component<Props> {
-  static info(text: React.ReactNode): MessageType {
+export class Messages extends Component<Props> {
+  static info(text: ReactNode): MessageType {
     return Messages.message("info", text);
   }
 
-  static success(text: React.ReactNode): MessageType {
+  static success(text: ReactNode): MessageType {
     return Messages.message("success", text);
   }
 
-  static error(text: React.ReactNode): MessageType {
+  static error(text: ReactNode): MessageType {
     return Messages.message("error", text);
   }
 
-  static warning(text: React.ReactNode): MessageType {
+  static warning(text: ReactNode): MessageType {
     return Messages.message("warning", text);
   }
 
-  static message(severityIn: Severity, textIn: React.ReactNode): MessageType {
+  static message(severityIn: Severity, textIn: ReactNode): MessageType {
     return { severity: severityIn, text: textIn };
   }
 
@@ -92,9 +91,9 @@ export class Messages extends React.Component<Props> {
 
 export const fromServerMessage = (
   message: ServerMessageType,
-  messageMap?: Record<string, React.ReactNode>
+  messageMap?: Record<string, ReactNode>
 ): MessageType | null | undefined => {
-  let messageText: React.ReactNode = message.text;
+  let messageText: ReactNode = message.text;
   if (messageMap && message.text in messageMap) {
     const mappedMessage = messageMap[message.text];
     if (typeof mappedMessage === "function") {
@@ -121,7 +120,7 @@ export const fromServerMessage = (
   return msg;
 };
 
-function msg(severityIn: Severity, textIn: React.ReactNode, listMultiple: boolean, header?: string) {
+function msg(severityIn: Severity, textIn: ReactNode, listMultiple: boolean, header?: string) {
   if (textIn === null || textIn === undefined) {
     return [];
   }
@@ -165,16 +164,16 @@ function msg(severityIn: Severity, textIn: React.ReactNode, listMultiple: boolea
  * entries will generate multiple separated messages.
  */
 export const Utils = {
-  info: function (text: React.ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
+  info: function (text: ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
     return msg("info", text, listMultiple, header);
   },
-  success: function (text: React.ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
+  success: function (text: ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
     return msg("success", text, listMultiple, header);
   },
-  warning: function (text: React.ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
+  warning: function (text: ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
     return msg("warning", text, listMultiple, header);
   },
-  error: function (text: React.ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
+  error: function (text: ReactNode, listMultiple: boolean = false, header?: string): MessageType[] {
     return msg("error", text, listMultiple, header);
   },
 };

--- a/web/html/src/components/package/PackageListActionScheduler.tsx
+++ b/web/html/src/components/package/PackageListActionScheduler.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { ActionChain, ActionSchedule } from "components/action-schedule";
 import { AsyncButton, Button } from "components/buttons";
@@ -28,7 +28,7 @@ type Props = {
   listSummary: string;
   listEmptyText: string;
   listActionLabel: string;
-  listColumns: React.ReactNode[];
+  listColumns: ReactNode[];
   confirmTitle: string;
 };
 
@@ -40,7 +40,7 @@ type State = {
   actionChain?: ActionChain;
 };
 
-export class PackageListActionScheduler extends React.Component<Props, State> {
+export class PackageListActionScheduler extends Component<Props, State> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/components/pagination.tsx
+++ b/web/html/src/components/pagination.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useRef } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 
 import { Button, DropdownButton } from "components/buttons";
 
@@ -61,8 +60,8 @@ const PaginationBlock = (props: PaginationBlockProps) => {
 type PaginationButtonProps = {
   disabled?: boolean;
   onClick: (...args: any[]) => any;
-  text?: React.ReactNode;
-  icon?: React.ReactNode;
+  text?: ReactNode;
+  icon?: ReactNode;
   title?: string;
   ariaLabel: string;
 };

--- a/web/html/src/components/panels/BootstrapPanel.tsx
+++ b/web/html/src/components/panels/BootstrapPanel.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { Panel } from "./Panel";
 
 type Props = {
   title?: string;
   icon?: string;
-  header?: React.ReactNode;
-  footer?: React.ReactNode;
-  children?: React.ReactNode;
-  buttons?: React.ReactNode;
+  header?: ReactNode;
+  footer?: ReactNode;
+  children?: ReactNode;
+  buttons?: ReactNode;
 };
 
 function BootstrapPanel(props: Props) {

--- a/web/html/src/components/panels/CreatorPanel.tsx
+++ b/web/html/src/components/panels/CreatorPanel.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 import { Button } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
@@ -45,7 +44,7 @@ const CreatorPanel = (props: Props) => {
   const panelCollapseId = props.collapsible ? `${props.id}-panel` : null;
 
   return (
-    <React.Fragment>
+    <Fragment>
       <Panel
         headingLevel={panelLevels[props.panelLevel]}
         collapseId={panelCollapseId}
@@ -87,7 +86,7 @@ const CreatorPanel = (props: Props) => {
           })}
           onClose={() => setOpen(false)}
           footer={
-            <React.Fragment>
+            <Fragment>
               <div className="btn-group col-lg-6">
                 {props.onDelete && (
                   <Button
@@ -132,11 +131,11 @@ const CreatorPanel = (props: Props) => {
                   />
                 </div>
               </div>
-            </React.Fragment>
+            </Fragment>
           }
         />
       )}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/components/panels/InnerPanel.tsx
+++ b/web/html/src/components/panels/InnerPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Children } from "react";
 
 import { SectionToolbar } from "components/section-toolbar/section-toolbar";
 import { cloneReactElement, HelpLink } from "components/utils";
@@ -6,16 +6,16 @@ import { cloneReactElement, HelpLink } from "components/utils";
 type Props = {
   title: string;
   icon: string;
-  buttons?: React.ReactNode[];
-  buttonsLeft?: React.ReactNode[];
-  children: React.ReactNode;
-  summary?: React.ReactNode;
+  buttons?: ReactNode[];
+  buttonsLeft?: ReactNode[];
+  children: ReactNode;
+  summary?: ReactNode;
   helpUrl?: string;
 };
 
 function InnerPanel(props: Props) {
   const help = props.helpUrl ? <HelpLink url={props.helpUrl} /> : null;
-  let toolbar: React.ReactNode = null;
+  let toolbar: ReactNode = null;
 
   if (props.buttons?.length || props.buttonsLeft?.length) {
     toolbar = (
@@ -23,16 +23,14 @@ function InnerPanel(props: Props) {
         {props.buttonsLeft?.length ? (
           <div className="selector-button-wrapper">
             <div className="btn-group">
-              {React.Children.toArray(props.buttonsLeft).map((child, index) =>
-                cloneReactElement(child, { key: index })
-              )}
+              {Children.toArray(props.buttonsLeft).map((child, index) => cloneReactElement(child, { key: index }))}
             </div>
           </div>
         ) : null}
         {props.buttons?.length ? (
           <div className="action-button-wrapper">
             <div className="btn-group">
-              {React.Children.toArray(props.buttons).map((child, index) => cloneReactElement(child, { key: index }))}
+              {Children.toArray(props.buttons).map((child, index) => cloneReactElement(child, { key: index }))}
             </div>
           </div>
         ) : null}

--- a/web/html/src/components/panels/Panel.tsx
+++ b/web/html/src/components/panels/Panel.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-
+import { type ReactNode, Fragment } from "react";
 type Props = {
   headingLevel?: keyof JSX.IntrinsicElements;
   collapseId?: string | null | undefined;
@@ -7,27 +6,27 @@ type Props = {
   title?: string | null | undefined;
   className?: string;
   icon?: string | null | undefined;
-  header?: React.ReactNode;
-  footer?: React.ReactNode;
-  children: React.ReactNode;
-  buttons?: React.ReactNode;
+  header?: ReactNode;
+  footer?: ReactNode;
+  children: ReactNode;
+  buttons?: ReactNode;
 };
 
 export const Panel = (props: Props) => {
   const { headingLevel: HeadingLevel = "h1" } = props;
 
   const titleContent = props.title && (
-    <React.Fragment>
+    <Fragment>
       {props.icon && <i className={`fa ${props.icon}`} />}
       {props.title}
-    </React.Fragment>
+    </Fragment>
   );
 
   const bodyContent = (
-    <React.Fragment>
+    <Fragment>
       <div className="panel-body">{props.children}</div>
       {props.footer && <div className="panel-footer">{props.footer}</div>}
-    </React.Fragment>
+    </Fragment>
   );
 
   return (

--- a/web/html/src/components/panels/PanelRow.tsx
+++ b/web/html/src/components/panels/PanelRow.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 type Props = {
   className?: string;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 function PanelRow(props: Props) {

--- a/web/html/src/components/panels/TopPanel.tsx
+++ b/web/html/src/components/panels/TopPanel.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { HelpLink } from "components/utils/HelpLink";
 
 type Props = {
   helpUrl?: string;
-  button?: React.ReactNode;
+  button?: ReactNode;
   title: string;
   icon?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export function TopPanel(props: Props) {

--- a/web/html/src/components/picker/recurring-event-picker.tsx
+++ b/web/html/src/components/picker/recurring-event-picker.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Combobox, ComboboxItem } from "components/combobox";
 import { DateTimePicker } from "components/datetime";
@@ -44,7 +44,7 @@ type RecurringEventPickerState = {
   cronTimes: CronTimes;
 };
 
-class RecurringEventPicker extends React.Component<RecurringEventPickerProps, RecurringEventPickerState> {
+class RecurringEventPicker extends Component<RecurringEventPickerProps, RecurringEventPickerState> {
   public static readonly defaultProps: Partial<RecurringEventPickerProps> = {
     mode: "Panel",
     hideScheduleName: false,

--- a/web/html/src/components/popup.tsx
+++ b/web/html/src/components/popup.tsx
@@ -1,21 +1,20 @@
-import * as React from "react";
-
+import { type ReactNode, Component } from "react";
 type Props = {
   /** The id of the html div tag */
   id: string;
   /** The css className for the 'modal-dialog' div */
   className?: string;
-  title?: React.ReactNode;
+  title?: ReactNode;
   /** The body of the popup */
-  content?: React.ReactNode;
-  footer?: React.ReactNode;
+  content?: ReactNode;
+  footer?: ReactNode;
   hideHeader?: boolean;
   closableModal?: boolean;
   /** A callback function with no parameters */
   onClosePopUp?: () => any;
 };
 
-export class PopUp extends React.Component<Props> {
+export class PopUp extends Component<Props> {
   componentDidMount() {
     if (this.props.onClosePopUp) {
       jQuery("#" + this.props.id).on("hidden.bs.modal", this.props.onClosePopUp);

--- a/web/html/src/components/product-migration/MigrationChannelsSelectorForm.tsx
+++ b/web/html/src/components/product-migration/MigrationChannelsSelectorForm.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useMemo, useState } from "react";
+import { type FC, type ReactNode, useMemo, useState } from "react";
 
 import BaseChannel from "manager/content-management/shared/components/panels/sources/channels/base-channel";
 import { ChannelProcessor } from "manager/content-management/shared/components/panels/sources/channels/channel-processor";
@@ -32,7 +31,7 @@ type Props = {
   onBack: () => void;
 };
 
-export const MigrationChannelsSelectorForm: React.FC<Props> = ({
+export const MigrationChannelsSelectorForm: FC<Props> = ({
   migrationSource,
   migrationTarget,
   baseChannelTrees,
@@ -134,7 +133,7 @@ export const MigrationChannelsSelectorForm: React.FC<Props> = ({
     onChannelSelection(channelTree, selectedAllowVendorChange);
   }
 
-  function renderChildren(): React.ReactNode {
+  function renderChildren(): ReactNode {
     if (selectedChannelTree === undefined) {
       return <></>;
     }

--- a/web/html/src/components/product-migration/MigrationConfirmScheduleForm.tsx
+++ b/web/html/src/components/product-migration/MigrationConfirmScheduleForm.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type FC, useState } from "react";
 
 import { ChannelTreeType } from "core/channels/type/channels.type";
 
@@ -24,7 +23,7 @@ type Props = {
   onConfirm: (dryRun: boolean, earliest: moment.Moment, actionChain?: ActionChain) => Promise<void>;
 };
 
-export const MigrationConfirmScheduleForm: React.FC<Props> = ({
+export const MigrationConfirmScheduleForm: FC<Props> = ({
   systemsData,
   actionChains,
   migrationTarget,

--- a/web/html/src/components/product-migration/MigrationProductList.tsx
+++ b/web/html/src/components/product-migration/MigrationProductList.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useCallback } from "react";
+import { type FC, type ReactNode, useCallback } from "react";
 
 import { MigrationProduct } from "./types";
 
@@ -9,9 +8,9 @@ type Props = {
   customAddonRenderer?: (id: number, name: string) => JSX.Element;
 };
 
-export const MigrationProductList: React.FC<Props> = ({ className, product, customAddonRenderer }): JSX.Element => {
+export const MigrationProductList: FC<Props> = ({ className, product, customAddonRenderer }): JSX.Element => {
   const renderProduct = useCallback(
-    (addon: MigrationProduct): React.ReactNode => {
+    (addon: MigrationProduct): ReactNode => {
       if (customAddonRenderer) {
         return customAddonRenderer(addon.id, addon.name);
       }
@@ -22,7 +21,7 @@ export const MigrationProductList: React.FC<Props> = ({ className, product, cust
   );
 
   const renderAddons = useCallback(
-    (addons: MigrationProduct[]): React.ReactNode => {
+    (addons: MigrationProduct[]): ReactNode => {
       if (addons.length === 0) {
         return <></>;
       }

--- a/web/html/src/components/product-migration/MigrationTargetSelectorForm.tsx
+++ b/web/html/src/components/product-migration/MigrationTargetSelectorForm.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type FC, useState } from "react";
 
 import { AsyncButton } from "components/buttons";
 import { IconTag } from "components/icontag";
@@ -19,7 +18,7 @@ type FormModel = {
   selectedTarget?: string;
 };
 
-export const MigrationTargetSelectorForm: React.FC<Props> = ({
+export const MigrationTargetSelectorForm: FC<Props> = ({
   migrationSource,
   migrationTargets,
   targetId,

--- a/web/html/src/components/progressbar.tsx
+++ b/web/html/src/components/progressbar.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 type Props = {
   width?: string;
   progress: number;

--- a/web/html/src/components/ranking-table.tsx
+++ b/web/html/src/components/ranking-table.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import _cloneDeep from "lodash/cloneDeep";
 
@@ -40,7 +40,7 @@ type RankingTableState = {
   items: any[];
 };
 
-class RankingTable extends React.Component<RankingTableProps, RankingTableState> {
+class RankingTable extends Component<RankingTableProps, RankingTableState> {
   defaultEmptyMsg = t("There are no entries to show.");
   node: Element | null = null;
 

--- a/web/html/src/components/salt-state-popup.tsx
+++ b/web/html/src/components/salt-state-popup.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { AceEditor } from "./ace-editor";
 import { LinkButton } from "./buttons";
@@ -21,12 +21,12 @@ type SaltStatePopupProps = {
   saltState?: {
     id: string;
     name: string;
-    content: React.ReactNode;
+    content: ReactNode;
   };
   onClosePopUp: () => any;
 };
 
-class SaltStatePopup extends React.Component<SaltStatePopupProps> {
+class SaltStatePopup extends Component<SaltStatePopupProps> {
   render() {
     let popUpContent, icon, title, footer;
 

--- a/web/html/src/components/section-toolbar/section-toolbar.tsx
+++ b/web/html/src/components/section-toolbar/section-toolbar.tsx
@@ -1,8 +1,6 @@
-import * as React from "react";
-import { useEffect } from "react";
-
+import { type ReactNode, useEffect } from "react";
 type Props = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 export const SectionToolbar = ({ children }: Props) => {

--- a/web/html/src/components/states-picker.tsx
+++ b/web/html/src/components/states-picker.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import _partition from "lodash/partition";
 import _sortBy from "lodash/sortBy";
@@ -64,13 +64,13 @@ class StatesPickerState {
   showSaltState?: {
     id: string;
     name: string;
-    content: React.ReactNode;
+    content: ReactNode;
   } = undefined;
   rank?: boolean = undefined;
   messages: MessageType[] = [];
 }
 
-class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState> {
+class StatesPicker extends Component<StatesPickerProps, StatesPickerState> {
   state = new StatesPickerState();
 
   constructor(props: StatesPickerProps) {
@@ -243,7 +243,7 @@ class StatesPicker extends React.Component<StatesPickerProps, StatesPickerState>
   };
 
   tableBody = () => {
-    const elements: React.ReactNode[] = [];
+    const elements: ReactNode[] = [];
     let rows: any[] = [];
     rows = this.state.search.results.map((channel) => {
       const changed = this.state.changed.get(channelKey(channel));
@@ -480,7 +480,7 @@ type ExecuteStatesProps = {
   applySaltState: (memberIds: any[]) => any;
 };
 
-class ExecuteStatesButton extends React.Component<ExecuteStatesProps> {
+class ExecuteStatesButton extends Component<ExecuteStatesProps> {
   state = {
     selected: [],
     showPopup: false,
@@ -576,7 +576,7 @@ class ExecuteStatesButton extends React.Component<ExecuteStatesProps> {
   }
 }
 
-class ExecuteStatesFilter extends React.Component {
+class ExecuteStatesFilter extends Component {
   render() {
     const filterOptions = [{ value: "name", label: t("System Name") }];
     return <TableFilter filterOptions={filterOptions} {...this.props} />;

--- a/web/html/src/components/systems.tsx
+++ b/web/html/src/components/systems.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 
@@ -110,7 +110,7 @@ function statusDisplay(system: any, isAdmin: boolean) {
 
   const { iconType, iconTitle, url } = systems[type];
 
-  let locked: React.ReactNode = "";
+  let locked: ReactNode = "";
   if (DEPRECATED_unsafeEquals(system["locked"], 1)) {
     locked = <IconTag type="system-locked" title={t("System Locked")} />;
   }

--- a/web/html/src/components/tab-container.tsx
+++ b/web/html/src/components/tab-container.tsx
@@ -1,16 +1,15 @@
-import * as React from "react";
-
+import { type ReactNode, Component } from "react";
 type Props = {
-  labels: React.ReactNode[];
+  labels: ReactNode[];
   /** Must start with # */
   hashes: string[];
-  tabs: React.ReactNode[];
+  tabs: ReactNode[];
   initialActiveTabHash: string;
   /** Takes a hash parameter */
   onTabHashChange: (hash: string) => any;
 };
 
-class TabContainer extends React.Component<Props> {
+class TabContainer extends Component<Props> {
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.setState({ activeTabHash: this.sanitizeHash(nextProps.initialActiveTabHash, nextProps.hashes) });
   }
@@ -66,7 +65,7 @@ type TabLabelProps = {
   active?: boolean;
   hash?: string;
   onClick?: (...args: any[]) => any;
-  text: React.ReactNode;
+  text: ReactNode;
 };
 
 const TabLabel = (props: TabLabelProps) => (

--- a/web/html/src/components/table/Column.tsx
+++ b/web/html/src/components/table/Column.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { Comparator } from "utils/data-providers";
 
@@ -7,10 +7,10 @@ export type ColumnProps = {
   columnKey: string;
 
   /** Content of the cell or function to compute it from the row data */
-  cell?: React.ReactNode | ((data: any, criteria?: string, nestingLevel?: number) => React.ReactNode);
+  cell?: ReactNode | ((data: any, criteria?: string, nestingLevel?: number) => ReactNode);
 
   /** Title of the row, prefer `string` where possible for consistency */
-  header?: string | React.ReactNode;
+  header?: string | ReactNode;
 
   /** CSS value for the column width */
   width?: string;
@@ -52,7 +52,7 @@ export type ColumnProps = {
  * This component is also used internally to reprent each cell
  */
 export function Column(props: ColumnProps) {
-  let content: React.ReactNode = null;
+  let content: ReactNode = null;
   if (typeof props.cell === "function") {
     content = props.cell(props.data, props.criteria, props.nestingLevel);
   } else {

--- a/web/html/src/components/table/CustomDataHandler.tsx
+++ b/web/html/src/components/table/CustomDataHandler.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactComponentElement, type ReactNode, Children } from "react";
 
 import { cloneReactElement } from "components/utils";
 
@@ -16,7 +16,7 @@ type Props = {
   cssClassFunction?: (...args: any[]) => any;
 
   /** the React Object that contains the filter search field */
-  searchField?: React.ReactComponentElement<typeof SearchField>;
+  searchField?: ReactComponentElement<typeof SearchField>;
 
   /** the initial number of how many row-per-page to show */
   initialItemsPerPage?: number;
@@ -40,10 +40,10 @@ type Props = {
   loadingText?: string;
 
   /** Children node in the table */
-  children: React.ReactNode;
+  children: ReactNode;
 
   /** Other filter fields */
-  additionalFilters?: React.ReactNode[];
+  additionalFilters?: ReactNode[];
 };
 
 export function CustomDataHandler(props: Props) {
@@ -51,7 +51,7 @@ export function CustomDataHandler(props: Props) {
   return (
     <TableDataHandler {...allProps} selectable={() => selectable}>
       {({ currItems, criteria }) =>
-        React.Children.toArray(props.children).map((child) => cloneReactElement(child, { data: currItems, criteria }))
+        Children.toArray(props.children).map((child) => cloneReactElement(child, { data: currItems, criteria }))
       }
     </TableDataHandler>
   );

--- a/web/html/src/components/table/Header.tsx
+++ b/web/html/src/components/table/Header.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 type HeaderProps = {
   /** key differenciating a header from its siblings */
@@ -20,7 +20,7 @@ type HeaderProps = {
   onSortChange?: (columnKey: string | null, sortDirection: number) => void;
 
   /** children nodes */
-  children?: React.ReactNode;
+  children?: ReactNode;
 
   /** identifier for the column */
   columnKey?: string;

--- a/web/html/src/components/table/HierarchicalTable.tsx
+++ b/web/html/src/components/table/HierarchicalTable.tsx
@@ -1,5 +1,13 @@
-import * as React from "react";
-import { useState } from "react";
+import {
+  type ReactComponentElement,
+  type ReactElement,
+  type ReactNode,
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useState,
+} from "react";
 
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 
@@ -31,10 +39,10 @@ type HierarchicalTableProps = {
   identifier: (row: HierarchicalRow) => string | number;
 
   /** The search field to show on the table  */
-  searchField?: React.ReactComponentElement<typeof SearchField>;
+  searchField?: ReactComponentElement<typeof SearchField>;
 
   /** Other filter fields */
-  additionalFilters?: React.ReactNode[];
+  additionalFilters?: ReactNode[];
 
   /** Function to determine which column has expand/collapse controls */
   expandColumnKey?: string;
@@ -64,13 +72,13 @@ type HierarchicalTableProps = {
   indentSize?: number;
 
   /** Children node in the table (Column components) */
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 /**
  * @deprecated Use `Table` instead, it supports nested data, see `/rhn/manager/storybook`.
  */
-export const DEPRECATED_HierarchicalTable = React.forwardRef<TableRef, HierarchicalTableProps>((props, ref) => {
+export const DEPRECATED_HierarchicalTable = forwardRef<TableRef, HierarchicalTableProps>((props, ref) => {
   const {
     className,
     data,
@@ -162,7 +170,7 @@ export const DEPRECATED_HierarchicalTable = React.forwardRef<TableRef, Hierarchi
   const treeData = buildTreeStructure(data);
   const visibleRows = getVisibleRows(treeData);
 
-  const renderCellContent = (row: HierarchicalRow, child: React.ReactElement) => {
+  const renderCellContent = (row: HierarchicalRow, child: ReactElement) => {
     // Get the cell content (either from custom renderer or from data property)
     const cellContent = child.props.cell ? child.props.cell(row) : row[child.props.columnKey || ""];
     // Apply special styling for non-leaf or indented nodes
@@ -174,12 +182,12 @@ export const DEPRECATED_HierarchicalTable = React.forwardRef<TableRef, Hierarchi
     return cellContent;
   };
 
-  const isColumnElement = (element: React.ReactNode): element is React.ReactElement => {
-    if (!React.isValidElement(element)) return false;
+  const isColumnElement = (element: ReactNode): element is ReactElement => {
+    if (!isValidElement(element)) return false;
     return element.props && ("columnKey" in element.props || "header" in element.props || "cell" in element.props);
   };
 
-  const enhancedChildren = React.Children.map(children, (child) => {
+  const enhancedChildren = Children.map(children, (child) => {
     if (!isColumnElement(child)) return child;
     if (child.props.columnKey === expandColumnKey) {
       const cellRenderer = (row: any) => {
@@ -202,7 +210,7 @@ export const DEPRECATED_HierarchicalTable = React.forwardRef<TableRef, Hierarchi
           </div>
         );
       };
-      return React.cloneElement(child, {
+      return cloneElement(child, {
         ...child.props,
         cell: cellRenderer,
       });

--- a/web/html/src/components/table/Highlight.tsx
+++ b/web/html/src/components/table/Highlight.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 type HighlightProps = {
   /** text to display */
@@ -36,9 +36,9 @@ export function Highlight({ enabled = false, ...props }: HighlightProps) {
     );
   }
 
-  let chunk1: React.ReactNode = text.substring(0, pos);
-  let chunk2: React.ReactNode = text.substring(pos, pos + high.length);
-  let chunk3: React.ReactNode = text.substring(pos + high.length, text.length);
+  let chunk1: ReactNode = text.substring(0, pos);
+  let chunk2: ReactNode = text.substring(pos, pos + high.length);
+  let chunk3: ReactNode = text.substring(pos + high.length, text.length);
 
   chunk1 = chunk1 ? <span key="m1">{chunk1}</span> : null;
   chunk2 = chunk2 ? (

--- a/web/html/src/components/table/SearchField.test.tsx
+++ b/web/html/src/components/table/SearchField.test.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { render, screen, type } from "utils/test-utils";

--- a/web/html/src/components/table/SearchField.tsx
+++ b/web/html/src/components/table/SearchField.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { DEPRECATED_Select } from "components/input";
 import { Form } from "components/input/form/Form";
 

--- a/web/html/src/components/table/SearchPanel.tsx
+++ b/web/html/src/components/table/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Children } from "react";
 
 import { cloneReactElement } from "components/utils";
 
@@ -18,14 +18,14 @@ type SearchPanelProps = {
   field?: string;
 
   /** Search field components */
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 /** Panel containing the search fields for a table */
 export function SearchPanel(props: SearchPanelProps) {
   return (
     <div className={`spacewalk-list-filter ${styles.searchPanel}`}>
-      {React.Children.toArray(props.children).map((child) =>
+      {Children.toArray(props.children).map((child) =>
         cloneReactElement(child, {
           criteria: props.criteria,
           field: props.field,

--- a/web/html/src/components/table/SelectedRowDetails.tsx
+++ b/web/html/src/components/table/SelectedRowDetails.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Button } from "components/buttons";
 
 type SearchPanelPropss = {

--- a/web/html/src/components/table/Table.test.tsx
+++ b/web/html/src/components/table/Table.test.tsx
@@ -3,7 +3,7 @@
  * Module specific tests belong on the submodule instead.
  */
 
-import * as React from "react";
+import type { ReactElement } from "react";
 
 import { render, RenderOptions, screen, server, type, waitForElementToBeRemoved } from "utils/test-utils";
 
@@ -22,7 +22,7 @@ describe("Table component", () => {
   };
 
   /** Render and wait for the first load to be done */
-  async function renderAndLoad(ui: React.ReactElement, options?: Omit<RenderOptions, "queries">) {
+  async function renderAndLoad(ui: ReactElement, options?: Omit<RenderOptions, "queries">) {
     const result = render(ui, options);
     await waitForElementToBeRemoved(() => screen.queryByText(baseProps.loadingText));
     return result;

--- a/web/html/src/components/table/Table.tsx
+++ b/web/html/src/components/table/Table.tsx
@@ -1,5 +1,15 @@
-import * as React from "react";
-import { forwardRef, useImperativeHandle } from "react";
+import {
+  type ComponentProps,
+  type ReactComponentElement,
+  type ReactElement,
+  type ReactNode,
+  Children,
+  cloneElement,
+  forwardRef,
+  Fragment,
+  useImperativeHandle,
+  useRef,
+} from "react";
 
 import { Button } from "components/buttons";
 
@@ -45,7 +55,7 @@ type TableProps = {
   onSearch?: (criteria: string) => void;
 
   /** the React Object that contains the filter search field */
-  searchField?: React.ReactComponentElement<typeof SearchField>;
+  searchField?: ReactComponentElement<typeof SearchField>;
 
   /** the initial number of how many row-per-page to show */
   initialItemsPerPage?: number;
@@ -83,10 +93,10 @@ type TableProps = {
   onLoad?: () => void;
 
   /** Children node in the table */
-  children: React.ReactNode;
+  children: ReactNode;
 
   /** Other filter fields */
-  additionalFilters?: React.ReactNode[];
+  additionalFilters?: ReactNode[];
 
   /** Default search field */
   defaultSearchField?: string;
@@ -95,10 +105,10 @@ type TableProps = {
   initialSearch?: string;
 
   /** Title buttons to add next to the items per page selection */
-  titleButtons?: React.ReactNode[];
+  titleButtons?: ReactNode[];
 };
 
-function isColumn(input: any): input is React.ReactElement<React.ComponentProps<typeof Column>> {
+function isColumn(input: any): input is ReactElement<ComponentProps<typeof Column>> {
   return input?.type === Column || input?.type?.displayName === "Column";
 }
 
@@ -108,8 +118,8 @@ export type TableRef = {
 
 export const Table = forwardRef<TableRef, TableProps>((props, ref) => {
   const { ...allProps } = props;
-  const columns = React.Children.toArray(props.children).filter(isColumn);
-  const dataHandlerRef = React.useRef<TableDataHandler>(null);
+  const columns = Children.toArray(props.children).filter(isColumn);
+  const dataHandlerRef = useRef<TableDataHandler>(null);
 
   const expanded = useExpanded();
 
@@ -125,10 +135,10 @@ export const Table = forwardRef<TableRef, TableProps>((props, ref) => {
         const selectableValue = DEPRECATED_unsafeEquals(props.selectable, null) ? false : props.selectable;
 
         const renderRow = (item: ArrayElement<typeof currItems>, index: number, nestingLevel: number) => {
-          const cells: React.ReactNode[] = React.Children.toArray(props.children)
+          const cells: ReactNode[] = Children.toArray(props.children)
             .filter(isColumn)
             .map((column, index) =>
-              React.cloneElement(column, {
+              cloneElement(column, {
                 key: column.props.columnKey,
                 data: item,
                 criteria: criteria,
@@ -215,13 +225,13 @@ export const Table = forwardRef<TableRef, TableProps>((props, ref) => {
             key = index;
           }
           return (
-            <React.Fragment key={key}>
+            <Fragment key={key}>
               <tr className={rowClass}>{cells}</tr>
               {props.expandable &&
                 "children" in item &&
                 expanded.has(props.identifier(item)) &&
                 item.children.map((childItem, childIndex) => renderRow(childItem, childIndex, nestingLevel + 1))}
-            </React.Fragment>
+            </Fragment>
           );
         };
 

--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactComponentElement, type ReactElement, type ReactNode, Children, Component } from "react";
 
 import _isEqual from "lodash/isEqual";
 
@@ -18,7 +18,7 @@ import { SelectedRowDetails } from "./SelectedRowDetails";
 
 type ChildrenArgsProps = {
   currItems: any[];
-  headers: React.ReactNode;
+  headers: ReactNode;
   handleSelect: (...args: any[]) => any;
   selectedItems: any[];
   criteria?: string;
@@ -26,7 +26,7 @@ type ChildrenArgsProps = {
 };
 
 type Props = {
-  columns: React.ReactElement<any>[];
+  columns: ReactElement<any>[];
 
   /**
    * Either an array of data items of any type where each element is a row data,
@@ -57,7 +57,7 @@ type Props = {
   onSearch?: (criteria: string) => void;
 
   /** the React Object that contains the filter search field */
-  searchField?: React.ReactComponentElement<typeof SearchField>;
+  searchField?: ReactComponentElement<typeof SearchField>;
 
   /** Default column to search on */
   defaultSearchField?: string;
@@ -103,13 +103,13 @@ type Props = {
   onLoad?: () => void;
 
   /** Children node in the table */
-  children: (args: ChildrenArgsProps) => React.ReactNode;
+  children: (args: ChildrenArgsProps) => ReactNode;
 
   /** Other filter fields */
-  additionalFilters?: React.ReactNode[];
+  additionalFilters?: ReactNode[];
 
   /** Title buttons to add next to the items per page selection */
-  titleButtons?: React.ReactNode[];
+  titleButtons?: ReactNode[];
 };
 
 type State = {
@@ -125,7 +125,7 @@ type State = {
   loading: boolean;
 };
 
-export class TableDataHandler extends React.Component<Props, State> {
+export class TableDataHandler extends Component<Props, State> {
   static defaultProps = {
     selectable: false,
     deletable: false,
@@ -283,7 +283,7 @@ export class TableDataHandler extends React.Component<Props, State> {
   };
 
   renderTitleButtons = () => {
-    return React.Children.map(this.props.titleButtons, (item: React.ReactNode) =>
+    return Children.map(this.props.titleButtons, (item: ReactNode) =>
       cloneReactElement(item, {
         search: { field: this.state.field, criteria: this.state.criteria },
       })

--- a/web/html/src/components/target-systems.tsx
+++ b/web/html/src/components/target-systems.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { FC, ReactNode } from "react";
 
 import { pageSize } from "core/user-preferences";
 
@@ -14,10 +14,10 @@ export type SystemData = {
 
 type Props = {
   systemsData: SystemData[];
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
-export const TargetSystems: React.FC<Props> = ({ systemsData, children }: Props): JSX.Element => {
+export const TargetSystems: FC<Props> = ({ systemsData, children }: Props): JSX.Element => {
   function renderSystemLink(system: SystemData) {
     return <SystemLink id={system.id}>{system.name}</SystemLink>;
   }

--- a/web/html/src/components/toastr/toastr.example.tsx
+++ b/web/html/src/components/toastr/toastr.example.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { MessagesContainer, showSuccessToastr } from "./toastr";
 
 export default () => {

--- a/web/html/src/components/toastr/toastr.tsx
+++ b/web/html/src/components/toastr/toastr.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-
+import type { ReactNode, ReactNodeArray } from "react";
 import { cssTransition, toast, ToastContainer } from "react-toastify";
 
 type OptionalParams = {
@@ -18,9 +17,9 @@ const FadeTransition = cssTransition({
   collapseDuration: 0,
 });
 
-function show(message: React.ReactNode, notify: (arg0: React.ReactNode) => void) {
+function show(message: ReactNode, notify: (arg0: ReactNode) => void) {
   if (Array.isArray(message)) {
-    const combinedMessages = message.reduce((acc: React.ReactNodeArray, val) => acc.concat(val), []);
+    const combinedMessages = message.reduce((acc: ReactNodeArray, val) => acc.concat(val), []);
     for (const msg of combinedMessages) {
       notify(msg);
     }
@@ -35,7 +34,7 @@ function parseAutoHide(input: boolean) {
   return input === true ? undefined : false;
 }
 
-export function showSuccessToastr(message: React.ReactNode, optionalParams: OptionalParams = { autoHide: true }) {
+export function showSuccessToastr(message: ReactNode, optionalParams: OptionalParams = { autoHide: true }) {
   const notify = (msg) =>
     toast.success(msg, {
       autoClose: parseAutoHide(optionalParams.autoHide),
@@ -44,7 +43,7 @@ export function showSuccessToastr(message: React.ReactNode, optionalParams: Opti
   show(message, notify);
 }
 
-export function showWarningToastr(message: React.ReactNode, optionalParams: OptionalParams = { autoHide: true }) {
+export function showWarningToastr(message: ReactNode, optionalParams: OptionalParams = { autoHide: true }) {
   const notify = (msg) =>
     toast.warning(msg, {
       autoClose: parseAutoHide(optionalParams.autoHide),
@@ -53,7 +52,7 @@ export function showWarningToastr(message: React.ReactNode, optionalParams: Opti
   show(message, notify);
 }
 
-export function showErrorToastr(message: React.ReactNode | Error, optionalParams: OptionalParams = { autoHide: true }) {
+export function showErrorToastr(message: ReactNode | Error, optionalParams: OptionalParams = { autoHide: true }) {
   const notify = (msg) => {
     toast.error(msg, {
       autoClose: parseAutoHide(optionalParams.autoHide),
@@ -69,7 +68,7 @@ export function showErrorToastr(message: React.ReactNode | Error, optionalParams
   }
 }
 
-export function showInfoToastr(message: React.ReactNode, optionalParams: OptionalParams = { autoHide: true }) {
+export function showInfoToastr(message: ReactNode, optionalParams: OptionalParams = { autoHide: true }) {
   const notify = (msg) =>
     toast.info(msg, {
       autoClose: parseAutoHide(optionalParams.autoHide),

--- a/web/html/src/components/toggler.tsx
+++ b/web/html/src/components/toggler.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-
+import { type ReactNode, Component } from "react";
 /** @module toggler */
 
 type Props = {
@@ -7,7 +6,7 @@ type Props = {
   handler: (value: boolean) => void;
 
   /** Text to display on the toggler. */
-  text?: React.ReactNode;
+  text?: ReactNode;
 
   /** The boolean value represented by the toggler. */
   value?: boolean;
@@ -22,7 +21,7 @@ type Props = {
 /**
  * A customized toggle switch element to represent boolean values.
  */
-class Toggler extends React.Component<Props> {
+class Toggler extends Component<Props> {
   render() {
     let classes = this.props.disabled ? "text-muted" : "pointer";
 

--- a/web/html/src/components/tree/tree.tsx
+++ b/web/html/src/components/tree/tree.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type ChangeEvent, type ReactNode, useState } from "react";
 
 import { CustomDiv } from "components/custom-objects";
 
@@ -18,8 +17,8 @@ export type TreeData = {
 
 export type Props = {
   data?: TreeData;
-  renderItem: (item: TreeItem, renderNameColumn: (...args: any[]) => any) => React.ReactNode;
-  header?: React.ReactNode;
+  renderItem: (item: TreeItem, renderNameColumn: (...args: any[]) => any) => ReactNode;
+  header?: ReactNode;
   initiallyExpanded?: string[];
   onItemSelectionChanged?: (item: TreeItem, checked: boolean) => void;
   initiallySelected?: string[];
@@ -45,7 +44,7 @@ export const Tree = (props: Props) => {
     return selected.indexOf(id) !== -1;
   }
 
-  function handleSelectionChange(changeEvent: React.ChangeEvent): void {
+  function handleSelectionChange(changeEvent: ChangeEvent): void {
     if (changeEvent.target instanceof HTMLInputElement) {
       const { value: id, checked } = changeEvent.target;
 

--- a/web/html/src/components/utils/HelpIcon.tsx
+++ b/web/html/src/components/utils/HelpIcon.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 type Props = {
   /** Title of the icon */
   text?: string | null;

--- a/web/html/src/components/utils/HelpLink.tsx
+++ b/web/html/src/components/utils/HelpLink.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { docsLocale } from "core/user-preferences";
 
 import HelpIcon from "./HelpIcon";

--- a/web/html/src/components/utils/cloneReactElement.test.tsx
+++ b/web/html/src/components/utils/cloneReactElement.test.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Children } from "react";
 
 import { render, screen } from "utils/test-utils";
 
@@ -6,14 +6,12 @@ import { cloneReactElement } from "./cloneReactElement";
 
 describe("cloneReactElement", () => {
   type Props<T> = T & {
-    children?: React.ReactNode;
+    children?: ReactNode;
   };
   function Wrapper<T>(props: Props<T>) {
     const { children, ...rest } = props;
     return (
-      <div data-testid="wrapper">
-        {React.Children.toArray(props.children).map((child) => cloneReactElement(child, rest))}
-      </div>
+      <div data-testid="wrapper">{Children.toArray(props.children).map((child) => cloneReactElement(child, rest))}</div>
     );
   }
 

--- a/web/html/src/components/utils/cloneReactElement.ts
+++ b/web/html/src/components/utils/cloneReactElement.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type Attributes, type ReactNode, cloneElement, isValidElement } from "react";
 
 /**
  * When cloning an element, the element might be either a component that accepts custom props or a regular DOM node such
@@ -8,11 +8,11 @@ import * as React from "react";
  * the props and a different layer adds the rest.
  * Please use this sparingly since it makes refactoring and understanding intent by reading code considerably harder.
  */
-export function cloneReactElement<P extends (Partial<unknown> & React.Attributes) | undefined>(
-  element: React.ReactNode | ((props: P) => JSX.Element),
+export function cloneReactElement<P extends (Partial<unknown> & Attributes) | undefined>(
+  element: ReactNode | ((props: P) => JSX.Element),
   props?: P,
-  ...children: React.ReactNode[]
+  ...children: ReactNode[]
 ) {
   const unwrappedProps = typeof element === "string" || typeof (element as any)?.type === "string" ? undefined : props;
-  return React.isValidElement(element) ? React.cloneElement(element, unwrappedProps, ...children) : element;
+  return isValidElement(element) ? cloneElement(element, unwrappedProps, ...children) : element;
 }

--- a/web/html/src/components/utils/loading/Loading.tsx
+++ b/web/html/src/components/utils/loading/Loading.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 type LoadingProps = {
   /** Text to be displayed with the loading spinner */
   text?: string;

--- a/web/html/src/components/virtual-list/VirtualList.tsx
+++ b/web/html/src/components/virtual-list/VirtualList.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Virtuoso } from "react-virtuoso";
 
 import styles from "./VirtualList.module.scss";

--- a/web/html/src/core/auth/roles-context.tsx
+++ b/web/html/src/core/auth/roles-context.tsx
@@ -1,15 +1,14 @@
 // Note: to use this component you have to make sure the current user roles are injected with withRolesTemplate
 // and jade mixin userRoles
-import * as React from "react";
-
+import { type ReactNode, createContext } from "react";
 export type rolesType = string[];
 declare global {
   var global_userRoles: rolesType | undefined;
 }
 
-const RolesContext = React.createContext<rolesType>([]);
+const RolesContext = createContext<rolesType>([]);
 
-const RolesProvider = ({ children }: { children: React.ReactNode }) => (
+const RolesProvider = ({ children }: { children: ReactNode }) => (
   <RolesContext.Provider value={typeof global_userRoles !== "undefined" ? global_userRoles : []}>
     {children}
   </RolesContext.Provider>

--- a/web/html/src/core/intl/index.test.tsx
+++ b/web/html/src/core/intl/index.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Fragment } from "react";
 
 import ReactDOMServer from "react-dom/server";
 
@@ -26,9 +26,7 @@ describe("new t()", () => {
     };
     const expected = 'foo <a href="/">bar</a>';
 
-    expect(
-      ReactDOMServer.renderToStaticMarkup(<React.Fragment key="key">{t(input, inputArgs)}</React.Fragment>)
-    ).toEqual(expected);
+    expect(ReactDOMServer.renderToStaticMarkup(<Fragment key="key">{t(input, inputArgs)}</Fragment>)).toEqual(expected);
   });
 
   test("tags with named placeholders", () => {
@@ -39,9 +37,7 @@ describe("new t()", () => {
     };
     const expected = 'foo <a href="/">something</a> bar';
 
-    expect(
-      ReactDOMServer.renderToStaticMarkup(<React.Fragment key="key">{t(input, inputArgs)}</React.Fragment>)
-    ).toEqual(expected);
+    expect(ReactDOMServer.renderToStaticMarkup(<Fragment key="key">{t(input, inputArgs)}</Fragment>)).toEqual(expected);
   });
 
   // This behavior allows existing `handleResponseError` implementations to pass `{ arg: undefined }` even when there is no arg

--- a/web/html/src/core/spa/spa-engine.tsx
+++ b/web/html/src/core/spa/spa-engine.tsx
@@ -1,8 +1,6 @@
 import "senna/build/senna.css";
 import "./spa-engine.css";
 
-import * as React from "react";
-
 import App, { HtmlScreen } from "senna";
 
 import SpaRenderer from "core/spa/spa-renderer";

--- a/web/html/src/core/spa/spa-renderer.ts
+++ b/web/html/src/core/spa/spa-renderer.ts
@@ -1,7 +1,7 @@
 // This binds the global translation logic
 import "core/intl";
 
-import * as React from "react";
+import { cloneElement } from "react";
 import ReactDOM from "react-dom";
 
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
@@ -34,7 +34,7 @@ function renderGlobalReact(element: JSX.Element, container: Element | null | und
   function registerGlobalRender(instance) {
     window.pageRenderers?.spa?.globalRenderersToUpdate?.push(instance);
   }
-  const elementWithRef = React.cloneElement(element, { ref: registerGlobalRender });
+  const elementWithRef = cloneElement(element, { ref: registerGlobalRender });
   ReactDOM.render(elementWithRef, container);
 }
 

--- a/web/html/src/core/user-localization/user-localization-context.tsx
+++ b/web/html/src/core/user-localization/user-localization-context.tsx
@@ -1,7 +1,6 @@
 // Note: to use this component you have to make sure the current user localization are injected with
 // the jade mixin userLocalization
-import * as React from "react";
-
+import { type ReactNode, createContext } from "react";
 export type userLocalizationType = {
   timezone: string;
   localTime: string;
@@ -10,9 +9,9 @@ declare global {
   var global_user_localization: userLocalizationType | undefined;
 }
 
-const UserLocalizationContext = React.createContext<Partial<userLocalizationType>>({});
+const UserLocalizationContext = createContext<Partial<userLocalizationType>>({});
 
-const UserLocalizationProvider = ({ children }: { children: React.ReactNode }) => (
+const UserLocalizationProvider = ({ children }: { children: ReactNode }) => (
   <UserLocalizationContext.Provider
     value={typeof global_user_localization !== "undefined" ? global_user_localization : {}}
   >

--- a/web/html/src/manager/admin/config/monitoring-admin.tsx
+++ b/web/html/src/manager/admin/config/monitoring-admin.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect } from "react";
+import { Fragment, useEffect } from "react";
 
 import { docsLocale, isUyuni, productName } from "core/user-preferences";
 
@@ -228,7 +227,7 @@ const MonitoringAdmin = () => {
     switch (action) {
       case "checking":
         buttons = (
-          <React.Fragment>
+          <Fragment>
             <Button
               id="enable-monitoring-btn"
               disabled={true}
@@ -243,12 +242,12 @@ const MonitoringAdmin = () => {
               icon="fa-stop"
               text={t("Disable")}
             />
-          </React.Fragment>
+          </Fragment>
         );
         break;
       case "enabling":
         buttons = (
-          <React.Fragment>
+          <Fragment>
             <Button
               id="enable-monitoring-btn"
               disabled={true}
@@ -263,12 +262,12 @@ const MonitoringAdmin = () => {
               icon="fa-pause"
               text={t("Disable")}
             />
-          </React.Fragment>
+          </Fragment>
         );
         break;
       case "disabling":
         buttons = (
-          <React.Fragment>
+          <Fragment>
             <Button
               id="enable-monitoring-btn"
               disabled={true}
@@ -283,7 +282,7 @@ const MonitoringAdmin = () => {
               icon="fa-circle-o-notch fa-spin"
               text={t("Disable")}
             />
-          </React.Fragment>
+          </Fragment>
         );
         break;
       default:
@@ -291,7 +290,7 @@ const MonitoringAdmin = () => {
     }
   } else {
     buttons = (
-      <React.Fragment>
+      <Fragment>
         <AsyncButton
           id="enable-monitoring-btn"
           defaultType="btn-default"
@@ -307,7 +306,7 @@ const MonitoringAdmin = () => {
           text={t("Disable")}
           action={() => changeMonitoringStatus(false)}
         />
-      </React.Fragment>
+      </Fragment>
     );
   }
 

--- a/web/html/src/manager/admin/config/monitoring.renderer.tsx
+++ b/web/html/src/manager/admin/config/monitoring.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import MonitoringAdmin from "./monitoring-admin";

--- a/web/html/src/manager/admin/create-payg/create-payg.renderer.tsx
+++ b/web/html/src/manager/admin/create-payg/create-payg.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/create-payg/create-payg.tsx
+++ b/web/html/src/manager/admin/create-payg/create-payg.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import useLifecyclePaygActionsApi from "manager/admin/payg-shared/api/payg-actions-api";

--- a/web/html/src/manager/admin/hub/hub-details.renderer.tsx
+++ b/web/html/src/manager/admin/hub/hub-details.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/hub/hub-details.tsx
+++ b/web/html/src/manager/admin/hub/hub-details.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Button } from "components/buttons";
 import { DangerDialog } from "components/dialog/DangerDialog";
@@ -17,7 +17,7 @@ type State = {
   confirmSyncBunch: boolean;
 };
 
-export class HubDetails extends React.Component<Props, State> {
+export class HubDetails extends Component<Props, State> {
   public constructor(props: Props) {
     super(props);
 
@@ -27,7 +27,7 @@ export class HubDetails extends React.Component<Props, State> {
     };
   }
 
-  private renderSyncBunch(): React.ReactNode {
+  private renderSyncBunch(): ReactNode {
     return (
       <>
         <Button
@@ -51,7 +51,7 @@ export class HubDetails extends React.Component<Props, State> {
     );
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <TopPanel
         title={t("Hub Details")}

--- a/web/html/src/manager/admin/hub/list-tokens.renderer.tsx
+++ b/web/html/src/manager/admin/hub/list-tokens.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { TokenList } from "manager/admin/hub/list-tokens";
 
 import { RolesProvider } from "core/auth/roles-context";

--- a/web/html/src/manager/admin/hub/list-tokens.tsx
+++ b/web/html/src/manager/admin/hub/list-tokens.tsx
@@ -1,20 +1,20 @@
-import * as React from "react";
+import { type ReactNode, type RefObject, Component, createRef } from "react";
 
 import { AddTokenButton, TokenTable } from "components/hub";
 import { TopPanel } from "components/panels";
 
 type Props = Record<never, never>;
 
-export class TokenList extends React.Component<Props> {
-  private tokenTable: React.RefObject<TokenTable>;
+export class TokenList extends Component<Props> {
+  private tokenTable: RefObject<TokenTable>;
 
   public constructor(props: Props) {
     super(props);
 
-    this.tokenTable = React.createRef();
+    this.tokenTable = createRef();
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <TopPanel
         title={t("Access Tokens")}

--- a/web/html/src/manager/admin/hub/migrate-from-v1.renderer.tsx
+++ b/web/html/src/manager/admin/hub/migrate-from-v1.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/hub/migrate-from-v2.renderer.tsx
+++ b/web/html/src/manager/admin/hub/migrate-from-v2.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/hub/peripheral-details.renderer.tsx
+++ b/web/html/src/manager/admin/hub/peripheral-details.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/hub/peripheral-details.tsx
+++ b/web/html/src/manager/admin/hub/peripheral-details.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Button } from "components/buttons";
 import { DeregisterServer, IssRole, PeripheralDetailData, ServerDetailsForm } from "components/hub";
@@ -9,12 +9,12 @@ export type Props = {
   peripheral: PeripheralDetailData;
 };
 
-export class PeripheralDetails extends React.Component<Props> {
+export class PeripheralDetails extends Component<Props> {
   public constructor(props: Props) {
     super(props);
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <TopPanel
         title={t("{fqdn} - Peripheral Details", this.props.peripheral)}

--- a/web/html/src/manager/admin/hub/peripherals.tsx
+++ b/web/html/src/manager/admin/hub/peripherals.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect } from "react";
 
 import { Button, DropdownButton, LinkButton } from "components/buttons";
 import withPageWrapper from "components/general/with-page-wrapper";
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const IssPeripheral = (props: Props) => {
-  React.useEffect(() => {
+  useEffect(() => {
     if (props.flashMessage !== undefined && props.flashMessage.length > 0) {
       showSuccessToastr(props.flashMessage);
     }

--- a/web/html/src/manager/admin/hub/register-peripheral.renderer.tsx
+++ b/web/html/src/manager/admin/hub/register-peripheral.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/list-payg/list-payg.renderer.tsx
+++ b/web/html/src/manager/admin/list-payg/list-payg.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/list-payg/list-payg.tsx
+++ b/web/html/src/manager/admin/list-payg/list-payg.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect } from "react";
 
 import _truncate from "lodash/truncate";

--- a/web/html/src/manager/admin/payg-shared/common/payg-status.tsx
+++ b/web/html/src/manager/admin/payg-shared/common/payg-status.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { IconTag } from "components/icontag";
 
@@ -16,10 +16,10 @@ const PaygStatus = (props: Props) => {
   }
 
   return (
-    <React.Fragment>
+    <Fragment>
       <IconTag type={icon} />
       {props.statusMessage}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/admin/payg-shared/info/payg-info-edit.tsx
+++ b/web/html/src/manager/admin/payg-shared/info/payg-info-edit.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { PaygFullType } from "manager/admin/payg/payg";
 import useLifecyclePaygActionsApi from "manager/admin/payg-shared/api/payg-actions-api";
 import PaygInfoForm from "manager/admin/payg-shared/info/payg-info-form";

--- a/web/html/src/manager/admin/payg-shared/info/payg-info-form.tsx
+++ b/web/html/src/manager/admin/payg-shared/info/payg-info-form.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { paygProperties } from "manager/admin/payg/payg";
 
 import { Form, Text } from "components/input";

--- a/web/html/src/manager/admin/payg-shared/info/payg-info-view.tsx
+++ b/web/html/src/manager/admin/payg-shared/info/payg-info-view.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { PaygFullType } from "manager/admin/payg/payg";
 import PaygStatus from "manager/admin/payg-shared/common/payg-status";
@@ -9,7 +9,7 @@ type Props = {
 
 const PaygInfoView = (props: Props) => {
   return (
-    <React.Fragment>
+    <Fragment>
       <dl className="row">
         <dt className="col-2">{t("Description")}</dt>
         <dd className="col-10">{props.payg.properties.description}</dd>
@@ -24,7 +24,7 @@ const PaygInfoView = (props: Props) => {
         <dt className="col-2">{t("Last Status Update")}</dt>
         <dd className="col-10">{props.payg.lastChange}</dd>
       </dl>
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-edit.tsx
+++ b/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-edit.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { paygProperties } from "manager/admin/payg/payg";
 import useLifecyclePaygActionsApi from "manager/admin/payg-shared/api/payg-actions-api";
 import PaygSshDataForm from "manager/admin/payg-shared/sshData/payg-ssh-data-form";

--- a/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-form.tsx
+++ b/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-form.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { paygProperties } from "manager/admin/payg/payg";
 
@@ -38,7 +38,7 @@ type PropsFields = {
 export const PaygSshDataFormFields = (props: PropsFields) => {
   const prefix = props.isInstance ? "" : "bastion_";
   return (
-    <React.Fragment>
+    <Fragment>
       {props.editing && (
         <div className="alert alert-info" style={{ marginTop: "0px" }}>
           {t("When editing the SSH connection all needed credentials must be re-provided.")}
@@ -104,6 +104,6 @@ export const PaygSshDataFormFields = (props: PropsFields) => {
           divClass="col-md-10"
         />
       </div>
-    </React.Fragment>
+    </Fragment>
   );
 };

--- a/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-view.tsx
+++ b/web/html/src/manager/admin/payg-shared/sshData/payg-ssh-data-view.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { paygProperties } from "manager/admin/payg/payg";
 
 const passHidden = "*****";

--- a/web/html/src/manager/admin/payg/payg.renderer.tsx
+++ b/web/html/src/manager/admin/payg/payg.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/payg/payg.tsx
+++ b/web/html/src/manager/admin/payg/payg.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import useLifecyclePaygActionsApi from "manager/admin/payg-shared/api/payg-actions-api";

--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Button } from "components/buttons";
 import { Messages, MessageType } from "components/messages/messages";
@@ -61,7 +61,7 @@ class SCCDialogState {
   errors: MessageType[] = [];
 }
 
-class SCCDialog extends React.Component<Props, SCCDialogState> {
+class SCCDialog extends Component<Props, SCCDialogState> {
   state = new SCCDialogState();
 
   UNSAFE_componentWillMount() {

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component, useEffect, useState } from "react";
 
 import _partition from "lodash/partition";
 
@@ -92,7 +92,7 @@ class ProductsPageWrapperState {
  * Generate the page wrapper, tabs, scc-popup,
  * and everything around the product list except the list
  */
-class ProductsPageWrapper extends React.Component<ProductsPageWrapperProps, ProductsPageWrapperState> {
+class ProductsPageWrapper extends Component<ProductsPageWrapperProps, ProductsPageWrapperState> {
   state = new ProductsPageWrapperState();
 
   UNSAFE_componentWillMount() {
@@ -435,7 +435,7 @@ class ProductsState {
 /**
  * Show the products data
  */
-class Products extends React.Component<ProductsProps, ProductsState> {
+class Products extends Component<ProductsProps, ProductsState> {
   state = new ProductsState();
 
   getDistinctArchsFromData = (data: any[] = []) => {
@@ -568,7 +568,7 @@ type CheckListProps = {
 /**
  * Generate a custom list of elements for the products data
  */
-class CheckList extends React.Component<CheckListProps> {
+class CheckList extends Component<CheckListProps> {
   isRootLevel = (level) => {
     return DEPRECATED_unsafeEquals(level, 1);
   };
@@ -661,7 +661,7 @@ class CheckListItemState {
  * A component to generate a list item which contains
  * all information for a single product
  */
-class CheckListItem extends React.Component<CheckListItemProps, CheckListItemState> {
+class CheckListItem extends Component<CheckListItemProps, CheckListItemState> {
   state = new CheckListItemState();
 
   UNSAFE_componentWillReceiveProps(nextProps) {
@@ -825,7 +825,7 @@ class CheckListItem extends React.Component<CheckListItemProps, CheckListItemSta
     const currentItem = this.props.item;
 
     /** generate item selector content **/
-    let selectorContent: React.ReactNode = null;
+    let selectorContent: ReactNode = null;
     if (this.props.bypassProps.isSelectable && currentItem.status === _PRODUCT_STATUS.available) {
       selectorContent = (
         <input
@@ -1042,13 +1042,13 @@ class CheckListItem extends React.Component<CheckListItemProps, CheckListItemSta
 }
 
 const ChannelsPopUp = (props) => {
-  const [checked, setChecked] = React.useState<boolean[]>([]);
-  const [installed, setInstalled] = React.useState<boolean>(props.item.status === _PRODUCT_STATUS.installed);
+  const [checked, setChecked] = useState<boolean[]>([]);
+  const [installed, setInstalled] = useState<boolean>(props.item.status === _PRODUCT_STATUS.installed);
 
   const sorted = props.item.channels.sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
   const [mandatoryChannels, optionalChannels] = _partition(sorted, (c) => !c.optional);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setInstalled(props.item.status === _PRODUCT_STATUS.installed);
     setChecked(optionalChannels.map((i) => i.status === _CHANNEL_STATUS.synced));
   }, [props.item]);
@@ -1120,7 +1120,7 @@ const ChannelsPopUp = (props) => {
 };
 
 const decodeChannelStatus = (status) => {
-  let decoded: React.ReactNode = "";
+  let decoded: ReactNode = "";
   switch (status) {
     case _CHANNEL_STATUS.notSynced:
       decoded = <span className="text-muted">{t("not synced")}</span>;

--- a/web/html/src/manager/admin/setup/proxy/proxy.renderer.tsx
+++ b/web/html/src/manager/admin/setup/proxy/proxy.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/admin/task-engine-status/taskotop.tsx
+++ b/web/html/src/manager/admin/task-engine-status/taskotop.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -17,7 +17,7 @@ type Props = {
   refreshInterval: number;
 };
 
-class TaskoTop extends React.Component<Props> {
+class TaskoTop extends Component<Props> {
   timerId?: number;
   state = {
     serverData: null,

--- a/web/html/src/manager/audit/coco/coco-global-scans-list.renderer.tsx
+++ b/web/html/src/manager/audit/coco/coco-global-scans-list.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import CoCoScansList from "components/CoCoScansList";

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -132,7 +132,7 @@ type State = {
   auditExecuted?: boolean;
 };
 
-class CVEAudit extends React.Component<Props, State> {
+class CVEAudit extends Component<Props, State> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-matcher-run-panel.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-matcher-run-panel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { fromNow } from "components/datetime/FromNow";
 
@@ -19,7 +19,7 @@ type MatcherRunPanelState = {
   error: boolean;
 };
 
-class MatcherRunPanel extends React.Component<MatcherRunPanelProps, MatcherRunPanelState> {
+class MatcherRunPanel extends Component<MatcherRunPanelProps, MatcherRunPanelState> {
   state = {
     latestStart: this.props.initialLatestStart,
     latestEnd: this.props.initialLatestEnd,
@@ -145,7 +145,7 @@ type MatcherScheduleButtonProps = {
   matcherRunning?: boolean;
 };
 
-class MatcherScheduleButton extends React.Component<MatcherScheduleButtonProps> {
+class MatcherScheduleButton extends Component<MatcherScheduleButtonProps> {
   onClick = () => {
     Network.post("/rhn/manager/api/subscription-matching/schedule-matcher-run").catch(() => this.props.onError());
     this.props.onScheduled();

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-messages.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Column } from "components/table/Column";
 import { Table } from "components/table/Table";
@@ -23,7 +23,7 @@ const systemName = (systems, messageData) => {
   return systems[messageData["id"]].name;
 };
 
-class Messages extends React.Component<Props> {
+class Messages extends Component<Props> {
   buildRows = (rawMessages, systems, subscriptions) => {
     return rawMessages.map(function (rawMessage, index) {
       const data = rawMessage["data"];

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-pins.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-pins.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import isNil from "lodash/isNil";
 
@@ -23,7 +23,7 @@ type PinsProps = {
   subscriptions: any[];
 };
 
-class Pins extends React.Component<PinsProps> {
+class Pins extends Component<PinsProps> {
   state = {
     showPopUp: false,
   };
@@ -228,7 +228,7 @@ type AddPinPopUpProps = {
   subscriptions: any[];
 };
 
-class AddPinPopUp extends React.Component<AddPinPopUpProps> {
+class AddPinPopUp extends Component<AddPinPopUpProps> {
   state = {
     systemId: null,
   };
@@ -362,7 +362,7 @@ type PinSubscriptionSelectorProps = {
   onSubscriptionSelected: (...args: any[]) => any;
 };
 
-class PinSubscriptionSelector extends React.Component<PinSubscriptionSelectorProps> {
+class PinSubscriptionSelector extends Component<PinSubscriptionSelectorProps> {
   render() {
     if (this.props.subscriptions.length > 0) {
       return (

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { Column } from "components/table/Column";
 import { SearchField } from "components/table/SearchField";
@@ -14,7 +14,7 @@ type SubscriptionsProps = {
   subscriptions: any[];
 };
 
-class Subscriptions extends React.Component<SubscriptionsProps> {
+class Subscriptions extends Component<SubscriptionsProps> {
   sortByPolicy = (aRaw, bRaw, columnKey, sortDirection) => {
     let result = 0;
     const aValue = humanReadablePolicy(aRaw[columnKey]);
@@ -47,7 +47,7 @@ class Subscriptions extends React.Component<SubscriptionsProps> {
   };
 
   render() {
-    let body: React.ReactNode = null;
+    let body: ReactNode = null;
     if (Object.keys(this.props.subscriptions).length > 0) {
       body = (
         <div>

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-unmatched-products.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-unmatched-products.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { ModalButton } from "components/dialog/ModalButton";
 import { PopUp } from "components/popup";
@@ -16,7 +16,7 @@ type UnmatchedProductsProps = {
   products: any[];
 };
 
-class UnmatchedProducts extends React.Component<UnmatchedProductsProps> {
+class UnmatchedProducts extends Component<UnmatchedProductsProps> {
   state = {
     selectedProductId: null,
   };
@@ -111,7 +111,7 @@ type UnmatchedSystemPopUpProps = {
   onClosePopUp?: (...args: any[]) => any;
 };
 
-class UnmatchedSystemPopUp extends React.Component<UnmatchedSystemPopUpProps> {
+class UnmatchedSystemPopUp extends Component<UnmatchedSystemPopUpProps> {
   buildTableData = (props) => {
     if (!props.selectedProductId) {
       return [];

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-util.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-util.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 const ToolTip = (props) => <span title={props.title}>{props.content}</span>;
 
 const CsvLink = (props) => (

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -26,7 +26,7 @@ class SubscriptionMatchingState {
   error: any | null = null;
 }
 
-class SubscriptionMatching extends React.Component<SubscriptionMatchingProps, SubscriptionMatchingState> {
+class SubscriptionMatching extends Component<SubscriptionMatchingProps, SubscriptionMatchingState> {
   timerId?: number;
   refreshRequest?: Cancelable;
   state = new SubscriptionMatchingState();
@@ -123,7 +123,7 @@ type SubscriptionMatchingTabContainerProps = {
   onPinChanged: (...args: any[]) => any;
 };
 
-class SubscriptionMatchingTabContainer extends React.Component<SubscriptionMatchingTabContainerProps> {
+class SubscriptionMatchingTabContainer extends Component<SubscriptionMatchingTabContainerProps> {
   state = { activeTabHash: document.location.hash };
 
   UNSAFE_componentWillMount() {

--- a/web/html/src/manager/content-management/create-project/create-project.renderer.tsx
+++ b/web/html/src/manager/content-management/create-project/create-project.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/content-management/create-project/create-project.tsx
+++ b/web/html/src/manager/content-management/create-project/create-project.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { isOrgAdmin } from "core/auth/auth.utils";

--- a/web/html/src/manager/content-management/create-project/top-panel-buttons.tsx
+++ b/web/html/src/manager/content-management/create-project/top-panel-buttons.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { AsyncButton } from "components/buttons";
 
 type TopPanelButtonsProps = {

--- a/web/html/src/manager/content-management/list-filters/appstreams/appstreams.tsx
+++ b/web/html/src/manager/content-management/list-filters/appstreams/appstreams.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { Button } from "components/buttons";

--- a/web/html/src/manager/content-management/list-filters/appstreams/module-selector.tsx
+++ b/web/html/src/manager/content-management/list-filters/appstreams/module-selector.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useContext } from "react";
 
 import { DEPRECATED_Select, FormContext } from "components/input";

--- a/web/html/src/manager/content-management/list-filters/appstreams/select-input.tsx
+++ b/web/html/src/manager/content-management/list-filters/appstreams/select-input.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { DEPRECATED_Select } from "components/input";

--- a/web/html/src/manager/content-management/list-filters/appstreams/text-input.tsx
+++ b/web/html/src/manager/content-management/list-filters/appstreams/text-input.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Text } from "components/input";
 
 export default function TextInput() {

--- a/web/html/src/manager/content-management/list-filters/filter-edit.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import { type ComponentProps, Fragment, useEffect, useState } from "react";
 
 import { Button } from "components/buttons";
 import { closeDialog, Dialog } from "components/dialog/LegacyDialog";
@@ -13,7 +12,7 @@ import { FilterFormType } from "../shared/type/filter.type";
 import { mapFilterFormToRequest } from "./filter.utils";
 import FilterForm from "./filter-form";
 
-type FilterEditModalContentProps = React.ComponentProps<typeof FilterForm> & {
+type FilterEditModalContentProps = ComponentProps<typeof FilterForm> & {
   open: boolean;
   isLoading: boolean;
 };
@@ -123,7 +122,7 @@ const FilterEdit = (props: FilterEditProps) => {
   const modalTitle = props.editing ? t("Filter Details") : t("Create a new filter");
 
   return (
-    <React.Fragment>
+    <Fragment>
       <ModalButton
         id={`${props.id}-modal-link`}
         icon={props.icon}
@@ -136,7 +135,6 @@ const FilterEdit = (props: FilterEditProps) => {
           setFormData(props.initialFilterForm);
         }}
       />
-
       <Dialog
         id={modalNameId}
         title={modalTitle}
@@ -201,7 +199,7 @@ const FilterEdit = (props: FilterEditProps) => {
           </div>
         }
       />
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/content-management/list-filters/filter-form.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-form.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 import { Button } from "components/buttons";
 import { DateTime, DEPRECATED_Select, Form, Radio, Text } from "components/input";
@@ -68,7 +67,7 @@ const FilterForm = (props: Props) => {
         props.onChange(model);
       }}
     >
-      <React.Fragment>
+      <Fragment>
         {props.editing && (
           <div className="alert alert-info" style={{ marginTop: "0px" }}>
             {t("Bear in mind that all the associated projects need to be rebuilt after a filter update")}
@@ -120,7 +119,7 @@ const FilterForm = (props: Props) => {
         ) : null}
 
         {filterBy === FilterBy.Type ? (
-          <React.Fragment>
+          <Fragment>
             <DEPRECATED_Select
               name="type"
               label={t("Filter Type")}
@@ -311,11 +310,11 @@ const FilterForm = (props: Props) => {
                 divClass="col-md-8"
               />
             )}
-          </React.Fragment>
+          </Fragment>
         ) : null}
 
         {filterBy === FilterBy.Template ? <TemplatesForm {...props} /> : null}
-      </React.Fragment>
+      </Fragment>
     </Form>
   );
 };

--- a/web/html/src/manager/content-management/list-filters/list-filters.renderer.tsx
+++ b/web/html/src/manager/content-management/list-filters/list-filters.renderer.tsx
@@ -1,7 +1,5 @@
 import "./list-filters.css";
 
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 import { UserLocalizationProvider } from "core/user-localization/user-localization-context";

--- a/web/html/src/manager/content-management/list-filters/list-filters.tsx
+++ b/web/html/src/manager/content-management/list-filters/list-filters.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import { isOrgAdmin } from "core/auth/auth.utils";

--- a/web/html/src/manager/content-management/list-filters/templates/app-streams.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/app-streams.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import { DEPRECATED_Select, FormContext } from "components/input";
 
@@ -23,7 +22,7 @@ export default (props: FilterFormProps & { template: Template }) => {
   const template = props.template;
   const prevTemplate = usePrevious(template);
 
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   const setModelValue = formContext.setModelValue;
   const [channels, setChannels] = useState<Channel[]>([]);
 

--- a/web/html/src/manager/content-management/list-filters/templates/index.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useContext } from "react";
 
 import { DEPRECATED_Select, FormContext } from "components/input";
 
@@ -13,7 +13,7 @@ export enum Template {
 }
 
 const TemplateForm = (props: FilterFormProps) => {
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   const template = formContext.model.template;
   switch (template) {
     case Template.LivePatchingSystem:

--- a/web/html/src/manager/content-management/list-filters/templates/live-patching.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/live-patching.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 
 import { DEPRECATED_Select, FormContext } from "components/input";
 
@@ -51,7 +50,7 @@ export default (props: FilterFormProps & { template: Template }) => {
   const template = props.template;
   const prevTemplate = usePrevious(template);
 
-  const formContext = React.useContext(FormContext);
+  const formContext = useContext(FormContext);
   const setModelValue = formContext.setModelValue;
   const { productId, systemId, systemName, kernelName } = formContext.model;
   const [products, setProducts] = useState<Product[]>([]);

--- a/web/html/src/manager/content-management/list-projects/list-projects.renderer.tsx
+++ b/web/html/src/manager/content-management/list-projects/list-projects.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/content-management/list-projects/list-projects.tsx
+++ b/web/html/src/manager/content-management/list-projects/list-projects.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect } from "react";
 
 import _truncate from "lodash/truncate";

--- a/web/html/src/manager/content-management/project/project.renderer.tsx
+++ b/web/html/src/manager/content-management/project/project.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { RolesProvider } from "core/auth/roles-context";
 import SpaRenderer from "core/spa/spa-renderer";
 

--- a/web/html/src/manager/content-management/project/project.tsx
+++ b/web/html/src/manager/content-management/project/project.tsx
@@ -1,6 +1,5 @@
 import "./project.css";
 
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import _groupBy from "lodash/groupBy";

--- a/web/html/src/manager/content-management/shared/components/down-arrow/down-arrow.tsx
+++ b/web/html/src/manager/content-management/shared/components/down-arrow/down-arrow.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 const DownArrow = () => {
   return (
     <div

--- a/web/html/src/manager/content-management/shared/components/messages/messages.tsx
+++ b/web/html/src/manager/content-management/shared/components/messages/messages.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-
 import _isEmpty from "lodash/isEmpty";
+import type { ReactNode } from "react";
 
 import { Messages } from "components/messages/messages";
 
@@ -8,7 +7,7 @@ import { ProjectMessageType } from "../../type";
 
 type ValidationMessagesType = {
   panelClass: string;
-  messages: React.ReactNode | null | undefined;
+  messages: ReactNode | null | undefined;
 };
 
 const msgClassMap = {

--- a/web/html/src/manager/content-management/shared/components/panels/build/build-version.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build-version.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import styles from "./build-version.module.scss";
 
 type Props = {

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import _last from "lodash/last";

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { DEPRECATED_Select, Form, Text } from "components/input";
 
@@ -20,7 +20,7 @@ const EnvironmentForm = (props: Props) => (
       props.onChange(model);
     }}
   >
-    <React.Fragment>
+    <Fragment>
       <div className="row">
         <Text
           required
@@ -58,7 +58,7 @@ const EnvironmentForm = (props: Props) => (
           />
         </div>
       )}
-    </React.Fragment>
+    </Fragment>
   </Form>
 );
 

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { isOrgAdmin } from "core/auth/auth.utils";
 import useRoles from "core/auth/use-roles";
@@ -83,7 +83,7 @@ const EnvironmentLifecycle = (props: Props) => {
             {messages.messages}
             {props.environments.length === 0 && <h4>{t("No environments created")}</h4>}
             {props.environments.map((environment, i) => (
-              <React.Fragment key={environment.label}>
+              <Fragment key={environment.label}>
                 <CreatorPanel
                   id={`environment${environment.label}`}
                   title={environment.name}
@@ -173,7 +173,7 @@ const EnvironmentLifecycle = (props: Props) => {
                     onChange={props.onChange}
                   />
                 )}
-              </React.Fragment>
+              </Fragment>
             ))}
           </>
         </div>

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment, memo } from "react";
 
 import _isEmpty from "lodash/isEmpty";
 
@@ -32,9 +32,9 @@ const environmentStatusEnum: EnvironmentStatusEnumType = {
   failed: { key: "failed", text: t("Failed"), isBuilding: false },
 };
 
-const EnvironmentView = React.memo((props: Props) => {
+const EnvironmentView = memo((props: Props) => {
   return (
-    <React.Fragment>
+    <Fragment>
       <dl className="row">
         <dt className="col-3">{t("Label")}:</dt>
         <dd className="col-9">{props.environment.label}</dd>
@@ -70,7 +70,7 @@ const EnvironmentView = React.memo((props: Props) => {
           <dd className="col-9">{props.environment.builtTime}</dd>
         </dl>
       ) : null}
-    </React.Fragment>
+    </Fragment>
   );
 });
 

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project-selection.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 import _xor from "lodash/xor";
 
@@ -37,7 +36,7 @@ const FiltersProjectSelection = (props: FiltersProps) => {
   }
 
   return (
-    <React.Fragment>
+    <Fragment>
       <LinkButton
         id={`create-new-filter-link`}
         icon="fa-plus"
@@ -67,7 +66,7 @@ const FiltersProjectSelection = (props: FiltersProps) => {
             </label>
           </div>
         ))}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { isOrgAdmin } from "core/auth/auth.utils";
 import useRoles from "core/auth/use-roles";
@@ -53,7 +53,7 @@ const renderFilterEntry = (filter, projectId, symbol, last) => {
   }
 
   return (
-    <React.Fragment key={`filter_list_item_${filter.id}`}>
+    <Fragment key={`filter_list_item_${filter.id}`}>
       <li className={`list-group-item ${styles.wrapper} ${filterClassName}`}>
         {filterIconName && <i className={`fa ${filterIconName}`}></i>}
         {descr}
@@ -64,7 +64,7 @@ const renderFilterEntry = (filter, projectId, symbol, last) => {
           {symbol}
         </div>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 
 import { isOrgAdmin } from "core/auth/auth.utils";
 import useRoles from "core/auth/use-roles";
@@ -75,7 +74,7 @@ const Promote = (props: Props) => {
           isLoading ? (
             <Loading text={t("Promoting project..")} />
           ) : (
-            <React.Fragment>
+            <Fragment>
               <dl className="row">
                 <dt className="col-4">{t("Version")}:</dt>
                 <dd className="col-8">
@@ -92,7 +91,7 @@ const Promote = (props: Props) => {
                 <dt className="col-4">{t("Target environment")}:</dt>
                 <dd className="col-8">{props.environmentTarget.name}</dd>
               </dl>
-            </React.Fragment>
+            </Fragment>
           )
         }
         title={t("Promote version {version} into {environmentName}", {

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-create.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-create.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Panel } from "components/panels/Panel";
 
 import { ProjectPropertiesType } from "../../../type/project.type";

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { isOrgAdmin } from "core/auth/auth.utils";
 import useRoles from "core/auth/use-roles";
@@ -75,10 +75,10 @@ const PropertiesEdit = (props: Props) => {
       }}
       onCancel={() => cancelAction()}
       renderContent={() => (
-        <React.Fragment>
+        <Fragment>
           {messages.messages}
           <PropertiesView properties={propertiesToShow} />
-        </React.Fragment>
+        </Fragment>
       )}
       renderCreationContent={({ item, setItem, errors }) => {
         if (isLoading) {

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-form.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-form.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Form, Text } from "components/input";
 
 import { ProjectPropertiesType } from "../../../type";

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-view.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Dialog } from "components/dialog/LegacyDialog";
 import { ModalLink } from "components/dialog/ModalLink";
 

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/base-channel.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/base-channel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { FC, ReactElement } from "react";
 
 import { BaseChannelType, ChannelTreeType, ChildChannelType } from "core/channels/type/channels.type";
 
@@ -31,14 +31,14 @@ type Props = {
   onToggleChannelOpen?: (channel: BaseChannelType) => void;
 };
 
-const BaseChannel: React.FC<Props> = ({
+const BaseChannel: FC<Props> = ({
   search = "",
   showBase = true,
   isOpen = true,
   recommendedToggle = true,
   onToggleChannelOpen = () => {},
   ...props
-}: Props): React.ReactElement => {
+}: Props): ReactElement => {
   const { base, children } = props.channelTree;
   const { id, name } = base;
 
@@ -51,7 +51,7 @@ const BaseChannel: React.FC<Props> = ({
     .reduce((total: number, id: number) => total + Number(props.selectedChannelIds.has(id)), 0);
   const totalSelectedCount = Number(isSelected) + selectedChildrenCount;
 
-  function renderBaseChannel(): React.ReactElement {
+  function renderBaseChannel(): ReactElement {
     return (
       <h4
         className={`${styles.base_channel} ${isSelectedBaseChannel ? styles.initial_selected : ""}`}
@@ -85,7 +85,7 @@ const BaseChannel: React.FC<Props> = ({
     );
   }
 
-  function renderChildren(): React.ReactElement {
+  function renderChildren(): ReactElement {
     if (props.channelTree.children.length === 0) {
       return <EmptyChild key={`empty_child_${id}`} />;
     }

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-filters.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-filters.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { memo } from "react";
+import { Fragment, memo } from "react";
 
 import { channelsFiltersAvailableValues, FilterType } from "./channels-filters-state";
 
@@ -10,7 +9,7 @@ type Props = {
 
 const ChannelsFilters = (props: Props) => {
   return (
-    <React.Fragment>
+    <Fragment>
       {channelsFiltersAvailableValues.map((filter: FilterType) => (
         <div key={filter.id} className="checkbox">
           <label htmlFor={`filter_${filter.id}`}>
@@ -25,7 +24,7 @@ const ChannelsFilters = (props: Props) => {
           </label>
         </div>
       ))}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { memo, useCallback, useEffect, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useState } from "react";
 
 import debounce from "lodash/debounce";
 import xor from "lodash/xor";
@@ -169,7 +168,7 @@ const ChannelsSelection = (props: PropsType) => {
     : undefined;
 
   return (
-    <React.Fragment>
+    <Fragment>
       <div className="row">
         <DEPRECATED_Select
           data-testid="selectedBaseChannel"
@@ -241,7 +240,7 @@ const ChannelsSelection = (props: PropsType) => {
           <VirtualList items={rows} renderItem={Row} defaultItemHeight={29} itemKey={(row) => row.base.id} />
         </div>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/child-channel.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/child-channel.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type { FC, ReactElement } from "react";
 
 import { BaseChannelType, ChildChannelType } from "core/channels/type/channels.type";
 
@@ -37,7 +37,7 @@ function getTooltip(channelDependencies: ChannelDependencyData): string {
   return tooltip;
 }
 
-const ChildChannel: React.FC<Props> = ({ search = "", ...props }: Props): React.ReactElement => {
+const ChildChannel: FC<Props> = ({ search = "", ...props }: Props): ReactElement => {
   const { id, name, recommended, parent } = props.channel;
   const identifier = "child_" + id;
 

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/empty-child.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/empty-child.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import styles from "./channels-selection.module.scss";
 
 const EmptyChild = () => {

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/recommended-toggle.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/recommended-toggle.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { BaseChannelType, ChildChannelType } from "core/channels/type/channels.type";
 
 import { Toggler } from "components/toggler";

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useMemo } from "react";
 
 import { isOrgAdmin } from "core/auth/auth.utils";
@@ -145,23 +144,21 @@ const Sources = (props: SourcesProps) => {
           {props.softwareSources.length > 0 && (
             <Panel headingLevel="h4" title={t("Software Channels")}>
               <div className="col-12">
-                <React.Fragment>
-                  <dl className="row">
-                    <dt className="col-2">Base Channel:</dt>
-                    <dd className="col-10">{renderSourceEntry(props.softwareSources[0])}</dd>
-                  </dl>
+                <dl className="row">
+                  <dt className="col-2">Base Channel:</dt>
+                  <dd className="col-10">{renderSourceEntry(props.softwareSources[0])}</dd>
+                </dl>
 
-                  <dl className="row">
-                    <dt className="col-2">Child Channels:</dt>
-                    <dd className="col-6">
-                      <ul className="list-unstyled">
-                        {props.softwareSources.slice(1, props.softwareSources.length).map((source) => (
-                          <li key={`softwareSources_entry_${source.channelId}`}>{renderSourceEntry(source)}</li>
-                        ))}
-                      </ul>
-                    </dd>
-                  </dl>
-                </React.Fragment>
+                <dl className="row">
+                  <dt className="col-2">Child Channels:</dt>
+                  <dd className="col-6">
+                    <ul className="list-unstyled">
+                      {props.softwareSources.slice(1, props.softwareSources.length).map((source) => (
+                        <li key={`softwareSources_entry_${source.channelId}`}>{renderSourceEntry(source)}</li>
+                      ))}
+                    </ul>
+                  </dd>
+                </dl>
               </div>
             </Panel>
           )}

--- a/web/html/src/manager/errors/default-js-error.tsx
+++ b/web/html/src/manager/errors/default-js-error.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 const DefaultJsError = () => (
   <div className="container-fluid">
     <h1>Something wrong happened.</h1>

--- a/web/html/src/manager/errors/not-found.tsx
+++ b/web/html/src/manager/errors/not-found.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 const NotFound = ({ currentUrl }) => (

--- a/web/html/src/manager/groups/config-channels/group-config-channels.tsx
+++ b/web/html/src/manager/groups/config-channels/group-config-channels.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { ConfigChannels } from "components/config-channels";

--- a/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { FormulaSelection } from "components/formula-selection";

--- a/web/html/src/manager/groups/formula/group-formula.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import FormulaForm from "components/FormulaForm";

--- a/web/html/src/manager/header/search/focus-group.tsx
+++ b/web/html/src/manager/header/search/focus-group.tsx
@@ -1,9 +1,7 @@
-import * as React from "react";
-import { useEffect, useRef } from "react";
-
+import { type ReactNode, useEffect, useRef } from "react";
 type Props = {
   onFocusOut: () => void;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export const FocusGroup = (props: Props) => {

--- a/web/html/src/manager/header/search/search.renderer.tsx
+++ b/web/html/src/manager/header/search/search.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { HeaderSearch } from "./search";

--- a/web/html/src/manager/header/search/search.tsx
+++ b/web/html/src/manager/header/search/search.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ChangeEvent, type SyntheticEvent, PureComponent } from "react";
 
 import { Button, SubmitButton } from "components/buttons";
 
@@ -27,20 +27,20 @@ class HeaderSearchState {
   searchType = SEARCH_TYPES[0].value;
 }
 
-export class HeaderSearch extends React.PureComponent<HeaderSearchProps, HeaderSearchState> {
+export class HeaderSearch extends PureComponent<HeaderSearchProps, HeaderSearchState> {
   state = new HeaderSearchState();
 
   onSPAEndNavigation() {
     this.setState(new HeaderSearchState());
   }
 
-  onChange = (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+  onChange = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     this.setState({
       [event.target.name]: event.target.value,
     } as any);
   };
 
-  onSubmit = (event: React.SyntheticEvent) => {
+  onSubmit = (event: SyntheticEvent) => {
     event.preventDefault();
     window.pageRenderers?.spaengine?.navigate?.(
       `/rhn/Search.do?csrf_token=${window.csrfToken}&submitted=true&search_string=${this.state.searchString}&search_type=${this.state.searchType}`

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -59,7 +59,7 @@ type State = {
   isInvalid?: boolean;
 };
 
-class BuildImage extends React.Component<Props, State> {
+class BuildImage extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/images/image-import.tsx
+++ b/web/html/src/manager/images/image-import.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -56,7 +56,7 @@ function emptyModel(): Model {
   };
 }
 
-class ImageImport extends React.Component {
+class ImageImport extends Component {
   state: {
     imageStores?: any | null;
     messages: any[];

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { default as ReactSelect } from "react-select";
 
@@ -52,7 +52,7 @@ type State = {
   isInvalid?: boolean;
 };
 
-class CreateImageProfile extends React.Component<Props, State> {
+class CreateImageProfile extends Component<Props, State> {
   defaultModel: any;
 
   constructor(props) {

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -42,7 +42,7 @@ type State = {
   selected?: any;
 };
 
-class ImageProfiles extends React.Component<Props, State> {
+class ImageProfiles extends Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/images/image-store-edit.tsx
+++ b/web/html/src/manager/images/image-store-edit.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -40,7 +40,7 @@ type State = {
   isInvalid?: boolean;
 };
 
-class CreateImageStore extends React.Component<Props, State> {
+class CreateImageStore extends Component<Props, State> {
   defaultModel: any;
 
   constructor(props: Props) {

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -42,7 +42,7 @@ type State = {
   selected?: any;
 };
 
-class ImageStores extends React.Component<Props, State> {
+class ImageStores extends Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/images/image-view-overview.tsx
+++ b/web/html/src/manager/images/image-view-overview.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { productName } from "core/user-preferences";
 
@@ -100,7 +100,7 @@ function StatusIcon(props) {
 }
 
 function BuildStatus(props) {
-  let status: React.ReactNode;
+  let status: ReactNode;
   if (props.data.external) {
     status = (
       <span>
@@ -162,7 +162,7 @@ type ImageInfoState = {
   instancePopupContent: any;
 };
 
-class ImageInfo extends React.Component<ImageInfoProps, ImageInfoState> {
+class ImageInfo extends Component<ImageInfoProps, ImageInfoState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -474,7 +474,7 @@ type ImageCustomInfoProps = {
   data: any;
 };
 
-class ImageCustomInfo extends React.Component<ImageCustomInfoProps> {
+class ImageCustomInfo extends Component<ImageCustomInfoProps> {
   render() {
     const data = this.props.data.customData;
     return (
@@ -503,7 +503,7 @@ type ImageViewOverviewProps = {
   onDelete?: (...args: any[]) => any;
 };
 
-class ImageViewOverview extends React.Component<ImageViewOverviewProps> {
+class ImageViewOverview extends Component<ImageViewOverviewProps> {
   renderStatus(row) {
     let status;
 
@@ -701,7 +701,7 @@ type BuildDialogState = {
   };
 };
 
-class BuildDialog extends React.Component<BuildDialogProps, BuildDialogState> {
+class BuildDialog extends Component<BuildDialogProps, BuildDialogState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -778,7 +778,7 @@ type InspectDialogState = {
   };
 };
 
-class InspectDialog extends React.Component<InspectDialogProps, InspectDialogState> {
+class InspectDialog extends Component<InspectDialogProps, InspectDialogState> {
   constructor(props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/images/image-view-packages.tsx
+++ b/web/html/src/manager/images/image-view-packages.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { FromNow } from "components/datetime";
 import { Column } from "components/table/Column";
@@ -22,7 +22,7 @@ type Props = {
   data: any;
 };
 
-class ImageViewPackages extends React.Component<Props> {
+class ImageViewPackages extends Component<Props> {
   searchData(row, criteria) {
     if (criteria) {
       return (

--- a/web/html/src/manager/images/image-view-patches.tsx
+++ b/web/html/src/manager/images/image-view-patches.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { FromNow } from "components/datetime";
 import { Column } from "components/table/Column";
@@ -38,7 +38,7 @@ type ImageViewPatchesProps = {
   data: any;
 };
 
-class ImageViewPatches extends React.Component<ImageViewPatchesProps> {
+class ImageViewPatches extends Component<ImageViewPatchesProps> {
   searchData(row, criteria) {
     if (criteria) {
       return (

--- a/web/html/src/manager/images/image-view-runtime.tsx
+++ b/web/html/src/manager/images/image-view-runtime.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { productName } from "core/user-preferences";
 
@@ -20,7 +20,7 @@ type ImageViewRuntimeProps = {
   gotRuntimeInfo: any;
 };
 
-class ImageViewRuntime extends React.Component<ImageViewRuntimeProps> {
+class ImageViewRuntime extends Component<ImageViewRuntimeProps> {
   render() {
     const data = this.props.data;
     const runtimeInfo = data.clusters
@@ -59,7 +59,7 @@ type PodInfoProps = {
   data: any;
 };
 
-class PodInfo extends React.Component<PodInfoProps> {
+class PodInfo extends Component<PodInfoProps> {
   renderStatusIcon(statusId) {
     let icon;
 
@@ -97,7 +97,7 @@ type ClusterInfoProps = {
   data: any;
 };
 
-class ClusterInfo extends React.Component<ClusterInfoProps> {
+class ClusterInfo extends Component<ClusterInfoProps> {
   renderTitle(data) {
     const statusId = data.pods.map((p) => p.statusId).reduce((a, b) => Math.max(a, b));
 

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 import { productName } from "core/user-preferences";
@@ -76,7 +76,7 @@ type ImageViewState = {
   selectedCount?: any;
 };
 
-class ImageView extends React.Component<ImageViewProps, ImageViewState> {
+class ImageView extends Component<ImageViewProps, ImageViewState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -436,7 +436,7 @@ type ImageViewListState = {
   showObsolete: boolean;
 };
 
-class ImageViewList extends React.Component<ImageViewListProps, ImageViewListState> {
+class ImageViewList extends Component<ImageViewListProps, ImageViewListState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -604,7 +604,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
   };
 
   render() {
-    const runtimeColumns: React.ReactNode[] = [];
+    const runtimeColumns: ReactNode[] = [];
     if (this.props.runtimeInfoEnabled) {
       runtimeColumns.push(
         <Column columnKey="runtime" header={t("Runtime")} cell={(row) => this.renderRuntimeIcon(row)} />
@@ -772,7 +772,7 @@ type ImageViewDetailsProps = {
   onCancel: (...args: any[]) => any;
 };
 
-class ImageViewDetails extends React.Component<ImageViewDetailsProps> {
+class ImageViewDetails extends Component<ImageViewDetailsProps> {
   getHashUrls(tabs) {
     const id = this.props.data.id;
     return tabs.map((t) => "#/" + t + "/" + id);

--- a/web/html/src/manager/legacy/DateTimePicker.tsx
+++ b/web/html/src/manager/legacy/DateTimePicker.tsx
@@ -3,7 +3,6 @@
  * It is the Javascript helper side for DateTimePickerTag.java but bound to the timezone-aware picker component.
  * This wrapper is NOT HMR-ready, you will need to reload for your changes.
  */
-import * as React from "react";
 import { useState } from "react";
 import ReactDOM from "react-dom";
 

--- a/web/html/src/manager/legacy/FormatDateTag.tsx
+++ b/web/html/src/manager/legacy/FormatDateTag.tsx
@@ -1,6 +1,5 @@
 // Humanize dates for `FormatDateTag.java` the same way we do in frontend code
 
-import * as React from "react";
 import ReactDOM from "react-dom";
 
 import { FromNow, HumanDateTime } from "components/datetime";

--- a/web/html/src/manager/login/login.renderer.tsx
+++ b/web/html/src/manager/login/login.renderer.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import ReactDOM from "react-dom";
 
 import Login from "./login";

--- a/web/html/src/manager/login/login.tsx
+++ b/web/html/src/manager/login/login.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Fragment } from "react";
 
 import { isUyuni } from "core/user-preferences";
 
@@ -13,10 +13,10 @@ const products = {
   suma: {
     productName: "SUSE Multi-Linux Manager",
     headerTitle: (
-      <React.Fragment>
+      <Fragment>
         <span>SUSE</span>
         <i className="fa fa-registered" /> <span>Multi-Linux Manager</span>
-      </React.Fragment>
+      </Fragment>
     ),
     bodyTitle: (
       <span>

--- a/web/html/src/manager/login/messages.tsx
+++ b/web/html/src/manager/login/messages.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { Messages, MessageType } from "components/messages/messages";
 
 export const getGlobalMessages = (validationErrors, schemaUpgradeRequired, diskspaceSeverity, sccForwardWarning) => {

--- a/web/html/src/manager/login/susemanager/login.tsx
+++ b/web/html/src/manager/login/susemanager/login.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { docsLocale, productName } from "core/user-preferences";

--- a/web/html/src/manager/login/uyuni/login.tsx
+++ b/web/html/src/manager/login/uyuni/login.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 import { docsLocale, productName } from "core/user-preferences";
 
@@ -22,7 +21,7 @@ const UyuniThemeLogin = (props: ThemeProps) => {
   const { product } = props;
 
   return (
-    <React.Fragment>
+    <Fragment>
       <header className="navbar-pf navbar" role="presentation" />
       <div className="spacewalk-main-column-layout">
         <section className={styles.contentArea}>
@@ -125,7 +124,7 @@ const UyuniThemeLogin = (props: ThemeProps) => {
           </div>
         </div>
       </div>
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/web/html/src/manager/maintenance/calendar/web-calendar.test.tsx
+++ b/web/html/src/manager/maintenance/calendar/web-calendar.test.tsx
@@ -1,16 +1,12 @@
-import * as React from "react";
-
-// TODO: This should eventually be localizedMoment instead
-/* eslint-disable local-rules/no-raw-date */
-import moment from "moment";
+import localizedMoment from "moment";
 
 import { WebCalendar } from "manager/maintenance/calendar/web-calendar";
 
 import { click, render, screen, server, waitFor } from "utils/test-utils";
 
-const initialDate = moment.utc("2021-07-09", "YYYY-MM-DD");
+const initialDate = localizedMoment.utc("2021-07-09", "YYYY-MM-DD");
 
-function getApiPath(operation: string, date: moment.Moment) {
+function getApiPath(operation: string, date: localizedMoment.Moment) {
   return `/rhn/manager/api/maintenance/events/${operation}/schedule/0/${date.valueOf()}/0`;
 }
 
@@ -53,7 +49,7 @@ describe("Web calendar", () => {
       },
     ];
 
-    const date = moment.utc("2021-08-01", "YYYY-MM-DD");
+    const date = localizedMoment.utc("2021-08-01", "YYYY-MM-DD");
 
     server.mockGetJson(getApiPath("initial", initialDate), []);
     server.mockGetJson(getApiPath("next", date), data);
@@ -92,7 +88,7 @@ describe("Web calendar", () => {
       },
     ];
 
-    const date = moment.utc("2021-06-30", "YYYY-MM-DD");
+    const date = localizedMoment.utc("2021-06-30", "YYYY-MM-DD");
 
     server.mockGetJson(getApiPath("initial", initialDate), []);
     server.mockGetJson(getApiPath("back", date), data);
@@ -131,7 +127,7 @@ describe("Web calendar", () => {
       },
     ];
 
-    const date = moment.utc("2021-08-01", "YYYY-MM-DD");
+    const date = localizedMoment.utc("2021-08-01", "YYYY-MM-DD");
 
     server.mockGetJson(getApiPath("initial", initialDate), []);
     server.mockGetJson(getApiPath("skipNext", date), data);
@@ -170,7 +166,7 @@ describe("Web calendar", () => {
       },
     ];
 
-    const date = moment.utc("2021-06-30", "YYYY-MM-DD");
+    const date = localizedMoment.utc("2021-06-30", "YYYY-MM-DD");
 
     server.mockGetJson(getApiPath("initial", initialDate), []);
     server.mockGetJson(getApiPath("skipBack", date), data);
@@ -209,7 +205,7 @@ describe("Web calendar", () => {
       },
     ];
 
-    const date = moment.utc("2021-08-01", "YYYY-MM-DD");
+    const date = localizedMoment.utc("2021-08-01", "YYYY-MM-DD");
 
     server.mockGetJson(getApiPath("initial", initialDate), []);
     server.mockGetJson(getApiPath("next", date), []);

--- a/web/html/src/manager/maintenance/calendar/web-calendar.tsx
+++ b/web/html/src/manager/maintenance/calendar/web-calendar.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
 // Needs to be imported before plugins and rest

--- a/web/html/src/manager/maintenance/details/calendar-details.tsx
+++ b/web/html/src/manager/maintenance/details/calendar-details.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { WebCalendar } from "manager/maintenance/calendar/web-calendar";

--- a/web/html/src/manager/maintenance/details/maintenance-windows-details.tsx
+++ b/web/html/src/manager/maintenance/details/maintenance-windows-details.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { Button } from "components/buttons";

--- a/web/html/src/manager/maintenance/details/schedule-details.tsx
+++ b/web/html/src/manager/maintenance/details/schedule-details.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import { WebCalendar } from "manager/maintenance/calendar/web-calendar";

--- a/web/html/src/manager/maintenance/edit/calendar-edit.tsx
+++ b/web/html/src/manager/maintenance/edit/calendar-edit.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 
 import { Button } from "components/buttons";

--- a/web/html/src/manager/maintenance/edit/maintenance-windows-edit.tsx
+++ b/web/html/src/manager/maintenance/edit/maintenance-windows-edit.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useRef, useState } from "react";
 
 import { AsyncButton, Button } from "components/buttons";

--- a/web/html/src/manager/maintenance/edit/schedule-edit.tsx
+++ b/web/html/src/manager/maintenance/edit/schedule-edit.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
 
 import { Button } from "components/buttons";

--- a/web/html/src/manager/maintenance/list/calendar-list.tsx
+++ b/web/html/src/manager/maintenance/list/calendar-list.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { Button } from "components/buttons";

--- a/web/html/src/manager/maintenance/list/maintenance-windows-list.tsx
+++ b/web/html/src/manager/maintenance/list/maintenance-windows-list.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { Button } from "components/buttons";

--- a/web/html/src/manager/maintenance/list/schedule-list.tsx
+++ b/web/html/src/manager/maintenance/list/schedule-list.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { Button } from "components/buttons";

--- a/web/html/src/manager/maintenance/maintenance-windows.tsx
+++ b/web/html/src/manager/maintenance/maintenance-windows.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";

--- a/web/html/src/manager/maintenance/shared/cancel-actions-dialog.tsx
+++ b/web/html/src/manager/maintenance/shared/cancel-actions-dialog.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { DangerDialog } from "components/dialog/LegacyDangerDialog";
 
 type Props = {

--- a/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
+++ b/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useContext, useEffect, useState } from "react";
 
 import { AsyncButton } from "components/buttons";

--- a/web/html/src/manager/maintenance/ssm/system-assignment.tsx
+++ b/web/html/src/manager/maintenance/ssm/system-assignment.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";

--- a/web/html/src/manager/minion/ansible/accordion-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/accordion-path-content.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { AceEditor } from "components/ace-editor";
 import { Button } from "components/buttons";
@@ -53,7 +53,7 @@ type InventoryDetails = {
   unknownSystems: string[];
 };
 
-class AccordionPathContent extends React.Component<PropsType, StateType> {
+class AccordionPathContent extends Component<PropsType, StateType> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -28,7 +28,7 @@ type StateType = {
   loading: boolean;
 };
 
-export class AnsibleControlNode extends React.Component<PropsType, StateType> {
+export class AnsibleControlNode extends Component<PropsType, StateType> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/manager/minion/ansible/ansible-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-path-content.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -27,7 +27,7 @@ type StateType = {
   loading: boolean;
 };
 
-class AnsiblePathContent extends React.Component<PropsType, StateType> {
+class AnsiblePathContent extends Component<PropsType, StateType> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/manager/minion/ansible/edit-ansible-path.tsx
+++ b/web/html/src/manager/minion/ansible/edit-ansible-path.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { AsyncButton, Button } from "components/buttons";
 import { TextField } from "components/fields";
 

--- a/web/html/src/manager/minion/ansible/new-ansible-path.tsx
+++ b/web/html/src/manager/minion/ansible/new-ansible-path.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { AsyncButton } from "components/buttons";
 import { TextField } from "components/fields";
 

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import { AceEditor } from "components/ace-editor";

--- a/web/html/src/manager/minion/coco/coco-scans-list.renderer.tsx
+++ b/web/html/src/manager/minion/coco/coco-scans-list.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import CoCoScansList from "components/CoCoScansList";

--- a/web/html/src/manager/minion/coco/coco-settings.renderer.tsx
+++ b/web/html/src/manager/minion/coco/coco-settings.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import CoCoSettings from "./coco-settings";

--- a/web/html/src/manager/minion/coco/coco-settings.tsx
+++ b/web/html/src/manager/minion/coco/coco-settings.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import CoCoSettingsForm from "components/coco-attestation/CoCoSettingsForm";
 import { Settings } from "components/coco-attestation/Utils";
@@ -21,7 +21,7 @@ type State = {
   loading: boolean;
 };
 
-class CoCoSettings extends React.Component<Props, State> {
+class CoCoSettings extends Component<Props, State> {
   public static readonly defaultProps: Partial<Props> = {
     showOnScheduleOption: true,
   };
@@ -53,7 +53,7 @@ class CoCoSettings extends React.Component<Props, State> {
     );
   }
 
-  render(): React.ReactNode {
+  render(): ReactNode {
     if (this.state.loading) {
       return (
         <div className="panel panel-default">

--- a/web/html/src/manager/minion/config-channels/minion-config-channels.tsx
+++ b/web/html/src/manager/minion/config-channels/minion-config-channels.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { ConfigChannels } from "components/config-channels";

--- a/web/html/src/manager/minion/details/support-data.renderer.tsx
+++ b/web/html/src/manager/minion/details/support-data.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { SupportData, UploadRegionArray } from "./support-data";

--- a/web/html/src/manager/minion/details/support-data.tsx
+++ b/web/html/src/manager/minion/details/support-data.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 
 import { SubmitButton } from "components/buttons";
 import { DateTime, DEPRECATED_Select, Form, Text } from "components/input";
@@ -38,7 +37,7 @@ type Props = {
   supportProgramName: string | null;
 };
 
-export const SupportData: React.FC<Props> = ({ serverId, availableRegions, supportProgramName }): JSX.Element => {
+export const SupportData: FC<Props> = ({ serverId, availableRegions, supportProgramName }): JSX.Element => {
   const [formModel, setFormModel] = useState(
     () => new SupportDataRequest("", availableRegions[0].label, "", localizedMoment())
   );
@@ -52,11 +51,11 @@ export const SupportData: React.FC<Props> = ({ serverId, availableRegions, suppo
       : []
   );
 
-  function getFormattedProgramName(programName: string): React.ReactNode {
+  function getFormattedProgramName(programName: string): ReactNode {
     return <code>{programName}</code>;
   }
 
-  function getActionLink(text: string, actionId: number): React.ReactNode {
+  function getActionLink(text: string, actionId: number): ReactNode {
     return <ActionLink id={actionId}>{text}</ActionLink>;
   }
 

--- a/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { FormulaSelection } from "components/formula-selection";

--- a/web/html/src/manager/minion/formula/minion-formula.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import FormulaForm from "components/FormulaForm";

--- a/web/html/src/manager/minion/packages/package-states.renderer.tsx
+++ b/web/html/src/manager/minion/packages/package-states.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { MessagesContainer } from "components/toastr/toastr";

--- a/web/html/src/manager/minion/packages/package-states.tsx
+++ b/web/html/src/manager/minion/packages/package-states.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useEffect, useRef, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import { useImmer } from "use-immer";
 
@@ -254,7 +253,7 @@ const PackageStates = ({ serverId }: PropsType) => {
   };
 
   const tableBody = () => {
-    const elements: React.ReactNode[] = [];
+    const elements: ReactNode[] = [];
     for (const row of tableRows) {
       const currentState = row.value !== undefined ? row.value : row.original;
 
@@ -283,8 +282,8 @@ const PackageStates = ({ serverId }: PropsType) => {
   };
 
   const renderState = (row, currentState) => {
-    let versionConstraintSelect: React.ReactNode = null;
-    let undoButton: React.ReactNode = null;
+    let versionConstraintSelect: ReactNode = null;
+    let undoButton: ReactNode = null;
 
     if (currentState.packageStateId === packageHelpers.INSTALLED) {
       versionConstraintSelect = (

--- a/web/html/src/manager/minion/packages/use-package-states.api.tsx
+++ b/web/html/src/manager/minion/packages/use-package-states.api.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { MessageType, Utils as MessagesUtils } from "components/messages/messages";

--- a/web/html/src/manager/minion/proxy/proxy-config-messages.tsx
+++ b/web/html/src/manager/minion/proxy/proxy-config-messages.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { Messages, MessageType } from "components/messages/messages";
 
 type SuccessType = boolean | undefined;
 
-export const ContainerConfigMessages = (success: SuccessType, messagesIn: React.ReactNode[], loading: boolean) => {
+export const ContainerConfigMessages = (success: SuccessType, messagesIn: ReactNode[], loading: boolean) => {
   let items: MessageType[] = [];
   if (success) {
     items = [

--- a/web/html/src/manager/minion/proxy/proxy-config.tsx
+++ b/web/html/src/manager/minion/proxy/proxy-config.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import { AsyncButton, SubmitButton } from "components/buttons";

--- a/web/html/src/manager/minion/ptf/ptf-install.renderer.tsx
+++ b/web/html/src/manager/minion/ptf/ptf-install.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { PackageListActionScheduler } from "components/package/PackageListActionScheduler";

--- a/web/html/src/manager/minion/ptf/ptf-list-remove.renderer.tsx
+++ b/web/html/src/manager/minion/ptf/ptf-list-remove.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { PackageListActionScheduler } from "components/package/PackageListActionScheduler";

--- a/web/html/src/manager/minion/ptf/ptf-overview.renderer.tsx
+++ b/web/html/src/manager/minion/ptf/ptf-overview.renderer.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -24,7 +24,7 @@ type State = {
   allowedActions: string[];
 };
 
-class PtfOverview extends React.Component<Props, State> {
+class PtfOverview extends Component<Props, State> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/manager/notifications/notifications-list.renderer.tsx
+++ b/web/html/src/manager/notifications/notifications-list.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { NotificationList } from "./notifications-list";

--- a/web/html/src/manager/notifications/notifications-list.tsx
+++ b/web/html/src/manager/notifications/notifications-list.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { AsyncButton, LinkButton } from "components/buttons";
 import { Dialog } from "components/dialog/Dialog";
@@ -39,7 +39,7 @@ type State = {
   typeCriteria: string[];
 };
 
-export class NotificationList extends React.Component<Props, State> {
+export class NotificationList extends Component<Props, State> {
   private readonly typeMap: Map<string, string>;
 
   public constructor(props: Props) {
@@ -72,7 +72,7 @@ export class NotificationList extends React.Component<Props, State> {
     }
   }
 
-  public render(): React.ReactNode {
+  public render(): ReactNode {
     return (
       <TopPanel title={t("Notification Messages")} icon="fa-envelope">
         <MessageContainer items={this.state.messages} />
@@ -174,7 +174,7 @@ export class NotificationList extends React.Component<Props, State> {
     );
   }
 
-  private renderFilters(): React.ReactNode[] {
+  private renderFilters(): ReactNode[] {
     return [
       <div key="typeFilter" className="multiple-select-wrapper table-input-search">
         {/* TODO: Remove this <Form> wrapper once https://github.com/SUSE/spacewalk/issues/14250 is implemented */}
@@ -193,7 +193,7 @@ export class NotificationList extends React.Component<Props, State> {
     ];
   }
 
-  private renderTabs(): React.ReactNode {
+  private renderTabs(): ReactNode {
     return (
       <div className="spacewalk-content-nav">
         <ul className="nav nav-tabs">
@@ -212,7 +212,7 @@ export class NotificationList extends React.Component<Props, State> {
     );
   }
 
-  private renderSummary(data: Notification): React.ReactNode {
+  private renderSummary(data: Notification): ReactNode {
     return (
       <span className="align-middle" style={{ whiteSpace: "pre" }}>
         {stringToReact(data.summary)}
@@ -227,7 +227,7 @@ export class NotificationList extends React.Component<Props, State> {
     );
   }
 
-  private renderReaction(data: Notification): React.ReactNode {
+  private renderReaction(data: Notification): ReactNode {
     if (!data.actionable) {
       return <></>;
     }
@@ -242,7 +242,7 @@ export class NotificationList extends React.Component<Props, State> {
     );
   }
 
-  private renderItemActions(row: Notification): React.ReactNode {
+  private renderItemActions(row: Notification): ReactNode {
     return (
       <div className="btn-group">
         <AsyncButton
@@ -329,7 +329,7 @@ export class NotificationList extends React.Component<Props, State> {
     }
   }
 
-  private decodeIconBySeverity(severity: Severity): React.ReactNode {
+  private decodeIconBySeverity(severity: Severity): ReactNode {
     switch (severity) {
       case Severity.Info:
         return (

--- a/web/html/src/manager/notifications/notifications.tsx
+++ b/web/html/src/manager/notifications/notifications.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -15,7 +15,7 @@ type State = {
   pageUnloading?: boolean;
 };
 
-class Notifications extends React.Component<Props, State> {
+class Notifications extends Component<Props, State> {
   state: State = {
     unreadMessagesLength: null,
     websocket: null,

--- a/web/html/src/manager/organizations/config-channels/org-config-channels.tsx
+++ b/web/html/src/manager/organizations/config-channels/org-config-channels.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { ConfigChannels } from "components/config-channels";

--- a/web/html/src/manager/packages/list.renderer.tsx
+++ b/web/html/src/manager/packages/list.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { MessagesContainer } from "components/toastr";

--- a/web/html/src/manager/packages/list.tsx
+++ b/web/html/src/manager/packages/list.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { AsyncButton } from "components/buttons";
 import { ActionConfirm } from "components/dialog/ActionConfirm";
@@ -24,13 +23,13 @@ type Props = {
 };
 
 export function PackageList(props: Props) {
-  const [open, setOpen] = React.useState(false);
-  const [selectedPackages, setSelectedPackages] = React.useState<string[]>(props.selected);
-  const [formModel, setFormModel] = React.useState<object>({ binary: "binary", channel: props.selectedChannel });
-  const [channels, setChannels] = React.useState([]);
+  const [open, setOpen] = useState(false);
+  const [selectedPackages, setSelectedPackages] = useState<string[]>(props.selected);
+  const [formModel, setFormModel] = useState<object>({ binary: "binary", channel: props.selectedChannel });
+  const [channels, setChannels] = useState([]);
   const tableRef = useRef<TableRef>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     let ignore = false;
     Network.get("/rhn/manager/api/channels/owned")
       .then((resp) => {

--- a/web/html/src/manager/proxy/container-config-messages.tsx
+++ b/web/html/src/manager/proxy/container-config-messages.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import type { ReactNode } from "react";
 
 import { Messages } from "components/messages/messages";
 
 type SuccessType = boolean | undefined;
 
-export const ContainerConfigMessages = (success: SuccessType, messagesIn: React.ReactNode[], loading: boolean) => {
+export const ContainerConfigMessages = (success: SuccessType, messagesIn: ReactNode[], loading: boolean) => {
   if (success) {
     return (
       <Messages

--- a/web/html/src/manager/proxy/container-config.tsx
+++ b/web/html/src/manager/proxy/container-config.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useState } from "react";
 
 import { AsyncButton, SubmitButton } from "components/buttons";

--- a/web/html/src/manager/recurring/recurring-actions-details.tsx
+++ b/web/html/src/manager/recurring/recurring-actions-details.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import _sortBy from "lodash/sortBy";
 
@@ -57,7 +57,7 @@ type RecurringActionsDetailsState = {
   details: any;
 };
 
-class RecurringActionsDetails extends React.Component<RecurringActionsDetailsProps, RecurringActionsDetailsState> {
+class RecurringActionsDetails extends Component<RecurringActionsDetailsProps, RecurringActionsDetailsState> {
   weekDays = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
   constructor(props: RecurringActionsDetailsProps) {

--- a/web/html/src/manager/recurring/recurring-actions-edit.tsx
+++ b/web/html/src/manager/recurring/recurring-actions-edit.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import _isEqual from "lodash/isEqual";
 
@@ -36,7 +36,7 @@ type State = {
   details?: any;
 };
 
-class RecurringActionsEdit extends React.Component<Props, State> {
+class RecurringActionsEdit extends Component<Props, State> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/manager/recurring/recurring-actions-list.tsx
+++ b/web/html/src/manager/recurring/recurring-actions-list.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type RefObject, Component, createRef } from "react";
 
 import { pageSize } from "core/user-preferences";
 
@@ -34,11 +34,11 @@ type State = {
   schedules: any[];
 };
 
-class RecurringActionsList extends React.Component<Props, State> {
-  tableRef: React.RefObject<any>;
+class RecurringActionsList extends Component<Props, State> {
+  tableRef: RefObject<any>;
   constructor(props) {
     super(props);
-    this.tableRef = React.createRef();
+    this.tableRef = createRef();
     this.state = {
       schedules: [],
       itemsToDelete: [],

--- a/web/html/src/manager/recurring/recurring-actions.tsx
+++ b/web/html/src/manager/recurring/recurring-actions.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -55,7 +55,7 @@ type State = {
   selected?: any;
 };
 
-class RecurringActions extends React.Component<Props, State> {
+class RecurringActions extends Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/recurring/recurring-playbook-picker.tsx
+++ b/web/html/src/manager/recurring/recurring-playbook-picker.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { AnsiblePathContent } from "manager/minion/ansible/ansible-path-content";
 
@@ -18,7 +18,7 @@ type StateType = {
   editPlaybook: boolean;
 };
 
-class RecurringPlaybookPicker extends React.Component<PropsType, StateType> {
+class RecurringPlaybookPicker extends Component<PropsType, StateType> {
   constructor(props) {
     super(props);
 

--- a/web/html/src/manager/salt/cmd/remote-commands.tsx
+++ b/web/html/src/manager/salt/cmd/remote-commands.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -8,14 +8,14 @@ import { TopPanel } from "components/panels/TopPanel";
 type MinionResultViewProps = {
   id?: any;
   result?: any;
-  label?: React.ReactNode;
+  label?: ReactNode;
 };
 
 type MinionResultViewState = {
   open: boolean;
 };
 
-class MinionResultView extends React.Component<MinionResultViewProps, MinionResultViewState> {
+class MinionResultView extends Component<MinionResultViewProps, MinionResultViewState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -134,7 +134,7 @@ type RemoteCommandState = {
   pageUnloading?: boolean;
 };
 
-class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandState> {
+class RemoteCommand extends Component<RemoteCommandProps, RemoteCommandState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -152,7 +152,7 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
   }
 
   render() {
-    const msgs: React.ReactNode[] = [];
+    const msgs: ReactNode[] = [];
     const style = {
       paddingBottom: "0px",
     };
@@ -558,7 +558,7 @@ class RemoteCommand extends React.Component<RemoteCommandProps, RemoteCommandSta
   };
 
   commandResult = (result) => {
-    const elements: React.ReactNode[] = [];
+    const elements: ReactNode[] = [];
     for (const kv of result.minions) {
       const id = kv[0];
       const value = kv[1];

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.renderer.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { ServerMessageType } from "components/messages/messages";

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import withPageWrapper from "components/general/with-page-wrapper";
 import { Messages, MessageType, ServerMessageType } from "components/messages/messages";
@@ -19,7 +19,7 @@ type State = {
   messages: any[];
 };
 
-class FormulaCatalog extends React.Component<Props, State> {
+class FormulaCatalog extends Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/salt/formula-catalog/org-formula-details.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-details.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -19,7 +19,7 @@ type State = {
   metadata: any;
 };
 
-class FormulaDetail extends React.Component<Props, State> {
+class FormulaDetail extends Component<Props, State> {
   constructor(props, context) {
     super(props, context);
     this.getServerData();
@@ -36,7 +36,7 @@ class FormulaDetail extends React.Component<Props, State> {
   };
 
   generateMetadata = () => {
-    const metadata: React.ReactNode[] = [];
+    const metadata: ReactNode[] = [];
     for (const item in this.state.metadata) {
       metadata.push(
         <div className="form-group" key={item}>

--- a/web/html/src/manager/salt/keys/key-management.tsx
+++ b/web/html/src/manager/salt/keys/key-management.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -97,7 +97,7 @@ type State = {
   loading: boolean;
 };
 
-class KeyManagement extends React.Component<Props, State> {
+class KeyManagement extends Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/shared/menu/menu.tsx
+++ b/web/html/src/manager/shared/menu/menu.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type MouseEvent, type ReactNode, Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 import { isUyuni } from "core/user-preferences";
@@ -16,8 +16,8 @@ type LinkProps = {
   className?: string;
   target?: string;
   title?: string;
-  responsiveLabel?: React.ReactNode;
-  label?: React.ReactNode;
+  responsiveLabel?: ReactNode;
+  label?: ReactNode;
 };
 
 const Link = (props: LinkProps) => (
@@ -28,7 +28,7 @@ const Link = (props: LinkProps) => (
 );
 
 type NodeProps = {
-  handleClick: ((event?: React.MouseEvent) => any) | null;
+  handleClick: ((event?: MouseEvent) => any) | null;
   isLeaf?: boolean;
   icon?: string;
   url: string;
@@ -38,7 +38,7 @@ type NodeProps = {
   isOpen?: boolean;
 };
 
-class Node extends React.Component<NodeProps> {
+class Node extends Component<NodeProps> {
   handleClick = (event) => {
     // if the click is triggered on a link, do not toggle the menu, just offload the page and go to the requested link
     if (!event.target.href) {
@@ -76,7 +76,7 @@ class ElementState {
   }
 }
 
-class Element extends React.Component<ElementProps, ElementState> {
+class Element extends Component<ElementProps, ElementState> {
   state: ElementState;
 
   constructor(props: ElementProps) {
@@ -166,7 +166,7 @@ type MenuLevelProps = {
   forceCollapse?: any;
 };
 
-class MenuLevel extends React.Component<MenuLevelProps> {
+class MenuLevel extends Component<MenuLevelProps> {
   render() {
     const contentMenu = this.props.elements.map((el, i) => (
       <Element
@@ -182,7 +182,7 @@ class MenuLevel extends React.Component<MenuLevelProps> {
   }
 }
 
-class Nav extends React.Component {
+class Nav extends Component {
   state = { search: "", forceCollapse: false };
 
   onSearch = (e) => {
@@ -232,7 +232,7 @@ class Nav extends React.Component {
 
 SpaRenderer.renderGlobalReact(<Nav />, document.getElementById("nav"));
 
-class Breadcrumb extends React.Component {
+class Breadcrumb extends Component {
   onSPAEndNavigation() {
     this.forceUpdate();
   }

--- a/web/html/src/manager/shared/websocket/useWebSocket.ts
+++ b/web/html/src/manager/shared/websocket/useWebSocket.ts
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useEffect, useState } from "react";
 
 export function useWebSocket(
   errors: string[],
@@ -6,14 +6,14 @@ export function useWebSocket(
   property: string,
   callback: (value: any) => void
 ) {
-  const [webSocketErr, setWebSocketErr] = React.useState(false);
-  const [pageUnloading, setPageUnloading] = React.useState(false);
+  const [webSocketErr, setWebSocketErr] = useState(false);
+  const [pageUnloading, setPageUnloading] = useState(false);
 
   const onBeforeUnload = () => {
     setPageUnloading(true);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     const { port } = window.location;
     const url = `wss://${window.location.hostname}${port ? `:${port}` : ""}/rhn/websocket/notifications`;
     const ws = new WebSocket(url);

--- a/web/html/src/manager/state/display-highstate.tsx
+++ b/web/html/src/manager/state/display-highstate.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type ReactNode, Component, useState } from "react";
 
 import HighstateSummary from "./highstate-summary";
 
@@ -48,7 +47,7 @@ type DisplayHighstateState = {
   minions?: any;
 };
 
-class DisplayHighstate extends React.Component<DisplayHighstateProps, DisplayHighstateState> {
+class DisplayHighstate extends Component<DisplayHighstateProps, DisplayHighstateState> {
   constructor(props: DisplayHighstateProps) {
     super(props);
 
@@ -58,7 +57,7 @@ class DisplayHighstate extends React.Component<DisplayHighstateProps, DisplayHig
   }
 
   renderMinions = () => {
-    const minionList: React.ReactNode[] = [];
+    const minionList: ReactNode[] = [];
     for (const minion of this.state.minions) {
       minionList.push(<MinionHighstate minion={minion} />);
     }

--- a/web/html/src/manager/state/highstate-summary.tsx
+++ b/web/html/src/manager/state/highstate-summary.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { useEffect, useState } from "react";
 
 import { productName } from "core/user-preferences";

--- a/web/html/src/manager/state/highstate.tsx
+++ b/web/html/src/manager/state/highstate.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -37,7 +37,7 @@ type HighstateState = {
   actionChain?: any;
 };
 
-class Highstate extends React.Component<HighstateProps, HighstateState> {
+class Highstate extends Component<HighstateProps, HighstateState> {
   constructor(props) {
     super(props);
     const state = {

--- a/web/html/src/manager/storybook/layout.tsx
+++ b/web/html/src/manager/storybook/layout.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import type { ReactNode } from "react";
 
 import styles from "./layout.module.scss";
 
 type Props = {
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export const StorySection = (props: Props) => {
@@ -23,7 +23,7 @@ export const StripedStorySection = (props: Props) => {
 };
 
 type RowProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export const StoryRow = (props: RowProps) => {

--- a/web/html/src/manager/storybook/storybook.renderer.tsx
+++ b/web/html/src/manager/storybook/storybook.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { MessagesContainer } from "components/toastr";

--- a/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import Network from "utils/network";
@@ -45,7 +45,7 @@ type ActivationKeyChannelsState = {
   fetchedData: Map<number, availableChannelsType>;
 };
 
-class ActivationKeyChannelsApi extends React.Component<ActivationKeyChannelsProps, ActivationKeyChannelsState> {
+class ActivationKeyChannelsApi extends Component<ActivationKeyChannelsProps, ActivationKeyChannelsState> {
   constructor(props: ActivationKeyChannelsProps) {
     super(props);
 

--- a/web/html/src/manager/systems/activation-key/activation-key-channels.renderer.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import ActivationKeyChannels from "./activation-key-channels";

--- a/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ChangeEvent, Component } from "react";
 
 import MandatoryChannelsApi from "core/channels/api/mandatory-channels-api";
 import { productName } from "core/user-preferences";
@@ -18,7 +18,7 @@ type ActivationKeyChannelsState = {
   currentChildSelectedIds: number[];
 };
 
-class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, ActivationKeyChannelsState> {
+class ActivationKeyChannels extends Component<ActivationKeyChannelsProps, ActivationKeyChannelsState> {
   constructor(props: ActivationKeyChannelsProps) {
     super(props);
     this.state = {
@@ -37,7 +37,7 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
     };
   }
 
-  handleBaseChange = (event: React.ChangeEvent<HTMLSelectElement>): Promise<number> => {
+  handleBaseChange = (event: ChangeEvent<HTMLSelectElement>): Promise<number> => {
     const newBaseId: number = parseInt(event.target.value, 10);
     return new Promise((resolve) => this.setState({ currentSelectedBaseId: newBaseId }, () => resolve(newBaseId)));
   };

--- a/web/html/src/manager/systems/activation-key/child-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/child-channels.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ChangeEvent, Component } from "react";
 
 import { RequiredChannelsResultType } from "core/channels/api/use-mandatory-channels-api";
 
@@ -24,7 +24,7 @@ type ChildChannelsState = {
   collapsed: boolean;
 };
 
-class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsState> {
+class ChildChannels extends Component<ChildChannelsProps, ChildChannelsState> {
   constructor(props: ChildChannelsProps) {
     super(props);
 
@@ -37,7 +37,7 @@ class ChildChannels extends React.Component<ChildChannelsProps, ChildChannelsSta
     this.props.fetchMandatoryChannelsByChannelIds({ base: this.props.base, channels: this.props.channels });
   };
 
-  handleChannelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  handleChannelChange = (event: ChangeEvent<HTMLInputElement>) => {
     const channelId = parseInt(event.target.value, 10);
     const selectedFlag = event.target.checked;
     const channelIds: number[] = this.selectChannelWithDependencies(channelId, selectedFlag);

--- a/web/html/src/manager/systems/all-list.renderer.tsx
+++ b/web/html/src/manager/systems/all-list.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import _unescape from "lodash/unescape";
 
 import SpaRenderer from "core/spa/spa-renderer";

--- a/web/html/src/manager/systems/all-list.tsx
+++ b/web/html/src/manager/systems/all-list.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useState } from "react";
 
 import { LinkButton } from "components/buttons";
 import { IconTag } from "components/icontag";
@@ -37,7 +37,7 @@ const DownloadCSVButton = ({ search }) => {
 };
 
 export function AllSystems(props: Props) {
-  const [selectedSystems, setSelectedSystems] = React.useState<string[]>([]);
+  const [selectedSystems, setSelectedSystems] = useState<string[]>([]);
 
   const handleSelectedSystems = (items: string[]) => {
     const removed = selectedSystems.filter((item) => !items.includes(item)).map((item) => [item, false]);

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 import { productName } from "core/user-preferences";
@@ -31,7 +31,7 @@ type ErrorDetailsDialogProps = {
   onDialogClose: () => void;
 };
 
-class ErrorDetailsDialog extends React.Component<ErrorDetailsDialogProps> {
+class ErrorDetailsDialog extends Component<ErrorDetailsDialogProps> {
   render() {
     let content, title, buttons;
 
@@ -150,7 +150,7 @@ type State = {
   errorDetails: ErrorDetails | null;
 };
 
-class BootstrapMinions extends React.Component<Props, State> {
+class BootstrapMinions extends Component<Props, State> {
   initState: State;
 
   constructor(props: Props) {

--- a/web/html/src/manager/systems/coco/ssm-schedule.tsx
+++ b/web/html/src/manager/systems/coco/ssm-schedule.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { ActionChain, ActionSchedule } from "components/action-schedule";
 import { AsyncButton } from "components/buttons";
@@ -24,7 +24,7 @@ type State = {
   actionChain?: ActionChain;
 };
 
-class CoCoSSMSchedule extends React.Component<Props, State> {
+class CoCoSSMSchedule extends Component<Props, State> {
   public constructor(props) {
     super(props);
 
@@ -89,7 +89,7 @@ class CoCoSSMSchedule extends React.Component<Props, State> {
       });
   };
 
-  render(): React.ReactNode {
+  render(): ReactNode {
     return (
       <>
         <TopPanel title="Confidential Computing Schedule">

--- a/web/html/src/manager/systems/coco/ssm-settings.tsx
+++ b/web/html/src/manager/systems/coco/ssm-settings.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import CoCoSettingsForm from "components/coco-attestation/CoCoSettingsForm";
 import { Settings } from "components/coco-attestation/Utils";
@@ -20,7 +20,7 @@ type State = {
   messages: MessageType[];
 };
 
-class CoCoSSMSettings extends React.Component<Props, State> {
+class CoCoSSMSettings extends Component<Props, State> {
   private readonly emptySettings: Settings;
 
   constructor(props: Props) {
@@ -55,7 +55,7 @@ class CoCoSSMSettings extends React.Component<Props, State> {
     );
   };
 
-  render(): React.ReactNode {
+  render(): ReactNode {
     return (
       <>
         <TopPanel title="Confidential Computing Settings">

--- a/web/html/src/manager/systems/delete-system-confirm.tsx
+++ b/web/html/src/manager/systems/delete-system-confirm.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { Utils } from "utils/functions";

--- a/web/html/src/manager/systems/delete-system.tsx
+++ b/web/html/src/manager/systems/delete-system.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import { AsyncButton, Button } from "components/buttons";
 import { Dialog } from "components/dialog/LegacyDialog";
@@ -15,7 +15,7 @@ const messageMap = {
 type Props = {
   serverId: string;
   buttonClass?: string;
-  buttonText?: React.ReactNode;
+  buttonText?: ReactNode;
   onDeleteSuccess?: (...args: any[]) => any;
 };
 
@@ -24,7 +24,7 @@ type State = {
   cleanupErr: boolean;
 };
 
-class DeleteSystem extends React.Component<Props, State> {
+class DeleteSystem extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/systems/details/mgr-server-info.renderer.tsx
+++ b/web/html/src/manager/systems/details/mgr-server-info.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { MgrServer } from "./mgr-server-info";

--- a/web/html/src/manager/systems/details/mgr-server-info.tsx
+++ b/web/html/src/manager/systems/details/mgr-server-info.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { AsyncButton } from "components/buttons";
 import { Messages, MessageType, Utils as MessagesUtils } from "components/messages/messages";
@@ -32,7 +32,7 @@ const messageMap = {
   set_reportdb_creds_failed: t("Setting new credentials for the report database failed"),
 };
 
-class MgrServer extends React.Component<Props, State> {
+class MgrServer extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/systems/duplicate-systems-compare-delete.tsx
+++ b/web/html/src/manager/systems/duplicate-systems-compare-delete.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { DeleteSystem } from "./delete-system";

--- a/web/html/src/manager/systems/product-migration/migration-from-dry-run.tsx
+++ b/web/html/src/manager/systems/product-migration/migration-from-dry-run.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type FC, useState } from "react";
 
 import moment from "moment";
 
@@ -26,7 +25,7 @@ export type Props = {
   actionChains?: ActionChain[];
 };
 
-export const SSMProductMigrationFromDryRun: React.FC<Props> = ({
+export const SSMProductMigrationFromDryRun: FC<Props> = ({
   targetProduct,
   selectedChannels,
   systemsData,

--- a/web/html/src/manager/systems/product-migration/ssm-product-migration.tsx
+++ b/web/html/src/manager/systems/product-migration/ssm-product-migration.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { useState } from "react";
+import { type FC, type ReactNode, useState } from "react";
 
 import { ChannelTreeType } from "core/channels/type/channels.type";
 
@@ -41,7 +40,7 @@ export type Props = {
   actionChains?: ActionChain[];
 };
 
-export const SSMProductMigration: React.FC<Props> = ({
+export const SSMProductMigration: FC<Props> = ({
   commonBaseProduct,
   migrationSource,
   migrationTargets,
@@ -101,14 +100,14 @@ export const SSMProductMigration: React.FC<Props> = ({
     }
   }
 
-  function renderBaseProduct(system: MigrationSystemData): React.ReactNode {
+  function renderBaseProduct(system: MigrationSystemData): ReactNode {
     const highlight =
       !commonBaseProduct && migrationSource !== null && system.installedProduct.id === migrationSource.id;
 
     return <span className={highlight ? "fw-bold" : ""}>{system.installedProduct.name}</span>;
   }
 
-  function renderProductDetails(system: MigrationSystemData): React.ReactNode {
+  function renderProductDetails(system: MigrationSystemData): ReactNode {
     return (
       <LinkButton
         className="btn-link"
@@ -119,11 +118,11 @@ export const SSMProductMigration: React.FC<Props> = ({
     );
   }
 
-  function renderEligible(system: MigrationSystemData): React.ReactNode {
+  function renderEligible(system: MigrationSystemData): ReactNode {
     return <span>{system.eligible ? t("Yes") : t("No")}</span>;
   }
 
-  function renderReason(system: MigrationSystemData): React.ReactNode {
+  function renderReason(system: MigrationSystemData): ReactNode {
     let title: string, className: string;
 
     if (system.eligible) {
@@ -149,7 +148,7 @@ export const SSMProductMigration: React.FC<Props> = ({
     );
   }
 
-  function renderTargetSystems(data: MigrationSystemData[]): React.ReactNode {
+  function renderTargetSystems(data: MigrationSystemData[]): ReactNode {
     if (migrationStep === MigrationStep.ScheduleConfirmation) {
       return <></>;
     }

--- a/web/html/src/manager/systems/proxy.renderer.tsx
+++ b/web/html/src/manager/systems/proxy.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { Proxy } from "./proxy";

--- a/web/html/src/manager/systems/proxy.tsx
+++ b/web/html/src/manager/systems/proxy.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { AsyncButton } from "components/buttons";
 import { ActionLink } from "components/links";
@@ -33,7 +33,7 @@ type State = {
   proxy: number;
 };
 
-class Proxy extends React.Component<Props, State> {
+class Proxy extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 

--- a/web/html/src/manager/systems/ssm/ssm-counter.renderer.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-counter.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { SsmCounter } from "./ssm-counter";

--- a/web/html/src/manager/systems/ssm/ssm-counter.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-counter.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useState } from "react";
 
 import { Button } from "components/buttons";
 
@@ -11,8 +11,8 @@ type Props = {
 };
 
 export function SsmCounter(props: Props) {
-  const [count, setCount] = React.useState(props.count ?? 0);
-  const [errors, setErrors] = React.useState([]);
+  const [count, setCount] = useState(props.count ?? 0);
+  const [errors, setErrors] = useState([]);
   useWebSocket(errors, setErrors, "ssm-count", (value: number) => {
     setCount(value);
   });

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import * as ChannelUtils from "core/channels/utils/channels-dependencies.utils";
 import SpaRenderer from "core/spa/spa-renderer";
@@ -57,7 +57,7 @@ type ServersListPopupProps = {
   onClosePopUp: () => void;
 };
 
-class ServersListPopup extends React.Component<ServersListPopupProps> {
+class ServersListPopup extends Component<ServersListPopupProps> {
   render() {
     return (
       <PopUp
@@ -92,7 +92,7 @@ class ServersListPopup extends React.Component<ServersListPopupProps> {
 type BaseChannelProps = {
   baseChannels: SsmAllowedBaseChannelsJson[];
   baseChanges: SsmBaseChannelChangesJson;
-  footer: React.ReactNode;
+  footer: ReactNode;
   onSelectBase: (arg0: string, arg1: string) => void;
 };
 
@@ -102,7 +102,7 @@ type BaseChannelState = {
   popupServersChannelName: string;
 };
 
-class BaseChannelPage extends React.Component<BaseChannelProps, BaseChannelState> {
+class BaseChannelPage extends Component<BaseChannelProps, BaseChannelState> {
   constructor(props: BaseChannelProps) {
     super(props);
     this.state = {
@@ -270,7 +270,7 @@ type SsmAllowedChildChannelsDto = {
 type ChildChannelProps = {
   childChannels: SsmAllowedChildChannelsDto[];
   childChanges: ChannelChangeDto[];
-  footer: React.ReactNode;
+  footer: ReactNode;
   // Here and below, strings and numbers are used interchangably for childId, if you work on this code, please choose one or the other
   onChangeChild: (allowedChannels: SsmAllowedChildChannelsDto, childId: string | number, action: string) => void;
 };
@@ -285,7 +285,7 @@ type ChildChannelState = {
   requiredByChannels: Map<number | string, Set<number>>;
 };
 
-class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelState> {
+class ChildChannelPage extends Component<ChildChannelProps, ChildChannelState> {
   constructor(props: ChildChannelProps) {
     super(props);
 
@@ -569,7 +569,7 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
 type SummaryPageProps = {
   allowedChanges: SsmAllowedChildChannelsDto[];
   finalChanges: ChannelChangeDto[];
-  footer: React.ReactNode;
+  footer: ReactNode;
   onChangeEarliest: (earliest: moment.Moment) => void;
   onChangeActionChain: (actionChain: ActionChain | null | undefined) => void;
 };
@@ -581,7 +581,7 @@ type SummaryPageState = {
   actionChain: ActionChain | null | undefined;
 };
 
-class SummaryPage extends React.Component<SummaryPageProps, SummaryPageState> {
+class SummaryPage extends Component<SummaryPageProps, SummaryPageState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -747,10 +747,10 @@ class SummaryPage extends React.Component<SummaryPageProps, SummaryPageState> {
 
 type ResultPageProps = {
   results: ScheduleChannelChangesResultDto[];
-  footer: React.ReactNode;
+  footer: ReactNode;
 };
 
-class ResultPage extends React.Component<ResultPageProps> {
+class ResultPage extends Component<ResultPageProps> {
   render() {
     return (
       <BootstrapPanel
@@ -858,7 +858,7 @@ type SsmScheduleChannelChangesResultJson = {
 
 type FooterProps = {
   page: number;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 const Footer = (props: FooterProps) => (
@@ -870,7 +870,7 @@ const Footer = (props: FooterProps) => (
   </span>
 );
 
-class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
+class SsmChannelPage extends Component<SsmChannelProps, SsmChannelState> {
   constructor(props) {
     super(props);
     this.state = {
@@ -1064,7 +1064,7 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
   };
 
   render() {
-    let content: React.ReactNode;
+    let content: ReactNode;
     if (DEPRECATED_unsafeEquals(this.state.page, 0)) {
       content = (
         <BaseChannelPage

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.renderer.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import SpaRenderer from "core/spa/spa-renderer";
 
 import { SubscribeChannels } from "./subscribe-channels";

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ChangeEvent, type ReactNode, Component } from "react";
 
 import * as ChannelUtils from "core/channels/utils/channels-dependencies.utils";
 
@@ -58,7 +58,7 @@ type SystemChannelsState = {
   dependencyDataAvailable: boolean;
 };
 
-class SystemChannels extends React.Component<SystemChannelsProps, SystemChannelsState> {
+class SystemChannels extends Component<SystemChannelsProps, SystemChannelsState> {
   constructor(props: SystemChannelsProps) {
     super(props);
     this.state = {
@@ -232,7 +232,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
     this.setState((prevState) => ({ messages: prevState.messages.concat(msg) }));
   };
 
-  handleBaseChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  handleBaseChange = (event: ChangeEvent<HTMLInputElement>) => {
     const baseId: number = parseInt(event.target.value, 10);
     this.setState((prevState) => ({
       selectedBase:
@@ -247,7 +247,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
     return { id: -1, name: t("(none, disable service)"), custom: false, subscribable: true, recommended: false };
   };
 
-  handleChildChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  handleChildChange = (event: ChangeEvent<HTMLInputElement>) => {
     this.selectChildChannel(parseInt(event.target.value, 10), event.target.checked);
   };
 
@@ -447,7 +447,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
   }
 
   renderSelectionPage = () => {
-    const baseChannels: React.ReactNode[] = [];
+    const baseChannels: ReactNode[] = [];
     let childChannels;
     const isNoneChecked = -1 === (this.state.selectedBase && this.state.selectedBase.id);
     baseChannels.push(

--- a/web/html/src/manager/systems/virtual-list.renderer.tsx
+++ b/web/html/src/manager/systems/virtual-list.renderer.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import _unescape from "lodash/unescape";
 
 import SpaRenderer from "core/spa/spa-renderer";

--- a/web/html/src/manager/systems/virtual-list.tsx
+++ b/web/html/src/manager/systems/virtual-list.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useState } from "react";
 
 import { IconTag } from "components/icontag";
 import * as Systems from "components/systems";
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export function VirtualSystems(props: Props) {
-  const [selectedSystems, setSelectedSystems] = React.useState<string[]>([]);
+  const [selectedSystems, setSelectedSystems] = useState<string[]>([]);
 
   const handleSelectedSystems = (items: string[]) => {
     const removed = selectedSystems.filter((item) => !items.includes(item)).map((item) => [item, false]);

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Button } from "components/buttons";
 import { DeleteDialog } from "components/dialog/DeleteDialog";
@@ -23,7 +23,7 @@ type State = {
   nodes?: any;
 };
 
-class VirtualHostManagerDetails extends React.Component<Props, State> {
+class VirtualHostManagerDetails extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Button, SubmitButton } from "components/buttons";
 import { DEPRECATED_Select } from "components/input";
@@ -26,7 +26,7 @@ type State = {
   isInvalid?: boolean;
 };
 
-class VirtualHostManagerEdit extends React.Component<Props, State> {
+class VirtualHostManagerEdit extends Component<Props, State> {
   form?: HTMLFormElement;
 
   constructor(props) {

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-list.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-list.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { Component } from "react";
 
 import { Button } from "components/buttons";
 import { DeleteDialog } from "components/dialog/DeleteDialog";
@@ -19,7 +19,7 @@ type State = {
   itemToDelete?: any;
 };
 
-class VirtualHostManagerList extends React.Component<Props, State> {
+class VirtualHostManagerList extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {};

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { type ReactNode, Component } from "react";
 
 import SpaRenderer from "core/spa/spa-renderer";
 
@@ -46,7 +46,7 @@ type State = {
   id?: any;
 };
 
-class VirtualHostManager extends React.Component<Props, State> {
+class VirtualHostManager extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -158,8 +158,7 @@ class VirtualHostManager extends React.Component<Props, State> {
       // first use the localized name
       msgModuleTypes[moduleId] ??
       // then the module name as returned by the server
-      this.state.availableModules.find((name) => name.toLocaleLowerCase() === moduleId) ??
-      // if still undefined, fallback to the lowercase module id (execution should never reach here)
+      this.state.availableModules.find((name) => name.toLocaleLowerCase() === moduleId) ?? // if still undefined, fallback to the lowercase module id (execution should never reach here)
       moduleId
     );
   }
@@ -195,7 +194,7 @@ class VirtualHostManager extends React.Component<Props, State> {
     );
   }
 
-  renderContent(action: string): React.ReactNode {
+  renderContent(action: string): ReactNode {
     switch (action) {
       case "details":
         return (

--- a/web/html/src/utils/stringToReact.test.tsx
+++ b/web/html/src/utils/stringToReact.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Fragment } from "react";
 
 import ReactDOMServer from "react-dom/server";
 
@@ -9,8 +9,8 @@ describe("stringToReact", () => {
     a: string | JSX.Element | (string | JSX.Element)[],
     b: string | JSX.Element | (string | JSX.Element)[]
   ) => {
-    const aResult = ReactDOMServer.renderToStaticMarkup(<React.Fragment key="a">{a}</React.Fragment>);
-    const bResult = ReactDOMServer.renderToStaticMarkup(<React.Fragment key="b">{b}</React.Fragment>);
+    const aResult = ReactDOMServer.renderToStaticMarkup(<Fragment key="a">{a}</Fragment>);
+    const bResult = ReactDOMServer.renderToStaticMarkup(<Fragment key="b">{b}</Fragment>);
 
     return expect(aResult).toEqual(bResult);
   };


### PR DESCRIPTION
## What does this PR change?

This pr eliminates redundant react imports as explained [here](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports) 

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #7971

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
