### PR TITLE
Change expected prometheus endpoint in testsuite

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1151,7 +1151,7 @@ When(/^I visit "([^"]*)" endpoint of this "([^"]*)"$/) do |service, host|
   port, protocol, path, text =
     case service
     when 'Proxy' then [443, 'https', '/pub/', 'Index of /pub']
-    when 'Prometheus' then [9090, 'http', '/query', 'Prometheus Time Series Collection']
+    when 'Prometheus' then [9090, 'http', '/graph', 'Prometheus']
     when 'Prometheus node exporter' then [9100, 'http', '', 'Node Exporter']
     when 'Prometheus apache exporter' then [9117, 'http', '', 'Apache Exporter']
     when 'Prometheus postgres exporter' then [9187, 'http', '', 'Postgres Exporter']


### PR DESCRIPTION
## What does this PR change?

fixes failing test for head https://github.com/SUSE/spacewalk/issues/29798. As of yet untested in head because the env was not available. tested in 5.1 and it works and does not break any other monitoring feature using this step. 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: already covered


- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29798
Port(s): 5.1: https://github.com/SUSE/spacewalk/pull/29824
The other 2 branches the test does not fail, I think the older versions of prometheus has different endpoints
5.0: not needed 
4.3: not needed

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
