### PR TITLE
Fix reposync mediaproduct fetch when URL contains auth token (bsc#1252388)

### DIFF
--- a/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
+++ b/python/spacewalk/satellite_tools/repo_plugins/yum_src.py
@@ -1437,7 +1437,14 @@ password={passwd}
         url = "media.1/products"
         media_products_path = os.path.join(self._get_repodata_path(), url)
         grabber = urlgrabber.grabber.URLGrabber()
-        mirror_group = MirrorGroup(grabber, self.repo.urls)
+        urls = []
+        for url in self.repo.urls:
+            # A URL might contain an auth token
+            if url.endswith("/"):
+                url = url[:-1]
+            urls.append(url)
+        mirror_group = MirrorGroup(grabber, urls)
+
         try:
             urlgrabber_opts = {}
             self.set_download_parameters(urlgrabber_opts, url, media_products_path)

--- a/python/spacewalk/spacewalk-backend.changes.mczernek.reposync-product-fix
+++ b/python/spacewalk/spacewalk-backend.changes.mczernek.reposync-product-fix
@@ -1,0 +1,2 @@
+- Fix reposync mediaproduct fetch when
+  URL contains auth token (bsc#1252388)

--- a/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
+++ b/python/test/unit/spacewalk/satellite_tools/test_yum_src.py
@@ -534,6 +534,19 @@ class YumSrcTest(unittest.TestCase):
             assert not cs.get_mediaproducts()
             log_mock.assert_not_called()
 
+    def test_get_mediaproduct_adds_no_trailing_backslash(self):
+        cs = self._make_dummy_cs()
+        mirror_mock = Mock()
+
+        with patch(
+            "spacewalk.satellite_tools.repo_plugins.yum_src.MirrorGroup", mirror_mock
+        ):
+            cs.get_mediaproducts()
+
+        urls = mirror_mock.call_args[1]
+        for url in urls:
+            assert url[-1] != "/"
+
     @patch("spacewalk.satellite_tools.repo_plugins.yum_src.initCFG", Mock())
     @patch("spacewalk.satellite_tools.repo_plugins.yum_src.os.unlink", Mock())
     @patch("urlgrabber.grabber.PyCurlFileObject", Mock())


### PR DESCRIPTION
## What does this PR change?

`yum_src.py` automatically adds a slash `/` at the end of every URL. But, when fetching media/products file from reposync, if we're authenticating against a MLM, `/` is added at the end of the auth token, which makes the token malformed and fails MLM auth process.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): # https://github.com/SUSE/spacewalk/issues/28715
Port(s): # TODO

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
