### PR TITLE
(MU) Add check for virt vm_info availability (bsc#1254316)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/VmInfoSlsResult.java
+++ b/java/core/src/main/java/com/suse/manager/webui/utils/salt/custom/VmInfoSlsResult.java
@@ -34,10 +34,11 @@ public class VmInfoSlsResult {
      */
     public Map<String, Map<String, Object>> getVmInfos() {
         return Optional.ofNullable(vminfo)
+                .filter(StateApplyResult::isResult)
                 .map(StateApplyResult::getChanges)
                 .map(Ret::getRet)
                 .orElseGet(() -> {
-                    LOG.info("No virtual machines found");
+                    LOG.info("No virtual machines found (or libvirtd not available)");
                     return Map.of();
                 });
     }

--- a/java/core/src/test/java/com/redhat/rhn/domain/action/test/VirtualInstanceRefreshActionTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/action/test/VirtualInstanceRefreshActionTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.domain.action.test;
+
+import com.redhat.rhn.domain.action.VirtualInstanceRefreshAction;
+import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.testing.MockObjectTestCase;
+
+import com.suse.utils.Json;
+
+import com.google.gson.JsonElement;
+
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+
+/**
+ * VirtualInstanceRefreshActionTest
+ */
+public class VirtualInstanceRefreshActionTest extends MockObjectTestCase {
+
+    private static final String SUCCESS = "Success";
+    private static final JsonElement VMINFO_NULL = Json.GSON.fromJson("{\"vminfo\": null}", JsonElement.class);
+
+    private VirtualInstanceRefreshAction action;
+    private ServerAction serverAction;
+    private Server server;
+    private MinionServer minionServer;
+
+    @BeforeEach
+    void setUp() {
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        action = new VirtualInstanceRefreshAction();
+        serverAction = context.mock(ServerAction.class);
+        server = context.mock(Server.class);
+        minionServer = context.mock(MinionServer.class);
+    }
+
+    /**
+     * Test handleUpdateServerAction when server is not a MinionServer
+     * Expected: Result message should be "Success" and no exception should be thrown
+     */
+    @Test
+    void testHandleUpdateServerActionWhenServerIsNotMinionServer() {
+        context.checking(new Expectations() {{
+            oneOf(serverAction).isStatusFailed();
+            will(returnValue(false));
+            oneOf(serverAction).setResultMsg(SUCCESS);
+            oneOf(serverAction).getServer();
+            will(returnValue(server));
+            oneOf(server).asMinionServer();
+            will(returnValue(Optional.empty()));
+        }});
+
+        action.handleUpdateServerAction(serverAction, VMINFO_NULL, null);
+    }
+
+
+    /**
+     * Test handleUpdateServerAction when server action status is successful but returns no VMs
+     * Expected: Result message should be "Success"
+     */
+    @Test
+    void testHandleUpdateServerActionWhenActionIsSuccessfulAndEmptyVMs() {
+        JsonElement jsonResult = Json.GSON.fromJson(VMINFO_NULL, JsonElement.class);
+
+        context.checking(new Expectations() {{
+            oneOf(serverAction).isStatusFailed();
+            will(returnValue(false));
+            oneOf(serverAction).setResultMsg(SUCCESS);
+            oneOf(serverAction).getServer();
+            will(returnValue(server));
+            oneOf(server).asMinionServer();
+            will(returnValue(Optional.of(minionServer)));
+        }});
+
+        action.handleUpdateServerAction(serverAction, jsonResult, null);
+    }
+
+    /**
+     * Test handleUpdateServerAction when server action fails and returns no VMs
+     * Expected: Result message should be "Failure" and no exception should be thrown
+     */
+    @Test
+    void testHandleUpdateServerActionWhenActionFailsAndEmptyVMs() {
+        JsonElement jsonResult = Json.GSON.fromJson(VMINFO_NULL, JsonElement.class);
+
+        context.checking(new Expectations() {{
+            oneOf(serverAction).isStatusFailed();
+            will(returnValue(true));
+            oneOf(serverAction).setResultMsg("Failure");
+            oneOf(serverAction).getServer();
+            will(returnValue(server));
+            oneOf(server).asMinionServer();
+            will(returnValue(Optional.of(minionServer)));
+        }});
+
+        action.handleUpdateServerAction(serverAction, jsonResult, null);
+    }
+
+    /**
+     * Test handleUpdateServerAction with several VMs, in different states
+     * Expected: Result message should be "Success"
+     */
+    @Test
+    void testHandleUpdateServerActionWithMultipleVMs()  {
+        Map<String, Object> runningVM = Map.of(
+                "state", "running",
+                "uuid", "uuid-running",
+                "maxMem", 4096.0,
+                "cpu", 4.0
+        );
+
+        Map<String, Object> pausedVM = Map.of(
+                "state", "paused",
+                "uuid", "uuid-paused",
+                "maxMem", 2048.0,
+                "cpu", 2.0
+        );
+
+        Map<String, Object> shutdownVM = Map.of(
+                "state", "shutdown",
+                "uuid", "uuid-shutdown",
+                "maxMem", 1024.0,
+                "cpu", 1.0
+        );
+
+        Map<String, Map<String, Object>> vmsMap = Map.of(
+                "running-vm", runningVM,
+                "paused-vm", pausedVM,
+                "stopped-vm", shutdownVM
+        );
+
+        String jsonString = Json.GSON.toJson(Map.of("vminfo", vmsMap));
+        JsonElement jsonResult = Json.GSON.fromJson(jsonString, JsonElement.class);
+
+        context.checking(new Expectations() {{
+            oneOf(serverAction).isStatusFailed();
+            will(returnValue(false));
+            oneOf(serverAction).setResultMsg(SUCCESS);
+            oneOf(serverAction).getServer();
+            will(returnValue(server));
+            oneOf(server).asMinionServer();
+            will(returnValue(Optional.of(minionServer)));
+        }});
+
+        action.handleUpdateServerAction(serverAction, jsonResult, null);
+    }
+}

--- a/java/core/src/test/java/com/suse/manager/webui/utils/salt/test/VmInfoSlsResultTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/utils/salt/test/VmInfoSlsResultTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 SUSE LCC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.suse.manager.webui.utils.salt.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.redhat.rhn.testing.MockObjectTestCase;
+
+import com.suse.manager.webui.utils.salt.custom.VmInfoSlsResult;
+import com.suse.salt.netapi.results.Ret;
+import com.suse.salt.netapi.results.StateApplyResult;
+
+import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+class VmInfoSlsResultTest extends MockObjectTestCase {
+
+    @BeforeEach
+    void setUp() {
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+    }
+
+    /**
+     * Test the scenario where state result is false (virt.vm_info module not available, e.g., libvirtd not installed)
+     * This reflects as the following example:
+     * mgrcompat_|-mgr_virt_profile_|-virt.vm_info_|-module_run": {
+     * "id": "mgr_virt_profile",
+     * "run_num": ...,
+     * "sls": "hardware.virtprofile",
+     * "changes": {},
+     * "comment": "Module function virt.vm_info is not available",
+     * "duration": ...,
+     * "name": "virt.vm_info",
+     * "result": false,
+     * "start_time": ...
+     * }
+     *
+     * @throws Exception if an error occurs
+     */
+    @Test
+    void testGetVmInfosWhenStateResultIsFalse() throws Exception {
+        StateApplyResult<Ret<Map<String, Map<String, Object>>>> failedState = context.mock(StateApplyResult.class);
+
+        context.checking(new Expectations() {{
+            oneOf(failedState).isResult();
+            will(returnValue(false));
+        }});
+
+        VmInfoSlsResult result = new VmInfoSlsResult();
+        setVmInfoByReflection(result, failedState);
+
+        assertTrue(result.getVmInfos().isEmpty());
+    }
+
+    /**
+     * Test the scenario where vminfo is null
+     * @throws Exception if an error occurs
+     */
+    @Test
+    void testGetVmInfosWhenVmInfoIsNull() throws Exception {
+        VmInfoSlsResult result = new VmInfoSlsResult();
+        setVmInfoByReflection(result, null);
+
+        assertTrue(result.getVmInfos().isEmpty());
+    }
+
+    /**
+     * Test the scenario where changes is null
+     * @throws Exception if an error occurs
+     */
+    @Test
+    void testGetVmInfosWhenChangesIsNull() throws Exception {
+        StateApplyResult<Ret<Map<String, Map<String, Object>>>> successfulState = context.mock(StateApplyResult.class);
+
+        context.checking(new Expectations() {{
+            oneOf(successfulState).isResult();
+            will(returnValue(true));
+            oneOf(successfulState).getChanges();
+            will(returnValue(null));
+        }});
+
+        VmInfoSlsResult result = new VmInfoSlsResult();
+        setVmInfoByReflection(result, successfulState);
+
+        assertTrue(result.getVmInfos().isEmpty());
+    }
+
+    /**
+     * Test the scenario where ret is null
+     * @throws Exception if an error occurs
+     */
+    @Test
+    void testGetVmInfosWhenRetIsNull() throws Exception {
+        StateApplyResult<Ret<Map<String, Map<String, Object>>>> failedStateRet = context.mock(StateApplyResult.class);
+        Ret<Map<String, Map<String, Object>>> mockRet = context.mock(Ret.class);
+
+        context.checking(new Expectations() {{
+            oneOf(failedStateRet).isResult();
+            will(returnValue(true));
+            oneOf(failedStateRet).getChanges();
+            will(returnValue(mockRet));
+            oneOf(mockRet).getRet();
+            will(returnValue(null));
+        }});
+
+        VmInfoSlsResult result = new VmInfoSlsResult();
+        setVmInfoByReflection(result, failedStateRet);
+
+        assertTrue(result.getVmInfos().isEmpty());
+    }
+
+
+    /**
+     * Test the scenario where ret is an empty map
+     * @throws Exception if an error occurs
+     */
+    @Test
+    void testGetVmInfosWithSuccessfulWhenEmptyVmData() throws Exception {
+        StateApplyResult<Ret<Map<String, Map<String, Object>>>> emptyState = context.mock(StateApplyResult.class);
+        Ret<Map<String, Map<String, Object>>> mockRet = context.mock(Ret.class);
+
+        context.checking(new Expectations() {{
+            oneOf(emptyState).isResult();
+            will(returnValue(true));
+            oneOf(emptyState).getChanges();
+            will(returnValue(mockRet));
+            oneOf(mockRet).getRet();
+            will(returnValue(new HashMap<>()));
+        }});
+
+        VmInfoSlsResult result = new VmInfoSlsResult();
+        setVmInfoByReflection(result, emptyState);
+
+        assertTrue(result.getVmInfos().isEmpty());
+    }
+
+    /**
+     * Test the scenario where ret contains multiple VMs
+     * @throws Exception if an error occurs
+     */
+    @Test
+    void testGetVmInfosWithSuccessfulWhenMultipleVms() throws Exception {
+        StateApplyResult<Ret<Map<String, Map<String, Object>>>> multiVmState = context.mock(StateApplyResult.class);
+        Ret<Map<String, Map<String, Object>>> mockRet = context.mock(Ret.class);
+        Map<String, Map<String, Object>> vmData =
+                Map.of(
+                        "vm1", Map.of(
+                                "state", "running",
+                                "vcpus", 2
+                        ),
+                        "vm2", Map.of(
+                                "state", "paused",
+                                "vcpus", 4
+                        )
+                );
+
+        context.checking(new Expectations() {{
+            oneOf(multiVmState).isResult();
+            will(returnValue(true));
+            oneOf(multiVmState).getChanges();
+            will(returnValue(mockRet));
+            oneOf(mockRet).getRet();
+            will(returnValue(vmData));
+        }});
+
+        VmInfoSlsResult result = new VmInfoSlsResult();
+        setVmInfoByReflection(result, multiVmState);
+
+        //
+        Map<String, Map<String, Object>> vmInfos = result.getVmInfos();
+
+        assertEquals(2, vmInfos.size());
+        Map<String, Object> vm1 = vmInfos.get("vm1");
+        Map<String, Object> vm2 = vmInfos.get("vm2");
+
+        assertNotNull(vm1);
+        assertEquals("running", vm1.get("state"));
+        assertEquals(2, vm1.get("vcpus"));
+
+        assertNotNull(vm2);
+        assertEquals("paused", vm2.get("state"));
+        assertEquals(4, vm2.get("vcpus"));
+    }
+
+    /**
+     * Set the vminfo field of VmInfoSlsResult using reflection
+     * @param result the VmInfoSlsResult instance
+     * @param vminfo the StateApplyResult to set
+     * @throws Exception if an error occurs
+     */
+    private void setVmInfoByReflection(
+            VmInfoSlsResult result,
+            StateApplyResult<Ret<Map<String, Map<String, Object>>>> vminfo
+    ) throws Exception {
+        Field field = VmInfoSlsResult.class.getDeclaredField("vminfo");
+        field.setAccessible(true);
+        field.set(result, vminfo);
+    }
+}

--- a/java/spacewalk-java.changes.rjpmestre.bsc1254316
+++ b/java/spacewalk-java.changes.rjpmestre.bsc1254316
@@ -1,0 +1,1 @@
+- Add check for virt vm_info availability (bsc#1254316)

--- a/susemanager-utils/susemanager-sls/salt/hardware/virtprofile.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/virtprofile.sls
@@ -1,4 +1,6 @@
 mgr_virt_profile:
   mgrcompat.module_run:
     - name: virt.vm_info
+    - onlyif:
+      - virsh list
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes.rjpmestre.bsc1254316
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes.rjpmestre.bsc1254316
@@ -1,0 +1,1 @@
+- Add check for virt vm_info availability (bsc#1254316)


### PR DESCRIPTION
## What does this PR change?

This PR adds a check to run virt.vm_info only when libvirt is available. 
Its uses `virsh list` as a runtime check to avoid failures when libvirt ( or the python libvirt bindings)  are not accessible inside the salt venv.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29127
Port(s): 
- M-5.1: https://github.com/SUSE/spacewalk/pull/29538
- MU-5.1.1: https://github.com/SUSE/spacewalk/pull/29539
- MU-5.1.2: https://github.com/SUSE/spacewalk/pull/29541

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
