### PR TITLE
On s390, the primary network interface is eth1000

### DIFF
--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -340,7 +340,7 @@ class RemoteNode
         return output.strip
       end
     else
-      %w[br0 eth0 eth1 ens0 ens1 ens2 ens3 ens4 ens5 ens6 ens7].each do |dev|
+      %w[br0 eth0 eth1 eth1000 ens0 ens1 ens2 ens3 ens4 ens5 ens6 ens7].each do |dev|
         output, code = run_local("ip address show dev #{dev} | grep 'inet '", check_errors: false)
 
         next unless code.zero?


### PR DESCRIPTION
## What does this PR change?

On s390, the primary network interface is eth1000.

This PR fixes the sanity checks for Build Validation.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/29149
 * 5.0: https://github.com/SUSE/spacewalk/pull/29150
 * 5.1:


## Changelogs

- [x] No changelog needed

