### PR TITLE
Cleanup salt leftovers on proxy

### DIFF
--- a/testsuite/features/proxy/proxy_container.feature
+++ b/testsuite/features/proxy/proxy_container.feature
@@ -15,6 +15,13 @@ Feature: Setup containerized proxy
   As the system administrator
   I want to register the containerized proxy on the server
 
+  Scenario: Clean up sumaform leftovers on proxy
+    When I perform a full salt minion cleanup on "proxy"
+
+@transactional_server
+  Scenario: Reboot after clean up
+    When I reboot the "proxy" host through SSH, waiting until it comes back
+
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 


### PR DESCRIPTION
## What does this PR change?

We clean up salt leftovers on minion and build host, but forgot to do it on proxy.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified.

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/29188
 * 5.0: https://github.com/SUSE/spacewalk/pull/29189
 * 5.1: https://github.com/SUSE/spacewalk/pull/29190

- [ ] **DONE**


## Changelogs

- [x] No changelog needed
