### PR TITLE
Exclude opensusessh minion from GitHub Actions

### DIFF
--- a/.github/workflows/acceptance_tests_base.yml
+++ b/.github/workflows/acceptance_tests_base.yml
@@ -202,17 +202,17 @@ jobs:
       #     - name: update_ca_in_controller
       #       run: podman exec controller bash -c "cat /tmp/spacewalk.crt >> /etc/ssl/ca-bundle.pem"
 
-      - name: Run SSH minion container
-        if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
-        run: ./testsuite/podman_runner/10_run_sshminion.sh
+      #- name: Run SSH minion container
+      #  if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
+      #  run: ./testsuite/podman_runner/10_run_sshminion.sh
 
       - name: Test access to server from controller
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
         run: curl --insecure https://localhost:8443/rhn/help/Copyright.do
 
-      - name: Test access to server from SSH minion
-        if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
-        run: sudo -i podman exec opensusessh curl --insecure https://server:443/rhn/help/Copyright.do
+      #- name: Test access to server from SSH minion
+      #  if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}
+      #  run: sudo -i podman exec opensusessh curl --insecure https://server:443/rhn/help/Copyright.do
 
       - name: Configure SSHD in controller, server, build host and SSH minion
         if: ${{ !inputs.skip_tests && needs.filters.outputs.require_acceptance_tests == 'true' }}

--- a/.github/workflows/acceptance_tests_coordinator.yml
+++ b/.github/workflows/acceptance_tests_coordinator.yml
@@ -14,7 +14,6 @@ concurrency:
 env:
   UYUNI_PROJECT: uyuni-project
   UYUNI_VERSION: master
-
 jobs:
   determine_tests:
     name: Get recommended tests

--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -45,8 +45,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ env.PLATFORMS }}
           build-args: |
-            BASE=registry.opensuse.org/uyuni/server
-            VERSION=2025.10
+            BASE=registry.opensuse.org/systemsmanagement/uyuni/master/containerfile/uyuni/server
+            VERSION=latest
   build-and-push-ubuntu-minion-image:
     runs-on: ubuntu-latest
     permissions:

--- a/testsuite/features/reposync/allcli_update_activationkeys.feature
+++ b/testsuite/features/reposync/allcli_update_activationkeys.feature
@@ -48,6 +48,7 @@ Feature: Update activation keys
 
 @scc_credentials
 @susemanager
+@ssh_minion
   Scenario: Update SLE SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Test Key x86_64" in the content area
@@ -65,6 +66,7 @@ Feature: Update activation keys
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been modified" text
 
 @uyuni
+@ssh_minion
   Scenario: Update openSUSE Tumbleweed SSH key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Test Key x86_64" in the content area
@@ -79,6 +81,7 @@ Feature: Update activation keys
 
 @scc_credentials
 @susemanager
+@ssh_minion
   Scenario: Update SLE SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area
@@ -96,6 +99,7 @@ Feature: Update activation keys
     Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been modified" text
 
 @uyuni
+@ssh_minion
   Scenario: Update openSUSE Tumbleweed SSH tunnel key with synced base product
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE SSH Tunnel Test Key x86_64" in the content area

--- a/testsuite/podman_runner/00_clean_env.sh
+++ b/testsuite/podman_runner/00_clean_env.sh
@@ -25,7 +25,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   podman machine rm --force ||:
 else
   echo "Killing old containers"
-  containers="authregistry.lab noauthregistry.lab buildhost deblike_minion rhlike_minion sle_minion opensusessh server controller uyuni-db"
+  containers="authregistry.lab noauthregistry.lab buildhost deblike_minion rhlike_minion sle_minion server controller uyuni-db"  # opensusessh --- IGNORE ---
   for i in ${containers};do
       $PODMAN_CMD kill ${i}
   done

--- a/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh
+++ b/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost.sh
@@ -17,7 +17,6 @@ export PUBLISH_CUCUMBER_REPORT=${PUBLISH_CUCUMBER_REPORT}
 export PROVIDER=podman
 export SERVER=server
 export HOSTNAME=controller
-export SSH_MINION=opensusessh
 export MINION=sle_minion
 export RHLIKE_MINION=rhlike_minion
 export DEBLIKE_MINION=deblike_minion
@@ -44,14 +43,14 @@ sudo -i podman exec buildhost bash -c "sed -e 's/http:\/\/download.opensuse.org/
 sudo -i podman exec buildhost bash -c "sed -e 's/https:\/\/download.opensuse.org/file:\/\/\/mirror\/download.opensuse.org/g' -i /etc/zypp/repos.d/*"
 sudo podman ps
 
-sudo docker pull ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.6:master
-sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.6:master localhost:5002/opensuse/leap:15.6
+sudo docker pull ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.6:$UYUNI_VERSION
+sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/opensuse/leap/15.6:$UYUNI_VERSION localhost:5002/opensuse/leap:15.6
 sudo docker push localhost:5002/opensuse/leap:15.6
 
-sudo docker pull ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:master
-sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:master localhost:5002/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
+sudo docker pull ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:$UYUNI_VERSION
+sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:$UYUNI_VERSION localhost:5002/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 sudo docker push localhost:5002/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 
 sudo docker login -u ${AUTH_REGISTRY_USER} -p ${AUTH_REGISTRY_PASSWD} localhost:5001
-sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:master localhost:5001/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
+sudo docker tag ghcr.io/$UYUNI_PROJECT/uyuni/uyuni-master-testsuite:$UYUNI_VERSION localhost:5001/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite
 sudo docker push localhost:5001/cucutest/systemsmanagement/uyuni/master/docker/containers/uyuni-master-testsuite

--- a/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost_darwin.sh
+++ b/testsuite/podman_runner/03_run_controller_and_registry_and_buildhost_darwin.sh
@@ -32,7 +32,6 @@ export PUBLISH_CUCUMBER_REPORT=${PUBLISH_CUCUMBER_REPORT}
 export PROVIDER=podman
 export SERVER=server
 export HOSTNAME=controller
-export SSH_MINION=opensusessh
 export MINION=sle_minion
 export RHLIKE_MINION=rhlike_minion
 export DEBLIKE_MINION=deblike_minion


### PR DESCRIPTION

## What does this PR change?

Comment out opensusessh SSH minion references across CI workflows and podman runner scripts to disable this minion in GitHub Actions.

This PR is tested against my fork with images from: https://github.com/szachovy?q=ci-&tab=packages&tab=packages&q=

After successful review before merge I will do:
* Remove placeholder testsuite file
* Change `UYUNI_PROJECT` and `UYUNI_VERSION` to default values pointing to uyuni-project
* Switch back:
```
sudo -i podman run --rm -d --pull newer --network network --name $AUTH_REGISTRY -h $AUTH_REGISTRY -e AUTH_REGISTRY=${AUTH_REGISTRY} -e AUTH_REGISTRY_USER=${AUTH_REGISTRY_USER} -e AUTH_REGISTRY_PASSWD={$AUTH_REGISTRY_USER} -p 5001:5000 ghcr.io/uyuni-project/uyuni/ci-container-registry-auth:master
sudo -i podman run --rm -d --pull newer --network network --name $NO_AUTH_REGISTRY -h $NO_AUTH_REGISTRY -e NO_AUTH_REGISTRY=${NO_AUTH_REGISTRY} -p 5002:5000 ghcr.io/uyuni-project/uyuni/ci-container-registry:master
```
->
```
sudo -i podman run --rm -d --pull newer --network network --name $AUTH_REGISTRY -h $AUTH_REGISTRY -e AUTH_REGISTRY=${AUTH_REGISTRY} -e AUTH_REGISTRY_USER=${AUTH_REGISTRY_USER} -e AUTH_REGISTRY_PASSWD={$AUTH_REGISTRY_USER} -p 5001:5000 ghcr.io/$UYUNI_PROJECT/uyuni/ci-container-registry-auth:$UYUNI_VERSION
sudo -i podman run --rm -d --pull newer --network network --name $NO_AUTH_REGISTRY -h $NO_AUTH_REGISTRY -e NO_AUTH_REGISTRY=${NO_AUTH_REGISTRY} -p 5002:5000 ghcr.io/$UYUNI_PROJECT/uyuni/ci-container-registry:$UYUNI_VERSION
```


## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Issue(s): https://github.com/SUSE/spacewalk/issues/29603
Port(s): None

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
