### PR TITLE
Handle "Connection reset by peer" errors

### DIFF
--- a/testsuite/features/support/network_utils.rb
+++ b/testsuite/features/support/network_utils.rb
@@ -26,7 +26,7 @@ def ssh_command(command, host, port: 22, timeout: DEFAULT_TIMEOUT, buffer_size: 
     end
   rescue Timeout::Error
     puts "SSH operation timed out after #{timeout} seconds."
-  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+  rescue Net::SSH::ConnectionTimeout, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ECONNRESET
     puts "Unable to reach the SSH server at #{host}:#{port}"
   rescue Net::SSH::AuthenticationFailed
     puts "Authentication failed for user #{user} on #{host}"


### PR DESCRIPTION
## What does this PR change?

Handle "Connection reset by peer" errors in the test suite, especially when a host is rebooting.


## GUI diff

No difference.

- [x] **DONE**


## Documentation

No documentation needed: only internal and user invisible changes.

- [x] **DONE**


## Test coverage

Cucumber tests were made more robust.

- [x] **DONE**


## Links

Port(s):
 * 4.3: https://github.com/SUSE/spacewalk/pull/29920
 * 5.0: https://github.com/SUSE/spacewalk/pull/29919
 * 5.1: https://github.com/SUSE/spacewalk/pull/29917

- [x] **DONE**


## Changelogs

- [x] No changelog needed


## Re-run a test

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
