### PR TITLE
Fix a bug in apidoc of sync.hub.syncPeripheralChannels (bsc#1250906)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/xmlrpc/iss/HubHandler.java
+++ b/java/core/src/main/java/com/suse/manager/xmlrpc/iss/HubHandler.java
@@ -542,7 +542,7 @@ public class HubHandler extends BaseHandler {
      * @return 1 on success, exception otherwise
      * @apidoc.doc Add peripheral channels to synchronize on a peripheral server
      * @apidoc.param #session_key()
-     * @apidoc.param #param_desc(" string ", " fqdn ", " The FQDN identifying the peripheral server ")
+     * @apidoc.param #param_desc("string", "fqdn", "The FQDN identifying the peripheral server")
      * @apidoc.param #prop_array_begin(" channelLabels ")
      * #prop_desc("string", "label", "The channel label")
      * #array_end()
@@ -611,7 +611,7 @@ public class HubHandler extends BaseHandler {
      * @return 1 on success, exception otherwise
      * @apidoc.doc Remove peripheral channels to synchronize on a peripheral server
      * @apidoc.param #session_key()
-     * @apidoc.param #param_desc(" string ", " fqdn ", " The FQDN identifying the peripheral server ")
+     * @apidoc.param #param_desc("string", "fqdn", "The FQDN identifying the peripheral server")
      * @apidoc.param #prop_array_begin(" channelLabels ")
      * #prop_desc("string", "label", "The channel label")
      * #array_end()
@@ -641,7 +641,7 @@ public class HubHandler extends BaseHandler {
      * @return a list of channel labels on success, exception otherwise
      * @apidoc.doc Lists current peripheral channel to synchronize on a peripheral server
      * @apidoc.param #session_key()
-     * @apidoc.param #param_desc(" string ", " fqdn ", " The FQDN identifying the peripheral server ")
+     * @apidoc.param #param_desc("string", "fqdn", "The FQDN identifying the peripheral server")
      * @apidoc.returntype #return_array_begin()
      * #prop_desc("string", "label", "Label of a peripheral channel to sync")
      * #array_end()
@@ -672,10 +672,7 @@ public class HubHandler extends BaseHandler {
      * @return 1 on success, exception otherwise
      * @apidoc.doc Synchronize peripheral channels on a peripheral server
      * @apidoc.param #session_key()
-     * @apidoc.param #param_desc(" string ", " fqdn ", " The FQDN identifying the peripheral server ")
-     * @apidoc.param #prop_array_begin(" channelLabels ")
-     * #prop_desc("string", "label", "The channel label")
-     * #array_end()
+     * @apidoc.param #param_desc("string", "fqdn", "The FQDN identifying the peripheral server")
      * @apidoc.returntype #return_int_success()
      */
     public int syncPeripheralChannels(User loggedInUser, String fqdn) {
@@ -702,7 +699,7 @@ public class HubHandler extends BaseHandler {
      *
      * @apidoc.doc Regenerate the username and the password for an existing peripheral.
      * @apidoc.param #session_key()
-     * @apidoc.param #param_desc(" string ", " fqdn ", " The FQDN identifying the peripheral server ")
+     * @apidoc.param #param_desc("string", "fqdn", "The FQDN identifying the peripheral server")
      * @apidoc.returntype #return_int_success()
      */
     public int regenerateSCCCredentials(User loggedInUser, String fqdn) {

--- a/java/spacewalk-java.changes.carlo.uyuni-1250906-sync-peripheral-channels-docs
+++ b/java/spacewalk-java.changes.carlo.uyuni-1250906-sync-peripheral-channels-docs
@@ -1,0 +1,1 @@
+- Fix a bug in apidoc of syncPeripheralChannels (bsc#1250906)


### PR DESCRIPTION
## What does this PR change?

Fixes a bug in apidoc of sync.hub.syncPeripheralChannels (bsc#1250906)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: not needed
- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28533
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/29081
5.0, 4.3: no need to backport
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
