### PR TITLE
QE: accept all SSH algorithms

### DIFF
--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -1,13 +1,10 @@
-# Copyright (c) 2025 SUSE LLC.
+# Copyright (c) 2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'net/scp'
 require 'net/ssh'
 require 'openssl'
 require 'stringio'
-
-Net::SSH::Transport::Algorithms::ALGORITHMS.each_value { |algs| algs.reject! { |a| a.match(/^ecd(sa|h)-sha2/) } }
-Net::SSH::KnownHosts::SUPPORTED_TYPE.reject! { |t| t.match(/^ecd(sa|h)-sha2/) }
 
 # This method is used to execute a command on a remote host using SSH and return the output of the command.
 #


### PR DESCRIPTION
## What does this PR change?

**PLEASE disregarded changes to timeouts, they are temporary and will be removed before merge, I just need to double check something else staying on this branch.**

We were forcefully removing elliptic curve algorithms from the list of valid ones, probably to avoid issues with old RSA keys. New SSH versions are starting to drop support for old algos, making it impossible to establish SSH connections as there is no overlap between the client and server list of supported algos.
In May 2025 we made an "official" and widespread change to ed25519 SSH keys, therefore we should now be able to accept all kind of SSH algorithms. This also improves our security posture.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Cucumber tests setup was modified

- [x] **DONE**

## Links

Port(s): # 

- 4.3 https://github.com/SUSE/spacewalk/pull/29367
- 5.0 https://github.com/SUSE/spacewalk/pull/29366
- 5.1 https://github.com/SUSE/spacewalk/pull/29365

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"