### PR TITLE
MU-Fix return type for sync.content.listProducts (bsc#1256422)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/core/src/main/java/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014--2021 SUSE LLC
+ * Copyright (c) 2014--2026 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -541,7 +541,7 @@ public class ContentSyncManager {
 
                         return new MgrSyncProductDto(
                                 ext.getFriendlyName(), ext.getProductId(), ext.getId(), ext.getVersion(), isRecommended,
-                                baseChannel, extChildChannels, Collections.emptySet()
+                                baseChannel, extChildChannels, new HashSet<>()
                         );
                     }).collect(Collectors.toSet());
 

--- a/java/spacewalk-java.changes.rjpmestre.bsc1256422
+++ b/java/spacewalk-java.changes.rjpmestre.bsc1256422
@@ -1,0 +1,2 @@
+- Fix return type for sync/content/listProducts
+  (bsc#1256422)


### PR DESCRIPTION
## What does this PR change?

Using the api endpoint "sync.content.listProducts" will always throw 
`java.lang.reflect.InaccessibleObjectException: Unable to make private java.util.Collections$EmptySet() `

The return object includes a `Collections.emptySet` as a default. JSON serialization fails as it doesn't handle internal JDK classes like Collections.emptySet, Optional, etc.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29369
Port(s): https://github.com/SUSE/spacewalk/pull/29412

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
