### PR TITLE
Fix the --cookie parameter in API scripts examples

### DIFF
--- a/java/webapp/src/apidoc/asciidoc/scripts.txt
+++ b/java/webapp/src/apidoc/asciidoc/scripts.txt
@@ -36,7 +36,7 @@ _The JSON output is pretty-printed for clarity._
 [source,bash]
 ----
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > $API/contentmanagement/lookupProject?projectLabel=myproject
 {
   "success": true,
@@ -64,7 +64,7 @@ _The JSON output is pretty-printed for clarity._
 [source,bash]
 ----
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" -X POST \
 > "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
 {
   "success": true,
@@ -84,7 +84,7 @@ The request body must be a top-level JSON object that contains all the parameter
 [source,bash]
 ----
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
 > $API/contentmanagement/createProject
 {

--- a/java/webapp/src/apidoc/docbook/scripts.txt
+++ b/java/webapp/src/apidoc/docbook/scripts.txt
@@ -37,7 +37,7 @@ Set-Cookie: pxt-session-cookie=&lt;tokenhash&gt;; ...
     <programlisting>
 <![CDATA[
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > $API/contentmanagement/lookupProject?projectLabel=myproject
 {
   "success": true,
@@ -64,7 +64,7 @@ $ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;token
     <programlisting>
 <![CDATA[
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" -X POST \
 > "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
 {
   "success": true,
@@ -81,7 +81,7 @@ $ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;token
     <programlisting>
 <![CDATA[
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
 > $API/contentmanagement/createProject
 {

--- a/java/webapp/src/apidoc/html/scripts.txt
+++ b/java/webapp/src/apidoc/html/scripts.txt
@@ -37,7 +37,7 @@ In a GET request, method parameters must be sent as query string key-value pairs
 <p/>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > $API/contentmanagement/lookupProject?projectLabel=myproject
 {
   "success": true,
@@ -64,7 +64,7 @@ The following examples show both approaches.<br/>
 <h4>Using the query string</h4>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" -X POST \
 > "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
 {
   "success": true,
@@ -83,7 +83,7 @@ properties.
 <p/>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
 > $API/contentmanagement/createProject
 {

--- a/java/webapp/src/apidoc/jsp/scripts.txt
+++ b/java/webapp/src/apidoc/jsp/scripts.txt
@@ -42,7 +42,7 @@ In a GET request, method parameters must be sent as query string key-value pairs
 <p/>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > $API/contentmanagement/lookupProject?projectLabel=myproject
 {
   "success": true,
@@ -69,7 +69,7 @@ The following examples show both approaches.<br/>
 <h4>Using the query string</h4>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" -X POST \
 > "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
 {
   "success": true,
@@ -88,7 +88,7 @@ properties.
 <p/>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
 > $API/contentmanagement/createProject
 {

--- a/java/webapp/src/apidoc/singlepage/scripts.txt
+++ b/java/webapp/src/apidoc/singlepage/scripts.txt
@@ -37,7 +37,7 @@ In a GET request, method parameters must be sent as query string key-value pairs
 <p/>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > $API/contentmanagement/lookupProject?projectLabel=myproject
 {
   "success": true,
@@ -64,7 +64,7 @@ The following examples show both approaches.<br/>
 <h4>Using the query string</h4>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" -X POST \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" -X POST \
 > "$API/contentmanagement/createProject?projectLabel=myproject&name=My%20Project&description="
 {
   "success": true,
@@ -83,7 +83,7 @@ properties.
 <p/>
 <pre>
 $ API=https://manager.example.com/rhn/manager/api
-$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie&lt;tokenhash&gt;;" \
+$ curl -H "Content-Type: application/json" --cookie "pxt-session-cookie=&lt;tokenhash&gt;;" \
 > -d '{"projectLabel":"myproject","name":"My Project","description":""}' \
 > $API/contentmanagement/createProject
 {


### PR DESCRIPTION
## What does this PR change?

curl's --cookie parameter value is in the form name=value. Add the missing equals sign in the docs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: doc

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
