### PR TITLE
Fix tooltip interception in step definitions for item button clicks

### DIFF
--- a/testsuite/features/step_definitions/content_lifecycle_steps.rb
+++ b/testsuite/features/step_definitions/content_lifecycle_steps.rb
@@ -63,7 +63,23 @@ When(/^I click the "([^"]*)" item (.*?) button$/) do |name, action|
   raise ScriptError, "xpath: #{name} item not found" unless td_element
 
   button_element = td_element.find(:xpath, "./ancestor::tr/td/button/#{button} | ./ancestor::tr/td/div/button/#{button}")
-  raise ScriptError, "xpath: #{action} button not found" unless button_element.click
+  raise ScriptError, "xpath: #{action} button not found" unless button_element
+
+  # Wait for tooltips to disappear before clicking, with retry on interception
+  max_retries = 3
+  retries = 0
+  begin
+    has_no_css?('.tooltip-inner', wait: 2) if has_css?('.tooltip-inner', wait: 0)
+    button_element.click
+  rescue Selenium::WebDriver::Error::ElementClickInterceptedError => e
+    retries += 1
+    if retries < max_retries
+      has_no_css?('.tooltip-inner', wait: 2)
+      retry
+    else
+      raise ScriptError, "Click on #{action} button failed after #{max_retries} retries: #{e.message}"
+    end
+  end
 end
 
 When(/^I click the "([^"]*)" item (.*?) button if exists$/) do |name, action|
@@ -80,7 +96,23 @@ When(/^I click the "([^"]*)" item (.*?) button if exists$/) do |name, action|
     raise ScriptError, "xpath: #{name} item not found" unless td_element
 
     button_element = td_element.find(:xpath, "./ancestor::tr/td/button/#{button} | ./ancestor::tr/td/div/button/#{button}")
-    raise ScriptError, "xpath: #{action} button not found" unless button_element.click
+    raise ScriptError, "xpath: #{action} button not found" unless button_element
+
+    # Wait for tooltips to disappear before clicking, with retry on interception
+    max_retries = 3
+    retries = 0
+    begin
+      has_no_css?('.tooltip-inner', wait: 2) if has_css?('.tooltip-inner', wait: 0)
+      button_element.click
+    rescue Selenium::WebDriver::Error::ElementClickInterceptedError => e
+      retries += 1
+      if retries < max_retries
+        has_no_css?('.tooltip-inner', wait: 2)
+        retry
+      else
+        raise ScriptError, "Click on #{action} button failed after #{max_retries} retries: #{e.message}"
+      end
+    end
   rescue Capybara::ElementNotFound
     # ignored - pending actions cannot be found
   end


### PR DESCRIPTION
## What does this PR change?

## Fix tooltip interception in step definitions for item button clicks

### Problem

Tests are failing with `ElementClickInterceptedError` when clicking item buttons (edit/delete/details) in maintenance windows and recurring actions features:

```
element click intercepted: Element <i class="fa fa-trash no-margin"></i> is not clickable at point (1967, 266).
Other element would receive the click: <div class="tooltip-inner">...</div>
```

Tooltips that appear on hover are intercepting the click attempts, causing intermittent test failures.

### Root Cause

Tooltips appear on hover and can remain visible when Selenium attempts to click, causing interception. This is likely due to:
- UI/tooltip behavior changes in newer versions
- Timing differences in tooltip dismissal
- Note: The same step definitions work in the 5.1 branch without this fix, suggesting a regression or UI change

### Solution

Added a retry mechanism with tooltip-aware waiting:
1. Check for tooltips and wait up to 2 seconds for them to disappear before clicking
2. Retry up to 3 times if a click is intercepted, waiting for tooltips between retries
3. Provide a clear error message if all retries fail

This handles tooltips that appear:
- Before the click attempt
- Between the check and the click (race condition)
- During the click action itself

### Impact Analysis

- **Affected features**: 2 (`srv_maintenance_windows.feature`, `min_recurring_action.feature`)
- **Total usages**: 20 calls across both step definitions
- **Maximum time impact**: ~2 minutes 40 seconds (if every click requires 3 retries)
- **Realistic impact**: ~40 seconds (if tooltips exist but clicks succeed on first attempt)
- **Typical impact**: Minimal (most clicks succeed immediately)

The retry mechanism only adds time when clicks are intercepted, which should be rare. Most clicks succeed on the first attempt.

### Testing

- Verified with instrumentation that tooltips are detected and handled correctly
- All affected scenarios pass consistently
- No changes needed to test scenarios themselves

### Files Changed

- `testsuite/features/step_definitions/content_lifecycle_steps.rb`
  - Updated `I click the "([^"]*)" item (.*?) button$` step definition
  - Updated `I click the "([^"]*)" item (.*?) button if exists$` step definition

This fix ensures reliable clicking of item buttons in the presence of tooltips while maintaining backward compatibility and minimal performance impact.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28602
Port(s): not needed only fails in master but maybe I will need to align the code across branches

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
