### PR TITLE
Fix openscap audit results with negative ids (bsc#1258141)

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/audit/XccdfTestResult.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/audit/XccdfTestResult.java
@@ -62,7 +62,7 @@ public class XccdfTestResult implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "xccdf_test_result_seq")
-    @SequenceGenerator(name = "xccdf_test_result_seq", sequenceName = "rhn_xccdf_tresult_id_seq")
+    @SequenceGenerator(name = "xccdf_test_result_seq", sequenceName = "rhn_xccdf_tresult_id_seq", allocationSize = 1)
     @Column(name = "id", nullable = false)
     private Long id;
 

--- a/java/spacewalk-java.changes.carlo.uyuni-1258141-openscap-results-negative-ids
+++ b/java/spacewalk-java.changes.carlo.uyuni-1258141-openscap-results-negative-ids
@@ -1,0 +1,1 @@
+- Fix openscap audit results with negative ids (bsc#1258141)


### PR DESCRIPTION
## What does this PR change?
In the first part of Hibernate migration towards version 7 we had to convert `*.hbm.xml` files into annotations.
This included table IDs generated by some sequence generator.

Class `XccdfRuleResult` was the only one that mistakenly had no `allocationSize = 1` directive in the `@SequenceGenerator` annotation.
This lead to an extremely weird behaviour: instead of getting the value from the correct sequence generator `rhn_xccdf_rresult_id_seq`, the id fields got a weird negative sequence number, got from an unknown source.
After adding `allocationSize = 1` to the annotation, the behaviour is as expected: the ID field is taken from the correct sequence, and even acting externally to the sequence (e.g. incrementing values from an external query) leads to the correct and expected results.

I also made a check that all classes with `@SequenceGenerator` annotation have the correct `allocationSize = 1` directive


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- Unit tests were added
- Cucumber tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/29669
Port(s): not backported: only for version 5.2/uyuni
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
