### PR TITLE
Fix dnf updateinfo showing wrong severity for security updates (bsc#1252937)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -589,12 +589,13 @@ public class ErrataOverview extends BaseDto {
      * @return the errata severity as string.
      */
     public String getSeverity() {
-        String retval = "low";
-        if (getSeverityLabel() != null) {
-            retval = LocalizationService.getInstance().getMessage(getSeverityLabel())
-                    .toLowerCase();
-        }
-        return retval;
+        return switch (getSeverityLabel()) {
+            case "errata.sev.label.critical" -> "Critical";
+            case "errata.sev.label.important" -> "Important";
+            case "errata.sev.label.moderate" -> "Moderate";
+            case "errata.sev.label.low" -> "Low";
+            default -> "Low";
+        };
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/UpdateInfoWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/UpdateInfoWriterTest.java
@@ -109,7 +109,7 @@ public class UpdateInfoWriterTest extends BaseTestCaseWithUser {
 
         assertContains(xml, "<id>SUSE-SLE-SERVER-2016-1234</id>");
         assertContains(xml, "<title>" + errata.getSynopsis() + "</title>");
-        assertContains(xml, "<severity>" + errata.getSeverity().getLocalizedLabel().toLowerCase() + "</severity>");
+        assertContains(xml, "<severity>" + errata.getSeverity().getLocalizedLabel() + "</severity>");
         assertContains(xml, "<issued date=\"" + df.format(errata.getIssueDate()) + "\"/>");
         assertContains(xml, "<updated date=\"" + df.format(errata.getUpdateDate()) + "\"/>");
         assertContains(xml, "<rights>" + errata.getRights() + "</rights>");

--- a/java/spacewalk-java.changes.carlo.uyuni-1252937-updateinfo-severity
+++ b/java/spacewalk-java.changes.carlo.uyuni-1252937-updateinfo-severity
@@ -1,0 +1,2 @@
+- Fix dnf updateinfo showing wrong severity for
+  security updates (bsc#1252937)


### PR DESCRIPTION
## What does this PR change?

It looks like Red Hat always uses severity starting with uppercase while Suse uses all lowercase. We are currently using the Suse style when generating the repos but DNF seems to have issues with that. This patch changes they way we generate the repo metadata to match what dnf expects.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28796
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/29047
5.0: https://github.com/SUSE/spacewalk/pull/29048
4.3: https://github.com/SUSE/spacewalk/pull/29049
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

