### PR TITLE
Enable second level cache

### DIFF
--- a/java/buildconf/test/rhn.conf.postgresql-example
+++ b/java/buildconf/test/rhn.conf.postgresql-example
@@ -31,6 +31,8 @@ hibernate.cache.region.factory_class = org.hibernate.cache.jcache.internal.JCach
 hibernate.jakarta.cache.uri = ehcache.xml
 hibernate.jakarta.cache.provider = org.ehcache.jsr107.EhcacheCachingProvider
 hibernate.jakarta.cache.missing_cache_strategy = create
+# Hibernate keeps backward-compatibility aliases for old property names. This will silence warnings
+hibernate.javax.cache.missing_cache_strategy = create
 
 # Hibernate configuration
 reporting.hibernate.connection.driver_class = org.postgresql.Driver

--- a/java/conf/default/rhn_hibernate.conf
+++ b/java/conf/default/rhn_hibernate.conf
@@ -30,9 +30,11 @@ hibernate.c3p0.preferredTestQuery=select 'c3p0 ping' from dual
 
 hibernate.bytecode.use_reflection_optimizer=false
 hibernate.id.new_generator_mappings = true
-hibernate.cache.use_second_level_cache = false
-#hibernate.cache.use_query_cache = true
-#hibernate.cache.region.factory_class = org.hibernate.cache.jcache.internal.JCacheRegionFactory
-#hibernate.jakarta.cache.uri = ehcache.xml
-#hibernate.jakarta.cache.provider = org.ehcache.jsr107.EhcacheCachingProvider
-#hibernate.jakarta.cache.missing_cache_strategy = create
+hibernate.cache.use_second_level_cache = true
+hibernate.cache.use_query_cache = true
+hibernate.cache.region.factory_class = org.hibernate.cache.jcache.internal.JCacheRegionFactory
+hibernate.jakarta.cache.uri = ehcache.xml
+hibernate.jakarta.cache.provider = org.ehcache.jsr107.EhcacheCachingProvider
+hibernate.jakarta.cache.missing_cache_strategy = create
+# Hibernate keeps backward-compatibility aliases for old property names. This will silence warnings
+hibernate.javax.cache.missing_cache_strategy=create

--- a/java/spacewalk-java.changes.rjpmestre.enable_second_level_cache
+++ b/java/spacewalk-java.changes.rjpmestre.enable_second_level_cache
@@ -1,0 +1,1 @@
+- Enable second level cache


### PR DESCRIPTION
## What does this PR change?

This PR is part of  [Tomcat major upgrade](https://github.com/SUSE/spacewalk/issues/25547) epic and follows up on the  upgrade of ehcache 2.x to 3.x ( https://github.com/SUSE/spacewalk/issues/28297 ).
The upgrade itself is already merged, but second-level cache temporarily disabled for stability reasons. This PR re-enables it.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered (HibernateCacheTest.java)

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/28297

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
