### PR TITLE
BV: Fix new prometheus URL request

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1151,7 +1151,7 @@ When(/^I visit "([^"]*)" endpoint of this "([^"]*)"$/) do |service, host|
   port, protocol, path, text =
     case service
     when 'Proxy' then [443, 'https', '/pub/', 'Index of /pub']
-    when 'Prometheus' then [9090, 'http', '', 'graph']
+    when 'Prometheus' then [9090, 'http', '/query', 'Prometheus Time Series Collection']
     when 'Prometheus node exporter' then [9100, 'http', '', 'Node Exporter']
     when 'Prometheus apache exporter' then [9117, 'http', '', 'Apache Exporter']
     when 'Prometheus postgres exporter' then [9187, 'http', '', 'Postgres Exporter']


### PR DESCRIPTION
## What does this PR change?

Prometheus has been upgraded. With this new version, the current verification request is failing.
The path change and the response too.
Update the test with the last values.

This changed has not impact on client monitoring.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28600#issuecomment-3850602839
Port(s):
 - 5.1: https://github.com/SUSE/spacewalk/pull/29568
 - 5.0: https://github.com/SUSE/spacewalk/pull/29654
 - 4.3: https://github.com/SUSE/spacewalk/pull/29655

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
