### PR TITLE
Revert accidental revert of help page tests

### DIFF
--- a/testsuite/features/secondary/srv_mainpage.feature
+++ b/testsuite/features/secondary/srv_mainpage.feature
@@ -24,8 +24,8 @@ Feature: Main landing page options and preferences
     Given I am authorized
     When I follow the left menu "Help"
     And I switch to last opened window
-    Then I should see a "SUSE Multi-Linux Manager Documentation" text
-    When I click on a button within the item containing "Legal"
+    Then I should see a "SUSE Multi-Linux Manager Guides" text
+    When I click on the Legal button
     And I wait until I see "Copyright Notice" text
     And I follow "Copyright Notice"
     Then I should see a "Copyright Notice" text
@@ -37,8 +37,8 @@ Feature: Main landing page options and preferences
     Given I am authorized
     When I follow the left menu "Help"
     And I switch to last opened window
-    Then I should see a "SUSE Multi-Linux Manager Documentation" text
-    When I click on a button within the item containing "Legal"
+    Then I should see a "SUSE Multi-Linux Manager Guides" text
+    When I click on the Legal button
     And I wait until I see "End User License Agreement" text
     And I follow "End User License Agreement"
     Then I should see a "End User License Agreement" text


### PR DESCRIPTION
## What does this PR change?

Revert accidental revert from #11427


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes

- [x] **DONE**


## Test coverage

Cucumber tests were reinstated.

- [x] **DONE**


## Links

Port(s):
 * 5.1:

- [ ] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
