### PR TITLE
Revert "QE: Update Uyuni version for PR tests to 2026.01"

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -46,7 +46,7 @@ jobs:
           platforms: ${{ env.PLATFORMS }}
           build-args: |
             BASE=registry.opensuse.org/uyuni/server
-            VERSION=2026.01
+            VERSION=2025.10
   build-and-push-ubuntu-minion-image:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Reverts uyuni-project/uyuni#11461

We need to revert this again. The fixes to make this work are bigger than expected. In the beginning you only need to update `libcares2`, but then it gets worse with `openssh` being outdated, etc. We need more time to fix this. The main reason is we use a 15.6 BCI image and we mix in Leap and devel repos.

I tried a few things but nothing worked so far.
```bash
Run ./testsuite/podman_runner/11_setup_sshd.sh
./testsuite/podman_runner/11_setup_sshd.sh
shell: /usr/bin/bash -e {0}
env:
UYUNI_PROJECT: nodeg
UYUNI_VERSION: master
NO_AUTH_REGISTRY: noauthregistry.lab
PUBLISH_CUCUMBER_REPORT: true
AUTH_REGISTRY: authregistry.lab
AUTH_REGISTRY_CREDENTIALS: cucutest|cucutest
++ uname
+ [[ Linux == \D\a\r\w\i\n ]]
+ PODMAN_CMD='sudo -i podman'
+ sudo -i podman exec server bash -c 'ssh-keygen -A && /usr/sbin/sshd -e'
OpenSSL version mismatch. Built against 30100040, you have 3050003f

``` 

```bash
#10 34.38 Building repository 'nodejs' cache [....done]
#10 34.67 Loading repository data...
#10 35.06 Reading installed packages...
#10 35.71 'npm' not found in package names. Trying capabilities.
#10 35.71 Resolving package dependencies...
#10 35.79 
#10 35.79 Problem: 1: the to be installed openssh-10.2p1-2.1.x86_64 requires 'openssh-server = 10.2p1-2.1', but this requirement cannot be provided
#10 35.79 not installable providers: openssh-server-10.2p1-2.1.x86_64[tumbleweed_repo]
#10 35.79 
#10 35.79  Solution 1: do not install openssh-10.2p1-2.1.x86_64
#10 35.79  Solution 2: remove lock to allow removal of filesystem-15.0-11.8.1.x86_64
#10 35.79  Solution 3: break openssh-10.2p1-2.1.x86_64 by ignoring some of its dependencies
#10 35.79 
#10 35.79 Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
```