### PR TITLE
QE: use unique data directories for Chromedriver sessions

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2025 SUSE LLC
+# Copyright (c) 2010-2026 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'English'
@@ -105,7 +105,7 @@ def capybara_register_driver
     )
     chrome_options.args << '--headless=new' unless $debug_mode
     chrome_options.args << "--remote-debugging-port=#{$chromium_dev_port}" if $chromium_dev_tools
-    chrome_options.args << '--user-data-dir=/root' if $is_cloud_provider
+    chrome_options.add_argument("--user-data-dir=/tmp/chrome_profile_#{Process.pid}_#{Time.now.to_i}") if $is_cloud_provider
 
     chrome_options.add_preference('prompt_for_download', false)
     chrome_options.add_preference('download.default_directory', '/tmp/downloads')


### PR DESCRIPTION
## What does this PR change?

Clients initialization is run in parallel in the Uyuni AWS CI,  this often times results in the Chromedriver being unable to spawn a new session because of .lock files inside the data directory which are being held by another session.

Making so that each sessions spawns with its dedicated , unique, data directory seems to solve this problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage

- Cucumber tests setup was modified

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29402
Port(s): To be determined

- [x] **DONE**

## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
