### PR TITLE
Change the tftp expected CA path

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.tftp-ca-fix
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.tftp-ca-fix
@@ -1,0 +1,2 @@
+- Move the expected CA to /etc/pki/anchors on tftp pod
+  (bsc#1258709)

--- a/containers/proxy-helm/templates/tftp.yaml
+++ b/containers/proxy-helm/templates/tftp.yaml
@@ -38,21 +38,23 @@ spec:
           - name: tftpd-volume
             mountPath: /etc/uyuni/
             readOnly: true
+          - mountPath: /etc/pki/trust/anchors/
+            name: ca-cert
+            readOnly: true
           ports:
             - containerPort: 69
               protocol: UDP
       volumes:
         - name: tftpd-volume
-          projected:
-            sources:
-              - configMap:
-                  name: proxy-configmap
-                  items:
-                    - key: config.yaml
-                      path: config.yaml
-              - configMap:
-                  name: uyuni-ca
-                  items:
-                    - key: ca.crt
-                      path: ca.crt
-                      mode: 420
+          configMap:
+            name: proxy-configmap
+            items:
+              - key: config.yaml
+                path: config.yaml
+        - name: ca-cert
+          configMap:
+            defaultMode: 420
+            name: uyuni-ca
+            items:
+              - key: ca.crt
+                path: RHN-ORG-TRUSTED-SSL-CERT

--- a/containers/proxy-tftpd-image/proxy-tftpd-image.changes.cbosdo.tftp-ca-fix
+++ b/containers/proxy-tftpd-image/proxy-tftpd-image.changes.cbosdo.tftp-ca-fix
@@ -1,0 +1,1 @@
+- Move the expected CA to /etc/pki/anchors (bsc#1258709)

--- a/containers/proxy-tftpd-image/tftp_wrapper.py
+++ b/containers/proxy-tftpd-image/tftp_wrapper.py
@@ -425,7 +425,7 @@ def get_arguments():
     parser.add_argument(
         "--caPath",
         type=str,
-        default="/etc/uyuni/ca.crt",
+        default="/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
         help="Path to CA certificate",
     )
     parser.add_argument(

--- a/containers/proxy-tftpd-image/uyuni-configure.py
+++ b/containers/proxy-tftpd-image/uyuni-configure.py
@@ -13,8 +13,12 @@ with open(config_path + "config.yaml", encoding="utf-8") as source:
     config = yaml.safe_load(source)
 
     # store SSL CA certificate
-    if "ca_crt" in config and not os.path.exists("/etc/uyuni/ca.crt"):
-        with open("/etc/uyuni/ca.crt", "w", encoding="utf-8") as file:
+    if "ca_crt" in config and not os.path.exists(
+        "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT"
+    ):
+        with open(
+            "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT", "w", encoding="utf-8"
+        ) as file:
             file.write(config.get("ca_crt"))
 
 sys.exit(0)


### PR DESCRIPTION
## What does this PR change?

Since /etc/uyuni is mounted read-only on podman, better expect the CA in a more suitable folder. bsc#1258709

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29813

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
