### PR TITLE
Revert "Use absolute in paths in salt scripts" (bsc#1253780)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootloader/autoinstall.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootloader/autoinstall.sls
@@ -11,10 +11,10 @@ mgr_copy_initrd:
 
 {% set loader_type = salt['cmd.run']('if [ -f /etc/sysconfig/bootloader ]; then source /etc/sysconfig/bootloader 2> /dev/null; fi;
 if [ -z "${LOADER_TYPE}" ]; then
-if [ $(/usr/bin/which grubonce 2> /dev/null) ] && [ !$(/usr/bin/which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="grub";
-elif [ $(/usr/bin/which elilo 2> /dev/null) ] && [ !$(/usr/bin/which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="elilo";
+if [ $(which grubonce 2> /dev/null) ] && [ !$(which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="grub";
+elif [ $(which elilo 2> /dev/null) ] && [ !$(which grub2-mkconfig 2> /dev/null) ]; then LOADER_TYPE="elilo";
 fi;
-fi; /usr/bin/echo "${LOADER_TYPE}"', python_shell=True) %}
+fi; echo "${LOADER_TYPE}"', python_shell=True) %}
 {% if loader_type == 'grub' %}
 mgr_create_grub_entry:
   file.append:
@@ -27,7 +27,7 @@ mgr_create_grub_entry:
 
 mgr_grub_boot_once:
   cmd.run:
-    - name: /usr/sbin/grubonce "{{ pillar.get('uyuni-reinstall-name') }}"
+    - name: grubonce "{{ pillar.get('uyuni-reinstall-name') }}"
     - onchanges:
       - file: mgr_create_grub_entry
 {% elif loader_type == 'elilo' %}
@@ -50,7 +50,7 @@ mgr_set_default_boot:
 
 mgr_elilo_copy_config:
   cmd.run:
-    - name: /sbin/elilo
+    - name: elilo
     - onchanges:
       - file: mgr_create_elilo_entry
       - file: mgr_set_default_boot
@@ -72,7 +72,7 @@ mgr_set_default_boot:
 
 mgr_generate_grubconf:
   cmd.run:
-    - name: /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg
+    - name: grub2-mkconfig -o /boot/grub2/grub.cfg
     - onchanges:
       - file: mgr_copy_kernel
       - file: mgr_copy_initrd
@@ -82,7 +82,7 @@ mgr_generate_grubconf:
 
 mgr_autoinstall_start:
   cmd.run:
-    - name: /usr/sbin/shutdown -r +1
+    - name: shutdown -r +1
     - require:
 {% if loader_type == 'grub' %}
       - cmd: mgr_grub_boot_once

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -165,7 +165,7 @@ bootstrap_repo:
 {% set salt_minion_installed = (salt['pkg.info_installed']('venv-salt-minion', attr='version', failhard=False).get('venv-salt-minion', {}).get('version') != None) %}
 check_bootstrap_dbg:
   cmd.run:
-    - name: /usr/bin/echo "{{ salt_minion_installed }}"
+    - name: echo "{{ salt_minion_installed }}"
 {% set venv_available_request = salt_minion_installed or salt['http.query'](bootstrap_repo_url + 'venv-enabled-' + grains['osarch'] + '.txt', status=True, verify_ssl=False) %}
 {# Prefer venv-salt-minion if available and not disabled #}
 {%- set use_venv_salt = salt['pillar.get']('mgr_force_venv_salt_minion') or ((salt_minion_installed or (0 < venv_available_request.get('status', 404) < 300)) and not salt['pillar.get']('mgr_avoid_venv_salt_minion')) %}
@@ -189,10 +189,10 @@ salt-minion-package:
 {# hack until transactional_update.run is fixed to use venv-salt-call #}
 {# Writing  to the future - find latest etc overlay which was created for package installation and use that as etc root #}
 {# this only works here in bootstrap when we are not running in transaction #}
-{%- set pending_transaction_id = salt['cmd.run']('/usr/bin/snapper --no-dbus list --columns=number | /usr/bin/grep "+" | tr -d "+"', python_shell=True) %}
+{%- set pending_transaction_id = salt['cmd.run']('snapper --no-dbus list --columns=number | grep "+" | tr -d "+"', python_shell=True) %}
 {%- if not pending_transaction_id %}
 {#  if we did not get pending transaction id, write to current upperdir #}
-{%- set pending_transaction_id = salt['cmd.run']('/usr/bin/snapper --no-dbus list --columns number | /usr/bin/grep "*" | tr -d "*"', python_shell=True) %}
+{%- set pending_transaction_id = salt['cmd.run']('snapper --no-dbus list --columns number | grep "*" | tr -d "*"', python_shell=True) %}
 {%- endif %}
 {# increase transaction id by 1 since jinja is doing this before new transaction for package install is created #}
 {# this is working under assumption there will be only one transaction between jinja render and actual package installation #}
@@ -316,7 +316,7 @@ salt-minion-master-pub-wipe:
 {{ salt_minion_name }}:
   mgrcompat.module_run:
     - name: transactional_update.run
-    - command: /usr/bin/systemctl enable {{ salt_minion_name }}
+    - command: systemctl enable {{ salt_minion_name }}
     - snapshot: continue
     - require:
       - salt-minion-package
@@ -335,7 +335,7 @@ copy_transactional_conf_file_to_etc:
     - name: /etc/transactional-update.conf
     - source: /usr/etc/transactional-update.conf
     - unless:
-      - /usr/bin/test -f /etc/transactional-update.conf
+      - test -f /etc/transactional-update.conf
 
 transactional_update_set_reboot_method_systemd:
   file.keyvalue:
@@ -348,9 +348,9 @@ transactional_update_set_reboot_method_systemd:
     - require:
       - file: copy_transactional_conf_file_to_etc
     - unless:
-      - /usr/bin/grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
+      - grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
 
 disable_reboot_timer_transactional_minions:
   cmd.run:
-    - name: /usr/bin/systemctl disable transactional-update.timer
+    - name: systemctl disable transactional-update.timer
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -42,7 +42,7 @@ remove_traditional_stack:
 {%- if grains['os_family'] == 'Suse' %}
       - suseRegisterInfo
 {%- endif %}
-    - unless: /usr/bin/rpm -q spacewalk-proxy-common || /usr/bin/rpm -q spacewalk-common
+    - unless: rpm -q spacewalk-proxy-common || rpm -q spacewalk-common
 
 # only removing apt-transport-spacewalk above
 # causes apt-get update to 'freeze' if this

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
@@ -20,7 +20,7 @@
 restart:
   mgrcompat.module_run:
     - name: cmd.run_bg
-    - cmd: "/usr/bin/sleep 2; /usr/sbin/service {{ salt_service }} restart"
+    - cmd: "sleep 2; service {{ salt_service }} restart"
     - python_shell: true
 
 {% else -%}

--- a/susemanager-utils/susemanager-sls/salt/certs/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/init.sls
@@ -8,4 +8,4 @@ mgr_proxy_ca_cert_symlink:
   file.symlink:
     - name: /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
     - target: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
-    - onlyif: /usr/bin/grep -Eq "^proxy.rhn_parent *= *[a-zA-Z0-9]+" /etc/rhn/rhn.conf && -e /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+    - onlyif: grep -Eq "^proxy.rhn_parent *= *[a-zA-Z0-9]+" /etc/rhn/rhn.conf && -e /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT

--- a/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
@@ -3,7 +3,7 @@ enable_ca_store:
   cmd.run:
     - name: /usr/bin/update-ca-trust enable
     - runas: root
-    - unless: "/usr/bin/update-ca-trust check | /usr/bin/grep \"PEM/JAVA Status: ENABLED\""
+    - unless: "/usr/bin/update-ca-trust check | grep \"PEM/JAVA Status: ENABLED\""
 {%- endif %}
 
 mgr_ca_cert:

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -18,7 +18,7 @@ include:
 {%- set dnf_supports_params = is_dnf and salt['pkg.version_cmp'](is_dnf, "4.0.9") >= 0 %}
 
 {%- if is_dnf and not dnf_supports_params %}
-{%- set dnf_plugins = salt['cmd.run']("/usr/bin/find /usr/lib -type d -name dnf-plugins -printf '%T@ %p\n' | /usr/bin/sort -nr | /usr/bin/cut -d ' ' -s -f 2- | /usr/bin/head -n 1", python_shell=True) %}
+{%- set dnf_plugins = salt['cmd.run']("find /usr/lib -type d -name dnf-plugins -printf '%T@ %p\n' | sort -nr | cut -d ' ' -s -f 2- | head -n 1", python_shell=True) %}
 {%- if dnf_plugins %}
 mgrchannels_susemanagerplugin_dnf:
   file.managed:
@@ -44,7 +44,7 @@ mgrchannels_enable_dnf_plugins:
     - pattern: plugins=.*
     - repl: plugins=1
 {#- default is '1' when option is not specififed #}
-    - onlyif: /usr/bin/grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
+    - onlyif: grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
 {%- endif %}
 
 {# this break the susemanagerplugin as it overwrite HTTP headers (bsc#1214601) #}
@@ -53,7 +53,7 @@ mgrchannels_disable_dnf_rhui_plugin:
     - name: /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
     - pattern: enabled=.*
     - repl: enabled=0
-    - onlyif: /usr/bin/grep -e 'enabled=1' -e 'enabled=True' -e 'enabled=yes' /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
+    - onlyif: grep -e 'enabled=1' -e 'enabled=True' -e 'enabled=yes' /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
 
 {%- endif %}
 
@@ -81,7 +81,7 @@ mgrchannels_enable_yum_plugins:
     - name: /etc/yum.conf
     - pattern: plugins=.*
     - repl: plugins=1
-    - onlyif: /usr/bin/grep plugins=0 /etc/yum.conf
+    - onlyif: grep plugins=0 /etc/yum.conf
 
 {%- endif %}
 {%- endif %}
@@ -149,7 +149,7 @@ mgrchannels_dnf_clean_all:
     - runas: root
     - onchanges:
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
-    -  unless: "/usr/bin/dnf repolist | /usr/bin/grep \"repolist: 0$\""
+    -  unless: "/usr/bin/dnf repolist | grep \"repolist: 0$\""
 {%- endif %}
 {%- if is_yum %}
 mgrchannels_yum_clean_all:
@@ -158,7 +158,7 @@ mgrchannels_yum_clean_all:
     - runas: root
     - onchanges: 
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
-    -  unless: "/usr/bin/yum repolist | /usr/bin/grep \"repolist: 0$\""
+    -  unless: "/usr/bin/yum repolist | grep \"repolist: 0$\""
 {%- endif %}
 {%- elif grains['os_family'] == 'Debian' %}
 install_gnupg_debian:

--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -60,7 +60,7 @@ mgr_remove_salt_master_key:
 {%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
 mgr_disable_salt:
   cmd.run:
-    - name: /usr/bin/systemctl disable {{ salt_minion_name }}
+    - name: systemctl disable {{ salt_minion_name }}
     - require:
       - file: mgr_remove_salt_config
 
@@ -68,7 +68,7 @@ mgr_disable_salt:
 mgr_stop_salt:
   cmd.run:
     - bg: True
-    - name: /usr/bin/sleep 9 && /usr/bin/systemctl stop {{ salt_minion_name }}
+    - name: sleep 9 && systemctl stop {{ salt_minion_name }}
     - order: last
     - require:
       - file: mgr_remove_salt_config

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
@@ -18,21 +18,21 @@ mgr_inst_snpguest:
 
 mgr_write_request_data:
   cmd.run:
-    - name: /usr/bin/echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | /usr/bin/base64 -d > /tmp/cocoattest/request-data.txt
-    - onlyif: /usr/bin/test -x /usr/bin/base64
+    - name: echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | base64 -d > /tmp/cocoattest/request-data.txt
+    - onlyif: test -x /usr/bin/base64
     - require:
       - file: mgr_create_attestdir
 
 mgr_create_snpguest_report:
   cmd.run:
-    - name: /usr/bin/snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
+    - name: snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
     - require:
       - cmd: mgr_write_request_data
       - file: mgr_create_attestdir
 
 mgr_snpguest_report:
   cmd.run:
-    - name: /usr/bin/cat /tmp/cocoattest/report.bin | /usr/bin/base64
+    - name: cat /tmp/cocoattest/report.bin | base64
     - require:
       - cmd: mgr_create_snpguest_report
       - file: mgr_create_attestdir
@@ -45,14 +45,14 @@ mgr_create_vlek_certificate:
 
 mgr_vlek_certificate:
   cmd.run:
-    - name: /usr/bin/cat /tmp/cocoattest/vlek.pem
+    - name: cat /tmp/cocoattest/vlek.pem
     - require:
       - cmd: mgr_create_vlek_certificate
       - file: mgr_create_attestdir
 
 mgr_secureboot_enabled:
   cmd.run:
-    - name: /usr/bin/mokutil --sb-state
+    - name: mokutil --sb-state
     - success_retcodes:
       - 255
       - 0

--- a/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
@@ -37,12 +37,12 @@ spmigration:
 
 spmigration:
   cmd.run:
-    - name: /usr/bin/cat {{ logname }}
-    - onlyif: /usr/bin/test -f /usr/bin/cat {{ logname }}
+    - name: cat {{ logname }}
+    - onlyif: /usr/bin/test -f cat {{ logname }}
 
 spmigration_liberated:
   cmd.run:
-    - name: /usr/bin/cat /etc/sysconfig/liberated
+    - name: cat /etc/sysconfig/liberated
     - require:
       - file: create_liberation_file
 

--- a/susemanager-utils/susemanager-sls/salt/distupgrade/sap.sls
+++ b/susemanager-utils/susemanager-sls/salt/distupgrade/sap.sls
@@ -3,24 +3,24 @@
 
 mgr_remove_release_package:
   cmd.run:
-    - name: "/usr/bin/rpm -e --nodeps sles-release"
+    - name: "rpm -e --nodeps sles-release"
 
 mgr_remove_flavor_package_dvd:
   cmd.run:
-    - name: "/usr/bin/rpm -e --nodeps sles-release-DVD"
-    - onlyif: /usr/bin/rpm -q sles-release-DVD
+    - name: "rpm -e --nodeps sles-release-DVD"
+    - onlyif: rpm -q sles-release-DVD
 
 mgr_remove_flavor_package_pool:
   cmd.run:
-    - name: "/usr/bin/rpm -e --nodeps sles-release-POOL"
-    - onlyif: /usr/bin/rpm -q sles-release-POOL
+    - name: "rpm -e --nodeps sles-release-POOL"
+    - onlyif: rpm -q sles-release-POOL
 
 {% set default_modules = ['SLES_SAP', 'sle-module-basesystem', 'sle-module-desktop-applications', 'sle-module-server-applications', 'sle-ha', 'sle-module-sap-applications'] %}
 
 {% for module in default_modules %}
 mgr_install_product_{{ module }}:
   cmd.run:
-    - name: /usr/bin/zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product {{ module }}
+    - name: zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product {{ module }}
     - require:
       - cmd: mgr_remove_release_package
       - cmd: mgr_remove_flavor_package_dvd

--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -154,7 +154,7 @@ dns_fqdns:
       - mgrcompat: sync_states
 {%- endif %}
     - onlyif:
-        /usr/bin/which host || /usr/bin/which nslookup
+        which host || which nslookup
 {% endif%}
 {% if 'network.fqdns' in salt %}
 fqdns:
@@ -183,7 +183,7 @@ sap_workloads:
 
 uname:
   cmd.run:
-    - name: /usr/bin/uname -r -v
+    - name: uname -r -v
 
 container_runtime:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -206,3 +206,4 @@ mgr_buildimage_kiwi_collect_logs:
     - path: {{ root_dir }}/build.log
     - upload_path: /image-{{ build_id }}.log
     - order: last
+

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
@@ -20,6 +20,6 @@ mgr_inspect_kiwi_image:
 
 mgr_kiwi_cleanup:
   cmd.run:
-    - name: "/usr/bin/rm -rf '{{ root_dir }}'"
+    - name: "rm -rf '{{ root_dir }}'"
     - require:
       - mgrcompat: mgr_inspect_kiwi_image

--- a/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
@@ -32,7 +32,7 @@ mgr_container_remove:
     - args: [ "{{ container_name }}" ]
     - force: False
     - onlyif:
-      - /usr/bin/docker ps -a | /usr/bin/grep "{{ container_name }}" >/dev/null
+      - docker ps -a | grep "{{ container_name }}" >/dev/null
 
 mgr_image_remove:
   mgrcompat.module_run:
@@ -85,7 +85,7 @@ mgr_container_remove:
     - args: [ "{{ container_name }}" ]
     - force: False
     - onlyif:
-      - /usr/bin/docker ps -a | /usr/bin/grep "{{ container_name }}" >/dev/null
+      - docker ps -a | grep "{{ container_name }}" >/dev/null
 
 mgr_image_remove:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -24,8 +24,8 @@ modules:
 {% elif grains['os_family'] == 'Debian' %}
 debianrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/os-release
-    - onlyif: /usr/bin/test -f /etc/os-release
+    - name: cat /etc/os-release
+    - onlyif: test -f /etc/os-release
 {% endif %}
 
 include:

--- a/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
@@ -1,38 +1,38 @@
 {% if grains['os_family'] == 'RedHat' %}
 rhelrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/redhat-release
-    - onlyif: /usr/bin/test -f /etc/redhat-release -a ! -L /etc/redhat-release
+    - name: cat /etc/redhat-release
+    - onlyif: test -f /etc/redhat-release -a ! -L /etc/redhat-release
 alibabarelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/alinux-release
-    - onlyif: /usr/bin/test -f /etc/alinux-release
+    - name: cat /etc/alinux-release
+    - onlyif: test -f /etc/alinux-release
 centosrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/centos-release
-    - onlyif: /usr/bin/test -f /etc/centos-release
+    - name: cat /etc/centos-release
+    - onlyif: test -f /etc/centos-release
 oraclerelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/oracle-release
-    - onlyif: /usr/bin/test -f /etc/oracle-release
+    - name: cat /etc/oracle-release
+    - onlyif: test -f /etc/oracle-release
 amazonrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/system-release
-    - onlyif: /usr/bin/test -f /etc/system-release && /usr/bin/grep -qi Amazon /etc/system-release
+    - name: cat /etc/system-release
+    - onlyif: test -f /etc/system-release && grep -qi Amazon /etc/system-release
 almarelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/almalinux-release
-    - onlyif: /usr/bin/test -f /etc/almalinux-release
+    - name: cat /etc/almalinux-release
+    - onlyif: test -f /etc/almalinux-release
 rockyrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/rocky-release
-    - onlyif: /usr/bin/test -f /etc/rocky-release
+    - name: cat /etc/rocky-release
+    - onlyif: test -f /etc/rocky-release    
 respkgquery:
   cmd.run:
-    - name: /usr/bin/rpm -q --whatprovides 'sles_es-release-server'
-    - onlyif: /usr/bin/rpm -q --whatprovides 'sles_es-release-server'
+    - name: rpm -q --whatprovides 'sles_es-release-server'
+    - onlyif: rpm -q --whatprovides 'sles_es-release-server'
 sllpkgquery:
   cmd.run:
-    - name: /usr/bin/rpm -q --whatprovides 'sll-release'
-    - onlyif: /usr/bin/rpm -q --whatprovides 'sll-release'
+    - name: rpm -q --whatprovides 'sll-release'
+    - onlyif: rpm -q --whatprovides 'sll-release'
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
+++ b/susemanager-utils/susemanager-sls/salt/proxy/apply_proxy_config.sls
@@ -116,15 +116,15 @@ install_proxy_packages:
 
         [Service]
         Type=oneshot
-        ExecStart=/bin/bash -c '/usr/bin/mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 2>&1 | /usr/bin/tee -a /var/log/mgrpxy_install.log'
+        ExecStart=/bin/bash -c 'mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 2>&1 | tee -a /var/log/mgrpxy_install.log'
         
         ExecStartPost=/bin/bash -c 'STATUS_OUTPUT=$(mgrpxy status 2>&1); \
-            /usr/bin/echo "$STATUS_OUTPUT" | /usr/bin/tee -a /var/log/mgrpxy_install.log; \
-            if ! /usr/bin/echo "$STATUS_OUTPUT" | /usr/bin/grep -q "Error: no installed proxy detected"; then \
-                /usr/bin/echo "mgrpxy was successfully {{ mgrpxy_operation }}ed. Removing apply mgrpxy service and configuration file." | /usr/bin/tee -a /var/log/mgrpxy_install.log; \
-                /usr/bin/rm -f /etc/systemd/system/apply_proxy_config.service; \
+            echo "$STATUS_OUTPUT" | tee -a /var/log/mgrpxy_install.log; \
+            if ! echo "$STATUS_OUTPUT" | grep -q "Error: no installed proxy detected"; then \
+                echo "mgrpxy was successfully {{ mgrpxy_operation }}ed. Removing apply mgrpxy service and configuration file." | tee -a /var/log/mgrpxy_install.log; \
+                rm -f /etc/systemd/system/apply_proxy_config.service; \
             else \
-                /usr/bin/echo "mgrpxy status check failed. Service file will remain for troubleshooting." | /usr/bin/tee -a /var/log/mgrpxy_install.log; \
+                echo "mgrpxy status check failed. Service file will remain for troubleshooting." | tee -a /var/log/mgrpxy_install.log; \
             fi'
 
         [Install]
@@ -139,7 +139,7 @@ install_proxy_packages:
 # The system will run this service to enable apply_proxy_config.service after reboot
 enable_apply_proxy_config_service:
   cmd.run:
-    - name: /usr/bin/systemctl enable apply_proxy_config.service
+    - name: systemctl enable apply_proxy_config.service
     - require:
       - file: /etc/systemd/system/apply_proxy_config.service
 
@@ -148,8 +148,8 @@ enable_apply_proxy_config_service:
 apply_proxy_configuration:
   cmd.run:
     - name: >
-        /usr/bin/mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 
-        2>&1 | /usr/bin/tee -a /var/log/mgrpxy_install.log
+        mgrpxy {{ mgrpxy_operation }} podman --logLevel debug {{ args | join(" ") }} 
+        2>&1 | tee -a /var/log/mgrpxy_install.log
     - shell: /bin/bash
     - require:
       - file: /etc/uyuni/proxy/config.yaml

--- a/susemanager-utils/susemanager-sls/salt/reboot.sls
+++ b/susemanager-utils/susemanager-sls/salt/reboot.sls
@@ -1,7 +1,3 @@
 mgr_reboot:
   cmd.run:
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
-    - name: /sbin/shutdown -r +5
-{%- else %}
-    - name: /usr/sbin/shutdown -r +5
-{% endif %}
+    - name: shutdown -r +5

--- a/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
+++ b/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
@@ -1,25 +1,21 @@
 {%- if salt['pillar.get']('mgr_reboot_if_needed', True) and salt['pillar.get']('custom_info:mgr_reboot_if_needed', 'true')|lower in ('true', '1', 'yes', 't') %}
 mgr_reboot_if_needed:
   cmd.run:
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
-    - name: /sbin/shutdown -r +5
-{%- else %}
-    - name: /usr/sbin/shutdown -r +5
-{%- endif %}
+    - name: shutdown -r +5
 {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 8 %}
-    - onlyif: '/usr/bin/dnf -q needs-restarting -r; /usr/bin/test $? -eq 1'
+    - onlyif: 'dnf -q needs-restarting -r; [ $? -eq 1 ]'
 {%- elif grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 7 %}
-    - onlyif: '/usr/bin/needs-restarting -r; /usr/bin/test $? -eq 1'
+    - onlyif: 'needs-restarting -r; [ $? -eq 1 ]'
 {%- elif grains['os_family'] == 'Debian' %}
     - onlyif:
-      - /usr/bin/test -e /var/run/reboot-required
+      - test -e /var/run/reboot-required
 {%- elif grains.get('transactional', False) and grains['os_family'] == 'Suse' %}
     - onlyif:
       - /usr/bin/snapper list --columns number 2>/dev/null | /usr/bin/grep '+'
 {%- elif grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
     - onlyif:
-      - /usr/bin/test -e /boot/do_purge_kernels
+      - test -e /boot/do_purge_kernels
 {%- else %}
-    - onlyif: '/usr/bin/zypper ps -s; [ $? -eq 102 ]'
+    - onlyif: 'zypper ps -s; [ $? -eq 102 ]'
 {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
@@ -30,8 +30,8 @@ jmx_taskomatic_config:
 
 mgr_enable_prometheus_self_monitoring:
   cmd.run:
-    - name: /usr/bin/grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && /usr/bin/sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 0/' /etc/rhn/rhn.conf || /usr/bin/echo 'prometheus_monitoring_enabled = 0' >> /etc/rhn/rhn.conf
+    - name: grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 0/' /etc/rhn/rhn.conf || echo 'prometheus_monitoring_enabled = 0' >> /etc/rhn/rhn.conf
 
 mgr_is_prometheus_self_monitoring_disabled:
   cmd.run:
-    - name: /usr/bin/grep -qF 'prometheus_monitoring_enabled = 0' /etc/rhn/rhn.conf
+    - name: grep -qF 'prometheus_monitoring_enabled = 0' /etc/rhn/rhn.conf

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
@@ -141,8 +141,8 @@ jmx_exporter_taskomatic_service_cleanup:
 
 mgr_enable_prometheus_self_monitoring:
   cmd.run:
-    - name:  /usr/bin/grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && /usr/bin/sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 1/' /etc/rhn/rhn.conf || /usr/bin/echo 'prometheus_monitoring_enabled = 1' >> /etc/rhn/rhn.conf
+    - name: grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 1/' /etc/rhn/rhn.conf || echo 'prometheus_monitoring_enabled = 1' >> /etc/rhn/rhn.conf
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
-    - name: /usr/bin/grep -qF 'prometheus_monitoring_enabled = 1' /etc/rhn/rhn.conf
+    - name: grep -qF 'prometheus_monitoring_enabled = 1' /etc/rhn/rhn.conf

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
@@ -22,7 +22,7 @@ jmx_taskomatic_java_config:
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
-    - name: /usr/bin/grep -q -E 'prometheus_monitoring_enabled\s*=\s*(1|y|true|yes|on)\s*$' /etc/rhn/rhn.conf
+    - name: grep -q -E 'prometheus_monitoring_enabled\s*=\s*(1|y|true|yes|on)\s*$' /etc/rhn/rhn.conf
 
 include:
   - util.syncstates

--- a/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
@@ -37,7 +37,7 @@ proxy_ssh_identity:
 
 generate_own_ssh_key:
   cmd.run:
-    - name: /usr/bin/ssh-keygen -N '' -C 'susemanager-own-ssh-push' -f {{ home }}/.ssh/mgr_own_id -t rsa -q
+    - name: ssh-keygen -N '' -C 'susemanager-own-ssh-push' -f {{ home }}/.ssh/mgr_own_id -t rsa -q
     - creates: {{ home }}/.ssh/mgr_own_id.pub
 
 ownership_own_ssh_key:

--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -4,17 +4,17 @@ include:
 {%- if grains['os_family'] == 'Suse' %}
 mgr_keep_system_up2date_updatestack:
   cmd.run:
-    - name: /usr/bin/zypper --non-interactive patch --updatestack-only
+    - name: zypper --non-interactive patch --updatestack-only
     - success_retcodes:
       - 104
       - 103
       - 106
       - 0
-    - onlyif: '/usr/bin/zypper patch-check --updatestack-only; r=$?; /usr/bin/test $r -eq 100 || /usr/bin/test $r -eq 101'
+    - onlyif: 'zypper patch-check --updatestack-only; r=$?; test $r -eq 100 || test $r -eq 101'
     - require:
       - sls: channels
 
-{% set patch_need_reboot = salt['cmd.retcode']('/usr/bin/zypper -x list-patches | /usr/bin/grep \'restart="true"\' > /dev/null', python_shell=True) %}
+{% set patch_need_reboot = salt['cmd.retcode']('zypper -x list-patches | grep \'restart="true"\' > /dev/null', python_shell=True) %}
 
 {% else %}
 

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
@@ -9,7 +9,7 @@ mgr_disable_fqdns_grains:
   file.append:
     - name: {{ susemanager_minion_config }}
     - text: "enable_fqdns_grains: False"
-    - unless: /usr/bin/grep 'enable_fqdns_grains:' {{ susemanager_minion_config }}
+    - unless: grep 'enable_fqdns_grains:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
@@ -10,7 +10,7 @@ mgr_disable_mine:
   file.managed:
     - name: {{ susemanager_minion_config }}
     - contents: "mine_enabled: False"
-    - unless: /usr/bin/grep 'mine_enabled:' {{ susemanager_minion_config }}
+    - unless: grep 'mine_enabled:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_rotate_saltssh_key.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_rotate_saltssh_key.sls
@@ -12,7 +12,7 @@ proxy_new_mgr_ssh_identity:
   ssh_auth.present:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/new_mgr_ssh_id.pub
-    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
+    - onlyif: grep -q mgrsshtunnel /etc/passwd
 {% endif %}
 
 {% if salt['cp.list_master'](prefix='salt_ssh/disabled_mgr_ssh_id.pub') %}
@@ -33,12 +33,12 @@ proxy_old_mgr_ssh_identity:
   ssh_auth.absent:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/disabled_mgr_ssh_id.pub
-    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
+    - onlyif: grep -q mgrsshtunnel /etc/passwd
 
 # to prevent to lock out yourself
 proxy_current_mgr_ssh_identity:
   ssh_auth.present:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/mgr_ssh_id.pub
-    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
+    - onlyif: grep -q mgrsshtunnel /etc/passwd
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
@@ -8,4 +8,4 @@ mgr_start_event_grains:
     - name: {{ susemanager_minion_config }}
     - text: |
         start_event_grains: [machine_id, saltboot_initrd, susemanager]
-    - unless: /usr/bin/grep 'start_event_grains:' {{ susemanager_minion_config }}
+    - unless: grep 'start_event_grains:' {{ susemanager_minion_config }}

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
@@ -27,11 +27,11 @@ mgr_copy_salt_minion_id:
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
-      - /usr/bin/test -f /etc/salt/minion_id
+      - test -f /etc/salt/minion_id
 
 mgr_copy_salt_minion_configs:
   cmd.run:
-    - name: /usr/bin/cp -r /etc/salt/minion.d /etc/venv-salt-minion/
+    - name: cp -r /etc/salt/minion.d /etc/venv-salt-minion/
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
@@ -44,17 +44,17 @@ mgr_copy_salt_minion_grains:
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
-      - /usr/bin/test -f /etc/salt/grains
+      - test -f /etc/salt/grains
 
 mgr_copy_salt_minion_keys:
   cmd.run:
-    - name: /usr/bin/cp -r /etc/salt/pki/minion/minion* /etc/venv-salt-minion/pki/minion/
+    - name: cp -r /etc/salt/pki/minion/minion* /etc/venv-salt-minion/pki/minion/
     - require:
       - cmd: mgr_copy_salt_minion_configs
     - onlyif:
-      - /usr/bin/test -f /etc/salt/pki/minion/minion_master.pub
+      - test -f /etc/salt/pki/minion/minion_master.pub
     - unless:
-      - /usr/bin/test -f /etc/venv-salt-minion/pki/minion/minion_master.pub
+      - test -f /etc/venv-salt-minion/pki/minion/minion_master.pub
 
 mgr_enable_venv_salt_minion:
   service.running:
@@ -91,9 +91,9 @@ mgr_purge_non_venv_salt_packages:
 {%- if salt['pillar.get']('mgr_purge_non_venv_salt_files') %}
 mgr_purge_non_venv_salt_pki_dir:
   cmd.run:
-    - name: /usr/bin/rm -rf /etc/salt/minion* /etc/salt/pki/minion
+    - name: rm -rf /etc/salt/minion* /etc/salt/pki/minion
     - onlyif:
-      - /usr/bin/test -d /etc/salt/pki/minion
+      - test -d /etc/salt/pki/minion
     - require:
       - service: mgr_disable_salt_minion
 
@@ -101,7 +101,7 @@ mgr_purge_non_venv_salt_conf_dir:
   file.absent:
     - name: /etc/salt
     - unless:
-      - /usr/bin/find /etc/salt -type f -print -quit | /usr/bin/grep -q .
+      - find /etc/salt -type f -print -quit | grep -q .
     - require:
       - cmd: mgr_purge_non_venv_salt_pki_dir
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.salt-usrmerge-sls
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.mczernek.salt-usrmerge-sls
@@ -1,0 +1,3 @@
+- Revert using absolute paths in sls, because
+  we cannot assume usrmerge is installed on
+  older Debian/Ubuntu clients (bsc#1253780)


### PR DESCRIPTION
## What does this PR change?

In https://github.com/uyuni-project/uyuni/commit/c4f0d68b23ac166ce40f1c9bc9fae7c1a5c695d3, we modified the SLS to use absolute paths. This was based on sonarcloud issue - https://github.com/SUSE/spacewalk/issues/24387

The problem is that older Ubuntu and Debian systems (that were updated and not reinstalled, e.g. 16.04 -> 18.04 -> 20.04 -> 22.04 -> 24.04) do not necessarily have `usrmerge` installed. Usrmerge is installed by default only on new installations.

This means that we cannot assume `/usr/bin` path for a lot of binaries on some Debians and Ubuntus, such as `uname`, `cat`, `ls`, etc.

Given that this change is related to sonarcloud, I propose reverting the change. 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): # 
- https://github.com/SUSE/spacewalk/issues/29075
- https://github.com/SUSE/spacewalk/issues/29295
Port(s): # TODO

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
