### PR TITLE
Use `command` in SLS files

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/actionchains/force_restart_minion.sh
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/force_restart_minion.sh
@@ -8,7 +8,7 @@ if [ "$(readlink /proc/1/exe)" = "/sbin/init" ]; then
        SALT_MINION_PID="/var/run/venv-salt-minion.pid"
    fi
    T0=$(stat -c '%Z' "$SALT_MINION_PID")
-   RESTART_MINION="/usr/sbin/rc$SALT_MINION_NAME restart"
+   RESTART_MINION="command -p rc$SALT_MINION_NAME restart"
 else
    # systemd
    SALT_MINION_NAME="salt-minion"

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -165,7 +165,7 @@ bootstrap_repo:
 {% set salt_minion_installed = (salt['pkg.info_installed']('venv-salt-minion', attr='version', failhard=False).get('venv-salt-minion', {}).get('version') != None) %}
 check_bootstrap_dbg:
   cmd.run:
-    - name: /usr/bin/echo "{{ salt_minion_installed }}"
+    - name: command -p echo "{{ salt_minion_installed }}"
 {% set venv_available_request = salt_minion_installed or salt['http.query'](bootstrap_repo_url + 'venv-enabled-' + grains['osarch'] + '.txt', status=True, verify_ssl=False) %}
 {# Prefer venv-salt-minion if available and not disabled #}
 {%- set use_venv_salt = salt['pillar.get']('mgr_force_venv_salt_minion') or ((salt_minion_installed or (0 < venv_available_request.get('status', 404) < 300)) and not salt['pillar.get']('mgr_avoid_venv_salt_minion')) %}
@@ -189,10 +189,10 @@ salt-minion-package:
 {# hack until transactional_update.run is fixed to use venv-salt-call #}
 {# Writing  to the future - find latest etc overlay which was created for package installation and use that as etc root #}
 {# this only works here in bootstrap when we are not running in transaction #}
-{%- set pending_transaction_id = salt['cmd.run']('/usr/bin/snapper --no-dbus list --columns=number | /usr/bin/grep "+" | tr -d "+"', python_shell=True) %}
+{%- set pending_transaction_id = salt['cmd.run']('command -p snapper --no-dbus list --columns=number | command -p grep "+" | tr -d "+"', python_shell=True) %}
 {%- if not pending_transaction_id %}
 {#  if we did not get pending transaction id, write to current upperdir #}
-{%- set pending_transaction_id = salt['cmd.run']('/usr/bin/snapper --no-dbus list --columns number | /usr/bin/grep "*" | tr -d "*"', python_shell=True) %}
+{%- set pending_transaction_id = salt['cmd.run']('command -p snapper --no-dbus list --columns number | command -p grep "*" | tr -d "*"', python_shell=True) %}
 {%- endif %}
 {# increase transaction id by 1 since jinja is doing this before new transaction for package install is created #}
 {# this is working under assumption there will be only one transaction between jinja render and actual package installation #}
@@ -321,7 +321,7 @@ salt-minion-master-pub-wipe:
 {{ salt_minion_name }}:
   mgrcompat.module_run:
     - name: transactional_update.run
-    - command: /usr/bin/systemctl enable {{ salt_minion_name }}
+    - command: command -p systemctl enable {{ salt_minion_name }}
     - snapshot: continue
     - require:
       - salt-minion-package
@@ -340,7 +340,7 @@ copy_transactional_conf_file_to_etc:
     - name: /etc/transactional-update.conf
     - source: /usr/etc/transactional-update.conf
     - unless:
-      - /usr/bin/test -f /etc/transactional-update.conf
+      - command -p test -f /etc/transactional-update.conf
 
 transactional_update_set_reboot_method_systemd:
   file.keyvalue:
@@ -353,9 +353,9 @@ transactional_update_set_reboot_method_systemd:
     - require:
       - file: copy_transactional_conf_file_to_etc
     - unless:
-      - /usr/bin/grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
+      - command -p grep -P '^(?=[\s]*+[^#])[^#]*(REBOOT_METHOD=(?!auto))' /etc/transactional-update.conf
 
 disable_reboot_timer_transactional_minions:
   cmd.run:
-    - name: /usr/bin/systemctl disable transactional-update.timer
+    - name: command -p systemctl disable transactional-update.timer
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/remove_traditional_stack.sls
@@ -42,7 +42,7 @@ remove_traditional_stack:
 {%- if grains['os_family'] == 'Suse' %}
       - suseRegisterInfo
 {%- endif %}
-    - unless: /usr/bin/rpm -q spacewalk-proxy-common || /usr/bin/rpm -q spacewalk-common
+    - unless: command -p rpm -q spacewalk-proxy-common || command -p rpm -q spacewalk-common
 
 # only removing apt-transport-spacewalk above
 # causes apt-get update to 'freeze' if this

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
@@ -20,7 +20,7 @@
 restart:
   mgrcompat.module_run:
     - name: cmd.run_bg
-    - cmd: "/usr/bin/sleep 2; /usr/sbin/service {{ salt_service }} restart"
+    - cmd: "command -p sleep 2; command -p service {{ salt_service }} restart"
     - python_shell: true
 
 {% else -%}

--- a/susemanager-utils/susemanager-sls/salt/certs/debian.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/debian.sls
@@ -7,7 +7,7 @@ mgr_ca_cert:
 
 mgr_update_ca_certs:
   cmd.run:
-    - name: /usr/sbin/update-ca-certificates
+    - name: command -p update-ca-certificates
     - runas: root
     - onchanges:
       - file: mgr_ca_cert

--- a/susemanager-utils/susemanager-sls/salt/certs/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/init.sls
@@ -8,4 +8,4 @@ mgr_proxy_ca_cert_symlink:
   file.symlink:
     - name: /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
     - target: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
-    - onlyif: /usr/bin/grep -Eq "^proxy.rhn_parent *= *[a-zA-Z0-9]+" /etc/rhn/rhn.conf && -e /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+    - onlyif: command -p grep -Eq "^proxy.rhn_parent *= *[a-zA-Z0-9]+" /etc/rhn/rhn.conf && -e /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT

--- a/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/redhat.sls
@@ -1,9 +1,9 @@
 {%- if grains['osrelease']|int == 6 %}
 enable_ca_store:
   cmd.run:
-    - name: /usr/bin/update-ca-trust enable
+    - name: command -p update-ca-trust enable
     - runas: root
-    - unless: "/usr/bin/update-ca-trust check | /usr/bin/grep \"PEM/JAVA Status: ENABLED\""
+    - unless: "command -p update-ca-trust check | command -p grep \"PEM/JAVA Status: ENABLED\""
 {%- endif %}
 
 mgr_ca_cert:
@@ -18,7 +18,7 @@ mgr_ca_cert:
 
 update-ca-certificates:
   cmd.run:
-    - name: /usr/bin/update-ca-trust extract
+    - name: command -p update-ca-trust extract
     - runas: root
     - onchanges:
       - file: mgr_ca_cert

--- a/susemanager-utils/susemanager-sls/salt/certs/suse.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/suse.sls
@@ -17,7 +17,7 @@ mgr_split_ca:
 
 c_rehash:
   cmd.run:
-    - name: /usr/bin/c_rehash
+    - name: command -p c_rehash
     - runas: root
     - onchanges:
       - file: mgr_ca_cert
@@ -27,7 +27,7 @@ c_rehash:
 
 update-ca-certificates:
   cmd.run:
-    - name: /usr/sbin/update-ca-certificates
+    - name: command -p update-ca-certificates
     - runas: root
     - onchanges:
       - file: mgr_ca_cert

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -18,7 +18,7 @@ include:
 {%- set dnf_supports_params = is_dnf and salt['pkg.version_cmp'](is_dnf, "4.0.9") >= 0 %}
 
 {%- if is_dnf and not dnf_supports_params %}
-{%- set dnf_plugins = salt['cmd.run']("/usr/bin/find /usr/lib -type d -name dnf-plugins -printf '%T@ %p\n' | /usr/bin/sort -nr | /usr/bin/cut -d ' ' -s -f 2- | /usr/bin/head -n 1", python_shell=True) %}
+{%- set dnf_plugins = salt['cmd.run']("command -p find /usr/lib -type d -name dnf-plugins -printf '%T@ %p\n' | command -p sort -nr | command -p cut -d ' ' -s -f 2- | command -p head -n 1", python_shell=True) %}
 {%- if dnf_plugins %}
 mgrchannels_susemanagerplugin_dnf:
   file.managed:
@@ -44,7 +44,7 @@ mgrchannels_enable_dnf_plugins:
     - pattern: plugins=.*
     - repl: plugins=1
 {#- default is '1' when option is not specififed #}
-    - onlyif: /usr/bin/grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
+    - onlyif: command -p grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
 {%- endif %}
 
 {# this break the susemanagerplugin as it overwrite HTTP headers (bsc#1214601) #}
@@ -53,7 +53,7 @@ mgrchannels_disable_dnf_rhui_plugin:
     - name: /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
     - pattern: enabled=.*
     - repl: enabled=0
-    - onlyif: /usr/bin/grep -e 'enabled=1' -e 'enabled=True' -e 'enabled=yes' /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
+    - onlyif: command -p grep -e 'enabled=1' -e 'enabled=True' -e 'enabled=yes' /etc/yum/pluginconf.d/dnf_rhui_plugin.conf
 
 {%- endif %}
 
@@ -81,7 +81,7 @@ mgrchannels_enable_yum_plugins:
     - name: /etc/yum.conf
     - pattern: plugins=.*
     - repl: plugins=1
-    - onlyif: /usr/bin/grep plugins=0 /etc/yum.conf
+    - onlyif: command -p grep plugins=0 /etc/yum.conf
 
 {%- endif %}
 {%- endif %}
@@ -145,20 +145,20 @@ aptauth_conf:
 {%- if is_dnf %}
 mgrchannels_dnf_clean_all:
   cmd.run:
-    - name: /usr/bin/dnf clean all
+    - name: command -p dnf clean all
     - runas: root
     - onchanges:
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
-    -  unless: "/usr/bin/dnf repolist | /usr/bin/grep \"repolist: 0$\""
+    -  unless: "command -p dnf repolist | command -p grep \"repolist: 0$\""
 {%- endif %}
 {%- if is_yum %}
 mgrchannels_yum_clean_all:
   cmd.run:
-    - name: /usr/bin/yum clean all
+    - name: command -p yum clean all
     - runas: root
     - onchanges: 
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
-    -  unless: "/usr/bin/yum repolist | /usr/bin/grep \"repolist: 0$\""
+    -  unless: "command -p yum repolist | command -p grep \"repolist: 0$\""
 {%- endif %}
 {%- elif grains['os_family'] == 'Debian' %}
 install_gnupg_debian:

--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -60,7 +60,7 @@ mgr_remove_salt_master_key:
 {%- if salt['pillar.get']('contact_method') not in ['ssh-push', 'ssh-push-tunnel'] %}
 mgr_disable_salt:
   cmd.run:
-    - name: /usr/bin/systemctl disable {{ salt_minion_name }}
+    - name: command -p systemctl disable {{ salt_minion_name }}
     - require:
       - file: mgr_remove_salt_config
 
@@ -68,7 +68,7 @@ mgr_disable_salt:
 mgr_stop_salt:
   cmd.run:
     - bg: True
-    - name: /usr/bin/sleep 9 && /usr/bin/systemctl stop {{ salt_minion_name }}
+    - name: command -p sleep 9 && command -p systemctl stop {{ salt_minion_name }}
     - order: last
     - require:
       - file: mgr_remove_salt_config

--- a/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
+++ b/susemanager-utils/susemanager-sls/salt/cocoattest/requestdata.sls
@@ -18,41 +18,41 @@ mgr_inst_snpguest:
 
 mgr_write_request_data:
   cmd.run:
-    - name: /usr/bin/echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | /usr/bin/base64 -d > /tmp/cocoattest/request-data.txt
-    - onlyif: /usr/bin/test -x /usr/bin/base64
+    - name: command -p echo "{{ salt['pillar.get']('attestation_data:nonce') }}" | command -p base64 -d > /tmp/cocoattest/request-data.txt
+    - onlyif: command -p test -x command -p base64
     - require:
       - file: mgr_create_attestdir
 
 mgr_create_snpguest_report:
   cmd.run:
-    - name: /usr/bin/snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
+    - name: command -p snpguest report /tmp/cocoattest/report.bin /tmp/cocoattest/request-data.txt
     - require:
       - cmd: mgr_write_request_data
       - file: mgr_create_attestdir
 
 mgr_snpguest_report:
   cmd.run:
-    - name: /usr/bin/cat /tmp/cocoattest/report.bin | /usr/bin/base64
+    - name: command -p cat /tmp/cocoattest/report.bin | command -p base64
     - require:
       - cmd: mgr_create_snpguest_report
       - file: mgr_create_attestdir
 
 mgr_create_vlek_certificate:
   cmd.run:
-    - name: /usr/bin/snpguest certificates PEM /tmp/cocoattest
+    - name: command -p snpguest certificates PEM /tmp/cocoattest
     - require:
       - file: mgr_create_attestdir
 
 mgr_vlek_certificate:
   cmd.run:
-    - name: /usr/bin/cat /tmp/cocoattest/vlek.pem
+    - name: command -p cat /tmp/cocoattest/vlek.pem
     - require:
       - cmd: mgr_create_vlek_certificate
       - file: mgr_create_attestdir
 
 mgr_secureboot_enabled:
   cmd.run:
-    - name: /usr/bin/mokutil --sb-state
+    - name: command -p mokutil --sb-state
     - success_retcodes:
       - 255
       - 0

--- a/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
@@ -37,12 +37,12 @@ spmigration:
 
 spmigration:
   cmd.run:
-    - name: /usr/bin/cat {{ logname }}
-    - onlyif: /usr/bin/test -f /usr/bin/cat {{ logname }}
+    - name: command -p cat {{ logname }}
+    - onlyif: command -p test -f {{ logname }}
 
 spmigration_liberated:
   cmd.run:
-    - name: /usr/bin/cat /etc/sysconfig/liberated
+    - name: command -p cat /etc/sysconfig/liberated
     - require:
       - file: create_liberation_file
 

--- a/susemanager-utils/susemanager-sls/salt/distupgrade/sap.sls
+++ b/susemanager-utils/susemanager-sls/salt/distupgrade/sap.sls
@@ -3,24 +3,24 @@
 
 mgr_remove_release_package:
   cmd.run:
-    - name: "/usr/bin/rpm -e --nodeps sles-release"
+    - name: "command -p rpm -e --nodeps sles-release"
 
 mgr_remove_flavor_package_dvd:
   cmd.run:
-    - name: "/usr/bin/rpm -e --nodeps sles-release-DVD"
-    - onlyif: /usr/bin/rpm -q sles-release-DVD
+    - name: "command -p rpm -e --nodeps sles-release-DVD"
+    - onlyif: command -p rpm -q sles-release-DVD
 
 mgr_remove_flavor_package_pool:
   cmd.run:
-    - name: "/usr/bin/rpm -e --nodeps sles-release-POOL"
-    - onlyif: /usr/bin/rpm -q sles-release-POOL
+    - name: "command -p rpm -e --nodeps sles-release-POOL"
+    - onlyif: command -p rpm -q sles-release-POOL
 
 {% set default_modules = ['SLES_SAP', 'sle-module-basesystem', 'sle-module-desktop-applications', 'sle-module-server-applications', 'sle-ha', 'sle-module-sap-applications'] %}
 
 {% for module in default_modules %}
 mgr_install_product_{{ module }}:
   cmd.run:
-    - name: /usr/bin/zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product {{ module }}
+    - name: command -p zypper --no-refresh --non-interactive install --no-recommends --auto-agree-with-product-licenses -t product {{ module }}
     - require:
       - cmd: mgr_remove_release_package
       - cmd: mgr_remove_flavor_package_dvd

--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -154,7 +154,7 @@ dns_fqdns:
       - mgrcompat: sync_states
 {%- endif %}
     - onlyif:
-        command -p which host || command -p which nslookup
+        command -v host || command -v nslookup
 {% endif%}
 {% if 'network.fqdns' in salt %}
 fqdns:

--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -154,7 +154,7 @@ dns_fqdns:
       - mgrcompat: sync_states
 {%- endif %}
     - onlyif:
-        /usr/bin/which host || /usr/bin/which nslookup
+        command -p which host || command -p which nslookup
 {% endif%}
 {% if 'network.fqdns' in salt %}
 fqdns:
@@ -183,7 +183,7 @@ sap_workloads:
 
 uname:
   cmd.run:
-    - name: /usr/bin/uname -r -v
+    - name: command -p uname -r -v
 
 container_runtime:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -61,23 +61,23 @@ mgr_eib:
   file.directory:
     - name: {{ source_dir }}/root/oem
     - onlyif:
-      - test -f {{ source_dir }}/eib/eib.yaml
+      - command -p test -f {{ source_dir }}/eib/eib.yaml
   cmd.run:
     - names:
-      - podman run --rm --privileged -v {{ source_dir }}/eib:/eib:ro,Z {{ eib_image }} build --definition-file=eib.yaml
-      - xorriso -osirrox on -indev {{ source_dir }}/eib/combustion.iso extract / {{ source_dir }}/root/oem
+      - command -p podman run --rm --privileged -v {{ source_dir }}/eib:/eib:ro,Z {{ eib_image }} build --definition-file=eib.yaml
+      - command -p xorriso -osirrox on -indev {{ source_dir }}/eib/combustion.iso extract / {{ source_dir }}/root/oem
     - require:
       - file: mgr_eib
     - onlyif:
-      - test -f {{ source_dir }}/eib/eib.yaml
+      - command -p test -f {{ source_dir }}/eib/eib.yaml
 
 {# need ca-certificates for kiwi to trust CA #}
 {# need /dev for losetup error during create #}
 {% set kiwi_mount = ' -v '+ kiwi_dir + ':/var/lib/Kiwi:Z ' %}
 {% set kiwi_yml_mount = ' -v ' + source_dir + '/kiwi.yml:/etc/kiwi.yml:ro,Z ' %}
-{%- set kiwi = '/usr/bin/podman run --rm --privileged -v /var/lib/ca-certificates:/var/lib/ca-certificates:ro -v /dev:/dev '+ kiwi_mount + kiwi_yml_mount + kiwi_image + ' kiwi-ng' -%}
+{%- set kiwi = 'command -p podman run --rm --privileged -v /var/lib/ca-certificates:/var/lib/ca-certificates:ro -v /dev:/dev '+ kiwi_mount + kiwi_yml_mount + kiwi_image + ' kiwi-ng' -%}
 {%- elif kiwi_method == 'kiwi-ng' -%}
-{%- set kiwi = '/usr/bin/kiwi-ng' -%}
+{%- set kiwi = 'command -p kiwi-ng' -%}
 {%- endif -%} {# kiwi_method #}
 
 {%- if kiwi_method == 'podman' or kiwi_method == 'kiwi-ng' %}
@@ -126,7 +126,7 @@ mgr_buildimage_kiwi_bundle:
 
 # i586 build on x86_64 host must be called with linux32
 # let's consider the build i586 if there is no x86_64 repo specified
-{%- set kiwi = '/usr/bin/linux32 /usr/sbin/kiwi' if (pillar.get('kiwi_repositories')|join(' ')).find('x86_64') == -1 and grains.get('osarch') == 'x86_64' else '/usr/sbin/kiwi' %}
+{%- set kiwi = 'command -p linux32 command -p kiwi' if (pillar.get('kiwi_repositories')|join(' ')).find('x86_64') == -1 and grains.get('osarch') == 'x86_64' else 'command -p kiwi' %}
 
 # in SLES11 Kiwi the --add-repotype is required
 {%- macro kiwi_params() -%}

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-inspect.sls
@@ -20,6 +20,6 @@ mgr_inspect_kiwi_image:
 
 mgr_kiwi_cleanup:
   cmd.run:
-    - name: "/usr/bin/rm -rf '{{ root_dir }}'"
+    - name: "command -p rm -rf '{{ root_dir }}'"
     - require:
       - mgrcompat: mgr_inspect_kiwi_image

--- a/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/profileupdate.sls
@@ -32,7 +32,7 @@ mgr_container_remove:
     - args: [ "{{ container_name }}" ]
     - force: False
     - onlyif:
-      - /usr/bin/docker ps -a | /usr/bin/grep "{{ container_name }}" >/dev/null
+      - command -p docker ps -a | command -p grep "{{ container_name }}" >/dev/null
 
 mgr_image_remove:
   mgrcompat.module_run:
@@ -85,7 +85,7 @@ mgr_container_remove:
     - args: [ "{{ container_name }}" ]
     - force: False
     - onlyif:
-      - /usr/bin/docker ps -a | /usr/bin/grep "{{ container_name }}" >/dev/null
+      - command -p docker ps -a | command -p grep "{{ container_name }}" >/dev/null
 
 mgr_image_remove:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -55,7 +55,7 @@ reboot_required:
     - name: reboot_info.reboot_required
     {%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] < 8 %}
     - onlyif:
-      - which needs-restarting
+      - command -v needs-restarting
     {%- endif %}
 {%- endif %}
 

--- a/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/profileupdate.sls
@@ -24,8 +24,8 @@ modules:
 {% elif grains['os_family'] == 'Debian' %}
 debianrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/os-release
-    - onlyif: /usr/bin/test -f /etc/os-release
+    - name: command -p cat /etc/os-release
+    - onlyif: command -p test -f /etc/os-release
 {% endif %}
 
 include:

--- a/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
@@ -1,38 +1,38 @@
 {% if grains['os_family'] == 'RedHat' %}
 rhelrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/redhat-release
-    - onlyif: /usr/bin/test -f /etc/redhat-release -a ! -L /etc/redhat-release
+    - name: command -p cat /etc/redhat-release
+    - onlyif: command -p test -f /etc/redhat-release -a ! -L /etc/redhat-release
 alibabarelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/alinux-release
-    - onlyif: /usr/bin/test -f /etc/alinux-release
+    - name: command -p cat /etc/alinux-release
+    - onlyif: command -p test -f /etc/alinux-release
 centosrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/centos-release
-    - onlyif: /usr/bin/test -f /etc/centos-release
+    - name: command -p cat /etc/centos-release
+    - onlyif: command -p test -f /etc/centos-release
 oraclerelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/oracle-release
-    - onlyif: /usr/bin/test -f /etc/oracle-release
+    - name: command -p cat /etc/oracle-release
+    - onlyif: command -p test -f /etc/oracle-release
 amazonrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/system-release
-    - onlyif: /usr/bin/test -f /etc/system-release && /usr/bin/grep -qi Amazon /etc/system-release
+    - name: command -p cat /etc/system-release
+    - onlyif: command -p test -f /etc/system-release && command -p grep -qi Amazon /etc/system-release
 almarelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/almalinux-release
-    - onlyif: /usr/bin/test -f /etc/almalinux-release
+    - name: command -p cat /etc/almalinux-release
+    - onlyif: command -p test -f /etc/almalinux-release
 rockyrelease:
   cmd.run:
-    - name: /usr/bin/cat /etc/rocky-release
-    - onlyif: /usr/bin/test -f /etc/rocky-release
+    - name: command -p cat /etc/rocky-release
+    - onlyif: command -p test -f /etc/rocky-release
 respkgquery:
   cmd.run:
-    - name: /usr/bin/rpm -q --whatprovides 'sles_es-release-server'
-    - onlyif: /usr/bin/rpm -q --whatprovides 'sles_es-release-server'
+    - name: command -p rpm -q --whatprovides 'sles_es-release-server'
+    - onlyif: command -p rpm -q --whatprovides 'sles_es-release-server'
 sllpkgquery:
   cmd.run:
-    - name: /usr/bin/rpm -q --whatprovides 'sll-release'
-    - onlyif: /usr/bin/rpm -q --whatprovides 'sll-release'
+    - name: command -p rpm -q --whatprovides 'sll-release'
+    - onlyif: command -p rpm -q --whatprovides 'sll-release'
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/reboot.sls
+++ b/susemanager-utils/susemanager-sls/salt/reboot.sls
@@ -1,7 +1,3 @@
 mgr_reboot:
   cmd.run:
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
-    - name: /sbin/shutdown -r +5
-{%- else %}
-    - name: /usr/sbin/shutdown -r +5
-{% endif %}
+    - name: command -p shutdown -r +5

--- a/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
+++ b/susemanager-utils/susemanager-sls/salt/rebootifneeded.sls
@@ -1,25 +1,19 @@
 {%- if salt['pillar.get']('mgr_reboot_if_needed', True) and salt['pillar.get']('custom_info:mgr_reboot_if_needed', 'true')|lower in ('true', '1', 'yes', 't') %}
 mgr_reboot_if_needed:
   cmd.run:
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
-    - name: /sbin/shutdown -r +5
-{%- else %}
-    - name: /usr/sbin/shutdown -r +5
-{%- endif %}
-{%- if grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 8 %}
-    - onlyif: '/usr/bin/dnf -q needs-restarting -r; /usr/bin/test $? -eq 1'
-{%- elif grains['os_family'] == 'RedHat' and grains['osmajorrelease'] >= 7 %}
-    - onlyif: '/usr/bin/needs-restarting -r; /usr/bin/test $? -eq 1'
+    - name: command -p shutdown -r +5
+{%- if grains['os_family'] == 'RedHat' %}
+    - onlyif: 'command -p needs-restarting -r; [ $? -eq 1 ]'
 {%- elif grains['os_family'] == 'Debian' %}
     - onlyif:
-      - /usr/bin/test -e /var/run/reboot-required
+      - command -p test -e /var/run/reboot-required
 {%- elif grains.get('transactional', False) and grains['os_family'] == 'Suse' %}
     - onlyif:
-      - /usr/bin/snapper list --columns number 2>/dev/null | /usr/bin/grep '+'
+      - command -p snapper list --columns number 2>/dev/null | command -p grep '+'
 {%- elif grains['os_family'] == 'Suse' and grains['osmajorrelease'] <= 12 %}
     - onlyif:
-      - /usr/bin/test -e /boot/do_purge_kernels
+      - command -p test -e /boot/do_purge_kernels
 {%- else %}
-    - onlyif: '/usr/bin/zypper ps -s; [ $? -eq 102 ]'
+    - onlyif: 'command -p zypper ps -s; [ $? -eq 102 ]'
 {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
@@ -35,8 +35,8 @@ legacy_taskomatic_systemd_dropin_jmx_cleanup:
 
 mgr_enable_prometheus_self_monitoring:
   cmd.run:
-    - name: /usr/bin/grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && /usr/bin/sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 0/' /etc/rhn/rhn.conf || /usr/bin/echo 'prometheus_monitoring_enabled = 0' >> /etc/rhn/rhn.conf
+    - name: command -p grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && command -p sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 0/' /etc/rhn/rhn.conf || command -p echo 'prometheus_monitoring_enabled = 0' >> /etc/rhn/rhn.conf
 
 mgr_is_prometheus_self_monitoring_disabled:
   cmd.run:
-    - name: /usr/bin/grep -qF 'prometheus_monitoring_enabled = 0' /etc/rhn/rhn.conf
+    - name: command -p grep -qF 'prometheus_monitoring_enabled = 0' /etc/rhn/rhn.conf

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
@@ -1,6 +1,6 @@
 node_exporter:
   cmd.run:
-    - name: /usr/bin/rpm --query --info golang-github-prometheus-node_exporter
+    - name: command -p rpm --query --info golang-github-prometheus-node_exporter
 
 node_exporter_service:
   service.running:
@@ -17,7 +17,7 @@ node_exporter_service:
 {% if global.has_pillar_data %}
 postgres_exporter:
   cmd.run:
-    - name: /usr/bin/rpm --query --info prometheus-postgres_exporter || /usr/bin/rpm --query --info golang-github-wrouesnel-postgres_exporter
+    - name: command -p rpm --query --info prometheus-postgres_exporter || command -p rpm --query --info golang-github-wrouesnel-postgres_exporter
 
 postgres_exporter_cleanup:
   file.absent:
@@ -63,7 +63,7 @@ postgres_exporter_service:
 
 jmx_exporter:
   cmd.run:
-    - name: /usr/bin/rpm --query --info prometheus-jmx_exporter
+    - name: command -p rpm --query --info prometheus-jmx_exporter
 
 jmx_exporter_tomcat_yaml_config:
   file.managed:
@@ -146,8 +146,8 @@ legacy_taskomatic_systemd_dropin_jmx_cleanup:
 
 mgr_enable_prometheus_self_monitoring:
   cmd.run:
-    - name:  /usr/bin/grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && /usr/bin/sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 1/' /etc/rhn/rhn.conf || /usr/bin/echo 'prometheus_monitoring_enabled = 1' >> /etc/rhn/rhn.conf
+    - name:  command -p grep -q '^prometheus_monitoring_enabled.*=.*' /etc/rhn/rhn.conf && command -p sed -i 's/^prometheus_monitoring_enabled.*/prometheus_monitoring_enabled = 1/' /etc/rhn/rhn.conf || command -p echo 'prometheus_monitoring_enabled = 1' >> /etc/rhn/rhn.conf
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
-    - name: /usr/bin/grep -qF 'prometheus_monitoring_enabled = 1' /etc/rhn/rhn.conf
+    - name: command -p grep -qF 'prometheus_monitoring_enabled = 1' /etc/rhn/rhn.conf

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
@@ -47,7 +47,7 @@ jmx_taskomatic_java_config:
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
-    - name: /usr/bin/grep -q -E 'prometheus_monitoring_enabled\s*=\s*(1|y|true|yes|on)\s*$' /etc/rhn/rhn.conf
+    - name: command -p grep -q -E 'prometheus_monitoring_enabled\s*=\s*(1|y|true|yes|on)\s*$' /etc/rhn/rhn.conf
 
 include:
   - util.syncstates

--- a/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
@@ -37,7 +37,7 @@ proxy_ssh_identity:
 
 generate_own_ssh_key:
   cmd.run:
-    - name: /usr/bin/ssh-keygen -N '' -C 'susemanager-own-ssh-push' -f {{ home }}/.ssh/mgr_own_id -t rsa -q
+    - name: command -p ssh-keygen -N '' -C 'susemanager-own-ssh-push' -f {{ home }}/.ssh/mgr_own_id -t rsa -q
     - creates: {{ home }}/.ssh/mgr_own_id.pub
 
 ownership_own_ssh_key:

--- a/susemanager-utils/susemanager-sls/salt/uptodate.sls
+++ b/susemanager-utils/susemanager-sls/salt/uptodate.sls
@@ -4,17 +4,17 @@ include:
 {%- if grains['os_family'] == 'Suse' %}
 mgr_keep_system_up2date_updatestack:
   cmd.run:
-    - name: /usr/bin/zypper --non-interactive patch --updatestack-only
+    - name: command -p zypper --non-interactive patch --updatestack-only
     - success_retcodes:
       - 104
       - 103
       - 106
       - 0
-    - onlyif: '/usr/bin/zypper patch-check --updatestack-only; r=$?; /usr/bin/test $r -eq 100 || /usr/bin/test $r -eq 101'
+    - onlyif: 'command -p zypper patch-check --updatestack-only; r=$?; command -p test $r -eq 100 || command -p test $r -eq 101'
     - require:
       - sls: channels
 
-{% set patch_need_reboot = salt['cmd.retcode']('/usr/bin/zypper -x list-patches | /usr/bin/grep \'restart="true"\' > /dev/null', python_shell=True) %}
+{% set patch_need_reboot = salt['cmd.retcode']('command -p zypper -x list-patches | command -p grep \'restart="true"\' > /dev/null', python_shell=True) %}
 
 {% else %}
 

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_disable_fqdns_grain.sls
@@ -9,7 +9,7 @@ mgr_disable_fqdns_grains:
   file.append:
     - name: {{ susemanager_minion_config }}
     - text: "enable_fqdns_grains: False"
-    - unless: /usr/bin/grep 'enable_fqdns_grains:' {{ susemanager_minion_config }}
+    - unless: command -p grep 'enable_fqdns_grains:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_mine_config_clean_up.sls
@@ -10,7 +10,7 @@ mgr_disable_mine:
   file.managed:
     - name: {{ susemanager_minion_config }}
     - contents: "mine_enabled: False"
-    - unless: /usr/bin/grep 'mine_enabled:' {{ susemanager_minion_config }}
+    - unless: command -p grep 'mine_enabled:' {{ susemanager_minion_config }}
 
 mgr_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_rotate_saltssh_key.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_rotate_saltssh_key.sls
@@ -12,7 +12,7 @@ proxy_new_mgr_ssh_identity:
   ssh_auth.present:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/new_mgr_ssh_id.pub
-    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
+    - onlyif: command -p grep -q mgrsshtunnel /etc/passwd
 {% endif %}
 
 {% if salt['cp.list_master'](prefix='salt_ssh/disabled_mgr_ssh_id.pub') %}
@@ -33,12 +33,12 @@ proxy_old_mgr_ssh_identity:
   ssh_auth.absent:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/disabled_mgr_ssh_id.pub
-    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
+    - onlyif: command -p grep -q mgrsshtunnel /etc/passwd
 
 # to prevent to lock out yourself
 proxy_current_mgr_ssh_identity:
   ssh_auth.present:
     - user: mgrsshtunnel
     - source: salt://salt_ssh/mgr_ssh_id.pub
-    - onlyif: /usr/bin/grep -q mgrsshtunnel /etc/passwd
+    - onlyif: command -p grep -q mgrsshtunnel /etc/passwd
 {% endif %}

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_start_event_grains.sls
@@ -8,4 +8,4 @@ mgr_start_event_grains:
     - name: {{ susemanager_minion_config }}
     - text: |
         start_event_grains: [machine_id, saltboot_initrd, susemanager]
-    - unless: /usr/bin/grep 'start_event_grains:' {{ susemanager_minion_config }}
+    - unless: command -p grep 'start_event_grains:' {{ susemanager_minion_config }}

--- a/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/mgr_switch_to_venv_minion.sls
@@ -36,15 +36,15 @@ mgr_purge_non_venv_salt_packages:
 {%- if salt['pillar.get']('mgr_purge_non_venv_salt_files') %}
 mgr_purge_non_venv_salt_pki_dir:
   cmd.run:
-    - name: /usr/bin/rm -rf /etc/salt/minion* /etc/salt/pki/minion
+    - name: command -p rm -rf /etc/salt/minion* /etc/salt/pki/minion
     - onlyif:
-      - /usr/bin/test -d /etc/salt/pki/minion
+      - command -p test -d /etc/salt/pki/minion
 
 mgr_purge_non_venv_salt_conf_dir:
   file.absent:
     - name: /etc/salt
     - unless:
-      - /usr/bin/find /etc/salt -type f -print -quit | /usr/bin/grep -q .
+      - command -p find /etc/salt -type f -print -quit | command -p grep -q .
     - require:
       - cmd: mgr_purge_non_venv_salt_pki_dir
 {%- endif %}
@@ -68,11 +68,11 @@ mgr_copy_salt_minion_id:
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
-      - /usr/bin/test -f /etc/salt/minion_id
+      - command -p test -f /etc/salt/minion_id
 
 mgr_copy_salt_minion_configs:
   cmd.run:
-    - name: /usr/bin/cp -r /etc/salt/minion.d /etc/venv-salt-minion/
+    - name: command -p cp -r /etc/salt/minion.d /etc/venv-salt-minion/
     - require:
       - pkg: mgr_venv_salt_minion_pkg
 
@@ -85,15 +85,15 @@ mgr_copy_salt_minion_grains:
     - require:
       - pkg: mgr_venv_salt_minion_pkg
     - onlyif:
-      - /usr/bin/test -f /etc/salt/grains
+      - command -p test -f /etc/salt/grains
 
 mgr_copy_salt_minion_keys:
   cmd.run:
-    - name: /usr/bin/rm -f /etc/venv-salt-minion/pki/minion/minion*; /usr/bin/cp -r /etc/salt/pki/minion/minion* /etc/venv-salt-minion/pki/minion/
+    - name: command -p rm -f /etc/venv-salt-minion/pki/minion/minion*; command -p cp -r /etc/salt/pki/minion/minion* /etc/venv-salt-minion/pki/minion/
     - require:
       - cmd: mgr_copy_salt_minion_configs
     - onlyif:
-      - /usr/bin/test -f /etc/salt/pki/minion/minion.pem
+      - command -p test -f /etc/salt/pki/minion/minion.pem
 
 mgr_enable_venv_salt_minion:
   service.running:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.use-command-in-sls-files
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.agraul.use-command-in-sls-files
@@ -1,0 +1,2 @@
+- Use `command` to find and execute commands from Salt states
+  (bsc#1253780, bsc#1255634)


### PR DESCRIPTION
## What does this PR change?

Replace absolute paths to executables and `which` usages with the shell built-in `command`. `command -p` finds built-ins and external commands using a default PATH (`"/bin:/usr/bin:/sbin:/usr/sbin"`). `command -v` shows what it would execute, similar to using `which`.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
Using our internal states is for a large part covered by cucumber tests.
- No tests: already covered


- [x] **DONE**

## Links

Issue(s): #https://github.com/SUSE/spacewalk/issues/29075
Related PRs: https://github.com/uyuni-project/uyuni/pull/11300, https://github.com/uyuni-project/uyuni/pull/11315, https://github.com/uyuni-project/uyuni/pull/11355
Port(s): https://github.com/SUSE/spacewalk/pull/30279, https://github.com/SUSE/spacewalk/pull/30283

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
