### PR TITLE
Fix debian repos sync in peripheral (bsc#1257647)

### DIFF
--- a/java/core/src/main/java/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/core/src/main/java/com/suse/manager/webui/controllers/DownloadController.java
@@ -87,22 +87,35 @@ public class DownloadController {
      * Invoked from Router. Initialize routes for Systems Views.
      */
     public void initRoutes() {
+        // endpoints commented with [deb] are used to sync debian repos to the peripheral. See (bsc#1257647)
+
+        // endpoints used by peripherals
         get("/manager/download/hubsync/:sccrepoid/getPackage/:file", this::downloadPackageHub);
+        get("/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file", this::downloadPackageHub); //[deb]
         get("/manager/download/hubsync/:sccrepoid/getPackage/:org/:checksum/:file", this::downloadPackageHub);
+        get("/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file",
+                this::downloadPackageHub); //[deb]
         get("/manager/download/hubsync/:sccrepoid/repodata/:file", this::downloadMetadataHub);
         get("/manager/download/hubsync/:sccrepoid/media.1/:file", this::downloadMediaFilesHub);
+        //
+        head("/manager/download/hubsync/:sccrepoid/getPackage/:file", this::downloadPackageHub);
+        head("/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file", this::downloadPackageHub); //[deb]
+        head("/manager/download/hubsync/:sccrepoid/getPackage/:org/:checksum/:file", this::downloadPackageHub);
+        head("/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file",
+                this::downloadPackageHub); //[deb]
+        head("/manager/download/hubsync/:sccrepoid/repodata/:file", this::downloadMetadataHub);
+        head("/manager/download/hubsync/:sccrepoid/media.1/:file", this::downloadMediaFilesHub);
+
+        // endpoints used by minions
         get("/manager/download/:channel/getPackage/:file", this::downloadPackage);
         get("/manager/download/:channel/getPackage/:org/:checksum/:file", this::downloadPackage);
         get("/manager/download/:channel/repodata/:file", this::downloadMetadata);
         get("/manager/download/:channel/media.1/:file", this::downloadMediaFiles);
+        //
         head("/manager/download/:channel/getPackage/:file", this::downloadPackage);
         head("/manager/download/:channel/getPackage/:org/:checksum/:file", this::downloadPackage);
         head("/manager/download/:channel/repodata/:file", this::downloadMetadata);
         head("/manager/download/:channel/media.1/:file", this::downloadMediaFiles);
-        head("/manager/download/hubsync/:sccrepoid/getPackage/:file", this::downloadPackageHub);
-        head("/manager/download/hubsync/:sccrepoid/getPackage/:org/:checksum/:file", this::downloadPackageHub);
-        head("/manager/download/hubsync/:sccrepoid/repodata/:file", this::downloadMetadataHub);
-        head("/manager/download/hubsync/:sccrepoid/media.1/:file", this::downloadMediaFilesHub);
     }
 
     /**

--- a/java/spacewalk-java.changes.carlo.uyuni-1257647_debian_peripheral_reposync
+++ b/java/spacewalk-java.changes.carlo.uyuni-1257647_debian_peripheral_reposync
@@ -1,0 +1,1 @@
+- Fix debian repo sync in peripheral (bsc#1257647)

--- a/schema/spacewalk/common/data/endpoint.sql
+++ b/schema/spacewalk/common/data/endpoint.sql
@@ -3363,7 +3363,13 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('', '/manager/download/hubsync/:sccrepoid/getPackage/:file', 'GET', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file', 'GET', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/download/hubsync/:sccrepoid/getPackage/:org/:checksum/:file', 'GET', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file', 'GET', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/download/hubsync/:sccrepoid/repodata/:file', 'GET', 'W', False)
@@ -3387,7 +3393,13 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
     VALUES ('', '/manager/download/hubsync/:sccrepoid/getPackage/:file', 'HEAD', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file', 'HEAD', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/download/hubsync/:sccrepoid/getPackage/:org/:checksum/:file', 'HEAD', 'W', False)
+    ON CONFLICT (endpoint, http_method) DO NOTHING;
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    VALUES ('', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file', 'HEAD', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/download/hubsync/:sccrepoid/repodata/:file', 'HEAD', 'W', False)
@@ -3407,6 +3419,7 @@ INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_re
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/download/:channel/media.1/:file', 'HEAD', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;
+
 INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
     VALUES ('', '/manager/download/saltssh/pubkey', 'GET', 'W', False)
     ON CONFLICT (endpoint, http_method) DO NOTHING;

--- a/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-1257647_debian_peripheral_reposync
+++ b/schema/spacewalk/susemanager-schema.changes.carlo.uyuni-1257647_debian_peripheral_reposync
@@ -1,0 +1,2 @@
+- Add hubsync endpoints to repo-sync debian repos in peripheral
+  (bsc#1257647)

--- a/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/100-add-missing-download-controller-endpoints.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-5.2.4-to-susemanager-schema-5.2.5/100-add-missing-download-controller-endpoints.sql
@@ -1,0 +1,18 @@
+
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file', 'GET', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file' AND http_method = 'GET');
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file', 'GET', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file' AND http_method = 'GET');
+
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file', 'HEAD', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:file' AND http_method = 'HEAD');
+INSERT INTO access.endpoint (class_method, endpoint, http_method, scope, auth_required)
+    SELECT '', '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file', 'HEAD', 'W', False
+    WHERE NOT EXISTS (SELECT 1 FROM access.endpoint WHERE endpoint = '/manager/download/hubsync/:sccrepoid/:channel/getPackage/:org/:checksum/:file' AND http_method = 'HEAD');
+
+
+


### PR DESCRIPTION
## What does this PR change?

Fix debian repos sync in peripheral (bsc#1257647)
Further research should be done, basing on https://github.com/SUSE/spacewalk/issues/29838

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): # https://github.com/SUSE/spacewalk/issues/29566
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/29823
5.0, 4.3: not backported (no hub/peripheral)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

