### PR TITLE
Fix terminal verification to use full system names with domain prefix

### DIFF
--- a/testsuite/features/step_definitions/retail_steps.rb
+++ b/testsuite/features/step_definitions/retail_steps.rb
@@ -195,10 +195,13 @@ end
 
 Then(/^I should not see any terminals imported from the configuration file$/) do
   terminals = read_terminals_from_yaml
+  domain = read_branch_prefix_from_yaml
   terminals.each do |terminal|
     next if (terminal.include? 'minion') || (terminal.include? 'client')
 
-    step %(I should not see a "#{terminal}" text)
+    # Construct full system name with domain prefix (e.g., "example.org.terminal1")
+    full_system_name = terminal.include?('pxeboot') ? "#{terminal}.#{domain}" : "#{domain}.#{terminal}"
+    step %(I wait at most 60 seconds until I do not see "#{full_system_name}" text, refreshing the page)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Fix the "I should not see any terminals imported from the configuration file" step to correctly verify terminal deletion by checking for the full system name (including domain prefix) instead of just the short terminal name.

Changes:
- Construct full system name with domain prefix (e.g., "example.org.terminal1" or "pxeboot.example.org")
- Add wait-and-refresh mechanism to handle asynchronous deletion after API calls

This fixes test failures where terminals were deleted via API but the UI still showed the short terminal name, causing false positives in the verification step.

after:

```gherkin
mlm-ci-head-podman-controller:~/spacewalk/testsuite # cucumber features/secondary/proxy_container_retail_mass_import.feature                                                                                             
Using Ruby version: 3.3.10                                                                                                                                                                                               
Initializing a remote node for 'server'.                                                                                                                                                                                 
Host 'server' is alive with determined hostname mlm-ci-head-podman-server and FQDN mlm-ci-head-podman-server.mgr.suse.de                                                                                                 
Node: mlm-ci-head-podman-server, OS Version: 15-SP7, Family: sles                                                                                                                                                        
Node: mlm-ci-head-podman-server, OS Version: 6.1, Family: sl-micro                                                                                                                                                       
Capybara APP Host: https://mlm-ci-head-podman-server.mgr.suse.de:8888                                                                                                                                                    
Activating XML-RPC API                                                                                                                                                                                                   
Using the default profile...                                                                                                                                                                                             
# Copyright (c) 2024 SUSE LLC                                                                                                                                                                                            
# Licensed under the terms of the MIT license.                                                                                                                                                                           
#                                                                                                                                                                                                                        
# The scenarios in this feature are skipped:                                                                                                                                                                             
# * if there is no proxy ($proxy is nil)                                                                                                                                                                                 
# * if there is no private network ($private_net is nil)                                                                                                                                                                 
# * if there is no PXE boot minion ($pxeboot_mac is nil)                                                                                                                                                                 
@containerized_server @skip_if_github_validation @proxy @private_net @pxeboot_minion @scope_retail @test_issue                                                                                                           
Feature: Mass import of Retail terminals behind a containerized proxy                                                                                                                                                    
  In order to manage my terminals in a Retail context                                                                                                                                                                    
  As the system administrator                                                                                                                                                                                            
  I perform a mass import of several virtual terminals and one real minion                                                                                                                                               
                                                                                                                                                                                                                         
  Scenario: Log in as admin user                  # features/secondary/proxy_container_retail_mass_import.feature:21                                                                                                     
      This scenario ran at: 2026-02-10 18:06:28 +0100                                                                                                                                                                    
    Given I am authorized for the "Admin" section # features/step_definitions/navigation_steps.rb:450                                                                                                                    
      This scenario took: 12 seconds

  Scenario: Mass import of terminals                                     # features/secondary/proxy_container_retail_mass_import.feature:24
      This scenario ran at: 2026-02-10 18:06:40 +0100
Initializing a remote node for 'localhost'.
Host 'localhost' is alive with determined hostname mlm-ci-head-podman-controller and FQDN mlm-ci-head-podman-controller.mgr.suse.de
Node: mlm-ci-head-podman-controller, OS Version: 15.6, Family: opensuse-leap
Node: mlm-ci-head-podman-controller, OS Version: 15.6, Family: opensuse-leap
Initializing a remote node for 'proxy'.
Host 'proxy' is alive with determined hostname mlm-ci-head-podman-proxy and FQDN mlm-ci-head-podman-proxy.mgr.suse.de
Node: mlm-ci-head-podman-proxy, OS Version: 6.1, Family: sl-micro
Node: mlm-ci-head-podman-proxy, OS Version: 6.1, Family: sl-micro
    When I prepare the retail configuration file on server               # features/step_definitions/retail_steps.rb:159
    And I import the retail configuration using retail_yaml command      # features/step_definitions/retail_steps.rb:176
    And I am on the Systems page                                         # features/step_definitions/common_steps.rb:279
    Then I should see the terminals imported from the configuration file # features/step_definitions/retail_steps.rb:191
      This scenario took: 38 seconds

  Scenario: Bootstrap the PXE boot minion                                                                                      # features/secondary/proxy_container_retail_mass_import.feature:30
      This scenario ran at: 2026-02-10 18:07:18 +0100
    # Workaround for bsc#1220864 - Containerized Proxy has not mgr-bootstrap command
    When I create the bootstrap script for "proxy.example.org" hostname and "1-TERMINAL-KEY-x86_64" activation key on "server" # features/step_definitions/retail_steps.rb:123
    And I bootstrap pxeboot minion via bootstrap script on the proxy                                                           # features/step_definitions/retail_steps.rb:135
    # Workaround: Increase timeout temporarily get rid of timeout issues
    And I wait at most 350 seconds until Salt master sees "pxeboot_minion" as "unaccepted"                                     # features/step_definitions/salt_steps.rb:93
    And I accept key of pxeboot minion in the Salt master                                                                      # features/step_definitions/retail_steps.rb:139
    Then I follow the left menu "Systems > System List > All"                                                                  # features/step_definitions/navigation_steps.rb:386
    And I wait until I see the name of "pxeboot_minion", refreshing the page                                                   # features/step_definitions/navigation_steps.rb:109
      This scenario took: 54 seconds

  Scenario: Check connection from bootstrapped terminal to proxy # features/secondary/proxy_container_retail_mass_import.feature:40
      This scenario ran at: 2026-02-10 18:08:12 +0100
    Given I am on the Systems page                               # features/step_definitions/common_steps.rb:279
    When I follow "pxeboot" terminal                             # features/step_definitions/retail_steps.rb:182
    And I follow "Details" in the content area                   # features/step_definitions/navigation_steps.rb:346
    And I follow "Connection" in the content area                # features/step_definitions/navigation_steps.rb:346
    Then I should see a "proxy.example.org" text                 # features/step_definitions/navigation_steps.rb:654
      This scenario took: 3 seconds

  Scenario: Install a package on the bootstrapped terminal                            # features/secondary/proxy_container_retail_mass_import.feature:47
      This scenario ran at: 2026-02-10 18:08:15 +0100
    Given I am on the Systems page                                                    # features/step_definitions/common_steps.rb:279
    When I follow "pxeboot" terminal                                                  # features/step_definitions/retail_steps.rb:182
    And I follow "Software" in the content area                                       # features/step_definitions/navigation_steps.rb:346
    And I follow "Install"                                                            # features/step_definitions/navigation_steps.rb:331
    And I enter "virgo" as the filtered package name                                  # features/step_definitions/navigation_steps.rb:921
    And I click on the filter button                                                  # features/step_definitions/navigation_steps.rb:893
    And I check "virgo-dummy-2.0-1.1" in the list                                     # features/step_definitions/navigation_steps.rb:1003
    And I click on "Install Packages"                                                 # features/step_definitions/navigation_steps.rb:292
    And I click on "Confirm"                                                          # features/step_definitions/navigation_steps.rb:292
    Then I should see a "1 package install has been scheduled" text                   # features/step_definitions/navigation_steps.rb:654
    When I wait until event "Package Install/Upgrade scheduled by admin" is completed # features/step_definitions/common_steps.rb:150
      This scenario took: 47 seconds

  Scenario: Remove the package from the bootstrapped terminal                 # features/secondary/proxy_container_retail_mass_import.feature:60
      This scenario ran at: 2026-02-10 18:09:02 +0100
    Given I am on the Systems page                                            # features/step_definitions/common_steps.rb:279
    When I follow "pxeboot" terminal                                          # features/step_definitions/retail_steps.rb:182
    And I follow "Software" in the content area                               # features/step_definitions/navigation_steps.rb:346
    And I follow "List / Remove"                                              # features/step_definitions/navigation_steps.rb:331
    And I enter "virgo" as the filtered package name                          # features/step_definitions/navigation_steps.rb:921
    And I click on the filter button                                          # features/step_definitions/navigation_steps.rb:893
    And I check "virgo-dummy-2.0-1.1" in the list                             # features/step_definitions/navigation_steps.rb:1003
    And I click on "Remove Packages"                                          # features/step_definitions/navigation_steps.rb:292
    And I click on "Confirm"                                                  # features/step_definitions/navigation_steps.rb:292
    Then I should see a "1 package removal has been scheduled" text           # features/step_definitions/navigation_steps.rb:654
    When I wait until event "Package Removal scheduled by admin" is completed # features/step_definitions/common_steps.rb:150
      This scenario took: 25 seconds

  Scenario: Cleanup: make sure salt-minion is stopped after mass import # features/secondary/proxy_container_retail_mass_import.feature:73
      This scenario ran at: 2026-02-10 18:09:27 +0100
    When I wait until Salt client is inactive on the PXE boot minion    # features/step_definitions/retail_steps.rb:155
      This scenario took: 22 seconds

  @test_issue
  Scenario: Cleanup: delete all imported Retail terminals                    # features/secondary/proxy_container_retail_mass_import.feature:77
      This scenario ran at: 2026-02-10 18:09:49 +0100
    Given I am on the Systems page                                           # features/step_definitions/common_steps.rb:279
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
log writing failed. closed stream
    When I delete all the imported terminals                                 # features/step_definitions/api_common.rb:11
      Terminals identified for deletion (short names): terminal1, terminal2, terminal3, terminal4, terminal5, terminal6, terminal7, terminal8, terminal9, pxeboot
    Then I should not see any terminals imported from the configuration file # features/step_definitions/retail_steps.rb:196
      This scenario took: 21 seconds

  Scenario: Cleanup: delete the terminal groups generated by retail_yaml command # features/secondary/proxy_container_retail_mass_import.feature:82
      This scenario ran at: 2026-02-10 18:10:10 +0100
    When I follow the left menu "Systems > System Groups"                        # features/step_definitions/navigation_steps.rb:386
    And I follow "HWTYPE:Intel-Genuine" in the content area                      # features/step_definitions/navigation_steps.rb:346
    And I follow "Delete Group" in the content area                              # features/step_definitions/navigation_steps.rb:346
    And I click on "Confirm Deletion"                                            # features/step_definitions/navigation_steps.rb:292
    Then I should see a "deleted" text                                           # features/step_definitions/navigation_steps.rb:654
    When I follow "example.org" in the content area                              # features/step_definitions/navigation_steps.rb:346
    And I follow "Delete Group" in the content area                              # features/step_definitions/navigation_steps.rb:346
    And I click on "Confirm Deletion"                                            # features/step_definitions/navigation_steps.rb:292
    Then I should see a "deleted" text                                           # features/step_definitions/navigation_steps.rb:654
    When I follow "TERMINALS" in the content area                                # features/step_definitions/navigation_steps.rb:346
    And I follow "Delete Group" in the content area                              # features/step_definitions/navigation_steps.rb:346
    And I click on "Confirm Deletion"                                            # features/step_definitions/navigation_steps.rb:292
    Then I should see a "deleted" text                                           # features/step_definitions/navigation_steps.rb:654
    When I follow "SERVERS" in the content area                                  # features/step_definitions/navigation_steps.rb:346
    And I follow "Delete Group" in the content area                              # features/step_definitions/navigation_steps.rb:346
    And I click on "Confirm Deletion"                                            # features/step_definitions/navigation_steps.rb:292
    Then I should see a "deleted" text                                           # features/step_definitions/navigation_steps.rb:654
      This scenario took: 5 seconds

9 scenarios (9 passed)
59 steps (59 passed)
3m47.081s
```
the warnings about `log writing failed. closed stream` are harmless and any change I made to suppress them caused more problems or was very intrusive, I think we can live with them. 


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28808
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/29636
5.0: https://github.com/SUSE/spacewalk/pull/29637

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
