### PR TITLE
Fix NPE for missing channel in ubuntu errata task (bsc#1250561)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ubuntu/UbuntuErrataManager.java
@@ -65,6 +65,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -256,6 +257,7 @@ public class UbuntuErrataManager {
         // Extract the deb packages from each channel
         var packagesByChannelMap = channelIds.stream()
                                              .map(ChannelFactory::lookupById)
+                                             .filter(Objects::nonNull)
                                              .filter(c -> c.isTypeDeb() && !c.isCloned())
                                              .collect(Collectors.toMap(c -> c,
                                                      c -> Set.copyOf(ChannelManager.listAllPackages(c))));

--- a/java/spacewalk-java.changes.carlo.uyuni-1250561-fix-ubuntu-errata-sync
+++ b/java/spacewalk-java.changes.carlo.uyuni-1250561-fix-ubuntu-errata-sync
@@ -1,0 +1,2 @@
+- Fix crash in ubuntu errata sync on deleted channel ids
+  (bsc#1250561)


### PR DESCRIPTION
## What does this PR change?

Fix NPE for missing channel in ubuntu errata task (bsc#1250561)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28807
Port(s):  5.1: https://github.com/SUSE/spacewalk/pull/29015
 5.0: https://github.com/SUSE/spacewalk/pull/29014
NOT BACKPORTED 4.3:
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

