### PR TITLE
Fix SLM 6.2 bootstrap script failure during first execution bsc#1258796

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -415,7 +415,7 @@ function setup_bootstrap_repo() {{
 
     if [ -n "$CLIENT_REPO_URL" ]; then
         echo " adding client software repository at $repourl"
-        cat <<EOF >"$repopath"
+        repo_cmd="cat <<EOF >$repopath
 [$reponame]
 name=$reponame
 baseurl=$repourl
@@ -423,7 +423,15 @@ enabled=1
 autorefresh=1
 keeppackages=0
 gpgcheck=0
-EOF
+EOF"
+        if [[ "$Z_CLIENT_CODE_BASE" = "slmicro" && \
+              "$Z_CLIENT_CODE_VERSION" = "6" && \
+              "$Z_CLIENT_CODE_PATCHLEVEL" -ge "2" ]]
+        then
+            call_tukit "$repo_cmd"
+        else
+            bash <<< "$repo_cmd"
+        fi
     fi
 
     # Avoid modularity failsafe mechanism in dnf 4.2.7 or greater
@@ -819,7 +827,11 @@ if [ ! -z "$ORG_GPG_KEY" ]; then
            apt-get --yes install --no-install-recommends gnupg
            apt-key add $GPG_KEY
         else
-           rpm --import $GPG_KEY
+            if [ -z "$SNAPSHOT_ID" ]; then
+                rpm --import $GPG_KEY
+            else
+                call_tukit "rpm --import $GPG_KEY"
+            fi
         fi
         rm -f ${GPG_KEY}
     done
@@ -913,7 +925,7 @@ echo
         # we need to copy certificate to the trustroot outside of transaction for zypper
         cp "$ORG_CA_CERT" /etc/pki/trust/anchors/
         call_tukit "test -d '$CERT_DIR' || mkdir -p '$CERT_DIR'"
-        call_tukit "cp '/etc/pki/trust/anchors/$ORG_CA_CERT' '${CERT_DIR}/${CERT_FILE}'"
+        call_tukit "cp '$ORG_CA_CERT' '${CERT_DIR}/${CERT_FILE}'"
     else
         test -d "$CERT_DIR" || mkdir -p "$CERT_DIR"
         mv "$ORG_CA_CERT" "${CERT_DIR}/${CERT_FILE}"
@@ -943,11 +955,12 @@ if [[ $ACTIVATION_KEYS =~ , ]]; then
 fi
 
 SNAPSHOT_PREFIX=""
-if [ -n "$SNAPSHOT_ID" ]; then
-    if [ -d "/var/lib/overlay" ]; then
-        # SLM 6.1 and older requires writing to snapshot
-        SNAPSHOT_PREFIX="/var/lib/overlay/$SNAPSHOT_ID"
-    fi
+if [[ "$Z_CLIENT_CODE_BASE" = "slmicro" && \
+      "$Z_CLIENT_CODE_VERSION" = "6" && \
+      "$Z_CLIENT_CODE_PATCHLEVEL" -lt "2" ]]
+then
+    # SLM 6.1 and older requires writing to snapshot
+    SNAPSHOT_PREFIX="/var/lib/overlay/$SNAPSHOT_ID"
 fi
 
 MINION_ID_FILE="${{SNAPSHOT_PREFIX}}/etc/salt/minion_id"
@@ -964,7 +977,10 @@ if [ $VENV_ENABLED -eq 1 ]; then
     MINION_SERVICE="venv-salt-minion"
 fi
 
-if [ -z "$SNAPSHOT_PREFIX" ] && [ -n "$SNAPSHOT_ID" ]; then
+if [[ "$Z_CLIENT_CODE_BASE" = "slmicro" && \
+      "$Z_CLIENT_CODE_VERSION" = "6" && \
+      "$Z_CLIENT_CODE_PATCHLEVEL" -ge "2" ]]
+then
     # TU minion writing to /etc, create /etc directories
     mkdir -p $MINION_CONFIG_DIR
 fi

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes.mczernek.bootstrap_script_slm62
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes.mczernek.bootstrap_script_slm62
@@ -1,0 +1,2 @@
+- Fix bootstrap script failure with SLM 6.2
+  during first execution (bsc#1258796)


### PR DESCRIPTION
## What does this PR change?

Bootstrap script on SLM 6.2 would fail the first time we execute it. This is because new `/etc` files are not available in an already opened transaction.

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29834
Port(s): https://github.com/SUSE/spacewalk/pull/30033, https://github.com/SUSE/spacewalk/pull/30034

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
