### PR TITLE
Fix wrong Raspberry Pi OS 12 bootstrap repo creation (bsc#1252867)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1519,6 +1519,13 @@ DATA = {
         "DEST": DOCUMENT_ROOT + "/pub/repositories/raspbian/12/bootstrap/",
         "TYPE": "deb",
     },
+    "raspberrypios-12-arm64": {
+        "PDID": [-48, 3029],
+        "BETAPDID": [3031],
+        "PKGLIST": PKGLISTRASPBERRYPIOS12,
+        "DEST": DOCUMENT_ROOT + "/pub/repositories/debian/12/bootstrap/",
+        "TYPE": "deb",
+    },
     "debian13-amd64": {
         # TODO: Use the right PDIDs
         #"PDID": [-43, 3028],
@@ -1566,12 +1573,5 @@ DATA = {
         "BETAPDID": [3042],
         "PKGLIST": OPENEULER,
         "DEST": DOCUMENT_ROOT + "/pub/repositories/openEuler/24.03/bootstrap/",
-    },
-    "raspberrypios12-arm64": {
-        "PDID": [-48, 3029],
-        "BETAPDID": [3031],
-        "PKGLIST": PKGLISTRASPBERRYPIOS12,
-        "DEST": DOCUMENT_ROOT + "/pub/repositories/raspbian/12/bootstrap/",
-        "TYPE": "deb",
-    },
+    }
 }

--- a/susemanager/susemanager.changes.carlo.uyuni-1252867_reposync_raspberry_pi
+++ b/susemanager/susemanager.changes.carlo.uyuni-1252867_reposync_raspberry_pi
@@ -1,0 +1,2 @@
+- Fix wrong Raspberry Pi OS 12 bootstrap repo creation
+  (bsc#1252867)


### PR DESCRIPTION
## What does this PR change?

Fix wrong raspberry pi bootstrap repo creation

1) raspberrypios-12-arm64-uyuni: 64 byte  = DEBIAN for uyuni (NO PDID)
2) raspberrypios-12-armhf-uyuni: 32 byte  = RASPBIAN for uyuni (NO PDID)
3) raspberrypios-12-arm64: 64 byte  = **_DEBIAN_** for suse (WITH PDID) 

## Codespace
<!-- Button to create CodeSpace -->

Check if you already have a running container clicking on [![Running CodeSpace](https://badgen.net/badge/Running/CodeSpace/green)](https://github.com/codespaces)

[![Create CodeSpace](https://img.shields.io/badge/Create-CodeSpace-blue.svg)](https://codespaces.new/uyuni-project/uyuni)  [![About billing for Github Codespaces](https://badgen.net/badge/CodeSpace/Price)](https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces) [![CodeSpace Billing Summary](https://badgen.net/badge/CodeSpace/Billing%20Summary)](https://github.com/settings/billing/summary) [![CodeSpace Limit](https://badgen.net/badge/CodeSpace/Spending%20Limit)](https://github.com/settings/billing/spending_limit)

## GUI diff
No difference.
- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: manually tested
- [x] **DONE**

## Links
Issue(s): https://github.com/SUSE/spacewalk/issues/28776
Port(s): 
5.1: https://github.com/SUSE/spacewalk/pull/29934
5.0, 4.3: Raspberry Pi not supported (port not needed)
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "frontend_checks"
- [ ] Re-run test "spacecmd_unittests"
