### PR TITLE
Fix test of Copyright Notice

### DIFF
--- a/testsuite/features/secondary/srv_mainpage.feature
+++ b/testsuite/features/secondary/srv_mainpage.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2025 SUSE LLC
+# Copyright (c) 2015-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization
@@ -24,8 +24,8 @@ Feature: Main landing page options and preferences
     Given I am authorized
     When I follow the left menu "Help"
     And I switch to last opened window
-    Then I should see a "SUSE Multi-Linux Manager Index" text
-    When I click on a button within the item containing "Legal"
+    Then I should see a "SUSE Multi-Linux Manager Guides" text
+    When I click on the Legal button
     And I wait until I see "Copyright Notice" text
     And I follow "Copyright Notice"
     Then I should see a "Copyright Notice" text
@@ -37,8 +37,8 @@ Feature: Main landing page options and preferences
     Given I am authorized
     When I follow the left menu "Help"
     And I switch to last opened window
-    Then I should see a "SUSE Multi-Linux Manager Index" text
-    When I click on a button within the item containing "Legal"
+    Then I should see a "SUSE Multi-Linux Manager Guides" text
+    When I click on the Legal button
     And I wait until I see "End User License Agreement" text
     And I follow "End User License Agreement"
     Then I should see a "End User License Agreement" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2025 SUSE LLC.
+# Copyright (c) 2010-2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning navigation through the Web UI
@@ -291,13 +291,6 @@ end
 #
 When(/^I click on "([^"]*)"$/) do |text|
   click_button_and_wait(text, match: :first)
-end
-
-#
-# Click on a button by nav item
-#
-When(/^I click on a button within the item containing "([^"]*)"$/) do |text_in_item|
-  find(:xpath, "//li[.//span[text()='#{text_in_item}']]//button").click
 end
 
 #
@@ -883,6 +876,10 @@ When(/^I check the first patch in the list, that does not require a reboot$/) do
   else
     step 'I check the first row in the list'
   end
+end
+
+When(/^I click on the Legal button$/) do
+  find_and_wait_click(:xpath, '//li[.//span[text()=\'Legal\']]//button').click
 end
 
 When(/^I click on the red confirmation button$/) do


### PR DESCRIPTION
## What does this PR change?

This PR fixes the test of Copyright Notice.

It also replaces a generic step implementation
```
When I click on a button within the item containing "Legal"
```
with an _ad hoc_ one:
```
When I click on the Legal button
```
Rationale:
 * the step was used only once, and given the complicated xpath expression,
    there's no chance it becomes used elsewhere -> YAGNI
 * its labeling was complicated and convoluted => KISS
 * it's not "a button" but "the button"
 * align with many other similar _ad hoc_ button press steps


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were modified

- [x] **DONE**


## Links

Port(s):
 * 5:1: https://github.com/SUSE/spacewalk/pull/29554
 * 5.0: not affected
 * 4.3: not affected

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
