### PR TITLE
Correctly identify SL micro 6.2

### DIFF
--- a/testsuite/features/support/remote_node.rb
+++ b/testsuite/features/support/remote_node.rb
@@ -402,8 +402,34 @@ class RemoteNode
     end
 
     os_version.delete! '"'
-    # on SLES, we need to replace the dot with '-SP'
-    os_version.gsub!('.', '-SP') if os_family.match(/^sles/)
+
+    if os_family.match(/^sles/)
+      if os_version.match(/^16/)
+        os_variant_raw, code = run('grep "^VARIANT=" /etc/os-release', runs_in_container: runs_in_container, check_errors: false)
+        return nil, nil unless code.zero?
+
+        os_variant = os_variant_raw.strip
+        os_variant = os_variant.split('=')[1]
+
+        os_variant.delete! '"'
+
+        if os_variant == 'Micro'
+          os_family = 'sle-micro'
+
+          os_version_raw, code = run('grep "^SUSE_SUPPORT_PRODUCT_VERSION=" /etc/os-release', runs_in_container: runs_in_container, check_errors: false)
+          return nil, nil unless code.zero?
+
+          os_version = os_version_raw.strip.split('=')[1]
+          return nil, nil if os_version.nil?
+
+          os_version.delete! '"'
+        end
+      else
+        # on older SLES, we need to replace the dot with '-SP'
+        os_version.gsub!('.', '-SP')
+      end
+    end
+
     $stdout.puts "Node: #{@hostname}, OS Version: #{os_version}, Family: #{os_family}"
     [os_version, os_family]
   end


### PR DESCRIPTION
## What does this PR change?

Correctly identify SL micro 6.2, as the syntax of /etc/os-release is... weird


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were refined.

- [x] **DONE**


## Links

Port(s):
* 5.1: https://github.com/SUSE/spacewalk/pull/29889
* 5.0: https://github.com/SUSE/spacewalk/pull/29890
* 4.3: https://github.com/SUSE/spacewalk/pull/29891

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
