### PR TITLE
Add meaningful error message for parsing and logging of class Token

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/utils/token/Token.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/token/Token.java
@@ -176,4 +176,74 @@ public class Token {
             .map(Instant::ofEpochSecond)
             .orElse(null);
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        String sep = ", ";
+
+        builder.append("Token {");
+        builder.append("value = [%s]".formatted(serializedForm)).append(sep);
+        builder.append("valueLen = [%d]".formatted(serializedForm.length())).append(sep);
+
+        try {
+            builder.append("jwtId = [%s]".formatted(getJwtId())).append(sep);
+            builder.append("jwtIdLen = [%d]".formatted(getJwtId().length())).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("jwtId = [%s]".formatted(ex.getMessage())).append(sep);
+        }
+
+        try {
+            builder.append("issuingTime = [%s]".formatted(getIssuingTime())).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("issuingTime = [%s]".formatted(ex.getMessage())).append(sep);
+        }
+
+        try {
+            builder.append("expirationTime = [%s]".formatted(getExpirationTime())).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("expirationTime = [%s]".formatted(ex.getMessage())).append(sep);
+        }
+
+        try {
+            builder.append("notBeforeTime = [%s]".formatted(getNotBeforeTime())).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("notBeforeTime = [%s]".formatted(ex.getMessage())).append(sep);
+        }
+
+        try {
+            builder.append("subject = [%s]".formatted(getSubject())).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("subject = [%s]".formatted(ex.getMessage())).append(sep);
+        }
+
+        try {
+            builder.append("name = [%s]".formatted(getClaim("name", String.class))).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("name = [%s]".formatted(ex.getMessage())).append(sep);
+        }
+        try {
+            builder.append("orgId = [%d]".formatted(getClaim("org", Long.class))).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("orgId = [none]");
+        }
+
+        try {
+            List<String> claimList = getListClaim("onlyChannels", String.class);
+            builder.append("onlyChannelsSize = [%d]".formatted(claimList.size())).append(sep);
+            builder.append("onlyChannels = [%s]".formatted(claimList)).append(sep);
+        }
+        catch (TokenParsingException ex) {
+            builder.append("onlyChannels = [%s]".formatted(ex.getMessage())).append(sep);
+        }
+
+        return builder.toString();
+    }
 }

--- a/java/core/src/main/java/com/suse/manager/webui/utils/token/TokenParser.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/token/TokenParser.java
@@ -127,7 +127,7 @@ public class TokenParser extends SecretHolder {
             return new Token(serializedForm, jwtConsumerBuilder.build().processToClaims(serializedForm));
         }
         catch (InvalidJwtException ex) {
-            throw new TokenParsingException("Unable to parse token claims", ex);
+            throw new TokenParsingException("Unable to parse token claims: " + ex.getMessage(), ex);
         }
     }
 

--- a/java/core/src/test/java/com/suse/manager/webui/utils/token/test/TokenParserTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/token/test/TokenParserTest.java
@@ -14,6 +14,7 @@ package com.suse.manager.webui.utils.token.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.suse.manager.webui.utils.token.DefaultTokenBuilder;
 import com.suse.manager.webui.utils.token.Token;
@@ -59,5 +60,29 @@ public class TokenParserTest {
         assertEquals("TokenParserTest", parsedToken.getSubject());
         assertEquals("7f695bb2-5c8a-4b29-8239-daf5687e947f", parsedToken.getJwtId());
         assertEquals("John Doe", parsedToken.getClaim("name", String.class));
+    }
+
+    @Test
+    public void testParseTokenWithUnrelatedSecret() {
+        //the secret is NOT the one of the token
+        String customRandomSecretAES256 = "8f3a7b2c9d4e1f6a5b8c7d2e9f0a3b6c4d8e2f9a0b5c8d7e1f4a9b2c5d8e3f7a";
+        String customToken = """
+                eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJfR0U0TzJSbnozTHBxSEVESzFYeG93IiwiZXhwIjoxNzU5NDk5MTA4LCJpY\
+                XQiOjE3NTkzMTE5MDgsIm5iZiI6MTc1OTMxMTc4OCwib3JnIjowLCJvbmx5Q2hhbm5lbHMiOlsic2xlLW1vZHVsZS1\
+                jb250YWluZXJzMTItcG9vbC14ODZfNjQtc3A1Il19.CzCF6nd3-S4R2aEqP_3alBxvbsZbRF7MeOf5haHNy1k""";
+
+        TokenParser tokenParser = new TokenParser().withCustomSecret(customRandomSecretAES256);
+
+        try {
+            tokenParser.parse(customToken);
+            fail("this should have thrown an exception");
+        }
+        catch (TokenParsingException ex) {
+            int errorStringLen = ex.getMessage().replace("Unable to parse token claims", "").length();
+            assertTrue(errorStringLen > 10); //some meaningful message
+            // Error message is something like:
+            // Unable to parse token claims: JWT rejected due to invalid signature. \
+            // Additional details: [[9] Invalid JWS Signature: JsonWebSignature{"alg":"HS256"}->"...]
+        }
     }
 }


### PR DESCRIPTION
## What does this PR change?

Adds a more meaningful toString() method to class Token and shows more meaningful error message when parsing Token fails

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links

Issue(s): no issue
Port(s): # 5.1: https://github.com/SUSE/spacewalk/pull/29200
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
