### PR TITLE
testsuite: enable to run the secondary https_connection.feature

### DIFF
--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -7,6 +7,7 @@
 ## Secondary features BEGIN ##
 
 # IDEMPOTENT
+- features/secondary/https_connection.feature
 - features/secondary/srv_mgr_sync_list_products.feature
 - features/secondary/srv_monitoring.feature
 - features/secondary/srv_virtual_host_manager.feature


### PR DESCRIPTION
## What does this PR change?
It enables to run basic https_connection tests.
The test feature was executed successfully several times on all MLM versions. The feature itself is already merged but has been never added to runs. This PR fixes that.