### PR TITLE
Fix error handling TODO in proxy setup and image build

### DIFF
--- a/web/html/src/manager/admin/setup/proxy/proxy.tsx
+++ b/web/html/src/manager/admin/setup/proxy/proxy.tsx
@@ -35,9 +35,8 @@ export default (props: Props) => {
       setSettings({ ...response });
       setSavedSettings({ ...response });
       setIsEditing(false);
-    } catch (error) {
-      // TODO: Show the error as a toast
-      Loggerhead.error(error);
+    } catch (error: any) {
+      Network.showResponseErrorToastr(error);
     }
   };
 

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -112,7 +112,15 @@ class BuildImage extends Component<Props, State> {
         // Get build hosts for the build type
         this.getBuildHosts(typeMap[data.imageType].buildType);
       } else {
-        //TODO: Handle error
+        this.setState({
+          messages: (
+            <Messages
+              items={res.messages.map((msg) => {
+                return { severity: "error", text: messageMap[msg] };
+              })}
+            />
+          ),
+        });
       }
     });
   }


### PR DESCRIPTION
## What does this PR change?

This PR implements proper error handling for the Proxy Setup and Image Build forms.

*   **Proxy Setup ([proxy.tsx](cci:7://file:///workspaces/uyuni/web/html/src/manager/admin/setup/proxy/proxy.tsx:0:0-0:0))**: Replaced a `TODO` comment with `Network.showResponseErrorToastr` to display a toast notification when saving proxy settings fails.
*   **Image Build ([image-build.tsx](cci:7://file:///workspaces/uyuni/web/html/src/manager/images/image-build.tsx:0:0-0:0))**: Implemented error handling (using inline [Messages](cci:1://file:///workspaces/uyuni/web/html/src/utils/network.ts:148:0-150:1)).

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference in layout, but errors will now be visible to the user.

Before:
*   Proxy Setup: Errors were logged to the console but not shown to the user.
*   Image Build: Errors were not handled gracefully.

After:
*   Proxy Setup: Users see a toast notification with the error message.
*   Image Build: Users see an inline error message.

- [X] **DONE**

## Documentation
- No documentation needed: The changes are minor UX improvements and error handling fixes, not new features requiring documentation.

- [X] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: The existing test infrastructure does not easily support unit testing these UI interactions with mocked network failures. The code follows existing patterns validated by TypeScript compilation and linting.

- [X] **DONE**

## Links

Issue(s): #
Port(s): # 

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!