### PR TITLE
Fix NPE when retrieving VM info (bsc#1254316)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/VmInfoSlsResult.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/VmInfoSlsResult.java
@@ -19,8 +19,8 @@ import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 public class VmInfoSlsResult {
 
@@ -33,10 +33,12 @@ public class VmInfoSlsResult {
      * @return return virtual machine information
      */
     public Map<String, Map<String, Object>> getVmInfos() {
-        if (vminfo == null) {
-            LOG.info("No virtual machines found");
-            return Collections.emptyMap();
-        }
-        return vminfo.getChanges().getRet();
+        return Optional.ofNullable(vminfo)
+                .map(StateApplyResult::getChanges)
+                .map(Ret::getRet)
+                .orElseGet(() -> {
+                    LOG.info("No virtual machines found");
+                    return Map.of();
+                });
     }
 }

--- a/java/spacewalk-java.changes.welder.bsc1254316
+++ b/java/spacewalk-java.changes.welder.bsc1254316
@@ -1,0 +1,1 @@
+- Fix NPE when retrieving VM info (bsc#1254316)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/29228

It fixes NPE when retrieving VM info

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29127
Port(s): https://github.com/SUSE/spacewalk/pull/29228

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
