### PR TITLE
Fix exception while reordering config channels ranking

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/server/Server.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/server/Server.java
@@ -63,6 +63,7 @@ import org.apache.logging.log4j.Logger;
 import org.cobbler.CobblerConnection;
 import org.cobbler.SystemRecord;
 import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CollectionType;
 import org.hibernate.annotations.ListIndexBase;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.WhereJoinTable;
@@ -233,6 +234,9 @@ public class Server extends BaseDomainHelper implements Identifiable {
             inverseJoinColumns = @JoinColumn(name = "config_channel_id")
     )
     @ListIndexBase(1)
+    @CollectionType(
+            type = "com.redhat.rhn.common.hibernate.ForceRecreationListType"
+    )
     private List<ConfigChannel> configChannels = new ArrayList<>();
 
     @ManyToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)

--- a/java/core/src/main/java/com/redhat/rhn/domain/token/Token.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/token/Token.java
@@ -32,6 +32,7 @@ import com.redhat.rhn.domain.user.legacy.UserImpl;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.CollectionType;
 import org.hibernate.annotations.ListIndexBase;
 import org.hibernate.annotations.Type;
 
@@ -144,7 +145,7 @@ public class Token implements Identifiable {
     )
     @OrderColumn(name = "position") // Handles list indexing.
     @ListIndexBase(1)
-    @org.hibernate.annotations.CollectionType(
+    @CollectionType(
             type = "com.redhat.rhn.common.hibernate.ForceRecreationListType"
     )
     private List<ConfigChannel> configChannels  = new ArrayList<>();

--- a/java/core/src/test/java/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -98,6 +98,39 @@ public class ServerTest extends BaseTestCaseWithUser {
     }
 
     @Test
+    public void testChangeConfigChannelsRankingOrder() throws Exception {
+        //create server and subscribe configuration channels in order 1,2,3
+        Server s = ServerTestUtils.createTestSystem(user);
+        ConfigChannel channel1 = ConfigTestUtils.createConfigChannel(user.getOrg(), "Ch 1", "cfg-channel-1");
+        ConfigChannel channel2 = ConfigTestUtils.createConfigChannel(user.getOrg(), "Ch 2", "cfg-channel-2");
+        ConfigChannel channel3 = ConfigTestUtils.createConfigChannel(user.getOrg(), "Ch 3", "cfg-channel-3");
+        s.subscribeConfigChannels(List.of(channel1, channel2, channel3), user);
+
+        //save and reload server, check configuration channels order
+        TestUtils.saveAndFlush(s);
+        Server s1 = ServerFactory.lookupByIdAndOrg(s.getId(), user.getOrg());
+        assertNotNull(s1);
+        List<ConfigChannel> result1ConfigChannelList = s1.getConfigChannelList();
+        assertEquals(3, result1ConfigChannelList.size());
+        assertEquals("cfg-channel-1", result1ConfigChannelList.get(0).getLabel());
+        assertEquals("cfg-channel-2", result1ConfigChannelList.get(1).getLabel());
+        assertEquals("cfg-channel-3", result1ConfigChannelList.get(2).getLabel());
+
+        //change configuration channels ranking order to 3,1,2
+        s1.subscribeConfigChannels(List.of(channel3, channel1, channel2), user);
+
+        //save and reload server, check configuration channels order
+        TestUtils.saveAndFlush(s1);
+        Server s2 = ServerFactory.lookupByIdAndOrg(s.getId(), user.getOrg());
+        assertNotNull(s2);
+        List<ConfigChannel> result2ConfigChannelList = s2.getConfigChannelList();
+        assertEquals(3, result2ConfigChannelList.size());
+        assertEquals("cfg-channel-3", result2ConfigChannelList.get(0).getLabel());
+        assertEquals("cfg-channel-1", result2ConfigChannelList.get(1).getLabel());
+        assertEquals("cfg-channel-2", result2ConfigChannelList.get(2).getLabel());
+    }
+
+    @Test
     public void testIsInactive() {
         Server s = ServerFactory.createServer();
         s.setServerInfo(new ServerInfo());


### PR DESCRIPTION
## What does this PR change?

This fixes a bug, reproducible this way

- create some config channels in >Configuration > Channels
- onboard a minion
- \> Systems > select the minion > Configuration
- \> Manage Configuration Channels > Subscribe to channels (subscribe the minion to some config channels)
- \> Manage Configuration Channels > View/Modify Rankings (modify the order of the channels)
- \> Update Channel Rankings

An exception is raised, like:
`ERROR org.hibernate.engine.jdbc.spi.SqlExceptionHelper - ERROR: duplicate key value violates unique constraint "rhn_servercc_sid_ccid_uq"  Detail: Key (server_id, config_channel_id)=(1000010000, 3) already exists.`

the annotation in Server class solves the problem:

```
@org.hibernate.annotations.CollectionType(
            type = "com.redhat.rhn.common.hibernate.ForceRecreationListType"
   )
    private List<ConfigChannel> configChannels = new ArrayList<>();
```

This bug has the same root cause as https://github.com/uyuni-project/uyuni/pull/10843

A unit test has been added to avoid this bug and another has been added to verify https://github.com/uyuni-project/uyuni/pull/10843

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- Unit tests were added
- [x] **DONE**

## Links
Issue(s): https://github.com/uyuni-project/uyuni/issues/11448
Port(s): not backported to 5.1, 5.0 and 4.3 (bug from 5.2 forward)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

