### PR TITLE
fix: color of labels of radios and spaces in create user

### DIFF
--- a/java/spacewalk-java.changes.MarekPetr.usercreate-cleanup
+++ b/java/spacewalk-java.changes.MarekPetr.usercreate-cleanup
@@ -1,0 +1,1 @@
+Change color of languages and remove spaces in user creation page

--- a/java/webapp/src/main/webapp/WEB-INF/pages/user/create/usercreate.jsp
+++ b/java/webapp/src/main/webapp/WEB-INF/pages/user/create/usercreate.jsp
@@ -163,7 +163,6 @@
               </c:if>/>
               <c:out value="${defaultLocale.localizedName}" />
               <br />
-              <br />
             </div>
           </div>
         <c:forEach var="item" items="${supportedLocales}">
@@ -175,7 +174,7 @@
               <c:if test="${item.key == currentLocale}">
                 checked="checked"
               </c:if>/>
-            <span class="text-info"><strong><c:out value="${item.value.localizedName}" /></strong></span>
+            <span><strong><c:out value="${item.value.localizedName}" /></strong></span>
           </div>
           <c:if test="${counter == 1}">
             </div>
@@ -210,7 +209,6 @@
                             <c:out value="${defaultDocsLocale.localizedName}" />
                         </div>
                         </br>
-                        </br>
                     </div>
                     <c:set var="counter" value="0"/>
                     <c:forEach var="item" items="${supportedDocsLocales}">
@@ -222,7 +220,7 @@
                                     <c:if test="${item.key == currentDocsLocale}">
                                         checked="checked"
                                     </c:if>/>
-                            <span class="text-info"><strong><c:out value="${item.value.localizedName}" /></strong></span>
+                            <span><strong><c:out value="${item.value.localizedName}" /></strong></span>
                         </div>
                         <c:if test="${counter == 1}">
                             </div>


### PR DESCRIPTION
## What does this PR change?

Use neutral color for the labels of radios in the create user view - https://localhost:8080/rhn/users/CreateUser.do.
Remove excessive vertical spaces.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

Before:
<img width="782" height="746" alt="before" src="https://github.com/user-attachments/assets/cbdc2217-b9cb-48ec-a705-af39370e83a0" />

After:
<img width="780" height="730" alt="after" src="https://github.com/user-attachments/assets/66066c67-1b74-43c7-8e4e-ce877521aae3" />

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #8763
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
