### PR TITLE
Fix sso metadata response in xml format

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/SSOController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/SSOController.java
@@ -26,6 +26,8 @@ import com.redhat.rhn.frontend.security.AuthenticationServiceFactory;
 import com.redhat.rhn.frontend.servlets.PxtSessionDelegateFactory;
 import com.redhat.rhn.manager.user.UserManager;
 
+import com.suse.manager.webui.utils.SparkApplicationHelper;
+
 import com.onelogin.saml2.Auth;
 import com.onelogin.saml2.exception.Error;
 import com.onelogin.saml2.exception.SettingsException;
@@ -187,14 +189,14 @@ public final class SSOController {
                 final String metadata = settings.getSPMetadata();
                 final List<String> errors = Saml2Settings.validateMetadata(metadata);
                 if (errors.isEmpty()) {
-                    response.raw().getOutputStream().println(metadata);
+                    response.type("text/xml; charset=UTF-8");
+                    return metadata;
                 }
                 else {
-                    response.raw().setContentType("text/html; charset=UTF-8");
-
                     for (final String error : errors) {
                         LOG.error(error);
                     }
+                    return SparkApplicationHelper.internalServerError(response, errors.toArray(new String[0]));
                 }
             }
             catch (IOException | SettingsException | Error | CertificateEncodingException e) {

--- a/java/core/src/test/java/com/suse/manager/webui/controllers/test/SSOControllerTest.java
+++ b/java/core/src/test/java/com/suse/manager/webui/controllers/test/SSOControllerTest.java
@@ -14,7 +14,6 @@
  */
 package com.suse.manager.webui.controllers.test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -26,7 +25,7 @@ import com.suse.manager.webui.controllers.SSOController;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.settings.SettingsBuilder;
 
-import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -78,15 +77,17 @@ public class SSOControllerTest extends BaseControllerTestCase {
     public void testMetadataWithSSO() throws IOException {
         Config.get().setBoolean(ConfigDefaults.SINGLE_SIGN_ON_ENABLED, "true");
         Request requestWithCsrf = getRequestWithCsrf("/manager/sso/metadata");
-        SSOController.getMetadata(requestWithCsrf, response);
-        assertTrue(response.raw().getOutputStream().toString().contains("entityID=\"https://localhost/metadata.jsp\""));
+        String metadata = (String) SSOController.getMetadata(requestWithCsrf, response);
+        assertTrue(response.type().contains("text/xml"));
+        Assertions.assertNotNull(metadata);
+        assertTrue(metadata.contains("md:EntityDescriptor"));
     }
 
     @Test
     public void testMetadataWithoutSSO() throws IOException {
         Config.get().setBoolean(ConfigDefaults.SINGLE_SIGN_ON_ENABLED, "false");
         Request requestWithCsrf = getRequestWithCsrf("/manager/sso/metadata");
-        SSOController.getMetadata(requestWithCsrf, response);
-        assertEquals(StringUtils.EMPTY, response.raw().getOutputStream().toString());
+        String metadata = (String) SSOController.getMetadata(requestWithCsrf, response);
+        Assertions.assertNull(metadata);
     }
 }

--- a/java/spacewalk-java.changes.carlo.uyuni-sso-metadata-xml-format
+++ b/java/spacewalk-java.changes.carlo.uyuni-sso-metadata-xml-format
@@ -1,0 +1,1 @@
+- Fix sso metadata response in xml format

--- a/java/webapp/src/main/webapp/WEB-INF/decorators.xml
+++ b/java/webapp/src/main/webapp/WEB-INF/decorators.xml
@@ -8,6 +8,7 @@
         <pattern>/errors/500.jsp</pattern>
         <pattern>/manager/download/saltssh/pubkey</pattern>
         <pattern>/manager/login</pattern>
+        <pattern>/manager/sso/metadata</pattern>
         <pattern>/ajax</pattern>
     </excludes>
     <decorator name="layout_bare" page="layout_bare.jsp">


### PR DESCRIPTION
## What does this PR change?

This PR fixes the SSO endpoint https://<FQDN>/rhn/manager/sso/metadata not giving as output an xml file as expected

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s):  https://github.com/SUSE/spacewalk/issues/21442, upstream: https://github.com/uyuni-project/uyuni/issues/6793
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/29768
5.0: https://github.com/SUSE/spacewalk/pull/29769
4.3: not backported
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

