### PR TITLE
Stop using the host's cgroupfs on Kubernetes server

### DIFF
--- a/containers/proxy-helm/proxy-helm.changes.cbosdo.server-selinux
+++ b/containers/proxy-helm/proxy-helm.changes.cbosdo.server-selinux
@@ -1,0 +1,1 @@
+- Ensure the symlinks are removed before creating them

--- a/containers/proxy-helm/templates/deployment.yaml
+++ b/containers/proxy-helm/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
             - -c
             - |2
               cp -r /etc/apache2/* /tmp/apache2/
+              rm -f /tmp/apache2/ssl.crt/server.crt
+              rm -f /tmp/apache2/ssl.key/server.key
+              rm -f /tmp/apache2/conf.d/apache_tuning.conf
               ln -s /etc/uyuni/server.crt /tmp/apache2/ssl.crt/server.crt
               ln -s /etc/uyuni/server.key /tmp/apache2/ssl.key/server.key
               ln -s /etc/uyuni/apache_tuning.conf /tmp/apache2/conf.d/apache_tuning.conf
@@ -46,6 +49,7 @@ spec:
             - -c
             - |2
               cp -r /etc/ssh/sshd_config.d/* /tmp/sshd/
+              rm -f /tmp/sshd/99-tuning.conf
               ln -s /etc/uyuni/ssh_tuning.conf /tmp/sshd/99-tuning.conf
           volumeMounts:
           - name: etc-sshd

--- a/containers/server-helm/Chart.yaml
+++ b/containers/server-helm/Chart.yaml
@@ -2,7 +2,7 @@
 #!BuildTag: uyuni/server-helm:latest
 apiVersion: v2
 name: server-helm
-description: Uyuni server containers.
+description: Uyuni server
 type: application
 home: https://www.uyuni-project.org/
 icon: https://www.uyuni-project.org/img/uyuni-logo.svg

--- a/containers/server-helm/README.md
+++ b/containers/server-helm/README.md
@@ -51,7 +51,7 @@ The following persistent volume claims will be created and will need to be bound
 - `var-cache`: (default size: 10Gi)
 - `var-cobbler`: (default size: 10Mi)
 - `var-log`: (default size: 2Gi)
-- `var-pgsql`: (default size: 50Gi)
+- `var-pgsql18`: (default size: 50Gi)
 - `var-salt`: (default size: 10Mi)
 - `var-search`: (default size: 10Gi)
 - `var-spacewalk`: (default size: 100Gi)

--- a/containers/server-helm/server-helm.changes.cbosdo.server-selinux
+++ b/containers/server-helm/server-helm.changes.cbosdo.server-selinux
@@ -1,0 +1,1 @@
+- Separate the cgroup mount from the host one

--- a/containers/server-helm/templates/NOTES.txt
+++ b/containers/server-helm/templates/NOTES.txt
@@ -1,0 +1,6 @@
+Thank you for installing the {{ .Chart.Description }}!
+Connect to the web UI using the credentials from the admin-credentials secret:
+
+  https://{{ .Values.global.fqdn }}
+
+Documentation can be found at {{ .Chart.Home }}

--- a/containers/server-helm/templates/server.yaml
+++ b/containers/server-helm/templates/server.yaml
@@ -22,13 +22,24 @@ spec:
     spec:
       containers:
       - env:
+        - name: container
+          value: oci
         - name: TZ
           value: {{ .Values.timezone | default "Etc/UTC" }}
 {{- if and .Values.server.mirror (or .Values.server.mirror.claimName .Values.server.mirror.hostPath) }}
           - name: MIRROR_PATH
             value: /mirror
 {{- end }}
+{{- if .Values.server.systemdLogLevel }}
+        - name: SYSTEMD_LOG_TARGET
+          value: console
+        - name: SYSTEMD_LOG_LEVEL
+          value: {{ .Values.server.systemdLogLevel }}
+        tty: true
+{{- end }}
         image: {{ include "uyuni.image" (dict "name" "server" "global" . "local" .Values.server) }}
+        command:
+        - /docker-entrypoint-init.d/00-kubernetes-systemd
         imagePullPolicy: {{ .Values.pullPolicy }}
         lifecycle:
           preStop:
@@ -36,7 +47,7 @@ spec:
               command:
               - /bin/sh
               - -c
-              - spacewalk-service stop && systemctl stop postgresql
+              - spacewalk-service stop
         livenessProbe:
           failureThreshold: 5
           httpGet:
@@ -48,6 +59,14 @@ spec:
           successThreshold: 1
           timeoutSeconds: 20
         name: uyuni
+        securityContext:
+          capabilities:
+            add:
+            - SYS_ADMIN
+  {{- if .Values.server.superPrivileged }}
+          seLinuxOptions:
+            type: "spc_t"
+  {{- end }}
         ports:
         - containerPort: 80
         - containerPort: 4505
@@ -338,10 +357,8 @@ spec:
           medium: Memory
           sizeLimit: 256Mi
         name: run
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: sys-fs-cgroup
+      - name: sys-fs-cgroup
+        emptyDir:
 {{- if .Values.server.mirror }}
   {{- if .Values.server.mirror.claimName }}
       - name: mirror

--- a/containers/server-helm/tests/global_settings_test.yaml
+++ b/containers/server-helm/tests/global_settings_test.yaml
@@ -14,21 +14,21 @@ tests:
         enable: true
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].env[0].value
+          path: spec.template.spec.containers[?(@.name=="uyuni")].env[?(@.name=="TZ")].value
           value: "Europe/Berlin"
         template: server.yaml
         documentSelector:
           path: metadata.name
           value: uyuni
       - equal:
-          path: spec.template.spec.containers[0].env[0].value
+          path: spec.template.spec.containers[?(@.name=="db")].env[?(@.name=="TZ")].value
           value: "Europe/Berlin"
         template: db.yaml
         documentSelector:
           path: metadata.name
           value: db
       - equal:
-          path: spec.template.spec.containers[0].env[1].value
+          path: spec.template.spec.containers[?(@.name=="saline")].env[?(@.name=="TZ")].value
           value: "Europe/Berlin"
         template: saline.yaml
         documentSelector:
@@ -52,21 +52,28 @@ tests:
       pullPolicy: "Always"
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].imagePullPolicy
+          path: spec.template.spec.containers[?(@.name=="uyuni")].imagePullPolicy
           value: "Always"
         template: server.yaml
         documentSelector:
           path: metadata.name
           value: uyuni
       - equal:
-          path: spec.template.spec.initContainers[0].imagePullPolicy
+          path: spec.template.spec.initContainers[?(@.name=="db-waiter")].imagePullPolicy
           value: "Always"
         template: server.yaml
         documentSelector:
           path: metadata.name
           value: uyuni
       - equal:
-          path: spec.template.spec.containers[0].imagePullPolicy
+          path: spec.template.spec.initContainers[?(@.name=="setup-waiter")].imagePullPolicy
+          value: "Always"
+        template: server.yaml
+        documentSelector:
+          path: metadata.name
+          value: uyuni
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="db")].imagePullPolicy
           value: "Always"
         template: db.yaml
         documentSelector:

--- a/containers/server-helm/values.schema.json
+++ b/containers/server-helm/values.schema.json
@@ -55,6 +55,16 @@
           "description": "Email address for notifications sent by the server",
           "default": "admin@uyuni.lab.org"
         },
+        "superPrivileged": {
+          "type": "boolean",
+          "description": "Run the server container with super privileges, bypassing a lot of selinux checks. This is dangerous!",
+          "default": false
+        },
+        "systemdLogLevel": {
+          "type": "string",
+          "enum": ["debug", "info", "notice", "warning", "err", "crit", "alert", "emerg", ""],
+          "description": "Value passed to systemd's --log-level parameter, can be useful for debugging"
+        },
         "mirror": {
           "type": "object",
           "description": "Defines a volume or host path to mount as server.susemanager.fromdir",

--- a/containers/server-helm/values.yaml
+++ b/containers/server-helm/values.yaml
@@ -39,6 +39,16 @@ server:
   #  claimName: mirror
   #  hostPath: /srv/mirror
 
+  ## superPrivileged may need to be set to true to run on a cluster with selinux enforced.
+  ## This is only for the server pod, since it runs systemd.
+  ## Setting this to true opens a big security can of worms.
+  superPrivileged: false
+
+  ## systemdLogLevel will be passed to systemd's --log-level parameter.
+  ## Note, that this will add a tty to the container.
+  ## The possible values are debug, info, notice, warning, err, crit, alert, emerg or "" to keep the default.
+  systemdLogLevel: ""
+
 
 global:
   ## fqdn is the fully qualified name the server will answer as.

--- a/containers/server-image/Dockerfile
+++ b/containers/server-image/Dockerfile
@@ -93,9 +93,15 @@ RUN echo "rpm.install.excludedocs = yes" >>/etc/zypp/zypp.conf && \
     ln -s "/etc/rhn/krb5.conf.d" "/etc/krb5.conf.d" && \
     mkdir -p /etc/systemd/system.conf.d/ && \
     printf "[Manager]\nLogColor=no" >/etc/systemd/system.conf.d/01-nocolor.conf && \
-# The RemoveIPC was needed for postgresql, not sure if it is safe to remove now that it's in its own container
-    mkdir -p /etc/systemd/logind.conf.d/ && \
-    printf "[Login]\nRemoveIPC=no" >/etc/systemd/logind.conf.d/disable-removeipc.conf && \
+# Credentials fail on Kubernetes, removing them to setup tmpfiles
+    sed -i "/^ImportCredential=.*/d" /usr/lib/systemd/system/systemd-tmpfiles-setup.service && \
+# Silence services that generate errors are not really needed in a container
+    ln -sf /dev/null /etc/systemd/system/dev-hugepages.mount && \
+    ln -sf /dev/null /etc/systemd/system/systemd-logind.service && \
+    ln -sf /dev/null /etc/systemd/system/systemd-sysusers.service && \
+    ln -sf /dev/null /etc/systemd/system/systemd-timedated.service && \
+    ln -sf /dev/null /etc/systemd/system/systemd-tmpfiles-clean.service && \
+    ln -sf /dev/null /etc/systemd/system/console-getty.service && \
     rm -rf /var/log/{alternatives.log,lastlog,tallylog,suseconnect.log,zypper.log,zypp/history,YaST2}
 
 ADD --chown=root:root root.tar.gz /

--- a/containers/server-image/root/docker-entrypoint-init.d/00-kubernetes-systemd
+++ b/containers/server-image/root/docker-entrypoint-init.d/00-kubernetes-systemd
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Prepare the cgroup mount for systemd
+mount -t cgroup2 none /sys/fs/cgroup
+exec /usr/lib/systemd/systemd

--- a/containers/server-image/root/etc/systemd/system/service.d/99-kubernetes.conf
+++ b/containers/server-image/root/etc/systemd/system/service.d/99-kubernetes.conf
@@ -1,0 +1,14 @@
+# On Kubernetes the tmp mounts (and others) cannot be remounted.
+# Disable the protections in the container for services to start
+[Service]
+ProtectSystem=false
+PrivateTmp=no
+ProtectHome=false
+PrivateDevices=false
+ProtectHostname=false
+ProtectClock=false
+ProtectKernelTunables=false
+ProtectKernelModules=false
+ProtectKernelLogs=false
+ProtectControlGroups=false
+RestrictRealtime=false

--- a/containers/server-image/root/usr/bin/timezone_alignment.sh
+++ b/containers/server-image/root/usr/bin/timezone_alignment.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-if [[ ! -z "$TZ" ]]; then
-    timedatectl set-timezone $TZ
+if [[ ! -z "$TZ"  ]]; then
+    if [[ ! -f "/usr/share/zoneinfo/$TZ" ]]; then
+        echo "Invalid timezone: $TZ"
+        exit 1
+    fi
+    rm -f /etc/localtime
+    ln -s "/usr/share/zoneinfo/$TZ" /etc/localtime
 fi

--- a/containers/server-image/server-image.changes.cbosdo.server-selinux
+++ b/containers/server-image/server-image.changes.cbosdo.server-selinux
@@ -1,0 +1,1 @@
+- Separate the cgroup mount from the host one on Kubernetes

--- a/spacewalk/admin/spacewalk-admin.changes.cbosdo.server-selinux
+++ b/spacewalk/admin/spacewalk-admin.changes.cbosdo.server-selinux
@@ -1,0 +1,1 @@
+- Remove old tomcat code in the startup helper

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -136,13 +136,7 @@ check_database() {
 }
 
 wait_for_tomcat() {
-if [ -x /etc/init.d/tomcat5 ]; then
-   TOMCAT_PID=$(cat /var/run/tomcat5.pid 2>/dev/null)
-elif [ -x /etc/init.d/tomcat6 ]; then
-   TOMCAT_PID=$(cat /var/run/tomcat6.pid 2>/dev/null)
-elif [ -e /usr/lib/systemd/system/tomcat.service ]; then
-   TOMCAT_PID=$(systemctl show --property=MainPID tomcat.service | sed 's/^MainPID=0*//')
-elif [ -e /usr/lib/systemd/system/tomcat.service ]; then
+if [ -e /usr/lib/systemd/system/tomcat.service ]; then
    TOMCAT_PID=$(systemctl show --property=MainPID tomcat.service | sed 's/^MainPID=0*//')
 else
    echo "No tomcat service found."


### PR DESCRIPTION
## What does this PR change?

Using a hostPath for the server cgroupfs can lead to the corruption of the cgroupfs on the host. Using an empty folder and mounting the cgroupfs in it is safer, but requires additional tricks for systemd to properly start on an selinux enforced node.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Will be covered with CI on rke2

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29483

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
