### PR TITLE
Move proxy initialization to run when proxy config is applied (bsc#1252948) 

### DIFF
--- a/java/core/src/main/java/com/suse/proxy/get/ProxyConfigGetFacadeImpl.java
+++ b/java/core/src/main/java/com/suse/proxy/get/ProxyConfigGetFacadeImpl.java
@@ -25,7 +25,6 @@ import com.suse.proxy.get.formdata.ProxyConfigGetFormDataAcquisitor;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDataContext;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDataContextHandler;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDataPreConditions;
-import com.suse.proxy.get.formdata.ProxyConfigGetFormDataProxyInitializer;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDefaults;
 import com.suse.proxy.model.ProxyConfig;
 import com.suse.utils.Json;
@@ -39,7 +38,7 @@ import java.util.Map;
  * Class responsible for getting proxy configurations
  */
 public class ProxyConfigGetFacadeImpl implements ProxyConfigGetFacade {
-    public static final String MGRPXY = "mgrpxy";
+
     private final List<ProxyConfigGetFormDataContextHandler> getFormDataContextHandlerChain = new ArrayList<>();
 
     /**
@@ -48,7 +47,6 @@ public class ProxyConfigGetFacadeImpl implements ProxyConfigGetFacade {
     public ProxyConfigGetFacadeImpl() {
         this.getFormDataContextHandlerChain.addAll(asList(
                 new ProxyConfigGetFormDataPreConditions(),
-                new ProxyConfigGetFormDataProxyInitializer(),
                 new ProxyConfigGetFormDefaults(),
                 new ProxyConfigGetFormDataAcquisitor()
         ));

--- a/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditions.java
+++ b/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataPreConditions.java
@@ -7,29 +7,20 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.proxy.get.formdata;
 
-import static com.suse.proxy.get.ProxyConfigGetFacadeImpl.MGRPXY;
+import static com.suse.proxy.ProxyConfigUtils.getSubscribableMgrpxyChannels;
+import static com.suse.proxy.ProxyConfigUtils.isMgrpxyInstalled;
 import static com.suse.utils.Predicates.isAbsent;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.server.Server;
-import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Pre-condition checks before handling Proxy Config Get Form Data
@@ -70,68 +61,6 @@ public class ProxyConfigGetFormDataPreConditions implements ProxyConfigGetFormDa
             context.getErrorReport().register(
                     "No channel with mgrpxy package found for server ID: {0}", server.getId());
         }
-
-    }
-
-    /**
-     * Check if mgrpxy is installed on the server
-     * @param server the server to check
-     * @return true if installed, false otherwise
-     */
-    private boolean isMgrpxyInstalled(Server server) {
-        return PackageManager.shallowSystemPackageList(server.getId())
-                .stream().anyMatch(p -> p.getName().equals(MGRPXY));
-    }
-
-    /**
-     * Returns the set of channels providing the mgrpxy package that should be subscribed to.
-     * Logic:
-     * - If mgrpxy is already available from a subscribed channel, returns an empty set.
-     * - If mgrpxy is available only from non-subscribed channels, returns those channels.
-     * - If no channels provide mgrpxy at all, returns {@code null}.
-     *
-     * @param server the server to inspect
-     * @param user   the user requesting the channels
-     * @return set of subscribable channels providing mgrpxy, an empty set if already subscribed,
-     * or {@code null} if unavailable
-     */
-    private Set<Channel> getSubscribableMgrpxyChannels(Server server, User user) {
-        Channel baseChannel = server.getBaseChannel();
-        if (baseChannel == null) {
-            return null;
-        }
-
-        Map<Boolean, Set<Channel>> channelsBySubscription =
-                collectAccessibleChannels(baseChannel, user).stream()
-                        .filter(c -> !ChannelManager.listLatestPackagesEqual(c.getId(), MGRPXY).isEmpty())
-                        .collect(Collectors.partitioningBy(
-                                server::isSubscribed,
-                                Collectors.toSet()
-                        ));
-
-        Set<Channel> subscribed = channelsBySubscription.getOrDefault(true, Set.of());
-        Set<Channel> unsubscribed = channelsBySubscription.getOrDefault(false, Set.of());
-
-        if (!subscribed.isEmpty()) {
-            return Set.of();
-        }
-
-        return unsubscribed.isEmpty() ? null : unsubscribed;
-    }
-
-    /**
-     * Recursively collects accessible channels for a given user.
-     * @param channel the channel to check
-     * @param user the user requesting access
-     * @return a set of accessible channels
-     */
-    private Set<Channel> collectAccessibleChannels(Channel channel, User user) {
-        Set<Channel> collected = new HashSet<>();
-        collected.add(channel);
-        for (Channel child : channel.getAccessibleChildrenFor(user)) {
-            collected.addAll(collectAccessibleChannels(child, user));
-        }
-        return collected;
     }
 
 }

--- a/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateAcquisitor.java
+++ b/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateAcquisitor.java
@@ -61,13 +61,11 @@ public class ProxyConfigUpdateAcquisitor implements ProxyConfigUpdateContextHand
         Long serverId = context.getRequest().getServerId();
         if (isProvided(serverId)) {
             MinionServerFactory.lookupById(serverId).ifPresent(minionServer -> {
-                if (minionServer.hasProxyEntitlement()) {
-                    context.setProxyMinion(minionServer);
-                    context.setProxyFqdn(ofNullable(minionServer.findPrimaryFqdn())
-                            .map(ServerFQDN::getName)
-                            .orElse(minionServer.getName()));
-                    context.setProxyConfig(context.getProxyConfigGetFacade().getProxyConfig(minionServer));
-                }
+                context.setProxyMinion(minionServer);
+                context.setProxyFqdn(ofNullable(minionServer.findPrimaryFqdn())
+                        .map(ServerFQDN::getName)
+                        .orElse(minionServer.getName()));
+                context.setProxyConfig(context.getProxyConfigGetFacade().getProxyConfig(minionServer));
             });
         }
     }

--- a/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateContext.java
+++ b/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateContext.java
@@ -7,21 +7,20 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.proxy.update;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.UyuniErrorReport;
 import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Pillar;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.manager.webui.utils.gson.ProxyConfigUpdateJson;
 import com.suse.proxy.ProxyContainerImagesEnum;
@@ -31,8 +30,10 @@ import com.suse.proxy.get.ProxyConfigGetFacadeImpl;
 import com.suse.proxy.model.ProxyConfig;
 
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This class holds relevant data through the steps of the proxy config update process.
@@ -54,6 +55,7 @@ public class ProxyConfigUpdateContext {
     private List<String> intermediateCAs;
     private String proxyCert;
     private String proxyKey;
+    private Set<Channel> subscribableChannels = new HashSet<>();
 
     private MinionServer proxyMinion;
     private Server parentServer;
@@ -63,12 +65,13 @@ public class ProxyConfigUpdateContext {
     private Pillar pillar;
     private Action action;
 
+
     /**
      * Constructor
      *
-     * @param requestIn       the request
-     * @param systemManagerIn the system manager
-     * @param userIn          the user
+     * @param requestIn                  the request
+     * @param systemManagerIn            the system manager
+     * @param userIn                     the user
      */
     public ProxyConfigUpdateContext(
             ProxyConfigUpdateJson requestIn,
@@ -81,10 +84,10 @@ public class ProxyConfigUpdateContext {
     /**
      * Full params constructor
      *
-     * @param requestIn              the request
-     * @param systemManagerIn        the system manager
-     * @param userIn                 the user
-     * @param proxyConfigGetFacadeIn the proxy config get facade
+     * @param requestIn                  the request
+     * @param systemManagerIn            the system manager
+     * @param userIn                     the user
+     * @param proxyConfigGetFacadeIn     the proxy config get facade
      */
     public ProxyConfigUpdateContext(
             ProxyConfigUpdateJson requestIn,
@@ -208,6 +211,18 @@ public class ProxyConfigUpdateContext {
 
     public ProxyConfigGetFacade getProxyConfigGetFacade() {
         return proxyConfigGetFacade;
+    }
+
+    public SystemEntitlementManager getSystemEntitlementManager() {
+        return GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    }
+
+    public Set<Channel> getSubscribableChannels() {
+        return subscribableChannels;
+    }
+
+    public void setSubscribableChannelsWithMgrpxy(Set<Channel> subscribableChannelsIn) {
+        subscribableChannels = subscribableChannelsIn;
     }
 }
 

--- a/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateInitializer.java
+++ b/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateInitializer.java
@@ -7,20 +7,16 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
-package com.suse.proxy.get.formdata;
+package com.suse.proxy.update;
 
 import static java.util.Collections.singleton;
 
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ProxyInfo;
-import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
@@ -43,26 +39,26 @@ import java.util.Set;
  * b) If server does not have a proxy entitlement, it is added.
  * c) If server is not subscribed to the appropriate proxy extension channel,it is subscribed to it.
  */
-public class ProxyConfigGetFormDataProxyInitializer implements ProxyConfigGetFormDataContextHandler {
-    private static final Logger LOG = LogManager.getLogger(ProxyConfigGetFormDataProxyInitializer.class);
+public class ProxyConfigUpdateInitializer implements ProxyConfigUpdateContextHandler {
+    private static final Logger LOG = LogManager.getLogger(ProxyConfigUpdateInitializer.class);
 
-    private Server server;
+    private MinionServer minion;
     private User user;
 
     @Override
-    public void handle(ProxyConfigGetFormDataContext context) {
-        this.server = context.getServer();
+    public void handle(ProxyConfigUpdateContext context) {
+        this.minion = context.getProxyMinion();
         this.user = context.getUser();
 
         ensureServerHasProxyInfo();
 
         if (!ensureServerHasProxyEntitlement(context.getSystemEntitlementManager())) {
-            context.getErrorReport().register("Failed to add proxy entitlement to server ID {0}", server.getId());
+            context.getErrorReport().register("Failed to add proxy entitlement to server ID {0}", minion.getId());
         }
 
         if (!ensureMgrpxyIsAvailable(context)) {
             context.getErrorReport().register(
-                    "Failed to subscribe to appropriate proxy extension channel for server ID {0}", server.getId());
+                    "Failed to subscribe to appropriate proxy extension channel for server ID {0}", minion.getId());
         }
     }
 
@@ -70,15 +66,15 @@ public class ProxyConfigGetFormDataProxyInitializer implements ProxyConfigGetFor
      * Ensures that the server has a {@link ProxyInfo}.
      */
     private void ensureServerHasProxyInfo() {
-        if (server.getProxyInfo() != null) {
+        if (minion.getProxyInfo() != null) {
             return;
         }
 
-        LOG.debug("ProxyInfo not found for server. Creating new ProxyInfo for server ID: {}", server.getId());
+        LOG.debug("ProxyInfo not found for server. Creating new ProxyInfo for server ID: {}", minion.getId());
         ProxyInfo proxyInfo = new ProxyInfo();
-        proxyInfo.setServer(server);
-        server.setProxyInfo(proxyInfo);
-        SystemManager.updateSystemOverview(server.getId());
+        proxyInfo.setServer(minion);
+        minion.setProxyInfo(proxyInfo);
+        SystemManager.updateSystemOverview(minion.getId());
     }
 
     /**
@@ -87,14 +83,14 @@ public class ProxyConfigGetFormDataProxyInitializer implements ProxyConfigGetFor
      * @return true if the server has proxy entitlement, false otherwise
      */
     private boolean ensureServerHasProxyEntitlement(SystemEntitlementManager systemEntitlementManager) {
-        if (server.hasProxyEntitlement()) {
+        if (minion.hasProxyEntitlement()) {
             return true;
         }
 
-        ValidatorResult result = systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.PROXY);
+        ValidatorResult result = systemEntitlementManager.addEntitlementToServer(minion, EntitlementManager.PROXY);
         if (result.hasErrors()) {
             LOG.error("Failed to add proxy entitlement to server. ID: {}, Errors: {}",
-                    server.getId(), result.getErrors());
+                    minion.getId(), result.getErrors());
         }
 
         return !result.hasErrors();
@@ -105,25 +101,25 @@ public class ProxyConfigGetFormDataProxyInitializer implements ProxyConfigGetFor
       * @param context the ProxyConfigGetFormDataContext
       * @return true if mgrpxy is available, false otherwise
       */
-    private boolean ensureMgrpxyIsAvailable(ProxyConfigGetFormDataContext context) {
+    private boolean ensureMgrpxyIsAvailable(ProxyConfigUpdateContext context) {
         Set<Channel> subscribableChannels = context.getSubscribableChannels();
         if (context.getSubscribableChannels().isEmpty()) {
             return true;
         }
 
-        Set<Channel> newChildChannels = new HashSet<>(server.getChildChannels());
+        Set<Channel> newChildChannels = new HashSet<>(minion.getChildChannels());
         newChildChannels.addAll(subscribableChannels);
 
         try {
             ActionChainManager.scheduleSubscribeChannelsAction(user,
-                    singleton(server.getId()),
-                    Optional.ofNullable(server.getBaseChannel()),
+                    singleton(minion.getId()),
+                    Optional.ofNullable(minion.getBaseChannel()),
                     newChildChannels,
                     new Date(System.currentTimeMillis() - 1000), null);
         }
         catch (TaskomaticApiException e) {
             LOG.error("Failed to subscribe server to proxy extensions channels {}. ID: {}, Error: {}",
-                    subscribableChannels, server.getId(), e.getMessage());
+                    subscribableChannels, minion.getId(), e.getMessage());
             return false;
         }
         return true;

--- a/java/core/src/test/java/com/suse/proxy/get/formdata/test/ProxyConfigGetFormDataPreConditionsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/get/formdata/test/ProxyConfigGetFormDataPreConditionsTest.java
@@ -11,7 +11,9 @@
 
 package com.suse.proxy.get.formdata.test;
 
-import static com.suse.proxy.get.ProxyConfigGetFacadeImpl.MGRPXY;
+import static com.suse.proxy.ProxyConfigUtils.MGRPXY;
+import static com.suse.proxy.ProxyConfigUtils.isMgrpxyAvailable;
+import static com.suse.proxy.ProxyConfigUtils.isMgrpxyInstalled;
 import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.SERVER_ID;
 import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertErrors;
 import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertNoErrors;
@@ -30,7 +32,6 @@ import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -365,26 +366,4 @@ public class ProxyConfigGetFormDataPreConditionsTest extends RhnJmockBaseTestCas
     private ProxyConfigGetFormDataContext createContext(Server server) {
         return new ProxyConfigGetFormDataContext(user, server, null, systemEntitlementManager);
     }
-
-    /**
-     * Helper method to check if mgrpxy is installed on server
-     * @param server the server to check
-     * @return true if installed, false otherwise
-     */
-    private boolean isMgrpxyInstalled(Server server) {
-        return PackageManager.shallowSystemPackageList(server.getId())
-                .stream().anyMatch(p -> p.getName().equals(MGRPXY));
-    }
-
-    /**
-     * Helper method to check if mgrpxy is available on server on a subscribed channel
-     * @param server the server to check
-     * @return true if available, false otherwise
-     */
-    private boolean isMgrpxyAvailable(Server server) {
-        return server.getChildChannels().stream()
-                .flatMap(c -> c.getPackages().stream())
-                .anyMatch(p -> MGRPXY.equals(p.getPackageName().getName()));
-    }
-
 }

--- a/java/core/src/test/java/com/suse/proxy/get/formdata/test/ProxyConfigGetFormTestUtils.java
+++ b/java/core/src/test/java/com/suse/proxy/get/formdata/test/ProxyConfigGetFormTestUtils.java
@@ -7,10 +7,6 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.proxy.get.formdata.test;
@@ -52,6 +48,9 @@ public class ProxyConfigGetFormTestUtils {
         context.checking(new Expectations() {{
             allowing(mockConfigDefaults).isUyuni();
             will(returnValue(expectedIsUyuni));
+
+            allowing(mockConfigDefaults).getProductVersion();
+            will(returnValue(expectedIsUyuni ? "2026.01" : "5.2.0"));
 
             allowing(mockConfigDefaults);
             will(new CustomAction("delegate to real object") {

--- a/java/core/src/test/java/com/suse/proxy/test/ProxyConfigGetFacadeImplTest.java
+++ b/java/core/src/test/java/com/suse/proxy/test/ProxyConfigGetFacadeImplTest.java
@@ -11,7 +11,6 @@
 
 package com.suse.proxy.test;
 
-import static com.suse.proxy.get.ProxyConfigGetFacadeImpl.MGRPXY;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -155,7 +154,7 @@ public class ProxyConfigGetFacadeImplTest extends BaseTestCaseWithUser {
                 ServerConstants.getServerGroupTypeProxyEntitled(),
                 ServerFactoryTest.TYPE_SERVER_PROXY);
         Channel channel = ChannelFactoryTest.createTestChannel(user);
-        PackageManagerTest.addPackageToSystemAndChannel(MGRPXY, server, channel);
+        PackageManagerTest.addPackageToSystemAndChannel(ProxyConfigUtils.MGRPXY, server, channel);
 
         // mocking the ConfigDefaults
         ConfigDefaults mockConfigDefaults = context.mock(ConfigDefaults.class);

--- a/java/core/src/test/java/com/suse/proxy/test/ProxyConfigUpdateAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/test/ProxyConfigUpdateAcquisitorTest.java
@@ -110,7 +110,7 @@ public class ProxyConfigUpdateAcquisitorTest extends BaseTestCaseWithUser {
     @Test
     public void testBlankRequest() {
         ProxyConfigUpdateJson request = Json.GSON.fromJson("{}", ProxyConfigUpdateJson.class);
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
 
         // execution
         new ProxyConfigUpdateAcquisitor().handle(proxyConfigUpdateContext);

--- a/java/core/src/test/java/com/suse/proxy/test/ProxyConfigUpdateValidationTest.java
+++ b/java/core/src/test/java/com/suse/proxy/test/ProxyConfigUpdateValidationTest.java
@@ -7,17 +7,18 @@
  * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
  * along with this software; if not, see
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
- *
- * Red Hat trademarks are not licensed under GPLv2. No permission is
- * granted to use or replicate Red Hat trademarks that are incorporated
- * in this software or its documentation.
  */
 
 package com.suse.proxy.test;
 
+import static com.suse.proxy.ProxyConfigUtils.MGRPXY;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_MODE_ADVANCED;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_MODE_SIMPLE;
 import static com.suse.proxy.ProxyConfigUtils.SOURCE_MODE_REGISTRY;
+import static com.suse.proxy.ProxyConfigUtils.isMgrpxyAvailable;
+import static com.suse.proxy.ProxyConfigUtils.isMgrpxyInstalled;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertErrors;
+import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.setConfigDefaultsInstance;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
@@ -29,28 +30,54 @@ import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_SERVER_ID;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_TAG;
 import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.assertExpectedErrors;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.MgrServerInfo;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ProxyInfo;
 import com.redhat.rhn.domain.server.Server;
-import com.redhat.rhn.testing.MockObjectTestCase;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.testing.ChannelTestUtils;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.suse.manager.webui.utils.gson.ProxyConfigUpdateJson;
+import com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils;
 import com.suse.proxy.model.ProxyConfig;
 import com.suse.proxy.update.ProxyConfigUpdateAcquisitor;
 import com.suse.proxy.update.ProxyConfigUpdateContext;
 import com.suse.proxy.update.ProxyConfigUpdateValidation;
 import com.suse.utils.Json;
 
+import org.jmock.Expectations;
+import org.jmock.api.Invocation;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.jmock.lib.action.CustomAction;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Set;
 
 /**
  * Tests for the {@link ProxyConfigUpdateValidation} class
  * These will assume the previous step in the chain of responsibility {@link ProxyConfigUpdateAcquisitor}
  * has been executed and, no errors have been added to the context.
  */
-public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
+public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
 
     public static final String UNKNOWN = "unknown";
+    private static final String JAVA_TEST = "java::test";
 
     /**
      * Test a scenario where ProxyConfigUpdateJson is resolved as being empty
@@ -70,7 +97,8 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
         };
 
         ProxyConfigUpdateJson request = Json.GSON.fromJson("{}", ProxyConfigUpdateJson.class);
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
+
 
         // execution
         new ProxyConfigUpdateValidation().handle(proxyConfigUpdateContext);
@@ -100,7 +128,8 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
                 .sourceRPM()
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext =
+                new ProxyConfigUpdateContext(request, null, null, null);
         // certificate content is handled in {@link ProxyConfigUpdateAcquisitor} and set directly in the context
         proxyConfigUpdateContext.setRootCA(DUMMY_ROOT_CA);
         proxyConfigUpdateContext.setProxyCert(DUMMY_PROXY_CERT);
@@ -120,7 +149,8 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
                 .replaceCerts(null, null, null, null)
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext =
+                new ProxyConfigUpdateContext(request, null, null, null);
         // certificate content is handled in {@link ProxyConfigUpdateAcquisitor} and set directly in the context
         proxyConfigUpdateContext.setRootCA(DUMMY_ROOT_CA);
         proxyConfigUpdateContext.setProxyCert(DUMMY_PROXY_CERT);
@@ -163,7 +193,7 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
                 .keepCerts(null, null, null, null)
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
         proxyConfigUpdateContext.setParentServer(new Server(DUMMY_SERVER_ID, DUMMY_PARENT_FQDN));
         proxyConfigUpdateContext.setProxyFqdn(DUMMY_PROXY_FQDN);
 
@@ -188,7 +218,7 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
                 .keepCerts(null, null, null, null)
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
         proxyConfigUpdateContext.setParentServer(new Server(DUMMY_SERVER_ID, DUMMY_PARENT_FQDN));
         proxyConfigUpdateContext.setProxyFqdn(DUMMY_PROXY_FQDN);
         proxyConfigUpdateContext.setProxyConfig(new ProxyConfig());
@@ -338,6 +368,224 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
         assertFalse(proxyConfigUpdateContext.getErrorReport().hasErrors());
     }
 
+    /**
+     * Test a scenario where the target minion fails all requirements, ie:
+     * - It is a manager server
+     * - Does not have proxy entitlement
+     * - Cannot be entitled as proxy
+     * - Does not have mgrpxy installed
+     * - There are no channels it can subscribe to that provide mgrpxy
+     */
+    @Test
+    public void testFailWhenMinionIsNotViable() {
+        ProxyConfigUpdateJson request = getBaseRequestWithRpm()
+                .keepCerts(null, null, null, null)
+                .build();
+
+        ConfigDefaults configDefaults = ConfigDefaults.get();
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+        SystemEntitlementManager mockSystemEntitlementManager = mock(SystemEntitlementManager.class);
+
+        // set up the minion
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        // setting the minion as manager
+        MgrServerInfo mgrServerInfo = new MgrServerInfo();
+        mgrServerInfo.setServer(minion);
+        minion.setMgrServerInfo(mgrServerInfo);
+        // not allowing minion to be entitleable as proxy
+        context().checking(new Expectations() {{
+            allowing(mockSystemEntitlementManager).canEntitleServer(minion, EntitlementManager.PROXY);
+            will(returnValue(false));
+        }});
+
+
+        assertFalse(isMgrpxyInstalled(minion));
+        assertFalse(isMgrpxyAvailable(minion));
+
+        ProxyConfigUpdateContext proxyConfigUpdateContext =
+                fillContextWithDummyData(
+                        new ProxyConfigUpdateContext(request, null, user)
+                );
+        proxyConfigUpdateContext.setProxyMinion(minion);
+
+        // Create a mock context
+        ProxyConfigUpdateContext mockProxyConfigUpdateContext = mock(ProxyConfigUpdateContext.class);
+
+        // Configure the mock
+        context.checking(new Expectations() {{
+            // Handle everything we want actually to mock
+            allowing(mockProxyConfigUpdateContext).getSystemEntitlementManager();
+            will(returnValue(mockSystemEntitlementManager));
+
+            // For all other methods, delegate to the real context
+            allowing(mockProxyConfigUpdateContext);
+            will(new CustomAction("delegate to real object") {
+                public Object invoke(Invocation invocation) throws Throwable {
+                    Method m = invocation.getInvokedMethod();
+                    return m.invoke(proxyConfigUpdateContext, invocation.getParametersAsArray());
+                }
+            });
+        }});
+
+        //
+        new ProxyConfigUpdateValidation().handle(mockProxyConfigUpdateContext);
+        assertErrors(proxyConfigUpdateContext.getErrorReport(),
+                "The system is a Management Server and cannot be converted to a Proxy",
+                "Cannot entitle server ID: ",
+                "No channel with mgrpxy package found for server ID: "
+        );
+
+        try {
+            setConfigDefaultsInstance(configDefaults);
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Error resetting ConfigDefaults instance", e);
+        }
+    }
+
+    /**
+     * Test a scenario where the target minion is not a minion yet, but fills all requirements, ie:
+     * - It not a manager server
+     * - Does not have proxy entitlement
+     * - Can be entitled as proxy
+     * - Does not have mgrpxy installed
+     * - Minion is subscribed to a channel providing mgrpxy
+     */
+    @Test
+    public void testSuccessWhenProxyConversionAlreadySubscribedToChannel() throws Exception {
+        ProxyConfigUpdateJson request = getBaseRequestWithRpm()
+                .keepCerts(null, null, null, null)
+                .build();
+
+        ConfigDefaults configDefaults = ConfigDefaults.get();
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        // set up the minion
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        // associate a child channel providing mgrpxy
+        Channel channelWithMgrpxy = createChannelWithMgrPxy(minion);
+        // subscribe to the channel
+        SystemManager.subscribeServerToChannel(user, minion, channelWithMgrpxy);
+        ChannelFactory.refreshNewestPackageCache(channelWithMgrpxy, JAVA_TEST);
+
+        assertFalse(isMgrpxyInstalled(minion));
+        assertTrue(isMgrpxyAvailable(minion));
+
+        ProxyConfigUpdateContext proxyConfigUpdateContext =
+                fillContextWithDummyData(
+                        new ProxyConfigUpdateContext(request, null, user)
+                );
+        proxyConfigUpdateContext.setProxyMinion(minion);
+
+        //
+        new ProxyConfigUpdateValidation().handle(proxyConfigUpdateContext);
+        assertFalse(proxyConfigUpdateContext.getErrorReport().hasErrors());
+        assertTrue(proxyConfigUpdateContext.getSubscribableChannels().isEmpty());
+
+        try {
+            setConfigDefaultsInstance(configDefaults);
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Error resetting ConfigDefaults instance", e);
+        }
+    }
+
+    /**
+     * Test a scenario where the target minion is not a minion yet, but fills all requirements, ie:
+     * - It not a manager server
+     * - Does not have proxy entitlement
+     * - Can be entitled as proxy
+     * - Does not have mgrpxy installed
+     * - There are subscribable channels that provide mgrpxy
+     */
+    @Test
+    public void testSuccessWhenProxyConversionNotSubscribedToChannel() throws Exception {
+        ProxyConfigUpdateJson request = getBaseRequestWithRpm()
+                .keepCerts(null, null, null, null)
+                .build();
+
+        ConfigDefaults configDefaults = ConfigDefaults.get();
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        // set up the minion with base channel
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        // associate a child channel providing mgrpxy
+        Channel channelWithMgrpxy = createChannelWithMgrPxy(minion);
+        ChannelFactory.refreshNewestPackageCache(channelWithMgrpxy, JAVA_TEST);
+
+        assertFalse(isMgrpxyInstalled(minion));
+        assertFalse(isMgrpxyAvailable(minion));
+
+        ProxyConfigUpdateContext proxyConfigUpdateContext =
+                fillContextWithDummyData(
+                        new ProxyConfigUpdateContext(request, null, user)
+                );
+        proxyConfigUpdateContext.setProxyMinion(minion);
+
+        //
+        new ProxyConfigUpdateValidation().handle(proxyConfigUpdateContext);
+        assertFalse(proxyConfigUpdateContext.getErrorReport().hasErrors());
+        Set<Channel> subscribableChannels = proxyConfigUpdateContext.getSubscribableChannels();
+        assertEquals(1, subscribableChannels.size());
+        assertEquals(channelWithMgrpxy, subscribableChannels.iterator().next());
+
+        try {
+            setConfigDefaultsInstance(configDefaults);
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Error resetting ConfigDefaults instance", e);
+        }
+    }
+
+    /**
+     * Test a scenario where the target minion is already a proxy. Meaning:
+     * - It is not a manager server
+     * - Has proxy entitlement
+     * - Has mgrpxy installed
+     */
+    @Test
+    public void testSuccessWhenMinionIsProxy() throws Exception {
+        ProxyConfigUpdateJson request = getBaseRequestWithRpm()
+                .keepCerts(null, null, null, null)
+                .build();
+
+        ConfigDefaults configDefaults = ConfigDefaults.get();
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+
+        // set up the minion with base channel
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        // add proxy info
+        ProxyInfo proxyInfo = new ProxyInfo();
+        proxyInfo.setServer(minion);
+        minion.setProxyInfo(proxyInfo);
+        // add package to minion
+        Channel channelWithMgrpxy = ChannelFactoryTest.createTestChannel(user);
+        PackageManagerTest.addPackageToSystemAndChannel(MGRPXY, minion, channelWithMgrpxy);
+
+        assertTrue(isMgrpxyInstalled(minion));
+
+        ProxyConfigUpdateContext proxyConfigUpdateContext =
+                fillContextWithDummyData(
+                        new ProxyConfigUpdateContext(request, null, user)
+                );
+        proxyConfigUpdateContext.setProxyMinion(minion);
+
+        //
+        new ProxyConfigUpdateValidation().handle(proxyConfigUpdateContext);
+        assertFalse(proxyConfigUpdateContext.getErrorReport().hasErrors());
+
+        try {
+            setConfigDefaultsInstance(configDefaults);
+        }
+        catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Error resetting ConfigDefaults instance", e);
+        }
+    }
+
 
     /**
      * Creates a {@link ProxyConfigUpdateContext} with the provided request and assuming previous step
@@ -347,7 +595,14 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
      * @return the context
      */
     private static ProxyConfigUpdateContext getProxyConfigUpdateContext(ProxyConfigUpdateJson request) {
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
+        return fillContextWithDummyData(
+                new ProxyConfigUpdateContext(request, null, null, null)
+        );
+    }
+
+    private static ProxyConfigUpdateContext fillContextWithDummyData(
+            ProxyConfigUpdateContext proxyConfigUpdateContext
+    ) {
         proxyConfigUpdateContext.setParentServer(new Server(DUMMY_SERVER_ID, DUMMY_PARENT_FQDN));
         proxyConfigUpdateContext.setProxyFqdn(DUMMY_PROXY_FQDN);
         // certificate content is handled in {@link ProxyConfigUpdateAcquisitor} and set directly in the context
@@ -357,6 +612,7 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
         proxyConfigUpdateContext.setProxyKey(DUMMY_PROXY_KEY);
         return proxyConfigUpdateContext;
     }
+
 
     /**
      * Creates a base request with the required fields for the proxy configuration using rpm as source
@@ -387,4 +643,21 @@ public class ProxyConfigUpdateValidationTest extends MockObjectTestCase {
                 .email(DUMMY_ADMIN_MAIL)
                 .replaceCerts(null, null, null, null);
     }
+
+    /**
+     * Helper method to set up a base channel and a child channel with mgrpxy package, and subscribes the server to
+     * the base channel.
+     * @param server the minion server to subscribe
+     * @return the created child channel
+     * @throws Exception on errors
+     */
+    private Channel createChannelWithMgrPxy(Server server) throws Exception {
+        Channel baseChannel = ChannelTestUtils.createBaseChannel(user);
+        server.addChannel(baseChannel);
+        Package pkg = PackageTest.createTestPackage(user.getOrg(), MGRPXY);
+        Channel childChannel = ChannelTestUtils.createChildChannel(user, server.getBaseChannel());
+        childChannel.getPackages().add(pkg);
+        return childChannel;
+    }
+
 }

--- a/java/spacewalk-java.changes.rjpmestre.bsc1252948
+++ b/java/spacewalk-java.changes.rjpmestre.bsc1252948
@@ -1,0 +1,2 @@
+- Move proxy initialization to run when proxy config is
+  applied (bsc#1252948)


### PR DESCRIPTION
## What does this PR change?

This PR moves the proxy initialization logic so that it gets executed only when the user applies a proxy configuration, instead of running immediately when the “Convert to Proxy” button is clicked.
As a result, a system will only be set/registered as a proxy after the configuration is confirmed, preventing partially initialized or cancelled conversions from appearing in the proxy system list.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28803

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
