### PR TITLE
Solve: undefined method `seconds_to_duration' for an instance of Cucumber::Core::Test::Result::Duration (NoMethodError)

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 
 gem 'bcrypt_pbkdf', '~> 1.1'
 gem 'capybara', '3.40.0'
-gem 'cucumber', '10.2.0'
+gem 'cucumber', '10.1.0'
 gem 'ed25519', '~> 1.4'
 gem 'faraday', '~>2.14'
 gem 'ffi', '~> 1.17'


### PR DESCRIPTION

## What does this PR change?

After gems update error appears:

```
Scenario: The server is healthy                    # features/core/allcli_sanity.feature:8
09:12:53        undefined method `seconds_to_duration' for an instance of Cucumber::Core::Test::Result::Duration (NoMethodError)
09:12:53  undefined method `seconds_to_duration' for an instance of Cucumber::Core::Test::Result::Duration (NoMethodError)
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/result.rb:411:in `to_message_duration'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/result.rb:137:in `to_message'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/formatter/message_builder.rb:199:in `on_test_step_finished'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/event_bus.rb:33:in `block in broadcast'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/event_bus.rb:33:in `each'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/event_bus.rb:33:in `broadcast'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/event_bus.rb:39:in `method_missing'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/runner.rb:38:in `around_hook'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/around_hook.rb:13:in `describe_to'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:93:in `block (2 levels) in compose_around_hooks'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:94:in `compose_around_hooks'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:31:in `block in describe_to'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/runner.rb:20:in `test_case'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:30:in `describe_to'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/filters/prepare_world.rb:11:in `test_case'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:30:in `describe_to'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/filter.rb:56:in `test_case'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/filters/retry.rb:23:in `test_case'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:30:in `describe_to'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/filters/broadcast_test_case_ready_event.rb:8:in `test_case'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:30:in `describe_to'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/filters/quit.rb:11:in `test_case'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/case.rb:30:in `describe_to'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/filters/broadcast_test_run_started_event.rb:21:in `block in done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/filters/broadcast_test_run_started_event.rb:20:in `map'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/filters/broadcast_test_run_started_event.rb:20:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/filter.rb:61:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/filter.rb:61:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/filter.rb:61:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/filter.rb:61:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/filter.rb:61:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/filters/locations_filter.rb:19:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/filter.rb:61:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/test/filters/tag_filter.rb:16:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/compiler.rb:32:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core/gherkin/parser.rb:36:in `done'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core.rb:35:in `parse'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-core-16.0.0/lib/cucumber/core.rb:24:in `compile'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/runtime.rb:80:in `run!'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/lib/cucumber/cli/main.rb:29:in `execute!'
09:12:53  /usr/lib64/ruby/gems/3.3.0/gems/cucumber-10.2.0/bin/cucumber:9:in `<top (required)>'
09:12:53  /usr/bin/cucumber:25:in `load'
09:12:53  /usr/bin/cucumber:25:in `<main>'
```

Error seems to be in saving outputs to html file, parameter that causes the error is `-f html -o <file>` everything else seems to work. Deducting, error seems to be in ... package which is updated with cucumber after `10.2.0` update, downgrading cucumber back to `10.1.0` temporarily solve the issue.

```
controller:~/spacewalk/testsuite # bundle install
Don't run Bundler as root. Installing your bundle as root will break this application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Using cucumber-ci-environment 10.0.1 (was 11.0.0)
Using cucumber-messages 27.2.0 (was 31.1.0)
Using cucumber-gherkin 36.1.0 (was 37.0.1)
Using cucumber-html-formatter 21.15.1 (was 22.3.0)
Using cucumber-core 15.4.0 (was 16.0.0)
Using cucumber 10.1.0 (was 10.2.0)
Bundle complete! 33 Gemfile dependencies, 74 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
3 installed gems you directly depend on are looking for funding.
  Run `bundle fund` for details
controller:~/spacewalk/testsuite # ^C
controller:~/spacewalk/testsuite # /usr/bin/ruby.ruby3.3 -S bundle exec cucumber -f html -o <file>.html -f json -o <file>.json -f pretty -r features features/core/allcli_sanity.feature
...
Feature: Sanity checks
  In order to use the product
  I want to be sure to use a sane environment

  Scenario: The server is healthy                    # features/core/allcli_sanity.feature:8
      This scenario ran at: 2025-12-23 10:37:54 +0100
    Then "server" should have a FQDN                 # features/step_definitions/command_steps.rb:15
    And reverse resolution should work for "server"  # features/step_definitions/command_steps.rb:28
^C
```


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage

- No tests: already covered

- [ ] **DONE**

## Links

Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/29291
 - 5.0: https://github.com/SUSE/spacewalk/pull/29292
 - 4.3: https://github.com/SUSE/spacewalk/pull/29293

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
