### PR TITLE
remove TFTPD from the server container image

### DIFF
--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -85,6 +85,8 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
         zchunk && \
     zypper --non-interactive clean --all && \
     rpm -e container-suseconnect && \
+# Remove tftp even if cobbler says it needs it: we only want its data folder
+    rpm -e --nodeps tftp && mkdir -p -m 755 /srv/tftpboot \
     systemctl enable prometheus-node_exporter && \
     systemctl enable sssd && \
     rm /etc/krb5.conf.d/crypto-policies && \

--- a/containers/server-image/root/docker-entrypoint-init.d/00-mgrSetup.sh
+++ b/containers/server-image/root/docker-entrypoint-init.d/00-mgrSetup.sh
@@ -27,8 +27,6 @@
 : "${SCC_PASS:=}"
 : "${ISS_PARENT:=}"
 
-: "${MANAGER_ENABLE_TFTP:=n}"
-
 DEFAULT_RHN_CONF="/usr/share/rhn/config-defaults/rhn.conf"
 TMPDIR="/var/spacewalk/tmp"
 MANAGER_COMPLETE="/root/.MANAGER_SETUP_COMPLETE"
@@ -146,7 +144,6 @@ report-db-host=${REPORT_DB_HOST}
 report-db-port=${REPORT_DB_PORT}
 report-db-user=${REPORT_DB_USER}
 report-db-password=${REPORT_DB_PASS}
-enable-tftp=${MANAGER_ENABLE_TFTP}
 product_name=${PRODUCT_NAME}
 hostname=${UYUNI_FQDN}
 " > /root/spacewalk-answers

--- a/spacewalk/setup/answers.txt
+++ b/spacewalk/setup/answers.txt
@@ -13,4 +13,3 @@ db-password=bar
 db-name=service_name.world
 db-host=hostname.of.your.db
 db-port=5432
-enable-tftp=N

--- a/susemanager/susemanager.changes.cbosdo.split-again
+++ b/susemanager/susemanager.changes.cbosdo.split-again
@@ -1,0 +1,1 @@
+- Split TFTPD in a new container for the server

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -33,25 +33,12 @@
 %global use_python_shebang python3
 %endif
 
-%if 0%{?rhel}
-%global apache_user root
-%global apache_group root
-%global tftp_group root
-%global salt_user root
-%global salt_group root
-%global serverdir %{_sharedstatedir}
-%global wwwroot %{_localstatedir}/www
-%endif
-
-%if 0%{?suse_version}
 %global apache_user wwwrun
 %global apache_group www
-%global tftp_group tftp
 %global salt_user salt
 %global salt_group salt
 %global serverdir /srv
 %global wwwroot %{serverdir}/www
-%endif
 
 %global sharedwwwroot %{_datadir}/susemanager/www
 %global reporoot %{sharedwwwroot}/pub
@@ -100,9 +87,6 @@ BuildRequires:  spacewalk-backend-sql-postgresql
 %if 0%{?suse_version}
 BuildRequires:  %fillup_prereq
 BuildRequires:  %insserv_prereq
-BuildRequires:  tftp
-Requires(pre):  %fillup_prereq %insserv_prereq tftp
-Requires(preun):%fillup_prereq %insserv_prereq tftp
 Requires(post): user(%{apache_user})
 %endif
 Requires(pre):  salt

--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -21,8 +21,6 @@ Feature: Sanity checks
     And service "salt-master" is active on "server"
     And service "taskomatic" is enabled on "server"
     And service "taskomatic" is active on "server"
-    And socket "tftp" is enabled on "server"
-    And socket "tftp" is active on "server"
     And service "tomcat" is enabled on "server"
     And service "tomcat" is active on "server"
 

--- a/testsuite/podman_runner/07_server_setup.sh
+++ b/testsuite/podman_runner/07_server_setup.sh
@@ -156,7 +156,6 @@ $PODMAN_CMD run --cap-add AUDIT_CONTROL \
     -e UYUNI_FQDN="server"  \
     -e MANAGER_ADMIN_EMAIL="a@b.com"  \
     -e MANAGER_MAIL_FROM="a@b.com"  \
-    -e MANAGER_ENABLE_TFTP="n"  \
     -e MANAGER_DB_NAME="susemanager"  \
     -e MANAGER_DB_HOST="db"  \
     -e MANAGER_DB_PORT="5432"  \


### PR DESCRIPTION
## What does this PR change?

Align the podman server deployments with those on Kubernetes: the TFTP server will now be handled by the same image than on the proxy, running in its own container.

This commit removes the tftpd server from the server image as it will no longer be used.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
