### PR TITLE
Change repos in uyuni openscap vs head testsuite

### DIFF
--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -14,6 +14,10 @@ Feature: OpenSCAP audit of Salt minion
 
 @Uyuni
   Scenario: Enable required repositories
+    When I enable repository "repo-oss" on this "sle_minion" without error control
+
+@susemanager
+  Scenario: Enable required repositories
     When I enable repository "os_pool_repo" on this "sle_minion" without error control
 
   Scenario: Install the OpenSCAP packages on the SLE minion
@@ -134,5 +138,9 @@ Feature: OpenSCAP audit of Salt minion
     When I remove OpenSCAP dependencies from "sle_minion"
 
 @Uyuni
+  Scenario: Cleanup: Disable required repositories
+    When I disable repository "repo-oss" on this "sle_minion" without error control
+
+@susemanager
   Scenario: Cleanup: Disable required repositories
     When I disable repository "os_pool_repo" on this "sle_minion" without error control


### PR DESCRIPTION
## What does this PR change?

In uyuni we don't have os_pool_repo set in sumaform. The right repo that has these dependencies is repo-oss which is set in sumaform. That is why the test fails only in uyuni but not in susemanager. The actual failure is just before the installation, in the repo enablement but since we do it without error control we never see it.

```
FAIL: zypper --non-interactive install -y openscap-utils openscap-content scap-security-guide returned status code = 104.
Output:
Loading repository data...
Reading installed packages...
'openscap-content' not found in package names. Trying capabilities.
'openscap-utils' not found in package names. Trying capabilities.
'scap-security-guide' not found in package names. Trying capabilities.
 (ScriptError)
./features/support/remote_node.rb:169:in `run_local'
./features/support/remote_node.rb:117:in `run'
./features/step_definitions/command_steps.rb:993:in `/^I install packages? "([^"]*)" on this "([^"]*)"((?: without error control)?)$/'
./features/step_definitions/command_steps.rb:971:in `/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/'
features/secondary/min_salt_openscap_audit.feature:23:in `I install OpenSCAP dependencies on "sle_minion"'
```


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Cucumber tests were added

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28822
Port(s): 
only needed in master since uyuni vs susemanager only has meaning in master but I will do ports to align the code in all branches so we don't diverge:
5.1: https://github.com/SUSE/spacewalk/pull/29642
5.0: https://github.com/SUSE/spacewalk/pull/29643
4.3: https://github.com/SUSE/spacewalk/pull/29644

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
