### PR TITLE
SLE 15 SP6 LTSS is not alpha anymore

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 SUSE LLC
+# Copyright 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Synchronize products in the products page of the Setup Wizard
@@ -40,7 +40,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP3 x86_64"
     And I select "SUSE Linux Enterprise Server LTSS 15 SP3 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 15 SP3 x86_64" selected
-    And I open the sub-list of the product "Basesystem Module 15 SP3 x86_64"
+    When I open the sub-list of the product "Basesystem Module 15 SP3 x86_64"
     And I select "Desktop Applications Module 15 SP3 x86_64" as a product
     Then I should see the "Desktop Applications Module 15 SP3 x86_64" selected
     When I open the sub-list of the product "Desktop Applications Module 15 SP3 x86_64"
@@ -113,7 +113,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "Desktop Applications Module 15 SP5 x86_64"
     And I select "Development Tools Module 15 SP5 x86_64" as a product
     Then I should see the "Development Tools Module 15 SP5 x86_64" selected
-    And I select "SUSE Linux Enterprise Server LTSS 15 SP5 x86_64" as a product
+    When I select "SUSE Linux Enterprise Server LTSS 15 SP5 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 15 SP5 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
@@ -150,8 +150,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "Desktop Applications Module 15 SP6 x86_64"
     And I select "Development Tools Module 15 SP6 x86_64" as a product
     Then I should see the "Development Tools Module 15 SP6 x86_64" selected
-    And I select "SUSE Linux Enterprise Server LTSS 15 SP6 x86_64 (ALPHA)" as a product
-    Then I should see the "SUSE Linux Enterprise Server LTSS 15 SP6 x86_64 (ALPHA)" selected
+    When I select "SUSE Linux Enterprise Server LTSS 15 SP6 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server LTSS 15 SP6 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Server 15 SP6 x86_64" product has been added


### PR DESCRIPTION
## What does this PR change?

Build Validation: remove `(ALPHA)` when synching SLE 15 SP6 LTSS


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s): 
 * 4.3: https://github.com/SUSE/spacewalk/pull/29426
 * 5.0: https://github.com/SUSE/spacewalk/pull/29425
 * 5.1: https://github.com/SUSE/spacewalk/pull/29424

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
