### PR TITLE
GHAction: Verify all DONE checkboxes are checked at PRs

### DIFF
--- a/.github/workflows/verify-done-checkboxes.yml
+++ b/.github/workflows/verify-done-checkboxes.yml
@@ -1,0 +1,36 @@
+name: Verify DONE checkboxes
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check-done-checkboxes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify all DONE checkboxes are checked in a PR description
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            // We can't get this via context.payload.pull_request.body
+            // as some pull_request status do not return the body
+            // and in such cases the test runs but does not fail
+            const prNumber = context.payload.pull_request.number;
+            const { data: pr } = await github.rest.pulls.get({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               pull_number: prNumber
+            });
+ 
+            const description = pr.body ?? "";
+            console.log(description)
+
+            // ATM we are not checking if the number of
+            // DONE checkboxes matches what the original template has
+            const regex = /^\s*-\s*\[\s*\]\s*\**\s*done\s*\**\s*$/im;
+
+            if (regex.test(description)) {
+               core.setFailed('There is at least one unchecked DONE checkbox!');
+            }


### PR DESCRIPTION
# QUESTION FOR @uyuni-project/workflows-reviewers 

Should we enforce this action to be passing before merging?

**DECISION:** Yes, we'll enforce it.

## What does this PR change?

As it happens quite frequently merge perge PRs without one or more checked, meaning we miss ports, cards
for documentation, tests or other stuff.

This workflow will fail as soon as it finds one of the `DONE` checkboxes unmarked.

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: GitHub action check.

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- Test added, for the PR description itself :-)

- [x] **DONE**

## Links

None. Backports are not required.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
