### PR TITLE
Remove run_local_until_ok

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -290,7 +290,7 @@ end
 When(/^I wait until "([^"]*)" container is active$/) do |service|
   node = get_target('server')
   cmd = "systemctl is-active #{service}"
-  node.run_local_until_ok(cmd)
+  node.run_until_ok(cmd, runs_in_container: false)
 end
 
 When(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, host|

--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -176,22 +176,6 @@ class RemoteNode
     end
   end
 
-  # Runs a local command until it succeeds or times out.
-  #
-  # @param cmd [String] The command to run.
-  # @param timeout [Integer] The timeout to be used, in seconds.
-  # @param runs_in_container [Boolean] Whether the command should be run in the container or on the host.
-  # @return [Array<String, Integer>] The result and exit code.
-  def run_local_until_ok(cmd, timeout: DEFAULT_TIMEOUT, runs_in_container: true)
-    repeat_until_timeout(timeout: timeout, report_result: true) do
-      result, code = run_local(cmd, check_errors: false, runs_in_container: runs_in_container)
-      return [result, code] if code.zero?
-
-      sleep 2
-      result
-    end
-  end
-
   # Runs a command until it succeeds or times out.
   #
   # @param cmd [String] The command to run.


### PR DESCRIPTION
## What does this PR change?

`run _local_until_ ok` is broken. The option `:runs_in_container` is not supported
This method is only used for the step `I wait until "([^"]*)" container is active`

```
And I wait until "uyuni-server" container is active
    features/step_definitions/command_steps.rb:289
    unknown keyword: :runs_in_container (ArgumentError)
```

It's better to use `run_until_ok` with option `runs_in_container: false` and delete this method.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): 
Port(s): 
 - 5.1: https://github.com/SUSE/spacewalk/pull/29738
 - 5.0: https://github.com/SUSE/spacewalk/pull/29803

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
