### PR TITLE
Add --metadata-only support to mgr-sync

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
+++ b/java/core/src/main/java/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
@@ -102,6 +102,12 @@ public class RepoSyncTask extends RhnJavaJob {
             if (csf.isNoStrict()) {
                 params.add("--no-strict");
             }
+            // Check for ad-hoc 'metadata_only' override from the schedule
+            boolean metadataOnly = jobDataMap.containsKey("metadata_only") &&
+                    Boolean.parseBoolean(jobDataMap.get("metadata_only").toString());
+            if (metadataOnly) {
+                params.add("--metadata-only");
+            }
 
             log.info("Syncing repos for channel: {}", channel.getName());
 

--- a/java/spacewalk-java.changes.srbarrios.mgr-sync-metadata-only
+++ b/java/spacewalk-java.changes.srbarrios.mgr-sync-metadata-only
@@ -1,0 +1,1 @@
+- Add --metadata-only support to spacewalk-repo-sync through taskomatic

--- a/python/spacewalk/satellite_tools/spacewalk-repo-sync
+++ b/python/spacewalk/satellite_tools/spacewalk-repo-sync
@@ -211,6 +211,14 @@ def main():
     )
     parser.add_option(
         "",
+        "--metadata-only",
+        action="store_true",
+        dest="metadata_only",
+        default=False,
+        help="Do not download packages, only sync metadata",
+    )
+    parser.add_option(
+        "",
         "--sync-kickstart",
         action="store_true",
         dest="sync_kickstart",
@@ -277,7 +285,7 @@ def main():
     # pylint: disable-next=consider-using-f-string
     log2disk(0, "Command: %s" % str(sys.argv))
 
-    l_params = ["no_errata", "sync_kickstart", "fail", "no-strict"]
+    l_params = ["no_errata", "sync_kickstart", "fail", "no-strict", "metadata_only"]
     d_chan_repo = reposync.getChannelRepo()
     l_ch_custom = reposync.getCustomChannels()
     d_parent_child = reposync.getParentsChilds()
@@ -407,7 +415,7 @@ def main():
             # pylint: disable-next=consider-using-f-string
             "Please check 'reposync/%s.log' for sync log of this channel." % ch,
             notimeYN=True,
-        )
+            )
         sync = reposync.RepoSync(
             channel_label=ch,
             repo_type=options.repo_type,
@@ -424,6 +432,7 @@ def main():
             log_level=log_level,
             force_all_errata=options.force_all_errata,
             show_packages_only=options.show_packages,
+            metadata_only=options.metadata_only,
         )
         if options.batch_size:
             sync.set_import_batch_size(options.batch_size)

--- a/python/spacewalk/spacewalk-backend.changes.srbarrios.mgr-sync-metadata-only
+++ b/python/spacewalk/spacewalk-backend.changes.srbarrios.mgr-sync-metadata-only
@@ -1,0 +1,1 @@
+- Add --metadata-only support to spacewalk-repo-sync

--- a/susemanager/src/mgr_sync/cli.py
+++ b/susemanager/src/mgr_sync/cli.py
@@ -130,6 +130,13 @@ def _create_add_subparser(subparsers):
         default=False,
         help="do not syncronize product channels automatically after adding",
     )
+    add_parser.add_argument(
+        "--metadata-only",
+        action="store_true",
+        dest="metadata_only",
+        default=False,
+        help="do not import any package",
+    )
 
 
 def _create_list_subparser(subparsers):

--- a/susemanager/susemanager.changes.srbarrios.mgr-sync-metadata-only
+++ b/susemanager/susemanager.changes.srbarrios.mgr-sync-metadata-only
@@ -1,0 +1,1 @@
+- Add --metadata-only support to mgr-sync


### PR DESCRIPTION
## What does this PR change?

This PR introduces the ability to perform a metadata-only repository synchronization when adding products or channels via the `mgr-sync` CLI. This is particularly useful for environments where we want to bootstrap and onboard systems without waiting to fully download all RPMs.

This feature is intended to work in conjunction with partial synchronizations where we filter only the required packages to prepare a bootstrap repository. For that purpose, one would typically use a command like: `spacewalk-repo-sync -c <channel_name> --include dmidecode --include libunwind ...`.

### Difference between `--no-sync` and `--metadata-only`

**`--no-sync`**

* **Function**: Prevents any repository synchronization from being scheduled automatically after the channel is added.
* **Behavior**: The channel is added to your organization, but it remains empty. No background task is sent to Taskomatic. The channel status remains "Not Installed" (or shows "Sync Failed" in the WebUI if previously attempted), and it does not generate valid repository metadata usable for onboarding systems.

**`--metadata-only`**

* **Function**: Schedules a synchronization immediately but instructs the backend to download **only the metadata**, skipping the actual RPM package binaries.
* **Behavior**: The channel is added, and a sync task is scheduled with the `metadata_only=True` parameter. The server imports all package information into the database (allowing for dependency resolution, searching, and a "Green/Installed" status in the WebUI), but the package files are not stored on the disk. This results in valid repository metadata that can be used to bootstrap/onboard a system.

### Key Changes

#### 1. Backend: Taskomatic Support (`RepoSyncTask.java`)

Modified `RepoSyncTask` to recognize a new ad-hoc parameter `metadata_only` from the Job Data Map.

* If `metadata_only` is true, Taskomatic appends the `--metadata-only` flag when invoking the underlying `spacewalk-repo-sync` Python script.
* Retained legacy support for `no_packages`.

#### 2. Backend Script: Argument Parsing (`spacewalk-repo-sync`)

Updated the executable script `/usr/bin/spacewalk-repo-sync` to parse the new `--metadata-only` CLI argument and pass it correctly to the `RepoSync` class constructor.

#### 3. CLI: New Argument (`cli.py`)

Added a new global argument to the `add` subparser:

* `--metadata-only`: A boolean flag that prevents the automatic download of RPM packages while still syncing metadata and populating the database.

#### 4. Logic: Taskomatic Integration (`mgr_sync.py`)

Since the standard XML-RPC API `channel.software.syncRepo` does not support custom flags like `metadata_only`, the synchronization logic was updated to:

* Bypass the standard API when `--metadata-only` is toggled.
* Communicate directly with the **Taskomatic XML-RPC API** (`tasko.scheduleSingleBunchRun`).
* **Robust Channel ID Lookup**: Tries to resolve channel labels to IDs using the local cache first. If the channel was just added and is missing from the cache, it performs a direct API lookup (`channel.software.getDetails`) to ensure the task can be scheduled immediately without errors.

#### 5. Testing (`test_channel_operations.py`)

Added a new test case `test_add_channel_metadata_only` to verify:

* Correct parsing of the new CLI flag.
* Proper resolution of channel IDs.
* Verification that the internal Taskomatic API is called with the expected payload (`metadata_only: True`) while the standard `syncRepo` call is suppressed.

### How to Test

1. Run `mgr-sync add channel <label> --metadata-only`.
2. Verify in `rhn_taskomatic_daemon.log` that `spacewalk-repo-sync` is executed with the `--metadata-only` argument.
3. Check the **WebUI Product Wizard**: The channel should show as **Installed** (Green) because the package data has been imported into the database (unlike `--no-packages` which leaves it empty/red).
4. Check the filesystem: Verify that RPMs were not downloaded to `/var/spacewalk/rhn/kickstart/...` or the corresponding repository cache.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Unit tests were added

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
