### PR TITLE
BV: Update system list with expected patches.

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -64,9 +64,10 @@ Feature: Smoke tests for <client>
     And I should see a "Location" text
     And I should see a "UUID" text
 
+# Patches are available for Ubuntu and Debian, but they are delivered through package updates rather than standalone patch files.
 @skip_for_debian
-@skip_for_rocky9
-@skip_for_alma9
+@skip_for_amazon2023
+@skip_for_ubuntu
   Scenario: Install a patch on the <client>
     Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -598,12 +598,12 @@ Before('@skip_for_debian') do |scenario|
   skip_this_scenario if scenario.location.file.include? 'debian'
 end
 
-Before('@skip_for_rocky9') do |scenario|
-  skip_this_scenario if scenario.location.file.include? 'rocky9'
+Before('@skip_for_ubuntu') do |scenario|
+  skip_this_scenario if scenario.location.file.include? 'ubuntu'
 end
 
-Before('@skip_for_alma9') do |scenario|
-  skip_this_scenario if scenario.location.file.include? 'alma9'
+Before('@skip_for_amazon2023') do |scenario|
+  skip_this_scenario if scenario.location.file.include? 'amazon2023'
 end
 
 Before('@skip_for_minion') do |scenario|


### PR DESCRIPTION
## What does this PR change?

From the last BV runs, update the list of system expected to have patch available.

The patches are not available for:
 - ubuntu
 - debian
 - amazonlinux2023
 
 The patches are NOW available for:
  - alma9 linux
  - rocky9 linux

<img width="785" height="268" alt="image" src="https://github.com/user-attachments/assets/f2d155e7-1d75-49cf-97ab-8da50ed5b432" />

<img width="785" height="268" alt="image" src="https://github.com/user-attachments/assets/44f62a1c-7c9f-4304-9e65-782d9a51ef07" />

  

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Port(s): # 
 - 5.1: https://github.com/SUSE/spacewalk/pull/29651
 - 5.0: https://github.com/SUSE/spacewalk/pull/29652
 - 4.3: https://github.com/SUSE/spacewalk/pull/29650

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
