### PR TITLE
Fix(CLM): Refresh channel state after errata filtering (bsc#1253007)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -1180,6 +1180,13 @@ public class ContentManager {
         // align errata and the cache (rhnServerNeededCache)
         alignErrata(src, tgt, errataFilters, user);
 
+        // alignErrata() modifies the database directly, leaving the in-memory object with stale packages.
+        // We need to flush and manually prune these items from the list so the cache calculation
+        // reflects the actual reality of the channel.
+        HibernateFactory.getSession().flush();
+        List<Long> realIds = ChannelFactory.getPackageIds(tgt.getId());
+        tgt.getPackages().removeIf(p -> !realIds.contains(p.getId()));
+
         // align the package cache
         // this must be done after aligning errata since some packages may belong to a retracted erratum and we don't
         // want them in the cache. For this we need the errata to be up-to-date in target

--- a/java/spacewalk-java.changes.welder.bsc1253007
+++ b/java/spacewalk-java.changes.welder.bsc1253007
@@ -1,0 +1,2 @@
+- Ensure consistency of pending package updates
+  after CLM build (bsc#1253007)


### PR DESCRIPTION
## What does this PR change?

It fixes the following scenario:

During a CLM build, `alignPackages()` may add packages to the Channel entity in memory, while `alignErrata()` filters data by running direct SQL DELETE statements to remove denied errata and their packages. When that happens, the Hibernate session and the in-memory Channel object aren’t aware of those direct deletions, leaving the object stale. As a result, `alignPackageCache()` computes the delta based on this outdated state (which still includes the deleted packages), incorrectly marking them as “new” and inserting them into the system cache.

~~Solution: Trigger a `HibernateFactory.getSession().refresh(tgt)` call immediately after `alignErrata()` to ensure the target channel is in sync with the latest changes.~~

Solution: manually refresh in memory target channel packages list to be according to DB. Using `refresh()` triggers polymorphic type mismatches (`Channel` vs `ClonedChannel`), which result in Hibernate `PropertyAccessException`.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28827


- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
