### PR TITLE
Allow LDAP users that are not visible to pam_unix (bsc#1256791)

### DIFF
--- a/containers/server-image/root/etc/pam.d/susemanager-account
+++ b/containers/server-image/root/etc/pam.d/susemanager-account
@@ -1,3 +1,3 @@
-account	requisite	pam_unix.so	try_first_pass 
+account [success=ok new_authtok_reqd=ok ignore=ignore user_unknown=ignore default=die]    pam_unix.so   try_first_pass
 account	sufficient	pam_localuser.so 
 account	required	pam_sss.so	use_first_pass	

--- a/containers/server-image/server-image.changes.nadvornik.pam_unix
+++ b/containers/server-image/server-image.changes.nadvornik.pam_unix
@@ -1,0 +1,1 @@
+- Allow LDAP users that are not visible to pam_unix (bsc#1256791)


### PR DESCRIPTION
## What does this PR change?

This PR modifies pam.d/susemanager-account to not fail on users that are unknown to pam_unix.
The users can be configured in LDAP as Uyuni-only users, they do not have to be visible to the OS via pam_unix.

`[success=ok new_authtok_reqd=ok ignore=ignore user_unknown=ignore default=die]` is the same as `requisite`, except for `user_unknown=ignore`



## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29438
https://bugzilla.suse.com/show_bug.cgi?id=1256791
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
