### PR TITLE
Fix ungrouped systems list menu item (bsc#1254251)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/core/src/main/java/com/suse/manager/webui/menu/MenuTree.java
@@ -173,7 +173,7 @@ public class MenuTree {
                         .addChild(new MenuItem("Extra Packages")
                                 .withPrimaryUrl("/rhn/manager/systems/list/all?qc=extra_pkg_count&q=>0"))
                         .addChild(new MenuItem("Ungrouped")
-                                .withPrimaryUrl("/rhn/manager/systems/list/all?qc=group_count&q=0")
+                                .withPrimaryUrl("/rhn/manager/systems/list/all?qc=group_count&q=<1")
                                 .withVisibility(adminRoles.get("org")))
                         .addChild(new MenuItem("Inactive")
                                 .withPrimaryUrl("/rhn/manager/systems/list/all?qc=status_type&q=awol"))

--- a/java/spacewalk-java.changes.welder.bsc1254251
+++ b/java/spacewalk-java.changes.welder.bsc1254251
@@ -1,0 +1,1 @@
+- Fix ungrouped systems list menu item (bsc#1254251)


### PR DESCRIPTION
## What does this PR change?

The URL parameter conversion used previously (`q=0`) wasn’t working, and the value was ending up as `None` in the React code. Changing it to `q=<1` fixed the issue.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29129
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
