### PR TITLE
Helm: add sshd tuning in the proxy container (bsc#1253738)

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.pxy-tuning-sshd
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.pxy-tuning-sshd
@@ -1,0 +1,1 @@
+- Add ssh_tuning value to configure sshd (bsc#1253738)

--- a/containers/proxy-helm/templates/config.yaml
+++ b/containers/proxy-helm/templates/config.yaml
@@ -16,6 +16,9 @@ data:
   squid_tuning: |
     # Add your Squid tuning configuration here
 {{ .Values.squid_tuning | indent 4 }}
+  ssh_tuning: |
+    # Add your SSHd tuning configuration here
+{{ .Values.ssh_tuning | indent 4 }}
   apache_tuning: |
     # Add your Apache tuning configuration here
 {{ .Values.apache_tuning | indent 4 }}

--- a/containers/proxy-helm/templates/deployment.yaml
+++ b/containers/proxy-helm/templates/deployment.yaml
@@ -82,6 +82,10 @@ spec:
             mountPath: /etc/uyuni/ssh.yaml
             subPath: ssh.yaml
             readOnly: true
+          - name: config-volume
+            mountPath: /etc/ssh/sshd_config.d/99-tuning.conf
+            subPath:  ssh_tuning
+            readOnly: true
           ports:
             - containerPort: 22
         - name: tftpd
@@ -109,6 +113,8 @@ spec:
                 path: squid_tuning
               - key: apache_tuning
                 path: apache_tuning
+              - key: ssh_tuning
+                path: ssh_tuning
         - name: httpd-secret-volume
           secret:
             secretName: proxy-secret

--- a/containers/proxy-helm/values.yaml
+++ b/containers/proxy-helm/values.yaml
@@ -68,3 +68,4 @@ services:
 
 squid_tuning: ""
 apache_tuning: ""
+ssh_tuning: ""


### PR DESCRIPTION
## What does this PR change?

Some users want to disable old algorithms for the SSH proxy, but this cannot be added to the image as it would break connection to older distros.

This commit adds a configuration in the proxy helm chart to pass this.

https://github.com/uyuni-project/uyuni/pull/11239 is needed for Kubernetes support.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: helm chart installs 

- [x] **DONE**

## Test coverage
- No tests: helm chart installs are not automatically tested yet

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29039
Port(s): # **add downstream PR(s), if any**
Uyuni-tools PR: https://github.com/uyuni-project/uyuni-tools/pull/681

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
