### PR TITLE
Fix exception error on spacecmd package refresh (bsc#1251995)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/common/translation/Translator.java
+++ b/java/core/src/main/java/com/redhat/rhn/common/translation/Translator.java
@@ -168,6 +168,15 @@ public class Translator extends Translations {
     }
 
     /**
+     * Convert from String to Integer.
+     * @param str The string to convert
+     * @return the resulting Integer
+     */
+    public static Integer string2Int(String str) {
+        return Integer.parseInt(str);
+    }
+
+    /**
      * Convert from Double to String.
      * @param d The double to convert
      * @return The resulting string.

--- a/java/core/src/test/java/com/redhat/rhn/common/translation/test/TranslatorTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/common/translation/test/TranslatorTest.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.common.translation.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.redhat.rhn.common.translation.Translator;
@@ -106,6 +107,22 @@ public class TranslatorTest extends RhnBaseTestCase {
         assertFalse(Translator.string2boolean("false"));
         assertFalse(Translator.string2boolean("faLSe"));
         assertFalse(Translator.string2boolean("rock on"));
+    }
+
+    @Test
+    public void testString2Int() {
+        assertEquals(1000010006, Translator.string2Int("1000010006"));
+        assertEquals(123, Translator.string2Int("+123"));
+        assertEquals(0, Translator.string2Int("0"));
+        assertEquals(-1, Translator.string2Int("-1"));
+        assertEquals(-1000010006, Translator.string2Int("-1000010006"));
+
+        assertThrows(NumberFormatException.class, () -> Translator.string2Int(null));
+        assertThrows(NumberFormatException.class, () -> Translator.string2Int(""));
+        assertThrows(NumberFormatException.class, () -> Translator.string2Int("true"));
+        assertThrows(NumberFormatException.class, () -> Translator.string2Int("F"));
+        assertThrows(NumberFormatException.class, () -> Translator.string2Int("n"));
+        assertThrows(NumberFormatException.class, () -> Translator.string2Int("rock on"));
     }
 
     @Test

--- a/java/spacewalk-java.changes.carlo.uyuni-1251995-translation-exception
+++ b/java/spacewalk-java.changes.carlo.uyuni-1251995-translation-exception
@@ -1,0 +1,1 @@
+- Fix exception error on spacecmd package refresh (bsc#1251995)


### PR DESCRIPTION
## What does this PR change?

While running the command

`spacecmd -u admin -p admin system_schedulepackagerefresh <minion>`

an error occourred:

`ERROR: com.redhat.rhn.common.translation.TranslationException: Could not find translator for class java.lang.String to class java.lang.Integer`

For some strange reason, the python script calling the rpc:

```
system_id = self.get_system_id(system)
self.client.system.schedulePackageRefresh(session, system_id, options.start_time )
```

is sending the system_id  as a string and not anymore as an integer.
Since no translator from string to integer is found, the error is raised.
         

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): https://bugzilla.suse.com/show_bug.cgi?id=1251995
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/29063
5.0: https://github.com/SUSE/spacewalk/pull/29064
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"


