### PR TITLE
[GH Actions] Replace not-grep with grep

### DIFF
--- a/.github/config/file-content-checks.toml
+++ b/.github/config/file-content-checks.toml
@@ -1,2 +1,0 @@
-[exclude]
-"susemanager-utils/susemanager-sls/salt/**/*.sls" = "module.run"

--- a/.github/workflows/salt-sls-files-checks.yml
+++ b/.github/workflows/salt-sls-files-checks.yml
@@ -6,14 +6,8 @@ on:
 
 jobs:
   salt_sls_files_checks:
-
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
-
-    - uses: mattsb42/not-grep@6830ab112798c6561640e1a3372e65f0bcb9435a #master
-      with:
-        config-file: ./.github/config/file-content-checks.toml
-        # If you don't set debug, passing checks will be hidden.
-        debug: true
+    - name: module.run must be absent
+      run: "! grep --fixed-strings module.run susemanager-utils/susemanager-sls/salt/**/*.sls"


### PR DESCRIPTION
## What does this PR change?

Do not use not-grep. Use grep instead.

mattsb42/not-grep is unmaintained and broke with a newer Python version, which it pulls in by building a Docker container from a "moving tag" at runtime. That's not really needed for our use-case.


## Links

Fixes Action failures like https://github.com/uyuni-project/uyuni/actions/runs/21864673189/job/63102604516?pr=11440