### PR TITLE
Use 5.2 proxy

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -695,19 +695,19 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until all synchronized channels for "uyuni-proxy" have finished
 
 @susemanager
-@run_if_proxy_transactional_or_slmicro61_minion
-  Scenario: Add SUSE Linux Micro 6.1
+@run_if_proxy_transactional_or_slmicro62_minion
+  Scenario: Add SUSE Linux Micro 6.2
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Micro 6.1" as the filtered product description
-    And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
+    And I enter "SUSE Linux Micro 6.2" as the filtered product description
+    And I select "SUSE Linux Micro 6.2 x86_64" as a product
+    Then I should see the "SUSE Linux Micro 6.2 x86_64" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Linux Micro 6.1 x86_64" product has been added
-    And I wait until all synchronized channels for "sl-micro-6.1" have finished
+    And I wait until I see "SUSE Linux Micro 6.2 x86_64" product has been added
+    And I wait until all synchronized channels for "sl-micro-6.2" have finished
 
 @susemanager
 @run_if_proxy_not_transactional_or_sles15sp7_minion
@@ -746,20 +746,20 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @susemanager
 @proxy
 @transactional_server
-  Scenario: Add SUSE Manager Proxy Extension 5.1 on top of SUSE Linux Enterprise Micro 6.1
+  Scenario: Add SUSE Manager Proxy Extension 5.2 on top of SUSE Linux Enterprise Micro 6.2
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Proxy Extension 5.1" as the filtered product description
-    Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
-    When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
+    And I enter "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" as the filtered product description
+    Then I should see the "SUSE Linux Micro 6.2 x86_64" selected
+    When I open the sub-list of the product "SUSE Linux Micro 6.2 x86_64"
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52" have finished
 
 @uyuni
 @proxy
@@ -790,20 +790,20 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @susemanager
 @proxy
 @transactional_server
-  Scenario: Add SUSE Manager Retail Branch Server Extension 5.1 on top of SUSE Linux Enterprise Micro 6.1
+  Scenario: Add SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 on top of SUSE Linux Enterprise Micro 6.2
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1" as the filtered product description
-    Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
-    When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
+    And I enter "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2" as the filtered product description
+    Then I should see the "SUSE Linux Micro 6.2 x86_64" selected
+    When I open the sub-list of the product "SUSE Linux Micro 6.2 x86_64"
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (ALPHA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (ALPHA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-51" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-52" have finished
 
 @susemanager
 @proxy

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2022-2025 SUSE LLC
+# Copyright (c) 2022-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Update activation keys
@@ -124,9 +124,9 @@ Feature: Update activation keys
     And I select the parent channel for the "proxy_container" from "selectedBaseChannel"
     And I wait for child channels to appear
     And I include the recommended child channels
-    And I wait until "ManagerTools-SL-Micro-6.1 for x86_64" has been checked
-    And I check "SUSE-Multi-Linux-Manager-Proxy-5.1 for x86_64"
-    And I check "SUSE-Multi-Linux-Manager-Retail-Branch-Server-5.1 for x86_64"
+    And I wait until "Multi-Linux-ManagerTools-SLE-16 for x86_64 6.2" has been checked
+    And I check "SUSE-Multi-Linux-Manager-Proxy-5.2 for x86_64"
+    And I check "SUSE-Multi-Linux-Manager-Retail-Branch-Server-5.2 for x86_64"
     And I click on "Update Activation Key"
     Then I should see a "Activation key Proxy Key x86_64 has been modified" text
 

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2025 SUSE LLC
+# Copyright (c) 2017-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Synchronize products in the products page of the Setup Wizard
@@ -118,20 +118,21 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @proxy
 @susemanager
 @transactional_server
-  Scenario: Add SL Micro 6.1 as base OS for proxy
+  Scenario: Add SL Micro 6.2 as base OS for proxy
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Micro 6.1" as the filtered product description
-    And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    Then I should see the "SUSE Linux Micro 6.1 x86_64" selected
-    When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I open the sub-list of the product "SUSE Multi-Linux Manager Client Tools for SL Micro 6 x86_64" if present
+    And I enter "SUSE Linux Micro 6.2" as the filtered product description
+    And I select "SUSE Linux Micro 6.2 x86_64" as a product
+    Then I should see the "SUSE Linux Micro 6.2 x86_64" selected
+    When I open the sub-list of the product "SUSE Linux Micro 6.2 x86_64"
+    And I select "SUSE Multi-Linux Manager Client Tools for SLE 16 x86_64" as a product
+    And I should see "SUSE Multi-Linux Manager Client Tools for SLE 16 x86_64" selected
     And I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Linux Micro 6.1 x86_64" product has been added
-    And I wait until all synchronized channels for "sl-micro-6.1" have finished
+    And I wait until I see "SUSE Linux Micro 6.2 x86_64" product has been added
+    And I wait until all synchronized channels for "sl-micro-6.2" have finished
 
 @proxy
 @susemanager
@@ -142,30 +143,30 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
     And I enter "SUSE Linux Enterprise Server 15 SP7" as the filtered product description
-    And I select "SUSE Linux Enterprise Server 15 SP7 (BETA)" as a product
-    Then I should see the "SUSE Linux Enterprise Server 15 SP7 (BETA)" selected
+    And I select "SUSE Linux Enterprise Server 15 SP7" as a product
+    Then I should see the "SUSE Linux Enterprise Server 15 SP7" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Linux Enterprise Server 15 SP7 (BETA)" product has been added
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP7" product has been added
     And I wait until all synchronized channels for "sles15-sp7" have finished
 
 @proxy
 @susemanager
 @transactional_server
-  Scenario: Add SUSE MLM Proxy Extension 5.1 with SL Micro 6.1 as base OS
+  Scenario: Add SUSE MLM Proxy Extension 5.2 with SL Micro 6.2 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Micro 6.1" as the filtered product description
-    When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    And I select "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" selected
+    And I enter "SUSE Linux Micro 6.2" as the filtered product description
+    When I open the sub-list of the product "SUSE Linux Micro 6.2 x86_64"
+    And I select "SUSE Linux Micro 6.2 x86_64" as a product
+    And I select "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.1 x86_64" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-51" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Proxy Extension 5.2 x86_64 (ALPHA)" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-proxy-52" have finished
 
 @proxy
 @susemanager
@@ -187,20 +188,20 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @proxy
 @susemanager
 @transactional_server
-  Scenario: Add SUSE MLM Retail Branch Server Extension 5.1 with SL Micro 6.1 as base OS
+  Scenario: Add SUSE MLM Retail Branch Server Extension 5.2 with SL Micro 6.2 as base OS
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "currently running" text
     And I wait until I do not see "Loading" text
-    And I enter "SUSE Linux Micro 6.1" as the filtered product description
-    When I open the sub-list of the product "SUSE Linux Micro 6.1 x86_64"
-    And I select "SUSE Linux Micro 6.1 x86_64" as a product
-    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" as a product
-    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" selected
+    And I enter "SUSE Linux Micro 6.2" as the filtered product description
+    When I open the sub-list of the product "SUSE Linux Micro 6.2 x86_64"
+    And I select "SUSE Linux Micro 6.2 x86_64" as a product
+    And I select "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (ALPHA)" as a product
+    Then I should see the "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (ALPHA)" selected
     When I click the Add Product button
     And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
-    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.1 x86_64" product has been added
-    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-51" have finished
+    And I wait until I see "SUSE Multi-Linux Manager Retail Branch Server Extension 5.2 x86_64 (ALPHA)" product has been added
+    And I wait until all synchronized channels for "suse-multi-linux-manager-retail-branch-server-52" have finished
 
 @proxy
 @susemanager

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2025 SUSE LLC
+# Copyright (c) 2015-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning the API.
@@ -359,7 +359,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   # Get the list of child channels for this base channel
   child_channels = $api_test.channel.software.list_child_channels(base_channel_label)
 
-  # filter out wrong child channels for SLE Micro 5.5 as normal Minion
+  # filter out wrong child channels for SLE Micro 5.5 as normal minion
   if client.include? 'slemicro55'
     child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-pool-x86_64' }
     child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-updates-x86_64' }
@@ -367,7 +367,7 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
     child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-updates-x86_64' }
   end
 
-  # filter out wrong child channels for SLES15sp6 as normal Minion
+  # filter out wrong child channels for SLES 15 SP6 as normal minion
   if client.include? 'sle15sp6'
     child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-pool-x86_64-sp6' }
     child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-updates-x86_64-sp6' }
@@ -375,14 +375,21 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
     child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-updates-x86_64-sp6' }
   end
 
-  # filter out wrong child channels for SL Micro 6.1 as normal Minion
+  # filter out wrong child channels for SL Micro 6.1 as normal minion
   if client.include? 'slmicro61'
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-5.1-x86_64' }
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-5.1-x86_64' }
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-server-5.1-x86_64' }
   end
 
-  # filter out wrong child channels for SLES15SP7 as normal Minion
+  # filter out wrong child channels for SL Micro 6.2 as normal Minion
+  if client.include? 'slmicro62'
+    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-5.2-x86_64' }
+    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-5.2-x86_64' }
+    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-server-5.2-x86_64' }
+  end
+
+  # filter out wrong child channels for SLES 15 SP7 as normal minion
   if client.include? 'sle15sp7'
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-sle-5.1-pool-x86_64-sp7' }
     child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-sle-5.1-updates-x86_64-sp7' }

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -38,6 +38,8 @@ ENV_VAR_BY_HOST = {
   'slmicro60_ssh_minion' => 'SLMICRO60_SSHMINION',
   'slmicro61_minion' => 'SLMICRO61_MINION',
   'slmicro61_ssh_minion' => 'SLMICRO61_SSHMINION',
+  'slmicro62_minion' => 'SLMICRO62_MINION',
+  'slmicro62_ssh_minion' => 'SLMICRO62_SSHMINION',
   'alma8_minion' => 'ALMA8_MINION',
   'alma8_ssh_minion' => 'ALMA8_SSHMINION',
   'alma9_minion' => 'ALMA9_MINION',
@@ -180,6 +182,8 @@ PACKAGE_BY_CLIENT = {
   'slmicro60_ssh_minion' => 'dejavu',
   'slmicro61_minion' => 'dejavu',
   'slmicro61_ssh_minion' => 'dejavu',
+  'slmicro62_minion' => 'dejavu',
+  'slmicro62_ssh_minion' => 'dejavu',
   'alma8_minion' => 'autoconf',
   'alma8_ssh_minion' => 'autoconf',
   'alma9_minion' => 'autoconf',
@@ -218,8 +222,8 @@ PACKAGE_BY_CLIENT = {
 # Then take a look at the Parent Channel selections
 BASE_CHANNEL_BY_CLIENT = {
   'SUSE Manager' => {
-    'proxy' => 'SL-Micro-6.1-Pool for x86_64',
-    'proxy_container' => 'SL-Micro-6.1-Pool for x86_64',
+    'proxy' => 'SL-Micro-6.2-Pool for x86_64',
+    'proxy_container' => 'SL-Micro-6.2-Pool for x86_64',
     'proxy_nontransactional' => 'SLE-Product-SLES15-SP7-Pool for x86_64',
     'sle_minion' => 'SLE-Product-SLES15-SP7-Pool for x86_64',
     'ssh_minion' => 'SLE-Product-SLES15-SP7-Pool for x86_64',
@@ -256,6 +260,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'slmicro60_ssh_minion' => 'SL-Micro-6.0-Pool for x86_64',
     'slmicro61_minion' => 'SL-Micro-6.1-Pool for x86_64',
     'slmicro61_ssh_minion' => 'SL-Micro-6.1-Pool for x86_64',
+    'slmicro62_minion' => 'SL-Micro-6.2-Pool for x86_64',
+    'slmicro62_ssh_minion' => 'SL-Micro-6.2-Pool for x86_64',
     'alma8_minion' => 'almalinux8 for x86_64',
     'alma8_ssh_minion' => 'almalinux8 for x86_64',
     'alma9_minion' => 'almalinux9 for x86_64',
@@ -325,6 +331,8 @@ BASE_CHANNEL_BY_CLIENT = {
     'slmicro60_ssh_minion' => 'SL-Micro-6.0-Pool for x86_64',
     'slmicro61_minion' => 'SL-Micro-6.1-Pool for x86_64',
     'slmicro61_ssh_minion' => 'SL-Micro-6.1-Pool for x86_64',
+    'slmicro62_minion' => 'SL-Micro-6.2-Pool for x86_64',
+    'slmicro62_ssh_minion' => 'SL-Micro-6.2-Pool for x86_64',
     'alma8_minion' => 'AlmaLinux 8 (x86_64)',
     'alma8_ssh_minion' => 'AlmaLinux 8 (x86_64)',
     'alma9_minion' => 'AlmaLinux 9 (x86_64)',
@@ -385,6 +393,7 @@ LABEL_BY_BASE_CHANNEL = {
     'SLE-Micro-5.5-Pool for x86_64' => 'sle-micro-5.5-pool-x86_64',
     'SL-Micro-6.0-Pool for x86_64' => 'sl-micro-6.0-pool-x86_64',
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
+    'SL-Micro-6.2-Pool for x86_64' => 'sl-micro-6.2-pool-x86_64',
     'almalinux8 for x86_64' => 'almalinux8-x86_64',
     'almalinux9 for x86_64' => 'almalinux9-x86_64',
     'amazonlinux2023 for x86_64' => 'amazonlinux2023-x86_64',
@@ -417,6 +426,7 @@ LABEL_BY_BASE_CHANNEL = {
     'SLE-Micro-5.5-Pool for x86_64' => 'sle-micro-5.5-pool-x86_64',
     'SL-Micro-6.0-Pool for x86_64' => 'sl-micro-6.0-pool-x86_64',
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
+    'SL-Micro-6.2-Pool for x86_64' => 'sl-micro-6.2-pool-x86_64',
     'AlmaLinux 8 (x86_64)' => 'almalinux8-x86_64',
     'AlmaLinux 9 (x86_64)' => 'almalinux9-x86_64',
     'Amazon Linux 2023 x86_64' => 'amazonlinux2023-x86_64',
@@ -453,6 +463,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SLE-Micro-5.5-Pool for x86_64' => 'SLE-MICRO-5.5-x86_64',
     'SL-Micro-6.0-Pool for x86_64' => 'SL-MICRO-6.0-x86_64',
     'SL-Micro-6.1-Pool for x86_64' => 'SL-MICRO-6.1-x86_64',
+    'SL-Micro-6.2-Pool for x86_64' => 'SL-MICRO-6.2-x86_64',
     'almalinux8 for x86_64' => 'almalinux-8-x86_64',
     'almalinux9 for x86_64' => 'almalinux-9-x86_64',
     'amazonlinux2023 for x86_64' => 'amazonlinux-2023-x86_64',
@@ -485,6 +496,7 @@ CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SLE-Micro-5.5-Pool for x86_64' => 'SLE-MICRO-5.5-x86_64',
     'SL-Micro-6.0-Pool for x86_64' => 'SL-MICRO-6.0-x86_64',
     'SL-Micro-6.1-Pool for x86_64' => 'SL-MICRO-6.1-x86_64',
+    'SL-Micro-6.2-Pool for x86_64' => 'SL-MICRO-6.2-x86_64',
     'AlmaLinux 8 (x86_64)' => 'almalinux-8-x86_64-uyuni',
     'AlmaLinux 9 (x86_64)' => 'almalinux-9-x86_64-uyuni',
     'Amazon Linux 2023 x86_64' => 'amazonlinux-2023-x86_64-uyuni',
@@ -522,6 +534,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SLE-Micro-5.5-Pool for x86_64' => 'sle-micro-5.5-pool-x86_64',
     'SL-Micro-6.0-Pool for x86_64' => 'sl-micro-6.0-pool-x86_64',
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
+    'SL-Micro-6.2-Pool for x86_64' => 'sl-micro-6.2-pool-x86_64',
     'almalinux8 for x86_64' => nil,
     'almalinux9 for x86_64' => nil,
     'amazonlinux2023 for x86_64' => nil,
@@ -554,6 +567,7 @@ PARENT_CHANNEL_LABEL_TO_SYNC_BY_BASE_CHANNEL = {
     'SLE-Micro-5.5-Pool for x86_64' => 'sle-micro-5.5-pool-x86_64',
     'SL-Micro-6.0-Pool for x86_64' => 'sl-micro-6.0-pool-x86_64',
     'SL-Micro-6.1-Pool for x86_64' => 'sl-micro-6.1-pool-x86_64',
+    'SL-Micro-6.2-Pool for x86_64' => 'sl-micro-6.2-pool-x86_64',
     'AlmaLinux 8 (x86_64)' => nil,
     'AlmaLinux 9 (x86_64)' => nil,
     'Amazon Linux 2023 x86_64' => nil,
@@ -601,6 +615,8 @@ PKGARCH_BY_CLIENT = {
   'slmicro60_ssh_minion' => 'x86_64',
   'slmicro61_minion' => 'x86_64',
   'slmicro61_ssh_minion' => 'x86_64',
+  'slmicro62_minion' => 'x86_64',
+  'slmicro62_ssh_minion' => 'x86_64',
   'alma8_minion' => 'x86_64',
   'alma8_ssh_minion' => 'x86_64',
   'alma9_minion' => 'x86_64',
@@ -940,6 +956,11 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
       %w[
         sl-micro-6.1-pool-x86_64
         managertools-sl-micro-6.1-x86_64
+      ],
+    'sl-micro-6.2' =>
+      %w[
+        sl-micro-6.2-pool-x86_64
+        multi-linux-managertools-sle-16-x86_64-6.2
       ],
     'ubuntu-2204' =>
       %w[
@@ -1309,6 +1330,11 @@ CHANNEL_TO_SYNC_BY_OS_PRODUCT_VERSION = {
         sl-micro-6.1-pool-x86_64
         sl-micro-6.1-devel-uyuni-client-x86_64
       ],
+    'sl-micro-6.2' =>
+      %w[
+        sl-micro-6.2-pool-x86_64
+        sl-micro-6.2-devel-uyuni-client-x86_64
+      ],
     'tumbleweed' =>
       %w[
         opensuse_tumbleweed-x86_64
@@ -1632,6 +1658,9 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'sl-micro-6.1-devel-uyuni-client-x86_64' => 120,
   'sl-micro-6.1-pool-x86_64' => 300,
   'managertools-sl-micro-6.1-x86_64' => 60,
+  'sl-micro-6.2-devel-uyuni-client-x86_64' => 120,
+  'sl-micro-6.2-pool-x86_64' => 300,
+  'multi-linux-managertools-sle-16-x86_64-6.2' => 60,
   'suse-manager-proxy-5.0-pool-x86_64' => 60,
   'suse-manager-proxy-5.0-pool-x86_64-sp6' => 60,
   'suse-manager-proxy-5.0-updates-x86_64' => 60,
@@ -1641,13 +1670,13 @@ TIMEOUT_BY_CHANNEL_NAME = {
   'suse-manager-retail-branch-server-5.0-updates-x86_64' => 60,
   'suse-manager-retail-branch-server-5.0-updates-x86_64-sp6' => 60,
   'suse-multi-linux-manager-proxy-5.1-x86_64' => 60, # for slmicro6.1
-  'suse-multi-linux-manager-proxy-5.2-x86_64' => 60, # for slmicro6.1
+  'suse-multi-linux-manager-proxy-5.2-x86_64' => 60, # for slmicro6.2
   'suse-multi-linux-manager-proxy-sle-5.1-pool-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-proxy-sle-5.1-updates-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-proxy-sle-5.2-pool-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-proxy-sle-5.2-updates-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-retail-branch-server-5.1-x86_64' => 60, # for slmicro6.1
-  'suse-multi-linux-manager-retail-branch-server-5.2-x86_64' => 60, # for slmicro6.1
+  'suse-multi-linux-manager-retail-branch-server-5.2-x86_64' => 60, # for slmicro6.2
   'suse-multi-linux-manager-retail-branch-server-sle-5.1-pool-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-retail-branch-server-sle-5.1-updates-x86_64-sp7' => 60, # for sles15sp7
   'suse-multi-linux-manager-retail-branch-server-sle-5.2-pool-x86_64-sp7' => 60, # for sles15sp7

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -308,8 +308,8 @@ Before('@proxy') do
   skip_this_scenario unless ENV.key? ENV_VAR_BY_HOST['proxy']
 end
 
-Before('@run_if_proxy_transactional_or_slmicro61_minion') do
-  skip_this_scenario unless suse_proxy_transactional? || ENV.key?(ENV_VAR_BY_HOST['slmicro61_minion'])
+Before('@run_if_proxy_transactional_or_slmicro62_minion') do
+  skip_this_scenario unless suse_proxy_transactional? || ENV.key?(ENV_VAR_BY_HOST['slmicro62_minion'])
 end
 
 Before('@run_if_proxy_not_transactional_or_sles15sp7_minion') do


### PR DESCRIPTION
## What does this PR change?

Use 5.2 proxy now that the product exists in SCC.
Base for 5.2 proxy is now SL micro 6.2.
It can also be SLES 15 SP7, but this will be done in a separate PR, after SCC fixed the issues with that combination.

To be merged at same time as https://github.com/SUSE/susemanager-ci/pull/1922 .

Piggyback: SLES 15 SP7 is not beta anymore.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were modified.

- [x] **DONE**


## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28063
No ports, 5.2 (head) only.

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
