### PR TITLE
Remove SystemEntitlementManager as proxy context parameter and reorga…

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyConfigurationController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/ProxyConfigurationController.java
@@ -25,7 +25,6 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserAndSer
 import static spark.Spark.get;
 import static spark.Spark.post;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.RhnRuntimeException;
 import com.redhat.rhn.common.UyuniGeneralException;
 import com.redhat.rhn.domain.server.Server;
@@ -126,9 +125,7 @@ public class ProxyConfigurationController {
      * @return the ModelAndView object to render the page
      */
     public ModelAndView getProxyConfiguration(Request request, Response response, User user, Server server) {
-        return new ModelAndView(
-                proxyConfigGetFacade.getFormData(user, server, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER),
-                "templates/minion/proxy-config.jade");
+        return new ModelAndView(proxyConfigGetFacade.getFormData(user, server), "templates/minion/proxy-config.jade");
     }
 
     /**

--- a/java/core/src/main/java/com/suse/proxy/get/ProxyConfigGetFacade.java
+++ b/java/core/src/main/java/com/suse/proxy/get/ProxyConfigGetFacade.java
@@ -17,7 +17,6 @@ package com.suse.proxy.get;
 
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.proxy.model.ProxyConfig;
 
@@ -40,9 +39,8 @@ public interface ProxyConfigGetFacade {
      *
      * @param user                       the user
      * @param server                     the server
-     * @param systemEntitlementManagerIn the systemEntitlementManager
      * @return the form data
      */
-    Map<String, Object> getFormData(User user, Server server, SystemEntitlementManager systemEntitlementManagerIn);
+    Map<String, Object> getFormData(User user, Server server);
 
 }

--- a/java/core/src/main/java/com/suse/proxy/get/ProxyConfigGetFacadeImpl.java
+++ b/java/core/src/main/java/com/suse/proxy/get/ProxyConfigGetFacadeImpl.java
@@ -18,7 +18,6 @@ import static java.util.Arrays.asList;
 
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.proxy.ProxyConfigUtils;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDataAcquisitor;
@@ -75,17 +74,12 @@ public class ProxyConfigGetFacadeImpl implements ProxyConfigGetFacade {
      *
      * @param user                       the user
      * @param server                     the server
-     * @param systemEntitlementManager   the systemEntitlementManager
      * @return the form data
      */
     @Override
-    public Map<String, Object> getFormData(
-            User user,
-            Server server,
-            SystemEntitlementManager systemEntitlementManager
-    ) {
+    public Map<String, Object> getFormData(User user, Server server) {
         ProxyConfigGetFormDataContext context =
-                new ProxyConfigGetFormDataContext(user, server, this.getProxyConfig(server), systemEntitlementManager);
+                new ProxyConfigGetFormDataContext(user, server, this.getProxyConfig(server));
 
         for (ProxyConfigGetFormDataContextHandler handler : getFormDataContextHandlerChain) {
             handler.handle(context);

--- a/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataContext.java
+++ b/java/core/src/main/java/com/suse/proxy/get/formdata/ProxyConfigGetFormDataContext.java
@@ -15,6 +15,7 @@
 
 package com.suse.proxy.get.formdata;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.UyuniErrorReport;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.server.Server;
@@ -36,7 +37,6 @@ import java.util.Set;
 public class ProxyConfigGetFormDataContext {
 
     private final UyuniErrorReport errorReport = new UyuniErrorReport();
-    private final SystemEntitlementManager systemEntitlementManager;
     private final User user;
     private final Server server;
     private final ProxyConfig proxyConfig;
@@ -54,18 +54,11 @@ public class ProxyConfigGetFormDataContext {
      * @param userIn        the user
      * @param serverIn      the server
      * @param proxyConfigIn the current proxy configuration
-     * @param systemEntitlementManagerIn the system entitlement manager
      */
-    public ProxyConfigGetFormDataContext(
-            User userIn,
-            Server serverIn,
-            ProxyConfig proxyConfigIn,
-            SystemEntitlementManager systemEntitlementManagerIn
-    ) {
+    public ProxyConfigGetFormDataContext(User userIn, Server serverIn, ProxyConfig proxyConfigIn) {
         this.user = userIn;
         this.server = serverIn;
         this.proxyConfig =  proxyConfigIn;
-        this.systemEntitlementManager = systemEntitlementManagerIn;
     }
 
     public User getUser() {
@@ -122,7 +115,7 @@ public class ProxyConfigGetFormDataContext {
     }
 
     public SystemEntitlementManager getSystemEntitlementManager() {
-        return systemEntitlementManager;
+        return GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     }
 
     public Set<Channel> getSubscribableChannels() {

--- a/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateContext.java
+++ b/java/core/src/main/java/com/suse/proxy/update/ProxyConfigUpdateContext.java
@@ -47,7 +47,7 @@ public class ProxyConfigUpdateContext {
             new EnumMap<>(ProxyContainerImagesEnum.class);
     private final SystemManager systemManager;
     private final User user;
-    private final ProxyConfigGetFacade proxyConfigGetFacade;
+    private final ProxyConfigGetFacade proxyConfigGetFacade = new ProxyConfigGetFacadeImpl();
 
     // Acquired/computed data
     private String proxyFqdn;
@@ -78,27 +78,9 @@ public class ProxyConfigUpdateContext {
             SystemManager systemManagerIn,
             User userIn
     ) {
-        this(requestIn, systemManagerIn, userIn, new ProxyConfigGetFacadeImpl());
-    }
-
-    /**
-     * Full params constructor
-     *
-     * @param requestIn                  the request
-     * @param systemManagerIn            the system manager
-     * @param userIn                     the user
-     * @param proxyConfigGetFacadeIn     the proxy config get facade
-     */
-    public ProxyConfigUpdateContext(
-            ProxyConfigUpdateJson requestIn,
-            SystemManager systemManagerIn,
-            User userIn,
-            ProxyConfigGetFacade proxyConfigGetFacadeIn
-    ) {
         this.request = requestIn;
         this.systemManager = systemManagerIn;
         this.user = userIn;
-        this.proxyConfigGetFacade = proxyConfigGetFacadeIn;
     }
 
     public ProxyConfigUpdateJson getRequest() {

--- a/java/core/src/test/java/com/suse/proxy/ProxyConfigTestUtils.java
+++ b/java/core/src/test/java/com/suse/proxy/ProxyConfigTestUtils.java
@@ -9,7 +9,7 @@
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
  */
 
-package com.suse.proxy.get.formdata.test;
+package com.suse.proxy;
 
 import static com.redhat.rhn.common.ExceptionMessage.NOT_INSTANTIABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,7 +30,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
-public class ProxyConfigGetFormTestUtils {
+public class ProxyConfigTestUtils {
 
     public static final Long SERVER_ID = 123L;
 
@@ -109,7 +109,7 @@ public class ProxyConfigGetFormTestUtils {
     /**
      * Private constructor to avoid instantiation
      */
-    private ProxyConfigGetFormTestUtils() {
+    private ProxyConfigTestUtils() {
         throw new UnsupportedOperationException(NOT_INSTANTIABLE);
     }
 }

--- a/java/core/src/test/java/com/suse/proxy/get/ProxyConfigGetFacadeImplTest.java
+++ b/java/core/src/test/java/com/suse/proxy/get/ProxyConfigGetFacadeImplTest.java
@@ -9,16 +9,15 @@
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.get;
 
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.Channel;
@@ -34,7 +33,6 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.proxy.ProxyConfigUtils;
-import com.suse.proxy.get.ProxyConfigGetFacadeImpl;
 import com.suse.proxy.model.ProxyConfig;
 
 import com.google.gson.Gson;
@@ -128,8 +126,7 @@ public class ProxyConfigGetFacadeImplTest extends BaseTestCaseWithUser {
         final String[] expectedValidationErrorMessages = { "Server not found" };
 
         //
-        Map<String, Object> formData = new ProxyConfigGetFacadeImpl().getFormData(user, null,
-                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
+        Map<String, Object> formData = new ProxyConfigGetFacadeImpl().getFormData(user, null);
 
         assertEquals(expectedCurrentConfig, formData.get("currentConfig"));
         assertEquals(expectedParents, formData.get("parents"));
@@ -168,8 +165,7 @@ public class ProxyConfigGetFacadeImplTest extends BaseTestCaseWithUser {
         setConfigDefaultsInstance(mockConfigDefaults);
 
         //
-        Map<String, Object> formData = new ProxyConfigGetFacadeImpl().getFormData(user, server,
-                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
+        Map<String, Object> formData = new ProxyConfigGetFacadeImpl().getFormData(user, server);
 
         assertEquals(expectedCurrentConfig, formData.get("currentConfig"));
         assertEquals(expectedParents, formData.get("parents"));

--- a/java/core/src/test/java/com/suse/proxy/get/ProxyConfigGetFormDataAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/get/ProxyConfigGetFormDataAcquisitorTest.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.get;
 
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_BASE_TAG;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_BASE_URL;
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -63,7 +62,7 @@ public class ProxyConfigGetFormDataAcquisitorTest extends BaseTestCaseWithUser {
     public void testWhenNoProxyConfigAndNoProxies() {
         final String expectedElectableParent = Config.get().getString(ConfigDefaults.SERVER_HOSTNAME);
         ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
-                testMinionServer, null, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
+                testMinionServer, null);
 
         //
         new ProxyConfigGetFormDataAcquisitor().handle(proxyConfigGetFormDataContext);
@@ -106,7 +105,7 @@ public class ProxyConfigGetFormDataAcquisitorTest extends BaseTestCaseWithUser {
         };
 
         ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
-                testMinionServer, new ProxyConfig(), GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
+                testMinionServer, new ProxyConfig());
 
         //
         new ProxyConfigGetFormDataAcquisitor().handle(proxyConfigGetFormDataContext);

--- a/java/core/src/test/java/com/suse/proxy/get/ProxyConfigGetFormDefaultsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/get/ProxyConfigGetFormDefaultsTest.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.get;
 
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_BASE_TAG;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_BASE_URL;
@@ -27,13 +27,13 @@ import static com.suse.proxy.get.formdata.ProxyConfigGetFormDefaults.MLM_REGISTR
 import static com.suse.proxy.get.formdata.ProxyConfigGetFormDefaults.UYUNI_REGISTRY_URL_EXAMPLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
+import com.suse.proxy.ProxyConfigTestUtils;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDataContext;
 import com.suse.proxy.get.formdata.ProxyConfigGetFormDefaults;
 
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.lang.reflect.Field;
 import java.util.Map;
 
 /**
@@ -78,7 +77,7 @@ public class ProxyConfigGetFormDefaultsTest extends BaseTestCaseWithUser {
     @Override
     @AfterEach
     public void tearDown() throws NoSuchFieldException, IllegalAccessException {
-        setConfigDefaultsInstance(configDefaults);
+        ProxyConfigTestUtils.setConfigDefaultsInstance(configDefaults);
     }
 
     /**
@@ -96,11 +95,11 @@ public class ProxyConfigGetFormDefaultsTest extends BaseTestCaseWithUser {
             will(returnValue("2025.10"));
         }});
 
-        setConfigDefaultsInstance(mockConfigDefaults);
+        ProxyConfigTestUtils.setConfigDefaultsInstance(mockConfigDefaults);
 
         //
         ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
-                testMinionServer, null, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
+                testMinionServer, null);
 
         //
         new ProxyConfigGetFormDefaults().handle(proxyConfigGetFormDataContext);
@@ -133,12 +132,12 @@ public class ProxyConfigGetFormDefaultsTest extends BaseTestCaseWithUser {
             will(returnValue(expectedRegistryBaseTag));
         }});
 
-        setConfigDefaultsInstance(mockConfigDefaults);
+        ProxyConfigTestUtils.setConfigDefaultsInstance(mockConfigDefaults);
 
 
         //
         ProxyConfigGetFormDataContext proxyConfigGetFormDataContext = new ProxyConfigGetFormDataContext(user,
-                testMinionServer, null, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
+                testMinionServer, null);
 
         //
         new ProxyConfigGetFormDefaults().handle(proxyConfigGetFormDataContext);
@@ -153,17 +152,4 @@ public class ProxyConfigGetFormDefaultsTest extends BaseTestCaseWithUser {
 
     }
 
-    /**
-     * Overrides the ConfigDefaults instance
-     * @param configDefaultsIn the ConfigDefaults instance
-     * @throws NoSuchFieldException if a field with the specified name is not found.
-     * @throws IllegalAccessException if the field is not accessible.
-     */
-    @SuppressWarnings("java:S3011")
-    private static void setConfigDefaultsInstance(ConfigDefaults configDefaultsIn)
-            throws NoSuchFieldException, IllegalAccessException {
-        Field field = ConfigDefaults.class.getDeclaredField("instance");
-        field.setAccessible(true);
-        field.set(null, configDefaultsIn);
-    }
 }

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateAcquisitorTest.java
@@ -13,26 +13,26 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_MODE_SIMPLE;
 import static com.suse.proxy.ProxyConfigUtils.SOURCE_MODE_REGISTRY;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_SERVER_ID;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_TAG;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_URL_PREFIX;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.assertExpectedErrors;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.getDummyTag;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.getDummyUrl;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_SERVER_ID;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_TAG;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_URL_PREFIX;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.assertExpectedErrors;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.getDummyTag;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.getDummyUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -60,8 +60,6 @@ import com.suse.proxy.ProxyConfigUtils;
 import com.suse.proxy.ProxyContainerImagesEnum;
 import com.suse.proxy.RegistryUrl;
 import com.suse.proxy.model.ProxyConfig;
-import com.suse.proxy.update.ProxyConfigUpdateAcquisitor;
-import com.suse.proxy.update.ProxyConfigUpdateContext;
 import com.suse.utils.Json;
 
 import org.jmock.imposters.ByteBuddyClassImposteriser;
@@ -110,7 +108,7 @@ public class ProxyConfigUpdateAcquisitorTest extends BaseTestCaseWithUser {
     @Test
     public void testBlankRequest() {
         ProxyConfigUpdateJson request = Json.GSON.fromJson("{}", ProxyConfigUpdateJson.class);
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
 
         // execution
         new ProxyConfigUpdateAcquisitor().handle(proxyConfigUpdateContext);

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateApplySaltStateTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateApplySaltStateTest.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,9 +26,6 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
-
-import com.suse.proxy.update.ProxyConfigUpdateApplySaltState;
-import com.suse.proxy.update.ProxyConfigUpdateContext;
 
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateFacadeImplTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateFacadeImplTest.java
@@ -13,17 +13,13 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.redhat.rhn.common.UyuniGeneralException;
 import com.redhat.rhn.testing.MockObjectTestCase;
-
-import com.suse.proxy.update.ProxyConfigUpdateContext;
-import com.suse.proxy.update.ProxyConfigUpdateContextHandler;
-import com.suse.proxy.update.ProxyConfigUpdateFacadeImpl;
 
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateFileAcquisitorTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateFileAcquisitorTest.java
@@ -13,22 +13,22 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_SSH_KEY;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_SSH_PARENT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_SSH_PUB;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.assertExpectedErrors;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_SSH_KEY;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_SSH_PARENT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_SSH_PUB;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.assertExpectedErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -50,9 +50,6 @@ import com.suse.manager.ssl.SSLCertPair;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.utils.gson.ProxyConfigUpdateJson;
-import com.suse.proxy.update.ProxyConfigUpdateContext;
-import com.suse.proxy.update.ProxyConfigUpdateFileAcquisitor;
-import com.suse.proxy.update.ProxyConfigUpdateValidation;
 
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateInitializerTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateInitializerTest.java
@@ -9,12 +9,12 @@
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
+import static com.suse.proxy.ProxyConfigTestUtils.SERVER_ID;
+import static com.suse.proxy.ProxyConfigTestUtils.assertErrors;
+import static com.suse.proxy.ProxyConfigTestUtils.assertNoErrors;
 import static com.suse.proxy.ProxyConfigUtils.MGRPXY;
-import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.SERVER_ID;
-import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertErrors;
-import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -39,8 +39,6 @@ import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.test.TestSaltApi;
-import com.suse.proxy.update.ProxyConfigUpdateContext;
-import com.suse.proxy.update.ProxyConfigUpdateInitializer;
 
 import org.jmock.Expectations;
 import org.jmock.api.Invocation;

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateJsonBuilder.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateJsonBuilder.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
 import static com.suse.proxy.ProxyConfigUtils.EMAIL_FIELD;
 import static com.suse.proxy.ProxyConfigUtils.INTERMEDIATE_CAS_FIELD;

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateSavePillarsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateSavePillarsTest.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
 import static com.suse.proxy.ProxyConfigUtils.PILLAR_REGISTRY_ENTRY;
 import static com.suse.proxy.ProxyConfigUtils.PILLAR_REGISTRY_TAG_ENTRY;
@@ -27,18 +27,18 @@ import static com.suse.proxy.ProxyContainerImagesEnum.PROXY_SALT_BROKER;
 import static com.suse.proxy.ProxyContainerImagesEnum.PROXY_SQUID;
 import static com.suse.proxy.ProxyContainerImagesEnum.PROXY_SSH;
 import static com.suse.proxy.ProxyContainerImagesEnum.PROXY_TFTPD;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.getDummyTag;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.getDummyUrl;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.getDummyTag;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.getDummyUrl;
 import static com.suse.utils.Predicates.isAbsent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,9 +66,6 @@ import com.suse.manager.webui.utils.gson.ProxyConfigUpdateJson;
 import com.suse.proxy.ProxyConfigUtils;
 import com.suse.proxy.ProxyContainerImagesEnum;
 import com.suse.proxy.RegistryUrl;
-import com.suse.proxy.update.ProxyConfigUpdateContext;
-import com.suse.proxy.update.ProxyConfigUpdateSavePillars;
-import com.suse.proxy.update.ProxyConfigUpdateValidation;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateTestUtils.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateTestUtils.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
 import static com.redhat.rhn.common.ExceptionMessage.NOT_INSTANTIABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +25,6 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.proxy.ProxyContainerImagesEnum;
-import com.suse.proxy.update.ProxyConfigUpdateContext;
 
 import org.jmock.Expectations;
 import org.jmock.api.Invocation;
@@ -113,8 +112,7 @@ public class ProxyConfigUpdateTestUtils {
             User user
     ) {
         // Create a real context with standard initialization
-        ProxyConfigUpdateContext proxyConfigUpdateContext =
-                new ProxyConfigUpdateContext(null, null, user, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(null, null, user);
         proxyConfigUpdateContext.setProxyMinion(minionServer);
 
         // Create a mock context

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateValidationTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUpdateValidationTest.java
@@ -9,27 +9,26 @@
  * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
+import static com.suse.proxy.ProxyConfigTestUtils.assertErrors;
 import static com.suse.proxy.ProxyConfigUtils.MGRPXY;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_MODE_ADVANCED;
 import static com.suse.proxy.ProxyConfigUtils.REGISTRY_MODE_SIMPLE;
 import static com.suse.proxy.ProxyConfigUtils.SOURCE_MODE_REGISTRY;
 import static com.suse.proxy.ProxyConfigUtils.isMgrpxyAvailable;
 import static com.suse.proxy.ProxyConfigUtils.isMgrpxyInstalled;
-import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.assertErrors;
-import static com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils.setConfigDefaultsInstance;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_SERVER_ID;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_TAG;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.assertExpectedErrors;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_SERVER_ID;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_TAG;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.assertExpectedErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,11 +52,8 @@ import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.suse.manager.webui.utils.gson.ProxyConfigUpdateJson;
-import com.suse.proxy.get.formdata.test.ProxyConfigGetFormTestUtils;
+import com.suse.proxy.ProxyConfigTestUtils;
 import com.suse.proxy.model.ProxyConfig;
-import com.suse.proxy.update.ProxyConfigUpdateAcquisitor;
-import com.suse.proxy.update.ProxyConfigUpdateContext;
-import com.suse.proxy.update.ProxyConfigUpdateValidation;
 import com.suse.utils.Json;
 
 import org.jmock.Expectations;
@@ -97,7 +93,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
         };
 
         ProxyConfigUpdateJson request = Json.GSON.fromJson("{}", ProxyConfigUpdateJson.class);
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
 
 
         // execution
@@ -128,8 +124,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
                 .sourceRPM()
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext =
-                new ProxyConfigUpdateContext(request, null, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
         // certificate content is handled in {@link ProxyConfigUpdateAcquisitor} and set directly in the context
         proxyConfigUpdateContext.setRootCA(DUMMY_ROOT_CA);
         proxyConfigUpdateContext.setProxyCert(DUMMY_PROXY_CERT);
@@ -149,8 +144,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
                 .replaceCerts(null, null, null, null)
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext =
-                new ProxyConfigUpdateContext(request, null, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
         // certificate content is handled in {@link ProxyConfigUpdateAcquisitor} and set directly in the context
         proxyConfigUpdateContext.setRootCA(DUMMY_ROOT_CA);
         proxyConfigUpdateContext.setProxyCert(DUMMY_PROXY_CERT);
@@ -193,7 +187,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
                 .keepCerts(null, null, null, null)
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
         proxyConfigUpdateContext.setParentServer(new Server(DUMMY_SERVER_ID, DUMMY_PARENT_FQDN));
         proxyConfigUpdateContext.setProxyFqdn(DUMMY_PROXY_FQDN);
 
@@ -218,7 +212,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
                 .keepCerts(null, null, null, null)
                 .build();
 
-        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null, null);
+        ProxyConfigUpdateContext proxyConfigUpdateContext = new ProxyConfigUpdateContext(request, null, null);
         proxyConfigUpdateContext.setParentServer(new Server(DUMMY_SERVER_ID, DUMMY_PARENT_FQDN));
         proxyConfigUpdateContext.setProxyFqdn(DUMMY_PROXY_FQDN);
         proxyConfigUpdateContext.setProxyConfig(new ProxyConfig());
@@ -384,7 +378,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
 
         ConfigDefaults configDefaults = ConfigDefaults.get();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
-        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+        ProxyConfigTestUtils.mockConfigDefaults(context, false);
         SystemEntitlementManager mockSystemEntitlementManager = mock(SystemEntitlementManager.class);
 
         // set up the minion
@@ -437,7 +431,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
         );
 
         try {
-            setConfigDefaultsInstance(configDefaults);
+            ProxyConfigTestUtils.setConfigDefaultsInstance(configDefaults);
         }
         catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException("Error resetting ConfigDefaults instance", e);
@@ -460,7 +454,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
 
         ConfigDefaults configDefaults = ConfigDefaults.get();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
-        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+        ProxyConfigTestUtils.mockConfigDefaults(context, false);
 
         // set up the minion
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
@@ -485,7 +479,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
         assertTrue(proxyConfigUpdateContext.getSubscribableChannels().isEmpty());
 
         try {
-            setConfigDefaultsInstance(configDefaults);
+            ProxyConfigTestUtils.setConfigDefaultsInstance(configDefaults);
         }
         catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException("Error resetting ConfigDefaults instance", e);
@@ -508,7 +502,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
 
         ConfigDefaults configDefaults = ConfigDefaults.get();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
-        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+        ProxyConfigTestUtils.mockConfigDefaults(context, false);
 
         // set up the minion with base channel
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
@@ -533,7 +527,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
         assertEquals(channelWithMgrpxy, subscribableChannels.iterator().next());
 
         try {
-            setConfigDefaultsInstance(configDefaults);
+            ProxyConfigTestUtils.setConfigDefaultsInstance(configDefaults);
         }
         catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException("Error resetting ConfigDefaults instance", e);
@@ -554,7 +548,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
 
         ConfigDefaults configDefaults = ConfigDefaults.get();
         setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
-        ProxyConfigGetFormTestUtils.mockConfigDefaults(context, false);
+        ProxyConfigTestUtils.mockConfigDefaults(context, false);
 
         // set up the minion with base channel
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
@@ -579,7 +573,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
         assertFalse(proxyConfigUpdateContext.getErrorReport().hasErrors());
 
         try {
-            setConfigDefaultsInstance(configDefaults);
+            ProxyConfigTestUtils.setConfigDefaultsInstance(configDefaults);
         }
         catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException("Error resetting ConfigDefaults instance", e);
@@ -595,9 +589,7 @@ public class ProxyConfigUpdateValidationTest extends JMockBaseTestCaseWithUser {
      * @return the context
      */
     private static ProxyConfigUpdateContext getProxyConfigUpdateContext(ProxyConfigUpdateJson request) {
-        return fillContextWithDummyData(
-                new ProxyConfigUpdateContext(request, null, null, null)
-        );
+        return fillContextWithDummyData(new ProxyConfigUpdateContext(request, null, null));
     }
 
     private static ProxyConfigUpdateContext fillContextWithDummyData(

--- a/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUtilsTest.java
+++ b/java/core/src/test/java/com/suse/proxy/update/ProxyConfigUtilsTest.java
@@ -13,7 +13,7 @@
  * in this software or its documentation.
  */
 
-package com.suse.proxy.test;
+package com.suse.proxy.update;
 
 import static com.suse.proxy.ProxyConfigUtils.EMAIL_FIELD;
 import static com.suse.proxy.ProxyConfigUtils.INTERMEDIATE_CAS_FIELD;
@@ -28,21 +28,21 @@ import static com.suse.proxy.ProxyConfigUtils.PROXY_KEY_FIELD;
 import static com.suse.proxy.ProxyConfigUtils.PROXY_PORT_FIELD;
 import static com.suse.proxy.ProxyConfigUtils.ROOT_CA_FIELD;
 import static com.suse.proxy.ProxyConfigUtils.SERVER_ID_FIELD;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_SERVER_ID;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_TAG;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.DUMMY_URL_PREFIX;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.getDummyTag;
-import static com.suse.proxy.test.ProxyConfigUpdateTestUtils.getDummyUrl;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ADMIN_MAIL;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_1;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_INTERMEDIATE_CA_2;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_MAX_CACHE;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PARENT_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_CERT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_FQDN;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_KEY;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_PROXY_PORT;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_ROOT_CA;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_SERVER_ID;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_TAG;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.DUMMY_URL_PREFIX;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.getDummyTag;
+import static com.suse.proxy.update.ProxyConfigUpdateTestUtils.getDummyUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
## What does this PR change?

This PR is a follow up on a [comment](https://github.com/uyuni-project/uyuni/pull/11196#pullrequestreview-3488176219). In short, we're removing a couple of parameters from proxy-related class constructors that were mainly used to support testing and are no longer needed, as we’ve found a suitable workaround.
Also, taking the oportunity of the recent maven update and file organization/restructure to reorganize proxy suitable subpackages.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
