### PR TITLE
BV: Harmonize the upgrade method and share it with all minions

### DIFF
--- a/testsuite/features/build_validation/migration/migration_sle15sp6_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_sle15sp6_minion.feature
@@ -7,9 +7,6 @@ Feature: Migrate a SLES 15 SP6 Salt minion to 15 SP7
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Prerequisite: update OS Salt to the latest version
-    When I upgrade "sle15sp6_minion" with the last "salt" version
-
   Scenario: Prerequisite: update OS zypper to the latest version
     When I upgrade "sle15sp6_minion" with the last "zypper" version
 

--- a/testsuite/features/build_validation/migration/migration_sle15sp6_ssh_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_sle15sp6_ssh_minion.feature
@@ -7,9 +7,6 @@ Feature: Migrate a SLES 15 SP6 Salt SSH minion to 15 SP7
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Prerequisite: update OS Salt to the latest version
-    When I upgrade "sle15sp6_ssh_minion" with the last "salt" version
-
   Scenario: Prerequisite: update OS zypper to the latest version
     When I upgrade "sle15sp6_ssh_minion" with the last "zypper" version
 

--- a/testsuite/features/build_validation/migration/migration_slemicro54_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_slemicro54_minion.feature
@@ -7,12 +7,6 @@ Feature: Migrate a SLE Micro 5.4 Salt minion to SLE Micro 5.5
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Prerequisite: update OS Salt to the latest version
-    When I upgrade "slemicro54_minion" with the last "salt" version
-
-  Scenario: Prerequisite: Reboot the slemicro 5.4 after updating salt
-    When I reboot the "slemicro54_minion" host through SSH, waiting until it comes back
-
   Scenario: Prerequisite: update OS zypper to the latest version
     When I upgrade "slemicro54_minion" with the last "zypper" version
 

--- a/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
+++ b/testsuite/features/build_validation/migration/migration_slemicro55_minion.feature
@@ -6,12 +6,6 @@ Feature: Migrate a SLE Micro 5.5 Salt minion to SL Micro 6.1
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
-    
-  Scenario: Prerequisite: update OS Salt to the latest version
-    When I upgrade "slemicro55_minion" with the last "salt" version
-
-  Scenario: Prerequisite: Reboot the slemicro 5.5 after updating salt
-    When I reboot the "slemicro55_minion" host through SSH, waiting until it comes back
 
   Scenario: Prerequisite: update OS zypper to the latest version
     When I upgrade "slemicro55_minion" with the last "zypper" version


### PR DESCRIPTION
## Context

The goal of this PR is to harmonize the migration stage prerequisites across all active branches. Currently, the package upgrade logic is inconsistent and prone to failure depending on the version being used.

### Current State & Issues
 - Manager 5.1: No prerequisites are currently defined.
 - Manager 5.0 & Uyuni: Upgrades for salt and zypper are forced; the process fails if no new updates are available.
 - Manager 4.3: Uses a more robust method that doesn't fail if updates are missing, but it is restricted to sles15sp6 only, ignoring slemicro versions.

## What does this PR change?

I am introducing a shared, consistent method across all versions that:
 - Supports "No Updates": The upgrade process will no longer fail if the system is already up to date.
 - Harmonized Package List: Standardizes the upgrade of ~salt and~ zypper.
 - Expanded OS Support: Extends these prerequisites to include slemicro5.4 and slemicro5.5 in addition to sles15sp6.

### Questions for QE / Reviewers
 - venv-salt-minion: I have excluded this from the upgrade list as it should technically always be at the latest version. Do we agree this is safe to omit? => no need, should be verified after bootstrap
 - SLE Micro Scope: Does everyone agree with applying these prerequisites to slemicro5.4 and slemicro5.5? From my perspective, this is necessary for environment consistency. => apply to all


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): #
Port(s): 
 - 4.3: https://github.com/SUSE/spacewalk/pull/29710
 - 5.0: https://github.com/SUSE/spacewalk/pull/29708
 - 5.1: https://github.com/SUSE/spacewalk/pull/29707

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
