### PR TITLE
Ignore commented lines in /etc/hosts when updating it (bsc#1253736)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/payg/PaygUpdateHostsTask.java
@@ -98,7 +98,7 @@ public class PaygUpdateHostsTask extends RhnJavaJob {
                         bw.write(HOST_COMMENT_START + RETAIN_COMMENT);
                         for (CloudRmtHost host : hostToUpdate) {
                             // search for already existing RMT Host definition
-                            if (newLines.stream().anyMatch(l -> l.contains(host.getHost()))) {
+                            if (newLines.stream().anyMatch(l -> l.contains(host.getHost()) && !l.startsWith("#"))) {
                                 // registercloudguest has added already this hostname.
                                 // defining multiple IP addresses for the same name can result in problems.
                                 // We write out only commented entries here

--- a/java/spacewalk-java.changes.cbosdo.payg-hosts
+++ b/java/spacewalk-java.changes.cbosdo.payg-hosts
@@ -1,0 +1,2 @@
+- Ignore commented lines in /etc/hosts when updating it
+  (bsc#1253736)


### PR DESCRIPTION
## What does this PR change?

If a hostname to add in the /etc/hosts is already in the file but commented, we neeed to add it.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test 
- No tests: not unit tested yet

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29020
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/29056

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
