### PR TITLE
Fix monitoring custom channel name

### DIFF
--- a/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
+++ b/testsuite/features/build_validation/add_MU_repositories/monitoring_server_add_maintenance_update_repositories.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025 SUSE LLC
+# Copyright (c) 2023-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @monitoring_server

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2025 SUSE LLC.
+# Copyright (c) 2013-2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'tempfile'
@@ -685,7 +685,7 @@ def channel_packages_are_downloaded?(channel_name)
   if channel_name.include?('custom_channel')
     client = channel_name.delete_prefix('custom_channel_')
     # Monitoring server doesn't have an entry in the custom repository JSON file.
-    return true if $custom_repositories[client].nil? && client != "monitoring_server"
+    return true if $custom_repositories[client].nil? && client != 'monitoring_server'
   end
   log_tmp_file = '/tmp/reposync.log'
   get_target('server').extract('/var/log/rhn/reposync.log', log_tmp_file)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 SUSE LLC

SPDX-License-Identifier: Apache-2.0
-->

## What does this PR change?

During add mu stage for monitoring, we are not waiting the synchronization of the correct channel.
Update the correct channel name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links


Port(s): 
 - Manager-5.1: https://github.com/SUSE/spacewalk/pull/29627
 - Manager-5.0: https://github.com/SUSE/spacewalk/pull/29628
 - Manager-4.3: https://github.com/SUSE/spacewalk/pull/29629

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
