### PR TITLE
Revert "Fix expiring subscription warnings (bsc#1257894)"

### DIFF
--- a/java/core/src/main/java/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
+++ b/java/core/src/main/java/com/redhat/rhn/domain/notification/types/SubscriptionWarning.java
@@ -13,7 +13,6 @@ package com.redhat.rhn.domain.notification.types;
 import static com.redhat.rhn.common.hibernate.HibernateFactory.getSession;
 
 import com.redhat.rhn.common.localization.LocalizationService;
-import com.redhat.rhn.domain.scc.SCCOrderItem;
 import com.redhat.rhn.domain.scc.SCCSubscription;
 
 
@@ -26,32 +25,18 @@ public class SubscriptionWarning implements NotificationData {
      * @return boolean
      **/
     public boolean expiresSoon() {
-        // The following query aims to find if there are subscriptions that will expire in 90 days
-        // or have expired within 30 days.
-        // Initially, the query was looking directly in the suseSCCSubscription table, but that approach was
-        // sometimes warning the user about subscriptions that were then not present in the subscription matcher page.
-        // To fill this discrepancy, now the query checks subscriptions "joined on" the orders, as they appear
-        // in the input for the subscription matcher (see MatcherJsonIO.getJsonSubscriptions).
-        // In this way, the user is warned only with subscriptions actually appearing in the subscription matcher page,
-        // while they don't get pointlessly warned about unmatched subscriptions or test/promotional subscriptions
-        // (hence not present in the subscription matcher page).
-        // Also, although the starts_at/expires_at subscription dates and the start_date/end_date order dates should be
-        // consistent, we take the suseSCCOrderItem.end_date as reference to check the subscription validity in time
-
         return getSession()
                 .createNativeQuery("""
                         SELECT EXISTS
                          (
-                            SELECT ord.sku, ord.quantity, subs.scc_id, subs.name, subs.status, subs.subtype
-                              FROM suseSCCOrderItem AS ord
-                                        JOIN suseSCCSubscription AS subs ON ord.subscription_id = subs.scc_id
-                              WHERE subs.subtype != 'internal' AND subs.subtype != 'test' AND (
-                                        (subs.status = 'ACTIVE' AND ord.end_date < now() + interval '90 DAY')
-                                            OR (subs.status = 'EXPIRED' AND ord.end_date > now() - interval '30 day')
+                            SELECT name, expires_at, status, subtype
+                              FROM suseSCCSubscription
+                              WHERE subtype != 'internal' AND subtype != 'test' AND (
+                                        (status = 'ACTIVE' AND expires_at < now() + interval '90 DAY')
+                                            OR (status = 'EXPIRED' AND expires_at > now() - interval '30 day')
                                     )
                         )
                         """, Boolean.class)
-                .addSynchronizedEntityClass(SCCOrderItem.class)
                 .addSynchronizedEntityClass(SCCSubscription.class)
                 .uniqueResultOptional()
                 .orElse(false);

--- a/java/spacewalk-java.changes.carlo.uyuni-1257894-expiring-subscription-warning
+++ b/java/spacewalk-java.changes.carlo.uyuni-1257894-expiring-subscription-warning
@@ -1,1 +1,0 @@
-- Fix expiring subscription warnings (bsc#1257894)


### PR DESCRIPTION
## What does this PR change?

This reverts commit 7deac3000e89174e1cb01f5c78aff682d9b18d69. since the provided bug solution proved to be wrong.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links
reverted PR: https://github.com/uyuni-project/uyuni/pull/11515
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"


