### PR TITLE
Fix : Allow reactivation when Salt key already exists (proxy bootstrap) 

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/bootstrap/AbstractMinionBootstrapper.java
@@ -389,15 +389,17 @@ public abstract class AbstractMinionBootstrapper {
             return Collections.singletonList(reactivationKeyError.get());
         }
 
+        if (params.getReactivationKey().isPresent()) {
+            return Collections.emptyList();
+        }
+        
         if (saltApi.keyExists(params.getHost(), KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED)) {
             return Collections.singletonList("A salt key for this" +
                     " host (" + params.getHost() +
                     ") seems to already exist, please check!");
         }
 
-        if (params.getReactivationKey().isPresent()) {
-            return Collections.emptyList();
-        }
+        
 
         return MinionServerFactory.findByMinionId(params.getHost())
                 .map(m -> Collections.singletonList("A system '" +


### PR DESCRIPTION
## What does this PR change?

Reactivation of a proxy fails in the #11261  Uyuni Web UI when a Salt key for the proxy
already exists on the master. This happens after reinstalling or migrating a
proxy system and attempting to re-register it using a Reactivation Key.

The Web UI returns the error:

```bash
A salt key for this host already exists, please check!
```

even though reactivation should *reuse* or *rotate* the existing key.

---

## Root Cause

In `BootstrapService.validateBootstrap()`, the logic checks for an existing
Salt key *before* checking whether a Reactivation Key is present.

Because of this ordering:

- If a Salt key exists → validation aborts early
- The reactivation logic is never reached
- The workflow incorrectly blocks valid reactivation

This does **not** happen in CLI bootstrap, only the Web UI.

---

## Fix

Reorder the conditions so that:

* If a *reactivationKey* is present → validation succeeds immediately  
* The “Salt key already exists” error only applies to *new bootstraps*  
*  Existing valid minion keys no longer block reactivation

No new functionality is added; this is purely a logic reorder.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): 
Port(s): 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!

