### PR TITLE
(MU) Commit DB changes before refreshing pillar for SSH push minions (bsc#1253712)

### DIFF
--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -470,6 +470,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
             handler.setChildChannels(admin, sid, ia32Children);
         }, "allowed invalid child channel to be set.");
+
+        commitHappened();
     }
 
     @Test
@@ -592,6 +594,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
             handler.setChildChannels(admin, sid, ia32Children);
         }, "allowed invalid child channel to be set.");
+
+        commitHappened();
     }
 
     @Test
@@ -681,6 +685,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         catch (InvalidChannelException e) {
             // success
         }
+
+        commitHappened();
     }
 
     @Test
@@ -763,6 +769,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
             handler.setBaseChannel(admin, sid, base1.getLabel());
         }, "allowed channel with incompatible arch to be set");
+
+        commitHappened();
     }
 
     @Test

--- a/java/core/src/test/java/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1290,7 +1290,6 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
     @Test
     public void testUpdateServerChannels() throws Exception {
-        User user = UserTestUtils.createUser(this);
         Server server = ServerFactoryTest.createTestServer(user, true);
 
         Channel base1 = ChannelFactoryTest.createBaseChannel(user);
@@ -1315,11 +1314,12 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(2, server.getChildChannels().size());
         assertTrue(server.getChildChannels().stream().anyMatch(cc -> cc.getId().equals(ch21.getId())));
         assertTrue(server.getChildChannels().stream().anyMatch(cc -> cc.getId().equals(ch22.getId())));
+
+        commitHappened();
     }
 
     @Test
     public void testUpdateServerChannelsNoChildren() throws Exception {
-        User user = UserTestUtils.createUser(this);
         Server server = ServerFactoryTest.createTestServer(user, true);
 
         ProductName pnbase = MgrSyncUtils.findOrCreateProductName("Product Name Base");
@@ -1352,11 +1352,12 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(base2.getId(), server.getBaseChannel().getId());
         assertEquals(1, server.getChildChannels().size());
         assertEquals(ch21, server.getChildChannels().iterator().next());
+
+        commitHappened();
     }
 
     @Test
     public void testUpdateServerChannelsNoBase() throws Exception {
-        User user = UserTestUtils.createUser(this);
         Server server = ServerFactoryTest.createTestServer(user, true);
 
         Channel base1 = ChannelFactoryTest.createBaseChannel(user);
@@ -1382,6 +1383,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         assertNull(server.getBaseChannel());
         assertEquals(0, server.getChildChannels().size());
+
+        commitHappened();
     }
 
     /**

--- a/java/core/src/test/java/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/core/src/test/java/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -2102,6 +2102,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertTokenChannel(minion, base);
         assertTokenChannel(minion, ch1);
         assertTokenChannel(minion, ch2);
+
+        commitHappened();
     }
 
     @Test
@@ -2152,6 +2154,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MinionServer reloaded = HibernateFactory.reload(minion);
         // check that tokens are really gone
         assertEquals(0, reloaded.getAccessTokens().size());
+
+        commitHappened();
     }
 
     private void assertTokenChannel(MinionServer minion, Channel channel) {

--- a/java/core/src/test/java/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -719,6 +719,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         assertTokenChannel(minion1, base);
         assertTokenChannel(minion1, ch1);
         assertTokenChannel(minion1, ch2);
+
+        commitHappened();
     }
 
     private void assertTokenChannel(MinionServer minionIn, Channel channel) {

--- a/java/spacewalk-java.changes.rjpmestre.bsc1253712
+++ b/java/spacewalk-java.changes.rjpmestre.bsc1253712
@@ -1,0 +1,2 @@
+- Commit DB changes before refreshing pillar for SSH push minions
+  (bsc#1253712)


### PR DESCRIPTION
## What does this PR change?

When updating a base channels for a SSH push minions, it receives the "non updated" pillars because saltutil.refresh_pillar ends up reading uncommitted DB data.
This PR ensures the transaction is committed before refreshing the pillar.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29019
Port(s): 
- M51 - https://github.com/SUSE/spacewalk/pull/29590
- M50 - https://github.com/SUSE/spacewalk/pull/29591

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
