### PR TITLE
Handle redirects with pycurl in suseLib

### DIFF
--- a/python/spacewalk/spacewalk-backend.changes.cbosdo.proxy-ssl
+++ b/python/spacewalk/spacewalk-backend.changes.cbosdo.proxy-ssl
@@ -1,0 +1,1 @@
+- Use pycurl redirects


### PR DESCRIPTION
## What does this PR change?

15 years ago we had to handle redirects in suseLib ourselves because pycurl didn't implement it properly for POST requests. Now this is fixed and handles more redirection codes than we do: it's time to get rid of our workaround.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: manually tested, the CI probably covers the it somehow

- [x] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
