### PR TITLE
Configure squid replacement policy properly before cache dir (bsc#1253773)

### DIFF
--- a/containers/proxy-squid-image/proxy-squid-image.changes.oholecek.fix_squid_replacement_config
+++ b/containers/proxy-squid-image/proxy-squid-image.changes.oholecek.fix_squid_replacement_config
@@ -1,0 +1,2 @@
+- Configure squid replacement policy properly before cache dir
+  (bsc#1253773)

--- a/containers/proxy-squid-image/squid.conf
+++ b/containers/proxy-squid-image/squid.conf
@@ -14,17 +14,17 @@ maximum_object_size_in_memory 1024 KB
 
 access_log /var/log/squid/access.log squid
 
-# Size should be about 60% of your free space
-cache_dir aufs /var/cache/squid 15000 16 256
-
 # Average object size, used to estimate number of objects your
 # cache can hold.  The default is 13 KB.
 store_avg_object_size 817 KB
 
 # We want to keep the largest objects around longer, and just download the smaller objects if we can.
 cache_replacement_policy heap LFUDA
-
 memory_replacement_policy heap GDSF
+
+# Size should be about 60% of your free space, default to 15G.
+# cache_dir needs to be configured only after replacement policy above.
+cache_dir aufs /var/cache/squid 15000 16 256
 
 # if transport is canceled, finish downloading anyway
 quick_abort_pct -1


### PR DESCRIPTION
## What does this PR change?

Squid replacement policy had to be configured before configuring cache dir.

Squid allows multiple cache dir options and so only previously configured replacement policies are valid for set cache dir.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: Hard to test without enabling squid management access

- [X] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29058
Port(s): https://github.com/SUSE/spacewalk/pull/29185 https://github.com/SUSE/spacewalk/pull/29186 https://github.com/SUSE/spacewalk/pull/29187

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
