### PR TITLE
Revert cucumber to previous version

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 
 gem 'bcrypt_pbkdf', '~> 1.1'
 gem 'capybara', '3.40.0'
-gem 'cucumber', '10.2.0'
+gem 'cucumber', '10.1.0'
 gem 'ed25519', '~> 1.4'
 gem 'faraday', '~>2.14'
 gem 'ffi', '~> 1.17'


### PR DESCRIPTION
## What does this PR change?

Revert cucumber to previous version, otherwise we fail at sanity checks.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**

## Test coverage

Cucumber tests were modified.

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/29506
 * 5.0: https://github.com/SUSE/spacewalk/pull/29505
 * 5.1: https://github.com/SUSE/spacewalk/pull/29504

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
