### PR TITLE
Fix path to shutdown command for SLE12

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/reboot.sls
+++ b/susemanager-utils/susemanager-sls/salt/reboot.sls
@@ -1,3 +1,7 @@
 mgr_reboot:
   cmd.run:
+{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
+    - name: /sbin/shutdown -r +5
+{%- else %}
     - name: /usr/sbin/shutdown -r +5
+{% endif %}

--- a/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
+++ b/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
@@ -1,7 +1,11 @@
 {%- if salt['pillar.get']('mgr_reboot_if_needed', True) and salt['pillar.get']('custom_info:mgr_reboot_if_needed', 'true')|lower in ('true', '1', 'yes', 't') %}
 mgr_reboot_if_needed:
   cmd.run:
+{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
+    - name: /sbin/shutdown -r +5
+{%- else %}
     - name: /usr/sbin/shutdown -r +5
+{%- endif %}
 {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 8 %}
     - onlyif: '/usr/bin/dnf -q needs-restarting -r; /usr/bin/test $? -eq 1'
 {%- elif grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 7 %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-reboot-cmd
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mcalmer.fix-reboot-cmd
@@ -1,0 +1,1 @@
+- Fix path to shutdown command for SLE12


### PR DESCRIPTION
## What does this PR change?

The shutdown command on SLE12 is in `/sbin` and not in `/usr/sbin`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): TBD

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
