### PR TITLE
Button got renamed

### DIFF
--- a/testsuite/features/build_validation/retail/sle15sp6_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp6_terminal_deploy.feature
@@ -46,7 +46,7 @@ Feature: PXE boot a SLES 15 SP6 retail terminal
     And I enter "rust" as the filtered package name
     And I click on the filter button
     And I check "rust-1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/build_validation/retail/sle15sp7_terminal_deploy.feature
+++ b/testsuite/features/build_validation/retail/sle15sp7_terminal_deploy.feature
@@ -46,7 +46,7 @@ Feature: PXE boot a SLES 15 SP7 retail terminal
     And I enter "rust" as the filtered package name
     And I click on the filter button
     And I check "rust-1" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
     When I wait until event "Package Install/Upgrade scheduled" is completed

--- a/testsuite/features/secondary/min_deblike_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/min_deblike_salt_install_package_and_patch.feature
@@ -42,7 +42,7 @@ Feature: Install and upgrade package on the Debian-like minion via Salt through 
     When I follow "Software" in the content area
     And I follow "Install"
     And I check "andromeda-dummy-2.0" in the list
-    And I click on "Install Selected Packages"
+    And I click on "Install Packages"
     And I click on "Confirm"
     And I should see a "1 package install has been scheduled for" text
     When I wait until event "Package Install/Upgrade scheduled" is completed


### PR DESCRIPTION
## What does this PR change?

This PR aligns tests with UI for the button "Install Selected Packages" (4.3, 5.0, and 5.1) aka "Install Packages" (head).


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified.

- [x] **DONE**


## Links

Port(s):
* 4.3: https://github.com/SUSE/spacewalk/pull/29244
* 5.0: clean
* 5.1: clean

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


