### PR TITLE
Spacecmd stores system IDs as int in internal cache (bsc#1251995)

### DIFF
--- a/spacecmd/spacecmd.changes.mczernek.spacecmd-schedulepackagerefresh
+++ b/spacecmd/spacecmd.changes.mczernek.spacecmd-schedulepackagerefresh
@@ -1,0 +1,1 @@
+- Convert cached IDs to int (bsc#1251995)

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -824,6 +824,14 @@ def load_caches(self, server, username):
         self.packages_by_id_cache_file
     )
 
+    # Fix String IDs to ints
+    # JSON structure is "id : value", e.g. { "123": "example.com", ... }
+    # JSON does not allow non-string keys, but Uyuni/spacecmd expects IDs to be ints
+    self.all_systems = {int(id): system for id, system in self.all_systems.items()}
+    self.all_packages_by_id = {
+        int(id): pkg for id, pkg in self.all_packages_by_id.items()
+    }
+
 
 def get_system_names(self):
     self.generate_system_cache()


### PR DESCRIPTION
## What does this PR change?

When spacecmd uses system ID, Uyuni expects the ID to be an integer. Without the change, first call succeeds. On second and further calls, we get something like this:

```
# spacecmd -d system_schedulepackagerefresh uyuni-ref-master-suse-minion.mgr.suse.de
DEBUG: command=, return_value=False
DEBUG: Read configuration from /root/.spacecmd/config
DEBUG: Loading configuration section [spacecmd]
DEBUG: Current Configuration: {'server': 'localhost', 'nossl': True, 'username': 'admin', 'password': '*****'}
DEBUG: Configuration section [localhost] does not exist
DEBUG: Connecting to http://localhost/rpc/api
DEBUG: Server API Version = 29
INFO: Spacewalk Username: admin
DEBUG: Loading cache from /root/.spacecmd/localhost/admin/ssm.json
DEBUG: /root/.spacecmd/localhost/admin/ssm.json does not exist
DEBUG: command=, return_value=False
DEBUG: Loading cache from /root/.spacecmd/localhost/admin/systems.json
DEBUG: Loading cache from /root/.spacecmd/localhost/admin/errata.json
DEBUG: /root/.spacecmd/localhost/admin/errata.json does not exist
DEBUG: Loading cache from /root/.spacecmd/localhost/admin/packages_short.json
DEBUG: /root/.spacecmd/localhost/admin/packages_short.json does not exist
DEBUG: Loading cache from /root/.spacecmd/localhost/admin/packages_long.json
DEBUG: /root/.spacecmd/localhost/admin/packages_long.json does not exist
DEBUG: Loading cache from /root/.spacecmd/localhost/admin/packages_by_id.json
DEBUG: /root/.spacecmd/localhost/admin/packages_by_id.json does not exist
INFO: Connected to http://localhost/rpc/api as admin
ERROR: com.redhat.rhn.common.translation.TranslationException: Could not find translator for class java.lang.String to class java.lang.Integer
Traceback (most recent call last):
  File "/usr/bin/spacecmd", line 245, in <module>
    result = shell.onecmd(precmd)
  File "/usr/lib64/python3.6/cmd.py", line 217, in onecmd
    return func(arg)
  File "/usr/lib/python3.6/site-packages/spacecmd/system.py", line 4525, in do_system_schedulepackagerefresh
    self.session, system_id, options.start_time
  File "/usr/lib64/python3.6/xmlrpc/client.py", line 1112, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib64/python3.6/xmlrpc/client.py", line 1452, in __request
    verbose=self.__verbose
  File "/usr/lib64/python3.6/xmlrpc/client.py", line 1154, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib64/python3.6/xmlrpc/client.py", line 1170, in single_request
    return self.parse_response(resp)
  File "/usr/lib64/python3.6/xmlrpc/client.py", line 1342, in parse_response
    return u.close()
  File "/usr/lib64/python3.6/xmlrpc/client.py", line 656, in close
    raise Fault(**self._stack[0])
xmlrpc.client.Fault: <Fault -1: 'com.redhat.rhn.common.translation.TranslationException: Could not find translator for class java.lang.String to class java.lang.Integer'>
``` 

This is because the internal cache of systems uses the following format:

```
{
    "1000010005": "uyuni-ref-master-build-host.mgr.suse.de",
    "1000010004": "uyuni-ref-master-deblike-minion.mgr.suse.de",
    "1000010000": "uyuni-ref-master-proxy.mgr.suse.de",
    "1000010003": "uyuni-ref-master-rhlike-minion.mgr.suse.de",
    "1000010001": "uyuni-ref-master-suse-minion.mgr.suse.de",
    "1000010002": "uyuni-ref-master-suse-sshminion.mgr.suse.de",
    "expire": "2025-11-26 19:17:00.046557"
}
```

Pickle allowed the IDs to stay int, but in JSON, the keys must be string. Therefore, we must do post-processing conversion of string keys to int keys.

With this change, we keep system IDs as ints internally, which means that `get_system_id` returns `1000010001` as int.


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28650
Port(s): 
- https://github.com/SUSE/spacewalk/pull/29087
- https://github.com/SUSE/spacewalk/pull/29088
- https://github.com/SUSE/spacewalk/pull/29089

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"     

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
