### PR TITLE
Fix transactional cleanup for multiple packages

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2025 SUSE LLC.
+# Copyright (c) 2014-2026 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 ### This file contains the definitions for all steps concerning the execution of commands on a system.
@@ -995,6 +995,9 @@ end
 
 When(/^I remove packages? "([^"]*)" from this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|
   node = get_target(host)
+  # Split the input string into an array to handle multiple packages
+  package_list = package.split
+
   if rh_host?(host)
     cmd = "yum -y remove #{package}"
     successcodes = [0]
@@ -1002,10 +1005,22 @@ When(/^I remove packages? "([^"]*)" from this "([^"]*)"((?: without error contro
     cmd = "dpkg --remove #{package}"
     successcodes = [0]
   elsif transactional_system?(host)
-    cmd = "transactional-update pkg rm -y #{package}"
+    # Pre-filter: transactional-update fails and rolls back the whole snapshot if a package isn't found (exit code 104).
+    # By only passing installed packages, we ensure a 0 exit code and prevent automatic rollback of the transaction.
+    check_cmd = "rpm -q --qf '%{NAME}\\n' #{package_list.join(' ')} 2>/dev/null"
+    raw_output, = node.run(check_cmd, check_errors: false)
+    # To avoid using | grep -v 'not installed' in command, use select to verify lane match the packages to remove
+    packages_to_remove = raw_output.split("\n").select { |line| package_list.include?(line.strip) }
+    if packages_to_remove.empty?
+      puts "None of the packages (#{package}) are installed on #{host}. Skipping."
+      next
+    end
+    # Use --continue to ensure we build upon the existing pending snapshot if one exists
+    cmd = "transactional-update --continue pkg rm -y #{packages_to_remove.join(' ')}"
     successcodes = [0, 100, 101, 102, 103, 106]
   else
     cmd = "zypper --non-interactive remove -y #{package}"
+    # Zypper is fine with 104 (package not found), but transactional-update is not
     successcodes = [0, 100, 101, 102, 103, 104, 106]
   end
   node.run(cmd, check_errors: error_control.empty?, successcodes: successcodes)


### PR DESCRIPTION
## What does this PR change?

This PR updates the Cucumber step for package removal to handle the atomic behavior of transactional systems (e.g., SLE Micro). 

Previously, attempting to remove a list of packages where one or more were missing caused `"transactional-update pkg rm` to return exit code **104**. While this is an informative code for standard systems, `transactional-update` treats any non-zero exit as a transaction failure. This triggers an automatic rollback that discards the entire snapshot, meaning even the packages that *were* successfully removed are restored after a reboot.

**Changes:**
* Added a pre-check using `rpm -q` to identify which packages are actually installed before running the removal command.
* Filtered the `rpm` output to ignore "package is not installed" strings that some versions print to stdout.
* Updated the command to use `--continue` to ensure changes are additive if a pending snapshot exists.
* The step now skips the removal command entirely if the filtered list is empty.

## Test

After change and bootstrap

```
maxime-minion4:~ # rpm -q venv-salt-minion
venv-salt-minion-3006.0-150002.5.6.1.x86_64
maxime-minion4:~ # rpm -q salt
package salt is not installed
maxime-minion4:~ # rpm -q salt-minion
package salt-minion is not installed
```

## Codespace
Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes to the test framework logic.

- [x] **DONE**

## Test coverage
- No tests: already covered. This is a logic fix for an existing step to ensure persistence on transactional minions.

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29684
Port(s): 
 - 4.3: https://github.com/SUSE/spacewalk/pull/29713
 - 5.0: https://github.com/SUSE/spacewalk/pull/29711
 - 5.1: https://github.com/SUSE/spacewalk/pull/29712

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!