### PR TITLE
Convert injected sumaform repositories into custom repositories for Head BV

### DIFF
--- a/testsuite/features/build_validation/add_MU_repositories/add_maintenance_update_repositories.template
+++ b/testsuite/features/build_validation/add_MU_repositories/add_maintenance_update_repositories.template
@@ -30,6 +30,10 @@ Feature: Add a Maintenance Update custom channel and the custom repositories for
     And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
+@head
+  Scenario: Create development custom repositories to the custom channel for <client>
+    When I prepare the development repositories of "<client>" as part of "custom_channel_<client>" channel
+
   Scenario: Synchronize the repositories in the custom channel for <client>
     When I follow the left menu "Software > Manage > Channels"
     And I enter "<client>" as the filtered channel name

--- a/testsuite/features/step_definitions/api_common.rb
+++ b/testsuite/features/step_definitions/api_common.rb
@@ -359,42 +359,40 @@ When(/^I create an activation key including custom channels for "([^"]*)" via AP
   # Get the list of child channels for this base channel
   child_channels = $api_test.channel.software.list_child_channels(base_channel_label)
 
-  # filter out wrong child channels for SLE Micro 5.5 as normal minion
-  if client.include? 'slemicro55'
-    child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-pool-x86_64' }
-    child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-updates-x86_64' }
-    child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-pool-x86_64' }
-    child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-updates-x86_64' }
+  # Define which clients trigger which exclusions
+  channel_filters = {
+    /sle15sp6|slemicro55/ => %w[
+      suse-manager-proxy
+      suse-manager-retail-branch-server
+      suse-manager-server
+    ],
+    /sle15sp7|slmicro6[12]/ => %w[
+      suse-multi-linux-manager-proxy
+      suse-multi-linux-manager-retail-branch-server
+      suse-multi-linux-manager-server
+    ]
+  }.freeze
+
+  # Apply the filters to don't have wrong child channels on normal minions
+  channel_filters.each do |pattern, exclusions|
+    child_channels.reject! { |channel| exclusions.any? { |ex| channel.include?(ex) } } if client.match?(pattern)
   end
 
-  # filter out wrong child channels for SLES 15 SP6 as normal minion
-  if client.include? 'sle15sp6'
-    child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-pool-x86_64-sp6' }
-    child_channels.reject! { |channel| channel.include? 'suse-manager-proxy-5.0-updates-x86_64-sp6' }
-    child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-pool-x86_64-sp6' }
-    child_channels.reject! { |channel| channel.include? 'suse-manager-retail-branch-server-5.0-updates-x86_64-sp6' }
-  end
+  if client.include?('proxy_nontransactional')
+    # The non-transactional proxy for 5.1 and 5.2 is based on the same HostOS SLES15 SP7
+    # we need to determine the proxy version and exclude the channels for the other proxy version.
+    version = product_version_full
+    version_to_exclude =
+      if version&.include?('5.1')
+        '5.2'
+      elsif version&.include?('5.2') || version&.include?('head')
+        '5.1'
+      else
+        nil
+      end
 
-  # filter out wrong child channels for SL Micro 6.1 as normal minion
-  if client.include? 'slmicro61'
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-5.1-x86_64' }
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-5.1-x86_64' }
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-server-5.1-x86_64' }
-  end
-
-  # filter out wrong child channels for SL Micro 6.2 as normal Minion
-  if client.include? 'slmicro62'
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-5.2-x86_64' }
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-5.2-x86_64' }
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-server-5.2-x86_64' }
-  end
-
-  # filter out wrong child channels for SLES 15 SP7 as normal minion
-  if client.include? 'sle15sp7'
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-sle-5.1-pool-x86_64-sp7' }
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-proxy-sle-5.1-updates-x86_64-sp7' }
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-sle-5.1-pool-x86_64-sp7' }
-    child_channels.reject! { |channel| channel.include? 'suse-multi-linux-manager-retail-branch-server-sle-5.1-updates-x86_64-sp7' }
+    # Reject the channels containing the version we want to exclude
+    child_channels.reject! { |channel| channel.include?(version_to_exclude) } if version_to_exclude
   end
 
   $stdout.puts "Child_channels for #{key}: <#{child_channels}>"

--- a/testsuite/features/step_definitions/setup_steps.rb
+++ b/testsuite/features/step_definitions/setup_steps.rb
@@ -532,20 +532,21 @@ end
 
 When(/^I prepare the development repositories of "([^"]*)" as part of "([^"]*)" channel$/) do |host, channel_label|
   target = get_target(host)
-  repo_urls =
-    if deb_host?(host)
-      repo_list_output, _code = target.run('grep -rh ^deb /etc/apt/sources.list.d/')
-      repo_list_output.split("\n").map { |line| line.split[-2].strip }
-    elsif rh_host?(host)
-      repo_list_output, _code = target.run('grep -rh ^baseurl /etc/yum.repos.d/')
-      repo_list_output.split("\n").map { |line| line.split('=').last.strip }
-    elsif suse_host?(host)
-      repo_list_output, _code = target.run('grep -rh ^baseurl /etc/zypp/repos.d/')
-      repo_list_output.split("\n").map { |line| line.split('=').last.strip }
-    else
-      raise ArgumentError, "OS family not supported: #{target.os_family}"
-    end
+  repo_urls = if deb_host?(host)
+                out, = target.run('grep -rh ^deb /etc/apt/sources.list.d/')
+                out.split("\n").map { |line| line.split[1].strip }
+              elsif rh_host?(host)
+                out, = target.run('grep -rh "^\s*baseurl" /etc/yum.repos.d/')
+                out.split("\n").map { |line| line.split('=', 2).last.strip }
+              elsif suse_host?(host)
+                out, = target.run('grep -rh "^\s*baseurl" /etc/zypp/repos.d/')
+                out.split("\n").map { |line| line.split('=', 2).last.strip }
+              else
+                raise ArgumentError, "OS family not supported: #{target.os_family}"
+              end.compact.uniq
+
   repo_urls.each do |repo_url|
+    next if repo_url.empty?
     next unless devel_repo?(repo_url)
 
     unique_repo_name = generate_repository_name(repo_url)

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -46,32 +46,17 @@ def product
   raise NotImplementedError, 'Could not determine product'
 end
 
-# Returns the version of the product
-#
-# @return [String] The version number of the product being tested.
-def product_version
-  product_raw, code = get_target('server').run('rpm -q patterns-uyuni_server', check_errors: false)
-  m = product_raw.match(/patterns-uyuni_server-(.*)-.*/)
-  return m[1] if code.zero? && !m.nil?
-
-  product_raw, code = get_target('server').run('rpm -q patterns-suma_server', check_errors: false)
-  m = product_raw.match(/patterns-suma_server-(.*)-.*/)
-  return m[1] if code.zero? && !m.nil?
-
-  raise NotImplementedError, 'Could not determine product version'
-end
-
 # Retrieves the full product version using the 'venv-salt-call' command.
 #
 # @return [String, nil] The full product version if the command execution was successful and
 #   the output is not empty, otherwise nil.
 def product_version_full
   cmd = 'venv-salt-call --local grains.get product_version | tail -n 1'
-  out, code = get_target('server').run(cmd)
+  out, code = get_target('server').run(cmd, runs_in_container: false)
   out.strip if code.zero? && !out.nil?
 end
 
-# WARN: It's working for /24 mask, but couldn't not work properly with others
+# WARN: It's working for /24 mask, but couldn't work properly with others
 # Returns the reverse DNS lookup address for a given network address.
 #
 # @param net [String] The network address in the format "x.x.x.x".

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -631,6 +631,11 @@ Before('@uyuni') do
   skip_this_scenario unless product == 'Uyuni'
 end
 
+# do some tests only for head product builds
+Before('@head') do
+  skip_this_scenario unless product_version_full&.include?('head')
+end
+
 # do some tests only if we are using salt bundle
 Before('@salt_bundle') do
   skip_this_scenario unless $use_salt_bundle

--- a/testsuite/features/support/file_management.rb
+++ b/testsuite/features/support/file_management.rb
@@ -190,5 +190,5 @@ end
 # @return [Boolean] Returns true if the repository is a development repository, false otherwise.
 def devel_repo?(repo_url)
   url = repo_url.downcase
-  (url.include?('devel') || url.include?('systemsmanagement')) && !url.include?('sle-module')
+  (url.include?('devel') || url.include?('totest') || url.include?('systemsmanagement')) && !url.include?('sle-module')
 end


### PR DESCRIPTION
## What does this PR change?

**Related Issue:** [SUSE/spacewalk#29746](https://github.com/SUSE/spacewalk/issues/29746)

This PR enables support for **Head Build Validation** within the testsuite. It introduces logic to parse development repositories (injected by `sumaform`) and convert them into custom channels, while significantly refactoring the channel exclusion and repository parsing logic for better maintainability.

* **Channel Filter Refactoring (`api_common.rb`):** 
  * Replaced a long chain of hardcoded `if/else` blocks with a structured `channel_filters` hash using **Regex keys**.
  * This centralizes the logic for excluding specific child channels (Proxy, Retail, Server) across different OS versions (SLE 15 SP6/7, SL Micro 6.x).
  * Added dynamic version detection for `proxy_nontransactional` to correctly exclude 5.1/5.2 channels based on the product version.


* **Hardened Repository Parsing (`setup_steps.rb`):**
  * Improved `grep` and `split` logic to be more resilient to whitespace and formatting in `/etc/zypp/repos.d/` and `/etc/yum.repos.d/`.
  * Added `.compact.uniq` to prevent duplicate or null repository entries.


* **Test Lifecycle & Cleanup:**
  * Introduced the **`@head` tag** and a corresponding `Before` hook in `env.rb` to skip head-specific tests on non-head builds.
  * Removed the deprecated `product_version` method in `commonlib.rb` in favor of the more reliable `product_version_full` (Salt-based).
  * Updated `product_version_full` to ensure it runs outside of containers where necessary.


* **New Scenario:** Added `Create development custom repositories` to the `add_maintenance_update_repositories.template`.
  * This allows the testsuite to leverage development repos as part of the custom channel validation flow.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite

- Cucumber tests were changed

- [x] **DONE**

## Links

No ports.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
