### PR TITLE
Tests for c3p0 and quartz

### DIFF
--- a/java/core/src/test/java/com/redhat/rhn/manager/content/test/C3P0ConnectionPoolTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/test/C3P0ConnectionPoolTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026 SUSE LCC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.manager.content.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.beans.PropertyVetoException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * C3P0 connection pool test
+ */
+public class C3P0ConnectionPoolTest {
+
+    private ComboPooledDataSource dataSource;
+    private static final String JDBC_DRIVER = "org.postgresql.Driver";
+    private static final String DB_HOST = "localhost";
+    private static final int DB_PORT = 5432;
+    private static final String DB_NAME = "susemanager";
+    private static final String DB_USER = "spacewalk";
+    private static final String DB_PASSWORD = "spacewalk";
+
+    @BeforeEach
+    public void setUp() throws PropertyVetoException {
+        dataSource = new ComboPooledDataSource();
+        dataSource.setDriverClass(JDBC_DRIVER);
+        dataSource.setJdbcUrl("jdbc:postgresql://" + DB_HOST + ":" + DB_PORT + "/" + DB_NAME);
+        dataSource.setUser(DB_USER);
+        dataSource.setPassword(DB_PASSWORD);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (dataSource != null) {
+            try {
+                dataSource.close();
+            } catch (Exception e) {
+                fail("Error closing datasource: " + e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Test maxPoolSize by trying to add more connections than max.
+     * Acquires max connections, then expects the following one to timeout.
+     */
+    @Test
+    @Timeout(value = 15, unit = TimeUnit.SECONDS)
+    public void testMaxPoolSizeViolation() throws SQLException, InterruptedException {
+        int maxPoolSize = 2;
+        List<Connection> connections = new ArrayList<>();
+
+        //
+        dataSource.setMaxPoolSize(maxPoolSize);
+        dataSource.setMinPoolSize(1);
+        dataSource.setCheckoutTimeout(2000);
+
+        try {
+            for(int i = 0 ; i < maxPoolSize; i++) {
+                connections.add(dataSource.getConnection());
+            }
+
+            assertEquals(maxPoolSize, dataSource.getNumBusyConnections());
+            assertEquals(0, dataSource.getNumIdleConnections());
+
+            long startTime = System.currentTimeMillis();
+            SQLException thrownException = null;
+            try {
+                dataSource.getConnection();
+                fail("Should not be able to acquire 3rd connection when maxPoolSize=" + maxPoolSize);
+            } catch (SQLException e) {
+                thrownException = e;
+                assertTrue(System.currentTimeMillis() - startTime >= 2000);
+            }
+
+            assertNotNull(thrownException, "Should have thrown SQLException for pool exhaustion");
+        } finally {
+            for (Connection conn : connections) {
+                if (conn != null && !conn.isClosed()) {
+                    conn.close();
+                }
+            }
+        }
+
+        Thread.sleep(500);
+        assertEquals(0, dataSource.getNumBusyConnections());
+        assertEquals(maxPoolSize, dataSource.getNumIdleConnections());
+    }
+
+    /**
+     * Same test as before, just with concurrency.
+     */
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    public void testMaxPoolSizeViolationWithConcurrency() throws InterruptedException, SQLException {
+        int maxPoolSize = 2;
+        int numberOfThreads = 10;
+        AtomicInteger successfulAcquired = new AtomicInteger(0);
+        AtomicInteger timeoutThreads = new AtomicInteger(0);
+
+        //
+        dataSource.setMaxPoolSize(maxPoolSize);
+        dataSource.setMinPoolSize(1);
+        dataSource.setCheckoutTimeout(2000);
+
+        // Create threads trying to acquire connections simultaneously
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < numberOfThreads; i++) {
+            Thread t = new Thread(() -> {
+                try {
+                    Connection conn = dataSource.getConnection();
+                    successfulAcquired.incrementAndGet();
+
+                    // Hold the connection for a longer time to force contention
+                    Thread.sleep(3000);
+                    conn.close();
+                } catch (SQLException e) {
+                    timeoutThreads.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            threads.add(t);
+        }
+
+        for (Thread t : threads) {
+            t.start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+
+        Thread.sleep(500);
+        assertEquals(maxPoolSize, successfulAcquired.get());
+        assertEquals(numberOfThreads - maxPoolSize, timeoutThreads.get());
+        assertEquals(0, dataSource.getNumBusyConnections());
+        assertEquals(maxPoolSize, dataSource.getNumIdleConnections());
+    }
+
+}
+

--- a/java/core/src/test/java/com/redhat/rhn/manager/content/test/QuartzMisfireVerifiedTest.java
+++ b/java/core/src/test/java/com/redhat/rhn/manager/content/test/QuartzMisfireVerifiedTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 SUSE LCC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ */
+package com.redhat.rhn.manager.content.test;
+
+import static org.junit.Assert.fail;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.quartz.*;
+import org.quartz.impl.StdSchedulerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Reproduces issue we see on logs:
+ * [DefaultQuartzScheduler_QuartzSchedulerThread] WARN  com.mchange.v2.c3p0.impl.NewPooledConnection - [c3p0] A PooledConnection that has already signalled a Connection error is still in use!
+ * [DefaultQuartzScheduler_QuartzSchedulerThread] WARN  com.mchange.v2.c3p0.impl.NewPooledConnection - [c3p0] Another error has occurred [ org.postgresql.util.PSQLException: This connection has been closed. ] which will not be reported to listeners!
+ * org.postgresql.util.PSQLException: This connection has been closed.
+ * 	at org.postgresql.jdbc.PgConnection.checkClosed(PgConnection.java:880) ~[postgresql.jar:42.2.25]
+ * 	...
+ * [DefaultQuartzScheduler_QuartzSchedulerThread] ERROR org.quartz.impl.jdbcjobstore.JobStoreTX - Couldn't rollback jdbc connection. This connection has been closed.
+ * org.postgresql.util.PSQLException: This connection has been closed.
+ * 	at org.postgresql.jdbc.PgConnection.checkClosed(PgConnection.java:880) ~[postgresql.jar:42.2.25]
+ * 	...
+ *
+ * It's been designed to match the exact error scenario:
+ * - [QuartzScheduler_..._MisfireHandler] thread
+ * - PSQLException: FATAL: terminating connection due to administrator command
+ * - c3p0 pool errors
+ * - JobStoreTX - MisfireHandler: Error handling misfires
+ */
+public class QuartzMisfireVerifiedTest {
+    private static final Logger LOG = LogManager.getLogger(QuartzMisfireVerifiedTest.class);
+
+    private static final String DB_URL = "jdbc:postgresql://localhost:5432/susemanager";
+    private static final String DB_USER = "spacewalk";
+    private static final String DB_PASSWORD = "spacewalk";
+    private static final String UNIQUE_JOB_ID = "verifiedJob_" + System.currentTimeMillis();
+    private static final String VERIFIED_GROUP = "verifiedGroup";
+
+    private Scheduler scheduler;
+    private Connection adminConnection;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        try {
+            adminConnection = DriverManager.getConnection(DB_URL, DB_USER, DB_PASSWORD);
+        } catch (Exception e) {
+            fail("Could not create admin connection to db: " + e.getMessage());
+        }
+
+        // Configure quartz from java/conf/default/rhn_org_quartz.conf
+        Properties props = new Properties();
+        props.setProperty("org.quartz.scheduler.instanceName", "VerifiedTestScheduler");
+        props.setProperty("org.quartz.scheduler.instanceId", "AUTO");
+        
+        // Thread pool
+        props.setProperty("org.quartz.threadPool.class", "org.quartz.simpl.SimpleThreadPool");
+        props.setProperty("org.quartz.threadPool.threadCount", "3");
+        
+        // Job store
+        props.setProperty("org.quartz.jobStore.class", "org.quartz.impl.jdbcjobstore.JobStoreTX");
+        props.setProperty("org.quartz.jobStore.driverDelegateClass", "org.quartz.impl.jdbcjobstore.PostgreSQLDelegate");
+        props.setProperty("org.quartz.jobStore.dataSource", "quartzDS");
+        props.setProperty("org.quartz.jobStore.tablePrefix", "QRTZ_");
+        props.setProperty("org.quartz.jobStore.isClustered", "false");
+        
+        // short misfire threshold
+        props.setProperty("org.quartz.jobStore.misfireThreshold", "1000");
+        
+        // Data source
+        props.setProperty("org.quartz.dataSource.quartzDS.driver", "org.postgresql.Driver");
+        props.setProperty("org.quartz.dataSource.quartzDS.URL", DB_URL);
+        props.setProperty("org.quartz.dataSource.quartzDS.user", DB_USER);
+        props.setProperty("org.quartz.dataSource.quartzDS.password", DB_PASSWORD);
+        props.setProperty("org.quartz.dataSource.quartzDS.maxConnections", "5");
+
+        StdSchedulerFactory factory = new StdSchedulerFactory(props);
+        scheduler = factory.getScheduler();
+    }
+
+    /**
+     * Clean up jobs from this test
+     * @throws Exception if an error occurs while cleaning up
+     */
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (scheduler != null && !scheduler.isShutdown()) {
+            try {
+                scheduler.clear();
+                scheduler.shutdown(true);
+            } catch (Exception e) {
+                LOG.error("Unexpected exception while shutting down scheduler: " + e.getMessage());
+            }
+        }
+
+        adminConnection.close();
+    }
+
+    public static class VerifiedJob implements Job {
+        @Override
+        public void execute(JobExecutionContext context) {
+            LOG.debug("Executing job key = " + context.getJobDetail().getKey());
+        }
+    }
+
+    /**
+     * Setup:
+     * 1) Start scheduler - MisfireHandler becomes active
+     * 2) Schedule a job that fires frequently
+     * 3) Let scheduler run normally
+     * 4) Terminate database connections while MisfireHandler periodically checks
+     * 5) Wait for MisfireHandler to hit the error
+     */
+    @Test
+    public void testMisfireHandlerWithConnectionTermination() {
+        try {
+            // Starting scheduler
+            scheduler.start();
+            LOG.info("Scheduler started");
+
+            // Schedule a job with a 1s interval
+            JobDetail job = JobBuilder.newJob(VerifiedJob.class)
+                    .withIdentity(UNIQUE_JOB_ID, VERIFIED_GROUP)
+                    .storeDurably()
+                    .requestRecovery()
+                    .build();
+
+            Trigger trigger = TriggerBuilder.newTrigger()
+                    .withIdentity(UNIQUE_JOB_ID + "_trigger", VERIFIED_GROUP)
+                    .startNow()
+                    .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                            .withIntervalInSeconds(1)
+                            .repeatForever()
+                            .withMisfireHandlingInstructionFireNow())
+                    .build();
+
+            scheduler.scheduleJob(job, trigger);
+            LOG.debug("Job scheduled (fires every 1 second)");
+
+            // allow scheduler to run normally
+            LOG.debug("Allowing jobs to run normally...");
+            Thread.sleep(2100);
+
+            // terminate connections
+            LOG.debug("Terminating connections...");
+            terminateConnections();
+
+            // wait for jobs to misfire
+            LOG.debug("Waiting for jobs to fail...");
+            Thread.sleep(2100);
+
+        } catch (Exception e) {
+            LOG.error("Test execution error: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Terminate active Quartz database connections using pg_terminate_backend
+     */
+    private void terminateConnections() {
+        try {
+            Statement stmt = adminConnection.createStatement();
+            
+            // Find active connections
+            String query = 
+                "SELECT pid, state, query FROM pg_stat_activity " +
+                "WHERE datname = 'susemanager' " +
+                "AND usename = '" + DB_USER + "' " +
+                "AND pid != pg_backend_pid() " +
+                "AND state IS NOT NULL";
+            
+            ResultSet rs = stmt.executeQuery(query);
+            
+            int count = 0;
+            while (rs.next()) {
+                int pid = rs.getInt("pid");
+                String state = rs.getString("state");
+                
+                try {
+                    Statement killStmt = adminConnection.createStatement();
+                    killStmt.execute("SELECT pg_terminate_backend(" + pid + ")");
+                    LOG.debug("Terminated PID " + pid + " (state: " + state + ")");
+                    count++;
+                    killStmt.close();
+                } catch (Exception e) {
+                    LOG.error("Failed to terminate PID " + pid + ": " + e.getMessage());
+                }
+            }
+            
+            rs.close();
+            stmt.close();
+            
+            if (count > 0) {
+                LOG.debug("Terminated " + count + " connections");
+            } else {
+                LOG.debug("No active connections found to terminate");
+                LOG.debug("(MisfireHandler may have finished already)");
+            }
+            
+        } catch (Exception e) {
+            LOG.error("Error terminating connections: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR change?

Dummy PR. Adding tests for c3p0 and quartz that aim to reproduce a specific failure we found in taskomatic first launch (also mentioned in https://bugzilla.suse.com/show_bug.cgi?id=1258551)

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Multi-Linux Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- API documentation added: please review the Wiki page [Writing Documentation for the API](https://github.com/uyuni-project/uyuni/wiki/Writing-documentation-for-the-API) if you have any changes to API documentation.
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Issue(s): #
Port(s): # **add downstream PR(s), if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
