### PR TITLE
Disable listing the content of /icons (bsc#1247544)

### DIFF
--- a/proxy/proxy/httpd-conf/spacewalk-proxy.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy.conf
@@ -37,6 +37,12 @@
     SetHandler None
 </LocationMatch>
 
+# Disable listing the content of /icons/
+<Directory "/usr/share/apache2/icons">
+   Options MultiViews
+   AllowOverride None
+</Directory>
+
 <IfModule mod_rewrite.c>
    RewriteEngine on
 

--- a/proxy/proxy/spacewalk-proxy.changes.cbosdo.proxy-indexes
+++ b/proxy/proxy/spacewalk-proxy.changes.cbosdo.proxy-indexes
@@ -1,0 +1,1 @@
+- Disable listing the content of /icons (bsc#1247544)


### PR DESCRIPTION
## What does this PR change?

See title

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: disabled directory listing

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28007
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/29010, 5.0: https://github.com/SUSE/spacewalk/pull/29011

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
