### PR TITLE
Refactor wait reposync, update channel names and tunes timeout

### DIFF
--- a/testsuite/features/build_validation/add_MU_repositories/add_maintenance_update_repositories.template
+++ b/testsuite/features/build_validation/add_MU_repositories/add_maintenance_update_repositories.template
@@ -45,3 +45,7 @@ Feature: Add a Maintenance Update custom channel and the custom repositories for
   Scenario: Wait for running reposyncs to finish after adding custom channel for <client>
     When I wait until the channel "custom_channel_<client>" has been synced
     Then the "custom_channel_<client>" reposync logs should not report errors
+
+  Scenario: Verify that all synchronized channels have their dependencies solved
+    When I wait until all synchronized channels have solved their dependencies
+    Then all channels have been synced without errors

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -852,6 +852,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 # There are no channels for Retail under Uyuni
 
+  Scenario: Verify all channels are solved
+    When I wait until all synchronized channels have solved their dependencies
+    Then all channels have been synced without errors
 
   Scenario: Detect product loading issues from the UI in Build Validation
     Given I am authorized for the "Admin" section

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -79,6 +79,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I kill running spacewalk-repo-sync for "opensuse_tumbleweed-x86_64" channel
     And I use spacewalk-repo-sync to sync channel "opensuse_tumbleweed-x86_64" including only client tools dependencies
     And I use spacewalk-common-channel to add all "tumbleweed-client-tools-x86_64" channels with arch "x86_64"
+    When I wait until all synchronized channels for "tumbleweed" have finished
 
 @containerized_server
 @proxy
@@ -223,6 +224,11 @@ Feature: Synchronize products in the products page of the Setup Wizard
   Scenario: Installer update channels got enabled when products were added
     When I execute mgr-sync "list channels" with user "admin" and password "admin"
     And I should get "    [I] SLE15-SP7-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 SP7 x86_64 [sle15-sp7-installer-updates-x86_64]"
+
+@scc_credentials
+  Scenario: Verify all channels are solved
+    When I wait until all synchronized channels have solved their dependencies
+    Then all channels have been synced without errors
 
 @scc_credentials
 @skip_if_github_validation

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1333,7 +1333,6 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
     'tumbleweed' =>
       %w[
         opensuse_tumbleweed-x86_64
-        opensuse_tumbleweed-updates-x86_64
         opensuse_tumbleweed-uyuni-client-x86_64
         opensuse_tumbleweed-uyuni-client-devel-x86_64
       ],
@@ -1708,7 +1707,6 @@ TIMEOUT_BY_CHANNEL_NAME = {
 
 EMPTY_CHANNELS = %w[
   el9-pool-x86_64
-  rhel-x86_64-server-7
   suse-multi-linux-manager-proxy-sle-5.1-updates-x86_64-sp7
   suse-multi-linux-manager-proxy-sle-5.2-updates-x86_64-sp7
   suse-multi-linux-manager-retail-branch-server-sle-5.1-updates-x86_64-sp7


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->
## Context

Currently, the Reposync stage in Build Validation (BV) takes ~32 hours to complete, whereas manual synchronization takes less than 20 hours. This discrepancy is largely caused by repeated timeouts and process inefficiencies.

### Key Issues Identified:

 - **Inaccurate Constants**: constant.rb contained non-existent channels, causing the system to wait for data that would never arrive.
 - **Inflated Timeouts**: Some channels had 90-minute timeouts for tasks that take only 15 minutes.
 - **Command Failures**: The dumpsolv command fails on channels with high package counts (e.g., RES7, Liberty 9).
 - **Process Bottlenecks**: Heavy repodata building was bundled with package downloads, slowing down the feedback loop.


## What does this PR change?

### 1. Configuration & Data Cleanup

- **Channel Accuracy**: Updated channel names, added missing channels, and moved channels to their correct product categories.
- **OS Updates**: Switched CentOS 7 from RES7 to RES7 LTSS.
- **Timeout Tuning**: Adjusted channel timeouts to reflect actual sync durations more accurately (still very conservative).

### 2. Performance & Logic Improvements

 - **Dumpsolv Optimization**: Fixed an issue where dumpresolv failed on large channels. It now uses a temporary file to handle high package volumes and improve processing speed.
 - **Decoupled Sync Logic**: Modified the reposync check to split the package download phase from the repodata creation phase.
 - **Contextual Tracking**: When adding a new product, the scenario now only verifies the download part. It then stores the new channel and the remaining timeout into two context variables (channels_to_sync and channels_timeout).
 - **Asynchronous Repodata Check**: Added a new dedicated scenario that waits for repodata creation only after all products have been added and packages downloaded.


### 3. Reliability Fixes

 - **Log Searching**: Improved the method for parsing reposync.log to ensure more reliable status detection.
 - **Error Handling**: Refactored the synchronization loop to safely remove failed channels from the context, preventing "stuck" states during $build_validation.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29286
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/29320
 - 4.3: https://github.com/SUSE/spacewalk/pull/29354
 - 5.0: https://github.com/SUSE/spacewalk/pull/29321

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
