### PR TITLE
Fix HTTP proxy verification avoiding embedded calls to myaccount.suse.com (bsc#1253501)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/setup/SetupWizardSessionCache.java
+++ b/java/code/src/com/redhat/rhn/manager/setup/SetupWizardSessionCache.java
@@ -154,7 +154,13 @@ public class SetupWizardSessionCache {
         // Ping SCC if refresh is enforced or status is unknown
         if (forceRefresh || ret == null) {
             try {
-                String url = Config.get().getString(ConfigDefaults.SCC_URL) + "/login";
+                // This URL used to be "https://scc.suse.com/login". The "login" ending has been removed since:
+                // 1) the "https://scc.suse.com/login" page redirects to "myaccount.suse.com" for SSO
+                // 2) "myaccount.suse.com" is not a site that has to be necessarily available behind a proxy
+                // 3) the "https://scc.suse.com" page (with no "/login" ending) does not refer to "myaccount.suse.com"
+                // 4) the aim here is to "ping" an external website to see whether the http proxy let us reach
+                // the external network, so the "login" ending is not strictly necessary
+                String url = Config.get().getString(ConfigDefaults.SCC_URL);
                 ret = MgrSyncUtils.verifyProxy(url);
             }
             catch (IOException e) {

--- a/java/spacewalk-java.changes.carlo.uyuni-11253501-proxy-settings-myaccount-blocked
+++ b/java/spacewalk-java.changes.carlo.uyuni-11253501-proxy-settings-myaccount-blocked
@@ -1,0 +1,1 @@
+- Fix http proxy verification (bsc#1253501)


### PR DESCRIPTION
## What does this PR change?

When the HTTP proxy is set (HTTP proxy username and password are not empty), the system does a check to understand if the HTTP proxy is set correctly. To do so, it performs a kind of a "ping call" towards the outside network to see if it can be reached. The chosen external address is (HEAD http://scc.suse.com/login).

The "login" ending has been removed since:
1) the "https://scc.suse.com/login" page redirects to "myaccount.suse.com" for SSO
2) "myaccount.suse.com" is not a site that has to be necessarily available behind a proxy
3) the "https://scc.suse.com" page (with no "/login" ending) does not refer to "myaccount.suse.com"
4) the aim here is to "ping" an external website to see whether the http proxy let us reach the external network, so the "login" ending is not strictly necessary


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: not needed
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28957
Port(s):  5.1: https://github.com/SUSE/spacewalk/pull/29005
 5.0: https://github.com/SUSE/spacewalk/pull/29004
 4.3: https://github.com/SUSE/spacewalk/pull/29003
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
