### PR TITLE
Added listMigrationTargetsWithChannels endpoint to return the target channels as well (jsc#SUMA-320)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -219,6 +219,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -7546,6 +7547,114 @@ public class SystemHandler extends BaseHandler {
         }
 
         return returnList;
+    }
+
+    /**
+     * Lists the valid migration targets for a given server, including channel details.
+     * @param loggedInUser The current user
+     * @param sid The server ID
+     * @return List of maps containing migration targets and their channel options
+     * @throws FaultException A FaultException is thrown if the server corresponding to
+     * sid cannot be found or if the server has no products installed.
+     *
+     * @apidoc.doc Lists the eligible migration targets for a given server, including channel details.
+     * @apidoc.param #session_key()
+     * @apidoc.param #param("int", "sid")
+     * @apidoc.returntype
+     *      #return_array_begin()
+     *          #struct_begin("migration target")
+     *              #prop("string", "ident", "Product IDs for the target product set ( e.g. '[1894, 1905]')")
+     *              #prop("string", "friendly", "Friendly name of the target product set")
+     *              #prop_array_begin("channel_options")
+     *                  #struct_begin("channel option")
+     *                      #prop("string", "base_channel_label", "Label of the base channel")
+     *                      #prop("string", "base_channel_name", "Name of the base channel")
+     *                      #prop_array_begin("child_channels")
+     *                          #struct_begin("child channel")
+     *                              #prop("string", "label", "Channel label")
+     *                              #prop("string", "name", "Channel name")
+     *                              #prop("boolean", "mandatory", "Whether the channel is mandatory")
+     *                          #struct_end()
+     *                      #array_end()
+     *                  #struct_end()
+     *              #array_end()
+     *          #struct_end()
+     *      #array_end()
+     */
+    public List<Map<String, Object>> listMigrationTargetsWithChannels(User loggedInUser, Integer sid) {
+        List<Map<String, Object>> returnList = new ArrayList<>();
+        Server server = lookupServer(loggedInUser, sid);
+        Optional<SUSEProductSet> installedProducts = server.getInstalledProductSet();
+        if (!installedProducts.isPresent()) {
+            throw new FaultException(-1, "listMigrationTargetError",
+                    "Server has no Products installed.");
+        }
+        ChannelArch arch = server.getServerArch().getCompatibleChannelArch();
+        List<SUSEProductSet> migrationTargets = DistUpgradeManager.
+                getTargetProductSets(installedProducts, arch, loggedInUser);
+
+        for (SUSEProductSet target : migrationTargets) {
+            if (!target.getIsEveryChannelSynced()) {
+                continue;
+            }
+
+            Map<String, Object> targetMap = new HashMap<>();
+            targetMap.put("ident", target.getSerializedProductIDs());
+            targetMap.put("friendly", target.toString());
+
+            List<Map<String, Object>> channelOptions = new ArrayList<>();
+
+            // 1. Default Base Channel
+            Channel baseChannel = DistUpgradeManager.getProductBaseChannel(
+                    target.getBaseProduct().getId(), arch, loggedInUser);
+
+            if (baseChannel != null) {
+                // Get required child channels for this target/base pairing
+                List<EssentialChannelDto> requiredChannels = DistUpgradeManager.getRequiredChannels(
+                        target, baseChannel.getId());
+                List<Long> requiredChannelIds = requiredChannels.stream()
+                        .map(EssentialChannelDto::getId)
+                        .collect(toList());
+
+                channelOptions.add(buildChannelOptionMap(baseChannel, loggedInUser, requiredChannelIds));
+            }
+
+            // 2. Alternative Base Channels (Clones)
+            SortedMap<ClonedChannel, List<Long>> alternatives = DistUpgradeManager.getAlternatives(
+                    target, arch, loggedInUser);
+
+            for (Map.Entry<ClonedChannel, List<Long>> entry : alternatives.entrySet()) {
+                channelOptions.add(buildChannelOptionMap(entry.getKey(), loggedInUser, entry.getValue()));
+            }
+
+            targetMap.put("channel_options", channelOptions);
+            returnList.add(targetMap);
+        }
+
+        return returnList;
+    }
+
+    private Map<String, Object> buildChannelOptionMap(Channel baseChannel, User user, List<Long> requiredChannelIds) {
+        Map<String, Object> optionMap = new HashMap<>();
+        optionMap.put("base_channel_label", baseChannel.getLabel());
+        optionMap.put("base_channel_name", baseChannel.getName());
+
+        List<Map<String, Object>> childChannelsList = new ArrayList<>();
+        List<Channel> accessibleChildren = baseChannel.getAccessibleChildrenFor(user);
+
+        // Sort by name
+        accessibleChildren.sort(Comparator.comparing(Channel::getName));
+
+        for (Channel child : accessibleChildren) {
+             Map<String, Object> childMap = new HashMap<>();
+             childMap.put("label", child.getLabel());
+             childMap.put("name", child.getName());
+             childMap.put("mandatory", requiredChannelIds.contains(child.getId()));
+             childChannelsList.add(childMap);
+        }
+
+        optionMap.put("child_channels", childChannelsList);
+        return optionMap;
     }
 
     /**

--- a/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7581,6 +7581,7 @@ public class SystemHandler extends BaseHandler {
      *          #struct_end()
      *      #array_end()
      */
+    @ReadOnly
     public List<Map<String, Object>> listMigrationTargetsWithChannels(User loggedInUser, Integer sid) {
         List<Map<String, Object>> returnList = new ArrayList<>();
         Server server = lookupServer(loggedInUser, sid);

--- a/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/frontend/xmlrpc/system/SystemHandlerTest.java
@@ -53,7 +53,9 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFactoryTest;
 import com.redhat.rhn.domain.channel.ChannelFamily;
+import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ChannelTestUtility;
+import com.redhat.rhn.domain.channel.PublicChannelFamily;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
@@ -64,7 +66,10 @@ import com.redhat.rhn.domain.kickstart.KickstartFactory;
 import com.redhat.rhn.domain.org.CustomDataKey;
 import com.redhat.rhn.domain.org.CustomDataKeyTest;
 import com.redhat.rhn.domain.org.Org;
+import com.redhat.rhn.domain.product.ChannelTemplate;
 import com.redhat.rhn.domain.product.SUSEProduct;
+import com.redhat.rhn.domain.product.SUSEProductChannel;
+import com.redhat.rhn.domain.product.SUSEProductExtension;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
 import com.redhat.rhn.domain.product.SUSEProductTestUtils;
 import com.redhat.rhn.domain.rhnpackage.Package;
@@ -74,6 +79,9 @@ import com.redhat.rhn.domain.rhnpackage.PackageTest;
 import com.redhat.rhn.domain.rhnpackage.profile.Profile;
 import com.redhat.rhn.domain.rhnpackage.profile.ProfileFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.scc.SCCCachingFactory;
+import com.redhat.rhn.domain.scc.SCCRepository;
+import com.redhat.rhn.domain.scc.SCCRepositoryNoAuth;
 import com.redhat.rhn.domain.server.CPU;
 import com.redhat.rhn.domain.server.CPUTest;
 import com.redhat.rhn.domain.server.CustomDataValue;
@@ -3756,5 +3764,127 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         }});
 
         return systemHandler;
+    }
+
+    @Test
+    public void testListMigrationTargetsWithChannels() throws Exception {
+        Map<String, Object> setupData = setupMigrationTargetsWithChannels();
+        Server server = (Server) setupData.get("server");
+        Channel targetAddonChannel = (Channel) setupData.get("targetAddonChannel");
+        Channel targetBaseChannel = (Channel) setupData.get("targetBaseChannel");
+        SUSEProduct targetBaseProduct = (SUSEProduct) setupData.get("targetBaseProduct");
+
+        List<Map<String, Object>> result = handler.listMigrationTargetsWithChannels(admin, server.getId().intValue());
+        assertNotNull(result);
+        assertFalse(result.isEmpty(), "Migration targets should not be empty");
+
+        // 1. Find the target that contains our expected base product
+        Optional<Map<String, Object>> targetOpt = result.stream()
+                .filter(m -> m.get("ident").toString().contains(String.valueOf(targetBaseProduct.getId())))
+                .findFirst();
+        assertTrue(targetOpt.isPresent(), "Migration target with product " + targetBaseProduct.getId() + " not found");
+
+        // 2. Find the channel option for our expected base channel
+        Map<String, Object> target = targetOpt.get();
+        List<Map<String, Object>> channelOptions = (List<Map<String, Object>>) target.get("channel_options");
+        Optional<Map<String, Object>> optionOpt = channelOptions.stream()
+                .filter(o -> targetBaseChannel.getLabel().equals(o.get("base_channel_label")))
+                .findFirst();
+
+        assertTrue(optionOpt.isPresent(), "Channel with base channel " + targetBaseChannel.getLabel() + " not found");
+        Map<String, Object> option = optionOpt.get();
+
+        // 3. Verify the child channels
+        List<Map<String, Object>> children = (List<Map<String, Object>>) option.get("child_channels");
+        boolean found = false;
+        for (Map<String, Object> child : children) {
+            if (child.get("name").equals(targetAddonChannel.getName())) {
+                 assertEquals(targetAddonChannel.getLabel(), child.get("label"));
+                 assertTrue(Boolean.TRUE.equals(child.get("mandatory")), "Channel should be mandatory");
+                 found = true;
+            }
+        }
+        assertTrue(found, "Expected mandatory channel not found in results for the target");
+    }
+
+    private Map<String, Object> setupMigrationTargetsWithChannels() throws Exception {
+        // Setup source products
+        ChannelFamily family = createTestChannelFamily();
+        SUSEProduct sourceBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        Channel sourceBaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(sourceBaseProduct, admin);
+        sourceBaseChannel.setChannelArch(ChannelFactory.findArchByLabel("channel-x86_64"));
+        SUSEProduct sourceAddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        sourceAddonProduct.setBase(false);
+        Server server = ServerFactoryTest.createTestServer(admin);
+
+        Set<InstalledProduct> installedProductSet = new java.util.HashSet<>();
+        installedProductSet.add(SUSEProductTestUtils.getInstalledProduct(sourceBaseProduct));
+        installedProductSet.add(SUSEProductTestUtils.getInstalledProduct(sourceAddonProduct));
+        server.setInstalledProducts(installedProductSet);
+
+        // Setup migration target product + upgrade path
+        SUSEProduct targetBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        Channel targetBaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(targetBaseProduct, admin);
+        targetBaseChannel.setChannelArch(ChannelFactory.findArchByLabel("channel-x86_64"));
+        sourceBaseProduct.setUpgrades(Collections.singleton(targetBaseProduct));
+
+        // Setup target addon product + upgrade path
+        SUSEProduct targetAddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        targetAddonProduct.setBase(false);
+        sourceAddonProduct.setUpgrades(Collections.singleton(targetAddonProduct));
+
+        Channel targetAddonChannel =
+                SUSEProductTestUtils.createChildChannelsForProduct(targetAddonProduct, targetBaseChannel, admin);
+        targetAddonProduct = SUSEProductFactory.getProductById(targetAddonProduct.getId());
+        for (SUSEProductChannel spc : targetAddonProduct.getSuseProductChannels()) {
+            if (spc.getChannel().getId().equals(targetAddonChannel.getId())) {
+                spc.setMandatory(true);
+                SUSEProductFactory.save(spc);
+            }
+        }
+        ChannelFamily cf = targetAddonProduct.getChannelFamily();
+        if (cf.getPublicChannelFamily() == null) {
+             PublicChannelFamily pcf = new PublicChannelFamily();
+             pcf.setChannelFamily(cf);
+             ChannelFamilyFactory.save(pcf);
+             cf.setPublicChannelFamily(pcf);
+             ChannelFamilyFactory.save(cf);
+        }
+        SCCRepository repo = new SCCRepository();
+        repo.setUrl("http://example.com/repo");
+        repo.setName("test-repo");
+        repo.setSccId(12345L);
+        repo.setDescription("Test Repository");
+        repo.setDistroTarget("x86_64");
+        HibernateFactory.getSession().persist(repo);
+        SCCRepositoryNoAuth auth = new SCCRepositoryNoAuth();
+        auth.setRepo(repo);
+        SCCCachingFactory.saveRepositoryAuth(auth);
+
+        repo.getRepositoryAuth().add(auth);
+        ChannelTemplate ct = new ChannelTemplate();
+        ct.setProduct(targetAddonProduct);
+        ct.setChannelLabel(targetAddonChannel.getLabel());
+        ct.setMandatory(true);
+        ct.setRootProduct(targetBaseProduct);
+        ct.setChannelName(targetAddonChannel.getName());
+        ct.setRepository(repo);
+        SUSEProductFactory.save(ct);
+        targetAddonProduct.getChannelTemplates().add(ct);
+        TestUtils.saveAndFlush(targetAddonProduct);
+
+        sourceAddonProduct.setUpgrades(Collections.singleton(targetAddonProduct));
+        SUSEProductExtension productExtension = new SUSEProductExtension(
+                targetBaseProduct, targetAddonProduct, targetBaseProduct, false);
+        TestUtils.saveAndFlush(productExtension);
+
+        SUSEProductTestUtils.populateRepository(targetBaseProduct, targetBaseChannel, targetBaseProduct,
+                targetBaseChannel, admin);
+        Map<String, Object> setupData = new HashMap<>();
+        setupData.put("server", server);
+        setupData.put("targetAddonChannel", targetAddonChannel);
+        setupData.put("targetBaseChannel", targetBaseChannel);
+        setupData.put("targetBaseProduct", targetBaseProduct);
+        return setupData;
     }
 }

--- a/java/spacewalk-java.changes.abid.add-api-endpoint-to-list-target-channels
+++ b/java/spacewalk-java.changes.abid.add-api-endpoint-to-list-target-channels
@@ -1,0 +1,2 @@
+- Added listMigrationTargetsWithChannels endpoint to return
+  the valid migration targets channels (jsc#SUMA-320)

--- a/schema/spacewalk/common/data/accessGroupNamespace.sql
+++ b/schema/spacewalk/common/data/accessGroupNamespace.sql
@@ -1286,3 +1286,10 @@ INSERT INTO access.accessGroupNamespace (group_id, namespace_id)
     )
     AND ns.access_mode = 'W'
 ON CONFLICT (group_id, namespace_id) DO NOTHING;
+
+-- New endpoint
+INSERT INTO access.accessGroupNamespace (group_id, namespace_id)
+    SELECT ag.id, ns.id
+    FROM access.accessGroup ag, access.namespace ns
+    WHERE ns.namespace = 'api.system.list_migration_targets_with_channels' AND ns.access_mode = 'R'
+    ON CONFLICT (group_id, namespace_id) DO NOTHING;

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -6046,6 +6046,9 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('com.redhat.rhn.frontend.xmlrpc.proxy.ProxyHandler.backupConfiguration', '/manager/api/proxy/backupConfiguration', 'POST', 'A', True)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listMigrationTargetsWithChannels', '/manager/api/system/listMigrationTargetsWithChannels', 'GET', 'A', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
 
 -- =============================================================================
 -- SCAP System API and Web UI Endpoints

--- a/schema/spacewalk/common/data/endpointNamespace.sql
+++ b/schema/spacewalk/common/data/endpointNamespace.sql
@@ -9664,6 +9664,12 @@ INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
     WHERE ns.namespace = 'api.proxy.backup_configuration' AND ns.access_mode = 'W'
     AND ep.endpoint = '/manager/api/proxy/backupConfiguration' AND ep.http_method = 'POST'
     ON CONFLICT DO NOTHING;
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.list_migration_targets_with_channels' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/manager/api/system/listMigrationTargetsWithChannels' AND ep.http_method = 'GET'
+    ON CONFLICT (endpoint_id, namespace_id) DO NOTHING;
+
 
 -- XML-RPC System SCAP New API Endpoints
 INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)

--- a/schema/spacewalk/common/data/namespace.sql
+++ b/schema/spacewalk/common/data/namespace.sql
@@ -3101,6 +3101,9 @@ INSERT INTO access.namespace (namespace, access_mode, description)
 INSERT INTO access.namespace (namespace, access_mode, description)
     VALUES ('api.proxy.backup_configuration', 'W', 'Saves the configuration of a proxy to the server for later conversion')
     ON CONFLICT (namespace, access_mode) DO NOTHING;
+INSERT INTO access.namespace (namespace, access_mode, description)
+    VALUES ('api.system.list_migration_targets_with_channels', 'R', 'Lists the valid migration targets for a given server, including channel details')
+    ON CONFLICT (namespace, access_mode) DO NOTHING;
 
 INSERT INTO access.namespace (namespace, access_mode, description) VALUES
     ('api.system.scap.list_scap_content', 'R', 'Lists SCAP content for a given system'),

--- a/schema/spacewalk/susemanager-schema.changes.abid.add-api-endpoint-to-list-target-channels
+++ b/schema/spacewalk/susemanager-schema.changes.abid.add-api-endpoint-to-list-target-channels
@@ -1,0 +1,2 @@
+- Added the rbac mapping for listMigrationTargetsWithChannels
+  end point (jsc#SUMA-320)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/230-new-api-rbac-mappings.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/230-new-api-rbac-mappings.sql
@@ -1,0 +1,23 @@
+-- Insert the endpoint
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('com.redhat.rhn.frontend.xmlrpc.system.SystemHandler.listMigrationTargetsWithChannels', '/manager/api/system/listMigrationTargetsWithChannels', 'GET', 'A', True)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;     
+
+-- Insert the namespace
+INSERT INTO access.namespace (namespace, access_mode, description)
+    VALUES ('api.system.list_migration_targets_with_channels', 'R', 'Lists the valid migration targets for a given server, including channel details')
+    ON CONFLICT (namespace, access_mode) DO NOTHING;    
+
+-- Insert the mapping between namespace and endpoint
+INSERT INTO access.endpointNamespace (namespace_id, endpoint_id)
+    SELECT ns.id, ep.id FROM access.namespace ns, access.endpoint ep
+    WHERE ns.namespace = 'api.system.list_migration_targets_with_channels' AND ns.access_mode = 'R'
+    AND ep.endpoint = '/manager/api/system/listMigrationTargetsWithChannels' AND ep.http_method = 'GET'
+    ON CONFLICT (endpoint_id, namespace_id) DO NOTHING;   
+
+-- This is inserting for all the accessgroup even for the custom ones.
+INSERT INTO access.accessGroupNamespace (group_id, namespace_id)
+    SELECT ag.id, ns.id
+    FROM access.accessGroup ag, access.namespace ns
+    WHERE ns.namespace = 'api.system.list_migration_targets_with_channels' AND ns.access_mode = 'R'
+    ON CONFLICT (group_id, namespace_id) DO NOTHING;


### PR DESCRIPTION
## What does this PR change?

Added listMigrationTargetsWithChannels endpoint to return the target channels as well

It would return something like this

```python
[
    {
       "ident": "[1894,1905,1901,1948,2066]",
       "friendly": "[base: SUSE Linux Enterprise Server 15 SP7 aarch64, addon: Server Applications Module 15 SP7 aarch64, Basesystem Module 15 SP7 aarch64, Python 3 Module 15 SP7 aarch64, Systems Management Module 15 SP7 aarch64]"
        "channel_options": [
            {
                "base_channel_name": "SLE-Product-SLES15-SP7-Pool for aarch64",
                "base_channel_label": "sle-product-sles15-sp7-pool-aarch64",
                "child_channels": [
                    {
                        "name": "SLE-Module-Basesystem15-SP7-Pool for aarch64",
                        "label": "sle-module-basesystem15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Module-Basesystem15-SP7-Updates for aarch64",
                        "label": "sle-module-basesystem15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Module-Python3-15-SP7-Pool for aarch64",
                        "label": "sle-module-python3-15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Module-Python3-15-SP7-Updates for aarch64",
                        "label": "sle-module-python3-15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Module-Server-Applications15-SP7-Pool for aarch64",
                        "label": "sle-module-server-applications15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Module-Server-Applications15-SP7-Updates for aarch64",
                        "label": "sle-module-server-applications15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Module-Systems-Management-15-SP7-Pool for aarch64",
                        "label": "sle-module-systems-management-15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Module-Systems-Management-15-SP7-Updates for aarch64",
                        "label": "sle-module-systems-management-15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE-Product-SLES15-SP7-Updates for aarch64",
                        "label": "sle-product-sles15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "SLE15-SP7-Installer-Updates for aarch64",
                        "label": "sle15-sp7-installer-updates-aarch64",
                        "mandatory": false
                    }
                ]
    
            },
            {
                "base_channel_name": "clm-test-SLE-Product-SLES15-SP7-Pool for aarch64",
                "base_channel_label": "clm-test-sle-product-sles15-sp7-pool-aarch64",
                "child_channels": [
                    {
                        "name": "clm-test-SLE-Module-Basesystem15-SP7-Pool for aarch64",
                        "label": "clm-test-sle-module-basesystem15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Module-Basesystem15-SP7-Updates for aarch64",
                        "label": "clm-test-sle-module-basesystem15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Module-Python3-15-SP7-Pool for aarch64",
                        "label": "clm-test-sle-module-python3-15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Module-Python3-15-SP7-Updates for aarch64",
                        "label": "clm-test-sle-module-python3-15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Module-Server-Applications15-SP7-Pool for aarch64",
                        "label": "clm-test-sle-module-server-applications15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Module-Server-Applications15-SP7-Updates for aarch64",
                        "label": "clm-test-sle-module-server-applications15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Module-Systems-Management-15-SP7-Pool for aarch64",
                        "label": "clm-test-sle-module-systems-management-15-sp7-pool-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Module-Systems-Management-15-SP7-Updates for aarch64",
                        "label": "clm-test-sle-module-systems-management-15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE-Product-SLES15-SP7-Updates for aarch64",
                        "label": "clm-test-sle-product-sles15-sp7-updates-aarch64",
                        "mandatory": true
                    },
                    {
                        "name": "clm-test-SLE15-SP7-Installer-Updates for aarch64",
                        "label": "clm-test-sle15-sp7-installer-updates-aarch64",
                        "mandatory": false
                    }
                ]
            }
        ],
    }
]
```

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.



- [x] **DONE**

## Documentation

- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Unit tests were added

- [x] **DONE**

## Links

Issue(s): # https://jira.suse.com/browse/SUMA-320
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
