### PR TITLE
Fix permission check when assigning system groups to a user (bsc#1257674)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/frontend/action/user/AssignedGroupsSetupAction.java
+++ b/java/core/src/main/java/com/redhat/rhn/frontend/action/user/AssignedGroupsSetupAction.java
@@ -102,12 +102,12 @@ public class AssignedGroupsSetupAction extends RhnListAction {
         //If the default system groups were submitted
         if (submit != null &&
                 submit.equals(ls.getMessage("assignedgroups.jsp.submitdefaults"))) {
-            ensureRoleBasedAccess(user, "users.groups", Namespace.AccessMode.W);
+            ensureRoleBasedAccess(currentUser, "users.groups", Namespace.AccessMode.W);
             updateDefaults(mapping, formIn, request, response);
         }
         else if (submit != null &&  //else if the update permissions button was clicked
                     submit.equals(ls.getMessage("assignedgroups.jsp.submitpermissions"))) {
-            ensureRoleBasedAccess(user, "users.groups", Namespace.AccessMode.W);
+            ensureRoleBasedAccess(currentUser, "users.groups", Namespace.AccessMode.W);
             updatePerm(mapping, formIn, request, response);
             dr = UserManager.getSystemGroups(user, null);
             ListTagHelper.setSelectedAmount(LIST_NAME, set.size(), request);

--- a/java/spacewalk-java.changes.cbbayburt.bsc1257674
+++ b/java/spacewalk-java.changes.cbbayburt.bsc1257674
@@ -1,0 +1,2 @@
+- Fix permission check when assigning system groups to a user
+  (bsc#1257674)


### PR DESCRIPTION
Fixes RBAC permission check when assigning system groups to a user in the web UI by enforcing the permissions on the current user instead of the target user.

Port of: https://github.com/SUSE/spacewalk/pull/29634

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
