### PR TITLE
Fix SQL grammar for rescheduling actions (bsc#1257022)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -260,7 +260,7 @@ public class ScriptRunAction extends ScriptAction {
     public void removeInvalidResults() {
         HibernateFactory.getSession().createNativeQuery("""
                   DELETE FROM rhnServerActionScriptResult sr WHERE sr.action_script_id = (
-                  SELECT as.id FROM rhnActionScript as WHERE as.action_id = :action)
+                  SELECT s.id FROM rhnActionScript s WHERE s.action_id = :action)
                   AND sr.server_id IN
                   (SELECT sa.server_id FROM rhnServerAction sa WHERE sa.action_id = :action AND sa.status = :queued)
                   """)

--- a/java/spacewalk-java.changes.cbbayburt.bsc1257022
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1257022
@@ -1,0 +1,1 @@
+- Fix SQL grammar for rescheduling actions (bsc#1257022)


### PR DESCRIPTION
Fixes the usage of reserved SQL keyword `as` in the SQL statement for rescheduling actions.

Port of: https://github.com/SUSE/spacewalk/pull/29481

Fixes https://github.com/SUSE/spacewalk/issues/29466

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
