### PR TITLE
Enable editing null variables of playbooks via WebUI (bsc#1258017)

### DIFF
--- a/web/html/src/manager/minion/ansible/edit-ansible-vars-modal.tsx
+++ b/web/html/src/manager/minion/ansible/edit-ansible-vars-modal.tsx
@@ -36,7 +36,10 @@ const EditAnsibleVarsModal = (props: Props) => {
     if (open) {
       try {
         const data = yaml.load(props.renderContent);
-        setEditorData(data?.[0]?.vars || {});
+        const vars = data?.[0]?.vars || {};
+
+        const sanitizedVars = Object.fromEntries(Object.entries(vars).map(([k, v]) => [k, v === null ? "" : v]));
+        setEditorData(sanitizedVars);
       } catch (e) {
         showErrorToastr("Invalid playbook YAML");
       }

--- a/web/spacewalk-web.changes.bisht-richa.playbook-null-variable-fix
+++ b/web/spacewalk-web.changes.bisht-richa.playbook-null-variable-fix
@@ -1,0 +1,2 @@
+- Enable editing of null variables in Ansible WebUI
+  (bsc#1258017)


### PR DESCRIPTION
## What does this PR change?

Enable editing of null variables in Ansible WebUI

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.
:

- [x] **DONE**

## Documentation
- No documentation needed: Enable editing of null variables in Ansible WebUI

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: Enable editing of null variables in Ansible WebUI

- [x] **DONE**

## Links

Issue(s): [#29639](https://github.com/SUSE/spacewalk/issues/29639)
Port(s): [5.1](https://github.com/SUSE/spacewalk/pull/29792)

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
