### PR TITLE
fix(spacewalk-debug): redact 'default_password_crypted' breaks yaml

### DIFF
--- a/python/spacewalk/satellite_tools/spacewalk-debug
+++ b/python/spacewalk/satellite_tools/spacewalk-debug
@@ -287,7 +287,7 @@ if [ -d /var/lib/rhn/kickstarts ]; then
 fi
 
 # Remove passwords from cobbler settings
-find "$DIR/conf/cobbler" -type f -name 'settings*' -exec sed -i 's/^default_password_crypted.*/default_password_crypted <replaced_by_debug_tool>/' {} \;
+find $DIR/conf/cobbler -type f -name 'settings*' -exec sed -i 's/^\(default_password_crypted:\).*/\1 <replaced_by_debug_tool>/' {} \;
 
 # ssl-build
 if [ -d /root/ssl-build ] ; then

--- a/python/spacewalk/spacewalk-backend.changes.wombelix.fix_10414_default_password_crypted-replacement-breaks-yaml
+++ b/python/spacewalk/spacewalk-backend.changes.wombelix.fix_10414_default_password_crypted-replacement-breaks-yaml
@@ -1,0 +1,2 @@
+- Redact 'default_password_crypted' broke coppler yaml syntax
+  uyuni supportconfig spacewalk-debug. Fixes #10414


### PR DESCRIPTION
## What does this PR change?

`spacewalk-debug` caused cobbler settings.yaml copies in uyuni supportconfig archives to be invalid YAML syntax because of a missing ':' between key/value. This PR changes the relevant `sed` command to construct valid yaml when replacing the value. Kudos to [jirib](https://github.com/uyuni-project/uyuni/issues/10414#issue-3117784218) for reporting the issue and suggesting a solution.

Fixes: https://github.com/uyuni-project/uyuni/issues/10414

### Manual validation

cobbler_example_settings.yaml
```
allow_duplicate_hostnames: false
auth_token_expiration: 3600
autoinstall_templates_dir: /var/lib/cobbler/templates
boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
bootloaders_formats:
  aarch64:
    binary_name: grubaa64.efi
  arm:
    binary_name: bootarm.efi
bootloaders_modules:
  - btrfs
  - xfs
syslinux_dir: '@@syslinux_dir@@'
build_reporting_smtp_server: "localhost"
build_reporting_subject: ""
build_reporting_ignorelist: []
cheetah_import_whitelist:
 - "random"
 - "re"
createrepo_flags: "-c cache -s sha"
default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
default_template_type: "cheetah"
default_virt_bridge: xenbr0
```

Behavior with old sed command:

```
sed 's/^default_password_crypted.*/default_password_crypted <replaced_by_debug_tool>/' cobbler_example_settings.yaml | yq '.default_password_crypted'
Error: bad file '-': yaml: line 21: could not find expected ':'

sed 's/^default_password_crypted.*/default_password_crypted <replaced_by_debug_tool>/' cobbler_example_settings.yaml | grep default_password_crypted
default_password_crypted <replaced_by_debug_tool>
```

`:` after `default_password_crypted` missing, makes the yaml invalid as reported in https://github.com/uyuni-project/uyuni/issues/10414

Behavior with new sed command (kudos to @jirib):

```
sed 's/^\(default_password_crypted:\).*/\1 <replaced_by_debug_tool>/' cobbler_example_settings.yaml | yq '.default_password_crypted'
<replaced_by_debug_tool>

sed 's/^\(default_password_crypted:\).*/\1 <replaced_by_debug_tool>/' cobbler_example_settings.yaml | grep default_password_crypted
default_password_crypted: <replaced_by_debug_tool>
```

`:` is now there after `default_password_crypted`, results in valid yaml file.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: Don't see that `spacewalk-debug` is covered by unit tests

- [x] **DONE**

## Links

Issue(s): https://github.com/uyuni-project/uyuni/issues/10414

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
